### PR TITLE
js_of_ocaml.3.4.0: require ppx_tools_versioned 5.1

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.3.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "js_of_ocaml-compiler" {= version}
 ]
 conflicts: [
-  "ppx_tools_versioned"     {<= "5.0beta0"}
+  "ppx_tools_versioned"     {<= "5.1"}
 ]
 
 url {

--- a/packages/js_of_ocaml/js_of_ocaml.3.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.4.0/opam
@@ -16,7 +16,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.02.0" & < "4.09.0"}
-  "dune" {>= "1.2"}
+  "dune" {>= "1.4"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "ppx_tools_versioned"
   "uchar"


### PR DESCRIPTION
It uses `ppx_tools_versioned.metaquot_406` that has been added in that version.
