### PR TITLE
Package duppy.0.9.1

### DIFF
--- a/packages/duppy/duppy.0.9.1/opam
+++ b/packages/duppy/duppy.0.9.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Library providing monadic threads"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-duppy"
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pcre"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
+url {
+  src: "https://github.com/savonet/ocaml-duppy/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=acc80c67fcb070da01768a5431c6a67b"
+    "sha512=f802a6d82f54970ef10d0a76cf8989cfcba509e10b4b04b0d0a3eac24c4a488d56f899fa92d879a52d82c139dc0d3dcd61d9cffa43d163dc6e3abc3840f3de67"
+  ]
+}


### PR DESCRIPTION
### `duppy.0.9.1`
Library providing monadic threads



---
* Homepage: https://github.com/savonet/ocaml-duppy
* Source repo: git+https://github.com/savonet/ocaml-duppy.git
* Bug tracker: https://github.com/savonet/ocaml-duppy/issues

---
:camel: Pull-request generated by opam-publish v2.0.3