### PR TITLE
[new release] terminal and progress (0.2.1)

### DIFF
--- a/packages/progress/progress.0.2.1/opam
+++ b/packages/progress/progress.0.2.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "User-definable progress bars"
+description: """
+A progress bar library for OCaml, featuring a DSL for declaratively specifying
+progress bar formats. Supports rendering multiple progress bars simultaneously."""
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "terminal" {= version}
+  "fmt" {>= "0.8.5"}
+  "logs" {>= "0.7.0"}
+  "mtime" {>= "1.1.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "vector"
+  "optint" {>= "0.1.0"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "astring" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/CraigFe/progress/releases/download/0.2.1/terminal-0.2.1.tbz"
+  checksum: [
+    "sha256=7ae7f5c5a2db88107d0b3fd37d5344f066921270a3e74d56dd13457feb9e586e"
+    "sha512=3828ac568e447e5f1e59450ee48491c256d8bc77abe234190e14e2db5be7b81f379837083f0eb28ea9572fce2781fd0addd7adc1701947c0b2de9d8319ace042"
+  ]
+}
+x-commit-hash: "04ad0ff1dcfdbd46133b640a4481924a56724640"

--- a/packages/terminal/terminal.0.2.1/opam
+++ b/packages/terminal/terminal.0.2.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Basic utilities for interacting with terminals"
+description: "Basic utilities for interacting with terminals"
+maintainer: ["Craig Ferguson <me@craigfe.io>"]
+authors: ["Craig Ferguson <me@craigfe.io>"]
+license: "MIT"
+homepage: "https://github.com/CraigFe/progress"
+doc: "https://CraigFe.github.io/progress/"
+bug-reports: "https://github.com/CraigFe/progress/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "uucp" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "stdlib-shims"
+  "alcotest" {with-test & >= "1.4.0"}
+  "fmt" {with-test}
+  "astring" {with-test}
+  "mtime" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CraigFe/progress.git"
+url {
+  src:
+    "https://github.com/CraigFe/progress/releases/download/0.2.1/terminal-0.2.1.tbz"
+  checksum: [
+    "sha256=7ae7f5c5a2db88107d0b3fd37d5344f066921270a3e74d56dd13457feb9e586e"
+    "sha512=3828ac568e447e5f1e59450ee48491c256d8bc77abe234190e14e2db5be7b81f379837083f0eb28ea9572fce2781fd0addd7adc1701947c0b2de9d8319ace042"
+  ]
+}
+x-commit-hash: "04ad0ff1dcfdbd46133b640a4481924a56724640"


### PR DESCRIPTION
Basic utilities for interacting with terminals

- Project page: <a href="https://github.com/CraigFe/progress">https://github.com/CraigFe/progress</a>
- Documentation: <a href="https://CraigFe.github.io/progress/">https://CraigFe.github.io/progress/</a>

##### CHANGES:

- Fix the count segment of `Progress.counter` (when `pp` is passed) to show the
  running total rather than the latest reported value. (CraigFe/progress#19; @CraigFe, report
  by @Ngoguey42)
- Fix `Terminal` stubs on MacOS. (CraigFe/progress#13; @CraigFe, report by @Ngoguey42)
- Fix package tests on Windows. `Progress` does not yet support the Windows and
  Cygwin terminals; this is tracked by CraigFe/progress#16. (CraigFe/progress#15; @emillon)
