### PR TITLE
[new release] opam-dune-lint (0.2)

### DIFF
--- a/packages/opam-dune-lint/opam-dune-lint.0.2/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Ensure dune and opam dependencies are consistent"
+description:
+  "opam-dune-lint checks that all ocamlfind libraries listed as dune dependencies have corresponding opam dependencies listed in the opam files. If not, it offers to add them (either to your opam files, or to your dune-project if you're generating your opam files from that)."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "ISC"
+homepage: "https://github.com/ocurrent/opam-dune-lint"
+bug-reports: "https://github.com/ocurrent/opam-dune-lint/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "astring" {>= "0.8.5"}
+  "sexplib" {>= "v0.14.0"}
+  "cmdliner" {>= "1.0.4"}
+  "dune-private-libs" {>= "2.8.0"}
+  "ocaml" {>= "4.10.0"}
+  "bos" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "opam-state" {>= "2.1.0~~"}
+  "opam-format"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/opam-dune-lint.git"
+flags: plugin
+url {
+  src:
+    "https://github.com/ocurrent/opam-dune-lint/releases/download/v0.2/opam-dune-lint-v0.2.tbz"
+  checksum: [
+    "sha256=14820dabe460fda8272596d02c3de938ae584720285b7538fc7ee6f7d7a93432"
+    "sha512=e25ed90fcddd68b92e7ff6092a6a3f357840d53eadf133348977771cd9d457cc1994a46cec88c95e101cfef354694f6b454f73b5e684da45bafe50f25304797c"
+  ]
+}
+x-commit-hash: "1345ed5872359b6f2708ccfc4e9cd3e1d1391204"


### PR DESCRIPTION
Ensure dune and opam dependencies are consistent

- Project page: <a href="https://github.com/ocurrent/opam-dune-lint">https://github.com/ocurrent/opam-dune-lint</a>

##### CHANGES:

- Cope with missing `(depends ...)` in `dune-project` (@talex5 ocurrent/opam-dune-lint#33). We tried to add the missing packages to an existing depends field, but if there wasn't one at all then we did nothing.

- Use quoted versions in the fix suggestion string (@tmcgilchrist ocurrent/opam-dune-lint#32). Makes copy-and-paste easier for people using it via a web UI.

- Support older versions of OCaml back to 4.10 (@tmcgilchrist ocurrent/opam-dune-lint#31).

- Ignore dependencies on sub-packages (@dra27 ocurrent/opam-dune-lint#27). Library `foo` may depend on library `foo.bar` but this cannot introduce an opam dependency on `foo` in `foo.opam`.

- Require opam libraries compatible with the client (@dra27 ocurrent/opam-dune-lint#26).

- Add support for multiple dependency clauses for the same package (@kit-ty-kate ocurrent/opam-dune-lint#25).

- Upgrade to dune-private-libs 2.8.0 (@kit-ty-kate ocurrent/opam-dune-lint#20).

- Remove dependency on ocamlfind, as we don't use it for anything now (@talex5 ocurrent/opam-dune-lint#18).
