### PR TITLE
[new release] gr (0.0.2)

### DIFF
--- a/packages/gr/gr.0.0.2/opam
+++ b/packages/gr/gr.0.0.2/opam
@@ -26,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/gr/gr.0.0.2/opam
+++ b/packages/gr/gr.0.0.2/opam
@@ -12,9 +12,9 @@ depends: [
   "ocaml" {>= "4.10"}
   "dune" {>= "1.11"}
   "ctypes" {>= "0.15"}
-  "ctypes-foreign" {true}
-  "base-unix" {with-test}
-  "owl" {with-test & >= "0.6.0"}
+  "ctypes-foreign"
+  # "base-unix" {with-test}
+  # "owl" {with-test & >= "0.6.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/gr/gr.0.0.2/opam
+++ b/packages/gr/gr.0.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to the GR plotting library"
+description: """
+GR is based on an implementation of a Graphical Kernel System (GKS) and OpenGL. As a self-contained system it can quickly and easily be integrated into existing applications.
+GR is characterized by its high interoperability and can be used with modern web technologies and mobile devices."""
+maintainer: ["Marcello Seri"]
+authors: ["Marcello Seri"]
+license: "ISC"
+homepage: "https://github.com/mseri/ocaml-gr"
+bug-reports: "https://github.com/mseri/ocaml-gr/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "ctypes" {>= "0.15"}
+  "ctypes-foreign" {true}
+  "base-unix" {with-test}
+  "owl" {with-test & >= "0.6.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/ocaml-gr.git"
+doc: "https://mseri.github.io/ocaml-gr"
+post-messages: "Make sure that libGR (gr-framework.org) is installed and, in case of error, that either of the GRDIR or LIBGRPATH env variables is set"
+x-commit-hash: "76fa2540642f505357bb20e3da90993cd2e5155a"
+url {
+  src:
+    "https://github.com/mseri/ocaml-gr/releases/download/0.0.2/gr-0.0.2.tbz"
+  checksum: [
+    "sha256=0be3daf1c5dc15db75257018d7e963fdd30d5227a12c8386ab4e4cbc2fc906c1"
+    "sha512=fa8965b84becabed37ef773ab976dfa3d69a0bdfd218ac13709b9af5265cb689972f1ac0d2daf8eaafefc54b617aac792e48bd4f9eea8482b12484c79aa80b37"
+  ]
+}

--- a/packages/gr/gr.0.0.2/opam
+++ b/packages/gr/gr.0.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "owl" {with-test & >= "0.6.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
OCaml bindings to the GR plotting library

- Project page: <a href="https://github.com/mseri/ocaml-gr">https://github.com/mseri/ocaml-gr</a>
- Documentation: <a href="https://mseri.github.io/ocaml-gr">https://mseri.github.io/ocaml-gr</a>

##### CHANGES:

- Makes more sense to show the ticks labels by default (Chris00 mseri/ocaml-gr#9 5261354) 
- Use default ocamlformat output
- Move to ocaml 4.10 and drop use of stdcompat
- Fix use of GRDIR, make LIBGRPATH more standard and fix for macos dylib version (Chris00 mseri/ocaml-gr#8 3056f1e)
- Moved `workstation_type` into `Workstation``
- Cleanup of documentation
