### PR TITLE
8 packages from ocaml/opam at 2.1.0~rc

### DIFF
--- a/packages/opam-0install-cudf/opam-0install-cudf.0.2/opam
+++ b/packages/opam-0install-cudf/opam-0install-cudf.0.2/opam
@@ -12,6 +12,7 @@ a different algorithm.
 This package uses 0install's solver algorithm with opam packages using
 the CUDF interface.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/talex5/opam-0install-solver"

--- a/packages/opam-0install-cudf/opam-0install-cudf.0.3/opam
+++ b/packages/opam-0install-cudf/opam-0install-cudf.0.3/opam
@@ -12,6 +12,7 @@ a different algorithm.
 This package uses 0install's solver algorithm with opam packages using
 the CUDF interface.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocaml-opam/opam-0install-solver"

--- a/packages/opam-0install-cudf/opam-0install-cudf.0.4/opam
+++ b/packages/opam-0install-cudf/opam-0install-cudf.0.4/opam
@@ -12,6 +12,7 @@ a different algorithm.
 This package uses 0install's solver algorithm with opam packages using
 the CUDF interface.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocaml-opam/opam-0install-solver"

--- a/packages/opam-0install/opam-0install.0.1/opam
+++ b/packages/opam-0install/opam-0install.0.1/opam
@@ -11,6 +11,7 @@ a different algorithm.
 
 This package uses 0install's solver algorithm with opam packages.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/talex5/opam-0install-solver"

--- a/packages/opam-0install/opam-0install.0.1/opam
+++ b/packages/opam-0install/opam-0install.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "2.0"}
   "fmt"
   "cmdliner"
-  "opam-state"
+  "opam-state" {< "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-client" {with-test}

--- a/packages/opam-0install/opam-0install.0.2/opam
+++ b/packages/opam-0install/opam-0install.0.2/opam
@@ -11,6 +11,7 @@ a different algorithm.
 
 This package uses 0install's solver algorithm with opam packages.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/talex5/opam-0install-solver"

--- a/packages/opam-0install/opam-0install.0.2/opam
+++ b/packages/opam-0install/opam-0install.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "2.0"}
   "fmt"
   "cmdliner"
-  "opam-state"
+  "opam-state" {< "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-client" {with-test}

--- a/packages/opam-0install/opam-0install.0.3/opam
+++ b/packages/opam-0install/opam-0install.0.3/opam
@@ -11,6 +11,7 @@ a different algorithm.
 
 This package uses 0install's solver algorithm with opam packages.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocaml-opam/opam-0install-solver"

--- a/packages/opam-0install/opam-0install.0.3/opam
+++ b/packages/opam-0install/opam-0install.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "2.0"}
   "fmt"
   "cmdliner"
-  "opam-state"
+  "opam-state" {< "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-client" {with-test}

--- a/packages/opam-0install/opam-0install.0.4.1/opam
+++ b/packages/opam-0install/opam-0install.0.4.1/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "2.0"}
   "fmt"
   "cmdliner"
