### PR TITLE
Make conf-libssl re-available on distributions derived from Alpine

### DIFF
--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -23,7 +23,7 @@ depexts: [
   ["openssl-devel"] {os-distribution = "ol"}
   ["openssl-devel"] {os-distribution = "fedora"}
   ["libopenssl-devel"] {os-family = "suse"}
-  ["openssl-dev"] {os-distribution = "alpine"}
+  ["openssl-dev"] {os-family = "alpine"}
   ["openssl"] {os-family = "arch"}
   ["openssl"] {os-distribution = "homebrew"}
   ["openssl"] {os-distribution = "macports"}


### PR DESCRIPTION
Removed in #18964 
cc @rjbou 