### PR TITLE
Package salsa20.1.2.0

### DIFF
--- a/packages/salsa20-core/salsa20-core.0.2.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ocb-stubblr" {build}
+  "ocb-stubblr" {build & >= "0.1.1"}
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "cstruct" {with-test & < "3.2.0"}
   "nocrypto" {with-test}

--- a/packages/salsa20-core/salsa20-core.0.3.0/opam
+++ b/packages/salsa20-core/salsa20-core.0.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "ocb-stubblr" {build}
+  "ocb-stubblr" {build & >= "0.1.1"}
   "cstruct" {>= "1.7.0" & < "6.0.1"}
   "alcotest" {with-test}
 ]

--- a/packages/salsa20/salsa20.1.2.0/opam
+++ b/packages/salsa20/salsa20.1.2.0/opam
@@ -19,7 +19,7 @@ utop[7]> Salsa20.encrypt (Cstruct.of_string "My secret text") state |> Cstruct.t
 """
 maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
 authors: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
-license: "BSD2"
+license: "BSD-2-Clause"
 homepage: "https://github.com/abeaumont/ocaml-salsa20"
 dev-repo: "git+https://github.com/abeaumont/ocaml-salsa20.git"
 bug-reports: "https://github.com/abeaumont/ocaml-salsa20/issues"
@@ -33,7 +33,7 @@ depends: [
   "alcotest" {with-test}
 ]
 build: [
-  ["dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-j" jobs "-p" name "@install" ]
   [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
 ]

--- a/packages/salsa20/salsa20.1.2.0/opam
+++ b/packages/salsa20/salsa20.1.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Salsa20 family of encryption functions, in pure OCaml"
+description: """
+```ocaml
+utop[0]> #require "mirage-crypto";;
+utop[1]> #require "mirage-crypto-rng.unix";;
+utop[2]> Mirage_crypto_rng_unix.initialize ();;
+- : unit = ()
+utop[3]> let key = Mirage_crypto_rng.generate 32;;
+val key : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 32}
+utop[4]> let nonce = Cstruct.create 8;;
+val nonce : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 8}
+utop[5]> #require "salsa20";;
+utop[6]> let state = Salsa20.create key nonce;;
+val state : Salsa20.t = <abstr>
+utop[7]> Salsa20.encrypt (Cstruct.of_string "My secret text") state |> Cstruct.to_string;;
+- : string = " 2\\193\\020`\\142\\182\\234\\188H[R\\241V"
+```
+"""
+maintainer: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+authors: "Alfredo Beaumont <alfredo.beaumont@gmail.com>"
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-salsa20"
+dev-repo: "git+https://github.com/abeaumont/ocaml-salsa20.git"
+bug-reports: "https://github.com/abeaumont/ocaml-salsa20/issues"
+doc: "https://abeaumont.github.io/ocaml-salsa20/"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.8.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto"
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
+]
+url {
+  src: "https://github.com/abeaumont/ocaml-salsa20/archive/1.2.0.tar.gz"
+  checksum: [
+    "md5=aabca4d3954543cf8afb5121e0719821"
+    "sha512=afe2212ee6f44a32811214b0a369be06ed7806e501adb4e98dd5b0bc0718ce311c8306919813d64ed7a6df3d6147d42ce819488801b863d5cd31079c37120fbb"
+  ]
+}


### PR DESCRIPTION
### `salsa20.1.2.0`
Salsa20 family of encryption functions, in pure OCaml
```ocaml
utop[0]> #require "mirage-crypto";;
utop[1]> #require "mirage-crypto-rng.unix";;
utop[2]> Mirage_crypto_rng_unix.initialize ();;
- : unit = ()
utop[3]> let key = Mirage_crypto_rng.generate 32;;
val key : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 32}
utop[4]> let nonce = Cstruct.create 8;;
val nonce : Cstruct.t = {Cstruct.buffer = <abstr>; off = 0; len = 8}
utop[5]> #require "salsa20";;
utop[6]> let state = Salsa20.create key nonce;;
val state : Salsa20.t = <abstr>
utop[7]> Salsa20.encrypt (Cstruct.of_string "My secret text") state |> Cstruct.to_string;;
- : string = " 2\193\020`\142\182\234\188H[R\241V"
```



---
* Homepage: https://github.com/abeaumont/ocaml-salsa20
* Source repo: git+https://github.com/abeaumont/ocaml-salsa20.git
* Bug tracker: https://github.com/abeaumont/ocaml-salsa20/issues

---
:camel: Pull-request generated by opam-publish v2.1.0