### PR TITLE
Fix cstruct.6.0.1's revdeps (use -warn-error and Cstruct.len is now deprecated)

### DIFF
--- a/packages/mirage-block-combinators/mirage-block-combinators.2.0.0/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.2.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-block/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
   "lwt" {>= "4.0.0"}
   "logs"

--- a/packages/mirage-block-combinators/mirage-block-combinators.2.0.1/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.2.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-block/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "io-page"
   "lwt" {>= "4.0.0"}
   "logs"

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "topkg" {build & >= "0.7.3"}
   "fmt"
   "lwt"
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "cstruct-lwt"
   "mirage-clock" {= "1.2.0"}
   "mirage-flow" {= "1.2.0"}

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "fmt"
   "lwt"
-  "cstruct" {>= "2.0.0"}
+  "cstruct" {>= "2.0.0" & < "6.0.1"}
   "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-flow" {>= "1.3.0" & < "2.0.0"}
 ]

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/opam
@@ -44,7 +44,7 @@ depends: [
   "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"
   "lwt" {with-test & < "5.0.0"}
-  "cstruct" {>= "2.3.0"}
+  "cstruct" {>= "2.3.0" & < "6.0.1"}
 ]
 synopsis: "Various implementations of the MirageOS FLOW interface"
 description: """

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-flow" {>= "1.3.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.3.0"}
   "lwt"
-  "cstruct" {>= "2.3.0"}
+  "cstruct" {>= "2.3.0" & < "6.0.1"}
   "alcotest" {with-test & < "1.4.0"}
 ]
 synopsis: "Flow implementations and combinators for MirageOS"

--- a/packages/mirage-vnetif/mirage-vnetif.0.1.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "lwt"
   "mirage-types" {< "3.0.0"}
-  "cstruct"
+  "cstruct" {< "6.0.1"}
   "ipaddr" {< "3.0.0"}
   "io-page"
   "mirage-profile"

--- a/packages/pbkdf/pbkdf.0.1.0/opam
+++ b/packages/pbkdf/pbkdf.0.1.0/opam
@@ -32,7 +32,7 @@ build: [
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.0"}
   "alcotest" {with-test}
   "ocamlbuild" {build}

--- a/packages/pbkdf/pbkdf.0.2.0/opam
+++ b/packages/pbkdf/pbkdf.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.0"}
   "alcotest" {with-test}
 ]

--- a/packages/salsa20-core/salsa20-core.0.1.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {>= "0.5.3"}
   "alcotest" {with-test}

--- a/packages/salsa20-core/salsa20-core.0.2.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "ocb-stubblr" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {with-test}
   "alcotest" {with-test}

--- a/packages/salsa20-core/salsa20-core.0.3.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build}
   "ocb-stubblr" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "alcotest" {with-test}
 ]
 synopsis: "Salsa20 core functions, in OCaml"

--- a/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.1.0/opam
@@ -28,7 +28,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocamlfind" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {>= "0.5.0"}
   "pbkdf" {>= "0.1.0"}

--- a/packages/scrypt-kdf/scrypt-kdf.0.2.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
   "pbkdf" {>= "0.1.0"}
   "alcotest" {with-test}

--- a/packages/scrypt-kdf/scrypt-kdf.0.3.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
   "pbkdf" {>= "0.1.0"}
   "alcotest" {with-test}

--- a/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.0.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "cstruct" {>= "1.7.0"}
+  "cstruct" {>= "1.7.0" & < "6.0.1"}
   "nocrypto" {>= "0.5.3"}
   "pbkdf" {>= "0.1.0"}
   "salsa20-core" {>= "0.1.0"}


### PR DESCRIPTION
Fix the remaining failures from https://github.com/ocaml/opam-repository/pull/18940