### PR TITLE
[new release] yaml and yaml-sexp (3.0.0)

### DIFF
--- a/packages/yaml-sexp/yaml-sexp.3.0.0/opam
+++ b/packages/yaml-sexp/yaml-sexp.3.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse and generate YAML 1.1 files"
+description: "ocaml-yaml with sexp support"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Rizo Isrof <rizo@odis.io>"
+  "Patrick Ferris"
+  "favonia@gmail.com"
+  "Alan J Hu <alanh@ccs.neu.edu>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "dune" {>= "1.3"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "yaml" {= version}
+  "mdx" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+  "bos" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v3.0.0/yaml-v3.0.0.tbz"
+  checksum: [
+    "sha256=4c48e27092d5c95cb49898ca637be92d2a70f1769fd1532b84a5e56c17359ac7"
+    "sha512=abf7d8c3e4e5f30f19f76b52e8c5b7593c8dca42050bc2d780cbc6e7e7cc49b40b6f27d8b884ce2b39ce0d63d5da715b86692ebe2792ecd1b455128c294a518d"
+  ]
+}
+x-commit-hash: "d70ba31b2e8d7e0f8f805d7d1de9c1c7297e0d75"

--- a/packages/yaml/yaml.3.0.0/opam
+++ b/packages/yaml/yaml.3.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Parse and generate YAML 1.1/1.2 files"
+description: """\
+This is an OCaml library to parse and generate the YAML file
+format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
+JSON handling library, if the simple common subset of Yaml
+is used.  Anchors and other advanced Yaml features are not
+implemented in the JSON compatibility layer.
+
+The [Yaml module docs](http://anil-code.recoil.org/ocaml-yaml/yaml/Yaml/index.html) are browseable online."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Rizo Isrof <rizo@odis.io>"
+  "Patrick Ferris"
+  "favonia@gmail.com"
+  "Alan J Hu <alanh@ccs.neu.edu>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.3"}
+  "dune-configurator"
+  "ctypes" {>= "0.12.0"}
+  "rresult"
+  "bos"
+  "fmt" {with-test}
+  "logs" {with-test}
+  "mdx" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v3.0.0/yaml-v3.0.0.tbz"
+  checksum: [
+    "sha256=4c48e27092d5c95cb49898ca637be92d2a70f1769fd1532b84a5e56c17359ac7"
+    "sha512=abf7d8c3e4e5f30f19f76b52e8c5b7593c8dca42050bc2d780cbc6e7e7cc49b40b6f27d8b884ce2b39ce0d63d5da715b86692ebe2792ecd1b455128c294a518d"
+  ]
+}
+x-commit-hash: "d70ba31b2e8d7e0f8f805d7d1de9c1c7297e0d75"

--- a/packages/yaml/yaml.3.0.0/opam
+++ b/packages/yaml/yaml.3.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.3"}
   "dune-configurator"
-  "ctypes" {>= "0.12.0"}
+  "ctypes" {>= "0.14.0"}
   "rresult"
   "bos"
   "fmt" {with-test}


### PR DESCRIPTION
Parse and generate YAML 1.1/1.2 files

- Project page: <a href="https://github.com/avsm/ocaml-yaml">https://github.com/avsm/ocaml-yaml</a>
- Documentation: <a href="https://avsm.github.io/ocaml-yaml/">https://avsm.github.io/ocaml-yaml/</a>

##### CHANGES:

* Support Yaml 1.2, and stop advertising Yaml 1.0 support.
  This also updates the vendored libyaml to 0.2.5 (@favonia avsm/ocaml-yaml#37).

* Add a `Yaml.Util` module with a number of useful combinators
  to manipulate `Yaml.value` types, such as retrieving keys and
  values, finding entries and converting to OCaml native
  types (@patricoferris avsm/ocaml-yaml#43)

* Move the sexpression derivers into a separate `Yaml_sexp`
  package (the `yaml-sexp` opam package). This reduces dependencies
  on the main library.  You can still use `Yaml` types in
  `ppx_sexplib_conv` derivers by simply replacing the
  `Yaml.value` (or other type) with `Yaml_sexp.value` which is
  an alias that also includes the Sexp conversion functions in
  its scope. (@alan-j-hu @avsm avsm/ocaml-yaml#46).

* When outputting values, wrap special values like "true" or
  "1.0" in double quotes, so that `Yaml.of_string` will not
  interpret them as a non-string value (@avsm avsm/ocaml-yaml#47).

* Track anchors and mappings in `Yaml.yaml` (but not in the
  `Yaml.value` JSON representation). This also allows non-scalar
   values to be used as keys. (@favonia avsm/ocaml-yaml#38)

* Bump the internal write buffer for stream emission to
  256k from 64k, as people are writing ever-larger Yaml
  files! In the future, this static buffer will be replaced
  by a dynamically growing output buffer but for now needs
  to be set manually.

* The minimum supported OCaml version is now OCaml 4.05.
