### PR TITLE
zoggy.github.com > zoggy.github.io

### DIFF
--- a/packages/chamo/chamo.2.01/opam
+++ b/packages/chamo/chamo.2.01/opam
@@ -18,6 +18,6 @@ synopsis:
   "A source code editor, even if it can be used to edit any text file."
 extra-files: ["chamo.install" "md5=61635a19e58f6af4d4587471c79bef4a"]
 url {
-  src: "http://zoggy.github.com/chamo/chamo-2.01.tar.gz"
+  src: "http://zoggy.github.io/chamo/chamo-2.01.tar.gz"
   checksum: "md5=e9e2047c929680884c35cee6a973735c"
 }

--- a/packages/chamo/chamo.2.02/opam
+++ b/packages/chamo/chamo.2.02/opam
@@ -22,6 +22,6 @@ synopsis:
   "A source code editor, even if it can be used to edit any text file."
 extra-files: ["chamo.install" "md5=61635a19e58f6af4d4587471c79bef4a"]
 url {
-  src: "http://zoggy.github.com/chamo/chamo-2.02.tar.gz"
+  src: "http://zoggy.github.io/chamo/chamo-2.02.tar.gz"
   checksum: "md5=efedc2453f1ca3e24c9de93f236db578"
 }

--- a/packages/chamo/chamo.2.03/opam
+++ b/packages/chamo/chamo.2.03/opam
@@ -28,6 +28,6 @@ synopsis:
   "A source code editor, even if it can be used to edit any text file."
 extra-files: ["chamo.install" "md5=61635a19e58f6af4d4587471c79bef4a"]
 url {
-  src: "http://zoggy.github.com/chamo/chamo-2.03.tar.gz"
+  src: "http://zoggy.github.io/chamo/chamo-2.03.tar.gz"
   checksum: "md5=f2dc1e57c4205349796a8745065f5e95"
 }

--- a/packages/dbforge/dbforge.2.0.1/opam
+++ b/packages/dbforge/dbforge.2.0.1/opam
@@ -30,6 +30,6 @@ synopsis:
   "A tool to describe database schemas and generate OCaml code to access these databases."
 extra-files: ["dbforge.install" "md5=9f4defb2eb0a5be350e947226ac51657"]
 url {
-  src: "http://zoggy.github.com/dbforge/dbforge-2.0.1.tar.gz"
+  src: "http://zoggy.github.io/dbforge/dbforge-2.0.1.tar.gz"
   checksum: "md5=0eba41e65fb5f802db9618ca38202af2"
 }

--- a/packages/dbforge/dbforge.2.0/opam
+++ b/packages/dbforge/dbforge.2.0/opam
@@ -20,6 +20,6 @@ synopsis:
   "A tool to describe database schemas and generate OCaml code to access these databases."
 extra-files: ["dbforge.install" "md5=9f4defb2eb0a5be350e947226ac51657"]
 url {
-  src: "http://zoggy.github.com/dbforge/dbforge-2.0.tar.gz"
+  src: "http://zoggy.github.io/dbforge/dbforge-2.0.tar.gz"
   checksum: "md5=78660bfc79e6b2e374ca992ca6ad887f"
 }

