### PR TITLE
[new release] carton, carton-lwt and carton-git (0.4.3)

### DIFF
--- a/packages/carton-git/carton-git.0.4.3/opam
+++ b/packages/carton-git/carton-git.0.4.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "carton-lwt" {= version}
+  "bigstringaf" {>= "0.7.0"}
+  "bigarray-compat"
+  "lwt"
+  "fpath"
+  "result"
+  "mmap"
+  "fmt" {>= "0.8.9"}
+  "base-unix"
+  "decompress" {>= "1.3.0"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "208fa79a9b4f4064ee93bfaeeb7ca06fff7878a0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.4.3/carton-carton-v0.4.3.tbz"
+  checksum: [
+    "sha256=f9c992b84235a32da3b756f42b2b3d3136b306415b0d4f4f259d07738a6ee963"
+    "sha512=4a52483100b4f16a66c248116b7e53528a52b20b4743d26d94463cc711ed04e0fc3215119ce9b0cb75c2f822667e0853102bff4bc7740170f816674862d18b9a"
+  ]
+}

--- a/packages/carton-lwt/carton-lwt.0.4.3/opam
+++ b/packages/carton-lwt/carton-lwt.0.4.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "lwt"
+  "decompress" {>= "1.3.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.7.0"}
+  "bigarray-compat" {with-test}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "result" {>= "1.5" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.0" & with-test}
+  "digestif" {>= "1.0.0" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "mmap" {>= "1.1.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "208fa79a9b4f4064ee93bfaeeb7ca06fff7878a0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.4.3/carton-carton-v0.4.3.tbz"
+  checksum: [
+    "sha256=f9c992b84235a32da3b756f42b2b3d3136b306415b0d4f4f259d07738a6ee963"
+    "sha512=4a52483100b4f16a66c248116b7e53528a52b20b4743d26d94463cc711ed04e0fc3215119ce9b0cb75c2f822667e0853102bff4bc7740170f816674862d18b9a"
+  ]
+}

--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "ke" {>= "0.4"}
+  "duff" {>= "0.3"}
+  "decompress" {>= "1.4.1"}
+  "cstruct" {>= "5.0.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.7.0"}
+  "checkseum" {>= "0.3.2"}
+  "logs"
+  "bigarray-compat"
+  "cmdliner" {>= "1.0.4"}
+  "hxd" {>= "0.3.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "result"
+  "rresult"
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "0.8.1"}
+  "mmap"
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "ocamlfind" {>= "1.8.1" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "208fa79a9b4f4064ee93bfaeeb7ca06fff7878a0"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.4.3/carton-carton-v0.4.3.tbz"
+  checksum: [
+    "sha256=f9c992b84235a32da3b756f42b2b3d3136b306415b0d4f4f259d07738a6ee963"
+    "sha512=4a52483100b4f16a66c248116b7e53528a52b20b4743d26d94463cc711ed04e0fc3215119ce9b0cb75c2f822667e0853102bff4bc7740170f816674862d18b9a"
+  ]
+}

--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -16,7 +16,7 @@ depends: [
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
   "decompress" {>= "1.4.1"}
-  "cstruct" {>= "5.0.0"}
+  "cstruct" {>= "6.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf" {>= "0.7.0"}
   "checkseum" {>= "0.3.2"}


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Use `Cstruct.length` instead of `Cstruct.len` (@dinosaure, mirage/ocaml-git#522)
- Fix big endian support via `decompress` and `checkseum` (@dinosaure, @talex5, @tmcgilchrist, mirage/ocaml-git#523)
- Handle huge PACK files (@dinosaure, @TheLortex, mirage/ocaml-git#526)
