### PR TITLE
[new release] wtr (2.0.0)

### DIFF
--- a/packages/wtr/wtr.2.0.0/opam
+++ b/packages/wtr/wtr.2.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Well Typed Router"
+description: "Wtr - A typed router for OCaml web applications"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem, <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/wtr"
+bug-reports: "https://github.com/lemaetech/wtr/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0"}
+  "uri" {>= "4.2.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ppx_expect" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/wtr.git"
+url {
+  src:
+    "https://github.com/lemaetech/wtr/releases/download/v2.0.0/wtr-v2.0.0.tbz"
+  checksum: [
+    "sha256=6242f9bec932d49f41957a05b2ddd826f38ef05ed14d87737962585143cf02aa"
+    "sha512=960a8bc6dad6d40bb248f25ec1560993c14b52fb928542ed3b5dc72842413101492ca7e0a708448aa6f3207a7c201073782fe045964d6a398cf2a9051a865092"
+  ]
+}
+x-commit-hash: "804379ce9b547286aebca1eb749bbea55c6823e6"


### PR DESCRIPTION
Well Typed Router

- Project page: <a href="https://github.com/lemaetech/wtr">https://github.com/lemaetech/wtr</a>

##### CHANGES:

- Convert `assert` based tests to `ppx_expect` tests
- Split README.md `mdx` test from tests
- BREAKING CHANGE: ppx `{%wtr| /home/about |}` now produces a function
  expecting a handler rather than a `uri`. Demos and tests have been updated to
  reflect this change.
- BREAKING CHANGE: remove functions `pp_uri` and `>-`.
- BREAKING CHANGE: `create` function now mandates `[route list list]` to create
  a router. Hopefully this should not cause much breakage since the `%wtr` ppx
  produces this value.
- NEW : `%wtr` ppx now allows specifying HTTP methods along with the uri route. A new
  type `meth` has been added to represent all standard HTTP methods.
- NEW : Add `Wtr.pp_route`, `Wtr.pp_method'` and `Wtr.pp` to pretty print a route, method
  and a router respectively.
