### PR TITLE
[new release] github, github-unix, github-jsoo and github-data (4.4.0)

### DIFF
--- a/packages/github-data/github-data.4.4.0/opam
+++ b/packages/github-data/github-data.4.4.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 data library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the data conversion library."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "yojson" {>= "1.7.0"}
+  "atdgen" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=c36e08b64ba189823d8215c366ff4e9fdbc41c790781246e96cf2c6c1fbb818a"
+    "sha512=6588691808a017b11c36031f8e923a47bbc4fd097652b90708cff4626267f0f535a9433dc95cbf1d1b871794a9f9f1391428e5a2f958cc12714c59f351659985"
+  ]
+}
+x-commit-hash: "a5919eb10679004e497794e5ce8915b5dbdfad0b"

--- a/packages/github-jsoo/github-jsoo.4.4.0/opam
+++ b/packages/github-jsoo/github-jsoo.4.4.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "github" {= version}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=c36e08b64ba189823d8215c366ff4e9fdbc41c790781246e96cf2c6c1fbb818a"
+    "sha512=6588691808a017b11c36031f8e923a47bbc4fd097652b90708cff4626267f0f535a9433dc95cbf1d1b871794a9f9f1391428e5a2f958cc12714c59f351659985"
+  ]
+}
+x-commit-hash: "a5919eb10679004e497794e5ce8915b5dbdfad0b"

--- a/packages/github-unix/github-unix.4.4.0/opam
+++ b/packages/github-unix/github-unix.4.4.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the Unix (Lwt) version."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "github" {= version}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "stringext"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=c36e08b64ba189823d8215c366ff4e9fdbc41c790781246e96cf2c6c1fbb818a"
+    "sha512=6588691808a017b11c36031f8e923a47bbc4fd097652b90708cff4626267f0f535a9433dc95cbf1d1b871794a9f9f1391428e5a2f958cc12714c59f351659985"
+  ]
+}
+x-commit-hash: "a5919eb10679004e497794e5ce8915b5dbdfad0b"

--- a/packages/github/github.4.4.0/opam
+++ b/packages/github/github.4.4.0/opam
@@ -32,7 +32,7 @@ depends: [
   "lwt" {>= "2.4.4"}
   "cohttp-lwt" {>= "4.0.0"}
   "github-data" {= version}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.7.0"}
   "stringext"
   "odoc" {with-doc}
 ]

--- a/packages/github/github.4.4.0/opam
+++ b/packages/github/github.4.4.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://docs.github.com/rest/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "lwt" {>= "2.4.4"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "github-data" {= version}
+  "yojson" {>= "1.6.0"}
+  "stringext"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.0/github-data-4.4.0.tbz"
+  checksum: [
+    "sha256=c36e08b64ba189823d8215c366ff4e9fdbc41c790781246e96cf2c6c1fbb818a"
+    "sha512=6588691808a017b11c36031f8e923a47bbc4fd097652b90708cff4626267f0f535a9433dc95cbf1d1b871794a9f9f1391428e5a2f958cc12714c59f351659985"
+  ]
+}
+x-commit-hash: "a5919eb10679004e497794e5ce8915b5dbdfad0b"


### PR DESCRIPTION
GitHub APIv3 OCaml library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Fixes to odoc warnings and cohttp dependencies (@Aaylor mirage/ocaml-github#244)
- Support cohttp 4.0. (@tmcgilchrist mirage/ocaml-github#257)
- Support for 4.12 and fixing recent compiler warnings (@tmcgilchrist mirage/ocaml-github#246 mirage/ocaml-github#252 and @emillon mirage/ocaml-github#250 mirage/ocaml-github#247 mirage/ocaml-github#251)
- Add a new package `github-data` which contains just the serialisation logic
  without a dependency on the web stack (mirage/ocaml-github#248 @emillon)
- Add Github checks API support (mirage/ocaml-github#249 @tmcgilchrist)
- Label field missing in branch refs for ghost (@dra27 and @tmcgilchrist mirage/ocaml-github#256)
- Get all commits for user/repo (@Stevendeo mirage/ocaml-github#245)
