### PR TITLE
4 packages from c-cube/qcheck at 0.18

### DIFF
--- a/packages/qcheck-alcotest/qcheck-alcotest.0.18/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.18/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Alcotest backend for qcheck"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "quickcheck"
+  "qcheck"
+  "alcotest"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=d95f793c549f8eeeeb039a031c3c0141"
+    "sha512=4ddbd11f822f69f0ffa132ba9964fb3b83664a42203c9a3ee8d519e4ed570140bc79651d0084cad276fe0d54e078cd036351a439baa6d8eca9a9f0b528262e21"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.18/opam
+++ b/packages/qcheck-core/qcheck-core.0.18/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+synopsis: "Core qcheck library"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=d95f793c549f8eeeeb039a031c3c0141"
+    "sha512=4ddbd11f822f69f0ffa132ba9964fb3b83664a42203c9a3ee8d519e4ed570140bc79651d0084cad276fe0d54e078cd036351a439baa6d8eca9a9f0b528262e21"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.18/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.18/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+synopsis: "OUnit backend for qcheck"
+tags: [
+  "qcheck"
+  "quickcheck"
+  "ounit"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=d95f793c549f8eeeeb039a031c3c0141"
+    "sha512=4ddbd11f822f69f0ffa132ba9964fb3b83664a42203c9a3ee8d519e4ed570140bc79651d0084cad276fe0d54e078cd036351a439baa6d8eca9a9f0b528262e21"
+  ]
+}

--- a/packages/qcheck/qcheck.0.18/opam
+++ b/packages/qcheck/qcheck.0.18/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Compatibility package for qcheck"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "qcheck-ounit" { = version }
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=d95f793c549f8eeeeb039a031c3c0141"
+    "sha512=4ddbd11f822f69f0ffa132ba9964fb3b83664a42203c9a3ee8d519e4ed570140bc79651d0084cad276fe0d54e078cd036351a439baa6d8eca9a9f0b528262e21"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.18`: Compatibility package for qcheck
-`qcheck-alcotest.0.18`: Alcotest backend for qcheck
-`qcheck-core.0.18`: Core qcheck library
-`qcheck-ounit.0.18`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.0.3