### PR TITLE
yices_bindings: requires ctypes 0.7.0

### DIFF
--- a/packages/yices2_bindings/yices2_bindings.0.1/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "containers" {< "3.0"}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.12.0"}
   "ctypes-foreign"
   "ppx_deriving"
   "ppx_optcomp"

--- a/packages/yices2_bindings/yices2_bindings.0.1/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "containers" {< "3.0"}
-  "ctypes"
+  "ctypes" {>= "0.7.0"}
   "ctypes-foreign"
   "ppx_deriving"
   "ppx_optcomp"

--- a/packages/yices2_bindings/yices2_bindings.0.1/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.1/opam
@@ -21,6 +21,9 @@ depends: [
   "ctypes-zarith" {>= "0.2.0"}
 #  "ctypes-of-clang"
 ]
+conflicts: [
+  "integers" {< "0.3.0"}
+]
 build: [
   make
 ]

--- a/packages/yices2_bindings/yices2_bindings.0.2/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "containers"  {>= "3.0.0"}
-  "ctypes"
+  "ctypes" {>= "0.7.0"}
   "ctypes-foreign"
   "ppx_deriving"
   "ppx_optcomp"

--- a/packages/yices2_bindings/yices2_bindings.0.2/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.2/opam
@@ -21,6 +21,9 @@ depends: [
   "ctypes-zarith" {>= "0.2.0"}
 #  "ctypes-of-clang"
 ]
+conflicts: [
+  "integers" {< "0.3.0"}
+]
 build: [
   make
 ]

--- a/packages/yices2_bindings/yices2_bindings.0.2/opam
+++ b/packages/yices2_bindings/yices2_bindings.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "containers"  {>= "3.0.0"}
-  "ctypes" {>= "0.7.0"}
+  "ctypes" {>= "0.12.0"}
   "ctypes-foreign"
   "ppx_deriving"
   "ppx_optcomp"


### PR DESCRIPTION
This is where SInt has been introduced. Seen on https://github.com/ocaml/opam-repository/pull/18913

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>