### PR TITLE
Package opam-grep.0.1.1

### DIFF
--- a/packages/opam-grep/opam-grep.0.1.1/opam
+++ b/packages/opam-grep/opam-grep.0.1.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin that greps anything in the sources of every opam packages"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-grep"
+bug-reports: "https://github.com/kit-ty-kate/opam-grep/issues"
+available: os = "linux" | os-family = "bsd"
+flags: plugin
+dev-repo: "git://github.com/kit-ty-kate/opam-grep.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-grep/archive/refs/tags/v0.1.1.tar.gz"
+  checksum: [
+    "md5=5d5156eb9d64b8e02b3d1b139d1817e7"
+    "sha512=a8d58be5cbc1e09e837fedcb63136251edfd32cbe7ce5b1bbaa3ed3fece87c17b1888ad7cabb34d58b8f42bbb40dcd904be1715787d2d4b53289d23009d557fa"
+  ]
+}


### PR DESCRIPTION
### `opam-grep.0.1.1`
An opam plugin that greps anything in the sources of every opam packages



---
* Homepage: https://github.com/kit-ty-kate/opam-grep
* Source repo: git://github.com/kit-ty-kate/opam-grep.git
* Bug tracker: https://github.com/kit-ty-kate/opam-grep/issues

---
:camel: Pull-request generated by opam-publish v2.0.3