### PR TITLE
2 packages from OCamlPro/ocp-index at 1.3.0

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.3.0/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis: "Console browser for the documentation of installed OCaml libraries"
+description: """
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: "GPL-3.0-only"
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "cppo" {build}
+  "dune" {>= "1.0"}
+  "ocp-index" {= version}
+  "cmdliner"
+  "lambda-term"
+  "zed" { >= "2.0.0" }
+  "odoc" {with-test}
+]
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/1.3.0.tar.gz"
+  checksum: [
+    "md5=be47ca1bf4a8ea7ff65449d2056e9bf9"
+    "sha512=79998be6d755ae6ab31c6aab360b1c039152644eb8e95fb40175a1eef0ccdae022936a42d1bbf03e03c948023b32ee3c8f5ce14d58d8038652995c5e3671f1ae"
+  ]
+}

--- a/packages/ocp-browser/ocp-browser.1.3.0/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.0/opam
@@ -17,7 +17,7 @@ dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.13~"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"

--- a/packages/ocp-browser/ocp-browser.1.3.0/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.0/opam
@@ -16,7 +16,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.13~"}
   "cppo" {build}
   "dune" {>= "1.0"}
   "ocp-index" {= version}

--- a/packages/ocp-index/ocp-index.1.3.0/opam
+++ b/packages/ocp-index/ocp-index.1.3.0/opam
@@ -22,7 +22,7 @@ dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.13~"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}

--- a/packages/ocp-index/ocp-index.1.3.0/opam
+++ b/packages/ocp-index/ocp-index.1.3.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "louis.gesbert@ocamlpro.com"
+synopsis:
+  "Lightweight completion and documentation browsing for OCaml libraries"
+description: """
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`.
+"""
+authors: [
+  "Louis Gesbert"
+  "Gabriel Radanne"
+]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+license: ["LGPL-2.1-only with OCaml-LGPL-linking-exception" "GPL-3.0-only"]
+tags: [ "org:ocamlpro" "org:typerex" ]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "cppo" {build}
+  "dune" {>= "1.0"}
+  "ocp-indent" {>= "1.4.2"}
+  "re" {>= "1.9.0"}
+  "cmdliner"
+  "odoc" {with-doc}
+]
+post-messages:
+  "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{prefix}%/share/emacs/site-lisp\")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim
+" {success & !user-setup:installed}
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/1.3.0.tar.gz"
+  checksum: [
+    "md5=be47ca1bf4a8ea7ff65449d2056e9bf9"
+    "sha512=79998be6d755ae6ab31c6aab360b1c039152644eb8e95fb40175a1eef0ccdae022936a42d1bbf03e03c948023b32ee3c8f5ce14d58d8038652995c5e3671f1ae"
+  ]
+}

--- a/packages/ocp-index/ocp-index.1.3.0/opam
+++ b/packages/ocp-index/ocp-index.1.3.0/opam
@@ -21,7 +21,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.13~"}
   "cppo" {build}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}


### PR DESCRIPTION
This pull-request concerns:
-`ocp-browser.1.3.0`: Console browser for the documentation of installed OCaml libraries
-`ocp-index.1.3.0`: Lightweight completion and documentation browsing for OCaml libraries



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: git+https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
:camel: Pull-request generated by opam-publish v2.1.0