### PR TITLE
[new release] git-cohttp, git-cohttp-unix, git-mirage, git, git-paf and git-unix (3.5.0)

### DIFF
--- a/packages/git-cohttp-unix/git-cohttp-unix.3.5.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.5.0/git-3.5.0.tbz"
+  checksum: [
+    "sha256=bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03"
+    "sha512=799465602170481834b7ee46cc7103b8ffa8784ca5e70e48b21d2ab81855002ccfc0feba693c6ff8a53ebed5c9929cc04a51e5c5844450412265cba2f76be486"
+  ]
+}
+x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"

--- a/packages/git-cohttp/git-cohttp.3.5.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.5.0/git-3.5.0.tbz"
+  checksum: [
+    "sha256=bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03"
+    "sha512=799465602170481834b7ee46cc7103b8ffa8784ca5e70e48b21d2ab81855002ccfc0feba693c6ff8a53ebed5c9929cc04a51e5c5844450412265cba2f76be486"
+  ]
+}
+x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"

--- a/packages/git-mirage/git-mirage.3.5.0/opam
+++ b/packages/git-mirage/git-mirage.3.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "awa"
+  "awa-mirage"
+  "dns-client" {>= "5.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.5.0/git-3.5.0.tbz"
+  checksum: [
+    "sha256=bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03"
+    "sha512=799465602170481834b7ee46cc7103b8ffa8784ca5e70e48b21d2ab81855002ccfc0feba693c6ff8a53ebed5c9929cc04a51e5c5844450412265cba2f76be486"
+  ]
+}
+x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"

--- a/packages/git-paf/git-paf.3.5.0/opam
+++ b/packages/git-paf/git-paf.3.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "mimic" {>= "0.0.3"}
+  "paf" {>= "0.0.2"}
+  "ca-certs-nss"
+  "fmt"
+  "ipaddr"
+  "logs"
+  "lwt"
+  "mirage-clock"
+  "mirage-stack"
+  "mirage-time"
+  "result"
+  "rresult"
+  "tls" {>= "0.14.0"}
+  "uri"
+  "bigarray-compat"
+  "bigstringaf"
+  "domain-name"
+  "httpaf"
+  "mirage-flow"
+  "tls-mirage"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.5.0/git-3.5.0.tbz"
+  checksum: [
+    "sha256=bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03"
+    "sha512=799465602170481834b7ee46cc7103b8ffa8784ca5e70e48b21d2ab81855002ccfc0feba693c6ff8a53ebed5c9929cc04a51e5c5844450412265cba2f76be486"
+  ]
+}
+x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"

--- a/packages/git-unix/git-unix.3.5.0/opam
+++ b/packages/git-unix/git-unix.3.5.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa"
+  "cmdliner" {>= "1.0.4"}
+  "decompress" {>= "1.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "awa-mirage"
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ptime"
+  "mimic"
+  "ca-certs-nss" {>= "3.60"}
+  "tls" {>= "0.14.0"}
+  "tls-mirage" {>= "0.14.0"}
+  "cohttp-lwt-unix" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.5.0/git-3.5.0.tbz"
+  checksum: [
+    "sha256=bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03"
+    "sha512=799465602170481834b7ee46cc7103b8ffa8784ca5e70e48b21d2ab81855002ccfc0feba693c6ff8a53ebed5c9929cc04a51e5c5844450412265cba2f76be486"
+  ]
+}
+x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"

--- a/packages/git/git.3.5.0/opam
+++ b/packages/git/git.3.5.0/opam
@@ -30,9 +30,9 @@ depends: [
   "mimic"
   "cstruct" {>= "6.0.0"}
   "angstrom" {>= "0.14.0"}
-  "carton" {>= "0.4.0"}
-  "carton-lwt" {>= "0.4.0"}
-  "carton-git" {>= "0.4.0"}
+  "carton" {>= "0.4.3"}
+  "carton-lwt" {>= "0.4.3"}
+  "carton-git" {>= "0.4.3"}
   "ke" {>= "0.4"}
   "fmt" {>= "0.8.7"}
   "checkseum" {>= "0.2.1"}

--- a/packages/git/git.3.5.0/opam
+++ b/packages/git/git.3.5.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic"
+  "cstruct" {>= "6.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.0"}
+  "carton-lwt" {>= "0.4.0"}
+  "carton-git" {>= "0.4.0"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "hxd" {>= "0.3.1"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.5.0/git-3.5.0.tbz"
+  checksum: [
+    "sha256=bcd5a0aef9957193cbaeeb17c22201e5ca4e815e67bbc696e88efdb38c25ec03"
+    "sha512=799465602170481834b7ee46cc7103b8ffa8784ca5e70e48b21d2ab81855002ccfc0feba693c6ff8a53ebed5c9929cc04a51e5c5844450412265cba2f76be486"
+  ]
+}
+x-commit-hash: "1908383243210d71d3595e0d2f239aaf2ca60c34"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.6.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.6.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-paf"      {>= "3.4.0"}
+  "git-paf"      {>= "3.4.0" & < "3.5.0"}
   "fmt"
   "git"          {>= "3.4.0"}
   "lwt"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.6.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-paf"      {>= "3.4.0"}
+  "git-paf"      {>= "3.4.0" & < "3.5.0"}
   "fmt"
   "git"          {>= "3.4.0"}
   "lwt"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.7.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.7.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-paf"      {>= "3.4.0"}
+  "git-paf"      {>= "3.4.0" & < "3.5.0"}
   "fmt"
   "git"          {>= "3.4.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.7.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.7.1/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-paf"      {>= "3.4.0"}
+  "git-paf"      {>= "3.4.0" & < "3.5.0"}
   "fmt"
   "git"          {>= "3.4.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.7.2/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.7.2/opam
@@ -20,7 +20,7 @@ depends: [
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"
-  "git-paf"      {>= "3.4.0"}
+  "git-paf"      {>= "3.4.0" & < "3.5.0"}
   "fmt"
   "git"          {>= "3.4.0"}
   "lwt"          {>= "5.3.0"}


### PR DESCRIPTION
A package to use HTTP-based ocaml-git with Unix backend

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix compilation of benchmarks (@dinosaure, mirage/ocaml-git#516)
- Remove `paf.cohttp` dependency from MirageOS stack (@dinosaure, mirage/ocaml-git#519)
- Use `Cstruct.length` instead of `Cstruct.len` (@dinosaure. mirage/ocaml-git#522)
- Update to `tls.0.14.0` (@dinosaure, mirage/ocaml-git#529)
