### PR TITLE
Package camlp-streams.5.0

### DIFF
--- a/packages/camlp-streams/camlp-streams.5.0/opam
+++ b/packages/camlp-streams/camlp-streams.5.0/opam
@@ -29,6 +29,7 @@ maintainer: [
 authors: ["Daniel de Rauglaudre" "Xavier Leroy"]
 homepage: "https://github.com/ocaml/camlp-streams"
 bug-reports: "https://github.com/ocaml/camlp-streams/issues"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.5"}
   "ocaml" {>= "4.05.0"}

--- a/packages/camlp-streams/camlp-streams.5.0/opam
+++ b/packages/camlp-streams/camlp-streams.5.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/camlp-streams/camlp-streams.5.0/opam
+++ b/packages/camlp-streams/camlp-streams.5.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "The Stream and Genlex libraries for use with Camlp4 and Camlp5"
+description: """
+
+This package provides two library modules:
+- Stream: imperative streams, with in-place update and memoization
+  of the latest element produced.
+- Genlex: a small parameterized lexical analyzer producing streams
+  of tokens from streams of characters.
+
+The two modules are designed for use with Camlp4 and Camlp5:
+- The stream patterns and stream expressions of Camlp4/Camlp5 consume
+  and produce data of type 'a Stream.t.
+- The Genlex tokenizer can be used as a simple lexical analyzer for
+  Camlp4/Camlp5-generated parsers.
+
+The Stream module can also be used by hand-written recursive-descent
+parsers, but is not very convenient for this purpose.
+
+The Stream and Genlex modules have been part of the OCaml standard library
+for a long time, and have been distributed as part of the core OCaml system.
+They will be removed from the OCaml standard library at some future point,
+but will be maintained and distributed separately in this camlpstreams package.
+"""
+maintainer: [
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+  "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+]
+authors: ["Daniel de Rauglaudre" "Xavier Leroy"]
+homepage: "https://github.com/ocaml/camlp-streams"
+bug-reports: "https://github.com/ocaml/camlp-streams/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.05.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/camlp-streams.git"
+url {
+  src: "https://github.com/ocaml/camlp-streams/archive/refs/tags/v5.0.tar.gz"
+  checksum: [
+    "md5=305d8eaf9cebaf137a8a63770f0ea162"
+    "sha512=f42e2f5e5ca353b3d647cd7e97a278c167c2d1abd185a634f155965cec29e35d9be7ce940b4c205b0577d7e9b6f714580bfd2e2fd79f1b1b461bc3fb96d26d36"
+  ]
+}


### PR DESCRIPTION
### `camlp-streams.5.0`
The Stream and Genlex libraries for use with Camlp4 and Camlp5
This package provides two library modules:
- Stream: imperative streams, with in-place update and memoization
  of the latest element produced.
- Genlex: a small parameterized lexical analyzer producing streams
  of tokens from streams of characters.

The two modules are designed for use with Camlp4 and Camlp5:
- The stream patterns and stream expressions of Camlp4/Camlp5 consume
  and produce data of type 'a Stream.t.
- The Genlex tokenizer can be used as a simple lexical analyzer for
  Camlp4/Camlp5-generated parsers.

The Stream module can also be used by hand-written recursive-descent
parsers, but is not very convenient for this purpose.

The Stream and Genlex modules have been part of the OCaml standard library
for a long time, and have been distributed as part of the core OCaml system.
They will be removed from the OCaml standard library at some future point,
but will be maintained and distributed separately in this camlpstreams package.



---
* Homepage: https://github.com/ocaml/camlp-streams
* Source repo: git+https://github.com/ocaml/camlp-streams.git
* Bug tracker: https://github.com/ocaml/camlp-streams/issues

---
:camel: Pull-request generated by opam-publish v2.0.2