--- a/packages/genet/genet.0.1/opam
+++ b/packages/genet/genet.0.1/opam
@@ -26,6 +26,6 @@ depends: [
 install: [make "install"]
 synopsis: "Genet is tool to build a continuous integration platform."
 url {
-  src: "http://zoggy.github.com/genet/genet-0.1.tar.gz"
+  src: "http://zoggy.github.io/genet/genet-0.1.tar.gz"
   checksum: "md5=807a4a297ba32a3a177b6ddf04d1a141"
 }

--- a/packages/genet/genet.0.2/opam
+++ b/packages/genet/genet.0.2/opam
@@ -26,6 +26,6 @@ depends: [
 install: [make "install"]
 synopsis: "Genet is tool to build a continuous integration platform."
 url {
-  src: "http://zoggy.github.com/genet/genet-0.2.tar.gz"
+  src: "http://zoggy.github.io/genet/genet-0.2.tar.gz"
   checksum: "md5=8a839c8fe8e0ab99abfaea1d45d3fea0"
 }

--- a/packages/gtktop/gtktop.2.0/opam
+++ b/packages/gtktop/gtktop.2.0/opam
@@ -15,6 +15,6 @@ depends: [
 install: [make "install"]
 synopsis: "A small library to ease the creation of graphical toplevels."
 url {
-  src: "http://zoggy.github.com/gtktop/gtktop-2.0.tar.gz"
+  src: "http://zoggy.github.io/gtktop/gtktop-2.0.tar.gz"
   checksum: "md5=c77091dcddc63711c370370a6860dbb3"
 }

--- a/packages/higlo/higlo.0.1/opam
+++ b/packages/higlo/higlo.0.1/opam
@@ -25,6 +25,6 @@ description:
   "The purpose of Higlo is not to provide syntax highlighting for every language, nor target every format (HTML, LaTeX, ...). It provides a simple way to support additional languages and develop the generator for the output format you need."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/higlo/higlo-0.1.tar.gz"
+  src: "http://zoggy.github.io/higlo/higlo-0.1.tar.gz"
   checksum: "md5=809f515b4c6232d27a068b8499d66cd1"
 }

--- a/packages/higlo/higlo.0.2/opam
+++ b/packages/higlo/higlo.0.2/opam
@@ -25,6 +25,6 @@ description:
   "The purpose of Higlo is not to provide syntax highlighting for every language, nor target every format (HTML, LaTeX, ...). It provides a simple way to support additional languages and develop the generator for the output format you need."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/higlo/higlo-0.2.tar.gz"
+  src: "http://zoggy.github.io/higlo/higlo-0.2.tar.gz"
   checksum: "md5=7cbe33e38658d83a681f8f0a91a2fe07"
 }

--- a/packages/higlo/higlo.0.3/opam
+++ b/packages/higlo/higlo.0.3/opam
@@ -28,6 +28,6 @@ description:
 flags: light-uninstall
 extra-files: ["higlo.install" "md5=5487db22ed91942f17aaaa5f228e695f"]
 url {
-  src: "http://zoggy.github.com/higlo/higlo-0.3.tar.gz"
+  src: "http://zoggy.github.io/higlo/higlo-0.3.tar.gz"
   checksum: "md5=fec0966ee2cf635d5dec952589106a16"
 }

--- a/packages/higlo/higlo.0.4/opam
+++ b/packages/higlo/higlo.0.4/opam
@@ -28,6 +28,6 @@ description:
 flags: light-uninstall
 extra-files: ["higlo.install" "md5=5487db22ed91942f17aaaa5f228e695f"]
 url {
-  src: "http://zoggy.github.com/higlo/higlo-0.4.tar.gz"
+  src: "http://zoggy.github.io/higlo/higlo-0.4.tar.gz"
   checksum: "md5=e9357a715b2d7f7ab4d28efbab908ec1"
 }

--- a/packages/higlo/higlo.0.5/opam
+++ b/packages/higlo/higlo.0.5/opam
@@ -28,6 +28,6 @@ description:
 flags: light-uninstall
 extra-files: ["higlo.install" "md5=5487db22ed91942f17aaaa5f228e695f"]
 url {
-  src: "http://zoggy.github.com/higlo/higlo-0.5.tar.gz"
+  src: "http://zoggy.github.io/higlo/higlo-0.5.tar.gz"
   checksum: "md5=6b3686189ade3ddec44db7b725a11f11"
 }

--- a/packages/ocamldiff/ocamldiff.1.0/opam
+++ b/packages/ocamldiff/ocamldiff.1.0/opam
@@ -10,6 +10,6 @@ description:
   "OCamldiff was previously part of Cameleon but is now developped separately and is findlib compatible."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocamldiff/ocamldiff-1.0.tar.gz"
+  src: "http://zoggy.github.io/ocamldiff/ocamldiff-1.0.tar.gz"
   checksum: "md5=10b3975775447d4c4dd8eb28ca7bbc78"
 }

