### PR TITLE
[new release] tezos-context-hash and tezos-context-hash-irmin (1.0.0)

### DIFF
--- a/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
+++ b/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
@@ -30,8 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
-    "@doc" {with-doc}
   ]
 ]
 dev-repo: "git+https://github.com/tarides/tezos-context-hash.git"

--- a/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
+++ b/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Irmin implementation of the Tezos context hash specification"
+description: "Irmin implementation of the Tezos context hash specification"
+maintainer: ["Tarides <contact@tarides.com>"]
+authors: [
+  "Clément Pascutto <clement@pascutto.fr>"
+  "Mattias Roux <mattias@tarides.com>"
+  "Thomas Gazagnaire <thomas@tarides.com>"
+]
+license: "MIT"
+homepage: "https://github.com/tarides/tezos-context-hash"
+bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "tezos-context-hash"
+  "irmin" {>= "2.7.0"}
+  "cmdliner"
+  "fmt"
+  "yojson"
+  "irmin-pack"
+  "ppx_irmin"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/tezos-context-hash.git"
+url {
+  src:
+    "https://github.com/tarides/tezos-context-hash/releases/download/1.0.0/tezos-context-hash-irmin-1.0.0.tbz"
+  checksum: [
+    "sha256=00bd31b1e360d9124a28fd33512a569b77afea106fc0fbeb59c5521fc5023d4a"
+    "sha512=211f978e7385d7fd2e753aa44df4d711e41baade3f6c6c820feaab3a255fb338b1975c9c2a4b68de3d24297f6a8ed650a0927a08092e70f2c1140710863325a2"
+  ]
+}
+x-commit-hash: "fb576cc84d7a2b5ede965627c5a5206d6966cc74"

--- a/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
+++ b/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ppx_irmin"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
+++ b/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
 depends: [
   "dune" {>= "2.6"}
   "digestif" {>= "0.9.0"}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "repr"
   "zarith"
 ]

--- a/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
+++ b/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Specification of the Tezos context hash"
+description: """
+This package contains the specification of the Tezos context hash
+as well as generators of datasets useful to verify that an implementation
+complies with the specification.
+"""
+maintainer: ["Tarides <contact@tarides.com>"]
+authors: [
+  "Clément Pascutto <clement@pascutto.fr>"
+  "Mattias Roux <mattias@tarides.com>"
+  "Thomas Gazagnaire <thomas@tarides.com>"
+]
+license: "MIT"
+homepage: "https://github.com/tarides/tezos-context-hash"
+bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "alcotest" {with-test}
+  "digestif" {>= "0.9.0"}
+  "fmt"
+  "repr"
+  "zarith"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/tezos-context-hash.git"
+url {
+  src:
+    "https://github.com/tarides/tezos-context-hash/releases/download/1.0.0/tezos-context-hash-irmin-1.0.0.tbz"
+  checksum: [
+    "sha256=00bd31b1e360d9124a28fd33512a569b77afea106fc0fbeb59c5521fc5023d4a"
+    "sha512=211f978e7385d7fd2e753aa44df4d711e41baade3f6c6c820feaab3a255fb338b1975c9c2a4b68de3d24297f6a8ed650a0927a08092e70f2c1140710863325a2"
+  ]
+}
+x-commit-hash: "fb576cc84d7a2b5ede965627c5a5206d6966cc74"

--- a/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
+++ b/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
@@ -16,7 +16,6 @@ homepage: "https://github.com/tarides/tezos-context-hash"
 bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
 depends: [
   "dune" {>= "2.6"}
-  "alcotest" {with-test}
   "digestif" {>= "0.9.0"}
   "fmt"
   "repr"
@@ -32,7 +31,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
+++ b/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "zarith"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
+++ b/packages/tezos-context-hash/tezos-context-hash.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.6"}
   "digestif" {>= "0.9.0"}
   "fmt" {>= "0.8.7"}
-  "repr"
+  "repr" {>= "0.2.0"}
   "zarith"
 ]
 build: [


### PR DESCRIPTION
Specification of the Tezos context hash

- Project page: <a href="https://github.com/tarides/tezos-context-hash">https://github.com/tarides/tezos-context-hash</a>

##### CHANGES:

- Initial release compatible with irmin.2.7
