### PR TITLE
[new release] bitwuzla, bitwuzla-c and bitwuzla-bin (1.0.0)

### DIFF
--- a/packages/bitwuzla-bin/bitwuzla-bin.1.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.1.0.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Bitwuzla SMT solver executable"
+description: """
+
+Standalone installer for the SMT solver Bitwuzla.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+bug-reports: "https://github.com/bitwuzla/bitwuzla/issues"
+depends: [
+  "conf-git" {build}
+  "conf-cmake" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp" {build}
+]
+build: [
+  [ "sh" "-c" "cd vendor/cadical && ./configure -fPIC" ]
+  [ make "-j" jobs "-C" "vendor/cadical/build" ]
+  [ "sh" "-c" "cd vendor/btor2tools && ./configure.sh" ]
+  [ make "-j" jobs "-C" "vendor/btor2tools/build" ]
+  [ "sh" "-c" "patch -p1 --directory vendor/symfpu \
+    	 < vendor/bitwuzla/contrib/symfpu_20201114.patch" ]
+  [ "sh" "-c"
+    "export LDFLAGS='-Wl,-rpath=$ORIGIN/../lib' && \
+    cd vendor/bitwuzla && ./configure.sh \
+    --no-testing --shared --only-cadical \
+    --path .. \
+    --path ../cadical/src \
+    --path ../cadical/build \
+    --path ../btor2tools/src/btor2parser \
+    --path ../btor2tools/build/lib \
+    --prefix %{prefix}%" ]
+  [ make "-j" jobs "-C" "vendor/bitwuzla/build" ]
+]
+install: [
+  [ "install" "vendor/btor2tools/build/lib/libbtor2parser.so" lib ]
+  [ make "install" "-j" jobs "-C" "vendor/bitwuzla/build" ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]
+x-commit-hash: "6dd263d8147829badd3c3c134293dc6be8d29ea9"
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/1.0.0/bitwuzla-1.0.0.tbz"
+  checksum: [
+    "sha256=004ccb630a070829fedcbaf071fc50f5c7df2e5f47d2016e228ab775df6961d8"
+    "sha512=9a3d46b0a0379228a17f9d5f88cf7c409eab7c72d9296a939bc254120bc89ede9471d0930f8d2f70463e99e627649e56e54556ed2f008a3800f9387a6959674a"
+  ]
+}

--- a/packages/bitwuzla-bin/bitwuzla-bin.1.0.0/opam
+++ b/packages/bitwuzla-bin/bitwuzla-bin.1.0.0/opam
@@ -42,7 +42,7 @@ install: [
   [ make "install" "-j" jobs "-C" "vendor/bitwuzla/build" ]
 ]
 dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
-available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) & (os-distribution != "ubuntu" | os-version >= "20.04") & (os-distribution != "debian" | os-version > 10) ]
 x-commit-hash: "6dd263d8147829badd3c3c134293dc6be8d29ea9"
 url {
   src:

--- a/packages/bitwuzla-c/bitwuzla-c.1.0.0/opam
+++ b/packages/bitwuzla-c/bitwuzla-c.1.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C API)"
+description: "OCaml binding for the SMT solver Bitwuzla C API."
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "bitwuzla" {< "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]
+x-commit-hash: "6dd263d8147829badd3c3c134293dc6be8d29ea9"
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/1.0.0/bitwuzla-1.0.0.tbz"
+  checksum: [
+    "sha256=004ccb630a070829fedcbaf071fc50f5c7df2e5f47d2016e228ab775df6961d8"
+    "sha512=9a3d46b0a0379228a17f9d5f88cf7c409eab7c72d9296a939bc254120bc89ede9471d0930f8d2f70463e99e627649e56e54556ed2f008a3800f9387a6959674a"
+  ]
+}

--- a/packages/bitwuzla/bitwuzla.1.0.0/opam
+++ b/packages/bitwuzla/bitwuzla.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "bitwuzla-c"
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]
+x-commit-hash: "6dd263d8147829badd3c3c134293dc6be8d29ea9"
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/1.0.0/bitwuzla-1.0.0.tbz"
+  checksum: [
+    "sha256=004ccb630a070829fedcbaf071fc50f5c7df2e5f47d2016e228ab775df6961d8"
+    "sha512=9a3d46b0a0379228a17f9d5f88cf7c409eab7c72d9296a939bc254120bc89ede9471d0930f8d2f70463e99e627649e56e54556ed2f008a3800f9387a6959674a"
+  ]
+}


### PR DESCRIPTION
SMT solver for AUFBVFP

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Brand new `Bitwuzla` OCaml API in addition the low level `Bitwuzla_c` C API.

Online documentation is available at https://bitwuzla.github.io/docs/ocaml/.

- `bitwuzla-c` package installs [C API](https://bitwuzla.github.io/docs/c/interface.html) binding;
- `bitwuzla` package installs more OCaml-ish, type safer Bitwuzla API.

Vendor submodules:
- [Cadical](https://github.com/arminbiere/cadical) tag:rel-1.4.1
- [SymFPU](https://github.com/martin-cs/symfpu) commit:8fbe139
- [Btor2Tools](https://github.com/Boolector/btor2tools) commit:6ba194b
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) commit:58d7205
