### PR TITLE
[new release] reparse, reparse-lwt and reparse-lwt-unix (3.0.0)

### DIFF
--- a/packages/reparse-lwt-unix/reparse-lwt-unix.3.0.0/opam
+++ b/packages/reparse-lwt-unix/reparse-lwt-unix.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Reparse lwt-unix based input support"
+description: "Reparse lwt-unix based input support"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.10.0"}
+  "lwt" {>= "5.4.1"}
+  "cstruct" {>= "6.0.0"}
+  "reparse" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v3.0.0/reparse-v3.0.0.tbz"
+  checksum: [
+    "sha256=0b525184593b324b1d93dae6c45179c9e38455a3d6f5fdc9f17e063bfdb09b0a"
+    "sha512=acac7a83e2f77297da3bad1a5ea217fe41bafed1f0d5f044ebf524fee19663661fe4aa4d4dfd2b94ff46033436cc25f5ea7bd3a5a08e58d1a573218746a305cb"
+  ]
+}
+x-commit-hash: "0c91626d3588040a5191f265bb89ddbeb7dd24ab"

--- a/packages/reparse-lwt/reparse-lwt.3.0.0/opam
+++ b/packages/reparse-lwt/reparse-lwt.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Reparse Lwt_stream.t input support"
+description: "char Lwt_stream.t parsing support for 'reparse'"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.10.0"}
+  "lwt" {>= "5.4.1"}
+  "cstruct" {>= "6.0.0"}
+  "reparse" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v3.0.0/reparse-v3.0.0.tbz"
+  checksum: [
+    "sha256=0b525184593b324b1d93dae6c45179c9e38455a3d6f5fdc9f17e063bfdb09b0a"
+    "sha512=acac7a83e2f77297da3bad1a5ea217fe41bafed1f0d5f044ebf524fee19663661fe4aa4d4dfd2b94ff46033436cc25f5ea7bd3a5a08e58d1a573218746a305cb"
+  ]
+}
+x-commit-hash: "0c91626d3588040a5191f265bb89ddbeb7dd24ab"

--- a/packages/reparse/reparse.3.0.0/opam
+++ b/packages/reparse/reparse.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Recursive descent parsing library for ocaml"
+description:
+  "Monadic, recursive descent based, parser construction library for ocaml. Comprehensively documented and tested"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.10.0"}
+  "cstruct" {>= "6.0.0"}
+  "mdx" {with-test}
+  "popper" {with-test}
+  "ppx_deriving_popper" {with-test}
+  "ppx_deriving" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v3.0.0/reparse-v3.0.0.tbz"
+  checksum: [
+    "sha256=0b525184593b324b1d93dae6c45179c9e38455a3d6f5fdc9f17e063bfdb09b0a"
+    "sha512=acac7a83e2f77297da3bad1a5ea217fe41bafed1f0d5f044ebf524fee19663661fe4aa4d4dfd2b94ff46033436cc25f5ea7bd3a5a08e58d1a573218746a305cb"
+  ]
+}
+x-commit-hash: "0c91626d3588040a5191f265bb89ddbeb7dd24ab"


### PR DESCRIPTION
Recursive descent parsing library for ocaml

- Project page: <a href="https://github.com/lemaetech/reparse">https://github.com/lemaetech/reparse</a>

##### CHANGES:

- Overhaul parser implementation - use functor based implementation. Introduce, `Make_buffered_input`, `Make_unbuffered_input` and `Make` functors.
- Remove `reparse-unix` package
- Remove base dependency
- Facilitate IO promise monads such as `Lwt` and `Async`
- Add package `reparse-lwt` which defines `Lwt_stream.t` as one of the input sources.
- Add package 'reparse-lwt-unix' which defines `Lwt_unix.file_descr` and `Lwt_io.input_channel` as parser input sources.
-
