### PR TITLE
[new release] magic-mime (1.2.0)

### DIFF
--- a/packages/magic-mime/magic-mime.1.2.0/opam
+++ b/packages/magic-mime/magic-mime.1.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {

--- a/packages/magic-mime/magic-mime.1.2.0/opam
+++ b/packages/magic-mime/magic-mime.1.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.2.0/magic-mime-v1.2.0.tbz"
+  checksum: [
+    "sha256=f121b67500f8dd97e2fc9fd5d01c7325e4c84bc5c0237442779fbd6fa20694f5"
+    "sha512=f55e39b11e145f97eaec6796cb99bdca3ac62130995fc36f82fdd097ab5ed6ff9130c671546b76b7c21777284977c02f6b6f74d5549a367481210342708886da"
+  ]
+}
+x-commit-hash: "11afeba987ca94cb9a6b1e4e1695f1d54c6e23b2"


### PR DESCRIPTION
Map filenames to common MIME types

- Project page: <a href="https://github.com/mirage/ocaml-magic-mime">https://github.com/mirage/ocaml-magic-mime</a>
- Documentation: <a href="https://mirage.github.io/ocaml-magic-mime/">https://mirage.github.io/ocaml-magic-mime/</a>

##### CHANGES:

* Sync MIME types with latest from Apache (mirage/ocaml-magic-mime#22 @avsm)
* Add `mjs` mapping to application/javascript manually (@avsm, request from @glondu)
