### PR TITLE
Luv 0.5.9: libuv binding

### DIFF
--- a/packages/luv/luv.0.5.9/opam
+++ b/packages/luv/luv.0.5.9/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.13.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "1.5.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.9/luv-0.5.9.tar.gz"
+  checksum: "md5=e19f39296b426215e0c21d3a7f8fe272"
+}

--- a/packages/luv/luv.0.5.9/opam
+++ b/packages/luv/luv.0.5.9/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/luv.git"
 
 depends: [
   "base-unix" {build}
-  "ctypes" {>= "0.13.0"}
+  "ctypes" {>= "0.14.0"}
   "dune" {>= "2.0.0"}
   "ocaml" {>= "4.02.0"}
   "result"


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/luv/releases/tag/0.5.9):

> Additions
>
> - Upgrade vendored libuv to [1.42.0](https://github.com/libuv/libuv/releases/tag/v1.42.0) (aantron/luv#118).
> - Expose [`UV_EOVERFLOW`](http://docs.libuv.org/en/v1.x/errors.html#c.UV_EOVERFLOW) as [`EOVERFLOW](https://aantron.github.io/luv/luv/Luv/Error/index.html#type-t.EOVERFLOW) (aantron/luv#118).
> - Expose [`UV_ESOCKTNOSUPPORT`](http://docs.libuv.org/en/v1.x/errors.html#c.UV_ESOCKTNOSUPPORT) as [`ESOCKTNOSUPPORT](https://aantron.github.io/luv/luv/Luv/Error/index.html#type-t.ESOCKTNOSUPPORT) (aantron/luv#118).
> - Expose [`uv_try_write2`](http://docs.libuv.org/en/v1.x/stream.html#c.uv_try_write2) as [`Luv.Stream.try_write2`](https://aantron.github.io/luv/luv/Luv/Stream/index.html#val-try_write2) (aantron/luv#118).
>
> Bugs fixed
>
> - Define `sa_family_t` on MinGW (aantron/luv#113, David Scott).
