### PR TITLE
Slug: URL-safe slug generator

### DIFF
--- a/packages/slug/slug.1.0.0/opam
+++ b/packages/slug/slug.1.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: "Khoa Nguyen"
+homepage: "https://github.com/thangngoc89/ocaml-slug"
+maintainer: "hi@khoanguyen.me"
+dev-repo: "git+ssh://git@github.com:thangngoc89/ocaml-slug.git"
+bug-reports: "https://github.com/thangngoc89/ocaml-slug/issues"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune"
+  "opam-lock" {dev}
+  "yojson" {dev}
+  "alcotest" {with-test}
+
+  "uunf"
+  "uuseg"
+  "uutf"
+  "re"
+]
+synopsis: "Url safe slug generator"
+description: "Url safe slug generator"
+
+url {
+  src: "https://github.com/thangngoc89/ocaml-slug/archive/1.0.0.tar.gz"
+  checksum: "md5=85a2ca8ddd75b97de98f103b5b250feb"
+}

--- a/packages/slug/slug.1.0.0/opam
+++ b/packages/slug/slug.1.0.0/opam
@@ -15,10 +15,10 @@ depends: [
   "yojson" {dev}
   "alcotest" {with-test}
 
-  "uunf"
+  "uunf" {>= "1.0.0"}
   "uuseg"
   "uutf"
-  "re"
+  "re" {>= "1.7.2"}
 ]
 synopsis: "Url safe slug generator"
 description: """

--- a/packages/slug/slug.1.0.0/opam
+++ b/packages/slug/slug.1.0.0/opam
@@ -4,6 +4,7 @@ homepage: "https://github.com/thangngoc89/ocaml-slug"
 maintainer: "hi@khoanguyen.me"
 dev-repo: "git+ssh://git@github.com:thangngoc89/ocaml-slug.git"
 bug-reports: "https://github.com/thangngoc89/ocaml-slug/issues"
+license: "MIT"
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/slug/slug.1.0.0/opam
+++ b/packages/slug/slug.1.0.0/opam
@@ -21,7 +21,11 @@ depends: [
   "re"
 ]
 synopsis: "Url safe slug generator"
-description: "Url safe slug generator"
+description: """
+A URL slug is the part of a URL or link that comes after the domain extension.
+
+In websites the keyword used for your URL slug can be used to SEO optimize the URL by showing Google the structure of your site and the contents of the page in question.
+"""
 
 url {
   src: "https://github.com/thangngoc89/ocaml-slug/archive/1.0.0.tar.gz"

--- a/packages/slug/slug.1.0.0/opam
+++ b/packages/slug/slug.1.0.0/opam
@@ -5,11 +5,12 @@ maintainer: "hi@khoanguyen.me"
 dev-repo: "git+ssh://git@github.com:thangngoc89/ocaml-slug.git"
 bug-reports: "https://github.com/thangngoc89/ocaml-slug/issues"
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune"
+   "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
   "opam-lock" {dev}
   "yojson" {dev}
   "alcotest" {with-test}


### PR DESCRIPTION
In summary,

```ocaml
Slug.slugify "Some page title"
```

returns

```ocaml
"some-page-title"
```

which is more suitable for use in URLs. Slug offers several options for tweaking the exact behavior.

<br>

From the README:

> A URL slug is the part of a URL or link that comes after the domain extension.
>
> In websites the keyword used for your URL slug can be used to SEO optimize the URL by showing Google the structure of your site and the contents of the page in question.

This library turns title into URL-safe slug with support for non-latin characters.

This library uses algorithm and data from [node-slugify](https://github.com/simov/slugify)