### PR TITLE
trie.0.1.1: Fix archive url

### DIFF
--- a/packages/trie/trie.0.1.1/opam
+++ b/packages/trie/trie.0.1.1/opam
@@ -26,6 +26,6 @@ synopsis: "trie tree"
 description: "Implementation of strict impure trie tree"
 flags: light-uninstall
 url {
-  src: "https://bitbucket.org/zandoye/trie/get/0.1.1.tar.gz"
-  checksum: "md5=a7460a1e9c1f1c94bb36b1ce48aea50f"
+  src: "https://github.com/kandu/trie/archive/refs/tags/0.1.1.tar.gz"
+  checksum: "md5=8b2b91a332ee085bb53d26af85f7559d"
 }


### PR DESCRIPTION
No change in archive apart from mercurial files
Detected in https://github.com/ocaml/opam-repository/pull/18887
```
$ diff -ru zandoye-trie-af4856e44518 trie-0.1.1
Only in zandoye-trie-af4856e44518: .hg_archival.txt
Only in zandoye-trie-af4856e44518: .hgtags
```