### PR TITLE
Package soupault.2.8.0

### DIFF
--- a/packages/soupault/soupault.2.8.0/opam
+++ b/packages/soupault/soupault.2.8.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ezjsonm"
   "containers" {>= "3.4"}
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.8.0/opam
+++ b/packages/soupault/soupault.2.8.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
+* Export extracted metadata to JSON.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.app"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.2"}
+  "markup" {>= "1.0.0-1"}
+  "toml" {>= "6.0.0"}
+  "fileutils"
+  "logs"
+  "fmt"
+  "re"
+  "ezjsonm"
+  "containers" {>= "3.4"}
+  "odate"
+  "spelll"
+  "base64"
+  "jingoo" {>= "1.4.2"}
+  "tsort" {>= "2.0.0"}
+  "lua-ml" {>= "0.9.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/refs/tags/2.8.0.tar.gz"
+  checksum: [
+    "md5=72bf1e2a4c3b6fcf891d7797be729118"
+    "sha512=cd1e0587c44d0876941a78b3c0441811703b2e88995162bd14062facd3294b4bbc9c44aa84d84f9eb04be410f0f8d17690bf72e9152968bef149826c392c6adf"
+  ]
+}

--- a/packages/soupault/soupault.2.8.0/opam
+++ b/packages/soupault/soupault.2.8.0/opam
@@ -36,10 +36,11 @@ depends: [
   "containers" {>= "3.4"}
   "odate"
   "spelll" {>= "0.3"}
-  "base64"
+  "base64" {>= "3.0.0"}
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.2"}
+  "result" {>= "1.5"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/soupault/soupault.2.8.0/opam
+++ b/packages/soupault/soupault.2.8.0/opam
@@ -40,7 +40,9 @@ depends: [
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.2"}
-  "result" {>= "1.5"}
+]
+conflicts: [
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
### `soupault.2.8.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

With soupault you can:

* Generate ToC and footnotes.
* Insert file content or an HTML snippet in any element.
* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
* Export extracted metadata to JSON.

Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
similar to web browsers.

The website generator mode is optional, you can use it as post-processor for existing sites.



---
* Homepage: https://www.soupault.app
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.0.3