### PR TITLE
[new release] charrua-unix, charrua, charrua-server and charrua-client (1.4.0)

### DIFF
--- a/packages/charrua-client/charrua-client.1.4.0/opam
+++ b/packages/charrua-client/charrua-client.1.4.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "DHCP client implementation"
+description: """\
+charrua-client is a DHCP client powered by [charrua](https://github.com/mirage/charrua).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease."""
+maintainer: "Mindy Preston"
+authors: "Mindy Preston"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://docs.mirage.io"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "charrua-server" {= version & with-test}
+  "charrua" {= version}
+  "cstruct" {>= "3.0.2"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "duration"
+  "logs"
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "tcpip" {>= "6.1.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+x-commit-hash: "06a19fba3a1174c1f694b62d969f3d13a59edd08"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.4.0/charrua-v1.4.0.tbz"
+  checksum: [
+    "sha256=7b51dbb887e3ddd26ad34245d2736239fd6d9b47a3700ada553930990d4e4263"
+    "sha512=bb88c2de0bea218a9d9c439a47c3fe67cfbee1ea7a5e41868206ea95aae6e39ef2217d587097c69194b92aab16154431bb94d2cf9910ab210100dab69f26b436"
+  ]
+}

--- a/packages/charrua-client/charrua-client.1.4.0/opam
+++ b/packages/charrua-client/charrua-client.1.4.0/opam
@@ -7,6 +7,7 @@ The base library exposes a simple state machine in `Dhcp_client`
 for use in acquiring a DHCP lease."""
 maintainer: "Mindy Preston"
 authors: "Mindy Preston"
+license: "ISC"
 tags: "org:mirage"
 homepage: "https://github.com/mirage/charrua"
 doc: "https://docs.mirage.io"
@@ -34,7 +35,7 @@ depends: [
   "tcpip" {>= "6.1.0" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/charrua-server/charrua-server.1.4.0/opam
+++ b/packages/charrua-server/charrua-server.1.4.0/opam
@@ -43,7 +43,7 @@ depends: [
   "tcpip" {>= "6.1.0" & with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]

--- a/packages/charrua-server/charrua-server.1.4.0/opam
+++ b/packages/charrua-server/charrua-server.1.4.0/opam
@@ -30,7 +30,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.4.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
-  "menhir" {build}
+  "menhir" {build & >= "20180523"}
   "charrua" {= version}
   "cstruct" {>= "3.0.1"}
   "sexplib"

--- a/packages/charrua-server/charrua-server.1.4.0/opam
+++ b/packages/charrua-server/charrua-server.1.4.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "DHCP server"
+description: """\
+Charrua-server consists of a single `Dhcp_server` module used for constructing DHCP
+servers.
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://mirage.github.io/charrua/"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "menhir" {build}
+  "charrua" {= version}
+  "cstruct" {>= "3.0.1"}
+  "sexplib"
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "macaddr-sexp"
+  "cstruct-unix" {with-test}
+  "ppx_cstruct" {>= "6.0.0" & with-test}
+  "tcpip" {>= "6.1.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+x-commit-hash: "06a19fba3a1174c1f694b62d969f3d13a59edd08"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.4.0/charrua-v1.4.0.tbz"
+  checksum: [
+    "sha256=7b51dbb887e3ddd26ad34245d2736239fd6d9b47a3700ada553930990d4e4263"
+    "sha512=bb88c2de0bea218a9d9c439a47c3fe67cfbee1ea7a5e41868206ea95aae6e39ef2217d587097c69194b92aab16154431bb94d2cf9910ab210100dab69f26b436"
+  ]
+}

--- a/packages/charrua-unix/charrua-unix.1.4.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Unix DHCP daemon"
+description: """\
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua](http://www.github.com/mirage/charrua)."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "3.0.0"}
+  "lwt_log"
+  "charrua" {= version}
+  "charrua-server" {= version}
+  "cstruct-unix"
+  "cmdliner"
+  "rawlink" {>= "1.0"}
+  "tuntap" {>= "2.0.0"}
+  "mtime" {>= "1.0.0"}
+  "cstruct-lwt" {>= "6.0.0"}
+  "ipaddr" {>= "5.1.0"}
+  "tcpip" {>= "6.1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+x-commit-hash: "06a19fba3a1174c1f694b62d969f3d13a59edd08"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.4.0/charrua-v1.4.0.tbz"
+  checksum: [
+    "sha256=7b51dbb887e3ddd26ad34245d2736239fd6d9b47a3700ada553930990d4e4263"
+    "sha512=bb88c2de0bea218a9d9c439a47c3fe67cfbee1ea7a5e41868206ea95aae6e39ef2217d587097c69194b92aab16154431bb94d2cf9910ab210100dab69f26b436"
+  ]
+}

--- a/packages/charrua-unix/charrua-unix.1.4.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.4.0/opam
@@ -25,7 +25,7 @@ depends: [
   "tcpip" {>= "6.1.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/charrua.git"

--- a/packages/charrua/charrua.1.4.0/opam
+++ b/packages/charrua/charrua.1.4.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/mirage/charrua.git"
 doc: "https://mirage.github.io/charrua/"
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 

--- a/packages/charrua/charrua.1.4.0/opam
+++ b/packages/charrua/charrua.1.4.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"         {>= "4.08.0"}
+  "dune"          {>= "1.4.0"}
+  "ppx_sexp_conv" {>="v0.10.0"}
+  "ppx_cstruct"
+  "cstruct"       {>= "3.0.1"}
+  "sexplib"
+  "ipaddr"        {>= "5.0.0"}
+  "macaddr"       {>= "4.0.0"}
+  "ipaddr-sexp"
+  "macaddr-sexp"
+  "ethernet"      {>= "2.2.0"}
+  "tcpip"         {>= "5.0.0"}
+  "rresult"
+]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
+constructing DHCP messages
+
+You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
+https://mirage.github.io/charrua/
+
+#### Features
+
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+x-commit-hash: "06a19fba3a1174c1f694b62d969f3d13a59edd08"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.4.0/charrua-v1.4.0.tbz"
+  checksum: [
+    "sha256=7b51dbb887e3ddd26ad34245d2736239fd6d9b47a3700ada553930990d4e4263"
+    "sha512=bb88c2de0bea218a9d9c439a47c3fe67cfbee1ea7a5e41868206ea95aae6e39ef2217d587097c69194b92aab16154431bb94d2cf9910ab210100dab69f26b436"
+  ]
+}


### PR DESCRIPTION
Unix DHCP daemon

- Project page: <a href="https://github.com/mirage/charrua">https://github.com/mirage/charrua</a>

##### CHANGES:

Changes in mirage/charrua#111 by @haesbaert

* Allow optional arguments to be erased in Dhcp_server.make
* maxleasetime -> max-lease-time in dhcpd.conf
* fix handling of DHCPRELEASE
* rewrite lease database
* charruad: collect garbage leases, write pid file, implement -u/--user and
  -g/--group
* opam lint, raise lower bound to 4.08.0
