### PR TITLE
conf-git: update version to not register a homebrew depext

### DIFF
--- a/packages/conf-git/conf-git.1.1/opam
+++ b/packages/conf-git/conf-git.1.1/opam
@@ -4,17 +4,17 @@ homepage: "https://git-scm.com"
 authors: "Linus Torvalds"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-2.0-or-later"
-build: [["which" "git"]]
-depends: [
-  "conf-which" {build}
-]
+build: ["git" "--version"]
 depexts: [
   ["git"] {os-distribution = "centos"}
   ["git"] {os-distribution = "fedora"}
+  ["git"] {os-distribution = "ol"}
   ["git"] {os-family = "suse"}
   ["git"] {os-family = "debian"}
+  ["git"] {os-family = "ubuntu"}
   ["git"] {os-distribution = "nixos"}
-  ["git"] {os-distribution = "arch"}
+  ["git"] {os-family = "arch"}
+  ["git"] {os-family = "alpine"}
 ]
 synopsis: "Virtual package relying on git"
 description:

--- a/packages/conf-git/conf-git.1.1/opam
+++ b/packages/conf-git/conf-git.1.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://git-scm.com"
+authors: "Linus Torvalds"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-2.0-or-later"
+build: [["which" "git"]]
+depends: [
+  "conf-which" {build}
+]
+depexts: [
+  ["git"] {os-distribution = "centos"}
+  ["git"] {os-distribution = "fedora"}
+  ["git"] {os-family = "suse"}
+  ["git"] {os-family = "debian"}
+  ["git"] {os-distribution = "nixos"}
+  ["git"] {os-distribution = "arch"}
+]
+synopsis: "Virtual package relying on git"
+description:
+  "This package can only install if the git program is installed on the system."
+flags: conf


### PR DESCRIPTION
The homebrew version of git is a newer version, but is not
necessary to explicitly specify in conf-git since there is
always a base `git` binary in macOS.  This matters when using
opam 2.1, which automatically tries to `brew install git`
unnecessarily.