### PR TITLE
4 packages from c-cube/qcheck at 0.18

### DIFF
--- a/packages/alg_structs_qcheck/alg_structs_qcheck.0.1.3/opam
+++ b/packages/alg_structs_qcheck/alg_structs_qcheck.0.1.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.11.3"}
   "ocaml" {>= "4.08.0"}
   "alg_structs" {>= "0.1.3" & < "0.2.0"}
-  "qcheck" {>= "0.11"}
+  "qcheck" {>= "0.11" & < "0.18"}
   "alcotest" {with-test & >= "0.8.5"}
   "qcheck-alcotest" {with-test & >= "0.11"}
 ]

--- a/packages/fadbadml/fadbadml.0.1.2/opam
+++ b/packages/fadbadml/fadbadml.0.1.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/fadbadml-dev/FADBADml/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
-  "qcheck" {with-test}
+  "qcheck" {with-test & < "0.18"}
   "conf-python-3" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/preface/preface.0.1.0/opam
+++ b/packages/preface/preface.0.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" { >= "2.8.0" }
   "either"
   "alcotest" {with-test}
-  "qcheck-core" {with-test}
+  "qcheck-core" {with-test & < "0.18"}
   "qcheck-alcotest" {with-test}
   "mdx" {with-test}
   "odoc"{with-doc}

--- a/packages/qcheck-alcotest/qcheck-alcotest.0.18/opam
+++ b/packages/qcheck-alcotest/qcheck-alcotest.0.18/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+license: "BSD-2-Clause"
+synopsis: "Alcotest backend for qcheck"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "quickcheck"
+  "qcheck"
+  "alcotest"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.2" }
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "alcotest"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=a830f187d3eed60eba960c8d626035a4"
+    "sha512=08da783ca991dcee26f88b8d6db2fcf2589d3e753ce355d5e3c8944b58ce43b444c6cde054971a557d7d345b4386e6e976111d4c537840a1269c7e361340fcfe"
+  ]
+}

--- a/packages/qcheck-core/qcheck-core.0.18/opam
+++ b/packages/qcheck-core/qcheck-core.0.18/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+homepage: "https://github.com/c-cube/qcheck/"
+license: "BSD-2-Clause"
+synopsis: "Core qcheck library"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.2" }
+  "base-bytes"
+  "base-unix"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=a830f187d3eed60eba960c8d626035a4"
+    "sha512=08da783ca991dcee26f88b8d6db2fcf2589d3e753ce355d5e3c8944b58ce43b444c6cde054971a557d7d345b4386e6e976111d4c537840a1269c7e361340fcfe"
+  ]
+}

--- a/packages/qcheck-ounit/qcheck-ounit.0.18/opam
+++ b/packages/qcheck-ounit/qcheck-ounit.0.18/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+homepage: "https://github.com/c-cube/qcheck/"
+doc: ["http://c-cube.github.io/qcheck/"]
+synopsis: "OUnit backend for qcheck"
+tags: [
+  "qcheck"
+  "quickcheck"
+  "ounit"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.2" }
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "ounit2"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=a830f187d3eed60eba960c8d626035a4"
+    "sha512=08da783ca991dcee26f88b8d6db2fcf2589d3e753ce355d5e3c8944b58ce43b444c6cde054971a557d7d345b4386e6e976111d4c537840a1269c7e361340fcfe"
+  ]
+}

--- a/packages/qcheck/qcheck.0.18/opam
+++ b/packages/qcheck/qcheck.0.18/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Compatibility package for qcheck"
+homepage: "https://github.com/c-cube/qcheck/"
+license: "BSD-2-Clause"
+doc: ["http://c-cube.github.io/qcheck/"]
+tags: [
+  "test"
+  "property"
+  "quickcheck"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.2" }
+  "base-bytes"
+  "base-unix"
+  "qcheck-core" { = version }
+  "qcheck-ounit" { = version }
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.08.0"}
+]
+dev-repo: "git+https://github.com/c-cube/qcheck.git"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
+conflicts: [
+  "ounit" { < "2.0" }
+]
+authors: "the qcheck contributors"
+url {
+  src: "https://github.com/c-cube/qcheck/archive/v0.18.tar.gz"
+  checksum: [
+    "md5=a830f187d3eed60eba960c8d626035a4"
+    "sha512=08da783ca991dcee26f88b8d6db2fcf2589d3e753ce355d5e3c8944b58ce43b444c6cde054971a557d7d345b4386e6e976111d4c537840a1269c7e361340fcfe"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`qcheck.0.18`: Compatibility package for qcheck
-`qcheck-alcotest.0.18`: Alcotest backend for qcheck
-`qcheck-core.0.18`: Core qcheck library
-`qcheck-ounit.0.18`: OUnit backend for qcheck



---
* Homepage: https://github.com/c-cube/qcheck/
* Source repo: git+https://github.com/c-cube/qcheck.git
* Bug tracker: https://github.com/c-cube/qcheck/issues

---
:camel: Pull-request generated by opam-publish v2.1.0