### PR TITLE
Disable qbf.0.2 when using opam >= 2.0.9

### DIFF
--- a/packages/qbf/qbf.0.2/opam
+++ b/packages/qbf/qbf.0.2/opam
@@ -33,7 +33,7 @@ It packs:
 - a binding to quantor, which is shipped with the library
 - a binding to Depqbf"""
 flags: light-uninstall
-available: opam-version < "2.1"
+available: opam-version < "2.0.9"
 url {
   src: "https://github.com/c-cube/ocaml-qbf/archive/0.2.tar.gz"
   checksum: "md5=4213a4a6138e2056ec5db3871d0dd17a"

--- a/packages/qbf/qbf.0.2/opam
+++ b/packages/qbf/qbf.0.2/opam
@@ -33,6 +33,7 @@ It packs:
 - a binding to quantor, which is shipped with the library
 - a binding to Depqbf"""
 flags: light-uninstall
+available: opam-version < "2.1"
 url {
   src: "https://github.com/c-cube/ocaml-qbf/archive/0.2.tar.gz"
   checksum: "md5=4213a4a6138e2056ec5db3871d0dd17a"


### PR DESCRIPTION
internal configure script uses /tmp