### PR TITLE
mirage-clock-*.0.9.9 are incompatible with mirage-clock

### DIFF
--- a/packages/mirage-clock-unix/mirage-clock-unix.0.9.9/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.0.9.9/opam
@@ -7,6 +7,10 @@ tags: [
 build: [make "unix-build"]
 remove: ["ocamlfind" "remove" "mirage-clock-unix"]
 depends: ["ocaml" "ocamlfind" "cstruct" "ocamlbuild" {build}]
+conflicts: [
+  "mirage-clock" # overwrites the mirage-clock library
+  "mirage-clock-xen" {< "1.0.0"} # also overwrites the mirage-clock library (same source)
+]
 dev-repo: "git://github.com/mirage/mirage-clock"
 install: [make "unix-install"]
 synopsis: "A Mirage-compatible Clock library for Unix"

--- a/packages/mirage-clock-xen/mirage-clock-xen.0.9.9/opam
+++ b/packages/mirage-clock-xen/mirage-clock-xen.0.9.9/opam
@@ -7,6 +7,10 @@ tags: [
 build: [make "xen-build"]
 remove: ["ocamlfind" "remove" "mirage-clock-xen"]
 depends: ["ocaml" "ocamlfind" "cstruct" "ocamlbuild" {build}]
+conflicts: [
+  "mirage-clock" # overwrites the mirage-clock library
+  "mirage-clock-unix" {< "1.0.0"} # also overwrites the mirage-clock library (same source)
+]
 dev-repo: "git://github.com/mirage/mirage-clock"
 install: [make "xen-install"]
 synopsis: "A Mirage-compatible Clock library for Xen"


### PR DESCRIPTION
 Those version are in fact uninstalling then installing a mirage-clock library
The build script:
```
ocamlbuild -use-ocamlfind -pkg cstruct ${OS}/mirage-clock.cma ${OS}/mirage-clock.cmxa ${OS}/mirage-clock.cmxs

B=_build/${OS}
if [ "$1" = "true" ]; then
  ocamlfind remove mirage-clock || true
  ocamlfind install mirage-clock ${OS}/META \
    $B/clock.cmo $B/clock.cmi $B/mirage-clock.cma \
    $B/mirage-clock.a $B/clock.cmx $B/mirage-clock.cmxa $B/mirage-clock.cmxs
```
Detected in #18907 