### PR TITLE
github: constraint yojson to 1.7.0 (uses Yojson.Safe.write_t)

### DIFF
--- a/packages/github/github.4.3.2/opam
+++ b/packages/github/github.4.3.2/opam
@@ -37,7 +37,7 @@ depends: [
   "cohttp-lwt" {>= "0.99"}
   "lwt" {>= "2.4.4"}
   "atdgen" {>= "2.0.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.7.0"}
   "stringext"
 ]
 url {


### PR DESCRIPTION
Detected in #18919:
```
#=== ERROR while compiling github.4.3.2 =======================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-base-compiler.4.04.2 | file:///src
# path                 ~/.opam/4.04/.opam-switch/build/github.4.3.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p github -j 47
# exit-code            1
# env-file             ~/.opam/log/github-23-b99ab6.env
# output-file          ~/.opam/log/github-23-b99ab6.out
### output ###
#     ocamlopt lib/.github.objs/native/github_j.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlopt.opt -w -40 -principal -strict-sequence -g -safe-string -w A-E-41-42-44-48 -w -27-32 -g -I lib/.github.objs/byte -I lib/.github.objs/native -I /home/opam/.opam/4.04/lib/atdgen -I /home/opam/.opam/4.04/lib/atdgen-runtime -I /home/opam/.opam/4.04/lib/base -I /home/opam/.opam/4.04/lib/base/caml -I /home/opam/.opam/4.04/lib/base/shadow_stdlib -I /home/opam/.opam/4.04/lib/base64 -I /home/opam/.opam/4.04/lib/biniou -I /home/opam/.opam/4.04/lib/bytes -I /home/opam/.opam/4.04/lib/cohttp -I /home/opam/.opam/4.04/lib/cohttp-lwt -I /home/opam/.opam/4.04/lib/easy-format -I /home/opam/.opam/4.04/lib/fieldslib -I /home/opam/.opam/4.04/lib/lwt -I /home/opam/.opam/4.04/lib/re -I /home/opam/.opam/4.04/lib/re/emacs -I /home/opam/.opam/4.04/lib/re/posix -I /home/opam/.opam/4.04/lib/result -I /home/opam/.opam/4.04/lib/seq -I /home/opam/.opam/4.04/lib/sexplib -I /home/opam/.opam/4.04/lib/sexplib/0 -I /home/opam/.opam/4.04/lib/stringext -I /home/opam/.opam/4.04/lib/uri -I /home/opam/.opam/4.04/lib/yojson -intf-suffix .ml -no-alias-deps -o lib/.github.objs/native/github_j.cmx -c -impl lib/github_j.ml)
# File "lib/github_j.ml", line 5086, characters 14-39:
# Error: Unbound value Yojson.Safe.write_t
# Hint: Did you mean write_int?
#       ocamlc lib/.github.objs/byte/github_j.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.04/bin/ocamlc.opt -w -40 -principal -strict-sequence -g -safe-string -w A-E-41-42-44-48 -w -27-32 -g -bin-annot -I lib/.github.objs/byte -I /home/opam/.opam/4.04/lib/atdgen -I /home/opam/.opam/4.04/lib/atdgen-runtime -I /home/opam/.opam/4.04/lib/base -I /home/opam/.opam/4.04/lib/base/caml -I /home/opam/.opam/4.04/lib/base/shadow_stdlib -I /home/opam/.opam/4.04/lib/base64 -I /home/opam/.opam/4.04/lib/biniou -I /home/opam/.opam/4.04/lib/bytes -I /home/opam/.opam/4.04/lib/cohttp -I /home/opam/.opam/4.04/lib/cohttp-lwt -I /home/opam/.opam/4.04/lib/easy-format -I /home/opam/.opam/4.04/lib/fieldslib -I /home/opam/.opam/4.04/lib/lwt -I /home/opam/.opam/4.04/lib/re -I /home/opam/.opam/4.04/lib/re/emacs -I /home/opam/.opam/4.04/lib/re/posix -I /home/opam/.opam/4.04/lib/result -I /home/opam/.opam/4.04/lib/seq -I /home/opam/.opam/4.04/lib/sexplib -I /home/opam/.opam/4.04/lib/sexplib/0 -I /home/opam/.opam/4.04/lib/stringext -I /home/opam/.opam/4.04/lib/uri -I /home/opam/.opam/4.04/lib/yojson -intf-suffix .ml -no-alias-deps -o lib/.github.objs/byte/github_j.cmo -c -impl lib/github_j.ml)
# File "lib/github_j.ml", line 5086, characters 14-39:
# Error: Unbound value Yojson.Safe.write_t
# Hint: Did you mean write_int?
```
ping @kit-ty-kate 