### PR TITLE
Package rdbg.1.196.12

### DIFF
--- a/packages/lustre-v6/lustre-v6.6.101.7/opam
+++ b/packages/lustre-v6/lustre-v6.6.101.7/opam
@@ -12,7 +12,7 @@ license: "CeCILL-1.0+"
 homepage: "http://www-verimag.imag.fr/lustre-v6.html"
 bug-reports: "http://www-verimag.imag.fr/lustre-v6.html"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.12"}
   "base-unix"
   "extlib" {build} | "extlib-compat" {build}
   "lutils" {>= "1.49"}

--- a/packages/lustre-v6/lustre-v6.6.101.7/opam
+++ b/packages/lustre-v6/lustre-v6.6.101.7/opam
@@ -19,7 +19,7 @@ depends: [
   "oasis" {build & >= "0.4.7"} | "oasis-mirage" {build & >= "0.4.7"}
   "ocamlbuild" {build}
   "ocamlfind"
-  "rdbg" {>= "1.184"}
+  "rdbg" {>= "1.184" & < 1.196 }
 ]
 build: [
   [make "build"]

--- a/packages/lustre-v6/lustre-v6.6.101.7/opam
+++ b/packages/lustre-v6/lustre-v6.6.101.7/opam
@@ -19,7 +19,7 @@ depends: [
   "oasis" {build & >= "0.4.7"} | "oasis-mirage" {build & >= "0.4.7"}
   "ocamlbuild" {build}
   "ocamlfind"
-  "rdbg" {>= "1.184" & < 1.196 }
+  "rdbg" {>= "1.184" & < "1.196" }
 ]
 build: [
   [make "build"]

--- a/packages/rdbg/rdbg.1.196.12/opam
+++ b/packages/rdbg/rdbg.1.196.12/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "RDBG: a reactive programs debugger"
+description: """\
+The library rdbg contains all the ocaml modules needed to use rdbg,
+a reactive programs debugger."""
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: "Erwan Jahier"
+license: "CeCILL-2.1"
+homepage:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix"
+  "lutils" {>= "1.51"}
+  "ocamlfind"
+  "ledit"
+  "dune" {>= "2.0"}
+  "ounit" {build & >= "2.0.0"}
+  "num" {>= "1.4"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.1.196.12.tgz"
+  checksum: [
+    "md5=9149f1e2f49e971c77ff519aef34f09b"
+    "sha512=8e88034b1eda8f1233b4990adc9746782148254c93d8d0c99c246c0d50f306eeb6aa4afcfca8834acb3e268860647f47a24cc6a2d29fb45cac11f098e2ede275"
+  ]
+}


### PR DESCRIPTION
### `rdbg.1.196.12`
RDBG: a reactive programs debugger
The library rdbg contains all the ocaml modules needed to use rdbg,
a reactive programs debugger.



---
* Homepage: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues

---
:camel: Pull-request generated by opam-publish v2.0.3