### PR TITLE
[new release] bytebuffer and h1_parser (0.0.2)

### DIFF
--- a/packages/bytebuffer/bytebuffer.0.0.2/opam
+++ b/packages/bytebuffer/bytebuffer.0.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Extensible buffers built on top of bigarrays"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+homepage: "https://github.com/anuragsoni/h1"
+doc: "https://anuragsoni.github.io/h1"
+bug-reports: "https://github.com/anuragsoni/h1/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base_bigstring"
+  "alcotest" {with-test}
+  "ocaml" {>= "4.11.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/h1.git"
+x-commit-hash: "d659ad37f1222523725e8f37f6250de549f64112"
+url {
+  src:
+    "https://github.com/anuragsoni/h1/releases/download/0.0.2/h1-0.0.2.tbz"
+  checksum: [
+    "sha256=6de8da90c7442c69d3ff2d82c393804dae4e90fe3abd963a896e825669c95dfd"
+    "sha512=496184c91b228dd19fa2074ca091b887b0d148af4207ebedfbad8b95582a600f13ba61c2c68bd316a5f74e69c1b964f5c690f5b212b29b80235e23958969c12e"
+  ]
+}

--- a/packages/h1_parser/h1_parser.0.0.2/opam
+++ b/packages/h1_parser/h1_parser.0.0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Parser for HTTP 1.1"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+homepage: "https://github.com/anuragsoni/h1"
+doc: "https://anuragsoni.github.io/h1"
+bug-reports: "https://github.com/anuragsoni/h1/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "cohttp" {>= "4.0.0"}
+  "base_bigstring"
+  "base" {with-test}
+  "alcotest" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_compare" {with-test}
+  "ppx_here" {with-test}
+  "base_quickcheck" {with-test}
+  "ppx_assert" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/h1.git"
+x-commit-hash: "d659ad37f1222523725e8f37f6250de549f64112"
+url {
+  src:
+    "https://github.com/anuragsoni/h1/releases/download/0.0.2/h1-0.0.2.tbz"
+  checksum: [
+    "sha256=6de8da90c7442c69d3ff2d82c393804dae4e90fe3abd963a896e825669c95dfd"
+    "sha512=496184c91b228dd19fa2074ca091b887b0d148af4207ebedfbad8b95582a600f13ba61c2c68bd316a5f74e69c1b964f5c690f5b212b29b80235e23958969c12e"
+  ]
+}


### PR DESCRIPTION
#### Bytebuffer

Extensible buffers built on top of bigarrays

#### H1_parser

Portable HTTP 1.1 parser

##### Notes

- Project page: <a href="https://github.com/anuragsoni/h1">https://github.com/anuragsoni/h1</a>
- Documentation: <a href="https://anuragsoni.github.io/h1">https://anuragsoni.github.io/h1</a>

##### CHANGES:

* Use cohttp types instead of writing yet another set of HTTP 1.1 types
* Switch parser tests to a combination of alcotest + ppx_assert
