### PR TITLE
Markup.ml 1.0.1 - standards-compliant HTML5 and XML parser

### DIFF
--- a/packages/markup/markup.1.0.1/opam
+++ b/packages/markup/markup.1.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+synopsis: "Error-recovering functional HTML5 and XML parsers and writers"
+
+license: "MIT"
+homepage: "https://github.com/aantron/markup.ml"
+doc: "http://aantron.github.io/markup.ml"
+bug-reports: "https://github.com/aantron/markup.ml/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/markup.ml.git"
+
+depends: [
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.02.0"}
+  "uchar"
+  "uutf" {>= "1.0.0"}
+
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ounit2" {dev}
+]
+# Markup.ml implicitly requires OCaml 4.02.3, as this is a contraint of Dune.
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: """
+Markup.ml provides an HTML parser and an XML parser. The parsers are wrapped in
+a simple interface: they are functions that transform byte streams to parsing
+signal streams. Streams can be manipulated in various ways, such as processing
+by fold, filter, and map, assembly into DOM tree structures, or serialization
+back to HTML or XML.
+
+Both parsers are based on their respective standards. The HTML parser, in
+particular, is based on the state machines defined in HTML5.
+
+The parsers are error-recovering by default, and accept fragments. This makes it
+very easy to get a best-effort parse of some input. The parsers can, however, be
+easily configured to be strict, and to accept only full documents.
+
+Apart from this, the parsers are streaming (do not build up a document in
+memory), non-blocking (can be used with threading libraries), lazy (do not
+consume input unless the signal stream is being read), and process the input in
+a single pass. They automatically detect the character encoding of the input
+stream, and convert everything to UTF-8."""
+
+url {
+  src: "https://github.com/aantron/markup.ml/archive/1.0.1.tar.gz"
+  checksum: "md5=1c84ac672d7ad27981235b3ba6d90d3d"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/markup.ml/releases/tag/1.0.1):

> Bugs fixed
>
> - Fix reading of numeric references in the XML tokenizer (aantron/markup.ml#65, reported by @occtyping).