### PR TITLE
parsexp.v0.11.0 is not compatible with OCaml 4.13

### DIFF
--- a/packages/parsexp/parsexp.v0.11.0/opam
+++ b/packages/parsexp/parsexp.v0.11.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.13"}
   "sexplib0" {>= "v0.11" & < "v0.12"}
   "jbuilder" {>= "1.0+beta18.1"}
 ]


### PR DESCRIPTION
Backports https://github.com/ocaml/opam-repository/pull/18966 to v0.11.0  as well:
```
#=== ERROR while compiling parsexp.v0.11.0 ====================================#
# context              2.1.0~rc2 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///src
# path                 ~/.opam/4.13/.opam-switch/build/parsexp.v0.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p parsexp -j 47
# exit-code            1
# env-file             ~/.opam/log/parsexp-19-6f2f73.env
# output-file          ~/.opam/log/parsexp-19-6f2f73.out
### output ###
# File "src/parser_automaton_internal.ml", line 651, characters 8-30:
# 651 |         Sexp (Atom str, stack)
#               ^^^^^^^^^^^^^^^^^^^^^^
# Error: The constructor Sexp expects 0 argument(s),
#        but is applied here to 1 argument(s)
```
Detected in https://github.com/ocaml/opam-repository/pull/18994