### PR TITLE
eqaf.0.1: Add missing constraint (uses jbuilder build -p)

### DIFF
--- a/packages/eqaf/eqaf.0.1/opam
+++ b/packages/eqaf/eqaf.0.1/opam
@@ -11,7 +11,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta10"}
 ]
 synopsis: "Constant time equal function on `string`"
 description: """

--- a/packages/eqaf/eqaf.0.1/opam
+++ b/packages/eqaf/eqaf.0.1/opam
@@ -11,7 +11,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Constant time equal function on `string`"
 description: """


### PR DESCRIPTION
```
#=== ERROR while compiling eqaf.0.1 ===========================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.07/.opam-switch/build/eqaf.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p eqaf -j 31
# exit-code            1
# env-file             ~/.opam/log/eqaf-23-4ec847.env
# output-file          ~/.opam/log/eqaf-23-4ec847.out
### output ###
# jbuilder: unknown option `-p'.
# Usage: jbuilder build [OPTION]... TARGET...
# Try `jbuilder build --help' or `jbuilder --help' for more information.
```
Detected in #19179 