### PR TITLE
Record the absolute path of llvm-config when found in PATH

### DIFF
--- a/packages/conf-llvm/conf-llvm.10.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.10.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${ve
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.10.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.10.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm10"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=c684ff1f4e2fee80154115d172ca49d6"]
+extra-files: ["configure.sh" "md5=bc710689f7c84f6f68e91b2f68b385b1"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.11.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.11.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${ve
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '${llvm_config}')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.11.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.11.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${ve
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$(command -v '${llvm_config}')\"" >> conf-llvm.config
+        echo "config: \"$(command -v ${llvm_config})\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.11.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.11.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm11"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=2750506041c4edef4482ce9fb5f30aa1"]
+extra-files: ["configure.sh" "md5=c92c2868ab86c9635420dc550b99441d"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.11.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.11.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm11"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=c92c2868ab86c9635420dc550b99441d"]
+extra-files: ["configure.sh" "md5=22d6fdea8134c33fcf135d8ca35d060a"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.3.4/files/configure
+++ b/packages/conf-llvm/conf-llvm.3.4/files/configure
@@ -13,7 +13,7 @@ for llvm_config in $config llvm-config-$version llvm-config${version//./} llvm-c
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.3.4/opam
+++ b/packages/conf-llvm/conf-llvm.3.4/opam
@@ -16,5 +16,5 @@ post-messages:
   "If you use homebrew, please build and install llvm-3.4 manually, since brew formula is not available for this version"
     {failure & (os = "macos" | os = "macos")}
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure" "md5=67afff0753bd62bc5adbe9e205c91138"]
+extra-files: ["configure" "md5=567276d6cfb8e395de84013c2fd436f2"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.3.8/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.3.8/files/configure.sh
@@ -13,7 +13,7 @@ for llvm_config in $config llvm-config-$version llvm-config${version//./} llvm-c
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.3.8/opam
+++ b/packages/conf-llvm/conf-llvm.3.8/opam
@@ -14,5 +14,5 @@ depexts: [
   ["devel/llvm38"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=57f3b2473628ad9da28e94fb8b4746f9"]
+extra-files: ["configure.sh" "md5=9294c1d6f95da6b9cafb42edfa660142"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.3.9/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.3.9/files/configure.sh
@@ -13,7 +13,7 @@ for llvm_config in $config llvm-config-$version llvm-config${version//./} llvm-c
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.3.9/opam
+++ b/packages/conf-llvm/conf-llvm.3.9/opam
@@ -16,5 +16,5 @@ depexts: [
   ["devel/llvm39"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=57f3b2473628ad9da28e94fb8b4746f9"]
+extra-files: ["configure.sh" "md5=9294c1d6f95da6b9cafb42edfa660142"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.4.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.4.0.0/files/configure.sh
@@ -13,7 +13,7 @@ for llvm_config in $config llvm-config-$version llvm-config${version//./} llvm-c
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.4.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.4.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm40"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=8e501d281808e64c85d14cc521436d6c"]
+extra-files: ["configure.sh" "md5=f01bafcd226b25403419450d36984c38"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.5.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.5.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config${version//./} llvm-config-mp
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.5.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.5.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm50"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=76668caf3382b83f398fb3549306f431"]
+extra-files: ["configure.sh" "md5=f18e085508b5600051e99085753796f3"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.6.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.6.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config${version//./} llvm-config-mp
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.6.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.6.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm60"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=76668caf3382b83f398fb3549306f431"]
+extra-files: ["configure.sh" "md5=f18e085508b5600051e99085753796f3"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.7.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.7.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${ve
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.7.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.7.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm70"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=c684ff1f4e2fee80154115d172ca49d6"]
+extra-files: ["configure.sh" "md5=bc710689f7c84f6f68e91b2f68b385b1"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.8.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.8.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${ve
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.8.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.8.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm80"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=c684ff1f4e2fee80154115d172ca49d6"]
+extra-files: ["configure.sh" "md5=bc710689f7c84f6f68e91b2f68b385b1"]
 flags: conf

--- a/packages/conf-llvm/conf-llvm.9.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.9.0.0/files/configure.sh
@@ -11,7 +11,7 @@ for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${ve
     llvm_version="`$llvm_config --version`" || true
     case $llvm_version in
     $version*)
-        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "config: \"$(command -v '$llvm_config')\"" >> conf-llvm.config
         echo "version: \"$llvm_version\"" >> conf-llvm.config
         exit 0;;
     *)

--- a/packages/conf-llvm/conf-llvm.9.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.9.0.0/opam
@@ -18,5 +18,5 @@ depexts: [
   ["devel/llvm90"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on llvm library installation"
-extra-files: ["configure.sh" "md5=c684ff1f4e2fee80154115d172ca49d6"]
+extra-files: ["configure.sh" "md5=bc710689f7c84f6f68e91b2f68b385b1"]
 flags: conf


### PR DESCRIPTION
When conf-llvm finds the llvm-config executable in PATH, currently the config var only records the basename of the executable. If the PATH later changes, dependent packages can fail to build, or be built with the wrong `llvm-config`. This patch adds the absolute path the the found llvm-config executable to the config var to avoid this instability.

Cc: @kit-ty-kate 