### PR TITLE
hacl-star and hacl-star-raw (0.4.0)

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
@@ -17,7 +17,7 @@ which `hacl-star-raw` is a dependency.
 depends: [
   "ocaml" { >= "4.05.0" }
   "ocamlfind" {build}
-  "ctypes"
+  "ctypes" {>= "0.17.0"}
   "ctypes-foreign"
   "conf-which" {build}
 ]

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
@@ -1,12 +1,4 @@
 opam-version: "2.0"
-name: "hacl-star-raw"
-version: "0.4.0"
-maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
-authors: [ "Project Everest" ]
-homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
-license: "Apache-2.0"
 synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
 description: """
 This package contains a snapshot of the EverCrypt crypto provider and
@@ -14,19 +6,22 @@ the HACL* library, along with automatically generated Ctypes bindings.
 For a higher-level idiomatic API see the `hacl-star` package, of
 which `hacl-star-raw` is a dependency.
 """
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
 depends: [
-  "ocaml" { >= "4.05.0" }
+  "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
-  "ctypes" {>= "0.17.0"}
+  "ctypes" { >= "0.18.0" }
   "ctypes-foreign"
   "conf-which" {build}
 ]
+available: os-family != "bsd"
 x-ci-accept-failures: [
   "centos-7" # Default C compiler is too old
   "oraclelinux-7" # Default C compiler is too old
-]
-available: [
-  os-family != "bsd"
 ]
 build: [
   ["sh" "-exc" "cd raw && ./configure"]
@@ -35,11 +30,13 @@ build: [
 install: [
   make "-C" "raw" "install-hacl-star-raw"
 ]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
     "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
   checksum: [
-    "md5=8c96bbee8b91e07741685f7bf901b8fc"
-    "sha512=4f31c1a0fd42f03781e95c5159fa73a34b474d996801b3c8cdc3dbe4b0c94c521a5e6839ea5087121c5f707e158def5af387897df94368fb90140ced04fe93db"
+    "md5=b3ee6ef6c9ad801bfdebcc22cccb7bfa"
+    "sha256=bbf28ccf3b56ab85cc9b0a5d2f3e4bfbac1427d3e42c0b4b5596d012265eefd7"
+    "sha512=fbb4d29aedaedf6c77af162c59b85f787657138e47e83892115de2ded11f83b0339996d1ccdc823603507363cabc6f37219474f0775c00fbf7e51e77c1752f4e"
   ]
 }

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+name: "hacl-star-raw"
+version: "0.4.0"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+license: "Apache-2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency.
+"""
+depends: [
+  "ocaml" { >= "4.05.0" }
+  "ocamlfind" {build}
+  "ctypes"
+  "ctypes-foreign"
+  "conf-which" {build}
+]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
+available: [
+  os-family != "bsd"
+]
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [
+  make "-C" "raw" "install-hacl-star-raw"
+]
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
+  checksum: [
+    "md5=8c96bbee8b91e07741685f7bf901b8fc"
+    "sha512=4f31c1a0fd42f03781e95c5159fa73a34b474d996801b3c8cdc3dbe4b0c94c521a5e6839ea5087121c5f707e158def5af387897df94368fb90140ced04fe93db"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.4.0/opam
+++ b/packages/hacl-star/hacl-star.0.4.0/opam
@@ -23,7 +23,7 @@ build: [
   ]
 ]
 run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
 url {
   src:

--- a/packages/hacl-star/hacl-star.0.4.0/opam
+++ b/packages/hacl-star/hacl-star.0.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+name: "hacl-star"
+version: "0.4.0"
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+license: "Apache-2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+depends: [
+  "ocaml" { >= "4.05.0" }
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune" "build" "-p" name "-j" jobs
+    "@doc" {with-doc}
+  ]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
+  checksum: [
+    "md5=8c96bbee8b91e07741685f7bf901b8fc"
+    "sha512=4f31c1a0fd42f03781e95c5159fa73a34b474d996801b3c8cdc3dbe4b0c94c521a5e6839ea5087121c5f707e158def5af387897df94368fb90140ced04fe93db"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.4.0/opam
+++ b/packages/hacl-star/hacl-star.0.4.0/opam
@@ -1,21 +1,20 @@
 opam-version: "2.0"
-name: "hacl-star"
-version: "0.4.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
-homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 license: "Apache-2.0"
-synopsis: "OCaml API for EverCrypt/HACL*"
+homepage: "https://hacl-star.github.io/"
+doc: "https://hacl-star.github.io/ocaml_doc"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
 depends: [
-  "ocaml" { >= "4.05.0" }
+  "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
   "hacl-star-raw" {= version}
   "zarith"
   "cppo" {build}
   "odoc" {with-doc}
 ]
+available: os-family != "bsd"
 build: [
   [
     "dune" "build" "-p" name "-j" jobs
@@ -25,11 +24,13 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
     "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
   checksum: [
-    "md5=8c96bbee8b91e07741685f7bf901b8fc"
-    "sha512=4f31c1a0fd42f03781e95c5159fa73a34b474d996801b3c8cdc3dbe4b0c94c521a5e6839ea5087121c5f707e158def5af387897df94368fb90140ced04fe93db"
+    "md5=b3ee6ef6c9ad801bfdebcc22cccb7bfa"
+    "sha256=bbf28ccf3b56ab85cc9b0a5d2f3e4bfbac1427d3e42c0b4b5596d012265eefd7"
+    "sha512=fbb4d29aedaedf6c77af162c59b85f787657138e47e83892115de2ded11f83b0339996d1ccdc823603507363cabc6f37219474f0775c00fbf7e51e77c1752f4e"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-hacl-star.0.4.0: OCaml API for EverCrypt/HACL*
-hacl-star-raw.0.4.0: Auto-generated low-level OCaml bindings for EverCrypt/HACL*

This release is a major redesign of the OCaml API, which is now also [fully documented](https://hacl-star.github.io/ocaml_doc/hacl-star/index.html).
