### PR TITLE
Package http-multipart-formdata.2.0.0

### DIFF
--- a/packages/http-multipart-formdata/http-multipart-formdata.2.0.0/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.2.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Http multipart/formdata parser"
+description:
+  "OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem, <gbikal@gmail.com>"]
+license: "MPL-2.0"
+tags: ["http" "multipart" "formadata" "form" "web"]
+homepage: "https://github.com/lemaetech/http-mutlipart-formdata"
+bug-reports: "https://github.com/lemaetech/http-mutlipart-formdata/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "fmt"
+  "lwt"
+  "reparse" {>= "3.0.0"}
+  "reparse-lwt" {>= "3.0.0"}
+  "reparse-lwt-unix" {>= "3.0.0"}
+  "ppx_expect" {with-test}
+  "ppx_deriving" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-mutlipart-formdata.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-mutlipart-formdata/archive/v2.0.0.tar.gz"
+  checksum: [
+    "md5=45ed5a9452e3ddc6906870d53817abce"
+    "sha512=eaf893f5a14d77716eb6ebf49b629e2b06573f2a6ff9999dcc7c957187404f3ae1ea2cf5a7a84becfc341e1cf89898d083e6a2645b07795dd8a35b71ecbf3e65"
+  ]
+}


### PR DESCRIPTION
### `http-multipart-formdata.2.0.0`
Http multipart/formdata parser
OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578



---
* Homepage: https://github.com/lemaetech/http-mutlipart-formdata
* Source repo: git+https://github.com/lemaetech/http-mutlipart-formdata.git
* Bug tracker: https://github.com/lemaetech/http-mutlipart-formdata/issues

---
:camel: Pull-request generated by opam-publish v2.0.3