### PR TITLE
Package ocsigen-toolkit.2.12.2

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
@@ -12,7 +12,7 @@ install: [ make "install" ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "eliom" {>= "6.12.1"}
-  "calendar"
+  "calendar" {>= "2.0.0"}
 ]
 depexts: [
   ["libgdbm-dev"] {os-family = "debian"}

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar"
+]
+depexts: [
+  ["libgdbm-dev"] {os-family = "debian"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.12.2.tar.gz"
+  checksum: [
+    "md5=858dbbbcb856d02fda7d2851cc3afecc"
+    "sha512=ceb18e7483df78bef903e5898678d74fbe02170d05d5bdf97957d98decf3b687ba4756d786f16bc54b6ea2eb8504d463b6d10f72a959cf1715f5fa2ff98129c3"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.12.2`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0