### PR TITLE
[new release] mula (0.1.1)

### DIFF
--- a/packages/mula/mula.0.1.1/opam
+++ b/packages/mula/mula.0.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "ML's Universal Levenshtein Automata library"
+description: "ML's radishal Universal Levenshtein Automata library."
+maintainer: ["Ifaz Kabir"]
+authors: ["Ifaz Kabir"]
+license: "CC0-1.0"
+homepage: "https://github.com/ifazk/mula"
+doc: "https://ifazk.github.io/mula/"
+bug-reports: "https://github.com/ifazk/mula/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.1"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ifazk/mula.git"
+x-commit-hash: "b3d426d605a14987175de5939bcc4e86a7972876"
+url {
+  src: "https://github.com/ifazk/mula/releases/download/0.1.1/mula-0.1.1.tbz"
+  checksum: [
+    "sha256=ee5333b6f30b68a26af55b7f2f5a1f4f1189c13f4b678735da5dbb4685d0e225"
+    "sha512=22f63d6a077b5825d0b1ce076fa23f39bf4ae4280befec0a8765079fb9f542de2858e9a51e86547d47017c646dfe2c9d1fdd1c99d9f4c30aebf4f7cc06cfe995"
+  ]
+}


### PR DESCRIPTION
ML's Universal Levenshtein Automata library

- Project page: <a href="https://github.com/ifazk/mula">https://github.com/ifazk/mula</a>
- Documentation: <a href="https://ifazk.github.io/mula/">https://ifazk.github.io/mula/</a>

##### CHANGES:

- Early cutoff based on size difference for `Make.*.get_distance`.
- Bit fiddling optimizations: `snoc_ones`, `snoc_zeros`.
- `ppx_inline_test` is now a test dependency, support OCaml > 4.08.1.
- Improved subsumption for Demarau-Levenshtein
- Documentation and internal updates.
