### PR TITLE
[new release] anders.0.7.2

### DIFF
--- a/packages/anders/anders.0.7.2/opam
+++ b/packages/anders/anders.0.7.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "CCHM homotopy system type checker with strict equality"
+maintainer: "Namdak Tonpa <maxim@synrc.com>"
+authors: ["Namdak Tonpa @5HT" "Siegmentation Fault @siegment"]
+license: "ISC"
+homepage: "https://groupoid.space/homotopy/"
+bug-reports: "https://github.com/groupoid/anders/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.10"}
+  "menhir" {>= "20200123"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/groupoid/anders"
+url {
+  src: "https://github.com/groupoid/anders/archive/0.7.2.tar.gz"
+  checksum: [
+    "md5=e9f12921b951fa2529481390c6fb3864"
+    "sha512=afc27c83c4bdcb5fb93e1b58bdcc9b08a28f002f15d0e27a7e509666ca3f6bad47fc7296a72cd68aeee7d24175d2c64ee4688edeedc79adedab7cb1f5bb19760"
+  ]
+}


### PR DESCRIPTION
### `anders.0.7.2`
CCHM homotopy system type checker with strict equality

* Strict Equality (Id, ref, idJ)
* Cubical Subtypes (Sub, inc, ouc)
* Partials, Systems (Partial, [φ ↦ u])
* Kan Operations (hcomp, transp)
* Eliminate neutral elements (Mini-TT)
* Fast type checking
* Fast compilation
* Initial Base Library (OPAM share folder)
* New options `silent` and `indices`

---
* Homepage: https://groupoid.space/homotopy/
* Source repo: git+https://github.com/groupoid/anders
* Bug tracker: https://github.com/groupoid/anders/issues

---
:camel: Pull-request generated by opam-publish v2.1.0