### PR TITLE
camlp5 rel8.00.02: updates to support OCaml 4.13.0

### DIFF
--- a/packages/camlp5/camlp5.8.00.02/opam
+++ b/packages/camlp5/camlp5.8.00.02/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.02" & < "4.14.0"}
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "conf-diffutils" { with-test & os-distribution = "alpine" }
+  "pcre" { with-test }
+  "ounit" { with-test }
+  "rresult" { with-test }
+  "fmt" { with-test }
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test & ocaml:version >= "4.10.0" }
+  [make "-C" "test" "clean" "all"] {with-test & ocaml:version >= "4.10.0" }
+]
+install: [make "install"]
+
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion." { os = "macos" | os = "freebsd" | os = "openbsd" }
+
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/rel8.00.02.tar.gz"
+  checksum: [
+    "sha512=b9950cac70e77d62f147dc8edac0aef2a2bb563ca7bbc709dcf030e2536a0973188414c8612f8b2441a6e05c4d09579bc474974513bf0c59ad4702a46a0cc7f6"
+  ]
+}

--- a/packages/pa_ppx/pa_ppx.0.07.02/opam
+++ b/packages/pa_ppx/pa_ppx.0.07.02/opam
@@ -41,6 +41,7 @@ depends: [
   "camlp5"      { >= "8.00" & < "8.00.02" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
+  "result" { >= "1.5" }
   "yojson" { >= "1.7.0" }
   "sexplib0"
   "bos" { >= "0.2.0" }

--- a/packages/pa_ppx/pa_ppx.0.07.02/opam
+++ b/packages/pa_ppx/pa_ppx.0.07.02/opam
@@ -38,7 +38,7 @@ depends: [
   "conf-perl"
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"
-  "camlp5"      { >= "8.00" }
+  "camlp5"      { >= "8.00" & < "8.00.02" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
   "yojson" { >= "1.7.0" }

--- a/packages/pa_ppx/pa_ppx.0.07/opam
+++ b/packages/pa_ppx/pa_ppx.0.07/opam
@@ -41,6 +41,7 @@ depends: [
   "camlp5"      { >= "8.00" & < "8.00.02" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
+  "result" { >= "1.5" }
   "yojson" { >= "1.7.0" }
   "sexplib0"
   "ounit"

--- a/packages/pa_ppx/pa_ppx.0.07/opam
+++ b/packages/pa_ppx/pa_ppx.0.07/opam
@@ -38,7 +38,7 @@ depends: [
   "conf-perl"
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"
-  "camlp5"      { >= "8.00" }
+  "camlp5"      { >= "8.00" & < "8.00.02" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
   "yojson" { >= "1.7.0" }


### PR DESCRIPTION
New OCaml 4.13 syntax supported, with tests.