### PR TITLE
ocamldap/ldap: Various fixes

### DIFF
--- a/packages/ldap/ldap.2.4.0/opam
+++ b/packages/ldap/ldap.2.4.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: [
   "Kate <kit.ty.kate@disroot.org>"

--- a/packages/ldap/ldap.2.4.0/opam
+++ b/packages/ldap/ldap.2.4.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta18"}
   "ocamlnet" {>= "3.6.0"}
   "pcre"
   "ssl" {>= "0.5.3"}

--- a/packages/ldap/ldap.2.4.0/opam
+++ b/packages/ldap/ldap.2.4.0/opam
@@ -10,7 +10,6 @@ dev-repo: "git+https://github.com/kit-ty-kate/ocamldap.git"
 bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
-  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml"

--- a/packages/ldap/ldap.2.4.0/opam
+++ b/packages/ldap/ldap.2.4.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlnet" {>= "3.6.0"}
   "pcre"
   "ssl" {>= "0.5.3"}

--- a/packages/ldap/ldap.2.4.1/opam
+++ b/packages/ldap/ldap.2.4.1/opam
@@ -12,7 +12,6 @@ bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
 build: [
   "dune" "build" "-p" name "-j" jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
 ]
 depends: [

--- a/packages/ldap/ldap.2.4.1/opam
+++ b/packages/ldap/ldap.2.4.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Implementation of the Light Weight Directory Access Protocol"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: [
   "Kate <kit.ty.kate@disroot.org>"

--- a/packages/ldap/ldap.2.4.2/opam
+++ b/packages/ldap/ldap.2.4.2/opam
@@ -28,7 +28,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ldap/ldap.2.4.2/opam
+++ b/packages/ldap/ldap.2.4.2/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Implementation of the Light Weight Directory Access Protocol"
 maintainer: ["Kate <kit.ty.kate@disroot.org>"]
 authors: ["Eric Stokes <letaris@me.com>"]
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 tags: ["ldap"]
 homepage: "https://github.com/kit-ty-kate/ocamldap"
 doc: "https://kit-ty-kate.github.io/ocamldap"

--- a/packages/ocamldap/ocamldap.2.1.8/opam
+++ b/packages/ocamldap/ocamldap.2.1.8/opam
@@ -1,6 +1,13 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Kate <kit.ty.kate@disroot.org>"
+  "Eric Stokes <letaris@me.com>"
+]
+homepage: "https://github.com/kit-ty-kate/ocamldap"
+dev-repo: "git+https://github.com/kit-ty-kate/ocamldap.git"
+bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
 build: [
   [make "all"]
   [make "opt"]

--- a/packages/ocamldap/ocamldap.2.1.8/opam
+++ b/packages/ocamldap/ocamldap.2.1.8/opam
@@ -5,7 +5,6 @@ build: [
   [make "all"]
   [make "opt"]
 ]
-remove: [["ocamlfind" "remove" "ocamldap"]]
 depends: [
   "ocaml" {= "3.12.1"}
   "ocamlfind" {build}
@@ -15,7 +14,6 @@ depends: [
 ]
 install: [make "install"]
 synopsis: "Implementation of the Light Weight Directory Access Protocol"
-flags: light-uninstall
 url {
   src:
     "http://downloads.sourceforge.net/project/ocamldap/ocamldap/ocamldap-2.1.8/ocamldap-2.1.8.tar.bz2"

--- a/packages/ocamldap/ocamldap.2.1.8/opam
+++ b/packages/ocamldap/ocamldap.2.1.8/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: [
   [make "all"]

--- a/packages/ocamldap/ocamldap.2.2/opam
+++ b/packages/ocamldap/ocamldap.2.2/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: [
   "Kate <kit.ty.kate@disroot.org>"

--- a/packages/ocamldap/ocamldap.2.2/opam
+++ b/packages/ocamldap/ocamldap.2.2/opam
@@ -12,7 +12,6 @@ patches: [
   "ocaml-4.02.patch"
 ]
 build: make
-remove: [["ocamlfind" "remove" "ldap"]]
 depends: [
   "ocaml" {>= "3.12.1" & < "4.06.0"}
   "ocamlfind" {build}
@@ -23,7 +22,6 @@ depends: [
 ]
 install: [make "install"]
 synopsis: "Implementation of the Light Weight Directory Access Protocol"
-flags: light-uninstall
 extra-files: ["ocaml-4.02.patch" "md5=0e16f26afe3d32c5c35bb4754d34142d"]
 url {
   src: "http://bitbucket.org/deplai_j/ocamldap/downloads/ocamldap-2.2.tar.gz"

--- a/packages/ocamldap/ocamldap.2.3.0/opam
+++ b/packages/ocamldap/ocamldap.2.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: [
   "Kate <kit.ty.kate@disroot.org>"

--- a/packages/ocamldap/ocamldap.2.3.0/opam
+++ b/packages/ocamldap/ocamldap.2.3.0/opam
@@ -14,7 +14,6 @@ build: [
   [make "doc"] {with-doc}
 ]
 install: [make "install"]
-remove: ["ocamlfind" "remove" "ldap"]
 depends: [
   "ocaml" {>= "3.12.1"}
   "ocamlfind" {build}
@@ -28,7 +27,6 @@ tags: [
   "ldap"
 ]
 synopsis: "Implementation of the Light Weight Directory Access Protocol"
-flags: light-uninstall
 url {
   src: "https://github.com/kit-ty-kate/ocamldap/archive/2.3.0.tar.gz"
   checksum: "md5=6137a123978ac5b0dd301af26122e437"

--- a/packages/ocamldap/ocamldap.2.3.0/opam
+++ b/packages/ocamldap/ocamldap.2.3.0/opam
@@ -11,7 +11,6 @@ bug-reports: "https://github.com/kit-ty-kate/ocamldap/issues"
 build: [
   ["./configure" "--prefix" prefix "--enable-tests"]
   [make "build"]
-  [make "test"] {with-test}
   [make "doc"] {with-doc}
 ]
 install: [make "install"]

--- a/packages/ocamldap/ocamldap.transition/opam
+++ b/packages/ocamldap/ocamldap.transition/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "Kate <kit.ty.kate@disroot.org>"
 authors: [
   "Kate <kit.ty.kate@disroot.org>"


### PR DESCRIPTION
This will fix issues encountered in revdeps (e.g. https://github.com/ocaml/opam-repository/pull/19108) for good as the tests were using the network and thus incompatible with the opam sandbox and overall unreliable.

The rest of the commits are minor fixes.