### PR TITLE
[new release] ppx_distr_guards (0.3)

### DIFF
--- a/packages/ppx_distr_guards/ppx_distr_guards.0.3/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Extension to distribute guards over or-patterns"
+description:
+  "`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`"
+maintainer: ["Ralf Vogler <ralf.vogler@gmail.com>"]
+authors: ["Ralf Vogler <ralf.vogler@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/vogler/ppx_distr_guards"
+doc: "https://vogler.github.io/ppx_distr_guards"
+bug-reports: "https://github.com/vogler/ppx_distr_guards/issues"
+depends: [
+  "dune" {>= "2.7" & >= "2.3.0"}
+  "ppxlib" {>= "0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vogler/ppx_distr_guards.git"
+url {
+  src:
+    "https://github.com/vogler/ppx_distr_guards/releases/download/0.3/ppx_distr_guards-0.3.tbz"
+  checksum: [
+    "sha256=a05dc97065a18ef83eb5b8fcfeea9dfa07dcefbf7daf2e41f7fc09cfddea7f55"
+    "sha512=f4aba0549c93a67d935a3b1554c189db20efcf26c0d8474c9f015a252e17d7b641996e3d72ef466f537b83ef0ea6c35baa7d1d67788b51686d9c77da387973e8"
+  ]
+}
+x-commit-hash: "0ec3a096baa6f147c8981eb1f2d11fb72f865f2a"

--- a/packages/ppx_distr_guards/ppx_distr_guards.0.3/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.3/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/vogler/ppx_distr_guards"
 doc: "https://vogler.github.io/ppx_distr_guards"
 bug-reports: "https://github.com/vogler/ppx_distr_guards/issues"
 depends: [
-  "dune" {>= "2.7" & >= "2.3.0"}
+  "dune" {>= "2.7"}
   "ppxlib" {>= "0.15.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Extension to distribute guards over or-patterns

- Project page: <a href="https://github.com/vogler/ppx_distr_guards">https://github.com/vogler/ppx_distr_guards</a>
- Documentation: <a href="https://vogler.github.io/ppx_distr_guards">https://vogler.github.io/ppx_distr_guards</a>

##### CHANGES:

- Migrate from ocaml-migrate-parsetree to ppxlib.
