### PR TITLE
Remove references to the OCaml forge

### DIFF
--- a/packages/lablgtk/lablgtk.2.16.0/opam
+++ b/packages/lablgtk/lablgtk.2.16.0/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]

--- a/packages/lablgtk/lablgtk.2.18.10/opam
+++ b/packages/lablgtk/lablgtk.2.18.10/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk/lablgtk.2.18.11/opam
+++ b/packages/lablgtk/lablgtk.2.18.11/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk/lablgtk.2.18.2/opam
+++ b/packages/lablgtk/lablgtk.2.18.2/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]

--- a/packages/lablgtk/lablgtk.2.18.3/opam
+++ b/packages/lablgtk/lablgtk.2.18.3/opam
@@ -1,6 +1,10 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 build: [
   ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
   [make "world"]

--- a/packages/lablgtk/lablgtk.2.18.4/opam
+++ b/packages/lablgtk/lablgtk.2.18.4/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
-bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=220"
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 build: [

--- a/packages/lablgtk/lablgtk.2.18.5/opam
+++ b/packages/lablgtk/lablgtk.2.18.5/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
-bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=220"
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 build: [

--- a/packages/lablgtk/lablgtk.2.18.6/opam
+++ b/packages/lablgtk/lablgtk.2.18.6/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
-bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=220"
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 build: [

--- a/packages/lablgtk/lablgtk.2.18.7/opam
+++ b/packages/lablgtk/lablgtk.2.18.7/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk/lablgtk.2.18.8/opam
+++ b/packages/lablgtk/lablgtk.2.18.8/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk/lablgtk.2.18.9/opam
+++ b/packages/lablgtk/lablgtk.2.18.9/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk3/lablgtk3.0.beta1/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk3/lablgtk3.0.beta2/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta2/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk3/lablgtk3.0.beta3/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk3/lablgtk3.3.0.beta4/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta4/opam
@@ -5,7 +5,7 @@ synopsis: "OCaml interface to GTK+"
 
 maintainer: "garrigue@math.nagoya-u.ac.jp"
 authors: ["Jacques Garrigue et al., Nagoya University"]
-homepage: "http://lablgtk.forge.ocamlcore.org/"
+homepage: "https://garrigue.github.io/lablgtk/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
 license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"

--- a/packages/lablgtk3/lablgtk3.3.0.beta5-1/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5-1/opam
@@ -4,7 +4,7 @@ synopsis: "OCaml interface to GTK+3"
 description: """
 OCaml interface to GTK+3
 
-See http://lablgtk.forge.ocamlcore.org/ for more information.
+See https://garrigue.github.io/lablgtk/ for more information.
 """
 
 maintainer: "garrigue@math.nagoya-u.ac.jp"

--- a/packages/lablgtk3/lablgtk3.3.0.beta5/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5/opam
@@ -3,8 +3,7 @@ opam-version: "2.0"
 synopsis: "OCaml interface to GTK+3"
 description: """
 OCaml interface to GTK+3
-
-See http://lablgtk.forge.ocamlcore.org/ for more information.
+See https://garrigue.github.io/lablgtk/ for more information.
 """
 
 maintainer: "garrigue@math.nagoya-u.ac.jp"

--- a/packages/lablgtk3/lablgtk3.3.0.beta6/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta6/opam
@@ -4,7 +4,7 @@ synopsis: "OCaml interface to GTK+3"
 description: """
 OCaml interface to GTK+3
 
-See http://lablgtk.forge.ocamlcore.org/ for more information.
+See https://garrigue.github.io/lablgtk/ for more information.
 """
 
 maintainer: "garrigue@math.nagoya-u.ac.jp"

--- a/packages/lablgtk3/lablgtk3.3.0.beta7/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta7/opam
@@ -4,7 +4,7 @@ synopsis: "OCaml interface to GTK+3"
 description: """
 OCaml interface to GTK+3
 
-See http://lablgtk.forge.ocamlcore.org/ for more information.
+See https://garrigue.github.io/lablgtk/ for more information.
 """
 
 maintainer: "garrigue@math.nagoya-u.ac.jp"

--- a/packages/lablgtk3/lablgtk3.3.0.beta7/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta7/opam
@@ -12,7 +12,7 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-license: "LGPL with linking exception"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [

--- a/packages/lablgtk3/lablgtk3.3.0.beta8/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta8/opam
@@ -12,7 +12,7 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-license: "LGPL with linking exception"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [

--- a/packages/lablgtk3/lablgtk3.3.1.0/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.0/opam
@@ -12,7 +12,7 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-license: "LGPL with linking exception"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [

--- a/packages/lablgtk3/lablgtk3.3.1.1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.1/opam
@@ -12,7 +12,7 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-license: "LGPL with linking exception"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [


### PR DESCRIPTION
Old lablgtk packages still contained references to the OCaml forge.
While there is a redirection to github from there, it goes to repository page rather than the project home page.
This fixes these links, and homogenizes the packages.
The only remaining references to ocamlcore are the download links, which are still supported.