### PR TITLE
[new release] rfc1951 and decompress (1.4.2)

### DIFF
--- a/packages/decompress/decompress.1.4.2/opam
+++ b/packages/decompress/decompress.1.4.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "base-bytes"
+  "bigarray-compat"
+  "cmdliner"    {>= "1.0.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.3.2"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.2/decompress-v1.4.2.tbz"
+  checksum: [
+    "sha256=822f125b46c87f4a902c334db8c86d4d5f33ebe978e93c40351a4d3269b95225"
+    "sha512=9cb82615923a5fffc5c8dce1d9361a467e35e91092c25c98f5afda8f4226059c59eb695c55e63adf92d766c7747e15df186386bcaeb399497dd1ae5b024c09fa"
+  ]
+}
+x-commit-hash: "e65836aa077ff120354a7de63cfea52095a7ebd3"

--- a/packages/rfc1951/rfc1951.1.4.2/opam
+++ b/packages/rfc1951/rfc1951.1.4.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "bigarray-compat"
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.2/decompress-v1.4.2.tbz"
+  checksum: [
+    "sha256=822f125b46c87f4a902c334db8c86d4d5f33ebe978e93c40351a4d3269b95225"
+    "sha512=9cb82615923a5fffc5c8dce1d9361a467e35e91092c25c98f5afda8f4226059c59eb695c55e63adf92d766c7747e15df186386bcaeb399497dd1ae5b024c09fa"
+  ]
+}
+x-commit-hash: "e65836aa077ff120354a7de63cfea52095a7ebd3"


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Fix lower bounds of `cmdliner` (@kit-ty-kate, mirage/decompress#130)
- Fix big-endian support (@dinosaure, @talex5, mirage/decompress#131)
