### PR TITLE
[new release] index-bench and index (1.4.0)

### DIFF
--- a/packages/index-bench/index-bench.1.3.1/opam
+++ b/packages/index-bench/index-bench.1.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "cmdliner"
   "dune"    {>= "2.7.0"}
   "fmt"
-  "index"
+  "index"   {= version}
   "metrics"
   "metrics-unix"
   "ppx_deriving_yojson"

--- a/packages/index-bench/index-bench.1.3.1/opam
+++ b/packages/index-bench/index-bench.1.3.1/opam
@@ -26,6 +26,9 @@ depends: [
   "yojson"
   "ppx_repr"
 ]
+conflicts: [
+  "result" {< "1.5"} # requires [Result] to not be shadowed
+]
 
 synopsis: "Index benchmarking suite"
 url {

--- a/packages/index-bench/index-bench.1.3.1/opam
+++ b/packages/index-bench/index-bench.1.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "metrics"
   "metrics-unix"
   "ppx_deriving_yojson"
-  "re"
+  "re" {>= "1.7.2"}
   "stdlib-shims"
   "yojson"
   "ppx_repr"

--- a/packages/index-bench/index-bench.1.4.0/opam
+++ b/packages/index-bench/index-bench.1.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "rusage" {>= "1.0.0" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/index-bench/index-bench.1.4.0/opam
+++ b/packages/index-bench/index-bench.1.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cmdliner"
+  "dune" {>= "2.7.0"}
+  "fmt"
+  "index" {= version}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re"
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+  "tezos-context-hash"
+  "mtime"
+  "logs" {>= "0.7.0"}
+  "optint" {>= "0.1.0" & with-test}
+  "progress" {>= "0.1.1"}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"
+x-commit-hash: "a2ef9791eb79e29e3d46a7dde66d93cb5b7a19ef"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.0/index-1.4.0.tbz"
+  checksum: [
+    "sha256=8cd859751eb01b578402ec7de3d67fc0b92106381df9704331da81c25041ad8f"
+    "sha512=212d674b50b091f8fd3ad0e793e06c555bd012669ff6eb2fe0774469a64f008c1957795203a3b5e08a583e66aa34f2e11f02def7f818bd54c1bf3ad07b71c3ec"
+  ]
+}

--- a/packages/index/index.1.4.0/opam
+++ b/packages/index/index.1.4.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.1.0"}
+  "repr"    {>= "0.2.0"}
+  "ppx_repr"
+  "fmt"     {>= "0.8.5"}
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner"
+  "progress" {>= "0.1.1"}
+  "semaphore-compat" {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+x-commit-hash: "a2ef9791eb79e29e3d46a7dde66d93cb5b7a19ef"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.0/index-1.4.0.tbz"
+  checksum: [
+    "sha256=8cd859751eb01b578402ec7de3d67fc0b92106381df9704331da81c25041ad8f"
+    "sha512=212d674b50b091f8fd3ad0e793e06c555bd012669ff6eb2fe0774469a64f008c1957795203a3b5e08a583e66aa34f2e11f02def7f818bd54c1bf3ad07b71c3ec"
+  ]
+}

--- a/packages/irmin-pack/irmin-pack.2.3.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.4.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.4.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.4.0/opam
@@ -9,7 +9,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-pack/irmin-pack.2.5.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.5.1/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.1/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.5.1/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.1/opam
@@ -9,7 +9,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-pack/irmin-pack.2.5.2/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.2/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.5.2/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.2/opam
@@ -9,7 +9,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-pack/irmin-pack.2.5.3/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.3/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.5.3/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.3/opam
@@ -9,7 +9,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-pack/irmin-pack.2.5.4/opam
+++ b/packages/irmin-pack/irmin-pack.2.5.4/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.6.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"

--- a/packages/irmin-pack/irmin-pack.2.6.0/opam
+++ b/packages/irmin-pack/irmin-pack.2.6.0/opam
@@ -9,7 +9,7 @@ dev-repo:     "git+https://github.com/mirage/irmin.git"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [

--- a/packages/irmin-pack/irmin-pack.2.6.1/opam
+++ b/packages/irmin-pack/irmin-pack.2.6.1/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin"        {= version}
   "irmin-layers" {= version}
   "ppx_irmin"    {= version}
-  "index"        {>= "1.3.0"}
+  "index"        {>= "1.3.0" & < "1.4.0"}
   "fmt"
   "logs"
   "lwt"


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>

##### CHANGES:

## Fixed

- Fixed a crash-consistency bug due to a potential flush of an incomplete entry
  to disk. Entries are now flushed as complete strings. (mirage/index#301)

- Fixed a performance issue for `Index.sync` when there is a blocking merge in
  progress: the `log_async` file was not cached properly and fully reloaded
  from disk every time. (mirage/index#310)

- Added fsync after `Index.clear` to signal more quickly to read-only instances
  than something has changed in the file (mirage/index#308)

- Attempt to recover from `log_async` invariant violations during an explicit
  sync operation, rather than failing immediately. (mirage/index#329)

## Changed

- Release overly defensive warnings occuring when pre-fetching the disk. (mirage/index#322)

- Specialise `IO.v` to create read-only or read-write instances. (mirage/index#291)

- Optimised the in-memory representation of index handles and intermediate
  buffers, resulting in a significant reduction in memory use. (mirage/index#273, mirage/index#279)

- Benches are now executed 3 times and a new option `nb-exec` has been added (mirage/index#292)

- `clear` removes the files on disks and opens new ones containing only the
  header. (mirage/index#288)

- `Index.Make` now requires an implementation of a monotonic time source.
  (mirage/index#321)

- The `Index.Make` functor now takes a single `Platform` argument containing
  all system dependencies (i.e. `IO`, `Clock`, `Semaphore` and `Thread`). The
  `Platform` module holds the necessary types for these modules. (mirage/index#321, mirage/index#330)

## Added

- Added benchmarks that replay a trace of index operations. (mirage/index#300)

- Log reporter for the benches
