### PR TITLE
[new release] omd (2.0.0.alpha2)

### DIFF
--- a/packages/omd/omd.2.0.0.alpha2/opam
+++ b/packages/omd/omd.2.0.0.alpha2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A Markdown frontend in pure OCaml"
+description: """
+This Markdown library is implemented using only pure OCaml (including
+I/O operations provided by the standard OCaml compiler distribution).
+OMD is meant to be as faithful as possible to the original Markdown.
+Additionally, OMD implements a few Github markdown features, an
+extension mechanism, and some other features. Note that the opam
+package installs both the OMD library and the command line tool `omd`."""
+maintainer: ["Nicolás Ojeda Bär <n.oje.bar@gmail.com>"]
+authors: [
+  "Philippe Wang <philippe.wang@gmail.com>"
+  "Nicolás Ojeda Bär <n.oje.bar@gmail.com>"
+]
+license: "ISC"
+tags: ["org:ocamllabs" "org:mirage"]
+homepage: "https://github.com/ocaml/omd"
+bug-reports: "https://github.com/ocaml/omd/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.04"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/omd.git"
+x-commit-hash: "d38041aa00ffad3b41f14d72c048ad1d9d359cbd"
+url {
+  src:
+    "https://github.com/ocaml/omd/releases/download/2.0.0.alpha2/omd-2.0.0.alpha2.tbz"
+  checksum: [
+    "sha256=bee39a6fbb5e32efbbc7eb81574f6472d568f2cb37ba93f2de188d4b68fc7396"
+    "sha512=82c8716774f756071c8c9dbce838309cfc67d2b607b30d9f5add1307fa8330db8951bfd5406aef1dc3b8902ee67b6d43f76687257927944f118f79be7ea24ff1"
+  ]
+}

--- a/packages/omd/omd.2.0.0~alpha2/opam
+++ b/packages/omd/omd.2.0.0~alpha2/opam
@@ -7,7 +7,10 @@ OMD is meant to be as faithful as possible to the original Markdown.
 Additionally, OMD implements a few Github markdown features, an
 extension mechanism, and some other features. Note that the opam
 package installs both the OMD library and the command line tool `omd`."""
-maintainer: ["Nicolás Ojeda Bär <n.oje.bar@gmail.com>"]
+maintainer: [
+  "Shon Feder <shon.feder@gmail.com>"
+  "Raphael Sousa Santos"
+]
 authors: [
   "Philippe Wang <philippe.wang@gmail.com>"
   "Nicolás Ojeda Bär <n.oje.bar@gmail.com>"

--- a/packages/omd/omd.2.0.0~alpha2/opam
+++ b/packages/omd/omd.2.0.0~alpha2/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.04"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
A Markdown frontend in pure OCaml

- Project page: <a href="https://github.com/ocaml/omd">https://github.com/ocaml/omd</a>

##### CHANGES:

- Clean up AST representation (ocaml/omd#229, @sonologico)

- Restore table of contents generation functionality (ocaml/omd#240, @sonologico)

- Fix parsing of <...>-style links and inline code parsing (ocaml/omd#233, @SquidDev)

- Fix handing of the nonbreaking whitespace character, ASCII code 160 (ocaml/omd#247,
  @shonfeder)

- Downgrade dune requirements to 2.0 (@nobj)
