### PR TITLE
Conf-leveldb for leveldb >= 1.21

### DIFF
--- a/packages/conf-leveldb/conf-leveldb.2/files/test.cc
+++ b/packages/conf-leveldb/conf-leveldb.2/files/test.cc
@@ -1,0 +1,14 @@
+#include <leveldb/db.h>
+#ifndef STORAGE_LEVELDB_INCLUDE_DB_H_
+#error "No LevelDB headers"
+#endif
+
+using namespace leveldb;
+
+void test(void) {
+  leveldb::DB* db;
+  leveldb::Options options;
+  options.create_if_missing = true;
+  leveldb::Status status = leveldb::DB::Open(options, "/tmp/testdb", &db);
+  assert(status.ok());
+}

--- a/packages/conf-leveldb/conf-leveldb.2/opam
+++ b/packages/conf-leveldb/conf-leveldb.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Jeffrey Dean" "Sanjay Ghemawat" "Google Inc."]
+maintainer: "mfp@acm.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+homepage: "http://code.google.com/p/leveldb/"
+license: "BSD-3-Clause"
+build: [["cc" "-std=c++11" "-c" "test.cc"]]
+depexts: [
+  ["libleveldb-dev"] {os-family = "debian"}
+  ["libleveldb-dev"] {os-family = "ubuntu"}
+  ["leveldb-dev"] {os-family = "alpine"}
+  ["leveldb-devel" "epel-release"] {os-distribution = "centos"}
+  ["leveldb-devel"] {os-distribution = "fedora"}
+  ["leveldb-devel"] {os-family = "suse"}
+  ["dev-libs/leveldb"] {os-family = "gentoo"}
+  ["leveldb"] {os-family = "arch"}
+  ["leveldb"] {os = "macos" & os-distribution = "homebrew"}
+  ["leveldb"] {os = "macos" & os-distribution = "macports"}
+  ["leveldb"] {os = "freebsd"}
+  ["leveldb"] {os = "openbsd"}
+  ["leveldb"] {os = "netbsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # not available
+  "oraclelinux-8" # not available
+]
+synopsis: "Virtual package relying on a LevelDB lib system installation"
+description:
+  "This package can only install if the LevelDB lib is installed on the system."
+extra-files: ["test.cc" "md5=10b6f9d2e02bdee700ad6cb387f3a0a8"]
+flags: conf


### PR DESCRIPTION
[Since LevelDb >= 1.21, C++ 11 is required](https://github.com/google/leveldb/releases/tag/1.21) 

This add `-std=c++11` to build command .

More details could be see here: https://github.com/ocaml/opam-repository/issues/18167#issuecomment-885459238