### PR TITLE
hiredis < 0.8: Disable the tests (never worked, requires redis-server)

### DIFF
--- a/packages/hiredis/hiredis.0.2/opam
+++ b/packages/hiredis/hiredis.0.2/opam
@@ -10,7 +10,6 @@ build: [
   ["ocaml" "./pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
     {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/hiredis/hiredis.0.4/opam
+++ b/packages/hiredis/hiredis.0.4/opam
@@ -10,7 +10,6 @@ build: [
   ["ocaml" "./pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
     {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/hiredis/hiredis.0.6/opam
+++ b/packages/hiredis/hiredis.0.6/opam
@@ -10,7 +10,6 @@ build: [
   ["ocaml" "./pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
     {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/hiredis/hiredis.0.7.1/opam
+++ b/packages/hiredis/hiredis.0.7.1/opam
@@ -10,7 +10,6 @@ build: [
   ["ocaml" "./pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
     {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/hiredis/hiredis.0.7/opam
+++ b/packages/hiredis/hiredis.0.7/opam
@@ -10,7 +10,6 @@ build: [
   ["ocaml" "./pkg/pkg.ml" "build" "--pinned" "%{pinned}%"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]
     {with-test}
-  ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}


### PR DESCRIPTION
Detected in #18940 
```
#=== ERROR while compiling hiredis.0.7.1 ======================================#
# context              2.0.9 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12/.opam-switch/build/hiredis.0.7.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml test
# exit-code            1
# env-file             ~/.opam/log/hiredis-67-e7966f.env
# output-file          ~/.opam/log/hiredis-67-e7966f.out
### output ###
# Running Reader Get reply (invalid) ..... passed
# Running Reader Get reply (test) ..... passed
# Running Reader Get reply (nil) ..... passed
# Running Reader Get reply (array) ..... passed
# Fatal error: exception Unix.Unix_error(Unix.ENOENT, "create_process", "redis-server")
# pkg.ml: [ERROR] Some tests failed.

- Running Reader Get reply (invalid) ..... passed
- Running Reader Get reply (test) ..... passed
- Running Reader Get reply (nil) ..... passed
- Running Reader Get reply (array) ..... passed
- Fatal error: exception Unix.Unix_error(Unix.ENOENT, "create_process", "redis-server")
- pkg.ml: [ERROR] Some tests failed.
```