### PR TITLE
[new release] doi2bib (0.5.1)

### DIFF
--- a/packages/doi2bib/doi2bib.0.5.1/opam
+++ b/packages/doi2bib/doi2bib.0.5.1/opam
@@ -30,7 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/doi2bib/doi2bib.0.5.1/opam
+++ b/packages/doi2bib/doi2bib.0.5.1/opam
@@ -20,6 +20,9 @@ depends: [
   "re" {>= "1.0.0"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"} # uses Result.map but result can be pulled via lwt and takes over the Result module
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/doi2bib/doi2bib.0.5.1/opam
+++ b/packages/doi2bib/doi2bib.0.5.1/opam
@@ -12,9 +12,9 @@ depends: [
   "astring" {>= "0.8.0"}
   "cohttp-lwt-unix" {>= "2.5.0"}
   "cmdliner" {>= "1.0.0"}
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.4.0"}
   "ezxmlm" {>= "1.1.0"}
-  "lwt" {>= "5.2.0"}
+  "lwt" {>= "5.3.0"}
   "bigstringaf" {>= "0.2.0"}
   "tls" {>= "0.12.0"}
   "re" {>= "1.0.0"}

--- a/packages/doi2bib/doi2bib.0.5.1/opam
+++ b/packages/doi2bib/doi2bib.0.5.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "cmdliner" {>= "1.0.0"}
+  "decompress" {>= "1.3.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "lwt" {>= "5.2.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "tls" {>= "0.12.0"}
+  "re" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+x-commit-hash: "a95e236c59680e2078995501355ea0a143a37340"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.5.1/doi2bib-0.5.1.tbz"
+  checksum: [
+    "sha256=c63f3c4073c598c68beeb122c5bd95e393931130af623b57ef87399f2e3f6e5c"
+    "sha512=48355cdb7124ceb21b53e2676bf78ab73b4cb2b4dc30674e33e26b15295813fbee1fb678676788d26515bd91b884fc3435a871dd070d9e027b72340dd9df1f54"
+  ]
+}


### PR DESCRIPTION
Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID

- Project page: <a href="https://github.com/mseri/doi2bib">https://github.com/mseri/doi2bib</a>

##### CHANGES:

- Fix for transitive dependency in cuz
- Improved lower bounds on the opam file
