### PR TITLE
2 packages from c-cube/ezcurl at 0.1

### DIFF
--- a/packages/ezcurl-lwt/ezcurl-lwt.0.1/opam
+++ b/packages/ezcurl-lwt/ezcurl-lwt.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl, Lwt version"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl"
+  "ezcurl" { = version }
+  "lwt"
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "mdx" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" "lwt" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=e2213c3b66680ebaa4572660b8de4756"
+    "sha512=b40824b7a4d38b7082884f265918b4100a1492548ca37d1b495bffee15ea6743e3557d70b524a3a56a7c4504678becc16a3f40e7d5054c3d81ec2ee831f4adda"
+  ]
+}

--- a/packages/ezcurl/ezcurl.0.1/opam
+++ b/packages/ezcurl/ezcurl.0.1/opam
@@ -9,7 +9,7 @@ build: [
   #["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocurl"
+  "ocurl" {>= "0.8.0"}
   "dune" { >= "1.0" }
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/ezcurl/ezcurl.0.1/opam
+++ b/packages/ezcurl/ezcurl.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl"
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=e2213c3b66680ebaa4572660b8de4756"
+    "sha512=b40824b7a4d38b7082884f265918b4100a1492548ca37d1b495bffee15ea6743e3557d70b524a3a56a7c4504678becc16a3f40e7d5054c3d81ec2ee831f4adda"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezcurl.0.1`: Friendly wrapper around OCurl
-`ezcurl-lwt.0.1`: Friendly wrapper around OCurl, Lwt version



---
* Homepage: https://github.com/c-cube/ezcurl/
* Source repo: git+https://github.com/c-cube/ezcurl.git
* Bug tracker: https://github.com/c-cube/ezcurl/issues

---
:camel: Pull-request generated by opam-publish v2.0.3