### PR TITLE
mew: Add missing constraint

### DIFF
--- a/packages/mew/mew.0.1.0/opam
+++ b/packages/mew/mew.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "result"
-  "trie"
+  "trie" {>= "1.0.0"}
   "dune" {>= "1.1.0"}
 ]
 


### PR DESCRIPTION

Detected in https://github.com/ocaml/opam-repository/pull/18890
```
#=== ERROR while compiling mew.0.1.0 ==========================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///src
# path                 ~/.opam/4.03/.opam-switch/build/mew.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mew -j 31
# exit-code            1
# env-file             ~/.opam/log/mew-23-19c76d.env
# output-file          ~/.opam/log/mew-23-19c76d.out
### output ###
#       ocamlc src/.mew.objs/mew__Mode.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I src/.mew.objs -I src/.mew.objs/.private -I /home/opam/.opam/4.03/lib/base -I /home/opam/.opam/4.03/lib/base/caml -I /home/opam/.opam/4.03/lib/base/shadow_stdlib -I /home/opam/.opam/4.03/lib/bin_prot -I /home/opam/.opam/4.03/lib/bin_prot/shape -I /home/opam/.opam/4.03/lib/core_kernel -I /home/opam/.opam/4.03/lib/core_kernel/base_for_tests -I /home/opam/.opam/4.03/lib/fieldslib -I /home/opam/.opam/4.03/lib/jane-street-headers -I /home/opam/.opam/4.03/lib/num -I /home/opam/.opam/4.03/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.03/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.03/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.03/lib/ppx_expect/collector -I /home/opam/.opam/4.03/lib/ppx_expect/common -I /home/opam/.opam/4.03/lib/ppx_expect/config -I /home/opam/.opam/4.03/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.03/lib/ppx_inline_test/config -I /home/opam/.opam/4.03/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.03/lib/result -I /home/opam/.opam/4.03/lib/sexplib -I /home/opam/.opam/4.03/lib/sexplib/0 -I /home/opam/.opam/4.03/lib/stdio -I /home/opam/.opam/4.03/lib/trie -I /home/opam/.opam/4.03/lib/typerep -I /home/opam/.opam/4.03/lib/variantslib -no-alias-deps -open Mew__ -o src/.mew.objs/mew__Mode.cmo -c -impl src/mode.ml)
# File "src/mode.ml", line 16, characters 29-32:
# Error: Signature mismatch:
#        ...
#        The value `sexp_of_t' is required but not provided
#        The value `t_of_sexp' is required but not provided
```