### PR TITLE
2 packages from diskuv/dirsp-exchange at 0.1.0

### DIFF
--- a/packages/dirsp-proscript/dirsp-proscript.0.1.0/opam
+++ b/packages/dirsp-proscript/dirsp-proscript.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "OCaml-ified interfaces for the ProScript Cryptography Library"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-proscript] library vends an OCaml-ified interface for the
+ProScript language. ProScript is a subset of JavaScript that can be
+verified with formal security proofs."""
+maintainer: "opensource+dirsp-proscript@support.diskuv.com"
+authors: "[Diskuv, Inc. <opensource+dirsp-proscript@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=e2664e6f9b1444ea7503d4d88471a217"
+    "sha512=e430faf166396e61b3973b1095587810e3f9023e349d7aa9cc3c757dd1eaa7137d737df6da64259a6eb7dd42121fd5fe0d71bec7c2a40cbda674426b6b15a8f1"
+  ]
+}

--- a/packages/dirsp-ps2ocaml/dirsp-ps2ocaml.0.1.0/opam
+++ b/packages/dirsp-ps2ocaml/dirsp-ps2ocaml.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "ProScript to OCaml translator"
+description: """\
+Dirsp is a short form for Diskuv Implementations of Research Security Protocols.
+The [dirsp-ps2ocaml] executable translates ProScript, which is a subset of
+JavaScript that can be verified with formal security proofs, into OCaml."""
+maintainer: "opensource+dirsp-ps2ocaml@support.diskuv.com"
+authors: "[Diskuv, Inc. <opensource+dirsp-ps2ocaml@support.diskuv.com>]"
+license: "Apache-2.0"
+tags: "org:diskuv"
+homepage: "https://github.com/diskuv/dirsp-exchange"
+bug-reports: "https://github.com/diskuv/dirsp-exchange/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "menhirLib" {>= "20210419"}
+  "pcre" {>= "7.4.6"}
+  "ppx_deriving_protobuf" {>= "3.0.0"}
+  "ulex" {>= "1.2"}
+  "alcotest" {>= "1.4.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/diskuv/dirsp-exchange.git"
+url {
+  src: "https://github.com/diskuv/dirsp-exchange/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=e2664e6f9b1444ea7503d4d88471a217"
+    "sha512=e430faf166396e61b3973b1095587810e3f9023e349d7aa9cc3c757dd1eaa7137d737df6da64259a6eb7dd42121fd5fe0d71bec7c2a40cbda674426b6b15a8f1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dirsp-proscript.0.1.0`: OCaml-ified interfaces for the ProScript Cryptography Library
-`dirsp-ps2ocaml.0.1.0`: ProScript to OCaml translator



---
* Homepage: https://github.com/diskuv/dirsp-exchange
* Source repo: git+https://github.com/diskuv/dirsp-exchange.git
* Bug tracker: https://github.com/diskuv/dirsp-exchange/issues

---
:camel: Pull-request generated by opam-publish v2.0.3