### PR TITLE
conf-gnomecanvas.2: add required libart for pkg-config gnomecanvas

### DIFF
--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -9,7 +9,7 @@ depexts: [
   ["libgnomecanvas2-dev"] {os-family = "ubuntu"}
   ["libgnomecanvas-devel"] {os-family = "fedora" | os-family = "rhel"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
-  ["libgnomecanvas-dev@testing"] {os-family = "alpine"}
+  ["libgnomecanvas-dev@testing" "libart-lgpl-dev"] {os-family = "alpine"}
   ["libgnomecanvas"] {os-family = "arch"}
   ["libgnomecanvas"] {os = "freebsd"}
   ["libgnomecanvas"] {os = "openbsd"}

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -15,6 +15,12 @@ depexts: [
   ["libgnomecanvas"] {os = "openbsd"}
   ["gnome2.libgnomecanvas"] {os-distribution = "nixos"}
 ]
+x-ci-accept-failures: [
+  "centos-8" # libgnomecanvas-devel not available in the official repositories
+             # in CentOS 8 (it was in CentOS 7)
+  "oraclelinux-7"
+  "oraclelinux-8"
+]
 synopsis: "Virtual package relying on a Gnomecanvas system installation"
 description: """
 This package can only install if libgnomecanvas2-dev is installed


### PR DESCRIPTION
Currently, when installing `libgnomecanvas-dev` from testing, the `pkg-config` command executed by the `conf-gnomecanvas` script fails. Manually running `pkg-config libgnomecanvas-2.0 --libs` gives the following message:

```
Package libart-2.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libart-2.0.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libart-2.0', required by 'libgnomecanvas-2.0', not found
```

If I then try `sudo apk add libart-lgpl-dev`, and retry `opam install conf-gnomecanvas`, it succeeds.

I don't know if the actual issue is upstream and should be reported to Alpine itself, but in any case, this patch should improve things. If someone more familiar with Alpine wants to try to report the missing dependency, please do so.