### PR TITLE
Package scrypt-kdf.1.2.0

### DIFF
--- a/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-j" jobs "-p" name "@install" ]
-  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
+  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 url {
   src: "https://github.com/abeaumont/ocaml-scrypt-kdf/archive/1.2.0.tar.gz"

--- a/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
@@ -7,7 +7,7 @@ including test cases from the RFC.
 """
 maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
 authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
-license: "BSD2"
+license: "BSD-2-Clause"
 homepage: "https://github.com/abeaumont/ocaml-scrypt-kdf"
 bug-reports: "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
 dev-repo: "git+https://github.com/abeaumont/ocaml-scrypt-kdf.git"
@@ -22,7 +22,7 @@ depends: [
   "alcotest" {with-test}
 ]
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-j" jobs "-p" name "@install" ]
   [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
 ]

--- a/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
+++ b/packages/scrypt-kdf/scrypt-kdf.1.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "The scrypt Password-Based Key Derivation Function"
+description: """
+A pure OCaml implementation of [scrypt](https://en.wikipedia.org/wiki/Scrypt) password based key derivation function,
+as defined in [The scrypt Password-Based Key Derivation Function internet draft](https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-04),
+including test cases from the RFC.
+"""
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>"]
+license: "BSD2"
+homepage: "https://github.com/abeaumont/ocaml-scrypt-kdf"
+bug-reports: "https://github.com/abeaumont/ocaml-scrypt-kdf/issues"
+dev-repo: "git+https://github.com/abeaumont/ocaml-scrypt-kdf.git"
+doc: "https://abeaumont.github.io/ocaml-scrypt-kdf/"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.8.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto"
+  "pbkdf" {>= "0.1.0"}
+  "salsa20-core" {>= "0.1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  [ "dune" "runtest" "-j" jobs "-p" name ] {with-test}
+]
+url {
+  src: "https://github.com/abeaumont/ocaml-scrypt-kdf/archive/1.2.0.tar.gz"
+  checksum: [
+    "md5=f94cf5985bceb9b57efe3979a791cd81"
+    "sha512=9d4f4ba1153b6c92abc2194da93e98d7f18c539ddf405e6619f0a9336790aee80b6dabb52ffa046138bdfe8a41b2b9c4361962011b37bcb9b8ab54d509b58d68"
+  ]
+}


### PR DESCRIPTION
### `scrypt-kdf.1.2.0`
The scrypt Password-Based Key Derivation Function
A pure OCaml implementation of [scrypt](https://en.wikipedia.org/wiki/Scrypt) password based key derivation function,
as defined in [The scrypt Password-Based Key Derivation Function internet draft](https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-04),
including test cases from the RFC.



---
* Homepage: https://github.com/abeaumont/ocaml-scrypt-kdf
* Source repo: git+https://github.com/abeaumont/ocaml-scrypt-kdf.git
* Bug tracker: https://github.com/abeaumont/ocaml-scrypt-kdf/issues

---
:camel: Pull-request generated by opam-publish v2.1.0