### PR TITLE
8 packages from ocaml/opam at 2.0.9

### DIFF
--- a/packages/opam-client/opam-client.2.0.9/opam
+++ b/packages/opam-client/opam-client.2.0.9/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Client library for opam 2.0"
+description:
+  "Actions on the opam root, switches, installations, and front-end."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "extlib" {>= "1.7.3" & < "1.7.8"}
+  "opam-repository" {= version}
+  "re" {>= "1.7.2"}
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-core/opam-core.2.0.9/opam
+++ b/packages/opam-core/opam-core.2.0.9/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Core library for opam 2.0"
+description:
+  "Small standard library extensions, and generic system interaction modules used by opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.5.0"}
+  "dune" {>= "1.2.1"}
+  "cppo" {build & >= "1.1.0"}
+]
+conflicts: ["extlib-compat"]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.0.9/opam
+++ b/packages/opam-devel/opam-devel.2.0.9/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Bootstrapped development binary for opam 2.0"
+description:
+  "This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= version}
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "1.2.1"}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+  [make "tests"] {with-test}
+]
+post-messages:
+  """\
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.0.9/opam
+++ b/packages/opam-devel/opam-devel.2.0.9/opam
@@ -25,6 +25,7 @@ depends: [
   "dune" {>= "1.2.1"}
   "conf-openssl" {with-test}
   "conf-diffutils" {with-test}
+  "conf-which" {with-test}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]

--- a/packages/opam-dune-lint/opam-dune-lint.0.1/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.1/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+license: "ISC"
 synopsis: "Ensure dune and opam dependencies are consistent"
 description:
   "opam-dune-lint checks that all ocamlfind libraries listed as dune dependencies have corresponding opam dependencies listed in the opam files. If not, it offers to add them (either to your opam files, or to your dune-project if you're generating your opam files from that)."
@@ -15,7 +16,7 @@ depends: [
   "ocaml" {>= "4.11.0"}
   "ocamlfind"
   "bos"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "opam-state" {< "2.1.0~~" & opam-version < "2.1"}
   "opam-state" {>= "2.1.0~~" & opam-version >= "2.1"}
   "opam-format"

--- a/packages/opam-dune-lint/opam-dune-lint.0.1/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"
   "bos"
   "fmt"
-  "opam-state"
+  "opam-state" {>= "2.1.0~~"}
   "opam-format"
   "odoc" {with-doc}
 ]

--- a/packages/opam-dune-lint/opam-dune-lint.0.1/opam
+++ b/packages/opam-dune-lint/opam-dune-lint.0.1/opam
@@ -16,7 +16,8 @@ depends: [
   "ocamlfind"
   "bos"
   "fmt"
-  "opam-state" {>= "2.1.0~~"}
+  "opam-state" {< "2.1.0~~" & opam-version < "2.1"}
+  "opam-state" {>= "2.1.0~~" & opam-version >= "2.1"}
   "opam-format"
   "odoc" {with-doc}
 ]

--- a/packages/opam-format/opam-format.2.0.9/opam
+++ b/packages/opam-format/opam-format.2.0.9/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Format library for opam 2.0"
+description: "Definition of opam datastructures and its file interface."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.0.0~rc2"}
+  "re" {>= "1.5.0"}
+  "dune" {>= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.0.9/opam
+++ b/packages/opam-installer/opam-installer.2.0.9/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """\
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.0.9/opam
+++ b/packages/opam-repository/opam-repository.2.0.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Repository library for opam 2.0"
+description:
+  "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "dune" {>= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.0.9/opam
+++ b/packages/opam-solver/opam-solver.2.0.9/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Solver library for opam 2.0"
+description:
+  "Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "5" & < "6.0"}
+  "cudf" {>= "0.7"}
+  "re" {>= "1.5.0"}
+  "dune" {>= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}

--- a/packages/opam-state/opam-state.2.0.9/opam
+++ b/packages/opam-state/opam-state.2.0.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "State library for opam 2.0"
+description:
+  "Handling of the ~/.opam hierarchy, repository and switch states."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= version}
+  "dune" {>= "1.2.1"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/2.0.9.tar.gz"
+  checksum: [
+    "md5=abb7d7788f290d81d73b924b307b4bef"
+    "sha512=0d8ee19ac0f3df9de4fd9cfa8daab1f7228f090f5e2e7e26bedf24d8c2ab377aade95048f2d7cd9ee9dbbe738729e26dc99f41f730fa2252df74953362464a22"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`opam-client.2.0.9`: Client library for opam 2.0
-`opam-core.2.0.9`: Core library for opam 2.0
-`opam-devel.2.0.9`: Bootstrapped development binary for opam 2.0
-`opam-format.2.0.9`: Format library for opam 2.0
-`opam-installer.2.0.9`: Installation of files to a prefix, following opam conventions
-`opam-repository.2.0.9`: Repository library for opam 2.0
-`opam-solver.2.0.9`: Solver library for opam 2.0
-`opam-state.2.0.9`: State library for opam 2.0



---
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.1.0