### PR TITLE
Package cps_toolbox.0.1

### DIFF
--- a/packages/cps_toolbox/cps_toolbox.0.1/opam
+++ b/packages/cps_toolbox/cps_toolbox.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A partial OCaml standard library replacement written with continuation passing style in mind"
+maintainer: "Soren Norbaek <sorennorbaek@gmail.com>"
+authors: "Soren Norbaek <sorennorbaek@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/soren-n/cps-toolbox"
+bug-reports: "https://github.com/soren-n/cps-toolbox/issues"
+dev-repo: "git+https://github.com/soren-n/cps-toolbox.git"
+build: [
+  "dune" "build" "-p" name "-j" jobs "@install"
+  "@runtest" {with-test}
+]
+depends: [
+  "dune" {>= "2.8"}
+  "qcheck" {>= "0.17"}
+]
+url {
+  src: "https://github.com/soren-n/cps-toolbox/archive/0.1.tar.gz"
+  checksum: [
+    "md5=fe950590e2382cfcb0c628902a0614ad"
+    "sha512=cf0c75d21abec26d5847a0a83588dbcc88e149a868379fe05c060ee2fb22eee7b756d28225201b2ceb6e389420a6aedceeca828508272595ff8218aad3d66b0a"
+  ]
+}


### PR DESCRIPTION
### `cps_toolbox.0.1`
A partial OCaml standard library replacement written with continuation passing style in mind



---
* Homepage: https://github.com/soren-n/cps-toolbox
* Source repo: git+https://github.com/soren-n/cps-toolbox.git
* Bug tracker: https://github.com/soren-n/cps-toolbox/issues

---
:camel: Pull-request generated by opam-publish v2.0.3