### PR TITLE
Add missing opam constraint to recent depext releases

### DIFF
--- a/packages/opam-depext/opam-depext.1.1.4/opam
+++ b/packages/opam-depext/opam-depext.1.1.4/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: ["ocaml" {>= "4.00"}]
-available: opam-version >= "2.0.0~beta5"
+available: opam-version >= "2.0.0~beta5" & opam-version < "2.1"
 flags: plugin
 build: make
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"

--- a/packages/opam-depext/opam-depext.1.1.5/opam
+++ b/packages/opam-depext/opam-depext.1.1.5/opam
@@ -11,7 +11,7 @@ license: "LGPL-2.1 with OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: ["ocaml" {>= "4.00"}]
-available: opam-version >= "2.0.0~beta5"
+available: opam-version >= "2.0.0~beta5" & opam-version < "2.1"
 flags: plugin
 build: make
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"


### PR DESCRIPTION
#17435 & #17642 are missing the constraint away from opam 2.1 added in #16325