### PR TITLE
[new release] dune-release (1.5.0)

### DIFF
--- a/packages/dune-release/dune-release.1.5.0/opam
+++ b/packages/dune-release/dune-release.1.5.0/opam
@@ -10,6 +10,7 @@ doc: "https://ocamllabs.github.io/dune-release/"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "clean"] {with-test}
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 

--- a/packages/dune-release/dune-release.1.5.0/opam
+++ b/packages/dune-release/dune-release.1.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "2.4.0"}
   "curly"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "bos"
   "cmdliner"
   "re"
@@ -31,7 +31,12 @@ depends: [
   "odoc"
   "alcotest" {with-test}
   "mdx" {with-test & >= "1.6.0"}
-  "yojson"
+  "yojson" {>= "1.6.0"}
+]
+
+x-ci-accept-failures: [
+  "centos-7" # tests require a newer version of git
+  "oraclelinux-7" # tests require a newer version of git
 ]
 
 synopsis: "Release dune packages in opam"

--- a/packages/dune-release/dune-release.1.5.0/opam
+++ b/packages/dune-release/dune-release.1.5.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: ["Daniel Bünzli" "Thomas Gazagnaire" "Nathan Rebours"]
+homepage: "https://github.com/ocamllabs/dune-release"
+license: "ISC"
+dev-repo: "git+https://github.com/ocamllabs/dune-release.git"
+bug-reports: "https://github.com/ocamllabs/dune-release/issues"
+doc: "https://ocamllabs.github.io/dune-release/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.4.0"}
+  "curly"
+  "fmt"
+  "bos"
+  "cmdliner"
+  "re"
+  "astring"
+  "opam-format" {>= "2.1.0~beta"}
+  "opam-state" {>= "2.1.0~beta"}
+  "opam-core" {>= "2.1.0~beta"}
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+  "mdx" {with-test & >= "1.6.0"}
+  "yojson"
+]
+
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com).
+"""
+url {
+  src:
+    "https://github.com/ocamllabs/dune-release/releases/download/1.5.0/dune-release-1.5.0.tbz"
+  checksum: [
+    "sha256=fb0e9f0c3469790eb3982e5f54876ed99d41927adcf8782bb478b5a93f53ced3"
+    "sha512=d6feb92dfc383db2775546f5b2fb5356923e86529af708519b975a5b0805acc33cbfdea909c3f21d8d923cfe555ca7171bd9a7ea4b535fa7fe824ac1cbed5ea2"
+  ]
+}
+x-commit-hash: "8036ace015b4fd1a87b1c3382992ff7bc361a348"

--- a/packages/dune-release/dune-release.1.5.0/opam
+++ b/packages/dune-release/dune-release.1.5.0/opam
@@ -23,6 +23,7 @@ depends: [
   "cmdliner"
   "re"
   "astring"
+  "opam-file-format" {>= "2.1.1"}
   "opam-format" {>= "2.1.0~beta"}
   "opam-state" {>= "2.1.0~beta"}
   "opam-core" {>= "2.1.0~beta"}


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/ocamllabs/dune-release">https://github.com/ocamllabs/dune-release</a>
- Documentation: <a href="https://ocamllabs.github.io/dune-release/">https://ocamllabs.github.io/dune-release/</a>

##### CHANGES:

### Added

- Add `--no-auto-open` to the default command. It was previously only available for
  `dune-release opam`. (ocamllabs/dune-release#374, @NathanReb)
- Add a `config create` subcommand to create a fresh configuration if you don't have one yet
  (ocamllabs/dune-release#373, @NathanReb)
- Add `--local-repo`, `--remote-repo` and `--opam-repo` options to the default command,
  they used to be only available for the `opam` subcommand (ocamllabs/dune-release#363, @NathanReb)
- Add a `--token` option to `dune-release publish` and `dune-release opam` commands
  to specify a github token. This allows dune-release to be called through a Github
  Actions workflow and use the github token through an environment variable.
  (ocamllabs/dune-release#284 ocamllabs/dune-release#368, @gpetiot @NathanReb)
- Log curl calls on verbose/debug mode (ocamllabs/dune-release#281, @gpetiot)
- Try to publish the release asset again after it failed (ocamllabs/dune-release#272, @gpetiot)
- Improve error reporting of failing git comands (ocamllabs/dune-release#257, @gpetiot)
- Suggest a solution for users without ssh setup (ocamllabs/dune-release#304, @pitag-ha)
- Allow including git submodules to the distrib tarball by passing the
  `--include-submodules` flag to `dune-release`, `dune-release bistro` or
  `dune-release distrib` (ocamllabs/dune-release#300, @NathanReb)
- Support 'git://' scheme for dev-repo uri (ocamllabs/dune-release#331, @gpetiot)
- Support creation of draft releases and draft PRs. Define a new option
  `--draft` for `dune-release publish` and `dune-release opam submit` commands.
  (ocamllabs/dune-release#248, @gpetiot)
- Add a new command `check` to check the prerequisites of dune-release and
  avoid starting a release process that couldn't be finished (ocamllabs/dune-release#318, ocamllabs/dune-release#351, @pitag-ha)
- When preparing the opam-repository PR and pushing the local branch to
  the user's remote opam-repository fork, use `--set-upstream` to ease any further
  update of the PR (ocamllabs/dune-release#350, @gpetiot)

### Changed

- Entirely rely on the remote fork of opam-repository URL in `opam submit` instead of
  reading the user separately. The information was redundant and could only lead to bugs
  when unproperly set. (ocamllabs/dune-release#372, @NathanReb)
- Use pure token authentication for Github API requests rather than "token as passwords"
  authentication (ocamllabs/dune-release#369, @NathanReb)
- Require tokens earlier in the execution of commands that use the github API. If the token
  isn't saved to the user's configuration, the prompt for creating one will show up at the
  command startup rather than on sending the first request (ocamllabs/dune-release#368, @NathanReb)
- Attach the changelog to the annotated tag message (ocamllabs/dune-release#283, @gpetiot)
- Do not remove versioned files from the tarball anymore. We used to exclude
  `.gitignore`, `.gitattributes` and other such files from the archive.
  (ocamllabs/dune-release#299, @NathanReb)
- Don't try to push the tag if it is already present and point to the same ref on the remote.
  `dune-release` must guess which URI to pass to `git push` and may guess it wrong.
  This change allows users to push the tag manually to avoid using that code. (ocamllabs/dune-release#219, @Julow)
- Don't try to create the release if it is already present and points to the same tag (ocamllabs/dune-release#277, @kit-ty-kate)
- Recursively exclude all `.git`/`.hg` files and folders from the distrib
  tarball (ocamllabs/dune-release#300, @NathanReb)
- Make the automatic dune-release workflow to stop if a step exits with a non-zero code (ocamllabs/dune-release#332, @gpetiot)
- Make git-related mdx tests more robust in unusual environments (ocamllabs/dune-release#334, @sternenseemann)
- Set the default tag message to "Release <tag>" instead of "Distribution <tag>"
- Opam file linter: check for `synopsis` instead of `description` (ocamllabs/dune-release#291, @kit-ty-kate)
- Upgrade the use of the opam libraries to opam 2.1 (ocamllabs/dune-release#343, @kit-ty-kate)

### Deprecated

- Deprecate the `--user` CLI options and configuration field, they were redundant with
  the remote-repo option and field and could be set unproperly, leading to bugs (ocamllabs/dune-release#372, @NathanReb)
- Deprecate the use of delegates in `dune-release publish` (ocamllabs/dune-release#276, ocamllabs/dune-release#302, @pitag-ha)
- Deprecate the use of opam file format 1.x (ocamllabs/dune-release#352, @NathanReb)

### Removed

- Option --name is removed from all commands. When used with
  `dune-release distrib`, it was previously effectively ignored. Now
  it is required to add a `(name <name>)` stanza to
  `dune-project`. (ocamllabs/dune-release#327, @lehy)

### Fixed

- Fix a bug where `opam submit` would look up a config file, even though all the required
  information was provided on the command line. This would lead to starting the interactive
  config creation quizz if that file did not exist which made it impossible to use it in a CI
  for instance. (ocamllabs/dune-release#373, @NathanReb)
- Fix a bug where `opam submit` would fail on non-github repositories if the user had no
  configuration file (ocamllabs/dune-release#372, @NathanReb)
- Fix a bug where subcommands wouldn't properly read the token files, leading to authentication
  failures on API requests (ocamllabs/dune-release#368, @NathanReb)
- Fix a bug in `opam submit` preventing non-github users to create the opam-repo PR
  via dune-release. (ocamllabs/dune-release#359, @NathanReb)
- Fix a bug where `opam submit` would try to parse the custom URI provided through
  `--distrib-uri` as a github repo URI instead of using the dev-repo (ocamllabs/dune-release#358, @NathanReb)
- Fix the priority of the `--distrib-uri` option in `dune-release opam pkg`.
  It used to have lower precendence than the url file written by `dune-release publish`
  and therefore made it impossible to overwrite it if needed. (ocamllabs/dune-release#255, @NathanReb)
- Fix a bug with --distrib-file in `dune-release opam pkg` where you would need
  the regular dune-release generated archive to be around even though you specified
  a custom distrib archive file. (ocamllabs/dune-release#255, @NathanReb)
- Use int64 for timestamps. (ocamllabs/dune-release#261, @gpetiot)
- Define the order of packages (ocamllabs/dune-release#263, @gpetiot)
- Allow the dry-run mode to continue even after some API call's response were expected by using placeholder values (ocamllabs/dune-release#262, @gpetiot)
- Build and run tests for all selected packages when checking distribution tarball
  (ocamllabs/dune-release#266, @NathanReb)
- Improve trimming of the changelog to preserve the indentation of the list of changes. (ocamllabs/dune-release#268, @gpetiot)
- Trim the data of the `url` file before filling the `url.src` field. This fixes an issue that caused the `url.src` field to be a multi-line string instead of single line. (ocamllabs/dune-release#270, @gpetiot)
- Fix a bug causing dune-release to exclude all hidden files and folders (starting with `.`) at the
  repository from the distrib archive (ocamllabs/dune-release#298, @NathanReb)
- Better report GitHub API errors, all of the error messages reported by the GitHub API are now checked and reported to the user. (ocamllabs/dune-release#290, @gpetiot)
- Fix error message when `dune-release tag` cannot guess the project name (ocamllabs/dune-release#319, @lehy)
- Always warn about uncommitted changes at the start of `dune-release
  distrib` (ocamllabs/dune-release#325, @lehy).  Otherwise uncommitted changes to
  dune-project would be silently ignored by `dune-release distrib`.
- Fix rewriting of github references in changelog (ocamllabs/dune-release#330, @gpetiot)
- Fixes a bug under cygwin where dune-release was unable to find the commit hash corresponding to the release tag (ocamllabs/dune-release#329, @gpetiot)
- Fixes release names by explicitly setting it to match the released version (ocamllabs/dune-release#338, @NathanReb)
- Fix a bug that prevented release of a package whose version number contains invalid characters for a git branch. The git branch names are now sanitized. (ocamllabs/dune-release#271, @gpetiot)
- `publish`: Fix the process of inferring user name and repo from the dev repo uri (ocamllabs/dune-release#348, @pitag-ha)
