### PR TITLE
[new release] opam-monorepo (0.2.3)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.2.3/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/opam-monorepo"
+bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "conf-pkg-config" {build}
+]
+conflicts: [
+  "dune-build-info" {= "2.7.0" | = "2.7.1"}
+  "dune-configurator" {= "2.7.0" | = "2.7.1"}
+]
+dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
+flags: [ plugin ]
+url {
+  src:
+    "https://github.com/ocamllabs/opam-monorepo/releases/download/0.2.3/opam-monorepo-0.2.3.tbz"
+  checksum: [
+    "sha256=3b0d04349413c57675af966b486a7a26d366e5e3f83df5783118e4ff42b66fc6"
+    "sha512=75ec3ffd06c53a88580239fe76e8fe3a225ab034dff12c48e1746996ea5e3697fe81b80fefba61d285518102fea64509d6b5c8b1c38374043be1076054216207"
+  ]
+}
+x-commit-hash: "d8c1fe8d38656c32df3ee66efbf82ae8606f2e8f"


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/ocamllabs/opam-monorepo">https://github.com/ocamllabs/opam-monorepo</a>

##### CHANGES:

### Fixed

- Fix compat with opam 2.1.0~rc2 by upgrading vendored opam libs
