### PR TITLE
Add coq-of-ocaml version 2.5.1

### DIFF
--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.1/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/clarus/coq-of-ocaml"
+dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
+bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["sh" "-c" "cd proofs && ./configure.sh"] {coq:installed}
+  [make "-C" "proofs" "-j%{jobs}%"] {coq:installed}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  [make "-C" "proofs" "install"] {coq:installed}
+]
+depends: [
+  "csexp"
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12" & < "4.13"}
+  "ocamlfind" {>= "1.5.2"}
+  "result"
+  "smart-print"
+  "yojson" {>= "1.6.0"}
+]
+depopts: [
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.11"}
+]
+tags: [
+  "keyword:compilation"
+  "keyword:OCaml"
+  "logpath:CoqOfOCaml"
+]
+synopsis: "Compile a subset of OCaml to Coq"
+
+url {
+  src: "https://github.com/clarus/coq-of-ocaml/releases/download/2.5.1/coq-of-ocaml-full.2.5.1.tar.gz"
+  checksum: [
+    "sha256=809eaf4d5d21f6169aefc8c1fe4eb366dc44cfbda26ea3671087cc455e4409c5"
+    "sha512=252f941e20fd7b0ede673fab647c8a60a28777d3de14ebaea38099efb9964ce1f717f8c516b6e48b322ed4cecf86578abdee62e7b48d044f805bf830986a00b8"
+  ]
+}


### PR DESCRIPTION
With this pull-request, we add `coq-of-ocaml` version 2.5.1 with small bug fixes.