### PR TITLE
Mark mirage-dns as deprecated (new name is dns-mirage)

### DIFF
--- a/packages/mirage-dns/mirage-dns.2.0.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.0.0/opam
@@ -15,3 +15,4 @@ depends: [
 ]
 synopsis: "Virtual package for the MirageOS DNS transports"
 authors: "Anil Madhavapeddy"
+flags: deprecated

--- a/packages/mirage-dns/mirage-dns.2.0.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.0.0/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "anil@recoil.org"
+license: "ISC"
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 dev-repo: "git+https://github.com/mirage/ocaml-dns.git"

--- a/packages/mirage-dns/mirage-dns.2.5.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.5.0/opam
@@ -24,3 +24,4 @@ depends: [
   "tcpip"
 ]
 synopsis: "Virtual package for the MirageOS DNS transports"
+flags: deprecated

--- a/packages/mirage-dns/mirage-dns.2.6.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.6.0/opam
@@ -28,6 +28,7 @@ depends: [
   "mirage-profile"
 ]
 tags: "org:mirage"
+flags: deprecated
 synopsis: "Virtual package for the MirageOS DNS transports"
 url {
   src: "https://github.com/mirage/ocaml-dns/archive/v0.19.0.tar.gz"

--- a/packages/mirage-dns/mirage-dns.2.6.1/opam
+++ b/packages/mirage-dns/mirage-dns.2.6.1/opam
@@ -29,6 +29,7 @@ depends: [
   "mirage-profile"
 ]
 tags: "org:mirage"
+flags: deprecated
 synopsis: "Virtual package for the MirageOS DNS transports"
 url {
   src: "https://github.com/mirage/ocaml-dns/archive/v0.19.1.tar.gz"

--- a/packages/mirage-dns/mirage-dns.2.7.0/opam
+++ b/packages/mirage-dns/mirage-dns.2.7.0/opam
@@ -28,6 +28,7 @@ depends: [
   "lwt"
   "mirage-profile"
 ]
+flags: deprecated
 synopsis: "Virtual package for the MirageOS DNS transports"
 url {
   src: "https://github.com/mirage/ocaml-dns/archive/v0.20.0.tar.gz"

--- a/packages/mirage-dns/mirage-dns.3.0.0/opam
+++ b/packages/mirage-dns/mirage-dns.3.0.0/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-time-lwt"
   "mirage-profile" {>= "0.8.0"}
 ]
+flags: deprecated
 synopsis: "DNS client and server implementation in pure OCaml"
 description: """
 This is a pure OCaml implementation of the DNS protocol.  It is intended to be

--- a/packages/mirage-dns/mirage-dns.3.0.1/opam
+++ b/packages/mirage-dns/mirage-dns.3.0.1/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-time-lwt"
   "mirage-profile" {>= "0.8.0"}
 ]
+flags: deprecated
 synopsis: "DNS client and server implementation in pure OCaml"
 description: """
 This is a pure OCaml implementation of the DNS protocol.  It is intended to be

--- a/packages/mirage-dns/mirage-dns.3.1.0/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.0/opam
@@ -12,6 +12,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+flags: deprecated
 synopsis: "DNS implementation for the MirageOS unikernel framework"
 description: """
 This is an implementation of a DNS server and client resolver

--- a/packages/mirage-dns/mirage-dns.3.1.1/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.1/opam
@@ -12,6 +12,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+flags: deprecated
 synopsis: "DNS implementation for the MirageOS unikernel framework"
 description: """
 This is an implementation of a DNS server and client resolver

--- a/packages/mirage-dns/mirage-dns.3.1.2/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.2/opam
@@ -12,6 +12,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+flags: deprecated
 synopsis: "DNS implementation for the MirageOS unikernel framework"
 description: """
 This is an implementation of a DNS server and client resolver

--- a/packages/mirage-dns/mirage-dns.3.1.3/opam
+++ b/packages/mirage-dns/mirage-dns.3.1.3/opam
@@ -12,6 +12,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/mirage/ocaml-dns"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+flags: deprecated
 synopsis: "DNS implementation for the MirageOS unikernel framework"
 description: """
 This is an implementation of a DNS server and client resolver


### PR DESCRIPTION
cc @hannesm 