### PR TITLE
[new release] pecu (0.6)

### DIFF
--- a/packages/pecu/pecu.0.6/opam
+++ b/packages/pecu/pecu.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/pecu"
+bug-reports:  "https://github.com/mirage/pecu/issues"
+dev-repo:     "git+https://github.com/mirage/pecu.git"
+doc:          "https://mirage.github.io/pecu/"
+license:      "MIT"
+synopsis:     "Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)"
+description:  """A non-blocking encoder/decoder of Quoted-Printable according to
+RFC2045 and RFC2047 (about encoded-word). Useful to translate contents of emails."""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.4"}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "astring" {with-test}
+]
+url {
+  src: "https://github.com/mirage/pecu/releases/download/v0.6/pecu-v0.6.tbz"
+  checksum: [
+    "sha256=a9d2b7da444c83b20f879f6c3b7fc911d08ac1e6245ad7105437504f9394e5c7"
+    "sha512=8cae31da1fcb8b684a949846b1668131de244fbb89faf7421761da208f87092523a9e184e91a04c26739e6793501307b30ed255d540dcb268b171b7a56b56e24"
+  ]
+}
+x-commit-hash: "295862d499e63ef77b8fdeb08e951e6e6bdcbc42"


### PR DESCRIPTION
Encoder/Decoder of Quoted-Printable (RFC2045 & RFC2047)

- Project page: <a href="https://github.com/mirage/pecu">https://github.com/mirage/pecu</a>
- Documentation: <a href="https://mirage.github.io/pecu/">https://mirage.github.io/pecu/</a>

##### CHANGES:

* Fix a bug when we decode contents (@dinosaure, mirage/pecu#7)
* Lint OPAM file (@dinosaure, mirage/pecu#8)
* Add missing dune constraint (@kit-ty-kate, @dinosaure, mirage/pecu#9)
* Add regression tests (@dinosaure, mirage/pecu#10)
