### PR TITLE
ocaml-r needs a recent version of alcotest

### DIFF
--- a/packages/ocaml-r/ocaml-r.0.4.0/opam
+++ b/packages/ocaml-r/ocaml-r.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conf-r-mathlib" {build}
   "dune" {>= "2.5"}
   "stdio" {>= "v0.14" & build}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.2.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
otherwise it fails with:

```
 File "tests/conversions.ml", line 60, characters 14-20:
 60 |     Alcotest.(check' (array (float 0.000001)))
                    ^^^^^^
 Error: Unbound value check'
 Hint: Did you mean check?
```