### PR TITLE
[new release] pyre-ast (0.1.3)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.3/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+x-commit-hash: "35937e66c60f10da4eeb739f23a5ca229af227b0"
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.3/pyre-ast-0.1.3.tbz"
+  checksum: [
+    "sha256=9f891a0f59638d7e9efd2b0d49068f3096689fd249803788c07c47b93e49e700"
+    "sha512=cc7004453fb624e78bef15b9b0271b172e55e4cc856b4b7c3683af8172b4fa8323e05ba19462faf27a0371c16f7cd1e0e20f9fdc188b14cfe4b8993a7b575872"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- Fix crashes when parsing non-UTF8-decodable string literals.
- \N escape sequence in string literals will no longer cause a syntax error.
- Module parsing APIs now accept an additional `enable_type_comment` argument, controlling whether to parse type comments or not.