### PR TITLE
opam-grep: Refine availibility

### DIFF
--- a/packages/opam-grep/opam-grep.0.1.1/opam
+++ b/packages/opam-grep/opam-grep.0.1.1/opam
@@ -6,7 +6,7 @@ authors: "Kate <kit.ty.kate@disroot.org>"
 license: "MIT"
 homepage: "https://github.com/kit-ty-kate/opam-grep"
 bug-reports: "https://github.com/kit-ty-kate/opam-grep/issues"
-available: os = "linux" | os-family = "bsd"
+available: os != "win32"
 flags: plugin
 dev-repo: "git://github.com/kit-ty-kate/opam-grep.git"
 url {


### PR DESCRIPTION
opam-grep needs some sort of posix environment. MacOS should work and Cygwin should probably work too