### PR TITLE
Package duppy.0.9.2

### DIFF
--- a/packages/duppy/duppy.0.9.2/opam
+++ b/packages/duppy/duppy.0.9.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Library providing monadic threads"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-duppy"
+bug-reports: "https://github.com/savonet/ocaml-duppy/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "pcre"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-duppy.git"
+url {
+  src: "https://github.com/savonet/ocaml-duppy/archive/v0.9.2.tar.gz"
+  checksum: [
+    "md5=062bddf41b531c82c9fdb6c1fdbd5d9f"
+    "sha512=380947d4fa4d03c46ad5de82d8e9fbbd1fe3f0489ca7d3ef14de28f65aa189128a5496a194a35f833d29b0e7f32a4b90da76c68b83b729c536991c47fc4813b4"
+  ]
+}


### PR DESCRIPTION
### `duppy.0.9.2`
Library providing monadic threads



---
* Homepage: https://github.com/savonet/ocaml-duppy
* Source repo: git+https://github.com/savonet/ocaml-duppy.git
* Bug tracker: https://github.com/savonet/ocaml-duppy/issues

---
:camel: Pull-request generated by opam-publish v2.0.3