### PR TITLE
Package tezt.1.0.0

### DIFF
--- a/packages/tezt/tezt.1.0.0/opam
+++ b/packages/tezt/tezt.1.0.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/tezos/tezos/issues"
 dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
-  "dune" {>= "2.1.1"}
+  "dune" {>= "2.5"}
   "ocaml" {>= "4.08"}
   "re" {>= "1.9.0"}
   "lwt" {>= "5.4.1"}

--- a/packages/tezt/tezt.1.0.0/opam
+++ b/packages/tezt/tezt.1.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" {>= "2.1.1"}
+  "ocaml" {>= "4.08"}
+  "re" {>= "1.9.0"}
+  "lwt" {>= "5.4.1"}
+  "ezjsonm" {>= "1.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Framework for integration tests with external processes"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v10.0-rc1/tezos-v10.0-rc1.tar.bz2"
+  checksum: [
+    "sha256=a30b3c2f2945ed4a044419c80907cb962bc2ee9eef8d05e73fb34d163808346c"
+    "sha512=eb975c3d85910f544b8298ab1677793063a4f69e2733b90c0c1e50ba7164c2e5764783ff8321b7495b66aed63e55f6f6e6d77457f87fe6cd035200b6c7b98b0c"
+  ]
+}


### PR DESCRIPTION
This PR packages Tezos' integration testing framework. @rbardou suggested using the version number `1.0.0` since it is Tezt's first release.

More information about Tezt at: [https://tezos.gitlab.io/developer/tezt.html](https://tezos.gitlab.io/developer/tezt.html).