### PR TITLE
Package anders.0.7

### DIFF
--- a/packages/anders/anders.0.7/opam
+++ b/packages/anders/anders.0.7/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "CCHM homotopy system type checker based on Mini-TT for OCaml"
+maintainer: "Namdak Tonpa <maxim@synrc.com>"
+authors: "Groupoid Infinity"
+license: "ISC"
+homepage: "https://groupoid.space/homotopy/"
+bug-reports: "https://github.com/groupoid/anders/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.10.0"}
+  "menhir" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/groupoid/anders"
+url {
+  src: "https://github.com/groupoid/anders/archive/refs/tags/0.7.zip"
+  checksum: [
+    "md5=258c659c2b4dd602db1d844ef14189f8"
+    "sha512=d2e7f982ebcd99a05fc7a155c408f6317c0a70dfd33f6b2bc1d6a1fcdf920601b38169c7ee8ec8325a55143d7763ee5bc411c71bfb6a326a7d0b76c5f5ceb496"
+  ]
+}


### PR DESCRIPTION
### `anders.0.7`
CCHM homotopy system type checker based on Mini-TT for OCaml



---
* Homepage: https://groupoid.space/homotopy/
* Source repo: git+https://github.com/groupoid/anders
* Bug tracker: https://github.com/groupoid/anders/issues

---
:camel: Pull-request generated by opam-publish v2.1.0