### PR TITLE
hacl-star and hacl-star-raw (0.4.1)

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.4.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency.
+"""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "ocamlfind" {build}
+  "ctypes" { >= "0.18.0" }
+  "ctypes-foreign"
+  "conf-which" {build}
+]
+available: [
+  os = "freebsd" | os-family != "bsd"
+]
+x-ci-accept-failures: [
+  "centos-7" # Default C compiler is too old
+  "oraclelinux-7" # Default C compiler is too old
+]
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [
+  make "-C" "raw" "install-hacl-star-raw"
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.1/hacl-star.0.4.1.tar.gz"
+  checksum: [
+    "md5=d65e80f306cae1f20db320d69f3825d9"
+    "sha256=c5429d029b3e3ea012dcb8713cc506cc5349d6b6005ef244d9caf8b7ba26049d"
+    "sha512=5323ee067c113a24ecc94fd674c6ab51a3f9443c907363fd577607f9a434ed7ccf54d62bc92fe1ba259d2e7000262f3625a012aa887a6cf38a40cf7eadcf681c"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.4.1/opam
+++ b/packages/hacl-star/hacl-star.0.4.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+description: """
+Documentation for this library can be found
+[here](https://hacl-star.github.io/ocaml_doc/hacl-star/index.html).
+"""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+doc: "https://hacl-star.github.io/ocaml_doc"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+  "odoc" {with-doc}
+]
+available: [
+  os = "freebsd" | os-family != "bsd"
+]
+build: [
+  [
+    "dune" "build" "-p" name "-j" jobs
+    "@doc" {with-doc}
+  ]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.1/hacl-star.0.4.1.tar.gz"
+  checksum: [
+    "md5=d65e80f306cae1f20db320d69f3825d9"
+    "sha256=c5429d029b3e3ea012dcb8713cc506cc5349d6b6005ef244d9caf8b7ba26049d"
+    "sha512=5323ee067c113a24ecc94fd674c6ab51a3f9443c907363fd577607f9a434ed7ccf54d62bc92fe1ba259d2e7000262f3625a012aa887a6cf38a40cf7eadcf681c"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-hacl-star.0.4.1: OCaml API for EverCrypt/HACL*
-hacl-star-raw.0.4.1: Auto-generated low-level OCaml bindings for EverCrypt/HACL*