### PR TITLE
7 packages from andersfugmann/ppx_protocol_conv at 5.2.0

### DIFF
--- a/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.5.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "base" {>= "v0.14.0" }
+  "dune" {>= "1.2"}
+  "ppxlib" {>= "0.9.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis:
+  "Ppx for generating serialisation and de-serialisation functions of ocaml types"
+description: """
+Ppx_protocol_conv generates code to serialize and de-serialize
+types. The ppx itself does not contain any protocol specific code,
+but relies on 'drivers' that defines serialisation and
+de-serialisation of basic types and structures.
+
+Pre-defined drivers are available in separate packages:
+ppx_protocol_conv_json (Yojson.Safe.json)
+ppx_protocol_conv_jsonm (Ezjson.value)
+ppx_protocol_conv_msgpack (Msgpck.t)
+ppx_protocol_conv_xml-light (Xml.xml)
+ppx_protocol_conv_xmlm (Xmlm.node)
+ppx_protocol_conv_yaml (Yaml.value)"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.2.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.5.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= version}
+  "yojson" {>= "1.5.0" & < "2.0.0"}
+  "dune" {>= "1.2"}
+  "ppx_expect"
+  "ppx_inline_test"
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Yojson.Safe.json)
+serialization and de-serialization using the yojson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}

--- a/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.2.0/opam
+++ b/packages/ppx_protocol_conv_jsonm/ppx_protocol_conv_jsonm.5.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ppx_protocol_conv" {= version}
+  "ezjsonm"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Jsonm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for json (Ezjson.value)
+serialization and de-serialization using the Ezjson library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.2.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.5.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= version}
+  "msgpck" {>= "1.3"}
+  "msgpck" {with-test & >= "1.7"}
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "MessagePack driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for message pack (Msgpck.t)
+serialization and deserialization using the msgpck library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.2.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.5.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "ppx_protocol_conv" {= version}
+  "xml-light"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Xml driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xml (Xml.t) serialization and
+de-serialization using the xml-light library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}

--- a/packages/ppx_protocol_conv_xmlm/ppx_protocol_conv_xmlm.5.2.0/opam
+++ b/packages/ppx_protocol_conv_xmlm/ppx_protocol_conv_xmlm.5.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: ["Anders Fugmann <anders@fugmann.net>" "Nick Betteridge <lists.nick.betteridge@gmail.com"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "ppx_protocol_conv" {= version}
+  "ezxmlm"
+  "dune" {>= "1.2"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Xmlm driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for xmlm (Ezxmlm.node)
+serialization and de-serialization using the Ezxmlm library"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.2.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.5.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/ppx_protocol_conv"
+dev-repo: "git+https://github.com/andersfugmann/ppx_protocol_conv"
+bug-reports: "https://github.com/andersfugmann/ppx_protocol_conv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2"}
+  "ppx_protocol_conv" {= version}
+  "yaml" { >= "2.0.0"}
+  "yaml" {with-test & >= "3.0.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {with-test}
+  "alcotest" {with-test & >= "0.8.0"}
+]
+synopsis: "Json driver for Ppx_protocol_conv"
+description: """
+This package provides a driver for yaml (Yaml.value)
+serialization and de-serialization using the Yaml"""
+url {
+  src:
+    "https://github.com/andersfugmann/ppx_protocol_conv/archive/5.2.0.tar.gz"
+  checksum: [
+    "md5=e71abaeffcf8596d49a04acb27e00f24"
+    "sha512=b0322030fa81af86cbe7b8b502c743768daf60c73f0219d4ce12b175c9612b1fc34bb10bf2dbbcdf9743ab321157e2ffdd8e3160f92372c7b59785ae87fbbebd"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ppx_protocol_conv.5.2.0`: Ppx for generating serialisation and de-serialisation functions of ocaml types
-`ppx_protocol_conv_json.5.2.0`: Json driver for Ppx_protocol_conv
-`ppx_protocol_conv_jsonm.5.2.0`: Jsonm driver for Ppx_protocol_conv
-`ppx_protocol_conv_msgpack.5.2.0`: MessagePack driver for Ppx_protocol_conv
-`ppx_protocol_conv_xml_light.5.2.0`: Xml driver for Ppx_protocol_conv
-`ppx_protocol_conv_xmlm.5.2.0`: Xmlm driver for Ppx_protocol_conv
-`ppx_protocol_conv_yaml.5.2.0`: Json driver for Ppx_protocol_conv



---
* Homepage: https://github.com/andersfugmann/ppx_protocol_conv
* Source repo: git+https://github.com/andersfugmann/ppx_protocol_conv
* Bug tracker: https://github.com/andersfugmann/ppx_protocol_conv/issues

---
:camel: Pull-request generated by opam-publish v2.1.0