### PR TITLE
Disable the tests for frama-c.21.* (incompatible with opam sandbox)

### DIFF
--- a/packages/frama-c/frama-c.21.0/opam
+++ b/packages/frama-c/frama-c.21.0/opam
@@ -98,9 +98,10 @@ install: [
   [make "-C" "doc" "install"] {with-doc}
 ]
 
-run-test: [
-  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"]
-]
+#run-test: [
+#  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"]
+#]
+# Logs diffs against /tmp not /opam-tmp (imcompatible with opam sandbox)
 
 depends: [
   "ocaml" { >= "4.05.0" & ( < "4.08.0~" | >= "4.08.1" ) }
@@ -115,7 +116,7 @@ depends: [
   "conf-graphviz" { post }
   "yojson"
   "why3" { >= "1.3.1" & < "1.4~" }
-  "conf-time" {with-test}
+#  "conf-time" {with-test}
 ]
 
 depopts: [

--- a/packages/frama-c/frama-c.21.1/opam
+++ b/packages/frama-c/frama-c.21.1/opam
@@ -98,9 +98,10 @@ install: [
   [make "-C" "doc" "install"] {with-doc}
 ]
 
-run-test: [
-  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"]
-]
+#run-test: [
+#  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"]
+#]
+# Logs diffs against /tmp not /opam-tmp (imcompatible with opam sandbox)
 
 depends: [
   "ocaml" { >= "4.05.0" & ( < "4.08.0~" | >= "4.08.1" ) }
@@ -115,7 +116,7 @@ depends: [
   "conf-graphviz" { post }
   "yojson"
   "why3" { >= "1.3.1" & < "1.4~" }
-  "conf-time" {with-test}
+#  "conf-time" {with-test}
 ]
 
 depopts: [


### PR DESCRIPTION
```
# bin/toplevel.opt tests/syntax/cpp-command.c -check   -no-autoload-plugins -cpp-frama-c-compliant -cpp-command "echo [\$(basename '%1') \$(basename '%1') \$(basename '%i') \$(basename '%input')] ['%2' '%2' '%o' '%output'] ['%args']"  2>/opam-tmp/cpp-command.0f270ff.err.log | /bin/sed 's:/\(tmp\|var\|build\)/[^ ]*\.i:/tmp/FILE.i:g' >tests/syntax/result/cpp-command.0.res.log && /bin/sed 's:/\(tmp\|var\|build\)/[^ ]*\.i:/tmp/FILE.i:g' < /opam-tmp/cpp-command.0f270ff.err.log >tests/syntax/result/cpp-command.0.err.log && rm -f /opam-tmp/cpp-command.0f270ff.err.log
# --- tests/syntax/oracle/cpp-command.0.res.oracle	2020-06-11 01:00:00.000000000 +0100
# +++ tests/syntax/result/cpp-command.0.res.log	2021-07-27 23:41:13.062416828 +0100
# @@ -1,2 +1,2 @@
#  [kernel] Parsing tests/syntax/cpp-command.c (with preprocessing)
# -[cpp-command.c cpp-command.c cpp-command.c cpp-command.c] [/tmp/FILE.i /tmp/FILE.i /tmp/FILE.i /tmp/FILE.i] [ -I./share/libc -D__FRAMAC__ -D__FC_MACHDEP_X86_32 -dD -nostdinc -m32]
# +[cpp-command.c cpp-command.c cpp-command.c cpp-command.c] [/opam-tmp/cpp-command.c0d8217.i /opam-tmp/cpp-command.c0d8217.i /opam-tmp/cpp-command.c0d8217.i /opam-tmp/cpp-command.c0d8217.i] [ -I./share/libc -D__FRAMAC__ -D__FC_MACHDEP_X86_32 -dD -nostdinc -m32]
# Env:
# FRAMAC_LIB (set from outside) = "/home/opam/.opam/4.12/.opam-switch/build/frama-c.21.0/lib/fc"
# FRAMAC_PLUGIN_GUI = "./lib/plugins/gui"
# FRAMAC_PLUGIN = "./lib/plugins"
# FRAMAC_SHARE = "./share"
# FRAMAC_SESSION = "."
# OCAMLRUNPARAM = ""
# Command:
# bin/toplevel.opt tests/syntax/cpp-command.c -check   -no-autoload-plugins -cpp-frama-c-compliant -cpp-command "echo %%1 = \$(basename '%1') %%2 = '%2' %%args = '%args'"  2>/opam-tmp/cpp-command.104a5d0.err.log | /bin/sed 's:/\(tmp\|var\|build\)/[^ ]*\.i:/tmp/FILE.i:g' >tests/syntax/result/cpp-command.1.res.log && /bin/sed 's:/\(tmp\|var\|build\)/[^ ]*\.i:/tmp/FILE.i:g' < /opam-tmp/cpp-command.104a5d0.err.log >tests/syntax/result/cpp-command.1.err.log && rm -f /opam-tmp/cpp-command.104a5d0.err.log
# --- tests/syntax/oracle/cpp-command.1.res.oracle	2020-06-11 01:00:00.000000000 +0100
# +++ tests/syntax/result/cpp-command.1.res.log	2021-07-27 23:41:13.062416828 +0100
# @@ -1,2 +1,2 @@
#  [kernel] Parsing tests/syntax/cpp-command.c (with preprocessing)
# -%1 = cpp-command.c %2 = /tmp/FILE.i %args =  -I./share/libc -D__FRAMAC__ -D__FC_MACHDEP_X86_32 -dD -nostdinc -m32
# +%1 = cpp-command.c %2 = /opam-tmp/cpp-command.c008004.i %args =  -I./share/libc -D__FRAMAC__ -D__FC_MACHDEP_X86_32 -dD -nostdinc -m32
```