### PR TITLE
Fix tezos-storage constraints for Irmin

### DIFF
--- a/packages/tezos-storage/tezos-storage.9.1/opam
+++ b/packages/tezos-storage/tezos-storage.9.1/opam
@@ -8,8 +8,8 @@ license: "MIT"
 depends: [
   "dune" { >= "2.0" }
   "tezos-lmdb" { = "7.4" }
-  "irmin" { >= "2.5.4" & != "2.6.0" }
-  "irmin-pack" { >= "2.5.4" & != "2.6.0" }
+  "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
+  "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
   "digestif" {>= "0.7.3"}
   "tezos-shell-services" { = version }
   "alcotest-lwt" { with-test & >= "1.1.0" }

--- a/packages/tezos-storage/tezos-storage.9.2/opam
+++ b/packages/tezos-storage/tezos-storage.9.2/opam
@@ -8,8 +8,8 @@ license: "MIT"
 depends: [
   "dune" { >= "2.5" }
   "tezos-lmdb" { = "7.4" }
-  "irmin" { >= "2.5.4" & != "2.6.0" }
-  "irmin-pack" { >= "2.5.4" & != "2.6.0" }
+  "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
+  "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
   "digestif" {>= "0.7.3"}
   "tezos-shell-services" { = version }
   "alcotest-lwt" { with-test & >= "1.1.0" }


### PR DESCRIPTION
The Irmin version constraints in tezos-storage are a bit loose.