### PR TITLE
ocp-build does not support the seq compatibility package in some cases

### DIFF
--- a/packages/ocp-build/ocp-build.1.99.21/opam
+++ b/packages/ocp-build/ocp-build.1.99.21/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.12"}
-  ("ocaml" {>= "4.07.0"} | "seq" & "ocaml")
+  ("seq" {>= "base"} & "ocaml" {>= "4.07.0"} | "seq" & "ocaml")
   "ocamlfind"
   "cmdliner" {>= "1"}
   "re" {>= "1.7.3"}


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/18922
I've looked into the code and can't find why but the result is that on OCaml >= 4.07 we get:
```
# ocamlopt.opt -o boot/ocp-build.asm unix.cmxa str.cmxa /home/opam/.opam/4.08/lib/cmdliner/cmdliner.cmxa  /home/opam/.opam/4.08/lib/re/re.cmxa libs/ocplib-compat/string-compat/ocpCompat.cmx libs/ezcmd/ezcmd.cmx libs/ocplib-debug/ocpDebug.cmx libs/ocplib-lang/ocpList.cmx libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpArray.cmx libs/ocplib-lang/ocpDigest.cmx libs/ocplib-lang/ocpToposort.cmx libs/ocplib-lang/ocamllexer.cmx libs/ocplib-lang/ocpGenlex.cmx libs/ocplib-lang/ocpSubst.cmx libs/ocplib-lang/ocpReuse.cmx libs/ocplib-maxunix/minUnix.cmx libs/ocplib-maxunix/onlyUnix.cmx libs/ocplib-maxunix/onlyWin32.cmx libs/ocplib-file/fileSel.cmx libs/ocplib-file/fileSig.cmx libs/ocplib-file/fileOS.cmx libs/ocplib-file/fileDirMaker.cmx libs/ocplib-file/fileChannel.cmx libs/ocplib-file/fileString.cmx libs/ocplib-file/fileGen.cmx libs/ocplib-config/simpleConfigTypes.cmx libs/ocplib-config/simpleConfigOCaml.cmx libs/ocplib-config/simpleConfig.cmx tools/ocp-build/misc/logger.cmx tools/ocp-build/misc/buildMisc.cmx tools/ocp-build/misc/buildWarnings.cmx tools/ocp-build/misc/buildMtime.cmx tools/ocp-build/misc/buildScanner.cmx tools/ocp-build/misc/buildSubst.cmx tools/ocp-build/misc/buildFind.cmx tools/ocp-build/misc/buildTerm.cmx tools/ocp-build/misc/versioning.cmx tools/ocp-build/misc/ocamldot.cmx tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/lang-ocp/buildOCPTree.cmx tools/ocp-build/lang-ocp/buildOCPParser.cmx tools/ocp-build/lang-ocp/buildOCPParse.cmx tools/ocp-build/lang-ocp/buildOCPPrims.cmx tools/ocp-build/lang-ocp/buildOCPInterp.cmx tools/ocp-build/lang-ocp2/buildOCP2Tree.cmx tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmx tools/ocp-build/lang-ocp2/buildOCP2Parser.cmx tools/ocp-build/lang-ocp2/buildOCP2Parse.cmx tools/ocp-build/lang-ocp2/buildOCP2Prims.cmx tools/ocp-build/lang-ocp2/buildOCP2Interp.cmx tools/ocp-build/buildOCPPrinter.cmx tools/ocp-build/buildOCP.cmx tools/ocp-build/engine/buildEngineTypes.cmx tools/ocp-build/engine/buildEngineGlobals.cmx tools/ocp-build/engine/buildEngineRules.cmx tools/ocp-build/engine/buildEngineContext.cmx tools/ocp-build/engine/buildEngineDisplay.cmx tools/ocp-build/engine/buildEngineReport.cmx tools/ocp-build/engine/buildEngine.cmx tools/ocp-build/ocaml/buildObjectInspector.cmx tools/ocp-build/buildVersion.cmx tools/ocp-build/buildTypes.cmx tools/ocp-build/buildOptions.cmx tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildConfig.cmx tools/ocp-build/buildUninstall.cmx tools/ocp-build/buildDepMisc.cmx tools/ocp-build/meta/metaTypes.cmx tools/ocp-build/meta/metaLexer.cmx tools/ocp-build/meta/metaParser.cmx tools/ocp-build/meta/metaFile.cmx tools/ocp-build/meta/metaConfig.cmx tools/ocp-build/ocaml/buildOCamlConfig.cmx tools/ocp-build/ocaml/buildOCamlTypes.cmx tools/ocp-build/ocaml/buildOCamlMisc.cmx tools/ocp-build/ocaml/buildOCamlVariables.cmx tools/ocp-build/ocaml/buildOCamlGlobals.cmx tools/ocp-build/ocaml/buildOCamldep.cmx tools/ocp-build/ocaml/buildOCamlSyntaxes.cmx tools/ocp-build/ocaml/buildOCamlInstall.cmx tools/ocp-build/ocaml/buildOCamlDotReport.cmx tools/ocp-build/ocaml/buildOCamlVerifyPackages.cmx tools/ocp-build/ocaml/buildOCamlOCP2.cmx tools/ocp-build/ocaml/buildOCamlRules.cmx tools/ocp-build/ocaml/buildOCamlMeta.cmx tools/ocp-build/ocaml/buildOCamlTest.cmx tools/ocp-build/ocaml/buildOasis.cmx tools/ocp-build/ocaml/buildOCamlPlugin.cmx tools/ocp-build/actions/buildArgs.cmx tools/ocp-build/actions/buildActions.cmx tools/ocp-build/actions/buildActionsWarnings.cmx tools/ocp-build/actions/buildActionConfigure.cmx tools/ocp-build/actions/buildActionInit.cmx tools/ocp-build/actions/buildActionCheck.cmx tools/ocp-build/actions/buildActionPrefs.cmx tools/ocp-build/actions/buildActionMake.cmx tools/ocp-build/actions/buildActionInstall.cmx tools/ocp-build/actions/buildActionClean.cmx tools/ocp-build/actions/buildActionTests.cmx tools/ocp-build/actions/buildActionUninstall.cmx tools/ocp-build/actions/buildActionQuery.cmx tools/ocp-build/buildMain.cmx libs/ocplib-unix/minUnix_c.o libs/ocplib-unix/onlyWin32_c.o libs/ocplib-unix/onlyUnix_c.o
# File "_none_", line 1:
# Error: No implementations provided for the following modules:
#          Seq referenced from /home/opam/.opam/4.08/lib/re/re.cmxa(Re__Core)
# make[1]: *** [Makefile:219: create-booter] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.08/.opam-switch/build/ocp-build.1.99.21'
# make: *** [Makefile:215: boot/ocp-build.asm] Error 2
```
but on OCaml 4.06 it builds successfully:
```
- ocamlopt.opt -o boot/ocp-build.asm unix.cmxa str.cmxa /home/opam/.opam/4.06/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/4.06/lib/seq/seq.cmxa /home/opam/.opam/4.06/lib/re/re.cmxa libs/ocplib-compat/string-compat/ocpCompat.cmx libs/ezcmd/ezcmd.cmx libs/ocplib-debug/ocpDebug.cmx libs/ocplib-lang/ocpList.cmx libs/ocplib-lang/ocpString.cmx libs/ocplib-lang/ocpArray.cmx libs/ocplib-lang/ocpDigest.cmx libs/ocplib-lang/ocpToposort.cmx libs/ocplib-lang/ocamllexer.cmx libs/ocplib-lang/ocpGenlex.cmx libs/ocplib-lang/ocpSubst.cmx libs/ocplib-lang/ocpReuse.cmx libs/ocplib-maxunix/minUnix.cmx libs/ocplib-maxunix/onlyUnix.cmx libs/ocplib-maxunix/onlyWin32.cmx libs/ocplib-file/fileSel.cmx libs/ocplib-file/fileSig.cmx libs/ocplib-file/fileOS.cmx libs/ocplib-file/fileDirMaker.cmx libs/ocplib-file/fileChannel.cmx libs/ocplib-file/fileString.cmx libs/ocplib-file/fileGen.cmx libs/ocplib-config/simpleConfigTypes.cmx libs/ocplib-config/simpleConfigOCaml.cmx libs/ocplib-config/simpleConfig.cmx tools/ocp-build/misc/logger.cmx tools/ocp-build/misc/buildMisc.cmx tools/ocp-build/misc/buildWarnings.cmx tools/ocp-build/misc/buildMtime.cmx tools/ocp-build/misc/buildScanner.cmx tools/ocp-build/misc/buildSubst.cmx tools/ocp-build/misc/buildFind.cmx tools/ocp-build/misc/buildTerm.cmx tools/ocp-build/misc/versioning.cmx tools/ocp-build/misc/ocamldot.cmx tools/ocp-build/buildValue.cmx tools/ocp-build/buildOCPTypes.cmx tools/ocp-build/lang-ocp/buildOCPTree.cmx tools/ocp-build/lang-ocp/buildOCPParser.cmx tools/ocp-build/lang-ocp/buildOCPParse.cmx tools/ocp-build/lang-ocp/buildOCPPrims.cmx tools/ocp-build/lang-ocp/buildOCPInterp.cmx tools/ocp-build/lang-ocp2/buildOCP2Tree.cmx tools/ocp-build/lang-ocp2/buildOCP2Lexer.cmx tools/ocp-build/lang-ocp2/buildOCP2Parser.cmx tools/ocp-build/lang-ocp2/buildOCP2Parse.cmx tools/ocp-build/lang-ocp2/buildOCP2Prims.cmx tools/ocp-build/lang-ocp2/buildOCP2Interp.cmx tools/ocp-build/buildOCPPrinter.cmx tools/ocp-build/buildOCP.cmx tools/ocp-build/engine/buildEngineTypes.cmx tools/ocp-build/engine/buildEngineGlobals.cmx tools/ocp-build/engine/buildEngineRules.cmx tools/ocp-build/engine/buildEngineContext.cmx tools/ocp-build/engine/buildEngineDisplay.cmx tools/ocp-build/engine/buildEngineReport.cmx tools/ocp-build/engine/buildEngine.cmx tools/ocp-build/ocaml/buildObjectInspector.cmx tools/ocp-build/buildVersion.cmx tools/ocp-build/buildTypes.cmx tools/ocp-build/buildOptions.cmx tools/ocp-build/buildGlobals.cmx tools/ocp-build/buildConfig.cmx tools/ocp-build/buildUninstall.cmx tools/ocp-build/buildDepMisc.cmx tools/ocp-build/meta/metaTypes.cmx tools/ocp-build/meta/metaLexer.cmx tools/ocp-build/meta/metaParser.cmx tools/ocp-build/meta/metaFile.cmx tools/ocp-build/meta/metaConfig.cmx tools/ocp-build/ocaml/buildOCamlConfig.cmx tools/ocp-build/ocaml/buildOCamlTypes.cmx tools/ocp-build/ocaml/buildOCamlMisc.cmx tools/ocp-build/ocaml/buildOCamlVariables.cmx tools/ocp-build/ocaml/buildOCamlGlobals.cmx tools/ocp-build/ocaml/buildOCamldep.cmx tools/ocp-build/ocaml/buildOCamlSyntaxes.cmx tools/ocp-build/ocaml/buildOCamlInstall.cmx tools/ocp-build/ocaml/buildOCamlDotReport.cmx tools/ocp-build/ocaml/buildOCamlVerifyPackages.cmx tools/ocp-build/ocaml/buildOCamlOCP2.cmx tools/ocp-build/ocaml/buildOCamlRules.cmx tools/ocp-build/ocaml/buildOCamlMeta.cmx tools/ocp-build/ocaml/buildOCamlTest.cmx tools/ocp-build/ocaml/buildOasis.cmx tools/ocp-build/ocaml/buildOCamlPlugin.cmx tools/ocp-build/actions/buildArgs.cmx tools/ocp-build/actions/buildActions.cmx tools/ocp-build/actions/buildActionsWarnings.cmx tools/ocp-build/actions/buildActionConfigure.cmx tools/ocp-build/actions/buildActionInit.cmx tools/ocp-build/actions/buildActionCheck.cmx tools/ocp-build/actions/buildActionPrefs.cmx tools/ocp-build/actions/buildActionMake.cmx tools/ocp-build/actions/buildActionInstall.cmx tools/ocp-build/actions/buildActionClean.cmx tools/ocp-build/actions/buildActionTests.cmx tools/ocp-build/actions/buildActionUninstall.cmx tools/ocp-build/actions/buildActionQuery.cmx tools/ocp-build/buildMain.cmx libs/ocplib-unix/minUnix_c.o libs/ocplib-unix/onlyWin32_c.o libs/ocplib-unix/onlyUnix_c.o
- make[1]: Leaving directory '/home/opam/.opam/4.06/.opam-switch/build/ocp-build.1.99.21'
```
Notice the missing `/home/opam/.opam/4.06/lib/seq/seq.cmxa` from the first (failing) command.
cc @lefessan 