### PR TITLE
3 packages from 0xffea/ocaml-redis at 0.5

### DIFF
--- a/packages/redis-lwt/redis-lwt.0.5/opam
+++ b/packages/redis-lwt/redis-lwt.0.5/opam
@@ -7,7 +7,7 @@ authors: [
 ]
 homepage: "https://github.com/0xffea/ocaml-redis"
 bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
-license: "BSD3"
+license: "BSD-3-Clause"
 tags: ["redis" "lwt"]
 dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 synopsis: "Redis client (lwt interface)"

--- a/packages/redis-lwt/redis-lwt.0.5/opam
+++ b/packages/redis-lwt/redis-lwt.0.5/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "redis" { = version }
-  "lwt"
+  "lwt" {>= "2.4.7"}
   "ocaml" { >= "4.03.0" }
   "ounit2" {with-test}
   "containers" {with-test}

--- a/packages/redis-lwt/redis-lwt.0.5/opam
+++ b/packages/redis-lwt/redis-lwt.0.5/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis" "lwt"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client (lwt interface)"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  # ["dune" "runtest" "-p" name "-j" jobs] {with-test}  # need network
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "lwt"
+  "ocaml" { >= "4.03.0" }
+  "ounit2" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.5.tar.gz"
+  checksum: [
+    "md5=555ddcb04ef97e0fffbb011461cbe35e"
+    "sha512=46c34a751a93197ea7ca71cf797b1e5c3f9f74dacbe5d4cd064d20a008cbfe078bc331627bf5b5fcdbab5aab939a3c9042c260d10981bd81ecc4932345dd0e47"
+  ]
+}

--- a/packages/redis-sync/redis-sync.0.5/opam
+++ b/packages/redis-sync/redis-sync.0.5/opam
@@ -7,7 +7,7 @@ authors: [
 ]
 homepage: "https://github.com/0xffea/ocaml-redis"
 bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
-license: "BSD3"
+license: "BSD-3-Clause"
 tags: ["redis" "unix"]
 synopsis: "Redis client (blocking)"
 dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"

--- a/packages/redis-sync/redis-sync.0.5/opam
+++ b/packages/redis-sync/redis-sync.0.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis" "unix"]
+synopsis: "Redis client (blocking)"
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  # ["dune" "runtest" "-p" name "-j" jobs] {with-test} # need network
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "ocaml" { >= "4.03.0" }
+  "ounit2" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.5.tar.gz"
+  checksum: [
+    "md5=555ddcb04ef97e0fffbb011461cbe35e"
+    "sha512=46c34a751a93197ea7ca71cf797b1e5c3f9f74dacbe5d4cd064d20a008cbfe078bc331627bf5b5fcdbab5aab939a3c9042c260d10981bd81ecc4932345dd0e47"
+  ]
+}

--- a/packages/redis/redis.0.5/opam
+++ b/packages/redis/redis.0.5/opam
@@ -7,7 +7,7 @@ authors: [
 ]
 homepage: "https://github.com/0xffea/ocaml-redis"
 bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
-license: "BSD3"
+license: "BSD-3-Clause"
 tags: ["redis"]
 dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 synopsis: "Redis client"

--- a/packages/redis/redis.0.5/opam
+++ b/packages/redis/redis.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" { >= "1.0" }
   "base-unix"
   "uuidm"
-  "re"
+  "re" {>= "1.7.2"}
   "ocaml" { >= "4.03.0" }
   "odoc" {with-doc}
 ]

--- a/packages/redis/redis.0.5/opam
+++ b/packages/redis/redis.0.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD3"
+tags: ["redis"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  # ["dune" "runtest" "-p" name "-j" jobs] {with-test} # need network
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "base-unix"
+  "uuidm"
+  "re"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/0.5.tar.gz"
+  checksum: [
+    "md5=555ddcb04ef97e0fffbb011461cbe35e"
+    "sha512=46c34a751a93197ea7ca71cf797b1e5c3f9f74dacbe5d4cd064d20a008cbfe078bc331627bf5b5fcdbab5aab939a3c9042c260d10981bd81ecc4932345dd0e47"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`redis.0.5`: Redis client
-`redis-lwt.0.5`: Redis client (lwt interface)
-`redis-sync.0.5`: Redis client (blocking)



---
* Homepage: https://github.com/0xffea/ocaml-redis
* Source repo: git+https://github.com/0xffea/ocaml-redis.git
* Bug tracker: https://github.com/0xffea/ocaml-redis/issues

---
:camel: Pull-request generated by opam-publish v2.0.3