### PR TITLE
opam-devel < 2.1.0~rc: Disable tests

### DIFF
--- a/packages/opam-devel/opam-devel.2.0.0/opam
+++ b/packages/opam-devel/opam-devel.2.0.0/opam
@@ -18,7 +18,6 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.0.0~beta/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta/opam
@@ -17,7 +17,6 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make name]
   [make "%{name}%.install"]
-  [make "opam-check" "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.01.0"}

--- a/packages/opam-devel/opam-devel.2.0.0~beta3.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3.1/opam
@@ -17,7 +17,6 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make name]
   [make "%{name}%.install"]
-  [make "opam-check" "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.01.0"}

--- a/packages/opam-devel/opam-devel.2.0.0~beta3/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta3/opam
@@ -17,7 +17,6 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make name]
   [make "%{name}%.install"]
-  [make "opam-check" "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.01.0"}

--- a/packages/opam-devel/opam-devel.2.0.0~beta5/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~beta5/opam
@@ -16,7 +16,6 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.0.0~rc/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc/opam
@@ -16,7 +16,6 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.0.0~rc3/opam
+++ b/packages/opam-devel/opam-devel.2.0.0~rc3/opam
@@ -18,7 +18,6 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.0.1/opam
+++ b/packages/opam-devel/opam-devel.2.0.1/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.2/opam
+++ b/packages/opam-devel/opam-devel.2.0.2/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.3/opam
+++ b/packages/opam-devel/opam-devel.2.0.3/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.4/opam
+++ b/packages/opam-devel/opam-devel.2.0.4/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.5/opam
+++ b/packages/opam-devel/opam-devel.2.0.5/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.6/opam
+++ b/packages/opam-devel/opam-devel.2.0.6/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.7/opam
+++ b/packages/opam-devel/opam-devel.2.0.7/opam
@@ -23,7 +23,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  ["env" "--unset=OPAM_SWITCH_PREFIX" "--unset=OPAMEXTERNALSOLVER" make "tests"] {with-test}
 ]
 post-messages:
   """

--- a/packages/opam-devel/opam-devel.2.0.8/opam
+++ b/packages/opam-devel/opam-devel.2.0.8/opam
@@ -26,7 +26,6 @@ depends: [
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test & os-distribution = "debian" & arch = "x86_64" & opam-version < "2.1"}
 ]
 post-messages:
   """\

--- a/packages/opam-devel/opam-devel.2.0~alpha5/opam
+++ b/packages/opam-devel/opam-devel.2.0~alpha5/opam
@@ -17,7 +17,6 @@ build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make name]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.01.0"}

--- a/packages/opam-devel/opam-devel.2.1.0~beta2/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~beta2/opam
@@ -22,7 +22,6 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/opam-devel/opam-devel.2.1.0~beta4/opam
+++ b/packages/opam-devel/opam-devel.2.1.0~beta4/opam
@@ -22,7 +22,6 @@ dev-repo: "git+https://github.com/ocaml/opam.git"
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
   [make "%{name}%.install"]
-  [make "tests"] {with-test & opam-version < "2.1" & os-distribution != "alpine" & os-distribution != "arch" & os-distribution != "centos"} # https://github.com/ocaml/opam/pull/4500
 ]
 depends: [
   "ocaml" {>= "4.02.3"}


### PR DESCRIPTION
non-deterministic based on environment variables
Detected in https://github.com/ocaml/opam-repository/pull/18871
cc @rjbou 