### PR TITLE
[new release] bun (0.3.4)

### DIFF
--- a/packages/bun/bun.0.3.4/opam
+++ b/packages/bun/bun.0.3.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Simple management of afl-fuzz processes"
+maintainer: "maintenance@identity-function.com"
+authors: [
+  "Mindy Preston"
+  "Thomas Leonard"
+]
+license: "MIT"
+homepage: "https://github.com/ocurrent/bun"
+bug-reports: "https://github.com/ocurrent/bun/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath"
+  "rresult" {>= "0.3.0"}
+  "astring"
+  "crowbar" {with-test}
+  "afl" {= "2.52b"}
+  "logs"
+  "fmt"
+  "lwt"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "base-domains"
+]
+dev-repo: "git+https://github.com/ocurrent/bun.git"
+description: """
+A wrapper for OCaml processes using afl-fuzz, intended for easy use in CI environments.
+See the README.md for more information.
+"""
+url {
+  src:
+    "https://github.com/ocurrent/bun/releases/download/v0.3.4/bun-v0.3.4.tbz"
+  checksum: [
+    "sha256=95345fb1f8e0458579968fe5223dfa1e0c34582c2d48283fb7fbfd4c339ea5b6"
+    "sha512=32cb4903e5a5496b0cc3443089aeac899d5143bb8a2b579f5b3ce24a8ea9431064c066abf26cad5a69138f0187c9e7fc0b48bfcbebfaacedafd764ca641fd7bf"
+  ]
+}
+x-commit-hash: "84fdec2c72702e565ac5eae447f751eff0e79581"


### PR DESCRIPTION
Simple management of afl-fuzz processes

- Project page: <a href="https://github.com/ocurrent/bun">https://github.com/ocurrent/bun</a>

##### CHANGES:

- update to dune 2 (ocurrent/bun#18, by @talex5 and @edwintorok)
- use `-M` for first worker (ocurrent/bun#17, by @edwintorok and @talex5)
- move bun to https://github.com/ocurrent/bun (ocurrent/bun#20, by @talex5)
