### PR TITLE
httpaf-lwt-unix: Add missing constraints

### DIFF
--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.0/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "faraday-lwt-unix"
-  "httpaf"
+  "httpaf" {>= "0.6.0"}
   "dune"
   "lwt"
 ]

--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.0/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "faraday-lwt-unix"
   "httpaf" {>= "0.6.0"}
   "dune" {>= "1.5"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "Lwt support for http/af"
 url {

--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.0/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "faraday-lwt-unix"
   "httpaf" {>= "0.6.0"}
-  "dune"
+  "dune" {>= "1.5"}
   "lwt"
 ]
 synopsis: "Lwt support for http/af"

--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.5/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.5/opam
@@ -17,7 +17,7 @@ depends: [
   "faraday-lwt-unix"
   "httpaf" {>= "0.6.0"}
   "dune" {>= "1.5.0"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "Lwt support for http/af"
 url {

--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.6/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.6.6/opam
@@ -17,7 +17,7 @@ depends: [
   "faraday-lwt-unix"
   "httpaf" {>= "0.6.0"}
   "dune" {>= "1.5.0"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "Lwt support for http/af"
 url {

--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.7.0/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.7.0/opam
@@ -17,7 +17,7 @@ depends: [
   "faraday-lwt-unix"
   "httpaf" {>= "0.6.0"}
   "dune" {>= "1.5.0"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "Lwt support for http/af"
 url {

--- a/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.7.1/opam
+++ b/packages/httpaf-lwt-unix/httpaf-lwt-unix.0.7.1/opam
@@ -17,7 +17,7 @@ depends: [
   "faraday-lwt-unix"
   "httpaf" {>= "0.6.0"}
   "dune" {>= "1.5.0"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "Lwt support for http/af"
 url {


### PR DESCRIPTION
Detected in #18819 
```
#=== ERROR while compiling httpaf-lwt-unix.0.6.0 ==============================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///src
# path                 ~/.opam/4.08/.opam-switch/build/httpaf-lwt-unix.0.6.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p httpaf-lwt-unix -j 31
# exit-code            1
# env-file             ~/.opam/log/httpaf-lwt-unix-24-4b766d.env
# output-file          ~/.opam/log/httpaf-lwt-unix-24-4b766d.out
### output ###
# File "/home/opam/.opam/4.08/lib/faraday-lwt-unix/faraday-lwt-unix.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/faraday/faraday.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/faraday-lwt/faraday-lwt.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/httpaf/httpaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/angstrom/angstrom.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.08/lib/bigstringaf/bigstringaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
#       ocamlc lwt-unix/.httpaf_lwt_unix.objs/byte/httpaf_lwt_unix.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I lwt-unix/.httpaf_lwt_unix.objs/byte -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/faraday -I /home/opam/.opam/4.08/lib/faraday-lwt -I /home/opam/.opam/4.08/lib/faraday-lwt-unix -I /home/opam/.opam/4.08/lib/httpaf -I /home/opam/.opam/4.08/lib/lwt -I /home/opam/.opam/4.08/lib/lwt/unix -I /home/opam/.opam/4.08/lib/mmap -I /home/opam/.opam/4.08/lib/ocaml/threads -I /home/opam/.opam/4.08/lib/ocplib-endian -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/seq -no-alias-deps -o lwt-unix/.httpaf_lwt_unix.objs/byte/httpaf_lwt_unix.cmi -c -intf lwt-unix/httpaf_lwt_unix.mli)
# File "lwt-unix/httpaf_lwt_unix.mli", line 43, characters 25-33:
# 43 |     :  ?config         : Config.t
#                               ^^^^^^^^
# Error: Unbound module Config
```