### PR TITLE
[new release] doi2bib (0.5.0)

### DIFF
--- a/packages/doi2bib/doi2bib.0.5.0/opam
+++ b/packages/doi2bib/doi2bib.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "cmdliner" {>= "1.0.0"}
+  "decompress" {>= "1.3.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "tls" {>= "0.12.0"}
+  "re" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+x-commit-hash: "f83d01caf21705118eb9fe71ff058c9067996448"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.5.0/doi2bib-0.5.0.tbz"
+  checksum: [
+    "sha256=c694a95473f89318a2e84d82f7c03a6ba08435aad6644d64d5434b4776c6cd9f"
+    "sha512=0a4ffe1228d9165a084fbfd42fb19d3b416f171d14ba8f0140401106dc7d1229d81897bad5ad7a93d3764d19d8af38eadbca5d590f8ee0115a6cf393e077cb4c"
+  ]
+}

--- a/packages/doi2bib/doi2bib.0.5.0/opam
+++ b/packages/doi2bib/doi2bib.0.5.0/opam
@@ -11,6 +11,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "astring" {>= "0.8.0"}
   "cohttp-lwt-unix" {>= "2.5.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "lwt" {>= "5.3.0"}
   "cmdliner" {>= "1.0.0"}
   "decompress" {>= "1.3.0"}
   "ezxmlm" {>= "1.1.0"}

--- a/packages/doi2bib/doi2bib.0.5.0/opam
+++ b/packages/doi2bib/doi2bib.0.5.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "astring" {>= "0.8.0"}
   "cohttp-lwt-unix" {>= "2.5.0"}
-  "bigstringaf" {>= "0.2.0"}
+  "bigstringaf" {>= "0.5.0"}
   "lwt" {>= "5.3.0"}
   "cmdliner" {>= "1.0.0"}
   "decompress" {>= "1.3.0"}
@@ -30,7 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID

- Project page: <a href="https://github.com/mseri/doi2bib">https://github.com/mseri/doi2bib</a>

##### CHANGES:

- Use cuz for the get calls with compression
- Use arxiv.org/bibtex to obtain the bibtex entry for
  unpublished arxiv manuscripts and rely on the manual
  generation only if that fails reachable.
- Handcrafted pretty printing of the output from crossref
