### PR TITLE
[new release] key-parsers (1.2.1)

### DIFF
--- a/packages/key-parsers/key-parsers.1.2.1/opam
+++ b/packages/key-parsers/key-parsers.1.2.1/opam
@@ -6,7 +6,7 @@ authors: [
 ]
 homepage: "https://github.com/cryptosense/key-parsers"
 bug-reports: "https://github.com/cryptosense/key-parsers/issues"
-license: "BSD-2"
+license: "BSD-2-Clause"
 dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
 doc: "https://cryptosense.github.io/key-parsers/doc"
 build: [

--- a/packages/key-parsers/key-parsers.1.2.1/opam
+++ b/packages/key-parsers/key-parsers.1.2.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2"
+dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "asn1-combinators" {>= "0.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "dune" {>= "2.0"}
+  "hex" {>= "1.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppx_deriving" {>= "4.0"}
+  "result" {>= "1.5"}
+  "zarith" {>= "1.4.1"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+synopsis: "Parsers for multiple key formats"
+description: """
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or
+Elliptic curve public and private keys.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/key-parsers/releases/download/1.2.1/key-parsers-1.2.1.tbz"
+  checksum: [
+    "sha256=9f5cbf6391225f8af287859dc5427a2afa96952cfa8c3f5a90a1aebe04b077da"
+    "sha512=d4363c7509a7581fe5364bcc248082c2c75e32536338962d22ad529a89e825603b960dae62d8e918b9c119e33d0e72bf05a9040bf0cc15493bb6582c14fedf02"
+  ]
+}
+x-commit-hash: "241210b0a4b36c0e0e86f42729c793bfbdc2b470"


### PR DESCRIPTION
Parsers for multiple key formats

- Project page: <a href="https://github.com/cryptosense/key-parsers">https://github.com/cryptosense/key-parsers</a>
- Documentation: <a href="https://cryptosense.github.io/key-parsers/doc">https://cryptosense.github.io/key-parsers/doc</a>

##### CHANGES:

*2021-07-30*

### Changed

- Update the minimal Cstruct version to 6.0.0 and Dune to 2.0
