### PR TITLE
Package eliom.8.6.0

### DIFF
--- a/packages/eliom/eliom.8.6.0/opam
+++ b/packages/eliom/eliom.8.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "5.2"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "4.0.1"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+  "ppx_tools_versioned" {>= "5.2.3"}
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/8.6.0.tar.gz"
+  checksum: [
+    "md5=f0a6776774b3f95353e6df16e14cc01f"
+    "sha512=4c5d744b652b66752cd5e18588944f1116e4ccd5b8226167cf1d3d4a56723bb8bbad031e5d6641df35c33a0178c8687e272011ccf17d5872359d896d42857b7b"
+  ]
+}


### PR DESCRIPTION
### `eliom.8.6.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0