### PR TITLE
Disable tests of some packages

### DIFF
--- a/packages/KaSim/KaSim.4.0.0/opam
+++ b/packages/KaSim/KaSim.4.0.0/opam
@@ -31,7 +31,6 @@ build: [
   [make "META" "kappalib"]
   [make "agents"] {atdgen:installed}
   [make "bin/WebSim"] {atdgen:installed & cohttp-lwt-unix:installed}
-  [make "check"] {with-test & opam-version < "2.1"}
 ]
 install: [ [ make "install-lib" ] ]
 

--- a/packages/KaSim/KaSim.4.0.0/opam
+++ b/packages/KaSim/KaSim.4.0.0/opam
@@ -31,7 +31,7 @@ build: [
   [make "META" "kappalib"]
   [make "agents"] {atdgen:installed}
   [make "bin/WebSim"] {atdgen:installed & cohttp-lwt-unix:installed}
-  [make "check"] {with-test}
+  [make "check"] {with-test & opam-version < "2.1"}
 ]
 install: [ [ make "install-lib" ] ]
 

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
@@ -10,7 +10,6 @@ tags:         [ "org:mirage" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & opam-version < "2.1"}
 ]
 
 depends: [
@@ -20,9 +19,6 @@ depends: [
   "mirage-kv-lwt" {>= "1.0.0"}
   "lwt"
   "ptime"
-  "rresult" {with-test}
-  "mirage-clock-unix" {with-test & >= "2.0.0" & < "3.0.0"}
-  "alcotest" {with-test & >= "0.7.1" & < "1.4.0"}
 ]
 synopsis: "Key-value store for MirageOS backed by Unix filesystem"
 description: """

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.0.0/opam
@@ -10,7 +10,7 @@ tags:         [ "org:mirage" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos" & opam-version < "2.1"}
 ]
 
 depends: [

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.1.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.1.0/opam
@@ -10,7 +10,6 @@ tags:         [ "org:mirage" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & opam-version < "2.1"}
 ]
 
 depends: [
@@ -19,10 +18,6 @@ depends: [
   "mirage-kv" {>= "3.0.0"}
   "lwt"
   "ptime"
-  "cstruct" {with-test & >= "3.2.0"}
-  "rresult" {with-test}
-  "mirage-clock-unix" {with-test & >= "3.0.0"}
-  "alcotest" {with-test & >= "0.7.1" & < "1.4.0"}
 ]
 synopsis: "Key-value store for MirageOS backed by Unix filesystem"
 description: """

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.1.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.1.0/opam
@@ -10,7 +10,7 @@ tags:         [ "org:mirage" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & opam-version < "2.1"}
 ]
 
 depends: [


### PR DESCRIPTION
the sandbox now disables writes into /tmp since opam 2.0.9