### PR TITLE
2 packages from c-cube/tiny_httpd at 0.9

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.9/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.9/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-threads"
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+  "qtest" { >= "2.9" & with-test}
+  "qcheck" {with-test & >= "0.9" }
+  "ounit2" {with-test}
+  "ptime" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=8b2e4eaceabed877baedb6be01b3666b"
+    "sha512=6851341aaa03e1bdf37807e24a831d935532fd8e36129e240eaf1b52b0dd5aafbbff5d70ef92785ee2108c3e816d842fb73e6ad55657a3833e38246925aeaec0"
+  ]
+}

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.9/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.9/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Interface to camlzip for tiny_httpd"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "camlzip" {>= "1.06"}
+  "tiny_httpd" { = version }
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "gzip" "camlzip" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.9.tar.gz"
+  checksum: [
+    "md5=8b2e4eaceabed877baedb6be01b3666b"
+    "sha512=6851341aaa03e1bdf37807e24a831d935532fd8e36129e240eaf1b52b0dd5aafbbff5d70ef92785ee2108c3e816d842fb73e6ad55657a3833e38246925aeaec0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`tiny_httpd.0.9`: Minimal HTTP server using good old threads
-`tiny_httpd_camlzip.0.9`: Interface to camlzip for tiny_httpd



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.0