### PR TITLE
[new release] conduit, conduit-async, conduit-lwt, conduit-lwt-unix and conduit-mirage (4.0.1)

### DIFF
--- a/packages/conduit-async/conduit-async.4.0.1/opam
+++ b/packages/conduit-async/conduit-async.4.0.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "core"
   "uri" {>= "4.0.0"}
   "ppx_here" {>= "v0.9.0"}
@@ -25,7 +25,7 @@ conflicts: [
   "async_ssl" {< "v0.9.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit-async/conduit-async.4.0.1/opam
+++ b/packages/conduit-async/conduit-async.4.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "core"
+  "uri" {>= "4.0.0"}
+  "ppx_here" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.10.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp" {>= "4.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+x-commit-hash: "d3662ad5b40440c8474197a1856c4287294df372"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.1/conduit-v4.0.1.tbz"
+  checksum: [
+    "sha256=500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f"
+    "sha512=449aa5d1c609adaa507791c3130eda634cba4f89f46d94e557a076a1add90f93b0db3b22c43e4cb67266a7f8a52d47f5aae49af8e60ef8d07e1ca9b1f2381186"
+  ]
+}

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.4.0.1/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.4.0.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "base-unix"
   "logs"
   "ppx_sexp_conv" {>="v0.13.0"}
@@ -29,7 +29,7 @@ conflicts: [
   "ssl" {< "0.5.9"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.4.0.1/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.4.0.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "base-unix"
+  "logs"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "ca-certs"
+  "lwt_log" {with-test}
+  "ssl" {with-test}
+  "lwt_ssl" {with-test}
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.14.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+x-commit-hash: "d3662ad5b40440c8474197a1856c4287294df372"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.1/conduit-v4.0.1.tbz"
+  checksum: [
+    "sha256=500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f"
+    "sha512=449aa5d1c609adaa507791c3130eda634cba4f89f46d94e557a076a1add90f93b0db3b22c43e4cb67266a7f8a52d47f5aae49af8e60ef8d07e1ca9b1f2381186"
+  ]
+}

--- a/packages/conduit-lwt/conduit-lwt.4.0.1/opam
+++ b/packages/conduit-lwt/conduit-lwt.4.0.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "base-unix"
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "3.0.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit-lwt/conduit-lwt.4.0.1/opam
+++ b/packages/conduit-lwt/conduit-lwt.4.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+x-commit-hash: "d3662ad5b40440c8474197a1856c4287294df372"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.1/conduit-v4.0.1.tbz"
+  checksum: [
+    "sha256=500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f"
+    "sha512=449aa5d1c609adaa507791c3130eda634cba4f89f46d94e557a076a1add90f93b0db3b22c43e4cb67266a7f8a52d47f5aae49af8e60ef8d07e1ca9b1f2381186"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.4.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "uri" {>= "4.0.0"}
@@ -34,7 +34,7 @@ conflicts: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/conduit-mirage/conduit-mirage.4.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "uri" {>= "4.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "dns-client" {>= "5.0.0"}
+  "conduit-lwt" {=version}
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ca-certs-nss"
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+  "tcpip" {with-test}
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+x-commit-hash: "d3662ad5b40440c8474197a1856c4287294df372"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.1/conduit-v4.0.1.tbz"
+  checksum: [
+    "sha256=500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f"
+    "sha512=449aa5d1c609adaa507791c3130eda634cba4f89f46d94e557a076a1add90f93b0db3b22c43e4cb67266a7f8a52d47f5aae49af8e60ef8d07e1ca9b1f2381186"
+  ]
+}

--- a/packages/conduit-mirage/conduit-mirage.4.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.1/opam
@@ -11,6 +11,7 @@ depends: [
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "uri" {>= "4.0.0"}
+  "bigarray-compat"
   "cstruct" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
   "mirage-clock" {>= "3.0.0"}

--- a/packages/conduit/conduit.4.0.1/opam
+++ b/packages/conduit/conduit.4.0.1/opam
@@ -10,7 +10,7 @@ doc: "https://mirage.github.io/ocaml-conduit/"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "astring"
@@ -20,7 +20,7 @@ depends: [
   "ipaddr-sexp"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit/conduit.4.0.1/opam
+++ b/packages/conduit/conduit.4.0.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+x-commit-hash: "d3662ad5b40440c8474197a1856c4287294df372"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v4.0.1/conduit-v4.0.1.tbz"
+  checksum: [
+    "sha256=500d95bf2a524f4851e94373e32d26b6e99ee04e5134db69fe6e151c3aad9b1f"
+    "sha512=449aa5d1c609adaa507791c3130eda634cba4f89f46d94e557a076a1add90f93b0db3b22c43e4cb67266a7f8a52d47f5aae49af8e60ef8d07e1ca9b1f2381186"
+  ]
+}

--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-time"
   "result"
   "rresult"
-  "tls" {>= "0.13.0"}
+  "tls" {>= "0.13.0" & < "0.14.0"}
   "uri"
 ]
 build: [

--- a/packages/git-unix/git-unix.3.4.0/opam
+++ b/packages/git-unix/git-unix.3.4.0/opam
@@ -46,8 +46,8 @@ depends: [
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}
-  "tls" {>= "0.12.8"}
-  "tls-mirage" {>= "0.12.8"}
+  "tls" {>= "0.12.8" & < "0.14.0"}
+  "tls-mirage" {>= "0.12.8" & < "0.14.0"}
   "cohttp-lwt-unix" {with-test}
 ]
 x-ci-accept-failures: [


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* Add missing `ipaddr-sexp` dependency on conduit-async (mirage/ocaml-conduit#385, @anmonteiro)
* Update the link of the documentation (959f57a & mirage/ocaml-conduit#398, reported by @misterfish, @zshipko, @dinosaure)
* Gitignore `opam/` even if it is a symlink (mirage/ocaml-conduit#394, @CraigFe, @avsm)
* Adapt `conduit-lwt-unix` to `tls.0.14.0` (mirage/ocaml-conduit#396, @hannesm, @dinosaure)
