### PR TITLE
[new release] pyre-ast (0.1.1)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.1/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8" & > "2.0"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+x-commit-hash: "765c0319b6dac04dd23a835de64dbad25450f21c"
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.1/pyre-ast-0.1.1.tbz"
+  checksum: [
+    "sha256=2d92ed8a17d3f9a0cbcb2969eba17574971a893580af470f186e82474bb2a4d9"
+    "sha512=68bc9f40172a47f32a6a00138afb7204015eddac2c36f5ccd14ef66b72d521fef8611cd184e8779ee361cd7d4b2ad0f2a2f03ee89629767260212fdd381526cb"
+  ]
+}


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- Column number of default parsing error starts from 0 instead of 1.
- Correctly set up test dependency with `stdio`.
- Make C bindings compatible with pre-OCaml-4.11 by always defining `Val_none`.
