### PR TITLE
[new release] reparse, reparse-lwt and reparse-lwt-unix (3.1.0)

### DIFF
--- a/packages/reparse-lwt-unix/reparse-lwt-unix.3.1.0/opam
+++ b/packages/reparse-lwt-unix/reparse-lwt-unix.3.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Reparse lwt-unix based input support"
+description: "Reparse lwt-unix based input support"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.10.0"}
+  "lwt" {>= "5.4.1"}
+  "cstruct" {>= "6.0.0"}
+  "reparse" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v3.1.0/reparse-v3.1.0.tbz"
+  checksum: [
+    "sha256=60e57fdac0ae0b68b41a0cb5bd50327c84b306d40f74e9c21925c08049703e1d"
+    "sha512=329be459bbf3f354119298fcf4ac22c1a400b9acd213267e732b76bcf2add81eb80c713aec2b007ba9a47ace075a67467c10e305fad7fd2a63a5456f668b35ab"
+  ]
+}
+x-commit-hash: "12d53ec3c2a6a5b44bb68a2b47f9d5f0bcba6206"

--- a/packages/reparse-lwt/reparse-lwt.3.1.0/opam
+++ b/packages/reparse-lwt/reparse-lwt.3.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Reparse Lwt_stream.t input support"
+description: "char Lwt_stream.t parsing support for 'reparse'"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.10.0"}
+  "lwt" {>= "5.4.1"}
+  "cstruct" {>= "6.0.0"}
+  "reparse" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v3.1.0/reparse-v3.1.0.tbz"
+  checksum: [
+    "sha256=60e57fdac0ae0b68b41a0cb5bd50327c84b306d40f74e9c21925c08049703e1d"
+    "sha512=329be459bbf3f354119298fcf4ac22c1a400b9acd213267e732b76bcf2add81eb80c713aec2b007ba9a47ace075a67467c10e305fad7fd2a63a5456f668b35ab"
+  ]
+}
+x-commit-hash: "12d53ec3c2a6a5b44bb68a2b47f9d5f0bcba6206"

--- a/packages/reparse/reparse.3.1.0/opam
+++ b/packages/reparse/reparse.3.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Recursive descent parsing library for ocaml"
+description:
+  "Monadic, recursive descent based, parser construction library for ocaml. Comprehensively documented and tested"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/reparse"
+bug-reports: "https://github.com/lemaetech/reparse/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.10.0"}
+  "cstruct" {>= "6.0.0"}
+  "mdx" {with-test}
+  "popper" {with-test}
+  "ppx_deriving_popper" {with-test}
+  "ppx_deriving" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/reparse.git"
+url {
+  src:
+    "https://github.com/lemaetech/reparse/releases/download/v3.1.0/reparse-v3.1.0.tbz"
+  checksum: [
+    "sha256=60e57fdac0ae0b68b41a0cb5bd50327c84b306d40f74e9c21925c08049703e1d"
+    "sha512=329be459bbf3f354119298fcf4ac22c1a400b9acd213267e732b76bcf2add81eb80c713aec2b007ba9a47ace075a67467c10e305fad7fd2a63a5456f668b35ab"
+  ]
+}
+x-commit-hash: "12d53ec3c2a6a5b44bb68a2b47f9d5f0bcba6206"


### PR DESCRIPTION
Recursive descent parsing library for ocaml

- Project page: <a href="https://github.com/lemaetech/reparse">https://github.com/lemaetech/reparse</a>

##### CHANGES:

- Add `unsafe_take_cstruct_exact` and `unsafe_take_cstruct_ne` parsers.
- `PARSER.parse` function now takes `?pos` parameter and returns `pos` along with the parsed value. This allows creating pull based parsers.
- Expose `Promise` module.
