### PR TITLE
[new release] duration (0.2.0)

### DIFF
--- a/packages/duration/duration.0.2.0/opam
+++ b/packages/duration/duration.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+bug-reports: "https://github.com/hannesm/duration/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/duration.git"
+synopsis: "Conversions to various time units"
+description: """
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input.
+"""
+url {
+  src:
+    "https://github.com/hannesm/duration/releases/download/0.2.0/duration-0.2.0.tbz"
+  checksum: [
+    "sha256=ad14fb75a5a6f73fff7ef1721178925ee555cf0f23b23e3ab329184bc0c1ce69"
+    "sha512=6a259ca406739bfc6020c7de767e39c2a7ee06169aa1966d43d426b2a54fc69b81be6465d04b9bd8fbbbbfd9ebe1c82a1cbfbf62100a37eb0f7403f6cf53e3b8"
+  ]
+}
+x-commit-hash: "ec2b9a36901d1902cc90d202a8987d7e3b3e63df"


### PR DESCRIPTION
Conversions to various time units

- Project page: <a href="https://github.com/hannesm/duration">https://github.com/hannesm/duration</a>
- Documentation: <a href="https://hannesm.github.io/duration/doc">https://hannesm.github.io/duration/doc</a>

##### CHANGES:

* 32 bit compatibility:
  * Provide of_us_64, of_ms_64, of_sec_64 that take an int64 as input
  * Provide to_us_64, to_ms_64, to_sec_64 that produce an int64 as output
* Revise Duration.pp to print in a more concise way
