### PR TITLE
jekyll-format requires a recent version of ezjsonm

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.2.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ptime"
   "fpath"
   "yaml"
-  "ezjsonm"
+  "ezjsonm" {>= "1.1.0"}
   "alcotest" {with-test}
   "bos" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
Otherwise it fails with:

```
 File "src/jekyll_format.ml", line 66, characters 25-48:
 66 |         Fmt.pf fmt "%s" (Ezjsonm.value_to_string v))
                               ^^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound value Ezjsonm.value_to_string
```