### PR TITLE
[new release] checkseum (0.3.2)

### DIFF
--- a/packages/checkseum/checkseum.0.3.2/opam
+++ b/packages/checkseum/checkseum.0.3.2/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/checkseum"
+bug-reports:  "https://github.com/mirage/checkseum/issues"
+dev-repo:     "git+https://github.com/mirage/checkseum.git"
+doc:          "https://mirage.github.io/checkseum/"
+license:      "MIT"
+synopsis:     "Adler-32, CRC32 and CRC32-C implementation in C and OCaml"
+description: """
+Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C
+in C and OCaml.
+
+This library use the linking trick to choose between the C implementation
+(checkseum.c) or the OCaml implementation (checkseum.ocaml). This library is on
+top of optint to get the best representation of an int32. """
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+install: [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.6.0"}
+  "conf-pkg-config" {build}
+  "dune-configurator"
+  "optint"        {>= "0.0.5"}
+  "base-bytes"
+  "bigarray-compat"
+  "alcotest"      {with-test}
+  "bos"           {with-test}
+  "astring"       {with-test}
+  "fmt"           {with-test}
+  "fpath"         {with-test}
+  "rresult"       {with-test}
+  "ocamlfind"     {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.3"}
+]
+url {
+  src:
+    "https://github.com/mirage/checkseum/releases/download/v0.3.2/checkseum-v0.3.2.tbz"
+  checksum: [
+    "sha256=9cdd282ea1cfc424095d7284e39e4d0ad091de3c3f2580539d03f6966d45ccd5"
+    "sha512=d66cb268dddaedcd2781a40b5982e987603f35f9f55dbfc2ca8d49802d878805b4f77d6d1c74a7556579c789b2dc89554c28ff652128604bcb3ad1a9788e2e97"
+  ]
+}
+x-commit-hash: "7382b2c327d19470351300767ac98fe6c395470c"


### PR DESCRIPTION
Adler-32, CRC32 and CRC32-C implementation in C and OCaml

- Project page: <a href="https://github.com/mirage/checkseum">https://github.com/mirage/checkseum</a>
- Documentation: <a href="https://mirage.github.io/checkseum/">https://mirage.github.io/checkseum/</a>

##### CHANGES:

- `freenstanding` support does not need `opam` (@sternenseemann, @dinosaure, mirage/checkseum#53)
- Fix big-endian support (@dinosaure, mirage/checkseum#56)
- Use `which` when `command -v` is not available (@dinosaure, @sternenseemann, @mseri, mirage/checkseum#56)
- Fix `esy` support and on its environment the MirageOS 3 support (@dinosaure, @mseri, mirage/checkseum#56)
- Upgrade to `ocamlformat.0.19.0` (@dinosaure, mirage/checkseum#57)
