### PR TITLE
[new release] merlin 4.3 412, 4.3 411 and 3.6.0

### DIFF
--- a/packages/merlin/merlin.3.6.0/opam
+++ b/packages/merlin/merlin.3.6.0/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test & ocaml:version >= "4.03"}
+]
+depends: [
+  "ocaml" {>= "4.02.3" & < "4.12"}
+  "dune" {>= "1.8.0"}
+  "dot-merlin-reader" {>= "3.4.2"}
+  "yojson" {>= "1.6.0"}
+  "mdx" {with-test & >= "1.3.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "f2b7c36aa29f3c370338e40f62f3f4cd5f7e5884"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.6.0/merlin-v3.6.0.tbz"
+  checksum: [
+    "sha256=e68b4973cf5d55f32dfd53564e2ae6dcceccc2acc1d26bf12cd3fc907aed0f8e"
+    "sha512=668c57721d00784a32688c6e9f21269bb395d37252b7b3bb90b266feafe8b05b1b508d7d119282f99e0579c9cafcd67bda7e52991d9df2cda18bd4312f1d7526"
+  ]
+}

--- a/packages/merlin/merlin.3.6.0/opam
+++ b/packages/merlin/merlin.3.6.0/opam
@@ -8,7 +8,7 @@ license:      "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test & ocaml:version >= "4.03"}
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" jobs] {with-test & ocaml:version >= "4.03"}
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}

--- a/packages/merlin/merlin.4.3-411/opam
+++ b/packages/merlin/merlin.4.3-411/opam
@@ -8,7 +8,7 @@ license:      "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}

--- a/packages/merlin/merlin.4.3-411/opam
+++ b/packages/merlin/merlin.4.3-411/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.11.0" & < "4.12"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "c55eace80ac7e5cbe715f2040f37619eb5ebb893"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.3-411/merlin-v4.3-411.tbz"
+  checksum: [
+    "sha256=5dfc358f50f349c4fc008716b03a63807e95ba717490d301cd68774f3ff1345a"
+    "sha512=7db3e7eff446ace6d18a85bc3039d377166bae15f1f8186b6a94d1feadb18c5963e328c9987df7ef4ecbd5e9fd2730c8728c25d1990cd17af9a799a654c4bdc1"
+  ]
+}

--- a/packages/merlin/merlin.4.3-412/opam
+++ b/packages/merlin/merlin.4.3-412/opam
@@ -8,7 +8,7 @@ license:      "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.12" & < "4.13"}

--- a/packages/merlin/merlin.4.3-412/opam
+++ b/packages/merlin/merlin.4.3-412/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+x-commit-hash: "cdc6969e045e8308b2f72a4130fc924a525f9f1f"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.3-412/merlin-v4.3-412.tbz"
+  checksum: [
+    "sha256=f170a7b62685d0e2313ecddb255d6bf5d3a5992deaf046d5e5295ab5c9f526ae"
+    "sha512=dad8c22aa1dc559a90127ddb8dbb061d8a491724a10911d922148088964c1f84543da771554b02d041743f5fe5840e9dc310434a5c9f78da266613bcbba297c9"
+  ]
+}

--- a/packages/merlin/merlin.4.3-412/opam
+++ b/packages/merlin/merlin.4.3-412/opam
@@ -66,12 +66,12 @@ See https://github.com/OCamlPro/opam-user-setup
 "
   {success & !user-setup:installed}
 ]
-x-commit-hash: "cdc6969e045e8308b2f72a4130fc924a525f9f1f"
+x-commit-hash: "307bccaebaee69c0db23088e25393a10f0cf9e89"
 url {
   src:
-    "https://github.com/ocaml/merlin/releases/download/v4.3-412/merlin-v4.3-412.tbz"
+    "https://github.com/ocaml/merlin/releases/download/v4.3-412/merlin-v4.3-412-1-g307bccae.tbz"
   checksum: [
-    "sha256=f170a7b62685d0e2313ecddb255d6bf5d3a5992deaf046d5e5295ab5c9f526ae"
-    "sha512=dad8c22aa1dc559a90127ddb8dbb061d8a491724a10911d922148088964c1f84543da771554b02d041743f5fe5840e9dc310434a5c9f78da266613bcbba297c9"
+    "sha256=976ef48daa2b7ea7f8befd41f6cadf113f972e9ec3b7511f8ebb3a2e2031355e"
+    "sha512=71a501167328be2e90558debd8a6d7e4409ba02b37905819ce6d69084234c799bce7547885df5e7a9d579b0ce6aa7ed542c9ea2e6455acbe01b53045f3589011"
   ]
 }


### PR DESCRIPTION
Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more.

## CHANGES for 4.3-412 / 411:

  + merlin binary
    - recover ill-typed patterns (ocaml/merlin#1317, ocaml/merlin#1342)
    - more accurate type-enclosing for methods (ocaml/merlin#1328, fixes ocaml/merlin#1124)
    - fix location of patterns in Occurrences (ocaml/merlin#1324, fixes ocaml/ocaml-lsp#375)
    - fix location of module definitions done via functors (ocaml/merlin#1329, fixes ocaml/merlin#1199)
    - fix -cmt-path dirs mistakenly added to build path (ocaml/merlin#1330)
    - add new module holes that can replace module expressions (ocaml/merlin#1333)
    - add a new command `construct` that builds a list of possible terms when
      called on a typed hole (ocaml/merlin#1318)
    - `refactor-open` improvements (ocaml/merlin#1313, ocaml/merlin#1314, ocaml/merlin#1366, ocaml/merlin#1372)
      - do not make paths absolute, simply prefix with the identifier under
      the cursor
        ```ocaml
        open Foo (* calling refactor-open qualify on this open *)
        let _ = Foo.bar (* previously could result in [Dune__exe.Foo.bar] *)
        ```
      - do not return identical (duplicate) edits
      - do not return unnecessary edits that when applied do not change
        the document
      - handle record fields properly
      - handle multi-line paths
      - `unqualify` should not qualify
    - Handle `Persistent_env.Error` in `Typemod.initial_env` (ocaml/merlin#1355)
    - locate: reset global state from all entry points (ocaml/merlin#1364)
    - Windows: replace user name by its SID in socketnames (ocaml/merlin#1345, @ttamttam)
  + editor modes
    - vim: add a simple interface to the new `construct` command:
      `MerlinConstruct`. When several results are suggested,
      `<c-i>` and `<c-u>`
      to show more or less deep results. (ocaml/merlin#1318)
    - vim: add support for the `merlin-locate-type` command:
      `MerlinLocateType` (ocaml/merlin#1359)
    - emacs: add a simple interface to the new `construct` command:
      `merlin-construct`. (ocaml/merlin#1352)
    - emacs: add support for the `merlin-locate-type` command. (ocaml/merlin#1359)
    - emacs: fix issue with `merlin--highlight` and  various minor improvements
        (ocaml/merlin#1367, @mattiase)
  + test suite
    - cover the new `construct` command (ocaml/merlin#1318)


### CHANGES for 3.6.0

  + merlin binary
    - fix -cmt-path dirs mistakenly added to build path (ocaml/merlin#1330)
    - Windows: replace user name by its SID in socketnames (ocaml/merlin#1345, @ttamttam)
  + editor modes
    - vim: add support for the `merlin-locate-type` command:
      `MerlinLocateType` (ocaml/merlin#1359)
    - emacs: add support for the `merlin-locate-type` command. (ocaml/merlin#1359)