### PR TITLE
Package cps_toolbox.0.1

### DIFF
--- a/packages/cps_toolbox/cps_toolbox.0.1/opam
+++ b/packages/cps_toolbox/cps_toolbox.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A partial OCaml standard library replacement written with continuation passing style in mind"
+maintainer: "Soren Norbaek <sorennorbaek@gmail.com>"
+authors: "Soren Norbaek <sorennorbaek@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/soren-n/cps-toolbox"
+bug-reports: "https://github.com/soren-n/cps-toolbox/issues"
+dev-repo: "git+https://github.com/soren-n/cps-toolbox.git"
+build: [
+  "dune" "build" "-p" name "-j" jobs "@install"
+  "@runtest" {with-test}
+]
+depends: [
+  "dune" {>= "2.8"}
+  "qcheck" {>= "0.17"}
+]
+url {
+  src: "https://github.com/soren-n/cps-toolbox/archive/0.1.tar.gz"
+  checksum: [
+    "md5=cbd33039e46291a0977e6cb68c8b8326"
+    "sha512=8917f023d67d4394379b86d8f3a6c33c579663d389bc5136b8ebe26bf0a1f4611a0f1921146b6e069cbd5a40835800573feaad46b546f00f50d5c1e87245bd3f"
+  ]
+}


### PR DESCRIPTION
### `cps_toolbox.0.1`
A partial OCaml standard library replacement written with continuation passing style in mind



---
* Homepage: https://github.com/soren-n/cps-toolbox
* Source repo: git+https://github.com/soren-n/cps-toolbox.git
* Bug tracker: https://github.com/soren-n/cps-toolbox/issues

---
:camel: Pull-request generated by opam-publish v2.0.3