### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.0.5)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.0.5/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.5/paf-0.0.5.tbz"
+  checksum: [
+    "sha256=e85a018046eb062d2399fdbe8d9d3400a4d5cd51bb62840446503f557c3eeff1"
+    "sha512=15e7c46741e131995babadc318220fd562c740b467be2f356b90a528b0054c8b5e4434ca5ed8cbbacbc4e6efa1d4e58e8878a6c2633415b1578edc009518b1e5"
+  ]
+}
+x-commit-hash: "760a3ccd96ae93b55bd71e237beee58bdedf02ac"

--- a/packages/paf-le/paf-le.0.0.5/opam
+++ b/packages/paf-le/paf-le.0.0.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.3.0"}
+  "mirage-stack"
+  "mirage-time"
+  "tls-mirage"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.5/paf-0.0.5.tbz"
+  checksum: [
+    "sha256=e85a018046eb062d2399fdbe8d9d3400a4d5cd51bb62840446503f557c3eeff1"
+    "sha512=15e7c46741e131995babadc318220fd562c740b467be2f356b90a528b0054c8b5e4434ca5ed8cbbacbc4e6efa1d4e58e8878a6c2633415b1578edc009518b1e5"
+  ]
+}
+x-commit-hash: "760a3ccd96ae93b55bd71e237beee58bdedf02ac"

--- a/packages/paf/paf.0.0.5/opam
+++ b/packages/paf/paf.0.0.5/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-time"
+  "tls-mirage" {>= "0.14.0"}
+  "mimic"
+  "cohttp-lwt"
+  "letsencrypt"
+  "emile"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "tcpip" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "domain-name" {>= "0.3.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "duration" {>= "0.1.3"}
+  "faraday" {>= "0.7.2"}
+  "ipaddr" {>= "5.0.1"}
+  "tls" {>= "0.14.0"}
+  "x509" {>= "0.13.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.5/paf-0.0.5.tbz"
+  checksum: [
+    "sha256=e85a018046eb062d2399fdbe8d9d3400a4d5cd51bb62840446503f557c3eeff1"
+    "sha512=15e7c46741e131995babadc318220fd562c740b467be2f356b90a528b0054c8b5e4434ca5ed8cbbacbc4e6efa1d4e58e8878a6c2633415b1578edc009518b1e5"
+  ]
+}
+x-commit-hash: "760a3ccd96ae93b55bd71e237beee58bdedf02ac"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Use `tls.0.14.0` (@hannesm, @dinosaure, dinosaure/paf-le-chien#38)
