### PR TITLE
[new release] opam-monorepo (0.2.2)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.2.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.2/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.13.0"}
   "conf-pkg-config" {build}
 ]
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"

--- a/packages/opam-monorepo/opam-monorepo.0.2.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.2/opam
@@ -14,7 +14,6 @@ bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
-  "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]

--- a/packages/opam-monorepo/opam-monorepo.0.2.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.2/opam
@@ -14,28 +14,11 @@ bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08.0"}
+  "conf-pkg-config" {build}
 ]
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
 build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
 flags: [ plugin ]
-depexts: [
-  ["devel/pkgconf"] {os = "openbsd"}
-  ["pkg-config"] {os-family = "debian"}
-  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
-  ["pkgconf"] {os = "freebsd"}
-  ["pkgconf"] {os-distribution = "alpine"}
-  ["pkgconf"] {os-distribution = "arch"}
-  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
-  ["pkgconfig"] {os-distribution = "fedora"}
-  ["pkgconfig"] {os-distribution = "mageia"}
-  ["pkgconfig"] {os-distribution = "nixos"}
-  ["pkgconfig"] {os-distribution = "ol"}
-  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
-  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
-  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
-  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
-]
 url {
   src:
     "https://github.com/ocamllabs/opam-monorepo/releases/download/0.2.2/opam-monorepo-0.2.2.tbz"

--- a/packages/opam-monorepo/opam-monorepo.0.2.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/opam-monorepo"
+bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
+flags: [ plugin ]
+depexts: [
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os-family = "debian"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconfig"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkgconfig"] {os-distribution = "ol"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+]
+url {
+  src:
+    "https://github.com/ocamllabs/opam-monorepo/releases/download/0.2.2/opam-monorepo-0.2.2.tbz"
+  checksum: [
+    "sha256=4aa3244899e55ab4b5825033d86aba70504bf4e1601b1c365e11f1170ba655cb"
+    "sha512=a3b93138c195f11239821768bb9c6f588b03a7497b6c6539cbcf39d2c9c48639bc201928a632060cb3dc5200b7ad6cf2475aaf819ce0a9b9a4f9dc6f8c35b601"
+  ]
+}
+x-commit-hash: "035c4ba391089f58d48c7c57382b14d99775355b"


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/ocamllabs/opam-monorepo">https://github.com/ocamllabs/opam-monorepo</a>

##### CHANGES:

### Added

- Add `--ocaml-version` argument to `lock`: it allows to determine the ocaml version in the
  lockfile that's being generated (ocamllabs/opam-monorepo#161, @pitag-ha)

### Changed

- Exclude packages depending on `jbuilder` from the lock step. Since dune 2.0, `jbuild` files are
  not supported. A new `--allow-jbuilder` option have been added to enable the old behavior.
- Recognize packages with an optional dependency on dune as building with dune. This allows
  opam-monorepo to rightfully recognize `opam-file-format` latest versions as building with
  dune. (ocamllabs/opam-monorepo#176, @NathanReb)
- Only print the full list of selected root packages once and only in verbose mode, simply printing
  the number in the default logs. (ocamllabs/opam-monorepo#173, @NathanReb)
- Improve the solving process so it only accepts base-compilers unless one explicitly requires
  a compiler variant, either directly or using `ocaml-option-*` packages. (ocamllabs/opam-monorepo#178, @NathanReb)

### Fixed

- Fix the default branch mechanism when the opam remote starts with `git+https` (ocamllabs/opam-monorepo#166, @TheLortex)
- Fix a log that was still refering to the old tool name `duniverse` (ocamllabs/opam-monorepo#158, @rizo)
- Improve how the default branch for a git repository is queried, fixing a bug
  where opam-monorepo wouldn't work outside of of git repo and a bug where it wouldn't
  work on non-english systems. (ocamllabs/opam-monorepo#157, fixes ocamllabs/opam-monorepo#114, @TheLortex)