### PR TITLE
conf-gtk2: Fix homebrew (real package name is gtk+, gtk is an alias)

### DIFF
--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["gtk2-devel"] {os-family = "suse"}
   ["gtk2"] {os-family = "arch"}
   ["gtk2"] {os-distribution = "nixos"}
-  ["gtk" "expat"] {os-distribution = "homebrew" & os = "macos"}
+  ["gtk+" "expat"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on gtk2"
 description:


### PR DESCRIPTION
See https://formulae.brew.sh/formula/gtk+