### PR TITLE
[new release] index-bench and index (1.3.2)

### DIFF
--- a/packages/index-bench/index-bench.1.3.2/opam
+++ b/packages/index-bench/index-bench.1.3.2/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "cmdliner"
   "dune"    {>= "2.7.0"}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "index"
   "metrics"
   "metrics-unix"

--- a/packages/index-bench/index-bench.1.3.2/opam
+++ b/packages/index-bench/index-bench.1.3.2/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml"   {>= "4.03.0"}
-  "cmdliner"
+  "cmdliner" {>= "1.0.3"} # to avoid Result.result vs result errors
   "dune"    {>= "2.7.0"}
   "fmt" {>= "0.8.7"}
   "index" {= version}

--- a/packages/index-bench/index-bench.1.3.2/opam
+++ b/packages/index-bench/index-bench.1.3.2/opam
@@ -17,7 +17,7 @@ depends: [
   "cmdliner"
   "dune"    {>= "2.7.0"}
   "fmt" {>= "0.8.7"}
-  "index"
+  "index" {= version}
   "metrics"
   "metrics-unix"
   "ppx_deriving_yojson"

--- a/packages/index-bench/index-bench.1.3.2/opam
+++ b/packages/index-bench/index-bench.1.3.2/opam
@@ -21,7 +21,7 @@ depends: [
   "metrics"
   "metrics-unix"
   "ppx_deriving_yojson"
-  "re"
+  "re" {>= "1.9.0"}
   "stdlib-shims"
   "yojson"
   "ppx_repr"

--- a/packages/index-bench/index-bench.1.3.2/opam
+++ b/packages/index-bench/index-bench.1.3.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "cmdliner"
+  "dune"    {>= "2.7.0"}
+  "fmt"
+  "index"
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re"
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+]
+
+synopsis: "Index benchmarking suite"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.2/index-1.3.2.tbz"
+  checksum: [
+    "sha256=0e46ebc785eb5b947bcb6e04075dda694d7e951c5ac51103e4d5fa5105df5d14"
+    "sha512=fd82ba852bb43eae8fefca2563d114bc2fa99e0ba98c828bccc2e81737a05156297b64b5894e2d0a58457a3382730a34e16cf16c844f8a6e6844c2684d79c7b5"
+  ]
+}
+x-commit-hash: "7812ab558e26361dc3446d1b29ff983dee6fb38c"

--- a/packages/index/index.1.3.2/opam
+++ b/packages/index/index.1.3.2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "ppx_repr"
+  "fmt"
+  "logs"
+  "mtime"   {>= "1.0.0"}
+  "cmdliner"
+  "progress" {>= "0.1.1" & < "0.2.0"}
+  "semaphore-compat"  {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.2/index-1.3.2.tbz"
+  checksum: [
+    "sha256=0e46ebc785eb5b947bcb6e04075dda694d7e951c5ac51103e4d5fa5105df5d14"
+    "sha512=fd82ba852bb43eae8fefca2563d114bc2fa99e0ba98c828bccc2e81737a05156297b64b5894e2d0a58457a3382730a34e16cf16c844f8a6e6844c2684d79c7b5"
+  ]
+}
+x-commit-hash: "7812ab558e26361dc3446d1b29ff983dee6fb38c"

--- a/packages/index/index.1.3.2/opam
+++ b/packages/index/index.1.3.2/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_repr"
   "fmt"
   "logs" {>= "0.7.0"}
-  "mtime"   {>= "1.0.0"}
+  "mtime"   {>= "1.1.0"}
   "cmdliner"
   "progress" {>= "0.1.1" & < "0.2.0"}
   "semaphore-compat"  {>= "1.0.1"}

--- a/packages/index/index.1.3.2/opam
+++ b/packages/index/index.1.3.2/opam
@@ -24,7 +24,7 @@ depends: [
   "repr"    {>= "0.2.0"}
   "ppx_repr"
   "fmt"
-  "logs"
+  "logs" {>= "0.7.0"}
   "mtime"   {>= "1.0.0"}
   "cmdliner"
   "progress" {>= "0.1.1" & < "0.2.0"}


### PR DESCRIPTION
Index benchmarking suite

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>

##### CHANGES:

## Fixed

- Recover from crash of the merge thread. When this happen, the main thread can
  continue to run and will need to recover from the crash before doing a new
  merge. This fixes a critical issue which might cause data loss (#339)

- Make sure that no entries can disappear for read-only instances during
  log_async recovery (#338)