### PR TITLE
Package eliom.8.4.8

### DIFF
--- a/packages/eliom/eliom.8.4.8/opam
+++ b/packages/eliom/eliom.8.4.8/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
   "js_of_ocaml-tyxml" {>= "3.5.1"}
   "lwt_log"
-  "lwt_ppx"
+  "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.8.4.8/opam
+++ b/packages/eliom/eliom.8.4.8/opam
@@ -28,7 +28,7 @@ depends: [
   "reactiveData" {>= "0.2.1"}
   "dbm" | "sqlite3"
   "base-bytes"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
 ]
 url {
   src: "https://github.com/ocsigen/eliom/archive/8.4.8.tar.gz"

--- a/packages/eliom/eliom.8.4.8/opam
+++ b/packages/eliom/eliom.8.4.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "0.99.3"}
+  "js_of_ocaml-compiler" {>= "3.5.1"}
+  "js_of_ocaml" {>= "3.5.1"}
+  "js_of_ocaml-lwt" {>= "3.5.1"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.5.1"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
+  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "lwt_log"
+  "lwt_ppx"
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "3.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+  "ppx_tools_versioned"
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/8.4.8.tar.gz"
+  checksum: [
+    "md5=bd9fadfc7aff68520fcfd3d0cd052f13"
+    "sha512=4b9e81cbe11e665ad2bd45233ca9d78e312be10e28dbcffb8bbc2d1f83f856da091b4aa5f014378a19e201173c4ea3406751cf81f65c84a0a71639abf19908f3"
+  ]
+}

--- a/packages/eliom/eliom.8.4.8/opam
+++ b/packages/eliom/eliom.8.4.8/opam
@@ -12,14 +12,14 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "ocamlfind"
   "ppx_deriving"
-  "ppx_tools" {>= "0.99.3"}
-  "js_of_ocaml-compiler" {>= "3.5.1"}
-  "js_of_ocaml" {>= "3.5.1"}
-  "js_of_ocaml-lwt" {>= "3.5.1"}
+  "ppx_tools" {>= "5.2"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
   "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "3.5.1"}
-  "js_of_ocaml-ppx_deriving_json" {>= "3.5.1"}
-  "js_of_ocaml-tyxml" {>= "3.5.1"}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}


### PR DESCRIPTION
### `eliom.8.4.8`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.0.3