### PR TITLE
Dream alpha2: drop ppxlib constraints

### DIFF
--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -91,14 +91,9 @@ depends: [
   "psq"  # h2.
   "result"  # http/af, websocket/af.
 
-  # https://github.com/ocaml-ppx/ppxlib/issues/221.
-  # esy appears to ignore conflicts.
-  "ppxlib" {< "0.21.0" | > "0.22.0"}
-
   # Testing, development.
   "alcotest" {with-test}
-  # Commented out because of https://github.com/ocaml-ppx/ppxlib/issues/221.
-  # "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
   "caqti-driver-sqlite3" {with-test}
   "crunch" {with-test}
   "lambdasoup" {with-test}


### PR DESCRIPTION
Now that ppxlib 0.21.1 and 0.22.1 are out, the constraints are no longer necessary. They were meant to exclude 0.21.0 and 0.22.0, but it should be enough to just rely on the .1 versions being installed, in most cases.