### PR TITLE
[new release] ocaml-version (3.2.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.2.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "alcotest" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"

--- a/packages/ocaml-version/ocaml-version.3.2.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.2.0/ocaml-version-v3.2.0.tbz"
+  checksum: [
+    "sha256=a643dd6ef10676855916a1d45c69070587088673da00a2867a52251390bb7461"
+    "sha512=85e104d347c52e3be00e4e4d675e99dc43bf57aebd08c9934e70608a2657bfa5be1d8c9aa897dac4ce6e2da9175d3ac0eb22baa2851f4edc88063fede6b9b650"
+  ]
+}
+x-commit-hash: "41428c5e64b21a49f334822562bc73fd5033353c"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add support for S390x big-endian architectures (@avsm)
* Add 4.14.0 entry (@avsm)
* Add support for naked pointers checker option and add it to
  the 4.12+ variants (@kit-ty-kate @dra27 @avsm)
* Add a domains and effects variants for the experimental
  forks in 4.10 and 4.12, to aid in CI. (@avsm @ewanmellor)
* Do not advertise a 4.10 multicore as 4.12 is the preferred
  compiler now for that (@avsm)
