### PR TITLE
mirage-block-lwt isn't compatible with cstruct 6.0.1

### DIFF
--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "result" {< "1.5"}
 ]
 tags: "org:mirage"
-synopsis: "Utilities and module definitions for dealing with block devices."
+synopsis: "Utilities and module definitions for dealing with block devices"
 description:
   "This library is primarily useful in the context of a Mirage project."
 url {

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "base-bytes"
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
   "lwt"
   "logs"

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
-  "lwt"
+  "lwt" {>= "2.4.7"}
   "logs"
   "mirage-block" {= "1.0.0"}
   "result" {< "1.5"}

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta9"}
   "base-bytes"
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
   "lwt"
   "logs"

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
-  "lwt"
+  "lwt" {>= "2.4.7"}
   "logs"
   "mirage-block" {>= "1.0.0" & < "2.0.0"}
   "result" {< "1.5"}

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "result" {< "1.5"}
 ]
 tags: "org:mirage"
-synopsis: "Utilities and module definitions for dealing with block devices."
+synopsis: "Utilities and module definitions for dealing with block devices"
 description:
   "This library is primarily useful in the context of a Mirage project."
 url {

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-block/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
   "lwt"
   "logs"

--- a/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
+++ b/packages/mirage-block-lwt/mirage-block-lwt.1.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
-  "lwt"
+  "lwt" {>= "2.4.7"}
   "logs"
   "mirage-block" {>= "1.0.0" & < "2.0.0"}
 ]


### PR DESCRIPTION
Fix revdeps for https://github.com/ocaml/opam-repository/pull/18940