--- a/packages/ocamldiff/ocamldiff.1.1/opam
+++ b/packages/ocamldiff/ocamldiff.1.1/opam
@@ -15,6 +15,6 @@ description:
   "OCamldiff was previously part of Cameleon but is now developped separately and is findlib compatible."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocamldiff/ocamldiff-1.1.tar.gz"
+  src: "http://zoggy.github.io/ocamldiff/ocamldiff-1.1.tar.gz"
   checksum: "md5=3fe4b10fe15cdf544904dd0ca3448a77"
 }

--- a/packages/ocamldot/ocamldot.1.0/opam
+++ b/packages/ocamldot/ocamldot.1.0/opam
@@ -20,6 +20,6 @@ description:
 authors: "Maxence Guesdon"
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocamldot/ocamldot-1.0.tar.gz"
+  src: "http://zoggy.github.io/ocamldot/ocamldot-1.0.tar.gz"
   checksum: "md5=4aac21782a00e5db8e823732304e7db9"
 }

--- a/packages/ocamlrss/ocamlrss.2.0/opam
+++ b/packages/ocamlrss/ocamlrss.2.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
-homepage: "http://zoggy.github.com/ocamlrss"
+homepage: "http://zoggy.github.io/ocamlrss"
 build: make
 remove: [["ocamlfind" "remove" "rss"]]
 depends: ["ocaml" "ocamlfind" "xmlm"]
@@ -16,6 +16,6 @@ OCaml-RSS was previously part of Cameleon but is now developped
 separately and is findlib compatible."""
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocamlrss/ocamlrss-2.0.tar.gz"
+  src: "http://zoggy.github.io/ocamlrss/ocamlrss-2.0.tar.gz"
   checksum: "md5=4cb8fcd7e0950d7da0f2bf87009a836c"
 }

--- a/packages/ocamlrss/ocamlrss.2.1.0/opam
+++ b/packages/ocamlrss/ocamlrss.2.1.0/opam
@@ -20,6 +20,6 @@ OCaml-RSS was previously part of Cameleon but is now developped
 separately and is findlib compatible."""
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocamlrss/ocamlrss-2.1.0.tar.gz"
+  src: "http://zoggy.github.io/ocamlrss/ocamlrss-2.1.0.tar.gz"
   checksum: "md5=cfe5bc02f02b91f2578075ceb5cd2359"
 }

--- a/packages/ocf/ocf.0.1.0/opam
+++ b/packages/ocf/ocf.0.1.0/opam
@@ -26,6 +26,6 @@ depends: [
 synopsis: "Library to load and store configuration options in JSON syntax."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocf/ocf-0.1.0.tar.gz"
+  src: "http://zoggy.github.io/ocf/ocf-0.1.0.tar.gz"
   checksum: "md5=51e10c39063df2257f1b32fe699f72b3"
 }

--- a/packages/ocf/ocf.0.2.0/opam
+++ b/packages/ocf/ocf.0.2.0/opam
@@ -26,6 +26,6 @@ depends: [
 synopsis: "Library to load and store configuration options in JSON syntax."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocf/ocf-0.2.0.tar.gz"
+  src: "http://zoggy.github.io/ocf/ocf-0.2.0.tar.gz"
   checksum: "md5=93844cbc997014ed0ac03d78c36cd7e4"
 }

--- a/packages/ocf/ocf.0.3.0/opam
+++ b/packages/ocf/ocf.0.3.0/opam
@@ -26,6 +26,6 @@ depends: [
 synopsis: "Library to load and store configuration options in JSON syntax."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocf/ocf-0.3.0.tar.gz"
+  src: "http://zoggy.github.io/ocf/ocf-0.3.0.tar.gz"
   checksum: "md5=2cc3dfd3d4f2c0caf6a7978bf19b5dff"
 }

--- a/packages/ocf/ocf.0.4.0/opam
+++ b/packages/ocf/ocf.0.4.0/opam
@@ -25,6 +25,6 @@ depends: [
 synopsis: "Library to load and store configuration options in JSON syntax."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocf/ocf-0.4.0.tar.gz"
+  src: "http://zoggy.github.io/ocf/ocf-0.4.0.tar.gz"
   checksum: "md5=e3ca7aae3bda436711ad6c0719ecfbf9"
 }

