### PR TITLE
Package winsvc.1.0.1

### DIFF
--- a/packages/winsvc/winsvc.1.0.1/opam
+++ b/packages/winsvc/winsvc.1.0.1/opam
@@ -6,6 +6,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-winsvc"
 bug-reports: "https://github.com/savonet/ocaml-winsvc/issues"
 depends: [
+  "ocaml" {>= "4.06"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
 ]

--- a/packages/winsvc/winsvc.1.0.1/opam
+++ b/packages/winsvc/winsvc.1.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Library to make OCaml program act as a Windows service"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["Romain Beauxis <toots@rastageeks.org>"]
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-winsvc"
+bug-reports: "https://github.com/savonet/ocaml-winsvc/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-winsvc.git"
+available: [ os = "win32" ]
+url {
+  src: "https://github.com/savonet/ocaml-winsvc/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=e554b052745795a5721b40b820737226"
+    "sha512=d63a033d590d910239a377ef128847328b377ff2974e5e20e0daa5460d9fa6d3102c3205159b9c5ddce049bd43e96adb7ce4fdab24141832119196f006f68fb3"
+  ]
+}


### PR DESCRIPTION
### `winsvc.1.0.1`
Library to make OCaml program act as a Windows service



---
* Homepage: https://github.com/savonet/ocaml-winsvc
* Source repo: git+https://github.com/savonet/ocaml-winsvc.git
* Bug tracker: https://github.com/savonet/ocaml-winsvc/issues

---
:camel: Pull-request generated by opam-publish v2.0.3