### PR TITLE
[new release] non_empty_list (0.1)

### DIFF
--- a/packages/non_empty_list/non_empty_list.0.1/opam
+++ b/packages/non_empty_list/non_empty_list.0.1/opam
@@ -9,7 +9,6 @@ depends: [
   "dune" { >= "2.8" }
   "base" { >= "v0.14.1" }
   "ppx_deriving" { >= "4.5" }
-  "ocamlformat"
   "alcotest" {with-test}
 ]
 license: "MIT"
@@ -21,10 +20,8 @@ The hd and tl functions don't require option types, or exceptions, improving saf
 This library follows closely Janestreet's Base library,
 providing similar complexity and functions to Base.List. 
 """
-build: [
-  ["dune" "build" "-p" name]
-]
-run-test: ["dune" "runtest" "-p" name]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
 x-commit-hash: "32039e6b930d83f88ffb76f0ffc582a5b5922ff6"
 url {
   src:

--- a/packages/non_empty_list/non_empty_list.0.1/opam
+++ b/packages/non_empty_list/non_empty_list.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "ajo41@cam.ac.uk"
+authors: ["Alistair O'Brien"]
+homepage: "https://github.com/johnyob/ocaml-non-empty-list"
+bug-reports: "https://github.com/johnyob/ocaml-non-empty-list/issues"
+dev-repo: "git+https://github.com/johnyob/ocaml-non-empty-list.git"
+depends: [ 
+  "ocaml" { >= "4.08.0" }
+  "dune" { >= "2.8" }
+  "base" { >= "0.14.1" }
+  "ppx_deriving" { >= "4.5" }
+  "ocamlformat"
+  "alcotest" {with-test}
+]
+license: "MIT"
+synopsis: "A non empty list library for OCaml"
+description: """
+A list that is known, statically, to be nonempty. 
+The hd and tl functions don't require option types, or exceptions, improving safety.  
+
+This library follows closely Janestreet's Base library,
+providing similar complexity and functions to Base.List. 
+"""
+build: [
+  ["dune" "build" "-p" name]
+]
+run-test: ["dune" "runtest" "-p" name]
+x-commit-hash: "32039e6b930d83f88ffb76f0ffc582a5b5922ff6"
+url {
+  src:
+    "https://github.com/johnyob/ocaml-non-empty-list/releases/download/0.1/non_empty_list-0.1.tbz"
+  checksum: [
+    "sha256=af4bf61dc1beb8b5428955bff3a209a3c231fe93eaa02a70cbb13907bb65a85b"
+    "sha512=be98fd76da87c1b40452b970c9b9826d5ba16a0629e46f67230b654c8d5b954b12082ecfec68594abf6440fb531599972dc579537c0149801de86cd84f4c99f8"
+  ]
+}

--- a/packages/non_empty_list/non_empty_list.0.1/opam
+++ b/packages/non_empty_list/non_empty_list.0.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/johnyob/ocaml-non-empty-list.git"
 depends: [ 
   "ocaml" { >= "4.08.0" }
   "dune" { >= "2.8" }
-  "base" { >= "0.14.1" }
+  "base" { >= "v0.14.1" }
   "ppx_deriving" { >= "4.5" }
   "ocamlformat"
   "alcotest" {with-test}


### PR DESCRIPTION
A list that is known, statically, to be nonempty. Removes `option`, `result` types, or exceptions from many list functions that rely on non-empty lists. 
- https://github.com/johnyob/ocaml-non-empty-list 

**CHANGES:**

Initial release.