### PR TITLE
ppx_deriving_yaml: Add missing test constraint (uses Yaml.equal)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.08.1"}
   "ppxlib" {>= "0.14.0"}
   "yaml"
+  "yaml" {with-test & >= "2.0.0"}
   "rresult"
 ]
 build: [


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18913
```
#=== ERROR while compiling ppx_deriving_yaml.0.1.0 ============================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///src
# path                 ~/.opam/4.12/.opam-switch/build/ppx_deriving_yaml.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_deriving_yaml -j 47 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/ppx_deriving_yaml-2985-442ed9.env
# output-file          ~/.opam/log/ppx_deriving_yaml-2985-442ed9.out
### output ###
#       ocamlc test/.test.eobjs/byte/dune__exe__Test.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/4.12/lib/alcotest -I /home/opam/.opam/4.12/lib/alcotest/engine -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base/caml -I /home/opam/.opam/4.12/lib/bigarray-compat -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/ctypes -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/integers -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/parsexp -I /home/opam/.opam/4.12/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.12/lib/re -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/rresult -I /home/opam/.opam/4.12/lib/seq -I /home/opam/.opam/4.12/lib/sexplib -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uuidm -I /home/opam/.opam/4.12/lib/uutf -I /home/opam/.opam/4.12/lib/yaml -I /home/opam/.opam/4.12/lib/yaml/bindings -I /home/opam/.opam/4.12/lib/yaml/bindings/types -I /home/opam/.opam/4.12/lib/yaml/c -I /home/opam/.opam/4.12/lib/yaml/ffi -I /home/opam/.opam/4.12/lib/yaml/types -no-alias-deps -o test/.test.eobjs/byte/dune__exe__Test.cmo -c -impl test/test.pp.ml)
# File "test/test.ml", line 1, characters 37-47:
# 1 | let yaml = Alcotest.testable Yaml.pp Yaml.equal
#                                          ^^^^^^^^^^
# Error: Unbound value Yaml.equal

-       ocamlc test/.test.eobjs/byte/dune__exe__Test.{cmi,cmo,cmt} (exit 2)
- (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/4.12/lib/alcotest -I /home/opam/.opam/4.12/lib/alcotest/engine -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base/caml -I /home/opam/.opam/4.12/lib/bigarray-compat -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/ctypes -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/integers -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/parsexp -I /home/opam/.opam/4.12/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.12/lib/re -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/rresult -I /home/opam/.opam/4.12/lib/seq -I /home/opam/.opam/4.12/lib/sexplib -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uuidm -I /home/opam/.opam/4.12/lib/uutf -I /home/opam/.opam/4.12/lib/yaml -I /home/opam/.opam/4.12/lib/yaml/bindings -I /home/opam/.opam/4.12/lib/yaml/bindings/types -I /home/opam/.opam/4.12/lib/yaml/c -I /home/opam/.opam/4.12/lib/yaml/ffi -I /home/opam/.opam/4.12/lib/yaml/types -no-alias-deps -o test/.test.eobjs/byte/dune__exe__Test.cmo -c -impl test/test.pp.ml)
- File "test/test.ml", line 1, characters 37-47:
- 1 | let yaml = Alcotest.testable Yaml.pp Yaml.equal
-                                          ^^^^^^^^^^
- Error: Unbound value Yaml.equal
```
cc @patricoferris 