### PR TITLE
Package memprof-limits.0.2.0

### DIFF
--- a/packages/memprof-limits/memprof-limits.0.2.0/opam
+++ b/packages/memprof-limits/memprof-limits.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Memory limits, allocation limits, and thread cancellation"
+description: """\
+Memprof-limits provides per-thread global memory limits, per-thread
+allocation limits, and cancellation of threads, with ways to
+ensure resource-safety after interruption.
+
+Global memory limits let you bound the memory consumption of a task,
+in terms of the major heap size.
+
+Allocation limits let you bound the execution time of a task measured
+in number of allocations. Allocation limits do not count
+deallocations, and are therefore a measure of the work done, which can
+be more suitable (reliable, portable, deterministic) than wall-clock
+time.
+
+Token limits lets you cancel a (CPU-bound) task preemptively and at a
+distance.
+
+Tasks are interrupted by raising an asynchronous exception.
+Memprof-limits provides features and guidance for reasoning about the
+consistency of state in the presence of such interrupts.
+
+The implementation uses OCaml's Memprof engine with a low sampling
+rate that does not affect performance. A reimplementation of the
+Memprof interface compatible with memprof-limits running at the same
+time is provided for profiling needs."""
+maintainer:
+  "Guillaume Munch-Maccagnoni <Guillaume.Munch-Maccagnoni@inria.fr>"
+authors: "Guillaume Munch-Maccagnoni <Guillaume.Munch-Maccagnoni@inria.fr>"
+license: "LGPL-3.0-linking-exception"
+homepage: "https://gitlab.com/gadmm/memprof-limits/"
+doc: "https://guillaume.munch.name/software/ocaml/memprof-limits/"
+bug-reports: "https://gitlab.com/gadmm/memprof-limits/issues/"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "1.2"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/gadmm/memprof-limits.git"
+url {
+  src:
+    "https://gitlab.com/gadmm/memprof-limits/-/archive/v0.2.0/memprof-limits-v0.2.0.tar.bz2"
+  checksum: [
+    "md5=2173a686a3191968666865e919ec2f02"
+    "sha512=693abfef75c9639b8bb6dcb6f97e21ce4ede519bce69155b4045c89f8d42a46f696d46d77c7f59a8b7309b7df138e3f60ea1c6d5eba257e0c278facbcfd7b82d"
+  ]
+}

--- a/packages/memprof-limits/memprof-limits.0.2.0/opam
+++ b/packages/memprof-limits/memprof-limits.0.2.0/opam
@@ -28,7 +28,7 @@ time is provided for profiling needs."""
 maintainer:
   "Guillaume Munch-Maccagnoni <Guillaume.Munch-Maccagnoni@inria.fr>"
 authors: "Guillaume Munch-Maccagnoni <Guillaume.Munch-Maccagnoni@inria.fr>"
-license: "LGPL-3.0-linking-exception"
+license: "LGPL-3.0-only WITH LGPL-3.0-linking-exception"
 homepage: "https://gitlab.com/gadmm/memprof-limits/"
 doc: "https://guillaume.munch.name/software/ocaml/memprof-limits/"
 bug-reports: "https://gitlab.com/gadmm/memprof-limits/issues/"


### PR DESCRIPTION
### `memprof-limits.0.2.0`
Memory limits, allocation limits, and thread cancellation
Memprof-limits provides per-thread global memory limits, per-thread
allocation limits, and cancellation of threads, with ways to
ensure resource-safety after interruption.

Global memory limits let you bound the memory consumption of a task,
in terms of the major heap size.

Allocation limits let you bound the execution time of a task measured
in number of allocations. Allocation limits do not count
deallocations, and are therefore a measure of the work done, which can
be more suitable (reliable, portable, deterministic) than wall-clock
time.

Token limits lets you cancel a (CPU-bound) task preemptively and at a
distance.

Tasks are interrupted by raising an asynchronous exception.
Memprof-limits provides features and guidance for reasoning about the
consistency of state in the presence of such interrupts.

The implementation uses OCaml's Memprof engine with a low sampling
rate that does not affect performance. A reimplementation of the
Memprof interface compatible with memprof-limits running at the same
time is provided for profiling needs.



---
* Homepage: https://gitlab.com/gadmm/memprof-limits/
* Source repo: git+https://gitlab.com/gadmm/memprof-limits.git
* Bug tracker: https://gitlab.com/gadmm/memprof-limits/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0