### PR TITLE
Package otoml.0.9.0

### DIFF
--- a/packages/otoml/otoml.0.9.0/opam
+++ b/packages/otoml/otoml.0.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis:
+  "TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)"
+description: """\
+OTOML is a library for parsing, manipulating, and pretty-printing TOML files.
+
+* Fully 1.0.0-compliant.
+* No extra dependencies: default implementation uses native numbers and represents dates as strings.
+* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
+* Informative parse error reporting.
+* Pretty-printer offers flexible indentation options."""
+maintainer: "daniil+opam@baturin.org"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://github.com/dmbaturin/otoml"
+bug-reports: "https://github.com/dmbaturin/otoml/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "menhir"
+  "menhirLib" {>= "20200123"}
+  "dune" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dmbaturin/otoml.git"
+url {
+  src: "https://github.com/dmbaturin/otoml/archive/refs/tags/0.9.0.tar.gz"
+  checksum: [
+    "md5=ef9947d298d0300f4201343b05392807"
+    "sha512=ae53d8f58fce8efc6d22b1963b149e5421c81ce501cab6d0a6dcdf91921d4d3cc40213a97c265f6c94cfb4ff957aa9e9633cada799e8645533808d0ca38ce136"
+  ]
+}

--- a/packages/otoml/otoml.0.9.0/opam
+++ b/packages/otoml/otoml.0.9.0/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/dmbaturin/otoml/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "menhir"
-  "menhirLib" {>= "20200123"}
+  "menhirLib" {>= "20200525"}
   "dune" {>= "2.0.0"}
   "uutf" {>= "1.0.0"}
 ]


### PR DESCRIPTION
### `otoml.0.9.0`
TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)
OTOML is a library for parsing, manipulating, and pretty-printing TOML files.

* Fully 1.0.0-compliant.
* No extra dependencies: default implementation uses native numbers and represents dates as strings.
* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
* Informative parse error reporting.
* Pretty-printer offers flexible indentation options.



---
* Homepage: https://github.com/dmbaturin/otoml
* Source repo: git+https://github.com/dmbaturin/otoml.git
* Bug tracker: https://github.com/dmbaturin/otoml/issues

---
:camel: Pull-request generated by opam-publish v2.0.3