### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.0.4)

### DIFF
--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.3"}
-  "paf" {>= "0.0.2"}
+  "paf" {>= "0.0.2" < "0.0.4"}
   "ca-certs-nss"
   "cohttp"
   "cohttp-lwt"

--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.3"}
-  "paf" {>= "0.0.2" < "0.0.4"}
+  "paf" {>= "0.0.2" & < "0.0.4"}
   "ca-certs-nss"
   "cohttp"
   "cohttp-lwt"

--- a/packages/paf-cohttp/paf-cohttp.0.0.4/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.4/paf-0.0.4.tbz"
+  checksum: [
+    "sha256=4ba8a60d4375cb32007d950c5da62484f3dad613b27efd5d69112f91cf356e02"
+    "sha512=02c45b61fccf94829041546c6dc8f52b3531072897b89eedb309175d5630af2aa01a74e69f3746a382e1e944d9a51c285a70d7e8f2998af85f2184e9b0803092"
+  ]
+}
+x-commit-hash: "839da63cd33045005cafc6d7fc8046e47b72b63a"

--- a/packages/paf-le/paf-le.0.0.4/opam
+++ b/packages/paf-le/paf-le.0.0.4/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "paf" {= version}
   "duration"
-  "emile"
+  "emile" {>= "1.0"}
   "httpaf"
   "letsencrypt" {>= "0.3.0"}
   "mirage-stack"

--- a/packages/paf-le/paf-le.0.0.4/opam
+++ b/packages/paf-le/paf-le.0.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile"
+  "httpaf"
+  "letsencrypt" {>= "0.3.0"}
+  "mirage-stack"
+  "mirage-time"
+  "tls-mirage"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.4/paf-0.0.4.tbz"
+  checksum: [
+    "sha256=4ba8a60d4375cb32007d950c5da62484f3dad613b27efd5d69112f91cf356e02"
+    "sha512=02c45b61fccf94829041546c6dc8f52b3531072897b89eedb309175d5630af2aa01a74e69f3746a382e1e944d9a51c285a70d7e8f2998af85f2184e9b0803092"
+  ]
+}
+x-commit-hash: "839da63cd33045005cafc6d7fc8046e47b72b63a"

--- a/packages/paf/paf.0.0.4/opam
+++ b/packages/paf/paf.0.0.4/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "mirage-stack"
+  "mirage-time"
+  "tls-mirage" {>= "0.13.0"}
+  "mimic"
+  "cohttp-lwt"
+  "letsencrypt"
+  "emile"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "tcpip" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "domain-name" {>= "0.3.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "duration" {>= "0.1.3"}
+  "faraday" {>= "0.7.2"}
+  "ipaddr" {>= "5.0.1"}
+  "tls" {>= "0.13.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.4/paf-0.0.4.tbz"
+  checksum: [
+    "sha256=4ba8a60d4375cb32007d950c5da62484f3dad613b27efd5d69112f91cf356e02"
+    "sha512=02c45b61fccf94829041546c6dc8f52b3531072897b89eedb309175d5630af2aa01a74e69f3746a382e1e944d9a51c285a70d7e8f2998af85f2184e9b0803092"
+  ]
+}
+x-commit-hash: "839da63cd33045005cafc6d7fc8046e47b72b63a"

--- a/packages/paf/paf.0.0.4/opam
+++ b/packages/paf/paf.0.0.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
-  "mirage-stack"
+  "mirage-stack" {>= "2.2.0"}
   "mirage-time"
   "tls-mirage" {>= "0.13.0"}
   "mimic"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Don't use `disconnect` when the server terminates (@dinosaure, dinosaure/paf-le-chien#28)
- The main loop should not leave when it get an error from a client (@dinosaure, dinosaure/paf-le-chien#28)
- `Closed` error from TLS layer does not mean that the service is close,
  wrap such error into a client's `write_error` (@dinosaure, dinosaure/paf-le-chien#28)
- Do the compression of the ring-buffer at any call of `read` (@dinosaure, dinosaure/paf-le-chien#29)
- Refactore the loop under a common implementation (@dinosaure, dinosaure/paf-le-chien#30)
- Add a simple accessor to the peer identity (@dinosaure, dinosaure/paf-le-chien#31)
- Cut package between `paf` & `paf-cohttp` (@dinosaure, @hannesm, dinosaure/paf-le-chien#32)
- Cut package between `paf` & `paf-le` (@dinosaure, @hannesm, dinosaure/paf-le-chien#33)
- Update unikernels with the package layout (@dinosaure, dinosaure/paf-le-chien#34)
