### PR TITLE
biocaml.0.11.1 is not compatible w 32 bit systems

### DIFF
--- a/packages/biocaml/biocaml.0.11.1/opam
+++ b/packages/biocaml/biocaml.0.11.1/opam
@@ -45,6 +45,9 @@ depopts: [
   "core"
   "lwt"
 ]
+
+available: arch != "x86_32" & arch != "arm32"
+
 url {
   src: "https://github.com/biocaml/biocaml/archive/v0.11.1.tar.gz"
   checksum: [


### PR DESCRIPTION
Seen on the CI when releasing biotk https://github.com/ocaml/opam-repository/pull/19074#discussion_r673292297