### PR TITLE
Package sedlex.2.4

### DIFF
--- a/packages/css-parser/css-parser.0.2.2/opam
+++ b/packages/css-parser/css-parser.0.2.2/opam
@@ -10,7 +10,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "2.4"}
   "menhir" {>= "20200211"}
-  "sedlex" {>= "2.0"}
+  "sedlex" {>= "2.0" & < "2.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/css-parser/css-parser.0.2.3/opam
+++ b/packages/css-parser/css-parser.0.2.3/opam
@@ -10,7 +10,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "2.4"}
   "menhir" {>= "20200211"}
-  "sedlex" {>= "2.0"}
+  "sedlex" {>= "2.0" & < "2.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/css-parser/css-parser.0.2.4/opam
+++ b/packages/css-parser/css-parser.0.2.4/opam
@@ -10,7 +10,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "2.4"}
   "menhir" {>= "20200211"}
-  "sedlex" {>= "2.0"}
+  "sedlex" {>= "2.0" & < "2.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/css-parser/css-parser.0.2.5/opam
+++ b/packages/css-parser/css-parser.0.2.5/opam
@@ -10,7 +10,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "2.4"}
   "menhir" {>= "20200211"}
-  "sedlex" {>= "2.0"}
+  "sedlex" {>= "2.0" & < "2.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -20,7 +20,7 @@ depends: [
   "fileutils"
   "menhir" {build & >= "20161115"}
   "pprint" {build & >= "20130324"}
-  "sedlex" {build & >= "2.0"}
+  "sedlex" {build & >= "2.0" & < "2.4"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"

--- a/packages/sedlex/sedlex.2.4/opam
+++ b/packages/sedlex/sedlex.2.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "An OCaml lexer generator for Unicode"
+description: """
+sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
+Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
+OCaml source files. Lexing specific constructs are provided via a ppx syntax
+extension."""
+maintainer: ["Alain Frisch <alain.frisch@lexifi.com>"]
+authors: [
+  "Alain Frisch <alain.frisch@lexifi.com>"
+  "https://github.com/ocaml-community/sedlex/graphs/contributors"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-community/sedlex"
+bug-reports: "https://github.com/ocaml-community/sedlex/issues"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.8"}
+  "ppxlib" {>= "0.18.0"}
+  "gen"
+  "uchar"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/sedlex.git"
+doc: "https://ocaml-community.github.io/sedlex/index.html"
+url {
+  src: "https://github.com/ocaml-community/sedlex/archive/v2.4.tar.gz"
+  checksum: [
+    "md5=1caec7e0d17b2ab27ea9f5ccf193ad42"
+    "sha512=848a06517c89d40a8162c2d06d2ff3197de5aae5f22345f8f172183f8cf4d728406cc0e3f94365170a9d6167dc083973b4e4a4683871693138c8e82df7877b5f"
+  ]
+}


### PR DESCRIPTION
### `sedlex.2.4`
An OCaml lexer generator for Unicode
sedlex is a lexer generator for OCaml. It is similar to ocamllex, but supports
Unicode. Unlike ocamllex, sedlex allows lexer specifications within regular
OCaml source files. Lexing specific constructs are provided via a ppx syntax
extension.



---
* Homepage: https://github.com/ocaml-community/sedlex
* Source repo: git+https://github.com/ocaml-community/sedlex.git
* Bug tracker: https://github.com/ocaml-community/sedlex/issues

---
:camel: Pull-request generated by opam-publish v2.0.3