--- a/packages/ojs-base/ojs-base.0.1.0/opam
+++ b/packages/ojs-base/ojs-base.0.1.0/opam
@@ -24,6 +24,6 @@ synopsis:
   "Components to create web applications using js_of_ocaml and websockets."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ojs-base/ojs-base-0.1.0.tar.gz"
+  src: "http://zoggy.github.io/ojs-base/ojs-base-0.1.0.tar.gz"
   checksum: "md5=350993860f89177bb4db86b3247fab95"
 }

--- a/packages/ojs-base/ojs-base.0.2.0/opam
+++ b/packages/ojs-base/ojs-base.0.2.0/opam
@@ -24,6 +24,6 @@ synopsis:
   "Components to create web applications using js_of_ocaml and websockets."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ojs-base/ojs-base-0.2.0.tar.gz"
+  src: "http://zoggy.github.io/ojs-base/ojs-base-0.2.0.tar.gz"
   checksum: "md5=23e81210cba9f43542884e99ba8857b8"
 }

--- a/packages/ojs-base/ojs-base.0.3.0/opam
+++ b/packages/ojs-base/ojs-base.0.3.0/opam
@@ -33,6 +33,6 @@ synopsis:
   "Components to create web applications using js_of_ocaml and websockets."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ojs-base/ojs-base-0.3.0.tar.gz"
+  src: "http://zoggy.github.io/ojs-base/ojs-base-0.3.0.tar.gz"
   checksum: "md5=6075c2d55eaac6d1121085923bd73b4e"
 }

--- a/packages/ojs-base/ojs-base.0.4.0/opam
+++ b/packages/ojs-base/ojs-base.0.4.0/opam
@@ -33,6 +33,6 @@ synopsis:
   "Components to create web applications using js_of_ocaml and websockets."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ojs-base/ojs-base-0.4.0.tar.gz"
+  src: "http://zoggy.github.io/ojs-base/ojs-base-0.4.0.tar.gz"
   checksum: "md5=2761e50b1bea173dbf6c0c95678c76a9"
 }

--- a/packages/stog-rdf/stog-rdf.0.10.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.10.0/opam
@@ -22,6 +22,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-rdf-0.10.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-rdf-0.10.0.tar.gz"
   checksum: "md5=badf43d546827b4bec9bfe769fb06cb4"
 }

--- a/packages/stog-rdf/stog-rdf.0.11.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.11.0/opam
@@ -23,6 +23,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-rdf-0.11.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-rdf-0.11.0.tar.gz"
   checksum: "md5=f2f7ae23cc09fda109b8f861a86ffbd8"
 }

--- a/packages/stog-rdf/stog-rdf.0.15.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.15.0/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-rdf-0.15.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-rdf-0.15.0.tar.gz"
   checksum: "md5=6f49b1b8b94f7e9ffd7cb49022d87d28"
 }

--- a/packages/stog-rdf/stog-rdf.0.16.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.16.0/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-rdf-0.16.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-rdf-0.16.0.tar.gz"
   checksum: "md5=433eb9aa4ff3b8a14b75e24261fa111c"
 }

--- a/packages/stog-rdf/stog-rdf.0.7.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.7.0/opam
@@ -11,6 +11,6 @@ install: [make "install"]
 synopsis:
   "Plugin for Stog. Allow defining RDF triples to generate a RDF graph for the site."
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-rdf-0.7.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-rdf-0.7.0.tar.gz"
   checksum: "md5=18f23579b8aa8801752aca97ade79abf"
 }

--- a/packages/stog-writing/stog-writing.0.10.0/opam
+++ b/packages/stog-writing/stog-writing.0.10.0/opam
@@ -18,6 +18,6 @@ synopsis:
 description: "web sites."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.10.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.10.0.tar.gz"
   checksum: "md5=e09a39a07aa03c6512f6134db38736c2"
 }

