### PR TITLE
[new release] jekyll-format (0.3.0)

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.3.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.0/opam
@@ -14,6 +14,7 @@ depends: [
   "yaml-sexp" {>= "3.0.0"}
   "yaml" {>= "3.0.0"}
   "sexplib"
+  "sexplib0"
   "result"
   "astring"
   "omd"

--- a/packages/jekyll-format/jekyll-format.0.3.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.0/opam
@@ -14,7 +14,6 @@ depends: [
   "yaml-sexp" {>= "3.0.0"}
   "yaml" {>= "3.0.0"}
   "sexplib"
-  "sexplib0"
   "result"
   "astring"
   "omd"

--- a/packages/jekyll-format/jekyll-format.0.3.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "rresult"
   "ptime"
   "fpath"
-  "ezjsonm"
+  "ezjsonm" {>="1.1.0"}
   "alcotest" {with-test}
   "bos" {with-test}
   "odoc" {with-doc}

--- a/packages/jekyll-format/jekyll-format.0.3.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Jekyll post parsing library"
+description: """
+This library provides an OCaml interface to parsing
+posts in the Jekyll format."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy" "Patrick Ferris"]
+license: "MIT"
+homepage: "https://github.com/avsm/jekyll-format"
+bug-reports: "https://github.com/avsm/jekyll-format/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.05.0"}
+  "yaml-sexp" {>= "3.0.0"}
+  "yaml" {>= "3.0.0"}
+  "sexplib"
+  "result"
+  "astring"
+  "omd"
+  "fmt"
+  "rresult"
+  "ptime"
+  "fpath"
+  "ezjsonm"
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/avsm/jekyll-format.git"
+url {
+  src:
+    "https://github.com/avsm/jekyll-format/releases/download/v0.3.0/jekyll-format-v0.3.0.tbz"
+  checksum: [
+    "sha256=129fb63081b8dee1f4d44f5e8ef28d9e4fe8d7661f6371d35d1ee8038e1c792a"
+    "sha512=9da5a2e1f3c5e294ccc99d5f211d999042bada44e907ef4d89935f2b04b20368a472af66f210e29292a442909e0becf563b6fc976de4596cede73c8c051a3212"
+  ]
+}
+x-commit-hash: "50de2aa18fb062f8b0872c5303ecc74ba2371cae"

--- a/packages/yaml-sexp/yaml-sexp.3.0.0/opam
+++ b/packages/yaml-sexp/yaml-sexp.3.0.0/opam
@@ -18,6 +18,7 @@ depends: [
   "dune" {>= "1.3"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
+  "sexplib0"
   "yaml" {= version}
   "mdx" {with-test}
   "alcotest" {with-test}


### PR DESCRIPTION
Jekyll post parsing library

- Project page: <a href="https://github.com/avsm/jekyll-format">https://github.com/avsm/jekyll-format</a>

##### CHANGES:

- Shift to Yaml 3.0.0+ interface with separate `Yaml_sexp` module (@avsm avsm/jekyll-format#6)
