### PR TITLE
tezos-context-hash-irmin.1.0.0: add upper bound for irmin

### DIFF
--- a/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
+++ b/packages/tezos-context-hash-irmin/tezos-context-hash-irmin.1.0.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
 depends: [
   "dune" {>= "2.6"}
   "tezos-context-hash"
-  "irmin" {>= "2.7.0"}
+  "irmin" {>= "2.7.0" & < "2.7.2"}
   "cmdliner"
   "fmt"
   "yojson"


### PR DESCRIPTION
needed for https://github.com/ocaml/opam-repository/pull/19088