--- a/packages/stog-writing/stog-writing.0.11.0/opam
+++ b/packages/stog-writing/stog-writing.0.11.0/opam
@@ -18,6 +18,6 @@ synopsis:
 description: "web sites."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.11.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.11.0.tar.gz"
   checksum: "md5=1ff0f4208bb33021a8810ddcb7f6620b"
 }

--- a/packages/stog-writing/stog-writing.0.12.0/opam
+++ b/packages/stog-writing/stog-writing.0.12.0/opam
@@ -17,6 +17,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.12.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.12.0.tar.gz"
   checksum: "md5=65410bff18c66cd18e9f5980b673dbf8"
 }

--- a/packages/stog-writing/stog-writing.0.13.0/opam
+++ b/packages/stog-writing/stog-writing.0.13.0/opam
@@ -17,6 +17,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.13.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.13.0.tar.gz"
   checksum: "md5=9ebda81b5c411455477e4bef4d0be2b3"
 }

--- a/packages/stog-writing/stog-writing.0.15.0/opam
+++ b/packages/stog-writing/stog-writing.0.15.0/opam
@@ -23,6 +23,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.15.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.15.0.tar.gz"
   checksum: "md5=76fdc80b7195153d69f13da14be3b2ea"
 }

--- a/packages/stog-writing/stog-writing.0.16.0/opam
+++ b/packages/stog-writing/stog-writing.0.16.0/opam
@@ -23,6 +23,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.16.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.16.0.tar.gz"
   checksum: "md5=34ca6aeba93c3b9cc81c403e3c17e9b3"
 }

--- a/packages/stog-writing/stog-writing.0.6/opam
+++ b/packages/stog-writing/stog-writing.0.6/opam
@@ -12,6 +12,6 @@ synopsis:
   "Plugin for Stog. Allow adding footnotes and bibliographies in stog-generated"
 description: "web sites."
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.6.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.6.tar.gz"
   checksum: "md5=b123792d9de9a67f89edcc6747517528"
 }

--- a/packages/stog-writing/stog-writing.0.7.0/opam
+++ b/packages/stog-writing/stog-writing.0.7.0/opam
@@ -12,6 +12,6 @@ synopsis:
   "Plugin for Stog. Allow adding footnotes and bibliographies in stog-generated"
 description: "web sites."
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.7.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.7.0.tar.gz"
   checksum: "md5=52e7e94fcc4b39ec4a63fa1647391e6c"
 }

--- a/packages/stog-writing/stog-writing.0.8.0/opam
+++ b/packages/stog-writing/stog-writing.0.8.0/opam
@@ -12,6 +12,6 @@ synopsis:
   "Plugin for Stog. Allow adding footnotes and bibliographies in stog-generated"
 description: "web sites."
 url {
-  src: "http://zoggy.github.com/stog/plugins/stog-writing-0.8.0.tar.gz"
+  src: "http://zoggy.github.io/stog/plugins/stog-writing-0.8.0.tar.gz"
   checksum: "md5=c0a9009f1c8795556f535d6b8eec8d06"
 }

--- a/packages/stog/stog.0.10.0/opam
+++ b/packages/stog/stog.0.10.0/opam
@@ -39,6 +39,6 @@ The main differences are:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=93ed46b4ced08cae7715a843b7827eb7"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.10.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.10.0.tar.gz"
   checksum: "md5=4117d5f8fbc96e2b256ba0d49d69de75"
 }

--- a/packages/stog/stog.0.11.0/opam
+++ b/packages/stog/stog.0.11.0/opam
@@ -40,6 +40,6 @@ The main differences are:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=93ed46b4ced08cae7715a843b7827eb7"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.11.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.11.0.tar.gz"
   checksum: "md5=9339b1afb27cd531aef077c24a48b323"
 }

--- a/packages/stog/stog.0.11.1/opam
+++ b/packages/stog/stog.0.11.1/opam
@@ -40,6 +40,6 @@ The main differences are:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=93ed46b4ced08cae7715a843b7827eb7"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.11.1.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.11.1.tar.gz"
   checksum: "md5=4e6f33718224d5502447f9db82930a7c"
 }

