### PR TITLE
[new release] asn1-combinators (0.2.6)

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.6/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.6/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
 bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
 synopsis: "Embed typed ASN.1 grammars in OCaml"
-build: [ ["dune" "subst"] {pinned}
+build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 depends: [

--- a/packages/asn1-combinators/asn1-combinators.0.2.6/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.6/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors: "David Kaloper Meršinjak"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+homepage: "https://github.com/mirleft/ocaml-asn1-combinators"
+doc: "https://mirleft.github.io/ocaml-asn1-combinators/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/mirleft/ocaml-asn1-combinators.git"
+bug-reports: "https://github.com/mirleft/ocaml-asn1-combinators/issues"
+synopsis: "Embed typed ASN.1 grammars in OCaml"
+build: [ ["dune" "subst"] {pinned}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+depends: [
+  "ocaml" {>="4.08.0"}
+  "dune" {>= "1.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "zarith"
+  "ptime"
+  "alcotest" {with-test}
+]
+description: """
+asn1-combinators is a library for expressing ASN.1 in OCaml. Skip the notation
+part of ASN.1, and embed the abstract syntax directly in the language. These
+abstract syntax representations can be used for parsing, serialization, or
+random testing.
+
+The only ASN.1 encodings currently supported are BER and DER.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.2.6/asn1-combinators-v0.2.6.tbz"
+  checksum: [
+    "sha256=012ade0d8869ef621063752c1cf8ea026f6bc702fed10df9af56688e291b1a91"
+    "sha512=4c1b28f1d230395ff1ad3b8e8d03981b10015062ec270f29e2521914eb64c2fa4d5df68363e339e9a1158c3b58aef0e25156f7ec6addd85a580fecadc17edfac"
+  ]
+}
+x-commit-hash: "1fc666e8b4231846cf65704ffcb09d240981dcb6"


### PR DESCRIPTION
Embed typed ASN.1 grammars in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-asn1-combinators">https://github.com/mirleft/ocaml-asn1-combinators</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-asn1-combinators/doc">https://mirleft.github.io/ocaml-asn1-combinators/doc</a>

##### CHANGES:

* Use Cstruct.length instead of Cstruct.len, drop OCaml <4.08 support,
  remove bigarray-compat and stdlib-shims dependencies (mirleft/ocaml-asn1-combinators#37 by @hannesm)
