### PR TITLE
Package ppx_deriving_qcheck.0.1.0

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
@@ -15,11 +15,10 @@ authors: [
 
 depends: [
   "dune" {>= "2.8.0"}
-  "ocaml" {>= "4.10.2" & < "4.13.0" }
+  "ocaml" {>= "4.10.2"}
   "qcheck" {>= "0.17"}
-  "metaquot" {>= "0.4"}
   "ppxlib" {>= "0.22.0"}
-  "alcotest" {>= "1.4.0" }
+  "alcotest" {with-test & >= "1.4.0"}
 ]
 
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license: "MIT"
+synopsis: "PPX Deriver for qcheck"
+
+homepage: "https://github.com/vch9/ppx_deriving_qcheck"
+bug-reports: "https://github.com/vch9/ppx_deriving_qcheck/-/issues"
+
+maintainer: [
+  "Valentin Chaboche <valentin.chaboche@nomadic-labs.com>"
+]
+
+authors: [
+ "Valentin Chaboche <valentin.chaboche@nomadic-labs.com>"
+]
+
+depends: [
+  "dune" {>= "2.8.0"}
+  "ocaml" {>= "4.10.2"}
+  "qcheck" {>= "0.17"}
+  "metaquot" {>= "0.4"}
+  "ppxlib" {>= "0.22.0"}
+  "alcotest" {>= "1.4.0" }
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+
+dev-repo: "git+https://github.com/vch9/ppx_deriving_qcheck.git"
+url {
+  src: "https://github.com/vch9/ppx_qcheck/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=2e144a8c3c7074545478bd0dff430f05"
+    "sha512=2883cd669c7c65924aea241dd99e57c2d32bcde1101ef504e3053f3f0b4fc72348ba3aba79b397cbbfa51f164b5f569cb1a01a02a2e3f150097ecd5dcbefe933"
+  ]
+}

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
@@ -15,7 +15,7 @@ authors: [
 
 depends: [
   "dune" {>= "2.8.0"}
-  "ocaml" {>= "4.10.2"}
+  "ocaml" {>= "4.10.2" & < "4.13.0" }
   "qcheck" {>= "0.17"}
   "metaquot" {>= "0.4"}
   "ppxlib" {>= "0.22.0"}


### PR DESCRIPTION
### `ppx_deriving_qcheck.0.1.0`
PPX Deriver for qcheck



---
* Homepage: https://github.com/vch9/ppx_deriving_qcheck
* Source repo: git+https://github.com/vch9/ppx_deriving_qcheck.git
* Bug tracker: https://github.com/vch9/ppx_deriving_qcheck/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0