### PR TITLE
[new release] ocamlformat, ocamlformat-rpc and ocamlformat-rpc-lib (0.19.0)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.19.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.19.0/opam
@@ -31,7 +31,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-rpc-lib-0.19.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-0.19.0.tbz"
   checksum: [
     "sha256=62fc46aae8f0a4a33ce7f8d7726d7109bff615ea6fcb50d1482f21d20ee50f46"
     "sha512=408b3af533169f201d7492be869f8ae4acde5583e01693c586929f44b76d569d3d6d555bc056378743d7cb3bd8e11ebc9cbd178ca196bcb82db33127d14902f8"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.19.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.19.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.14"}
+  "csexp"
+  "sexplib0"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-rpc-lib-0.19.0.tbz"
+  checksum: [
+    "sha256=62fc46aae8f0a4a33ce7f8d7726d7109bff615ea6fcb50d1482f21d20ee50f46"
+    "sha512=408b3af533169f201d7492be869f8ae4acde5583e01693c586929f44b76d569d3d6d555bc056378743d7cb3bd8e11ebc9cbd178ca196bcb82db33127d14902f8"
+  ]
+}
+x-commit-hash: "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}
-  "re"
+  "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
@@ -19,9 +19,9 @@ depends: [
   "dune-build-info"
   "fix"
   "fpath"
-  "menhir" {>= "20180528"}
-  "menhirLib" {>= "20200624"}
-  "menhirSdk" {>= "20200624"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
@@ -4,8 +4,7 @@ description:
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
 maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
 authors: ["Josh Berdine <jjb@fb.com>"]
-license:
-  "OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license."
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"] # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
@@ -48,7 +48,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-rpc-lib-0.19.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-0.19.0.tbz"
   checksum: [
     "sha256=62fc46aae8f0a4a33ce7f8d7726d7109bff615ea6fcb50d1482f21d20ee50f46"
     "sha512=408b3af533169f201d7492be869f8ae4acde5583e01693c586929f44b76d569d3d6d555bc056378743d7cb3bd8e11ebc9cbd178ca196bcb82db33127d14902f8"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license:
+  "OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license."
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.14"}
+  "ocamlformat-rpc-lib"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocp-indent"
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc-parser" {>= "0.9.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-rpc-lib-0.19.0.tbz"
+  checksum: [
+    "sha256=62fc46aae8f0a4a33ce7f8d7726d7109bff615ea6fcb50d1482f21d20ee50f46"
+    "sha512=408b3af533169f201d7492be869f8ae4acde5583e01693c586929f44b76d569d3d6d555bc056378743d7cb3bd8e11ebc9cbd178ca196bcb82db33127d14902f8"
+  ]
+}
+x-commit-hash: "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591"

--- a/packages/ocamlformat/ocamlformat.0.19.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}
-  "re"
+  "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}

--- a/packages/ocamlformat/ocamlformat.0.19.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0/opam
@@ -47,7 +47,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-rpc-lib-0.19.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-0.19.0.tbz"
   checksum: [
     "sha256=62fc46aae8f0a4a33ce7f8d7726d7109bff615ea6fcb50d1482f21d20ee50f46"
     "sha512=408b3af533169f201d7492be869f8ae4acde5583e01693c586929f44b76d569d3d6d555bc056378743d7cb3bd8e11ebc9cbd178ca196bcb82db33127d14902f8"

--- a/packages/ocamlformat/ocamlformat.0.19.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0/opam
@@ -4,8 +4,7 @@ description:
   "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
 maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
 authors: ["Josh Berdine <jjb@fb.com>"]
-license:
-  "OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license."
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"] # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [

--- a/packages/ocamlformat/ocamlformat.0.19.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0/opam
@@ -18,9 +18,9 @@ depends: [
   "dune-build-info"
   "fix"
   "fpath"
-  "menhir" {>= "20180528"}
-  "menhirLib" {>= "20200624"}
-  "menhirSdk" {>= "20200624"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
   "ocp-indent"
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc-parser" {>= "0.9.0"}

--- a/packages/ocamlformat/ocamlformat.0.19.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license:
+  "OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license."
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.14"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocp-indent"
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc-parser" {>= "0.9.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.19.0/ocamlformat-rpc-lib-0.19.0.tbz"
+  checksum: [
+    "sha256=62fc46aae8f0a4a33ce7f8d7726d7109bff615ea6fcb50d1482f21d20ee50f46"
+    "sha512=408b3af533169f201d7492be869f8ae4acde5583e01693c586929f44b76d569d3d6d555bc056378743d7cb3bd8e11ebc9cbd178ca196bcb82db33127d14902f8"
+  ]
+}
+x-commit-hash: "ba67af28ddca8718ef8816b2b0dc1e5b2f5e9591"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Bug fixes

  + Fix formatting of odoc tags: the argument should be on the same line, indent description that wraps (ocaml-ppx/ocamlformat#1634, ocaml-ppx/ocamlformat#1635, @gpetiot)

  + Consistently format let bindings and monadic let bindings, do not drop comments before monadic bindings (ocaml-ppx/ocamlformat#1636, @gpetiot)

  + Fix dropped comments attached to pattern constrained by polynewtype (ocaml-ppx/ocamlformat#1645, @gpetiot)

  + Fix comment attachment on infix operators (ocaml-ppx/ocamlformat#1643, @gpetiot)

  + Add missing spaces inside begin-end delimiting an ite branch (ocaml-ppx/ocamlformat#1646, @gpetiot)

  + Add missing parens around function at RHS of infix op (ocaml-ppx/ocamlformat#1642, @gpetiot)

  + Preserve begin-end keywords delimiting match cases (ocaml-ppx/ocamlformat#1651, @gpetiot)

  + Fix alignment of closing paren on separate line for anonymous functions (ocaml-ppx/ocamlformat#1649, @gpetiot)

  + Preserve begin-end keywords around infix operators (ocaml-ppx/ocamlformat#1652, @gpetiot)

  + Preserve `begin%ext` syntax for infix opererator expressions (ocaml-ppx/ocamlformat#1653, @gpetiot)

  + Consistently format comments attached to let-and bindings located at toplevel (ocaml-ppx/ocamlformat#1663, @gpetiot)

  + Remove double parens around a functor in a module application (ocaml-ppx/ocamlformat#1681, @gpetiot)

  + Improve breaking of comments to avoid violating the margin (ocaml-ppx/ocamlformat#1676, @jberdine)

  + Fix parentheses around successive unary operations (ocaml-ppx/ocamlformat#1696, @gpetiot)

  + Add missing break between pattern and attribute (ocaml-ppx/ocamlformat#1711, @gpetiot)

  + Add missing parentheses around expression having attributes or comments inside a shorthand let-open clause (ocaml-ppx/ocamlformat#1708, @gpetiot)

  + Do not consider leading star '*' when checking the diff of doc comments (ocaml-ppx/ocamlformat#1712, @hhugo)

  + Fix formatting of multiline non-wrapping comments (ocaml-ppx/ocamlformat#1723, @gpetiot)

#### Changes

  + Improve the diff of unstable docstrings displayed in error messages (ocaml-ppx/ocamlformat#1654, @gpetiot)

  + Use UTF8 length of strings, not only in wrapped comments (ocaml-ppx/ocamlformat#1673, @jberdine)

  + Improve position of `;;` tokens (ocaml-ppx/ocamlformat#1688, @gpetiot)

  + Depend on `odoc-parser` instead of `odoc` (ocaml-ppx/ocamlformat#1683, ocaml-ppx/ocamlformat#1713, @kit-ty-kate, @jonludlam, @julow)
    The parser from odoc has been split from the main odoc package and put into its own package, `odoc-parser`.

  + Revert infix-form list formatting to pre-0.17.0 (ocaml-ppx/ocamlformat#1717, @gpetiot)

#### New features

  + Implement OCaml 4.13 features
    - Named existentials in pattern-matching (ocaml#9584)
    - Let-punning (ocaml#10013)
    - Module type substitutions (ocaml#10133)
  (ocaml-ppx/ocamlformat#1680, @gpetiot)

  + Emacs integration (disabled for ocamlformat < 0.19.0):
    - Indent a line or a region with ocamlformat when pressing <TAB>
    - Break the line and reindent the cursor when pressing <ENTER>
  (ocaml-ppx/ocamlformat#1639, ocaml-ppx/ocamlformat#1685, @gpetiot) (ocaml-ppx/ocamlformat#1687, @bcc32)

  + Add 'line-endings=lf|crlf' option to specify the line endings used in the
    formatted output. (ocaml-ppx/ocamlformat#1703, @nojb)

#### Internal

  + A script `tools/build-mingw64.sh` is provided to build a native Windows
    binary of `ocamlformat` using `mingw64` toolchain under Cygwin.
