### PR TITLE
[new release] eqaf (0.8)

### DIFF
--- a/packages/eqaf/eqaf.0.8/opam
+++ b/packages/eqaf/eqaf.0.8/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.07.0"}
+  "dune"           {>= "2.0"}
+  "cstruct"        {>= "1.1.0"}
+  "base64"         {with-test}
+  "alcotest"       {with-test}
+  "crowbar"        {with-test}
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.8/eqaf-v0.8.tbz"
+  checksum: [
+    "sha256=1145a160107437d7943e02e486df6bd233d3937ec1a597d7fa39edb9471cf875"
+    "sha512=303749bdbaae8fc27f57ebaa5cf9b16ed5b8cbaee35f0a35d69f91a437b1a3411a613d145d3aff7ff74a587509d877cc0a569fdae4d00cec65bf50d705361e25"
+  ]
+}
+x-commit-hash: "b17b607195fac4043e6c64c9ffb67df3d373fc86"


### PR DESCRIPTION
Constant-time equal function on string

- Project page: <a href="https://github.com/mirage/eqaf">https://github.com/mirage/eqaf</a>
- Documentation: <a href="https://mirage.github.io/eqaf/">https://mirage.github.io/eqaf/</a>

##### CHANGES:

- Fix the check tool on 4.11.0 (@dinosaure, @cfcs, @stedolan, mirage/eqaf#30)
  The compilation on 4.11 triggers a case where the locality of the expected
  value when we test `exists_uint8` must be the same. Otherwise, the access to
  this value can have a cost which faults our result.
- Add several utility functions (@cfcs, @dinosaure, mirage/eqaf#26)
  * `bytes_of_hex` & `string_of_hex`, hex decoding
  * `hex_of_bytes` & `hex_of_string`, hex encoding
  * `divmod`, unsigned `int32` division with small divisors
  * `ascii_of_int32`, conversion from `int32` to decimal `string`
    representation
  * `lowercase_ascii` & `uppercase_ascii`, _constant-time_ implementation of
    `String.{lower,upper}case_ascii`
  * `select_a_if_in_range`, like `select_int` but only supporting positive
    ranges
  * `int_of_bool` & `bool_of_int`, _constant-time_ of `Bool.to_int`

  A documentation exists for each function. The _constant-time_ is checked only
  systematically for `divmod`.
- Merge optional sub-packages (@kit-ty-kate, @hannesm, @dinosaure, mirage/eqaf#27)
  `cstruct` becomes a required dependency of `eqaf`
- Fix FreeBSD support and remove support of < OCaml 4.07 and remove the
  dependency to `bigarray-compat` (@hannesm, @dinosaure, mirage/eqaf#32)
- Add a CI on FreeBSD (@dinosaure, @hannesm, mirage/eqaf#33)
- Remove the test `check/check.exe` (@dinosaure, mirage/eqaf#31)
  The test `check/check.exe` is really volatile and should be executed into a
  controlled environment (for instance, with `nice -n19` and a _bare-metal_
  computer). We still require the test for any improvement of `eqaf` but it is
  executed separately from our CI.
