### PR TITLE
Package dtools.0.4.4

### DIFF
--- a/packages/dtools/dtools.0.4.4/opam
+++ b/packages/dtools/dtools.0.4.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Library providing various helper functions to make daemons"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-dtools"
+bug-reports: "https://github.com/savonet/ocaml-dtools/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+depopts: ["syslog"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
+url {
+  src: "https://github.com/savonet/ocaml-dtools/archive/v0.4.4.tar.gz"
+  checksum: [
+    "md5=dae98a36c13495c8af3a73f8786ef813"
+    "sha512=8416c3bfc49de7bfb92e6921c37512882589f3b7a6b9f51cb75e761697204b99a37827028a828861134c067a2efc06e80073dc0b5f5fb6529c7f4ff04f957984"
+  ]
+}


### PR DESCRIPTION
### `dtools.0.4.4`
Library providing various helper functions to make daemons



---
* Homepage: https://github.com/savonet/ocaml-dtools
* Source repo: git+https://github.com/savonet/ocaml-dtools.git
* Bug tracker: https://github.com/savonet/ocaml-dtools/issues

---
:camel: Pull-request generated by opam-publish v2.0.3