### PR TITLE
integers < 0.3.0: Add missing conflict

### DIFF
--- a/packages/integers/integers.0.1.0/opam
+++ b/packages/integers/integers.0.1.0/opam
@@ -13,7 +13,7 @@ build:
            "--pinned" "%{pinned}%"]]
 depends: [
   "ocaml"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}
 ]

--- a/packages/integers/integers.0.2.0/opam
+++ b/packages/integers/integers.0.2.0/opam
@@ -13,7 +13,7 @@ build:
            "--pinned" "%{pinned}%"]]
 depends: [
   "ocaml"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}
 ]

--- a/packages/integers/integers.0.2.1/opam
+++ b/packages/integers/integers.0.2.1/opam
@@ -13,7 +13,7 @@ build:
            "--pinned" "%{pinned}%"]]
 depends: [
   "ocaml"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}
 ]

--- a/packages/integers/integers.0.2.2/opam
+++ b/packages/integers/integers.0.2.2/opam
@@ -13,7 +13,7 @@ build:
            "--pinned" "%{pinned}%"]]
 depends: [
   "ocaml"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}
 ]


### PR DESCRIPTION
ocamlbuild.0.9.0 has a known bug with C bindings
Detected in https://github.com/ocaml/opam-repository/pull/18913
```
#=== ERROR while compiling integers.0.1.0 =====================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///src
# path                 ~/.opam/4.03/.opam-switch/build/integers.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false
# exit-code            1
# env-file             ~/.opam/log/integers-23-7c2d8f.env
# output-file          ~/.opam/log/integers-23-7c2d8f.out
### output ###
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/4.03/lib/ocamlbuild /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamlc -g -c -o src/unsigned_stubs.o src/unsigned_stubs.c
# ocamlfind ocamlmklib -o src/integers src/unsigned_stubs.o
# + ocamlfind ocamlmklib -o src/integers src/unsigned_stubs.o
# gcc: error: src/unsigned_stubs.o: No such file or directory
# gcc: fatal error: no input files
# compilation terminated.
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ["ocamlbuild"; "-use-ocamlfind"; "-classic-display"; "-build-dir";
#      "_build"; "opam"; "pkg/META"; "CHANGES.md"; "LICENSE.md"; "README.md";
#      "src/integers.a"; "src/integers.cmxs"; "src/integers.cmxa";
#      "src/integers.cma"; "src/unsigned.cmx"; "src/unsigned.cmi";
#      "src/unsigned.mli"; "src/signed.cmx"; "src/signed.cmi";
#      "src/signed.mli"; "src/dllintegers.so"; "src/libintegers.a";
#      "top/integer_printers.a"; "top/integer_printers.cmxs";
#      "top/integer_printers.cmxa"; "top/integer_printers.cma";
#      "top/install_integer_printers.cmx"; "top/install_integer_printers.cmi";
#      "top/install_integer_printers.mli"; "top/integer_printers.cmx";
#      "top/integer_printers.cmi"; "top/integer_printers.mli";
#      "src/ocaml_integers.h"]: exited with 10
```