### PR TITLE
[new release] index-bench and index (1.4.1)

### DIFF
--- a/packages/index-bench/index-bench.1.4.1/opam
+++ b/packages/index-bench/index-bench.1.4.1/opam
@@ -27,7 +27,7 @@ depends: [
   "rusage" {>= "1.0.0" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/index-bench/index-bench.1.4.1/opam
+++ b/packages/index-bench/index-bench.1.4.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/index"
 bug-reports: "https://github.com/mirage/index/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "cmdliner"
+  "cmdliner" {>= "1.0.3"}
   "dune" {>= "2.7.0"}
   "fmt"
   "index" {= version}

--- a/packages/index-bench/index-bench.1.4.1/opam
+++ b/packages/index-bench/index-bench.1.4.1/opam
@@ -14,7 +14,7 @@ depends: [
   "metrics"
   "metrics-unix"
   "ppx_deriving_yojson"
-  "re"
+  "re" {>= "1.9.0"}
   "stdlib-shims"
   "yojson"
   "ppx_repr"

--- a/packages/index-bench/index-bench.1.4.1/opam
+++ b/packages/index-bench/index-bench.1.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cmdliner"
+  "dune" {>= "2.7.0"}
+  "fmt"
+  "index" {= version}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re"
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+  "tezos-context-hash" {>= "1.0.0"}
+  "mtime"
+  "logs" {>= "0.7.0"}
+  "optint" {>= "0.1.0" & with-test}
+  "progress" {>= "0.2.1"}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.1/index-1.4.1.tbz"
+  checksum: [
+    "sha256=dde943f595ee9bb7d9b84cde05d0cb4675097e785dbf833521761fd843252206"
+    "sha512=9b4e1e2d684222205a5cb17370acfd90d36026de147d548319b7b411fa0c2c36fce970f3e7604880a38f5a17dfe338efd9e33cd70e51ee3d8cb66b038f2a8a69"
+  ]
+}
+x-commit-hash: "acdad0d033a81753e0fcf3fe95f915dbc5b1504b"

--- a/packages/index/index.1.4.1/opam
+++ b/packages/index/index.1.4.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.1.0"}
+  "repr"    {>= "0.2.0"}
+  "ppx_repr"
+  "fmt"     {>= "0.8.5"}
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner"
+  "progress" {>= "0.2.1"}
+  "semaphore-compat" {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.1/index-1.4.1.tbz"
+  checksum: [
+    "sha256=dde943f595ee9bb7d9b84cde05d0cb4675097e785dbf833521761fd843252206"
+    "sha512=9b4e1e2d684222205a5cb17370acfd90d36026de147d548319b7b411fa0c2c36fce970f3e7604880a38f5a17dfe338efd9e33cd70e51ee3d8cb66b038f2a8a69"
+  ]
+}
+x-commit-hash: "acdad0d033a81753e0fcf3fe95f915dbc5b1504b"


### PR DESCRIPTION
Index benchmarking suite

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>

##### CHANGES:

## Fixed

- Proper cleaning of merge file descriptors when aborting a merge (#326)

- Recover from crash of the merge thread. When this happen, the main thread can
  continue to run and will need to recover from the crash before doing a new
  merge. This fixes a critical issue which might cause data loss (#339)

- Make sure that no entries can disappear for read-only instances during
  log_async recovery (#338)


