### PR TITLE
Package dtools.0.4.3

### DIFF
--- a/packages/dtools/dtools.0.4.3/opam
+++ b/packages/dtools/dtools.0.4.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Library providing various helper functions to make daemons"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-dtools"
+bug-reports: "https://github.com/savonet/ocaml-dtools/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+depopts: ["syslog"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
+url {
+  src: "https://github.com/savonet/ocaml-dtools/archive/v0.4.3.tar.gz"
+  checksum: [
+    "md5=44c8d8e5e5a986a519064f268642fc5c"
+    "sha512=643aeb7cbfcdab79110daf85a29c4a6fff7a965888820859a6c0d9cc14ba92a5ad3a1e84cb60176ac8cbe4a7cd30602032a05924d2d48795c62867b09dc290d8"
+  ]
+}


### PR DESCRIPTION
### `dtools.0.4.3`
Library providing various helper functions to make daemons



---
* Homepage: https://github.com/savonet/ocaml-dtools
* Source repo: git+https://github.com/savonet/ocaml-dtools.git
* Bug tracker: https://github.com/savonet/ocaml-dtools/issues

---
:camel: Pull-request generated by opam-publish v2.0.3