### PR TITLE
Package sedlex.2.4

### DIFF
--- a/packages/sedlex/sedlex.2.4/opam
+++ b/packages/sedlex/sedlex.2.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "An OCaml lexer generator for Unicode"
+description: """
+sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
+Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
+OCaml source files. Lexing specific constructs are provided via a ppx syntax
+extension."""
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "https://github.com/ocaml-community/sedlex/graphs/contributors"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.8"}
+  "ppxlib" {>= "0.18.0"}
+  "gen"
+  "uchar"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
+doc: "https://ocaml-community.github.io/sedlex/index.html"
+url {
+  src: "https://github.com/ocaml-community/sedlex/archive/v2.4.tar.gz"
+  checksum: [
+    "md5=4bb80151d3b2857c4f385a13d7abaef7"
+    "sha512=e98fcc51570f1f962790abd33294abfde370d776635d4196fb7e4022db42bf886cb181afa11543fd2c26cd668763583b1f2e8ca1bf0f6ca640ecc9371a980fe5"
+  ]
+}


### PR DESCRIPTION
### `sedlex.2.4`
An OCaml lexer generator for Unicode
sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
OCaml source files. Lexing specific constructs are provided via a ppx syntax
extension.



---
* Homepage: https://github.com/ocaml-community/sedlex
* Source repo: git+https://github.com/ocaml-community/sedlex.git
* Bug tracker: https://github.com/ocaml-community/sedlex/issues

---
:camel: Pull-request generated by opam-publish v2.0.3