### PR TITLE
Package http-multipart-formdata.2.0.1

### DIFF
--- a/packages/http-multipart-formdata/http-multipart-formdata.2.0.1/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.2.0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Http multipart/formdata parser"
+description:
+  "OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem, <gbikal@gmail.com>"]
+license: "MPL-2.0"
+tags: ["http" "multipart" "formadata" "form" "web"]
+homepage: "https://github.com/lemaetech/http-mutlipart-formdata"
+bug-reports: "https://github.com/lemaetech/http-mutlipart-formdata/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt"
+  "reparse" {>= "3.0.0"}
+  "reparse-lwt" {>= "3.0.0"}
+  "reparse-lwt-unix" {>= "3.0.0"}
+  "ppx_expect" {with-test}
+  "ppx_deriving" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-mutlipart-formdata.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-mutlipart-formdata/archive/v2.0.1.tar.gz"
+  checksum: [
+    "md5=96b1851c7496072b5b0bf4f1a3894817"
+    "sha512=3c5402f28283db184fd56da59550c999fa08bb4db135993055a732cdf00c38aba41a5c7cab0e069bba940ccb889eb249100c4333dd4b8645aff1a998ece1cb4a"
+  ]
+}


### PR DESCRIPTION
### `http-multipart-formdata.2.0.1`
Http multipart/formdata parser
OCaml implementation of RFC 7578 (Returning Values from Forms: multipart/form-data)- https://tools.ietf.org/html/rfc7578



---
* Homepage: https://github.com/lemaetech/http-mutlipart-formdata
* Source repo: git+https://github.com/lemaetech/http-mutlipart-formdata.git
* Bug tracker: https://github.com/lemaetech/http-mutlipart-formdata/issues

---
:camel: Pull-request generated by opam-publish v2.0.3