### PR TITLE
[new release] ppx_deriving_cmdliner (0.6.1)

### DIFF
--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Seb Mondet <seb@mondet.org>"
+authors: [
+  "Isaac Hodes <isaachodes@gmail.com>"
+  "B. Arman Aksoy <arman@aksoy.org>"
+  "Seb Mondet <seb@mondet.org>"
+  "Nick Zalutskiy <nick@const.fun>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.fr>"
+  "Tom Repetti <trepetti@cs.columbia.edu>"
+  "Marcello Seri <m.seri@rug.nl>"
+]
+homepage: "https://github.com/hammerlab/ppx_deriving_cmdliner"
+bug-reports: "https://github.com/hammerlab/ppx_deriving_cmdliner/issues"
+dev-repo: "git+https://github.com/hammerlab/ppx_deriving_cmdliner.git"
+doc: "http://hammerlab.github.io/ppx_deriving_cmdliner"
+license: "MIT"
+tags: ["syntax" "cli"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.05"}
+  "cmdliner"     {>= "1.0.0"}
+  "result"
+  "ppx_deriving" {>= "5.0"}
+  "dune"
+  "ppxlib"       {>= "0.18.0"}
+  "alcotest"     {with-test}
+]
+synopsis: "Cmdliner.Term.t generator"
+description: """
+ppx_deriving_cmdliner is a ppx_deriving plugin that generates
+a Cmdliner Term.t for a record type."""
+url {
+  src:
+    "https://github.com/hammerlab/ppx_deriving_cmdliner/archive/refs/tags/v0.6.1.tar.gz"
+  checksum: "md5=f87015b84a926d76e2e612e74bdea921"
+}


### PR DESCRIPTION
**CHANGES:**

- Bump minimum ppxlib version to 0.18.0 to fix https://github.com/hammerlab/ppx_deriving_cmdliner/issues/49.