### PR TITLE
[new release] digestif (1.0.1)

### DIFF
--- a/packages/digestif/digestif.1.0.1/opam
+++ b/packages/digestif/digestif.1.0.1/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+install:  [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.6.0"}
+  "conf-pkg-config" {build}
+  "eqaf"
+  "base-bytes"
+  "bigarray-compat"
+  "stdlib-shims"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+  "bos"            {with-test}
+  "astring"        {with-test}
+  "fpath"          {with-test}
+  "rresult"        {with-test}
+  "ocamlfind"      {with-test}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.6.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v1.0.1/digestif-v1.0.1.tbz"
+  checksum: [
+    "sha256=cd7d6e706ce3592fd80c57f241a09f565bd71fecbf730c3611c33a6b3803a2b8"
+    "sha512=3e71393eafa9769bf44adc806121f7e27692f0d9c437032c701d7f11a4abbfb139115e02a4fa863516f9e554b8f69cf28660c720a9c9724b768e3f88e6af2a8a"
+  ]
+}
+x-commit-hash: "60fe6894be50d94932a54c91ad77a435a4565ffd"


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Fix `esy` support (@dinosaure, mirage/digestif#115)
- Fix big-endian support (@dinosaure, mirage/digestif#113)
