### PR TITLE
[new release] github, github-unix, github-jsoo and github-data (4.4.0)

### DIFF
--- a/packages/github-data/github-data.4.4.0/opam
+++ b/packages/github-data/github-data.4.4.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "-p" name "@doc"] {with-doc}

--- a/packages/github-data/github-data.4.4.0/opam
+++ b/packages/github-data/github-data.4.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 data library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the data conversion library."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "yojson" {>= "1.6.0"}
+  "atdgen" {>= "2.0.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=d47a404421c72372b6df79658757b6fc2af65d77e3ebaa20c5335cc984269317"
+    "sha512=f3a452f2d9a90927bfde4edde5618d28ca328c7e7196270a218578e462960fb47e431a23a40385f2459d7d56ebdaa586c1e58a44f64029de675f50968880d480"
+  ]
+}
+x-commit-hash: "fbfe619d69dba841fa7c21cc7b94fc1e7f2b14ad"

--- a/packages/github-data/github-data.4.4.0/opam
+++ b/packages/github-data/github-data.4.4.0/opam
@@ -29,7 +29,7 @@ This library provides an OCaml interface to the [GitHub APIv3](https://docs.gith
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.10"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.7.0"}
   "atdgen" {>= "2.0.0"}
 ]
 url {

--- a/packages/github-jsoo/github-jsoo.4.4.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0" & < "3.0.0"}
+  "cohttp-lwt-jsoo" {>= "0.99.0" & < "3.0.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=d47a404421c72372b6df79658757b6fc2af65d77e3ebaa20c5335cc984269317"
+    "sha512=f3a452f2d9a90927bfde4edde5618d28ca328c7e7196270a218578e462960fb47e431a23a40385f2459d7d56ebdaa586c1e58a44f64029de675f50968880d480"
+  ]
+}
+x-commit-hash: "fbfe619d69dba841fa7c21cc7b94fc1e7f2b14ad"

--- a/packages/github-unix/github-unix.4.4.0/opam
+++ b/packages/github-unix/github-unix.4.4.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "-p" name "@doc"] {with-doc}

--- a/packages/github-unix/github-unix.4.4.0/opam
+++ b/packages/github-unix/github-unix.4.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the Unix (Lwt) version."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "github" {= version}
+  "cohttp" {>= "0.99.0" & < "3.0.0"}
+  "cohttp-lwt-unix" {>= "0.99.0" & < "3.0.0"}
+  "stringext"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+  "lwt"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=d47a404421c72372b6df79658757b6fc2af65d77e3ebaa20c5335cc984269317"
+    "sha512=f3a452f2d9a90927bfde4edde5618d28ca328c7e7196270a218578e462960fb47e431a23a40385f2459d7d56ebdaa586c1e58a44f64029de675f50968880d480"
+  ]
+}
+x-commit-hash: "fbfe619d69dba841fa7c21cc7b94fc1e7f2b14ad"

--- a/packages/github/github.4.4.0/opam
+++ b/packages/github/github.4.4.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "-p" name "@doc"] {with-doc}

--- a/packages/github/github.4.4.0/opam
+++ b/packages/github/github.4.4.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+license: "MIT"
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://docs.github.com/rest/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.10"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "0.99.0" & < "3.0.0"}
+  "cohttp-lwt" {>= "0.99.0" & < "3.0.0"}
+  "lwt" {>= "2.4.4"}
+  "github-data" {= version}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=d47a404421c72372b6df79658757b6fc2af65d77e3ebaa20c5335cc984269317"
+    "sha512=f3a452f2d9a90927bfde4edde5618d28ca328c7e7196270a218578e462960fb47e431a23a40385f2459d7d56ebdaa586c1e58a44f64029de675f50968880d480"
+  ]
+}
+x-commit-hash: "fbfe619d69dba841fa7c21cc7b94fc1e7f2b14ad"


### PR DESCRIPTION
GitHub APIv3 OCaml library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Fixes to odoc warnings and cohttp dependencies (@Aaylor mirage/ocaml-github#244)
- Support for 4.12 and fixing recent compiler warnings (@tmcgilchrist mirage/ocaml-github#246 mirage/ocaml-github#252 and @emillon mirage/ocaml-github#250 mirage/ocaml-github#247 mirage/ocaml-github#251)
- Add a new package `github-data` which contains just the serialisation logic
  without a dependency on the web stack (mirage/ocaml-github#248 @emillon)
- Add Github checks API support (mirage/ocaml-github#249 @tmcgilchrist)
