### PR TITLE
user-agent-parser: Add missing test constraint

### DIFF
--- a/packages/user-agent-parser/user-agent-parser.0.1.3/opam
+++ b/packages/user-agent-parser/user-agent-parser.0.1.3/opam
@@ -17,6 +17,7 @@ depends: [
   "stdio" {>= "v0.11"}
   "re" {>= "1.8.0"}
   "yaml" {build & >= "0.2.1"}
+  "yaml" {with-test & >= "2.0.0"}
   "yojson" {>= "1.6.0"}
 ]
 description: """

--- a/packages/user-agent-parser/user-agent-parser.0.2.0/opam
+++ b/packages/user-agent-parser/user-agent-parser.0.2.0/opam
@@ -17,6 +17,7 @@ depends: [
   "stdio" {>= "v0.11"}
   "re" {>= "1.8.0"}
   "yaml" {build & >= "0.2.1"}
+  "yaml" {with-test & >= "2.0.0"}
   "yojson" {>= "1.6.0"}
 ]
 description: """


### PR DESCRIPTION
The tests expect "x: '1'\n" to be parsed as a string not as a float
Detected in https://github.com/ocaml/opam-repository/pull/18913
```
#=== ERROR while compiling user-agent-parser.0.2.0 ============================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///src
# path                 ~/.opam/4.12/.opam-switch/build/user-agent-parser.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p user-agent-parser -j 47
# exit-code            1
# env-file             ~/.opam/log/user-agent-parser-1446-3f4211.env
# output-file          ~/.opam/log/user-agent-parser-1446-3f4211.out
### output ###
#         test alias test/runtest (exit 2)
# (cd _build/default/test && ./test.exe --json --color=always)
# Fatal error: exception (Failure "bad test case json")
# Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
# Called from Base__List.Assoc.map.(fun) in file "src/list.ml", line 922, characters 52-59
# Called from Base__List.count_map in file "src/list.ml", line 402, characters 13-17
# Called from Base__List.count_map in file "src/list.ml", line 405, characters 13-17
# Called from Base__List.count_map in file "src/list.ml", line 415, characters 47-72
# Called from Test.generate_device_test_cases in file "test/test.ml", line 74, characters 11-64
# Called from Test in file "test/test.ml", line 96, characters 22-51

-         test alias test/runtest (exit 2)
- (cd _build/default/test && ./test.exe --json --color=always)
- Fatal error: exception (Failure "bad test case json")
- Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
- Called from Base__List.Assoc.map.(fun) in file "src/list.ml", line 922, characters 52-59
- Called from Base__List.count_map in file "src/list.ml", line 402, characters 13-17
- Called from Base__List.count_map in file "src/list.ml", line 405, characters 13-17
- Called from Base__List.count_map in file "src/list.ml", line 415, characters 47-72
- Called from Test.generate_device_test_cases in file "test/test.ml", line 74, characters 11-64
- Called from Test in file "test/test.ml", line 96, characters 22-51
```
cc @guandai 