### PR TITLE
[new release] key-parsers (1.3.0)

### DIFF
--- a/packages/key-parsers/key-parsers.1.3.0/opam
+++ b/packages/key-parsers/key-parsers.1.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "asn1-combinators" {>= "0.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "dune" {>= "2.0"}
+  "hex" {>= "1.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppx_deriving" {>= "4.0"}
+  "result" {>= "1.5"}
+  "zarith" {>= "1.4.1"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+synopsis: "Parsers for multiple key formats"
+description: """
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or
+Elliptic curve public and private keys.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/key-parsers/releases/download/1.3.0/key-parsers-1.3.0.tbz"
+  checksum: [
+    "sha256=db34bbf4eca5de52909de4e60d1d19112db0490fcde9f2b65927a9ab437cf315"
+    "sha512=646266928b4d0f0b67a4ca621bad7fa78ce1ccf74d06ea5c9934f5e7b5a0b690017729b130c2b84575076731b55631a48238ac946e1a4d8244f58839cf798488"
+  ]
+}
+x-commit-hash: "2ef242eefaa74fa2f4604dc75372e5d735c5f36d"


### PR DESCRIPTION
Parsers for multiple key formats

- Project page: <a href="https://github.com/cryptosense/key-parsers">https://github.com/cryptosense/key-parsers</a>
- Documentation: <a href="https://cryptosense.github.io/key-parsers/doc">https://cryptosense.github.io/key-parsers/doc</a>

##### CHANGES:

*2021-08-05*

### Changed

- Change the way ID packets are represented in the PGP module
