### PR TITLE
2 packages from LesBoloss-es/xoshiro at 0.1

### DIFF
--- a/packages/make-random/make-random.0.1/opam
+++ b/packages/make-random/make-random.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Helper to build a module similar to Stdlib.Random"
+description: """
+This package provides helpers to build a module similar to the
+  Random module of the standard library, by providing only a minimum amount of
+  things (in the simplest case, only a `val bits : unit -> int` function)."""
+maintainer: ["Niols “Niols” Jeannerod <niols@niols.fr>"]
+authors: [
+  "Niols “Niols” Jeannerod <niols@niols.fr>"
+  "Martin Pépin <kerl@wkerl.me>"
+]
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/LesBoloss-es/xoshiro"
+doc: "https://lesboloss-es.github.io/xoshiro/"
+bug-reports: "https://github.com/LesBoloss-es/xoshiro/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LesBoloss-es/xoshiro.git"
+url {
+  src: "https://github.com/LesBoloss-es/xoshiro/archive/0.1.tar.gz"
+  checksum: [
+    "md5=189dfb19a24fea0fdfe9627e419eb55d"
+    "sha512=ee9ced16ea5ede0e567522e8d82e35f27924c9b922bcd342dc8becb3cf4f176b79ab77e30bf472ce61642e879552d309506b5652f411455023cb9aef5162d2ca"
+  ]
+}

--- a/packages/xoshiro/xoshiro.0.1/opam
+++ b/packages/xoshiro/xoshiro.0.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Xoshiro PRNGs as drop-in replacements for Stdlib.Random"
+description: """
+This package provides the Xoshiro family of pseudo-random
+  number generators for OCaml, with an interface mimmicing that of the standard
+  library. The Xoshiro generator are not cryptographically safe, but they
+  provide better randomness than the standard library.
+
+  By default, this package comes as C bindings for efficiency. If bindings are
+  not welcome (eg. to compile to JS), one may depend on xoshiro.pure instead,
+  providing the exact same interface, implemented as pure OCaml."""
+maintainer: ["Niols “Niols” Jeannerod <niols@niols.fr>"]
+authors: [
+  "Niols “Niols” Jeannerod <niols@niols.fr>"
+  "Martin Pépin <kerl@wkerl.me>"
+]
+license: "LGPL-3.0-or-later"
+homepage: "https://github.com/LesBoloss-es/xoshiro"
+doc: "https://lesboloss-es.github.io/xoshiro/"
+bug-reports: "https://github.com/LesBoloss-es/xoshiro/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "make-random"
+  "base-bigarray"
+  "core_bench" {with-test}
+  "testu01" {with-test & >= "1.2.3-0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LesBoloss-es/xoshiro.git"
+url {
+  src: "https://github.com/LesBoloss-es/xoshiro/archive/0.1.tar.gz"
+  checksum: [
+    "md5=189dfb19a24fea0fdfe9627e419eb55d"
+    "sha512=ee9ced16ea5ede0e567522e8d82e35f27924c9b922bcd342dc8becb3cf4f176b79ab77e30bf472ce61642e879552d309506b5652f411455023cb9aef5162d2ca"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`make-random.0.1`: Helper to build a module similar to Stdlib.Random
-`xoshiro.0.1`: Xoshiro PRNGs as drop-in replacements for Stdlib.Random



---
* Homepage: https://github.com/LesBoloss-es/xoshiro
* Source repo: git+https://github.com/LesBoloss-es/xoshiro.git
* Bug tracker: https://github.com/LesBoloss-es/xoshiro/issues

---
:camel: Pull-request generated by opam-publish v2.0.3