### PR TITLE
0.08 release of pa_ppx add-on packages (for ocaml 4.13.0 compat)

### DIFF
--- a/packages/pa_ppx_ag/pa_ppx_ag.0.08/opam
+++ b/packages/pa_ppx_ag/pa_ppx_ag.0.08/opam
@@ -24,6 +24,7 @@ depends: [
   "pa_ppx_hashcons"    { >= "0.08" }
   "pa_ppx_unique"      { >= "0.08" }
   "not-ocamlfind" { >= "0.01" }
+  "ocamlgraph" { >= "2.0.0" }
   "pcre" { >= "7.4.3" }
   "ounit" {with-test}
   "vec"

--- a/packages/pa_ppx_ag/pa_ppx_ag.0.08/opam
+++ b/packages/pa_ppx_ag/pa_ppx_ag.0.08/opam
@@ -1,0 +1,42 @@
+synopsis: "A PPX Rewriter that Generates Attribute Grammar Evaulators"
+description:
+"""
+This is a PPX Rewriter that generates Attribute Grammar evaulators.
+Initially only ordered ones, but eventually other strategies too.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_ag"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_ag/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_ag.git"
+doc: "https://github.com/camlp5/pa_ppx_ag/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.14.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"     { >= "0.08" }
+  "pa_ppx_hashcons"    { >= "0.08" }
+  "pa_ppx_unique"      { >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "vec"
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+#  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_ag/archive/0.08.tar.gz"
+  checksum: [
+    "sha512=786910ca5e1c7654b8c6d2af1e8db85150d9953f969051cf8f4487e0893d8eaf145c6bc5195761172ff17a2426073ce87facf65d31abc2401e83b7e999f47d7e"
+  ]
+}

--- a/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.08/opam
+++ b/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.08/opam
@@ -1,0 +1,42 @@
+synopsis: "A PPX Rewriter for Hashconsing"
+description:
+"""
+This is a PPX Rewriter for generating hashconsing implementations
+of ASTs, mechanizing the ideas and code of Jean-Christophe Filliatre
+and Sylvain Conchon.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_hashcons"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_hashcons/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_hashcons.git"
+doc: "https://github.com/camlp5/pa_ppx_hashcons/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.14.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+  "hashcons"
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_hashcons/archive/0.08.tar.gz"
+  checksum: [
+    "sha512=2f6306a7794bcad347aed6915c44349681463102426e3f741564ec439eee6eb6b12d7f65219d63d35a578a7fb374f6298f98a7730b7e290a6af11cc9b111b320"
+  ]
+}

--- a/packages/pa_ppx_migrate/pa_ppx_migrate.0.08/opam
+++ b/packages/pa_ppx_migrate/pa_ppx_migrate.0.08/opam
@@ -1,0 +1,45 @@
+synopsis: "A PPX Rewriter for Migrating AST types (written using Camlp5)"
+description:
+"""
+This is a PPX Rewriter for generating "migrations" like those written
+by-hand (with some automated support) in "ocaml-migrate-parsetree".
+The goal here is that the input to the automated tool is the minimum
+possible, with no need for human massaging of output from the tool.
+
+There are two examples: a small one (in a unit-test) and a full set of
+migrations from Ocaml's AST 4.02 all the way up to 4.11, with all the
+intermediate ASTs, and migrations forward as well as backward.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_migrate"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_migrate/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_migrate.git"
+doc: "https://github.com/camlp5/pa_ppx_migrate/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.14.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_migrate/archive/0.08.tar.gz"
+  checksum: [
+    "sha512=ade97571b1c6160579b9b9d29fcc85d1739bfaf6ca20b962780bac0fbd06b6c151f9abc4e0ebc08dc338e981e4718275f08169d0d4256fa27773d1a748eb3341"
+  ]
+}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.08/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.08/opam
@@ -1,0 +1,43 @@
+synopsis: "A PPX Rewriter for automating generation of data-conversion code for use with Camlp5's Q_ast"
+description:
+"""
+This is a PPX Rewriter for generating data-conversion code that is otherwise
+hand-written, when using Camlp5's Q_ast.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_q_ast"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_q_ast/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_q_ast.git"
+doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.14.0" }
+  "conf-diffutils" { with-test }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "pa_ppx_hashcons"      { >= "0.08" }
+  "pa_ppx_unique"      { >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_q_ast/archive/0.08.tar.gz"
+  checksum: [
+    "sha512=80942d8287a9d48a84fbe1d3903d56d5d85fba3b9dcea102020dfa322de8937760e147572b9121c4d16be9693db7cecf3981c2e82a84cd841815c484fe40c399"
+  ]
+}

--- a/packages/pa_ppx_unique/pa_ppx_unique.0.08/opam
+++ b/packages/pa_ppx_unique/pa_ppx_unique.0.08/opam
@@ -1,0 +1,39 @@
+synopsis: "A PPX Rewriter for Uniqifying ASTs"
+description:
+"""
+This is a PPX Rewriter for uniqifying ASTs: inserting unique IDs
+systematically throughout an AST.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_unique"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_unique/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_unique.git"
+doc: "https://github.com/camlp5/pa_ppx_unique/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "4.14.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_unique/archive/0.08.tar.gz"
+  checksum: [
+    "sha512=1d74f235b061a744a5ffb962eeb0c8b6d90d31c9782f6ff4ba9c441eedf023de0948fc89fd3a370e36649d4d4c63bf83d27e8a31b9c341783534ceb02f473170"
+  ]
+}


### PR DESCRIPTION
This release is of all the pa_ppx add-on packages (hashcons, unique, migrate, q_ast, ag) for compat with ocaml 4.13.0.

Changes are minimal.