### PR TITLE
5 packages from diskuv/dirsp-exchange at 0.1.0

### DIFF
--- a/packages/dirsp-exchange-kbb2017/dirsp-exchange-kbb2017.0.1.0/opam
+++ b/packages/dirsp-exchange-kbb2017/dirsp-exchange-kbb2017.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "The formally verified KBB2017 protocol for 1-on-1 secure conversations similar to the Signal Protocol"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-exchange-kbb2017] library implements the Kobeissi, Bhargavan and Blanchet 2017
+protocol that is a variant of the Signal Protocol v3 and has been verified
+using two complementary formal methodologies."""
+maintainer: "opensource+dirsp-exchange-kbb2017@support.diskuv.com"
+authors:
+  "[Diskuv, Inc. <opensource+dirsp-exchange-kbb2017@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "dirsp-proscript" {= version}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dirsp-proscript-mirage" {= version & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a3c6f4b221fb9732bc55ab4c44e39c14"
+    "sha512=0500d75ff0d3ac187e876d0c3b888ce7d6396ea5bf55ec4aca4a0adfc4ac76d3838bbcb2d6efcc40e2cecb7fc2070ebe362ed2a6606dc42790588f7a0966d199"
+  ]
+}

--- a/packages/dirsp-exchange/dirsp-exchange.0.1.0/opam
+++ b/packages/dirsp-exchange/dirsp-exchange.0.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Published protocols for the authenticated message exchange"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-exchange] library is a no-op as of May 2021, but will have high-level
+APIs that can stitch together the sub-libraries like [dirsp-exchange-kbb2017].
+These [dirsp-exchange-*] sublibraries are implementations of research/academic
+protocols published in the field of authenticated message exchange."""
+maintainer: "opensource+dirsp-exchange@support.diskuv.com"
+authors: "[Diskuv, Inc. <opensource+dirsp-exchange@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "dirsp-exchange-kbb2017" {= version}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a3c6f4b221fb9732bc55ab4c44e39c14"
+    "sha512=0500d75ff0d3ac187e876d0c3b888ce7d6396ea5bf55ec4aca4a0adfc4ac76d3838bbcb2d6efcc40e2cecb7fc2070ebe362ed2a6606dc42790588f7a0966d199"
+  ]
+}

--- a/packages/dirsp-proscript-mirage/dirsp-proscript-mirage.0.1.0/opam
+++ b/packages/dirsp-proscript-mirage/dirsp-proscript-mirage.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Mirage crypto backed implementation of the ProScript Cryptography Library"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-proscript-mirage] library is an implementation based on
+mirage-crypto / mirage-crypto-rng / mirage-crypto-ecc of the
+ProScript Cryptography Library. ProScript is a subset of JavaScript that can be
+verified with formal security proofs.
+
+The implementation comes with tests: an overlapping-pairs-sparse-occupancy test
+for randomness, wycheproof test vectors for DH25519 (aka X25519) and RFC 8032
+test vectors for EDH25519 (aka Ed25519)."""
+maintainer: "opensource+dirsp-proscript-mirage@support.diskuv.com"
+authors:
+  "[Diskuv, Inc. <opensource+dirsp-proscript-mirage@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "dirsp-proscript" {= version}
+  "mirage-crypto-rng" {>= "0.8.1"}
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "iter" {>= "1.2.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a3c6f4b221fb9732bc55ab4c44e39c14"
+    "sha512=0500d75ff0d3ac187e876d0c3b888ce7d6396ea5bf55ec4aca4a0adfc4ac76d3838bbcb2d6efcc40e2cecb7fc2070ebe362ed2a6606dc42790588f7a0966d199"
+  ]
+}

--- a/packages/dirsp-proscript/dirsp-proscript.0.1.0/opam
+++ b/packages/dirsp-proscript/dirsp-proscript.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "OCaml-ified interfaces for the ProScript Cryptography Library"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-proscript] library vends an OCaml-ified interface for the
+ProScript language. ProScript is a subset of JavaScript that can be
+verified with formal security proofs."""
+maintainer: "opensource+dirsp-proscript@support.diskuv.com"
+authors: "[Diskuv, Inc. <opensource+dirsp-proscript@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a3c6f4b221fb9732bc55ab4c44e39c14"
+    "sha512=0500d75ff0d3ac187e876d0c3b888ce7d6396ea5bf55ec4aca4a0adfc4ac76d3838bbcb2d6efcc40e2cecb7fc2070ebe362ed2a6606dc42790588f7a0966d199"
+  ]
+}

--- a/packages/dirsp-ps2ocaml/dirsp-ps2ocaml.0.1.0/opam
+++ b/packages/dirsp-ps2ocaml/dirsp-ps2ocaml.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "ProScript to OCaml translator"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-ps2ocaml] executable translates ProScript, which is a subset of
+JavaScript that can be verified with formal security proofs, into OCaml."""
+maintainer: "opensource+dirsp-ps2ocaml@support.diskuv.com"
+authors: "[Diskuv, Inc. <opensource+dirsp-ps2ocaml@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "menhir" {>= "20210419"}
+  "menhirLib" {>= "20210419"}
+  "pcre" {>= "7.4.6"}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+  "ulex" {>= "1.2"}
+  "alcotest" {>= "1.4.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=a3c6f4b221fb9732bc55ab4c44e39c14"
+    "sha512=0500d75ff0d3ac187e876d0c3b888ce7d6396ea5bf55ec4aca4a0adfc4ac76d3838bbcb2d6efcc40e2cecb7fc2070ebe362ed2a6606dc42790588f7a0966d199"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dirsp-exchange.0.1.0`: Published protocols for the authenticated message exchange
-`dirsp-exchange-kbb2017.0.1.0`: The formally verified KBB2017 protocol for 1-on-1 secure conversations similar to the Signal Protocol
-`dirsp-proscript.0.1.0`: OCaml-ified interfaces for the ProScript Cryptography Library
-`dirsp-proscript-mirage.0.1.0`: Mirage crypto backed implementation of the ProScript Cryptography Library
-`dirsp-ps2ocaml.0.1.0`: ProScript to OCaml translator



---
* Homepage: https://github.com/diskuv/dirsp-exchange
* Source repo: git+https://github.com/diskuv/dirsp-exchange.git
* Bug tracker: https://github.com/diskuv/dirsp-exchange/issues

---
:camel: Pull-request generated by opam-publish v2.0.3