### PR TITLE
SPDX compliant license field for Links packages.

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.2/opam
+++ b/packages/links-mysql/links-mysql.0.9.2/opam
@@ -6,7 +6,7 @@ description: "MySQL database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 build: [
   [ "dune" "subst" ] {dev}

--- a/packages/links-mysql/links-mysql.0.9.3/opam
+++ b/packages/links-mysql/links-mysql.0.9.3/opam
@@ -6,7 +6,7 @@ description: "MySQL database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 build: [
   [ "dune" "subst" ] {dev}

--- a/packages/links-postgresql/links-postgresql.0.9.1/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.1/opam
@@ -6,7 +6,7 @@ description: "Postgresql database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 
 build: [

--- a/packages/links-postgresql/links-postgresql.0.9.2/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.2/opam
@@ -6,7 +6,7 @@ description: "Postgresql database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 
 build: [

--- a/packages/links-postgresql/links-postgresql.0.9.3/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.3/opam
@@ -6,7 +6,7 @@ description: "Postgresql database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 
 build: [

--- a/packages/links-sqlite3/links-sqlite3.0.9.1/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.1/opam
@@ -6,7 +6,7 @@ description: "SQLite database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 build: [
   [ "dune" "subst" ] {dev}

--- a/packages/links-sqlite3/links-sqlite3.0.9.2/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.2/opam
@@ -6,7 +6,7 @@ description: "SQLite database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 build: [
   [ "dune" "subst" ] {dev}

--- a/packages/links-sqlite3/links-sqlite3.0.9.3/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.3/opam
@@ -6,7 +6,7 @@ description: "SQLite database driver for the Links Programming Language"
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 build: [
   [ "dune" "subst" ] {dev}

--- a/packages/links/links.0.9.1/opam
+++ b/packages/links/links.0.9.1/opam
@@ -6,7 +6,7 @@ description: "Links is a functional programming language designed to make web pr
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 
 
 build: [

--- a/packages/links/links.0.9.2/opam
+++ b/packages/links/links.0.9.2/opam
@@ -6,7 +6,7 @@ description: "Links is a functional programming language designed to make web pr
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]

--- a/packages/links/links.0.9.3/opam
+++ b/packages/links/links.0.9.3/opam
@@ -6,7 +6,7 @@ description: "Links is a functional programming language designed to make web pr
 homepage: "https://github.com/links-lang/links"
 dev-repo: "git+https://github.com/links-lang/links.git"
 bug-reports: "https://github.com/links-lang/links/issues"
-license: "GPL-2"
+license: "GPL-2.0-only"
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]


### PR DESCRIPTION
Follow up on #18781.

This commit makes the license fields of previously released Links packages SPDX compliant.