### PR TITLE
[new release] repr-bench, repr, ppx_repr and repr-fuzz (0.4.0)

### DIFF
--- a/packages/ppx_repr/ppx_repr.0.4.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for type representations"
+description: "PPX deriver for type representations"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+doc: "https://mirage.github.io/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppxlib" {>= "0.12.0"}
+  "ppx_deriving"
+  "hex" {with-test}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "6081dda8ef1ef9a9b368968d692957bac4276950"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.4.0/repr-fuzz-0.4.0.tbz"
+  checksum: [
+    "sha256=bd92b40c417148afc6b1cd093d93a14f632e3ef82dcaaadde23c7390a4d2fbac"
+    "sha512=c559abc9bd7b7049987e84cc3dbdbca6c41d8789b2d7783959efc0df4975a14ae276fd6a9e4c6e74d146f24a18ea5fe50a8d263faa39b8580f64d7bbceebf6ca"
+  ]
+}

--- a/packages/repr-bench/repr-bench.0.4.0/opam
+++ b/packages/repr-bench/repr-bench.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Benchmarks for the `repr` package"
+description: "Benchmarks for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+doc: "https://mirage.github.io/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "ppx_repr" {= version}
+  "bechamel"
+  "yojson"
+  "fpath"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "6081dda8ef1ef9a9b368968d692957bac4276950"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.4.0/repr-fuzz-0.4.0.tbz"
+  checksum: [
+    "sha256=bd92b40c417148afc6b1cd093d93a14f632e3ef82dcaaadde23c7390a4d2fbac"
+    "sha512=c559abc9bd7b7049987e84cc3dbdbca6c41d8789b2d7783959efc0df4975a14ae276fd6a9e4c6e74d146f24a18ea5fe50a8d263faa39b8580f64d7bbceebf6ca"
+  ]
+}

--- a/packages/repr-fuzz/repr-fuzz.0.4.0/opam
+++ b/packages/repr-fuzz/repr-fuzz.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Fuzz tests for the `repr` package"
+description: "Fuzz tests for the `repr` package"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+doc: "https://mirage.github.io/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "repr" {= version}
+  "crowbar" {= "0.2"}
+  "ppxlib" {>= "0.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "6081dda8ef1ef9a9b368968d692957bac4276950"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.4.0/repr-fuzz-0.4.0.tbz"
+  checksum: [
+    "sha256=bd92b40c417148afc6b1cd093d93a14f632e3ef82dcaaadde23c7390a4d2fbac"
+    "sha512=c559abc9bd7b7049987e84cc3dbdbca6c41d8789b2d7783959efc0df4975a14ae276fd6a9e4c6e74d146f24a18ea5fe50a8d263faa39b8580f64d7bbceebf6ca"
+  ]
+}

--- a/packages/repr/repr.0.4.0/opam
+++ b/packages/repr/repr.0.4.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Dynamic type representations. Provides no stability guarantee"
+description: """
+This package defines a library of combinators for building dynamic type
+representations and a set of generic operations over representable types, used
+in the implementation of Irmin and related packages.
+
+It is not yet intended for public consumption and provides no stability
+guarantee.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire" "Craig Ferguson"]
+license: "ISC"
+homepage: "https://github.com/mirage/repr"
+doc: "https://mirage.github.io/repr"
+bug-reports: "https://github.com/mirage/repr/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.7"}
+  "uutf"
+  "either"
+  "jsonm" {>= "1.0.0"}
+  "base64" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/repr.git"
+x-commit-hash: "6081dda8ef1ef9a9b368968d692957bac4276950"
+url {
+  src:
+    "https://github.com/mirage/repr/releases/download/0.4.0/repr-fuzz-0.4.0.tbz"
+  checksum: [
+    "sha256=bd92b40c417148afc6b1cd093d93a14f632e3ef82dcaaadde23c7390a4d2fbac"
+    "sha512=c559abc9bd7b7049987e84cc3dbdbca6c41d8789b2d7783959efc0df4975a14ae276fd6a9e4c6e74d146f24a18ea5fe50a8d263faa39b8580f64d7bbceebf6ca"
+  ]
+}


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/repr">https://github.com/mirage/repr</a>
- Documentation: <a href="https://mirage.github.io/repr">https://mirage.github.io/repr</a>

##### CHANGES:

- Add `Repr.{random,random_state}`, a pair of generic functions for sampling
  random instances of representable types. (mirage/repr#58, @CraigFe)

- Add `Repr.Size`, which provides sizing functions for binary codecs that are
  more informative than the existing `Repr.size_of`. Types built using `Repr.v`
  and `Repr.like` must now pass a sizer built using `Repr.Size.custom_*`. (mirage/repr#69,
  @CraigFe)
