### PR TITLE
opam-client.2.0.6: Fix constraint (uses Cmdliner.Manpage.escape)

### DIFF
--- a/packages/opam-client/opam-client.2.0.6/opam
+++ b/packages/opam-client/opam-client.2.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "opam-state" {= "2.0.6"}
   "opam-solver" {= "2.0.6"}
   "re" {>= "1.7.2"}
-  "cmdliner" {>= "0.9.8"}
+  "cmdliner" {>= "1.0.0"}
   "dune" {>= "1.2.1"}
 ]
 build: [


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18872