### PR TITLE
Package opam-publish.2.1.0

### DIFF
--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -21,6 +21,7 @@ depends: [
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
 ]
+conflicts: "ssl" {= "0.5.6"}
 flags: plugin
 synopsis: "A tool to ease contributions to opam repositories"
 description: """

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+]
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "cmdliner"
+  "dune" {>= "1.0"}
+  "lwt_ssl"
+  "ocaml" {>= "4.03.0"}
+  "opam-core" {>= "2.1.0~rc"}
+  "opam-format" {>= "2.1.0~rc"}
+  "opam-state" {>= "2.1.0~rc"}
+  "github" {>= "2.0.0" & < "4.3.0" | >= "4.3.2"}
+  "github-unix" {>= "2.0.0" & < "4.3.0" | >= "4.3.2"}
+  ("ssl" {= "0.5.5"} | "tls")
+]
+flags: plugin
+synopsis: "A tool to ease contributions to opam repositories"
+description: """
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it.
+"""
+url {
+  src: "https://github.com/ocaml/opam-publish/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=b791b4b43a762b8b9168d073eddb7cb1"
+    "sha512=37914b4426af9c0776d66a028cb204c38dadb269e3179676957154c06e45dc5e60a828dd295d099f15661ab8dcffaebb96f02f5dc91c9d66dec4aac97e6576c6"
+  ]
+}

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-publish.git"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -14,13 +14,13 @@ depends: [
   "cmdliner"
   "dune" {>= "1.0"}
   "lwt_ssl"
+  "tls"
   "ocaml" {>= "4.03.0"}
   "opam-core" {>= "2.1.0~rc"}
   "opam-format" {>= "2.1.0~rc"}
   "opam-state" {>= "2.1.0~rc"}
-  "github" {>= "2.0.0" & < "4.3.0" | >= "4.3.2"}
-  "github-unix" {>= "2.0.0" & < "4.3.0" | >= "4.3.2"}
-  ("ssl" {= "0.5.5"} | "tls")
+  "github" {>= "4.3.2"}
+  "github-unix" {>= "4.3.2"}
 ]
 flags: plugin
 synopsis: "A tool to ease contributions to opam repositories"

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -14,7 +14,6 @@ depends: [
   "cmdliner"
   "dune" {>= "1.0"}
   "lwt_ssl"
-  "tls"
   "ocaml" {>= "4.03.0"}
   "opam-core" {>= "2.1.0~rc"}
   "opam-format" {>= "2.1.0~rc"}


### PR DESCRIPTION
### `opam-publish.2.1.0`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v2.1.0