### PR TITLE
[new release] camyll (0.3.0)

### DIFF
--- a/packages/camyll/camyll.0.3.0/opam
+++ b/packages/camyll/camyll.0.3.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "A static site generator"
+description: """
+Camyll is a static site generator.
+
+Features:
+
+- Conversion from Markdown to HTML
+- Syntax highlighting of any language via user-provided TextMate grammars
+- Post tagging
+- Processing of literate Agda"""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+tags: ["blog" "web" "website"]
+homepage: "https://alan-j-hu.github.io/camyll"
+bug-reports: "https://github.com/alan-j-hu/camyll/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "angstrom" {>= "0.15" & < "0.16"}
+  "calendar" {>= "2.01" & < "3.0"}
+  "cmdliner" {>= "1.0" & < "2.0"}
+  "httpaf" {>= "0.7.1" & < "0.8"}
+  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
+  "jingoo" {>= "1.4" & < "2.0"}
+  "lambdasoup" {>= "0.7" & < "0.8"}
+  "markup" {>= "0.8" & < "2.0"}
+  "ocaml" {>= "4.12"}
+  "omd" {= "2.0.0~alpha2"}
+  "plist-xml" {< "0.4"}
+  "re" {>= "1.9" & < "2.0"}
+  "textmate-language" {>= "0.3.1" & < "0.4"}
+  "toml" {>= "7" & < "8"}
+  "uri" {>= "4.2" & < "5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/camyll.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/camyll/releases/download/0.3.0/camyll-0.3.0.tbz"
+  checksum: [
+    "sha256=adea2b7dfc77cf55f35f527c68bcc10340594775d2982a2af6c8263b65746bfd"
+    "sha512=13d0929bdd0e33fc3a87e6ca80a3a389b66d546c88c9ff264e079d6b9a9bddfdb013f557137909e15950fe9b07fd220e210ce697cfaf989463a419fc4e2c76a3"
+  ]
+}
+x-commit-hash: "9cf12cf2da8ac5e28fa6ef99694b462a2a1920bc"


### PR DESCRIPTION
A static site generator

- Project page: <a href="https://alan-j-hu.github.io/camyll">https://alan-j-hu.github.io/camyll</a>

##### CHANGES:

- Validate colors from TextMate themes.
- Implement other theme attributes.
- Use proper URI parsing library in server; previous code didn't handle ? and
  #.
- Use opinionated directory names instead of making them configurable.
- Determine Agda module names by parsing file instead of deriving it from the
  filepath. This makes it possible to set the project root in a different
  directory (such as through `.agda-lib`).
- Don't leave Agda-processed Markdown files in the Agda documentation directory.
