### PR TITLE
Package rdbg.1.196.9

### DIFF
--- a/packages/rdbg/rdbg.1.196.9/opam
+++ b/packages/rdbg/rdbg.1.196.9/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "RDBG: a reactive programs debugger"
+description: """
+The library rdbg contains all the ocaml modules needed to use rdbg,
+a reactive programs debugger. 
+"""
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: "Erwan Jahier"
+license: "CeCILL"
+homepage:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix"
+  "lutils" {>= "1.49"}
+  "ocamlfind"
+  "ledit" 
+  "dune" {build & >= "2.0"}
+  "ounit" {build & >= "2.0.0"}
+]
+build: [
+  [make "build"]
+]
+install: [make "install"]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.1.196.9.tgz"
+  checksum: [
+    "md5=bf7b686d620b22e26391c2e6046192d2"
+    "sha512=1e49142132fa64e677f062da0675d7f9c38744ee0901a3a054cd66a0d446e05e3c42c06dab73c44111d2ef88b4141ab101c934dc215a80227378cbfca5410920"
+  ]
+}

--- a/packages/rdbg/rdbg.1.196.9/opam
+++ b/packages/rdbg/rdbg.1.196.9/opam
@@ -6,7 +6,7 @@ a reactive programs debugger.
 """
 maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
 authors: "Erwan Jahier"
-license: "CeCILL"
+license: "CECILL-2.1"
 homepage:
   "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg"
 bug-reports:
@@ -17,13 +17,13 @@ depends: [
   "lutils" {>= "1.49"}
   "ocamlfind"
   "ledit" 
-  "dune" {build & >= "2.0"}
+  "dune" {>= "2.0"}
   "ounit" {build & >= "2.0.0"}
 ]
 build: [
-  [make "build"]
+  [make "lib/rdbgVersion.ml"]
+  ["dune" "build" "-p" name "-j" jobs]
 ]
-install: [make "install"]
 post-messages:
   "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
 dev-repo:


### PR DESCRIPTION
### `rdbg.1.196.9`
RDBG: a reactive programs debugger
The library rdbg contains all the ocaml modules needed to use rdbg,
a reactive programs debugger.



---
* Homepage: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues

---
:camel: Pull-request generated by opam-publish v2.0.3