### PR TITLE
Package spdx_licenses.1.0.0

### DIFF
--- a/packages/spdx_licenses/spdx_licenses.1.0.0/opam
+++ b/packages/spdx_licenses/spdx_licenses.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A library providing a strict SPDX License Expression parser"
+description: """\
+An OCaml library aiming to provide an up-to-date and strict SPDX License Expression parser.
+It implements the format described in: https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
+See https://spdx.org/licenses/ for more details."""
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/spdx_licenses"
+bug-reports: "https://github.com/kit-ty-kate/spdx_licenses/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {>= "2.3"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@doc" {with-doc}
+]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/spdx_licenses.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.0.0/spdx_licenses-v1.0.0.tbz"
+  checksum: [
+    "md5=5393e25f7aa3e2b2a4e880d8dcbcc8e4"
+    "sha512=e0bc38d85204355a85cf862bdfe7a23b3fd422932bb6c85a6b31e311acf43553b6113792d839f8e629147f4c4021db91992ecb11e88a69c4d50e36c43d516b9a"
+  ]
+}


### PR DESCRIPTION
### `spdx_licenses.1.0.0`
A library providing a strict SPDX License Expression parser
An OCaml library aiming to provide an up-to-date and strict SPDX License Expression parser.
It implements the format described in: https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
See https://spdx.org/licenses/ for more details.



---
* Homepage: https://github.com/kit-ty-kate/spdx_licenses
* Source repo: git+https://github.com/kit-ty-kate/spdx_licenses.git
* Bug tracker: https://github.com/kit-ty-kate/spdx_licenses/issues

---
:camel: Pull-request generated by opam-publish v2.1.0