### PR TITLE
[new release] codept (0.11.0)

### DIFF
--- a/packages/codept/codept.0.11.0/opam
+++ b/packages/codept/codept.0.11.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Florian Angeletti <octa@polychoron.fr>"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+license: "GPL-3.0-or-later"
+dev-repo: "git+https://github.com/Octachron/codept.git"
+build: [
+  ["dune" "build" "-p" name]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+depends: ["dune" {>="2.5"} "menhir" {build & >="20180523" }  "ocaml" {>="4.03" & < "4.14~"}]
+synopsis: "Alternative ocaml dependency analyzer"
+description:"""
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+  when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."""
+x-commit-hash: "8a34ba4c5c2fec4011c565291d0dc0a858391d54"
+authors: "Florian Angeletti <octa@polychoron.fr>"
+url {
+  src:
+    "https://github.com/Octachron/codept/releases/download/0.11.0/codept-0.11.0.tbz"
+  checksum: [
+    "sha256=0444b0ea1d4256410868b1e78ad8a5f23914e5c9427a7d37c4216c51283c1000"
+    "sha512=02ba3513c7b892a9ec4b69bc56fb83ee3787a40c0a47342edc906f346068ca7fdae20b660b2944125568969377211ba011d5197c088384c959f19c65030c8518"
+  ]
+}

--- a/packages/codept/codept.0.11.0/opam
+++ b/packages/codept/codept.0.11.0/opam
@@ -5,12 +5,16 @@ bug-reports: "https://github.com/Octachron/codept/issues"
 license: "GPL-3.0-or-later"
 dev-repo: "git+https://github.com/Octachron/codept.git"
 build: [
-  ["dune" "build" "-p" name]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest"]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
-depends: ["dune" {>="2.5"} "menhir" {build & >="20180523" }  "ocaml" {>="4.03" & < "4.14~"}]
+depends: [
+  "dune" {>= "2.5"}
+  "menhir" {build & >= "20180523"}
+  "ocaml" {>= "4.03" & < "4.14~"}
+]
 synopsis: "Alternative ocaml dependency analyzer"
 description:"""
 Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:


### PR DESCRIPTION
This is a new version of codept, an alternative dependency analyzer for OCaml projects.

This new version restores the support for recent compiler (up to 4.13.0). 

It also extends codept to handle every module-level features of OCaml (including abstract modules types). 

Finally, the internal core of codept (the interruptible outliner for OCaml module system) has been entirely switched to the zipper-based engine. 

## Features

  * Support for abstract module types:
	Codept is now aware that `Y` is `X.M.Y` and not an external dependency in

```ocaml
  module F(X:sig module type t module M:t end) = X
  module X = struct
    module M = struct
      module Y = struct end
    end
    module type t = module type of M
  end
  open F(X)
  open M
  open Y
```

  * Support for OCaml 4.09, 4.10, 4.11, 4.12, 4.13

  * Support for split compilation units: the interface and  implementation files do not need to share a filesystem path to be identified as part of the same compilation unit

## Bug fix

 * Nested with constraints `with A.B. ...` triggers now alias dependencies in -no-alias-deps mode
In other words, in this example
```ocaml
module type s = sig module Alias = Deps end
module E = struct end
module type s2 = s with module Deps.Sub = E
```
`Deps` should be counted as an external dependency due to left hand side of the substitution.

* The signature of dune wrapped library can now be imported properly: libraries are now read in the `-no-alias-deps` mode by default.

## Internal

* Switch to the new zipper-based outliner
* Fully typed recursive definition for schema
* Extended testsuite
* More detailled AST for the simplified value level (no more encoding)