### PR TITLE
Package embedded_ocaml_templates.0.7

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.7/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.7/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "EML is a simple templating language that lets you generate text with plain OCaml"
+description: """
+Inspired by EJS templates, it does currently implements all of its functionnality.
+I plan to implement everything eventually, especially if someone actually want to use this.
+Please contact me if you find this interesting but there is a missing feature that you need !
+"""
+maintainer: "Emile Trotignon emile.trotignon@gmail.com"
+authors: "Emile Trotignon emile.trotignon@gmail.com"
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports: "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+dev-repo: "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.8.0"}
+    "sedlex" { >= "2.0" }
+    "uutf"
+    "menhir"
+    "pprint"
+    "ppxlib"
+    "containers"
+    "ppx_inline_test"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/archive/0.7.tar.gz"
+  checksum: [
+    "md5=c262b84b429163b6441e76554db18104"
+    "sha512=018abfb99112e355153ff00ecb5199921f01cd1311bc0943c54cba172fe66be72153f69433c3a3b440fecca02ca8be573b59b6419f4329e70dff6b2b67c66f7a"
+  ]
+}


### PR DESCRIPTION
### `embedded_ocaml_templates.0.7`
EML is a simple templating language that lets you generate text with plain OCaml
Inspired by EJS templates, it does currently implements all of its functionnality.
I plan to implement everything eventually, especially if someone actually want to use this.
Please contact me if you find this interesting but there is a missing feature that you need !



---
* Homepage: https://github.com/EmileTrotignon/embedded_ocaml_templates
* Source repo: git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git
* Bug tracker: https://github.com/EmileTrotignon/embedded_ocaml_templates/issues

---
:camel: Pull-request generated by opam-publish v2.0.2