### PR TITLE
parsexp: constraint ocaml to < 4.13

### DIFF
--- a/packages/parsexp/parsexp.v0.14.0/opam
+++ b/packages/parsexp/parsexp.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.04.2"}
+  "ocaml"    {>= "4.04.2" & < "4.13"}
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}


### PR DESCRIPTION
Detected in #18919

```
#=== ERROR while compiling parsexp.v0.14.0 ====================================#
# context              2.1.0~rc | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///src
# path                 ~/.opam/4.13/.opam-switch/build/parsexp.v0.14.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p parsexp -j 47
# exit-code            1
# env-file             ~/.opam/log/parsexp-20-72a07e.env
# output-file          ~/.opam/log/parsexp-20-72a07e.out
### output ###
#       ocamlc src/.parsexp.objs/byte/parsexp__Parser_automaton_internal.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.parsexp.objs/byte -I /home/opam/.opam/4.13/lib/base/caml -I /home/opam/.opam/4.13/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Parsexp__ -o src/.parsexp.objs/byte/parsexp__Parser_automaton_internal.cmo -c -impl src/parser_automaton_internal.ml)
# File "src/parser_automaton_internal.ml", lines 440-454, characters 6-66:
# 440 | ......match state.kind with
# 441 |       | Positions ->
# 442 |         (* Note we store end positions as inclusive in [Positions.t], so we use [delta:0],
# 443 |            while in the [Cst] case we save directly the final ranges, so we use
# 444 |            [delta:1]. *)
# ...
# 451 |           add_pos state ~delta:0;
# 452 |           make_list [] stack)
# 453 |         else stack
# 454 |       | Cst -> make_list_cst (current_pos state ~delta:1) [] stack
# Warning 18 [not-principal]: 
#   The return type of this pattern-matching is ambiguous.
#   Please add a type annotation, as the choice of `s' is not principal.
# File "src/parser_automaton_internal.ml", line 485, characters 44-66:
# 485 |     | Sexp -> if is_not_ignoring state then Sexp (Atom str, stack) else stack
#                                                   ^^^^^^^^^^^^^^^^^^^^^^
# Error: The constructor Sexp expects 0 argument(s),
#        but is applied here to 1 argument(s)
#     ocamlopt src/.parsexp.objs/native/parsexp__Parser_automaton_internal.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlopt.opt -w -40 -g -I src/.parsexp.objs/byte -I src/.parsexp.objs/native -I /home/opam/.opam/4.13/lib/base/caml -I /home/opam/.opam/4.13/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Parsexp__ -o src/.parsexp.objs/native/parsexp__Parser_automaton_internal.cmx -c -impl src/parser_automaton_internal.ml)
