### PR TITLE
New bugfix release of not-ocamlfind with better syntax predicate support

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.08/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.08/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+license: "MIT"
 maintainer: "Chet Murthy <chetsky@gmail.com>"
 
 (* Gerd wrote most of this code; I just modified it (and probably

--- a/packages/not-ocamlfind/not-ocamlfind.0.08/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.08/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.8.0"}
+  "conf-m4" {build}
+  "fmt" {>= "0.8.8"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "2.0.0"}
+  "conf-which"
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  ["./configure" "-bindir" bin "-sitelib" lib "-mandir" man "-config" "%{lib}%/findlib.conf" "-no-custom" "-no-topfind" {preinstalled}]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/0.07.02.tar.gz"
+  checksum: [
+    "sha512=b4ba4a1133a57e1cb1a44f4472c698ba3df02e4526524f09cd481ed0b4a875b5fea6b2968588efc88f38f4f599ee9f8ce69731e21a632fb5c44d9525c1ff27e6"
+  ]
+}


### PR DESCRIPTION
formerly, a syntax predicate gets added to "syntax_preds".
with this patch, "syntax_" prepended to that predicate
also gets added to "predicates".