### PR TITLE
[new release] dream-encoding (0.1.0)

### DIFF
--- a/packages/dream-encoding/dream-encoding.0.1.0/opam
+++ b/packages/dream-encoding/dream-encoding.0.1.0/opam
@@ -9,13 +9,16 @@ doc: "https://tmattio.github.io/dream-encoding/"
 bug-reports: "https://github.com/tmattio/dream-encoding/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "dream"
   "decompress" {>= "1.4.1"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"} # Might use result through lwt and explicitly uses Result.bind 
+]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/dream-encoding/dream-encoding.0.1.0/opam
+++ b/packages/dream-encoding/dream-encoding.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Encoding primitives for Dream"
+description: "Encoding primitives for Dream."
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/dream-encoding"
+doc: "https://tmattio.github.io/dream-encoding/"
+bug-reports: "https://github.com/tmattio/dream-encoding/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "dream"
+  "decompress" {>= "1.4.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/dream-encoding.git"
+x-commit-hash: "fd195e2d3cb31f712f76da49698f7bdf924555e8"
+url {
+  src:
+    "https://github.com/tmattio/dream-encoding/releases/download/0.1.0/dream-encoding-0.1.0.tbz"
+  checksum: [
+    "sha256=cb0bc45567f3297c7610e56689333dafc51f30592fe8c15ab9024ce0e6adaf9d"
+    "sha512=2b156e39a5b32ef04b069af30a3b1f3ff76f6bc7ccde68b1cb5878616d0b1a8440daf096e3500dd1dabcd1688bd06fa29193dfe0dfb34627dca67f436168af81"
+  ]
+}


### PR DESCRIPTION
Encoding primitives for Dream

- Project page: <a href="https://github.com/tmattio/dream-encoding">https://github.com/tmattio/dream-encoding</a>
- Documentation: <a href="https://tmattio.github.io/dream-encoding/">https://tmattio.github.io/dream-encoding/</a>

##### CHANGES:

- Initial release
