### PR TITLE
[new release] terminal and progress (0.2.0)

### DIFF
--- a/packages/index-bench/index-bench.1.4.0/opam
+++ b/packages/index-bench/index-bench.1.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mtime"
   "logs" {>= "0.7.0"}
   "optint" {>= "0.1.0" & with-test}
-  "progress" {>= "0.1.1"}
+  "progress" {>= "0.1.1" & < "0.2.0"}
   "repr" {>= "0.2.1" & with-test}
   "rusage" {>= "1.0.0" & with-test}
 ]

--- a/packages/index/index.1.3.0/opam
+++ b/packages/index/index.1.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
   "cmdliner"
-  "progress" {>= "0.1.1"}
+  "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"
   "stdlib-shims"

--- a/packages/index/index.1.3.1/opam
+++ b/packages/index/index.1.3.1/opam
@@ -27,7 +27,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
   "cmdliner"
-  "progress" {>= "0.1.1"}
+  "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"
   "stdlib-shims"

--- a/packages/index/index.1.4.0/opam
+++ b/packages/index/index.1.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
   "cmdliner"
-  "progress" {>= "0.1.1"}
+  "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"
   "stdlib-shims"

--- a/packages/irmin-bench/irmin-bench.2.3.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr" {>= "0.2.0"}
   "ppx_repr"
 ]

--- a/packages/irmin-bench/irmin-bench.2.4.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.5.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.5.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.5.1/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.1/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.5.1/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.1/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.5.2/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.2/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.5.2/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.2/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.5.3/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.3/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.5.3/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.3/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.5.4/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.4/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.5.4/opam
+++ b/packages/irmin-bench/irmin-bench.2.5.4/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.6.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.6.0/opam
+++ b/packages/irmin-bench/irmin-bench.2.6.0/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/irmin-bench/irmin-bench.2.6.1/opam
+++ b/packages/irmin-bench/irmin-bench.2.6.1/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "yojson"
-  "memtrace"
+  "memtrace" {>= "0.1.1"}
   "repr"         {>= "0.2.0"}
   "ppx_repr"
   "re"           {>= "1.9.0"}

--- a/packages/irmin-bench/irmin-bench.2.6.1/opam
+++ b/packages/irmin-bench/irmin-bench.2.6.1/opam
@@ -29,7 +29,7 @@ depends: [
   "fmt"
   "bentov"
   "uuidm"
-  "progress"
+  "progress" {< "0.2.0"}
   "mtime"
 ]
 

--- a/packages/progress/progress.0.2.0/opam
+++ b/packages/progress/progress.0.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "User-definable progress bars"
+description: """
+A progress bar library for OCaml, featuring a DSL for declaratively specifying
+progress bar formats. Supports rendering multiple progress bars simultaneously."""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "terminal" {= version}
+  "fmt" {>= "0.8.4"}
+  "logs" {>= "0.7.0"}
+  "mtime" {>= "1.1.0"}
+  "uucp"
+  "uutf"
+  "vector"
+  "optint" {>= "0.1.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "astring" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+x-commit-hash: "1813dac3859e88fa354e2ecad5cd9192e95e7761"
+url {
+  src:
+    "https://github.com/CraigFe/progress/releases/download/0.2.0/terminal-0.2.0.tbz"
+  checksum: [
+    "sha256=7a92f6aede3d5010a30e6e47ccbc8380cc5bece8ac95c508323eb25272e6ddd3"
+    "sha512=a2ccea467e2d0e419b569992102bd2c43ff97b47f7f8413ee8fbe775ce369a80ff11e0a8fd450ebf1776f7c65baf2482076a120318c9d818488ceba0b9196639"
+  ]
+}

--- a/packages/progress/progress.0.2.0/opam
+++ b/packages/progress/progress.0.2.0/opam
@@ -13,11 +13,11 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
   "terminal" {= version}
-  "fmt" {>= "0.8.4"}
+  "fmt" {>= "0.8.5"}
   "logs" {>= "0.7.0"}
   "mtime" {>= "1.1.0"}
-  "uucp"
-  "uutf"
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
   "vector"
   "optint" {>= "0.1.0"}
   "alcotest" {with-test & >= "1.4.0"}

--- a/packages/terminal/terminal.0.2.0/opam
+++ b/packages/terminal/terminal.0.2.0/opam
@@ -10,8 +10,8 @@ bug-reports: "https://github.com/CraigFe/progress/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03.0"}
-  "uucp" {>= "1.1.0"}
-  "uutf"
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
   "stdlib-shims"
   "alcotest" {with-test & >= "1.4.0"}
   "fmt" {with-test}

--- a/packages/terminal/terminal.0.2.0/opam
+++ b/packages/terminal/terminal.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Basic utilities for interacting with terminals"
+description: "Basic utilities for interacting with terminals"
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "uucp" {>= "1.1.0"}
+  "uutf"
+  "stdlib-shims"
+  "alcotest" {with-test & >= "1.4.0"}
+  "fmt" {with-test}
+  "astring" {with-test}
+  "mtime" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+x-commit-hash: "1813dac3859e88fa354e2ecad5cd9192e95e7761"
+url {
+  src:
+    "https://github.com/CraigFe/progress/releases/download/0.2.0/terminal-0.2.0.tbz"
+  checksum: [
+    "sha256=7a92f6aede3d5010a30e6e47ccbc8380cc5bece8ac95c508323eb25272e6ddd3"
+    "sha512=a2ccea467e2d0e419b569992102bd2c43ff97b47f7f8413ee8fbe775ce369a80ff11e0a8fd450ebf1776f7c65baf2482076a120318c9d818488ceba0b9196639"
+  ]
+}


### PR DESCRIPTION
Basic utilities for interacting with terminals

- Project page: <a href="https://github.com/CraigFe/progress">https://github.com/CraigFe/progress</a>
- Documentation: <a href="https://CraigFe.github.io/progress/">https://CraigFe.github.io/progress/</a>

##### CHANGES:

Major update of the API, including a number of new features:

- Rename the `Segment` module to `Line`, and improve the set of primitives for
  progress bar construction significantly. This includes time-sensitive segments
  (e.g `bytes_per_sec`, `eta`) and padding segments (`lpad` and `rpad`).
- Add `Progress.interject_with` for interleaving logging with rendering, and
  functions for using `Progress` with `Logs` reporters.
- Add support for adding lines to an ongoing rendering process via `Display`.
- Improve the behaviour of the rendering core: handle terminal width changes /
  respond to user input etc. more cleanly.
- Add many more examples and general improvements to the documentation.
- Extract terminal-specific utilities to a new `Terminal` package.

Also contains a number of smaller fixes:

- Fix the display of minutes and seconds of `Progress.Units.seconds` and
  `Progress_unix.counter`. (CraigFe/progress#6, @Ngoguey42)
- Raise an exception when attempting to run separate render processes
  simultaneously. (CraigFe/progress#8, @CraigFe)
