### PR TITLE
parsexp doesn't work on 4.13

### DIFF
--- a/packages/parsexp/parsexp.v0.14.0/opam
+++ b/packages/parsexp/parsexp.v0.14.0/opam
@@ -14,6 +14,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
+  "ocaml"    {<  "4.13~"}
 ]
 synopsis: "S-expression parsing library"
 description: "


### PR DESCRIPTION
It fails with:

```
 File "src/parser_automaton_internal.ml", lines 440-454, characters 6-66:
 440 | ......match state.kind with
 441 |       | Positions ->
 442 |         (* Note we store end positions as inclusive in [Positions.t], so we use [delta:0],
 443 |            while in the [Cst] case we save directly the final ranges, so we use
 444 |            [delta:1]. *)
 ...
 451 |           add_pos state ~delta:0;
 452 |           make_list [] stack)
 453 |         else stack
 454 |       | Cst -> make_list_cst (current_pos state ~delta:1) [] stack
 Warning 18 [not-principal]:
   The return type of this pattern-matching is ambiguous.
   Please add a type annotation, as the choice of `s' is not principal.
 File "src/parser_automaton_internal.ml", line 485, characters 44-66:
 485 |     | Sexp -> if is_not_ignoring state then Sexp (Atom str, stack) else stack
                                                   ^^^^^^^^^^^^^^^^^^^^^^
 Error: The constructor Sexp expects 0 argument(s),
        but is applied here to 1 argument(s)
```