### PR TITLE
Package graphql_ppx.1.2.2

### DIFF
--- a/packages/graphql_ppx/graphql_ppx.1.2.2/opam
+++ b/packages/graphql_ppx/graphql_ppx.1.2.2/opam
@@ -7,13 +7,14 @@ authors: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
 license: "MIT"
 homepage: "https://github.com/reasonml-community/graphql-ppx"
 bug-reports: "https://github.com/reasonml-community/graphql-ppx/issues"
+dev-repo: "git+https://github.com/reasonml-community/graphql-ppx.git"
 depends: [
   "alcotest" {with-test}
   "dune" {>= "2.5"}
   "ocaml" {>= "4.06"}
   "ppxlib" {>= "0.21.0"}
   "reason"
-  "yojson"
+  "yojson" {>= "1.6.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/graphql_ppx/graphql_ppx.1.2.2/opam
+++ b/packages/graphql_ppx/graphql_ppx.1.2.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "GraphQL PPX rewriter for ReScript/ReasonML"
+description:
+  "GraphQL language primitives for ReScript/ReasonML written in ReasonML"
+maintainer: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
+authors: "Tomasz Cichocinski <tomaszcichocinski@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/reasonml-community/graphql-ppx"
+bug-reports: "https://github.com/reasonml-community/graphql-ppx/issues"
+depends: [
+  "alcotest" {with-test}
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.06"}
+  "ppxlib" {>= "0.21.0"}
+  "reason"
+  "yojson"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/reasonml-community/graphql-ppx/archive/refs/tags/v1.2.2.tar.gz"
+  checksum: [
+    "md5=00455e2a595b925a697fd7e80aab3fb8"
+    "sha512=b6e0a5b353b6498c10d03a37ab4a2083ca0d17f227fa906e7c6f07053a7a9198476b7aa7d0e88f4e3c8c44a85469eb3a65805cd6d006ef64ff82fe5bc3524881"
+  ]
+}


### PR DESCRIPTION
### `graphql_ppx.1.2.2`
GraphQL PPX rewriter for ReScript/ReasonML
GraphQL language primitives for ReScript/ReasonML written in ReasonML



---
* Homepage: https://github.com/reasonml-community/graphql-ppx
* Bug tracker: https://github.com/reasonml-community/graphql-ppx/issues

---
:camel: Pull-request generated by opam-publish v2.1.0