### PR TITLE
Why3 and alt-ergo: update lower bounds 

### DIFF
--- a/packages/alt-ergo-free/alt-ergo-free.2.0.0/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.0.0/opam
@@ -50,6 +50,7 @@ patches:[
   "makefile.user_replace_echo_by_printf.patch"
   "patch_for_changes_in_num_library.patch"
 ]
+available: [ arch != "arm32" ]
 synopsis: "Alt-Ergo, an SMT Solver for Software Verification"
 description: """
 Alt-Ergo is an automatic prover of mathematical formulas used behind software verification tools such as Frama-C, SPARK, Why3, Atelier-B and Caveat.

--- a/packages/alt-ergo-free/alt-ergo-free.2.0.0/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.0.0/opam
@@ -27,7 +27,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "num"
-  "zarith"
+  "zarith" {>= "1.4"}
   "camlzip" {< "1.08"}
   "ocplib-simplex" {>= "0.4"}
   "menhir"

--- a/packages/alt-ergo-free/alt-ergo-free.2.2.0/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.2.0/opam
@@ -28,7 +28,7 @@ remove: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "num"
-  "zarith"
+  "zarith" {>= "1.4"}
   "camlzip"
   "ocplib-simplex" {>= "0.4"}
   "psmt2-frontend" {= "0.1" }

--- a/packages/why3/why3.1.4.0/opam
+++ b/packages/why3/why3.1.4.0/opam
@@ -44,7 +44,7 @@ depends: [
   "conf-autoconf" {build & dev}
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "menhir" {>= "20151112"}
+  "menhir" {>= "20170418"}
   "num"
 ]
 


### PR DESCRIPTION
To prevent
```
# Ocamlc   src/parser/parser.ml
# File src/parser/report.ml, line 34, characters 2-22:
# 34 |   current_state_number (env checkpoint)
#        ^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value current_state_number
```

and 

```
# File /home/opam/.opam/4.08/.opam-switch/build/alt-ergo-free.2.0.0/lib/util/zarithNumbers.ml, line 94, characters 4-13:
# 94 |     Z.testbit z n
#          ^^^^^^^^^
# Error: Unbound value Z.testbit
```
