### PR TITLE
jekyll-format.0.2.0: Add missing test constraint (uses Yaml.equal)

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.2.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.2.0/opam
@@ -19,6 +19,7 @@ depends: [
   "ptime"
   "fpath"
   "yaml"
+  "yaml" {with-test & >= "2.0.0"}
   "ezjsonm" {>= "1.1.0"}
   "alcotest" {with-test}
   "bos" {with-test}


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18913
```
#=== ERROR while compiling jekyll-format.0.2.0 ================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///src
# path                 ~/.opam/4.12/.opam-switch/build/jekyll-format.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p jekyll-format -j 47 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/jekyll-format-1800-63c1fe.env
# output-file          ~/.opam/log/jekyll-format-1800-63c1fe.out
### output ###
#       ocamlc test/.test.eobjs/byte/dune__exe__Test.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -32 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/4.12/lib/alcotest -I /home/opam/.opam/4.12/lib/alcotest/engine -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base/caml -I /home/opam/.opam/4.12/lib/bigarray-compat -I /home/opam/.opam/4.12/lib/bos -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/cstruct -I /home/opam/.opam/4.12/lib/ctypes -I /home/opam/.opam/4.12/lib/ezjsonm -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/fpath -I /home/opam/.opam/4.12/lib/hex -I /home/opam/.opam/4.12/lib/integers -I /home/opam/.opam/4.12/lib/jsonm -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/omd -I /home/opam/.opam/4.12/lib/parsexp -I /home/opam/.opam/4.12/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.12/lib/ptime -I /home/opam/.opam/4.12/lib/re -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/rresult -I /home/opam/.opam/4.12/lib/seq -I /home/opam/.opam/4.12/lib/sexplib -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uuidm -I /home/opam/.opam/4.12/lib/uutf -I /home/opam/.opam/4.12/lib/yaml -I /home/opam/.opam/4.12/lib/yaml/bindings -I /home/opam/.opam/4.12/lib/yaml/bindings/types -I /home/opam/.opam/4.12/lib/yaml/c -I /home/opam/.opam/4.12/lib/yaml/ffi -I /home/opam/.opam/4.12/lib/yaml/types -I src/.jekyll_format.objs/byte -no-alias-deps -o test/.test.eobjs/byte/dune__exe__Test.cmo -c -impl test/test.ml)
# File "test/test.ml", line 76, characters 30-40:
# 76 |   let yaml = testable Yaml.pp Yaml.equal in
#                                    ^^^^^^^^^^
# Error: Unbound value Yaml.equal
```
cc @avsm @patricoferris 