### PR TITLE
[new release] letsencrypt-app, letsencrypt and letsencrypt-dns (0.3.0)

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.0.3.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "letsencrypt-dns" {= version}
+  "cmdliner"
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto-rng"
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+x-commit-hash: "eef905dceda483d6ea2b2c8d7c849887d9522128"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.3.0/letsencrypt-v0.3.0.tbz"
+  checksum: [
+    "sha256=8772b7e6dbda0559a03a7b23b75c1431d42ae09a154eefd64b4c7e23b8d92deb"
+    "sha512=72b12219f279d4cf5353ef35a81b1f2f288d9aed471de2d9bf6b020df34e80a33fb44027a1ec1854cd60c7193a661b69c3b0de280a95f6e38d22765a677327a8"
+  ]
+}

--- a/packages/letsencrypt-dns/letsencrypt-dns.0.3.0/opam
+++ b/packages/letsencrypt-dns/letsencrypt-dns.0.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "dns"
+  "dns-tsig"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+x-commit-hash: "eef905dceda483d6ea2b2c8d7c849887d9522128"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.3.0/letsencrypt-v0.3.0.tbz"
+  checksum: [
+    "sha256=8772b7e6dbda0559a03a7b23b75c1431d42ae09a154eefd64b4c7e23b8d92deb"
+    "sha512=72b12219f279d4cf5353ef35a81b1f2f288d9aed471de2d9bf6b020df34e80a33fb44027a1ec1854cd60c7193a661b69c3b0de280a95f6e38d22765a677327a8"
+  ]
+}

--- a/packages/letsencrypt/letsencrypt.0.3.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "astring"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "logs"
+  "fmt"
+  "uri"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "x509" {>= "0.13.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "ptime"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+x-commit-hash: "eef905dceda483d6ea2b2c8d7c849887d9522128"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.3.0/letsencrypt-v0.3.0.tbz"
+  checksum: [
+    "sha256=8772b7e6dbda0559a03a7b23b75c1431d42ae09a154eefd64b4c7e23b8d92deb"
+    "sha512=72b12219f279d4cf5353ef35a81b1f2f288d9aed471de2d9bf6b020df34e80a33fb44027a1ec1854cd60c7193a661b69c3b0de280a95f6e38d22765a677327a8"
+  ]
+}

--- a/packages/paf/paf.0.0.1/opam
+++ b/packages/paf/paf.0.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "tls-mirage"        {< "0.13.0"}
   "mimic"
   "cohttp-lwt"
-  "letsencrypt"
+  "letsencrypt"       {< "0.3.0"}
   "emile"             {>= "1.0"}
   "ke"                {>= "0.4"}
   "lwt"               {with-test}

--- a/packages/paf/paf.0.0.2/opam
+++ b/packages/paf/paf.0.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "tls-mirage"
   "mimic"
   "cohttp-lwt"
-  "letsencrypt"
+  "letsencrypt" {< "0.3.0"}
   "emile" {>= "1.0"}
   "ke" {>= "0.4"}
   "lwt" {with-test}

--- a/packages/paf/paf.0.0.3/opam
+++ b/packages/paf/paf.0.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "tls-mirage" {>= "0.13.0"}
   "mimic"
   "cohttp-lwt"
-  "letsencrypt"
+  "letsencrypt" {< "0.3.0"}
   "emile" {>= "1.0"}
   "ke" {>= "0.4"}
   "lwt" {with-test}


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/mmaker/ocaml-letsencrypt">https://github.com/mmaker/ocaml-letsencrypt</a>
- Documentation: <a href="https://mmaker.github.io/ocaml-letsencrypt">https://mmaker.github.io/ocaml-letsencrypt</a>

##### CHANGES:

Reduce dependency cone (mmaker/ocaml-letsencrypt#26, @dinosaure & @hannesm)
- remove cohttp dependency, provide a HTTP_client module type
- provide letsencrypt-dns with dns solver
- provide letsencrypt-app for the client binary