--- a/packages/stog/stog.0.12.0/opam
+++ b/packages/stog/stog.0.12.0/opam
@@ -41,6 +41,6 @@ The main differences are:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=93ed46b4ced08cae7715a843b7827eb7"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.12.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.12.0.tar.gz"
   checksum: "md5=c4736b83d23a77ef565b90298115ec1c"
 }

--- a/packages/stog/stog.0.13.0/opam
+++ b/packages/stog/stog.0.13.0/opam
@@ -47,6 +47,6 @@ regular pages."""
 flags: light-uninstall
 extra-files: ["stog.install" "md5=474001f0f771f0085d55fb0b58b2e7fe"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.13.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.13.0.tar.gz"
   checksum: "md5=4411abab24e45341988216b5bf2ba4db"
 }

--- a/packages/stog/stog.0.14.0/opam
+++ b/packages/stog/stog.0.14.0/opam
@@ -49,6 +49,6 @@ regular pages."""
 flags: light-uninstall
 extra-files: ["stog.install" "md5=474001f0f771f0085d55fb0b58b2e7fe"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.14.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.14.0.tar.gz"
   checksum: "md5=bc647e0d60d01999aa920005ca762095"
 }

--- a/packages/stog/stog.0.15.0/opam
+++ b/packages/stog/stog.0.15.0/opam
@@ -62,6 +62,6 @@ Main features:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=dd45a8769ea4d237c8a5945c67192856"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.15.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.15.0.tar.gz"
   checksum: "md5=b21681f66efd00d53487f41fa86dd6e0"
 }

--- a/packages/stog/stog.0.16.0/opam
+++ b/packages/stog/stog.0.16.0/opam
@@ -63,6 +63,6 @@ Main features:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=dd45a8769ea4d237c8a5945c67192856"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.16.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.16.0.tar.gz"
   checksum: "md5=53be6770d7ec57c31f0f4f2954f73b32"
 }

--- a/packages/stog/stog.0.4/opam
+++ b/packages/stog/stog.0.4/opam
@@ -26,6 +26,6 @@ The main differences are:
 - It easily supports multi-language sites."""
 extra-files: ["stog.install" "md5=5c319af20a49fbceb8fc431c95a90198"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.4.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.4.tar.gz"
   checksum: "md5=2500ace40374e5e9a1d14d816e05bc20"
 }

--- a/packages/stog/stog.0.5/opam
+++ b/packages/stog/stog.0.5/opam
@@ -27,6 +27,6 @@ The main differences are:
 - It easily supports multi-language sites."""
 extra-files: ["stog.install" "md5=5c319af20a49fbceb8fc431c95a90198"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.5.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.5.tar.gz"
   checksum: "md5=527c583aaf493b107df6edc0e72eef7b"
 }

--- a/packages/stog/stog.0.6.1/opam
+++ b/packages/stog/stog.0.6.1/opam
@@ -26,6 +26,6 @@ The main differences are:
 - It easily supports multi-language sites."""
 extra-files: ["stog.install" "md5=5c319af20a49fbceb8fc431c95a90198"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.6.1.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.6.1.tar.gz"
   checksum: "md5=da460629c506d92fffaa457c4db78f17"
 }

--- a/packages/stog/stog.0.7.0/opam
+++ b/packages/stog/stog.0.7.0/opam
@@ -26,6 +26,6 @@ The main differences are:
 - It easily supports multi-language sites."""
 extra-files: ["stog.install" "md5=7f365388eaa51a97270309d4f828fa59"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.7.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.7.0.tar.gz"
   checksum: "md5=d6f16a77fdd4296b7e40e14d8606c216"
 }

