### PR TITLE
io-page < 2.0.0: Add missing conflict

### DIFF
--- a/packages/io-page/io-page.1.0.0/opam
+++ b/packages/io-page/io-page.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "mirage-types" {>= "1.0.0" & < "1.1.0"}
   "ounit"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 dev-repo: "git://github.com/mirage/io-page"

--- a/packages/io-page/io-page.1.1.0/opam
+++ b/packages/io-page/io-page.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "ounit"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 install: [make "install"]

--- a/packages/io-page/io-page.1.1.1/opam
+++ b/packages/io-page/io-page.1.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "ounit"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 install: [make "install"]

--- a/packages/io-page/io-page.1.2.0/opam
+++ b/packages/io-page/io-page.1.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 synopsis: "Allocate memory pages suitable for aligned I/O"

--- a/packages/io-page/io-page.1.3.0/opam
+++ b/packages/io-page/io-page.1.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.0.1"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 synopsis: "Allocate memory pages suitable for aligned I/O"

--- a/packages/io-page/io-page.1.4.0/opam
+++ b/packages/io-page/io-page.1.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.1.0"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 synopsis: "Allocate memory pages suitable for aligned I/O"

--- a/packages/io-page/io-page.1.5.0/opam
+++ b/packages/io-page/io-page.1.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.1.0"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 conflicts: ["io-page-xen" "io-page-unix"]
 synopsis: "Allocate memory pages suitable for aligned I/O"

--- a/packages/io-page/io-page.1.5.1/opam
+++ b/packages/io-page/io-page.1.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.1.0"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 depopts: [
   "mirage-xen-ocaml"

--- a/packages/io-page/io-page.1.6.0/opam
+++ b/packages/io-page/io-page.1.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.1.0"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 depopts: [
   "mirage-xen-ocaml"

--- a/packages/io-page/io-page.1.6.1/opam
+++ b/packages/io-page/io-page.1.6.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind"
   "cstruct" {>= "1.1.0"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"} # bug with C bindings
 ]
 depopts: [
   "mirage-xen-ocaml"


### PR DESCRIPTION
ocamlbuild.0.9.0 has a known bug with C bindings
Detected in https://github.com/ocaml/opam-repository/pull/18930
```
# + /home/opam/.opam/4.03/bin/ocamlfind ocamlmklib -o lib/io_page_unix_stubs lib/stub_alloc_pages.o
# gcc: error: lib/stub_alloc_pages.o: No such file or directory
# gcc: fatal error: no input files
# compilation terminated.
# Command exited with code 2.
# + /home/opam/.opam/4.03/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/4.03/lib/ocamlbuild /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "myocamlbuild.ml", line 471, characters 43-62:
# Warning 3: deprecated: Ocamlbuild_plugin.String.uncapitalize
# Use String.uncapitalize_ascii instead.
# File "myocamlbuild.ml", line 484, characters 51-70:
# Warning 3: deprecated: Ocamlbuild_plugin.String.uncapitalize
# Use String.uncapitalize_ascii instead.
# E: Failure("Command ''/home/opam/.opam/4.03/bin/ocamlbuild' lib/io_page.cma lib/io_page.cmxa lib/io_page.a lib/io_page.cmxs lib/libio_page_unix_stubs.a lib/dllio_page_unix_stubs.so lib/io_page_unix.cma lib/io_page_unix.cmxa lib/io_page_unix.a lib/io_page_unix.cmxs lib_test/portable.native -tag debug' terminated with error code 10")
# make: *** [Makefile:9: build] Error 1
```