### PR TITLE
2 packages from INRIA/zelus at 2.2

### DIFF
--- a/packages/zelus-gtk/zelus-gtk.2.2/opam
+++ b/packages/zelus-gtk/zelus-gtk.2.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Zelus GTK library"
+authors: [
+  "Timothy Bourke <timothy.bourke@inria.fr>"
+  "Marc Pouzet <marc.pouzet@ens.fr>"
+  ]
+maintainer: ["Marc Pouzet <marc.pouzet@ens.fr>"]
+homepage: "http://zelus.di.ens.fr"
+doc: "http://zelus.di.ens.fr/man/"
+bug-reports: "https://github.com/INRIA/zelus/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.6"}
+  "zelus" {= version}
+  "lablgtk"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune" "build" "-p" name "-j" jobs
+    "@install"
+  ]
+]
+dev-repo: "git+https://github.com/INRIA/zelus.git"
+url {
+  src: "https://github.com/INRIA/zelus/archive/2.2.tar.gz"
+  checksum: [
+    "md5=437ae922f1fda392efca3e37e8b8bb4c"
+    "sha512=d591cdbeedb8f3a7f568d6d4994de572093822cb354b112886326219174311715a71a35de57a4c2070eae349f65f0c8f3d6c2f6a5a79a8187bbffc687cd108a6"
+  ]
+}

--- a/packages/zelus-gtk/zelus-gtk.2.2/opam
+++ b/packages/zelus-gtk/zelus-gtk.2.2/opam
@@ -8,6 +8,7 @@ maintainer: ["Marc Pouzet <marc.pouzet@ens.fr>"]
 homepage: "http://zelus.di.ens.fr"
 doc: "http://zelus.di.ens.fr/man/"
 bug-reports: "https://github.com/INRIA/zelus/issues"
+license: "INRIA Non-Commercial License Agreement"
 depends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "2.6"}

--- a/packages/zelus/zelus.2.2/opam
+++ b/packages/zelus/zelus.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A synchronous language with ODEs"
+authors: [
+  "Timothy Bourke <timothy.bourke@inria.fr>"
+  "Marc Pouzet <marc.pouzet@ens.fr>"
+  ]
+maintainer: ["Marc Pouzet <marc.pouzet@ens.fr>"]
+homepage: "http://zelus.di.ens.fr"
+doc: "http://zelus.di.ens.fr/man/"
+bug-reports: "https://github.com/INRIA/zelus/issues"
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.6"}
+  "menhir"
+]
+depopts: ["sundialsml"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "./configure"
+    "--prefix" prefix
+  ]
+  [
+    "dune" "build" "-p" name "-j" jobs
+    "@install"
+  ]
+]
+dev-repo: "git+https://github.com/INRIA/zelus.git"
+url {
+  src: "https://github.com/INRIA/zelus/archive/2.2.tar.gz"
+  checksum: [
+    "md5=437ae922f1fda392efca3e37e8b8bb4c"
+    "sha512=d591cdbeedb8f3a7f568d6d4994de572093822cb354b112886326219174311715a71a35de57a4c2070eae349f65f0c8f3d6c2f6a5a79a8187bbffc687cd108a6"
+  ]
+}

--- a/packages/zelus/zelus.2.2/opam
+++ b/packages/zelus/zelus.2.2/opam
@@ -9,7 +9,7 @@ homepage: "http://zelus.di.ens.fr"
 doc: "http://zelus.di.ens.fr/man/"
 bug-reports: "https://github.com/INRIA/zelus/issues"
 license: "INRIA Non-Commercial License Agreement"
-epends: [
+depends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "2.6"}
   "menhir" {>= "20180523"}

--- a/packages/zelus/zelus.2.2/opam
+++ b/packages/zelus/zelus.2.2/opam
@@ -8,10 +8,11 @@ maintainer: ["Marc Pouzet <marc.pouzet@ens.fr>"]
 homepage: "http://zelus.di.ens.fr"
 doc: "http://zelus.di.ens.fr/man/"
 bug-reports: "https://github.com/INRIA/zelus/issues"
-depends: [
+license: "INRIA Non-Commercial License Agreement"
+epends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "2.6"}
-  "menhir"
+  "menhir" {>= "20180523"}
 ]
 depopts: ["sundialsml"]
 build: [


### PR DESCRIPTION
This pull-request concerns:
-`zelus.2.2`: A synchronous language with ODEs
-`zelus-gtk.2.2`: Zelus GTK library



---
* Homepage: http://zelus.di.ens.fr
* Source repo: git+https://github.com/INRIA/zelus.git
* Bug tracker: https://github.com/INRIA/zelus/issues

---
:camel: Pull-request generated by opam-publish v2.0.3