### PR TITLE
ppx_deriving_cmdliner.0.6.0: incorrect ppxlib lowerbound

### DIFF
--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "result"
   "ppx_deriving" {>= "5.0"}
   "dune"
-  "ppxlib"       {>= "0.14.0"}
+  "ppxlib"       {>= "0.18.0"}
   "alcotest"     {with-test}
 ]
 synopsis: "Cmdliner.Term.t generator"


### PR DESCRIPTION
Cfr https://github.com/ocaml/opam-repository/pull/19082