### PR TITLE
opium: Add missing constraints

### DIFF
--- a/packages/opium/opium.0.19.0/opam
+++ b/packages/opium/opium.0.19.0/opam
@@ -16,7 +16,7 @@ depends: [
   "httpaf-lwt-unix"
   "logs"
   "fmt"
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "cmdliner"
   "ptime"
   "magic-mime"
@@ -26,8 +26,8 @@ depends: [
   "base64"
   "astring"
   "re"
-  "uri"
-  "multipart-form-data"
+  "uri" {>= "2.2.0"}
+  "multipart-form-data" {>= "0.3.0"}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
 ]

--- a/packages/opium/opium.0.19.0/opam
+++ b/packages/opium/opium.0.19.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ptime"
   "magic-mime"
   "yojson" {>= "1.6.0"}
-  "tyxml"
+  "tyxml" {>= "4.0.0"}
   "mirage-crypto"
   "base64" {>= "3.1.0"}
   "astring"

--- a/packages/opium/opium.0.19.0/opam
+++ b/packages/opium/opium.0.19.0/opam
@@ -31,6 +31,9 @@ depends: [
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
 ]
+conflicts: [
+  "result" {< "1.5"} # used implicitly through lwt but uses Result.to_option
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/opium/opium.0.19.0/opam
+++ b/packages/opium/opium.0.19.0/opam
@@ -20,10 +20,10 @@ depends: [
   "cmdliner"
   "ptime"
   "magic-mime"
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "tyxml"
   "mirage-crypto"
-  "base64"
+  "base64" {>= "3.1.0"}
   "astring"
   "re"
   "uri" {>= "2.2.0"}

--- a/packages/opium/opium.0.19.0/opam
+++ b/packages/opium/opium.0.19.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ptime"
   "magic-mime"
   "yojson" {>= "1.6.0"}
-  "tyxml" {>= "4.0.0"}
+  "tyxml" {>= "4.3.0"}
   "mirage-crypto"
   "base64" {>= "3.1.0"}
   "astring"

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -17,7 +17,7 @@ depends: [
   "conf-libev"
   "logs"
   "fmt"
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "cmdliner"
   "ptime"
   "magic-mime"
@@ -27,8 +27,8 @@ depends: [
   "base64"
   "astring"
   "re"
-  "uri"
-  "multipart-form-data"
+  "uri" {>= "2.2.0"}
+  "multipart-form-data" {>= "0.3.0"}
   "odoc" {with-doc}
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -33,6 +33,9 @@ depends: [
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}
 ]
+conflicts: [
+  "result" {< "1.5"} # used implicitly through lwt but uses Result.to_option
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -21,10 +21,10 @@ depends: [
   "cmdliner"
   "ptime"
   "magic-mime"
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "tyxml"
   "mirage-crypto"
-  "base64"
+  "base64" {>= "3.1.0"}
   "astring"
   "re"
   "uri" {>= "2.2.0"}

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "magic-mime"
   "yojson" {>= "1.6.0"}
-  "tyxml" {>= "4.0.0"}
+  "tyxml" {>= "4.3.0"}
   "mirage-crypto"
   "base64" {>= "3.1.0"}
   "astring"

--- a/packages/opium/opium.0.20.0/opam
+++ b/packages/opium/opium.0.20.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ptime"
   "magic-mime"
   "yojson" {>= "1.6.0"}
-  "tyxml"
+  "tyxml" {>= "4.0.0"}
   "mirage-crypto"
   "base64" {>= "3.1.0"}
   "astring"


### PR DESCRIPTION
Uses Uri.pp, Multipart_form_data.parse and mtime.clock.os
Detected in https://github.com/ocaml/opam-repository/pull/18819
cc @tmattio @rgrinberg 
```
# File "opium/src/dune", line 3, characters 63-77:
# 3 |  (libraries rock cmdliner httpaf httpaf-lwt-unix logs logs.fmt mtime.clock.os
#                                                                    ^^^^^^^^^^^^^^
# Error: Library "mtime.clock.os" not found.
# Hint: try:
#   dune external-lib-deps --missing -p opium -j 31 @install
```
```
# File "opium/src/handlers/handler_serve.ml", line 3, characters 23-30:
# 3 | let respond_with_file ?headers ~read =
#                            ^^^^^^^
# Warning 16 [unerasable-optional-argument]: this optional argument cannot be erased.
#       ocamlc opium/src/.opium.objs/byte/opium__Cookie.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I opium/src/.opium.objs/byte -I /home/opam/.opam/4.12/lib/angstrom -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base/caml -I /home/opam/.opam/4.12/lib/base64 -I /home/opam/.opam/4.12/lib/bigarray-compat -I /home/opam/.opam/4.12/lib/bigstringaf -I /home/opam/.opam/4.12/lib/biniou -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/cstruct -I /home/opam/.opam/4.12/lib/easy-format -I /home/opam/.opam/4.12/lib/eqaf -I /home/opam/.opam/4.12/lib/eqaf/bigstring -I /home/opam/.opam/4.12/lib/eqaf/cstruct -I /home/opam/.opam/4.12/lib/faraday -I /home/opam/.opam/4.12/lib/faraday-lwt -I /home/opam/.opam/4.12/lib/faraday-lwt-unix -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/hmap -I /home/opam/.opam/4.12/lib/httpaf -I /home/opam/.opam/4.12/lib/httpaf-lwt-unix -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/lwt -I /home/opam/.opam/4.12/lib/lwt/unix -I /home/opam/.opam/4.12/lib/magic-mime -I /home/opam/.opam/4.12/lib/mirage-crypto -I /home/opam/.opam/4.12/lib/mmap -I /home/opam/.opam/4.12/lib/mtime -I /home/opam/.opam/4.12/lib/mtime/os -I /home/opam/.opam/4.12/lib/multipart-form-data -I /home/opam/.opam/4.12/lib/ocaml/threads -I /home/opam/.opam/4.12/lib/ocplib-endian -I /home/opam/.opam/4.12/lib/parsexp -I /home/opam/.opam/4.12/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.12/lib/ptime -I /home/opam/.opam/4.12/lib/re -I /home/opam/.opam/4.12/lib/re/posix -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/rock -I /home/opam/.opam/4.12/lib/seq -I /home/opam/.opam/4.12/lib/sexplib -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/stringext -I /home/opam/.opam/4.12/lib/tyxml -I /home/opam/.opam/4.12/lib/tyxml/functor -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uri -I /home/opam/.opam/4.12/lib/uutf -I /home/opam/.opam/4.12/lib/yojson -intf-suffix .ml -no-alias-deps -open Opium__ -o opium/src/.opium.objs/byte/opium__Cookie.cmo -c -impl opium/src/cookie.ml)
# File "opium/src/cookie.ml", line 548, characters 64-70:
# 548 |     ; List [ Atom "scope"; sexp_of_string (Format.asprintf "%a" Uri.pp t.scope) ]
#                                                                       ^^^^^^
# Error: Unbound value Uri.pp
#       ocamlc opium/src/.opium.objs/byte/opium__Request.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I opium/src/.opium.objs/byte -I /home/opam/.opam/4.12/lib/angstrom -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base/caml -I /home/opam/.opam/4.12/lib/base64 -I /home/opam/.opam/4.12/lib/bigarray-compat -I /home/opam/.opam/4.12/lib/bigstringaf -I /home/opam/.opam/4.12/lib/biniou -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/cstruct -I /home/opam/.opam/4.12/lib/easy-format -I /home/opam/.opam/4.12/lib/eqaf -I /home/opam/.opam/4.12/lib/eqaf/bigstring -I /home/opam/.opam/4.12/lib/eqaf/cstruct -I /home/opam/.opam/4.12/lib/faraday -I /home/opam/.opam/4.12/lib/faraday-lwt -I /home/opam/.opam/4.12/lib/faraday-lwt-unix -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/hmap -I /home/opam/.opam/4.12/lib/httpaf -I /home/opam/.opam/4.12/lib/httpaf-lwt-unix -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/lwt -I /home/opam/.opam/4.12/lib/lwt/unix -I /home/opam/.opam/4.12/lib/magic-mime -I /home/opam/.opam/4.12/lib/mirage-crypto -I /home/opam/.opam/4.12/lib/mmap -I /home/opam/.opam/4.12/lib/mtime -I /home/opam/.opam/4.12/lib/mtime/os -I /home/opam/.opam/4.12/lib/multipart-form-data -I /home/opam/.opam/4.12/lib/ocaml/threads -I /home/opam/.opam/4.12/lib/ocplib-endian -I /home/opam/.opam/4.12/lib/parsexp -I /home/opam/.opam/4.12/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.12/lib/ptime -I /home/opam/.opam/4.12/lib/re -I /home/opam/.opam/4.12/lib/re/posix -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/rock -I /home/opam/.opam/4.12/lib/seq -I /home/opam/.opam/4.12/lib/sexplib -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/stringext -I /home/opam/.opam/4.12/lib/tyxml -I /home/opam/.opam/4.12/lib/tyxml/functor -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uri -I /home/opam/.opam/4.12/lib/uutf -I /home/opam/.opam/4.12/lib/yojson -intf-suffix .ml -no-alias-deps -open Opium__ -o opium/src/.opium.objs/byte/opium__Request.cmo -c -impl opium/src/request.ml)
# File "opium/src/request.ml", line 159, characters 18-43:
# 159 |     let* result = Multipart_form_data.parse ~stream:body ~content_type ~callback in
#                         ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Multipart_form_data
#     ocamlopt opium/src/.opium.objs/native/opium__Cookie.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlopt.opt -w -40 -g -I opium/src/.opium.objs/byte -I opium/src/.opium.objs/native -I /home/opam/.opam/4.12/lib/angstrom -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base/caml -I /home/opam/.opam/4.12/lib/base64 -I /home/opam/.opam/4.12/lib/bigarray-compat -I /home/opam/.opam/4.12/lib/bigstringaf -I /home/opam/.opam/4.12/lib/biniou -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/cstruct -I /home/opam/.opam/4.12/lib/easy-format -I /home/opam/.opam/4.12/lib/eqaf -I /home/opam/.opam/4.12/lib/eqaf/bigstring -I /home/opam/.opam/4.12/lib/eqaf/cstruct -I /home/opam/.opam/4.12/lib/faraday -I /home/opam/.opam/4.12/lib/faraday-lwt -I /home/opam/.opam/4.12/lib/faraday-lwt-unix -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/hmap -I /home/opam/.opam/4.12/lib/httpaf -I /home/opam/.opam/4.12/lib/httpaf-lwt-unix -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/lwt -I /home/opam/.opam/4.12/lib/lwt/unix -I /home/opam/.opam/4.12/lib/magic-mime -I /home/opam/.opam/4.12/lib/mirage-crypto -I /home/opam/.opam/4.12/lib/mmap -I /home/opam/.opam/4.12/lib/mtime -I /home/opam/.opam/4.12/lib/mtime/os -I /home/opam/.opam/4.12/lib/multipart-form-data -I /home/opam/.opam/4.12/lib/ocaml/threads -I /home/opam/.opam/4.12/lib/ocplib-endian -I /home/opam/.opam/4.12/lib/parsexp -I /home/opam/.opam/4.12/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.12/lib/ptime -I /home/opam/.opam/4.12/lib/re -I /home/opam/.opam/4.12/lib/re/posix -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/rock -I /home/opam/.opam/4.12/lib/seq -I /home/opam/.opam/4.12/lib/sexplib -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/stringext -I /home/opam/.opam/4.12/lib/tyxml -I /home/opam/.opam/4.12/lib/tyxml/functor -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uri -I /home/opam/.opam/4.12/lib/uutf -I /home/opam/.opam/4.12/lib/yojson -intf-suffix .ml -no-alias-deps -open Opium__ -o opium/src/.opium.objs/native/opium__Cookie.cmx -c -impl opium/src/cookie.ml)
# File "opium/src/cookie.ml", line 548, characters 64-70:
# 548 |     ; List [ Atom "scope"; sexp_of_string (Format.asprintf "%a" Uri.pp t.scope) ]
#                                                                       ^^^^^^
# Error: Unbound value Uri.pp
```