### PR TITLE
rock: Add missing constraints

### DIFF
--- a/packages/rock/rock.0.19.0/opam
+++ b/packages/rock/rock.0.19.0/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "5.3.0"}
   "bigstringaf" {>= "0.5.0"}
   "hmap"
-  "httpaf" {>= "0.2.0"}
+  "httpaf" {>= "0.6.0"}
   "lwt"
   "sexplib0"
 ]

--- a/packages/rock/rock.0.19.0/opam
+++ b/packages/rock/rock.0.19.0/opam
@@ -12,9 +12,9 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08"}
   "lwt" {>= "5.3.0"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "hmap"
-  "httpaf"
+  "httpaf" {>= "0.2.0"}
   "lwt"
   "sexplib0"
 ]

--- a/packages/rock/rock.0.20.0/opam
+++ b/packages/rock/rock.0.20.0/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "5.3.0"}
   "bigstringaf" {>= "0.5.0"}
   "hmap"
-  "httpaf" {>= "0.2.0"}
+  "httpaf" {>= "0.6.0"}
   "lwt"
   "sexplib0"
   "odoc" {with-doc}

--- a/packages/rock/rock.0.20.0/opam
+++ b/packages/rock/rock.0.20.0/opam
@@ -12,9 +12,9 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08"}
   "lwt" {>= "5.3.0"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "hmap"
-  "httpaf"
+  "httpaf" {>= "0.2.0"}
   "lwt"
   "sexplib0"
   "odoc" {with-doc}


### PR DESCRIPTION
Uses Bigstringaf.to_string and Httpaf.Server_connection
Detected in https://github.com/ocaml/opam-repository/pull/18819
cc @tmattio @rgrinberg 
```
#=== ERROR while compiling rock.0.20.0 ========================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///src
# path                 ~/.opam/4.08/.opam-switch/build/rock.0.20.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p rock -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/rock-24-806f09.env
# output-file          ~/.opam/log/rock-24-806f09.out
### output ###
# File "/home/opam/.opam/4.08/lib/bigstringaf/bigstringaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/httpaf/httpaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/angstrom/angstrom.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/faraday/faraday.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
#       ocamlc rock/src/.rock.objs/byte/rock__Body.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I rock/src/.rock.objs/byte -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/faraday -I /home/opam/.opam/4.08/lib/hmap -I /home/opam/.opam/4.08/lib/httpaf -I /home/opam/.opam/4.08/lib/lwt -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Rock__ -o rock/src/.rock.objs/byte/rock__Body.cmo -c -impl rock/src/body.ml)
# File "rock/src/body.ml", line 31, characters 49-70:
# 31 |   | `Bigstring b -> sexp_of_string (escape_html (Bigstringaf.to_string b))
#                                                       ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Bigstringaf.to_string
# Hint: Did you mean of_string?
#       ocamlc rock/src/.rock.objs/byte/rock__Server_connection.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I rock/src/.rock.objs/byte -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/faraday -I /home/opam/.opam/4.08/lib/hmap -I /home/opam/.opam/4.08/lib/httpaf -I /home/opam/.opam/4.08/lib/lwt -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib0 -no-alias-deps -open Rock__ -o rock/src/.rock.objs/byte/rock__Server_connection.cmi -c -intf rock/src/server_connection.mli)
# File "rock/src/server_connection.mli", line 4, characters 22-52:
# 4 |   Httpaf.Headers.t -> Httpaf.Server_connection.error -> (Httpaf.Headers.t * Body.t) Lwt.t
#                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Httpaf.Server_connection
#     ocamlopt rock/src/.rock.objs/native/rock__Body.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlopt.opt -w -40 -g -I rock/src/.rock.objs/byte -I rock/src/.rock.objs/native -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/faraday -I /home/opam/.opam/4.08/lib/hmap -I /home/opam/.opam/4.08/lib/httpaf -I /home/opam/.opam/4.08/lib/lwt -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Rock__ -o rock/src/.rock.objs/native/rock__Body.cmx -c -impl rock/src/body.ml)
# File "rock/src/body.ml", line 31, characters 49-70:
# 31 |   | `Bigstring b -> sexp_of_string (escape_html (Bigstringaf.to_string b))
#                                                       ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Bigstringaf.to_string
# Hint: Did you mean of_string?
```