### PR TITLE
ssl.0.5.10: Accept failures on distributions shipping openssl < 1.1.0

### DIFF
--- a/packages/ssl/ssl.0.5.10/opam
+++ b/packages/ssl/ssl.0.5.10/opam
@@ -14,6 +14,10 @@ depends: [
   "base-unix"
   "conf-libssl"
 ]
+x-ci-accept-failures: [
+  "centos-7" # https://github.com/savonet/ocaml-ssl/pull/73
+  "oraclelinux-7" # https://github.com/savonet/ocaml-ssl/pull/73
+]
 synopsis: "Bindings for OpenSSL"
 authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
 url {


### PR DESCRIPTION
See https://github.com/savonet/ocaml-ssl/pull/73
```
#=== ERROR while compiling ssl.0.5.10 =========================================#
# context              2.1.0~rc2 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///src
# path                 ~/.opam/4.12/.opam-switch/build/ssl.0.5.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ssl -j 127
# exit-code            1
# env-file             ~/.opam/log/ssl-11-19aa08.env
# output-file          ~/.opam/log/ssl-11-19aa08.out
### output ###
# ssl_stubs.c: In function 'ocaml_ssl_version':
# ssl_stubs.c:880:10: error: 'TLS1_3_VERSION' undeclared (first use in this function)
#      case TLS1_3_VERSION:
#           ^
```