### PR TITLE
 [new release] anders.0.7.1

### DIFF
--- a/packages/anders/anders.0.7.1/opam
+++ b/packages/anders/anders.0.7.1/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "CCHM homotopy system type checker based on Mini-TT for OCaml"
+maintainer: "Namdak Tonpa <maxim@synrc.com>"
+authors: ["Namdak Tonpa @5HT" "Siegmentation Fault @siegment"]
+license: "ISC"
+homepage: "https://groupoid.space/homotopy/"
+bug-reports: "https://github.com/groupoid/anders/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.10"}
+  "menhir" {>= "20200123"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/groupoid/anders"
+url {
+  src: "https://github.com/groupoid/anders/archive/refs/tags/0.7.1.zip"
+  checksum: [
+    "md5=a993dfa86ac42d3dac6c089096b67e84"
+    "sha512=6acd8c46a281626e153f6bcc80c03ade45148b1f854ac303fab2932991b3d0ee77a2fa0c4611ee54017eb250ce0f6b732b23ddeef9d57d9eceb4a4d79e5354a8"
+  ]
+}


### PR DESCRIPTION
### `anders.0.7.1`
CCHM homotopy system type checker based on Mini-TT for OCaml

* Minor optimizations https://twitter.com/5HT/status/1412134817429348354
* Binary file distribution (fix)

---
* Homepage: https://groupoid.space/homotopy/
* Source repo: git+https://github.com/groupoid/anders
* Bug tracker: https://github.com/groupoid/anders/issues

---
:camel: Pull-request generated by opam-publish v2.1.0