### PR TITLE
[new release] index-bench and index (1.3.3)

### DIFF
--- a/packages/index-bench/index-bench.1.3.3/opam
+++ b/packages/index-bench/index-bench.1.3.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.03.0"}
+  "cmdliner"{>= "1.0.3"}
+  "dune"    {>= "2.7.0"}
+  "fmt"     {>= "0.8.7"}
+  "index"   {= version}
+  "re"     {>= "1.9.0"}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "stdlib-shims"
+  "yojson"
+  "repr"
+  "ppx_repr"
+]
+
+synopsis: "Index benchmarking suite"
+x-commit-hash: "d6c40553d044ee2257f1b7bbcef30dfc5b613bd3"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.3/index-1.3.3.tbz"
+  checksum: [
+    "sha256=6051cf8cad4ab425d8501063110c1fc91fb86fa90426b094dce34cdea5588a91"
+    "sha512=8fda03c25fef27d6744dd3aabc5928184cd62f32d0ab80c7b819b07f046988c83cd70527b87ec44d537d4650ea8b1fb949dc10b2e2acf66def219a4bcf3da022"
+  ]
+}

--- a/packages/index/index.1.3.3/opam
+++ b/packages/index/index.1.3.3/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.2.0"}
+  "ppx_repr"
+  "fmt"
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner"
+  "progress" {>= "0.1.1" & < "0.2.0"}
+  "semaphore-compat"  {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+x-commit-hash: "d6c40553d044ee2257f1b7bbcef30dfc5b613bd3"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.3.3/index-1.3.3.tbz"
+  checksum: [
+    "sha256=6051cf8cad4ab425d8501063110c1fc91fb86fa90426b094dce34cdea5588a91"
+    "sha512=8fda03c25fef27d6744dd3aabc5928184cd62f32d0ab80c7b819b07f046988c83cd70527b87ec44d537d4650ea8b1fb949dc10b2e2acf66def219a4bcf3da022"
+  ]
+}


### PR DESCRIPTION
Index benchmarking suite

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>

##### CHANGES:

## Fixed

- Attempt to recover from `log_async` invariant violations during an explicit
  sync operation, rather than failing immediately. (mirage/index#329)
