### PR TITLE
Http multipart formdata upper bound

### DIFF
--- a/packages/http-multipart-formdata/http-multipart-formdata.2.0.0/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.2.0.0/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
   "lwt"
-  "reparse" {>= "3.0.0"}
-  "reparse-lwt" {>= "3.0.0"}
-  "reparse-lwt-unix" {>= "3.0.0"}
+  "reparse" {(>= "3.0.0" & < "3.1.0")}
+  "reparse-lwt" {(>= "3.0.0" & < "3.1.0")}
+  "reparse-lwt-unix" {(>= "3.0.0" & < "3.1.0")}
   "ppx_expect" {with-test}
   "ppx_deriving" {with-test}
   "odoc" {with-doc}

--- a/packages/http-multipart-formdata/http-multipart-formdata.2.0.1/opam
+++ b/packages/http-multipart-formdata/http-multipart-formdata.2.0.1/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "fmt" {>= "0.8.9"}
   "lwt"
-  "reparse" {>= "3.0.0"}
-  "reparse-lwt" {>= "3.0.0"}
-  "reparse-lwt-unix" {>= "3.0.0"}
+  "reparse" {(>= "3.0.0" & < "3.1.0")}
+  "reparse-lwt" {(>= "3.0.0" & < "3.1.0")}
+  "reparse-lwt-unix" {(>= "3.0.0" & < "3.1.0")}
   "ppx_expect" {with-test}
   "ppx_deriving" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
Add upper bounds to package http-multipart-formdata v2.0.0 and v2.0.1 in preparation for reparse v3.1.0 release.
https://github.com/ocaml/opam-repository/pull/19054