### PR TITLE
Package rdbg.1.196.11

### DIFF
--- a/packages/rdbg/rdbg.1.196.11/opam
+++ b/packages/rdbg/rdbg.1.196.11/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "RDBG: a reactive programs debugger"
+description: """\
+The library rdbg contains all the ocaml modules needed to use rdbg,
+a reactive programs debugger."""
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: "Erwan Jahier"
+license: "CeCILL-2.1"
+homepage:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix"
+  "lutils" {>= "1.51"}
+  "ocamlfind"
+  "ledit"
+  "dune" {>= "2.0"}
+  "ounit" {build & >= "2.0.0"}
+  "num" {>= "1.4"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.1.196.11.tgz"
+  checksum: [
+    "md5=e729ad164db14bca78d9f3878bb41159"
+    "sha512=19cdf8732ea2f401b043a9733ba930b37a8effe5b5b817ca9512793d4866ba7ca790b72c42c0b234513bc324f1e4d2a36efb2d4b3fc742582c9e68f091d99c39"
+  ]
+}


### PR DESCRIPTION
### `rdbg.1.196.11`
RDBG: a reactive programs debugger
The library rdbg contains all the ocaml modules needed to use rdbg,
a reactive programs debugger.



---
* Homepage: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues

---
:camel: Pull-request generated by opam-publish v2.0.3