-  "opam-state"
+  "opam-state" {< "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-file-format" {>= "2.1.1"}

--- a/packages/opam-0install/opam-0install.0.4/opam
+++ b/packages/opam-0install/opam-0install.0.4/opam
@@ -11,6 +11,7 @@ a different algorithm.
 
 This package uses 0install's solver algorithm with opam packages.
 """
+license: "ISC"
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
 homepage: "https://github.com/ocaml-opam/opam-0install-solver"

--- a/packages/opam-0install/opam-0install.0.4/opam
+++ b/packages/opam-0install/opam-0install.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "2.0"}
   "fmt"
   "cmdliner"
-  "opam-state"
+  "opam-state" {< "2.1.0~rc"}
   "ocaml" {>= "4.08.0"}
   "0install-solver"
   "opam-client" {with-test}

--- a/packages/opam-client/opam-client.2.1.0~rc/opam
+++ b/packages/opam-client/opam-client.2.1.0~rc/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Client library for opam 2.1"
+description: """
+Actions on the opam root, switches, installations, and front-end.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "extlib" {>= "1.7.3" & < "1.7.8"}
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "1.11.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-client/opam-client.2.1.0~rc/opam
+++ b/packages/opam-client/opam-client.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "Client library for opam 2.1"
 description: """
 Actions on the opam root, switches, installations, and front-end.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-core/opam-core.2.1.0~rc/opam
+++ b/packages/opam-core/opam-core.2.1.0~rc/opam
@@ -30,7 +30,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.9.0"}
   "dune" {>= "1.11.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"
 url {

--- a/packages/opam-core/opam-core.2.1.0~rc/opam
+++ b/packages/opam-core/opam-core.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "Core library for opam 2.1"
 description: """
 Small standard library extensions, and generic system interaction modules used by opam.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-core/opam-core.2.1.0~rc/opam
+++ b/packages/opam-core/opam-core.2.1.0~rc/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Core library for opam 2.1"
+description: """
+Small standard library extensions, and generic system interaction modules used by opam.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.9.0"}
+  "dune" {>= "1.11.0"}
+  "cppo" {build}
+]
+conflicts: "extlib-compat"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.1.0~rc/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "Bootstrapped development binary for opam 2.1"
 description: """
 This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-devel/opam-devel.2.1.0~rc/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~rc/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Bootstrapped development binary for opam 2.1"
+description: """
+This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.11.0"}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
+]
+post-messages: [
+"The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2=\"OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""
+  {success}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-format/opam-format.2.1.0~rc/opam
+++ b/packages/opam-format/opam-format.2.1.0~rc/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Format library for opam 2.1"
+description: """
+Definition of opam datastructures and its file interface.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.1.3"}
+  "re" {>= "1.9.0"}
+  "dune" {>= "1.11.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-format/opam-format.2.1.0~rc/opam
+++ b/packages/opam-format/opam-format.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "Format library for opam 2.1"
 description: """
 Definition of opam datastructures and its file interface.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-installer/opam-installer.2.1.0~rc/opam
+++ b/packages/opam-installer/opam-installer.2.1.0~rc/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.11.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.1.0~rc/opam
+++ b/packages/opam-installer/opam-installer.2.1.0~rc/opam
@@ -5,6 +5,7 @@ opam-installer is a small tool that can read *.install files, as defined by opam
 
 [1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-repository/opam-repository.2.1.0~rc/opam
+++ b/packages/opam-repository/opam-repository.2.1.0~rc/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Repository library for opam 2.1"
+description: """
+This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "dune" {>= "1.11.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.1.0~rc/opam
+++ b/packages/opam-repository/opam-repository.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "Repository library for opam 2.1"
 description: """
 This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-solver/opam-solver.2.1.0~rc/opam
+++ b/packages/opam-solver/opam-solver.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "Solver library for opam 2.1"
 description: """
 Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"

--- a/packages/opam-solver/opam-solver.2.1.0~rc/opam
+++ b/packages/opam-solver/opam-solver.2.1.0~rc/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Solver library for opam 2.1"
+description: """
+Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5" & < "6.0"}
+  "cudf" {>= "0.7"}
+  "dune" {>= "1.11.0"}
+]
+depopts: [
+  "z3"
+  "opam-0install-cudf"
+]
+conflicts: [
+  "z3" {< "4.8.4"}
+  "opam-0install-cudf" {< "0.4"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-state/opam-state.2.1.0~rc/opam
+++ b/packages/opam-state/opam-state.2.1.0~rc/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "State library for opam 2.1"
+description: """
+Handling of the ~/.opam hierarchy, repository and switch states.
+"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+dev-repo: "git+https://github.com/ocaml/opam.git"
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= version}
+  "dune" {>= "1.11.0"}
+]
+url {
+  src: "https://github.com/ocaml/opam/archive/2.1.0-rc.tar.gz"
+  checksum: [
+    "md5=7af974033874dcb8d3e8f98312e1c146"
+    "sha512=5debf3f090e67ca7cfcaa02a59fc21245b68545a23a5909b9cca16547241b1c72ccbb4bfd12c29361a23e0efdb065255e62e874e094f52a513cffb3d0b130d5f"
+  ]
+}

--- a/packages/opam-state/opam-state.2.1.0~rc/opam
+++ b/packages/opam-state/opam-state.2.1.0~rc/opam
@@ -3,6 +3,7 @@ synopsis: "State library for opam 2.1"
 description: """
 Handling of the ~/.opam hierarchy, repository and switch states.
 """
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: [
   "Vincent Bernardoff <vb@luminar.eu.org>"


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.1.0~rc`: Client library for opam 2.1
-`opam-core.2.1.0~rc`: Core library for opam 2.1
-`opam-devel.2.1.0~rc`: Bootstrapped development binary for opam 2.1
-`opam-format.2.1.0~rc`: Format library for opam 2.1
-`opam-installer.2.1.0~rc`: Installation of files to a prefix, following opam conventions
-`opam-repository.2.1.0~rc`: Repository library for opam 2.1
-`opam-solver.2.1.0~rc`: Solver library for opam 2.1
-`opam-state.2.1.0~rc`: State library for opam 2.1



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.0.3