### PR TITLE
2 packages from sapristi/easy_logging at 0.8.2

### DIFF
--- a/packages/easy_logging/easy_logging.0.8.2/opam
+++ b/packages/easy_logging/easy_logging.0.8.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Module to log messages. Aimed at being both powerful and easy to use"
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "MPL-2.0"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.8"}
+  "calendar" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "easy_logging"] {with-test}
+]
+
+description: """Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/archive/v0.8.2.tar.gz"
+  checksum: [
+    "md5=467a966433b97693e0c226a90b9b833e"
+    "sha512=d4b97a29225c454a2d8ed04495aa7ecd3b012d7258372be2450e9b672498ba24ce9a3079307e762e12948661bc1e104a90f167fabf60c212fe67b13d6c4edf51"
+  ]
+}

--- a/packages/easy_logging_yojson/easy_logging_yojson.0.8.2/opam
+++ b/packages/easy_logging_yojson/easy_logging_yojson.0.8.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Configuration loader for easy_logging with yojson backend"
+maintainer: "mathiasmillet@gmail.com"
+authors: "Mathias Millet"
+license: "MPL-2.0"
+homepage: "https://sapristi.github.io/easy_logging/"
+bug-reports: "https://github.com/sapristi/easy_logging/issues"
+dev-repo: "git+https://github.com/sapristi/easy_logging.git"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.8"}
+  "ppx_deriving"{>= "4.0"}
+  "ppx_deriving_yojson"{>="3.5"}
+  "easy_logging" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "conf_loader_modules/yojson"] {with-test}
+]
+
+description: """Provides deserialisation of logging configuration
+(loggers instantation and handlers parameters) from json,
+using ppx_deriving_yojson.
+
+-------
+
+     Logging infrastructure inspired by the Python logging module.
+The aim of this module is to provide a quick and easy to use logging
+infrastructure.
+
+It has the following features :
+   * one line logger creation
+   * log messages printf style, or [string] or [string lazy_t]
+   * tree logging architecture for light configuration
+   * handlers associated to each logger will format, filter and treat the message independantly.
+   * use the infrastructure with your own handlers with the [MakeLogging] functor.
+   * use tags to add contextual information to log messages
+"""
+url {
+  src: "https://github.com/sapristi/easy_logging/archive/v0.8.2.tar.gz"
+  checksum: [
+    "md5=467a966433b97693e0c226a90b9b833e"
+    "sha512=d4b97a29225c454a2d8ed04495aa7ecd3b012d7258372be2450e9b672498ba24ce9a3079307e762e12948661bc1e104a90f167fabf60c212fe67b13d6c4edf51"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`easy_logging.0.8.2`: Module to log messages. Aimed at being both powerful and easy to use
-`easy_logging_yojson.0.8.2`: Configuration loader for easy_logging with yojson backend



---
* Homepage: https://sapristi.github.io/easy_logging/
* Source repo: git+https://github.com/sapristi/easy_logging.git
* Bug tracker: https://github.com/sapristi/easy_logging/issues

---
:camel: Pull-request generated by opam-publish v2.1.0