### PR TITLE
Package lutils.1.51.0

### DIFF
--- a/packages/lutils/lutils.1.51.0/opam
+++ b/packages/lutils/lutils.1.51.0/opam
@@ -16,9 +16,9 @@ depends: [
   "num"
 ]
 build: [
-  [make "build"]
+  [make "lib/lutilsVersion.ml"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
-install: [make "install"]
 post-messages:
   "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
 dev-repo:

--- a/packages/lutils/lutils.1.51.0/opam
+++ b/packages/lutils/lutils.1.51.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "erwan.jahier@imag.fr"
+authors: "Erwan Jahier"
+license: "CeCILL"
+homepage:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/issues"
+doc: "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6"
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune"  {>= "1.2"}
+  "base-unix"
+  "ocamlfind"
+  "num"
+]
+build: [
+  [make "build"]
+]
+install: [make "install"]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils.git"
+synopsis: "Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)"
+description: """
+The lutils library contains various modules shared between tools developped at
+Verimag in the synchronous group. Those modules deal with:
+- generate and parse RIF files
+- generate dro files (to call luciole)
+
+The gnuplot-rif tool vizualise RIF files using gnuplot. 
+"""
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.1.51.0.tgz"
+  checksum: [
+    "md5=6276d14e7a827f6665c68b460f79f474"
+    "sha512=6c5e1287260dfffe8bf58298a1d4b04109be80837ba6858ee5a2535dab3c5e5f02babe1b1ea4843d8495b31bd4180d5ecbffa447390e6220b956ee4aaf466ff8"
+  ]
+}

--- a/packages/lutils/lutils.1.51.0/opam
+++ b/packages/lutils/lutils.1.51.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "erwan.jahier@imag.fr"
 authors: "Erwan Jahier"
-license: "CeCILL"
+license: "CECILL-2.1"
 homepage:
   "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/"
 bug-reports:


### PR DESCRIPTION
### `lutils.1.51.0`
Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)
The lutils library contains various modules shared between tools developped at
Verimag in the synchronous group. Those modules deal with:
- generate and parse RIF files
- generate dro files (to call luciole)

The gnuplot-rif tool vizualise RIF files using gnuplot.



---
* Homepage: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils.git
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/issues

---
:camel: Pull-request generated by opam-publish v2.0.3