### PR TITLE
stale.yml: allow persistent issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,9 +7,10 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v2
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been open 90 days with no activity.  Consequently, it is being marked with the "stale" label.  What this means is that the issue will be automatically closed in 30 days unless more comments are added or the "stale" label is removed.  If you come across this issue in the future, you may also find it helpful to visit our forum at https://discuss.ocaml.org where queries related to OCaml package management are very welcome.'
         days-before-stale: 90
         days-before-close: 30
+        exempt-issue-labels: persist


### PR DESCRIPTION
There are some issues that we continuously mark as unstale and that we want to keep around for longer. Recent stale bots have the feature to ignore certain issues using some specific label.

I suggest to enable this on the opam-repository