### PR TITLE
Package ocaml-monadic.0.5

### DIFF
--- a/packages/ocaml-monadic/ocaml-monadic.0.5/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "ppxlib" {>= "0.18.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/ocaml-monadic/ocaml-monadic.0.5/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A PPX extension to provide an OCaml-friendly monadic syntax"
+maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
+authors: "JHU PL Lab <pl.cs@jhu.edu>"
+license: "BSD-3-clause"
+homepage: "http://github.com/zepalmer/ocaml-monadic"
+bug-reports: "https://github.com/zepalmer/ocaml-monadic/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "2.5"}
+  "ppxlib" {>= "0.18.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/zepalmer/ocaml-monadic.git"
+url {
+  src:
+    "https://github.com/zepalmer/ocaml-monadic/archive/d45256ba59dc01113bb472171467e43dedaaa65d.zip"
+  checksum: [
+    "md5=97a13f2bd6f914db1255765cf7ec2769"
+    "sha512=03d828166512c52323186ad40d4b3bcd0d171aab6871e3ca4ad652f195eb01384c48ff8efa551eb1837bd3d1835f5e97a61f592d7b2a265466bae196b0502e2e"
+  ]
+}


### PR DESCRIPTION
### `ocaml-monadic.0.5`
A PPX extension to provide an OCaml-friendly monadic syntax



---
* Homepage: http://github.com/zepalmer/ocaml-monadic
* Source repo: git+https://github.com/zepalmer/ocaml-monadic.git
* Bug tracker: https://github.com/zepalmer/ocaml-monadic/issues

---
:camel: Pull-request generated by opam-publish v2.0.3