### PR TITLE
Prometheus-app also works with cohttp 4

### DIFF
--- a/packages/prometheus-app/prometheus-app.1.1/opam
+++ b/packages/prometheus-app/prometheus-app.1.1/opam
@@ -31,8 +31,8 @@ depends: [
   "fmt"
   "re" {>= "1.5.0"}
   "cohttp" {>= "1.0.0"}
-  "cohttp-lwt" {< "3.0.0"}
-  "cohttp-lwt-unix" {< "3.0.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
   "lwt" {>= "2.5.0"}
   "cmdliner"
   "alcotest" {with-test}

--- a/packages/prometheus-app/prometheus-app.1.1/opam
+++ b/packages/prometheus-app/prometheus-app.1.1/opam
@@ -38,7 +38,7 @@ depends: [
   "alcotest" {with-test}
   "asetmap"
   "astring"
-  "logs"
+  "logs" {>= "0.6.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Same fix as for prometheus.1.0 (and now fixed upstream too):
https://github.com/ocaml/opam-repository/pull/18392/files#diff-60879fe2781d9550236f9fdbe6d36f97b30c6563e42b76355e57c9c3770b2419