### PR TITLE
mirage-vnetif.0.3.1 is incompatible with cstruct.6.0.1

### DIFF
--- a/packages/mirage-vnetif/mirage-vnetif.0.1.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "lwt"
   "mirage-types" {< "3.0.0"}
-  "cstruct" {< "6.0.1"}
+  "cstruct"
   "ipaddr" {< "3.0.0"}
   "io-page"
   "mirage-profile"

--- a/packages/mirage-vnetif/mirage-vnetif.0.3.1/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "mirage-clock-lwt" {>= "1.2.0"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
-  "cstruct"
+  "cstruct" {< "6.0.1"}
   "ipaddr" {< "3.0.0"}
   "io-page"
   "mirage-profile"


### PR DESCRIPTION
(uses warn-error and Cstruct.len is deprecated)

Only mirage-vnetif.0.3.1 is incompatible with cstruct 6.0.1, not mirage-vnetif.0.1.0
An oversight in #19143, my bad.