### PR TITLE
[new release] bytebuffer and h1_parser (0.0.2)

### DIFF
--- a/packages/bytebuffer/bytebuffer.0.0.2/opam
+++ b/packages/bytebuffer/bytebuffer.0.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Extensible buffers built on top of bigarrays"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+homepage: "https://github.com/anuragsoni/h1"
+doc: "https://anuragsoni.github.io/h1"
+bug-reports: "https://github.com/anuragsoni/h1/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base_bigstring"
+  "alcotest" {with-test}
+  "ocaml" {>= "4.11.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/h1.git"
+x-commit-hash: "5bbc2c3f199d4aa6aad0372d5a45b78d904c3a7a"
+url {
+  src:
+    "https://github.com/anuragsoni/h1/releases/download/0.0.2/h1-0.0.2.tbz"
+  checksum: [
+    "sha256=5f35114e00749062e0ce64fc32641dc11b99fac912f820df6132c63a3e4bad8a"
+    "sha512=439fde2c97ba98e3e1cb8c1aa984f84e00f23bfebb330cfb413afde9cb20946747ed2b6c318c78416389469b86b51c92303b5c4a8ea7f858177aba24a32b3be7"
+  ]
+}

--- a/packages/h1_parser/h1_parser.0.0.2/opam
+++ b/packages/h1_parser/h1_parser.0.0.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Parser for HTTP 1.1"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+homepage: "https://github.com/anuragsoni/h1"
+doc: "https://anuragsoni.github.io/h1"
+bug-reports: "https://github.com/anuragsoni/h1/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "cohttp" {>= "4.0.0"}
+  "base_bigstring"
+  "base" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_compare" {with-test}
+  "ppx_here" {with-test}
+  "base_quickcheck" {with-test}
+  "ppx_assert" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/h1.git"
+x-commit-hash: "5bbc2c3f199d4aa6aad0372d5a45b78d904c3a7a"
+url {
+  src:
+    "https://github.com/anuragsoni/h1/releases/download/0.0.2/h1-0.0.2.tbz"
+  checksum: [
+    "sha256=5f35114e00749062e0ce64fc32641dc11b99fac912f820df6132c63a3e4bad8a"
+    "sha512=439fde2c97ba98e3e1cb8c1aa984f84e00f23bfebb330cfb413afde9cb20946747ed2b6c318c78416389469b86b51c92303b5c4a8ea7f858177aba24a32b3be7"
+  ]
+}


### PR DESCRIPTION
#### Bytebuffer

Extensible buffers built on top of bigarrays

#### H1_parser

Portable HTTP 1.1 parser

##### Notes

- Project page: <a href="https://github.com/anuragsoni/h1">https://github.com/anuragsoni/h1</a>
- Documentation: <a href="https://anuragsoni.github.io/h1">https://anuragsoni.github.io/h1</a>

##### CHANGES:

* Use cohttp types instead of writing yet another set of HTTP 1.1 types
* Switch parser tests to a combination of alcotest + ppx_assert