--- a/packages/stog/stog.0.8.0/opam
+++ b/packages/stog/stog.0.8.0/opam
@@ -27,6 +27,6 @@ The main differences are:
 - It easily supports multi-language sites."""
 extra-files: ["stog.install" "md5=7f365388eaa51a97270309d4f828fa59"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.8.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.8.0.tar.gz"
   checksum: "md5=587af11965dfe000e65a54c6a93adfb7"
 }

--- a/packages/stog/stog.0.9.0/opam
+++ b/packages/stog/stog.0.9.0/opam
@@ -32,6 +32,6 @@ The main differences are:
 flags: light-uninstall
 extra-files: ["stog.install" "md5=7f365388eaa51a97270309d4f828fa59"]
 url {
-  src: "http://zoggy.github.com/stog/stog-0.9.0.tar.gz"
+  src: "http://zoggy.github.io/stog/stog-0.9.0.tar.gz"
   checksum: "md5=052d0d167164568e32330465f0712e11"
 }

--- a/packages/taglog/taglog.0.1.0/opam
+++ b/packages/taglog/taglog.0.1.0/opam
@@ -25,6 +25,6 @@ depends: [
 synopsis: "Logging library using levels and tags to determine what to log."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/ocaml-taglog/taglog-0.1.0.tar.gz"
+  src: "http://zoggy.github.io/ocaml-taglog/taglog-0.1.0.tar.gz"
   checksum: "md5=8774dcaa762fc1f99e0fe2c840d0c7cb"
 }

--- a/packages/taglog/taglog.0.2.0/opam
+++ b/packages/taglog/taglog.0.2.0/opam
@@ -23,6 +23,6 @@ depends: [
 ]
 synopsis: "Logging library using levels and tags to determine what to log."
 url {
-  src: "http://zoggy.github.com/ocaml-taglog/taglog-0.2.0.tar.gz"
+  src: "http://zoggy.github.io/ocaml-taglog/taglog-0.2.0.tar.gz"
   checksum: "md5=bedc5976836a956af817c945e80105d2"
 }

--- a/packages/xmldiff/xmldiff.0.1/opam
+++ b/packages/xmldiff/xmldiff.0.1/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Diffs on XML trees."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xmldiff/xmldiff-0.1.tar.gz"
+  src: "http://zoggy.github.io/xmldiff/xmldiff-0.1.tar.gz"
   checksum: "md5=5c9401877fd2319f0268cf4f97bb9472"
 }

--- a/packages/xmldiff/xmldiff.0.2/opam
+++ b/packages/xmldiff/xmldiff.0.2/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Diffs on XML trees."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xmldiff/xmldiff-0.2.tar.gz"
+  src: "http://zoggy.github.io/xmldiff/xmldiff-0.2.tar.gz"
   checksum: "md5=116bd5f107eb77cdc81f50c7f3b1b277"
 }

--- a/packages/xmldiff/xmldiff.0.3.0/opam
+++ b/packages/xmldiff/xmldiff.0.3.0/opam
@@ -25,6 +25,6 @@ install: [make "install"]
 synopsis: "Diffs on XML trees."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xmldiff/xmldiff-0.3.0.tar.gz"
+  src: "http://zoggy.github.io/xmldiff/xmldiff-0.3.0.tar.gz"
   checksum: "md5=35e5edf18412617a2ce7fd68099d9ddb"
 }

--- a/packages/xmldiff/xmldiff.0.4.0/opam
+++ b/packages/xmldiff/xmldiff.0.4.0/opam
@@ -25,6 +25,6 @@ install: [make "install"]
 synopsis: "Diffs on XML trees."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xmldiff/xmldiff-0.4.0.tar.gz"
+  src: "http://zoggy.github.io/xmldiff/xmldiff-0.4.0.tar.gz"
   checksum: "md5=db17c01285d7276f52e3269aa91f284d"
 }

--- a/packages/xmldiff/xmldiff.0.5.0/opam
+++ b/packages/xmldiff/xmldiff.0.5.0/opam
@@ -24,6 +24,6 @@ install: [make "install"]
 synopsis: "Diffs on XML trees."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xmldiff/xmldiff-0.5.0.tar.gz"
+  src: "http://zoggy.github.io/xmldiff/xmldiff-0.5.0.tar.gz"
   checksum: "md5=f2881ff25230e0c90dc7fb041a71b7a1"
 }

--- a/packages/xtmpl/xtmpl.0.10/opam
+++ b/packages/xtmpl/xtmpl.0.10/opam
@@ -23,6 +23,6 @@ depends: [
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.10.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.10.tar.gz"
   checksum: "md5=3229a1a6d4098fd6f6c945bd9c2e60be"
 }

--- a/packages/xtmpl/xtmpl.0.11/opam
+++ b/packages/xtmpl/xtmpl.0.11/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "XML templating library and ppx."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.11.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.11.tar.gz"
   checksum: "md5=87fdedecd1f2e83f89c7858490394ce3"
 }

--- a/packages/xtmpl/xtmpl.0.12/opam
+++ b/packages/xtmpl/xtmpl.0.12/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "XML templating library and ppx."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.12.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.12.tar.gz"
   checksum: "md5=55701024603bb8f8243dabc0a42ae452"
 }

--- a/packages/xtmpl/xtmpl.0.13.0/opam
+++ b/packages/xtmpl/xtmpl.0.13.0/opam
@@ -25,6 +25,6 @@ depends: [
 synopsis: "XML templating library and ppx."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.13.0.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.13.0.tar.gz"
   checksum: "md5=522f0f113fea8b6e9da72cacefb654f6"
 }

--- a/packages/xtmpl/xtmpl.0.14.0/opam
+++ b/packages/xtmpl/xtmpl.0.14.0/opam
@@ -27,6 +27,6 @@ description:
   "Provide an XML parser, templating and rewrite engine for XML documents."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.14.0.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.14.0.tar.gz"
   checksum: "md5=2a6d32ff75c29736839d91b932b1ab14"
 }

--- a/packages/xtmpl/xtmpl.0.3/opam
+++ b/packages/xtmpl/xtmpl.0.3/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.3.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.3.tar.gz"
   checksum: "md5=ce84ec66ef3198a036e0d2b01ecc1015"
 }

--- a/packages/xtmpl/xtmpl.0.4/opam
+++ b/packages/xtmpl/xtmpl.0.4/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.4.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.4.tar.gz"
   checksum: "md5=62b7b6984f595364c8230297ef56b00c"
 }

--- a/packages/xtmpl/xtmpl.0.5/opam
+++ b/packages/xtmpl/xtmpl.0.5/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.5.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.5.tar.gz"
   checksum: "md5=338b6fb96ad409fe31b0ed8b094da26f"
 }

--- a/packages/xtmpl/xtmpl.0.6/opam
+++ b/packages/xtmpl/xtmpl.0.6/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.6.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.6.tar.gz"
   checksum: "md5=1d2810d26fb11a5d4a803de4733b71fc"
 }

--- a/packages/xtmpl/xtmpl.0.7/opam
+++ b/packages/xtmpl/xtmpl.0.7/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.7.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.7.tar.gz"
   checksum: "md5=98172c98b16828b89d17db66f958b0db"
 }

--- a/packages/xtmpl/xtmpl.0.8/opam
+++ b/packages/xtmpl/xtmpl.0.8/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.8.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.8.tar.gz"
   checksum: "md5=d6a15094ee7defbd1a767b60bc764efe"
 }

--- a/packages/xtmpl/xtmpl.0.9/opam
+++ b/packages/xtmpl/xtmpl.0.9/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.com/xtmpl/xtmpl-0.9.tar.gz"
+  src: "http://zoggy.github.io/xtmpl/xtmpl-0.9.tar.gz"
   checksum: "md5=8659b35b25966363e9f7ed5df6f43866"
 }


### PR DESCRIPTION
I did not test every url, but every url I tested is broken before this fix.

See [GitHub Pages will stop redirecting Pages sites from *.github.com after April 15, 2021 ](https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/)

cc @zoggy 

i.e. currently, `ocamldiff` fails to install on my CI script

```
[ERROR] The sources of the following couldn't be obtained, aborting:
          - ocamldiff.1.1:
            http://zoggy.github.com/ocamldiff/ocamldiff-1.1.tar.gz (curl: code 404 while downloading http://zoggy.github.com/ocamldiff/ocamldiff-1.1.tar.gz)
```