### PR TITLE
add 4.12.0 multicore compiler variants

### DIFF
--- a/packages/base-domains/base-domains.base/opam
+++ b/packages/base-domains/base-domains.base/opam
@@ -4,14 +4,12 @@ description: """
 Domains-based parallelism distributed with the Multicore OCaml compiler"
 """
 depends: [
-  "ocaml" {>="4.06.1"}
+  "ocaml" {>="4.06.0"}
   "ocaml-variants" {
     = "4.12.0+domains+effects" |
     = "4.12.0+domains" |
     = "4.10.0+multicore" |
     = "4.10.0+multicore+no-effect-syntax" |
     = "4.06.1+multicore" |
-    = "4.04.2+multicore" |
-    = "4.02.2+multicore"
   }
 ]

--- a/packages/base-domains/base-domains.base/opam
+++ b/packages/base-domains/base-domains.base/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml-multicore/multicore-opam/issues"
+description: """
+Domains-based parallelism distributed with the Multicore OCaml compiler"
+"""
+depends: [
+  "ocaml" {>="4.06.1"}
+  "ocaml-variants" {
+    = "4.12.0+domains+effects" |
+    = "4.12.0+domains" |
+    = "4.10.0+multicore" |
+    = "4.10.0+multicore+no-effect-syntax" |
+    = "4.06.1+multicore" |
+    = "4.04.2+multicore" |
+    = "4.02.2+multicore"
+  }
+]

--- a/packages/base-domains/base-domains.base/opam
+++ b/packages/base-domains/base-domains.base/opam
@@ -10,6 +10,6 @@ depends: [
     = "4.12.0+domains" |
     = "4.10.0+multicore" |
     = "4.10.0+multicore+no-effect-syntax" |
-    = "4.06.1+multicore" |
+    = "4.06.1+multicore"
   }
 ]

--- a/packages/base-effects/base-effects.base/opam
+++ b/packages/base-effects/base-effects.base/opam
@@ -6,7 +6,7 @@ Effects-based variant distributed with the Multicore OCaml compiler"
 depends: [
  "ocaml" {>= "4.12.0"}
  "ocaml-variants" {
-    = "4.12.0+domains+effects" |
+    = "4.12.0+domains+effects"
  }
  "base-domains"
 ]

--- a/packages/base-effects/base-effects.base/opam
+++ b/packages/base-effects/base-effects.base/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml-multicore/multicore-opam/issues"
+description: """
+Effects-based variant distributed with the Multicore OCaml compiler"
+"""
+depends: [
+ "ocaml" {>= "4.12.0"}
+ "ocaml-variants" {
+    = "4.12.0+domains+effects" |
+    = "4.10.0+multicore" |
+    = "4.06.1+multicore" |
+    = "4.04.2+multicore" |
+    = "4.02.2+multicore"
+ }
+ "base-domains"
+]

--- a/packages/base-effects/base-effects.base/opam
+++ b/packages/base-effects/base-effects.base/opam
@@ -7,10 +7,6 @@ depends: [
  "ocaml" {>= "4.12.0"}
  "ocaml-variants" {
     = "4.12.0+domains+effects" |
-    = "4.10.0+multicore" |
-    = "4.06.1+multicore" |
-    = "4.04.2+multicore" |
-    = "4.02.2+multicore"
  }
  "base-domains"
 ]

--- a/packages/domainslib/domainslib.0.3.0/opam
+++ b/packages/domainslib/domainslib.0.3.0/opam
@@ -9,13 +9,10 @@ dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: ["org:ocamllabs"]
 depends: [
-  "ocamlfind"
-  "dune"
+  "dune" {>= "1.8"}
   "base-domains"
 ]
-build: [
-  "dune" "build" "-p" name
-]
+build: ["dune" "build" "-p" name "-j" jobs]
 url {
   src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.0.tar.gz"
   checksum: "md5=19ac2e92298b82a406bcb231a00bb3a4"

--- a/packages/domainslib/domainslib.0.3.0/opam
+++ b/packages/domainslib/domainslib.0.3.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "ocamlfind"
+  "dune"
+  "base-domains"
+]
+build: [
+  "dune" "build" "-p" name
+]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.0.tar.gz"
+  checksum: "md5=19ac2e92298b82a406bcb231a00bb3a4"
+}
+

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.12.0, with support for multicore domains and effects"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-effects" {post}
+  "ocaml-option-nnp"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    #"CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    #"CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    #"ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    #"ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    #"AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    #"AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    #"--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    #"--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    #"PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    # 32bit options above commented out just to reduce diff with ocaml-variants.4.12.0+options
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "git+https://github.com/ocaml-multicore/ocaml-multicore.git#4.12+domains+effects"
+}
+conflicts: [
+  "ocaml-options-vanilla"   # This is not vanilla OCaml!
+  "ocaml-option-32bit"      # Not yet implemented
+  "ocaml-option-nnpchecker" # Fundamentally not possible
+]
+depopts: [
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
@@ -49,7 +49,6 @@ url {
   src: "git+https://github.com/ocaml-multicore/ocaml-multicore.git#4.12+domains+effects"
 }
 conflicts: [
-  "ocaml-options-vanilla"   # This is not vanilla OCaml!
   "ocaml-option-32bit"      # Not yet implemented
   "ocaml-option-nnpchecker" # Fundamentally not possible
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
@@ -48,7 +48,6 @@ url {
   src: "git+https://github.com/ocaml-multicore/ocaml-multicore.git#4.12+domains"
 }
 conflicts: [
-  "ocaml-options-vanilla"   # This is not vanilla OCaml!
   "ocaml-option-32bit"      # Not yet implemented
   "ocaml-option-nnpchecker" # Fundamentally not possible
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "OCaml 4.12.0, with support for multicore domains"
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml" {= "4.12.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "ocaml-option-nnp"
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    #"CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    #"CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    #"ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    #"ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    #"AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    #"AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    #"--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    #"--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    #"PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    # 32bit options above commented out just to reduce diff with ocaml-variants.4.12.0+options
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "git+https://github.com/ocaml-multicore/ocaml-multicore.git#4.12+domains"
+}
+conflicts: [
+  "ocaml-options-vanilla"   # This is not vanilla OCaml!
+  "ocaml-option-32bit"      # Not yet implemented
+  "ocaml-option-nnpchecker" # Fundamentally not possible
+]
+depopts: [
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+]


### PR DESCRIPTION
These add two new base packages, base-domains (for indicating
the presence of Domain based parallelism) and base-effects
(for indicating the experimental effect system, which has extra
keywords that break some ecosystem packages)

This PR also introduces domainslib.0.3.0 as a library using
base-domains to illustrate how this works.

When this PR is merged, I will add followup packages that
uses these multicore compilers.

Package source: https://github.com/ocaml-multicore/multicore-opam