### PR TITLE
Tezos 9.7

### DIFF
--- a/packages/tezos-accuser-008-PtEdo2Zk/tezos-accuser-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-accuser-008-PtEdo2Zk/tezos-accuser-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-008-PtEdo2Zk-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/bin_accuser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: accuser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-accuser-009-PsFLoren/tezos-accuser-009-PsFLoren.9.7/opam
+++ b/packages/tezos-accuser-009-PsFLoren/tezos-accuser-009-PsFLoren.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-009-PsFLoren-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/bin_accuser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: accuser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-accuser-010-PtGRANAD/tezos-accuser-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-accuser-010-PtGRANAD/tezos-accuser-010-PtGRANAD.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-010-PtGRANAD-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/bin_accuser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: accuser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-alpha-test-helpers/tezos-alpha-test-helpers.9.7/opam
+++ b/packages/tezos-alpha-test-helpers/tezos-alpha-test-helpers.9.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-alpha-parameters" { = version }
+  "tezos-client-alpha" { = version }
+  "alcotest-lwt"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/test/helpers/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol testing framework"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baker-008-PtEdo2Zk/tezos-baker-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-baker-008-PtEdo2Zk/tezos-baker-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-008-PtEdo2Zk-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/bin_baker/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: baker binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baker-009-PsFLoren/tezos-baker-009-PsFLoren.9.7/opam
+++ b/packages/tezos-baker-009-PsFLoren/tezos-baker-009-PsFLoren.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-009-PsFLoren-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/bin_baker/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: baker binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baker-010-PtGRANAD/tezos-baker-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-baker-010-PtGRANAD/tezos-baker-010-PtGRANAD.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-010-PtGRANAD-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/bin_baker/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: baker binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-008-PtEdo2Zk-commands/tezos-baking-008-PtEdo2Zk-commands.9.7/opam
+++ b/packages/tezos-baking-008-PtEdo2Zk-commands/tezos-baking-008-PtEdo2Zk-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-008-PtEdo2Zk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-008-PtEdo2Zk/tezos-baking-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-baking-008-PtEdo2Zk/tezos-baking-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-shell-context" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-008-PtEdo2Zk" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/endorser/accuser`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-009-PsFLoren-commands/tezos-baking-009-PsFLoren-commands.9.7/opam
+++ b/packages/tezos-baking-009-PsFLoren-commands/tezos-baking-009-PsFLoren-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-009-PsFLoren" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-009-PsFLoren/tezos-baking-009-PsFLoren.9.7/opam
+++ b/packages/tezos-baking-009-PsFLoren/tezos-baking-009-PsFLoren.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-shell-context" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-009-PsFLoren" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/endorser/accuser`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-010-PtGRANAD-commands/tezos-baking-010-PtGRANAD-commands.9.7/opam
+++ b/packages/tezos-baking-010-PtGRANAD-commands/tezos-baking-010-PtGRANAD-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-010-PtGRANAD" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-010-PtGRANAD/tezos-baking-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-baking-010-PtGRANAD/tezos-baking-010-PtGRANAD.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-shell-context" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-010-PtGRANAD" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/endorser/accuser`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-alpha-commands/tezos-baking-alpha-commands.9.7/opam
+++ b/packages/tezos-baking-alpha-commands/tezos-baking-alpha-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-alpha" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-baking-alpha/tezos-baking-alpha.9.7/opam
+++ b/packages/tezos-baking-alpha/tezos-baking-alpha.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-shell-context" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-alpha" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_delegate/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/endorser/accuser`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-base/tezos-base.9.7/opam
+++ b/packages/tezos-base/tezos-base.9.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-crypto" { = version }
+  "tezos-micheline" { = version }
+  "ptime" { >= "0.8.4" }
+  "ezjsonm" { >= "1.1.0" }
+  "ipaddr" {>= "5.0.0" & < "6.0.0"}
+  "crowbar" { with-test }
+  "tezos-test-helpers" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_base/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] { with-test & ( arch = "x86_64" | arch = "arm64" ) }
+]
+synopsis: "Tezos: meta-package and pervasive type definitions for Tezos"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-clic/tezos-clic.9.7/opam
+++ b/packages/tezos-clic/tezos-clic.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-stdlib-unix" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_clic/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented command-line-parsing combinators"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-000-Ps9mPmXa/tezos-client-000-Ps9mPmXa.9.7/opam
+++ b/packages/tezos-client-000-Ps9mPmXa/tezos-client-000-Ps9mPmXa.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000-Ps9mPmXa (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-001-PtCJ7pwo-commands/tezos-client-001-PtCJ7pwo-commands.9.7/opam
+++ b/packages/tezos-client-001-PtCJ7pwo-commands/tezos-client-001-PtCJ7pwo-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-001-PtCJ7pwo" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_client_commands/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-001-PtCJ7pwo/tezos-client-001-PtCJ7pwo.9.7/opam
+++ b/packages/tezos-client-001-PtCJ7pwo/tezos-client-001-PtCJ7pwo.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-002-PsYLVpVv-commands/tezos-client-002-PsYLVpVv-commands.9.7/opam
+++ b/packages/tezos-client-002-PsYLVpVv-commands/tezos-client-002-PsYLVpVv-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-002-PsYLVpVv" { = version }
+  "tezos-client-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_002_PsYLVpVv/lib_client_commands/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-002-PsYLVpVv/tezos-client-002-PsYLVpVv.9.7/opam
+++ b/packages/tezos-client-002-PsYLVpVv/tezos-client-002-PsYLVpVv.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_002_PsYLVpVv/lib_client/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-003-PsddFKi3-commands/tezos-client-003-PsddFKi3-commands.9.7/opam
+++ b/packages/tezos-client-003-PsddFKi3-commands/tezos-client-003-PsddFKi3-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-003-PsddFKi3" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_003_PsddFKi3/lib_client_commands/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-003-PsddFKi3/tezos-client-003-PsddFKi3.9.7/opam
+++ b/packages/tezos-client-003-PsddFKi3/tezos-client-003-PsddFKi3.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_003_PsddFKi3/lib_client/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-004-Pt24m4xi-commands/tezos-client-004-Pt24m4xi-commands.9.7/opam
+++ b/packages/tezos-client-004-Pt24m4xi-commands/tezos-client-004-Pt24m4xi-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-004-Pt24m4xi" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-004-Pt24m4xi/tezos-client-004-Pt24m4xi.9.7/opam
+++ b/packages/tezos-client-004-Pt24m4xi/tezos-client-004-Pt24m4xi.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_004_Pt24m4xi/lib_client/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-005-PsBabyM1-commands/tezos-client-005-PsBabyM1-commands.9.7/opam
+++ b/packages/tezos-client-005-PsBabyM1-commands/tezos-client-005-PsBabyM1-commands.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-005-PsBabyM1" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_005_PsBabyM1/lib_client_commands/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-005-PsBabyM1/tezos-client-005-PsBabyM1.9.7/opam
+++ b/packages/tezos-client-005-PsBabyM1/tezos-client-005-PsBabyM1.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-signer-backends" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_005_PsBabyM1/lib_client/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-006-PsCARTHA-commands/tezos-client-006-PsCARTHA-commands.9.7/opam
+++ b/packages/tezos-client-006-PsCARTHA-commands/tezos-client-006-PsCARTHA-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-006-PsCARTHA" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.9.7/opam
+++ b/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+  "tezos-protocol-006-PsCARTHA-parameters" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_client/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-007-PsDELPH1-commands-registration/tezos-client-007-PsDELPH1-commands-registration.9.7/opam
+++ b/packages/tezos-client-007-PsDELPH1-commands-registration/tezos-client-007-PsDELPH1-commands-registration.9.7/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-007-PsDELPH1-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_client_commands/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-007-PsDELPH1-commands/tezos-client-007-PsDELPH1-commands.9.7/opam
+++ b/packages/tezos-client-007-PsDELPH1-commands/tezos-client-007-PsDELPH1-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-007-PsDELPH1" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-007-PsDELPH1/tezos-client-007-PsDELPH1.9.7/opam
+++ b/packages/tezos-client-007-PsDELPH1/tezos-client-007-PsDELPH1.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-mockup-registration" { = version }
+  "tezos-proxy" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-plugin-007-PsDELPH1" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-008-PtEdo2Zk-commands-registration/tezos-client-008-PtEdo2Zk-commands-registration.9.7/opam
+++ b/packages/tezos-client-008-PtEdo2Zk-commands-registration/tezos-client-008-PtEdo2Zk-commands-registration.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-sapling-008-PtEdo2Zk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-008-PtEdo2Zk-commands/tezos-client-008-PtEdo2Zk-commands.9.7/opam
+++ b/packages/tezos-client-008-PtEdo2Zk-commands/tezos-client-008-PtEdo2Zk-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-008-PtEdo2Zk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-008-PtEdo2Zk/tezos-client-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-client-008-PtEdo2Zk/tezos-client-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-mockup-registration" { = version }
+  "tezos-proxy" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-008-PtEdo2Zk-parameters" { = version }
+  "tezos-protocol-plugin-008-PtEdo2Zk" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-009-PsFLoren-commands-registration/tezos-client-009-PsFLoren-commands-registration.9.7/opam
+++ b/packages/tezos-client-009-PsFLoren-commands-registration/tezos-client-009-PsFLoren-commands-registration.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-sapling-009-PsFLoren" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-009-PsFLoren-commands/tezos-client-009-PsFLoren-commands.9.7/opam
+++ b/packages/tezos-client-009-PsFLoren-commands/tezos-client-009-PsFLoren-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-009-PsFLoren" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-009-PsFLoren/tezos-client-009-PsFLoren.9.7/opam
+++ b/packages/tezos-client-009-PsFLoren/tezos-client-009-PsFLoren.9.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-mockup-registration" { = version }
+  "tezos-proxy" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-009-PsFLoren-parameters" { = version }
+  "tezos-protocol-plugin-009-PsFLoren" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-010-PtGRANAD-commands-registration/tezos-client-010-PtGRANAD-commands-registration.9.7/opam
+++ b/packages/tezos-client-010-PtGRANAD-commands-registration/tezos-client-010-PtGRANAD-commands-registration.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-sapling-010-PtGRANAD" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-010-PtGRANAD-commands/tezos-client-010-PtGRANAD-commands.9.7/opam
+++ b/packages/tezos-client-010-PtGRANAD-commands/tezos-client-010-PtGRANAD-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-010-PtGRANAD" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-010-PtGRANAD/tezos-client-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-client-010-PtGRANAD/tezos-client-010-PtGRANAD.9.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-mockup-registration" { = version }
+  "tezos-proxy" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-010-PtGRANAD-parameters" { = version }
+  "tezos-protocol-plugin-010-PtGRANAD" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "ppx_inline_test"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-alpha-commands-registration/tezos-client-alpha-commands-registration.9.7/opam
+++ b/packages/tezos-client-alpha-commands-registration/tezos-client-alpha-commands-registration.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-sapling-alpha" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-alpha-commands/tezos-client-alpha-commands.9.7/opam
+++ b/packages/tezos-client-alpha-commands/tezos-client-alpha-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-alpha" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-alpha/tezos-client-alpha.9.7/opam
+++ b/packages/tezos-client-alpha/tezos-client-alpha.9.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-mockup-registration" { = version }
+  "tezos-proxy" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-alpha-parameters" { = version }
+  "tezos-protocol-plugin-alpha" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-base-unix/tezos-client-base-unix.9.7/opam
+++ b/packages/tezos-client-base-unix/tezos-client-base-unix.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-proxy" { = version }
+  "lwt-exit"
+  "tezos-test-services" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_client_base_unix/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: common helpers for `tezos-client` (unix-specific fragment)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-base/tezos-client-base.9.7/opam
+++ b/packages/tezos-client-base/tezos-client-base.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-storage" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-sapling" { = version }
+  "alcotest" { with-test }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_client_base/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: common helpers for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-commands/tezos-client-commands.9.7/opam
+++ b/packages/tezos-client-commands/tezos-client-commands.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_client_commands/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: protocol agnostic commands for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-demo-counter/tezos-client-demo-counter.9.7/opam
+++ b/packages/tezos-client-demo-counter/tezos-client-demo-counter.9.7/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-demo-counter" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_client/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-genesis-carthagenet/tezos-client-genesis-carthagenet.9.7/opam
+++ b/packages/tezos-client-genesis-carthagenet/tezos-client-genesis-carthagenet.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-genesis-carthagenet" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-genesis/tezos-client-genesis.9.7/opam
+++ b/packages/tezos-client-genesis/tezos-client-genesis.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-genesis" { = version }
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (protocol-specific commands for `tezos-client`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-sapling-008-PtEdo2Zk/tezos-client-sapling-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-client-sapling-008-PtEdo2Zk/tezos-client-sapling-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-008-PtEdo2Zk-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_client_sapling/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: sapling support for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-sapling-009-PsFLoren/tezos-client-sapling-009-PsFLoren.9.7/opam
+++ b/packages/tezos-client-sapling-009-PsFLoren/tezos-client-sapling-009-PsFLoren.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-009-PsFLoren-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_client_sapling/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: sapling support for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-sapling-010-PtGRANAD/tezos-client-sapling-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-client-sapling-010-PtGRANAD/tezos-client-sapling-010-PtGRANAD.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-010-PtGRANAD-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_client_sapling/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: sapling support for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client-sapling-alpha/tezos-client-sapling-alpha.9.7/opam
+++ b/packages/tezos-client-sapling-alpha/tezos-client-sapling-alpha.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-alpha-commands" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_client_sapling/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: sapling support for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-client/tezos-client.9.7/opam
+++ b/packages/tezos-client/tezos-client.9.7/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+
+  "tezos-client-genesis-carthagenet" { = version }
+  "tezos-client-000-Ps9mPmXa" { = version }
+  "tezos-client-009-PsFLoren-commands-registration" { = version }
+  "tezos-baking-009-PsFLoren-commands" { = version }
+  "tezos-client-010-PtGRANAD-commands-registration" { = version }
+  "tezos-baking-010-PtGRANAD-commands" { = version }
+
+  "tezos-node" { with-test & = version }
+  "tezos-protocol-compiler" { with-test & = version }
+  "tezos-client-alpha-commands-registration" { with-test & = version }
+]
+depopts: [
+  "tezos-client-genesis"
+  "tezos-client-demo-counter"
+  "tezos-client-alpha-commands-registration"
+  "tezos-baking-alpha-commands"
+
+  "tezos-client-001-PtCJ7pwo-commands"
+  "tezos-client-002-PsYLVpVv-commands"
+  "tezos-client-003-PsddFKi3-commands"
+  "tezos-client-004-Pt24m4xi-commands"
+  "tezos-client-005-PsBabyM1-commands"
+  "tezos-client-006-PsCARTHA-commands"
+  "tezos-client-007-PsDELPH1-commands-registration"
+  "tezos-client-008-PtEdo2Zk-commands-registration"
+  "tezos-baking-008-PtEdo2Zk-commands"
+]
+conflicts: [
+  "tezos-client-genesis" { != version }
+  "tezos-client-demo-counter" { != version }
+  "tezos-client-alpha-commands-registration" { != version }
+  "tezos-baking-alpha-commands" { != version }
+
+  "tezos-client-001-PtCJ7pwo-commands" { != version }
+  "tezos-client-002-PsYLVpVv-commands" { != version }
+  "tezos-client-003-PsddFKi3-commands" { != version }
+  "tezos-client-004-Pt24m4xi-commands" { != version }
+  "tezos-client-005-PsBabyM1-commands" { != version }
+  "tezos-client-006-PsCARTHA-commands" { != version }
+  "tezos-client-007-PsDELPH1-commands-registration" { != version }
+  "tezos-client-008-PtEdo2Zk-commands-registration" { != version }
+  "tezos-baking-008-PtEdo2Zk-commands" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_client/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-client` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-codec/tezos-codec.9.7/opam
+++ b/packages/tezos-codec/tezos-codec.9.7/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-signer-services" { = version }
+]
+depopts: [
+  "tezos-client-alpha"
+  "tezos-client-005-PsBabyM1"
+  "tezos-client-006-PsCARTHA"
+  "tezos-client-007-PsDELPH1"
+  "tezos-client-008-PtEdo2Zk"
+  "tezos-client-009-PsFLoren"
+  "tezos-client-010-PtGRANAD"
+]
+conflicts: [
+  "tezos-client-alpha" { != version }
+  "tezos-client-005-PsBabyM1" { != version }
+  "tezos-client-006-PsCARTHA" { != version }
+  "tezos-client-007-PsDELPH1" { != version }
+  "tezos-client-008-PtEdo2Zk" { != version }
+  "tezos-client-009-PsFLoren" { != version }
+  "tezos-client-010-PtGRANAD" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_codec/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-codec` binary to encode and decode values"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-crypto/tezos-crypto.9.7/opam
+++ b/packages/tezos-crypto/tezos-crypto.9.7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-clic" { = version }
+  "tezos-rpc" { = version }
+  "bls12-381" { = "0.3.15" }
+  "hacl-star" { >= "0.3.0" }
+  "secp256k1-internal"
+  "uecc" { >= "0.3" }
+  "ringo" { = "0.5" }
+#  "crowbar" { with-test }
+#  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+conflicts: [
+  "hacl_x25519"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_crypto/%{name}%.install" "./"]
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library with all the cryptographic primitives used by Tezos"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.9.7/opam
+++ b/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000-Ps9mPmXa (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.9.7/opam
+++ b/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.9.7/opam
+++ b/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.9.7/opam
+++ b/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.9.7/opam
+++ b/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.9.7/opam
+++ b/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-005-PsBABY5H" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBABY5H/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.9.7/opam
+++ b/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.9.7/opam
+++ b/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-007-PsDELPH1/tezos-embedded-protocol-007-PsDELPH1.9.7/opam
+++ b/packages/tezos-embedded-protocol-007-PsDELPH1/tezos-embedded-protocol-007-PsDELPH1.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-007-PsDELPH1" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-008-PtEdo2Zk/tezos-embedded-protocol-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-embedded-protocol-008-PtEdo2Zk/tezos-embedded-protocol-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-008-PtEdo2Zk" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-008-PtEdoTez/tezos-embedded-protocol-008-PtEdoTez.9.7/opam
+++ b/packages/tezos-embedded-protocol-008-PtEdoTez/tezos-embedded-protocol-008-PtEdoTez.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-008-PtEdoTez" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdoTez/lib_protocol/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-009-PsFLoren/tezos-embedded-protocol-009-PsFLoren.9.7/opam
+++ b/packages/tezos-embedded-protocol-009-PsFLoren/tezos-embedded-protocol-009-PsFLoren.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-009-PsFLoren" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-010-PtGRANAD/tezos-embedded-protocol-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-embedded-protocol-010-PtGRANAD/tezos-embedded-protocol-010-PtGRANAD.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-010-PtGRANAD" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.9.7/opam
+++ b/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.9.7/opam
+++ b/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-demo-counter" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_protocol/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.9.7/opam
+++ b/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-demo-noops" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_noops/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis-carthagenet/tezos-embedded-protocol-genesis-carthagenet.9.7/opam
+++ b/packages/tezos-embedded-protocol-genesis-carthagenet/tezos-embedded-protocol-genesis-carthagenet.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-genesis-carthagenet" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis_carthagenet (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.9.7/opam
+++ b/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-genesis" { = version }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (economic-protocol definition, embedded in `tezos-node`)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-endorser-008-PtEdo2Zk/tezos-endorser-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-endorser-008-PtEdo2Zk/tezos-endorser-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-008-PtEdo2Zk-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/bin_endorser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: endorser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-endorser-009-PsFLoren/tezos-endorser-009-PsFLoren.9.7/opam
+++ b/packages/tezos-endorser-009-PsFLoren/tezos-endorser-009-PsFLoren.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-009-PsFLoren-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/bin_endorser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: endorser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-endorser-010-PtGRANAD/tezos-endorser-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-endorser-010-PtGRANAD/tezos-endorser-010-PtGRANAD.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-baking-010-PtGRANAD-commands" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/bin_endorser/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: endorser binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-error-monad/tezos-error-monad.9.7/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-stdlib" { = version }
+  "data-encoding" { >= "0.3" & < "0.4" }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "tezos-lwt-result-stdlib" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_error_monad/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: error monad"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-event-logging/tezos-event-logging.9.7/opam
+++ b/packages/tezos-event-logging/tezos-event-logging.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "data-encoding" { >= "0.3" & < "0.4" }
+  "tezos-error-monad" { = version }
+  "lwt_log"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_event_logging/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos event logging library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-lwt-result-stdlib/tezos-lwt-result-stdlib.9.7/opam
+++ b/packages/tezos-lwt-result-stdlib/tezos-lwt-result-stdlib.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "ocaml" { >= "4.8.0" & < "4.12" }
+  "lwt" { >= "5.1.0" }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "crowbar" { with-test }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_lwt_result_stdlib/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: error-aware stdlib replacement"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-micheline/tezos-micheline.9.7/opam
+++ b/packages/tezos-micheline/tezos-micheline.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-error-monad" { = version }
+  "uutf"
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "ppx_inline_test"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_micheline/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: internal AST and parser for the Michelson language"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-mockup-commands/tezos-mockup-commands.9.7/opam
+++ b/packages/tezos-mockup-commands/tezos-mockup-commands.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-commands" { = version }
+  "tezos-mockup" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (commands)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-mockup-proxy/tezos-mockup-proxy.9.7/opam
+++ b/packages/tezos-mockup-proxy/tezos-mockup-proxy.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base" {= version}
+  "tezos-rpc-http-client" {= version}
+  "tezos-protocol-environment" {= version}
+  "tezos-shell-services" {= version}
+  "resto-cohttp-self-serving-client" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup_proxy/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: local RPCs"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-mockup-registration/tezos-mockup-registration.9.7/opam
+++ b/packages/tezos-mockup-registration/tezos-mockup-registration.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: protocol registration for the mockup mode"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-mockup/tezos-mockup.9.7/opam
+++ b/packages/tezos-mockup/tezos-mockup.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-p2p" { = version }
+  "tezos-mockup-proxy" { = version }
+  "tezos-mockup-registration" { = version }
+  "crowbar" { with-test }
+  "tezos-test-services" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_mockup/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (mockup mode)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-node/tezos-node.9.7/opam
+++ b/packages/tezos-node/tezos-node.9.7/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-rpc-http-server" { = version }
+  "tezos-validator" { = version }
+  "tezos-embedded-protocol-genesis-carthagenet" { = version }
+  "tezos-embedded-protocol-000-Ps9mPmXa" { = version }
+  "tezos-protocol-plugin-009-PsFLoren-registerer" { = version }
+  "tezos-protocol-plugin-010-PtGRANAD-registerer" { = version }
+  "cmdliner"
+  "tls" { >= "0.10" }
+]
+depopts: [
+  "tezos-embedded-protocol-001-PtCJ7pwo"
+  "tezos-embedded-protocol-002-PsYLVpVv"
+  "tezos-embedded-protocol-003-PsddFKi3"
+  "tezos-embedded-protocol-004-Pt24m4xi"
+  "tezos-embedded-protocol-005-PsBABY5H"
+  "tezos-embedded-protocol-005-PsBabyM1"
+  "tezos-embedded-protocol-006-PsCARTHA"
+  "tezos-embedded-protocol-007-PsDELPH1"
+  "tezos-protocol-plugin-007-PsDELPH1-registerer"
+  "tezos-embedded-protocol-008-PtEdoTez"
+  "tezos-embedded-protocol-008-PtEdo2Zk"
+  "tezos-protocol-plugin-008-PtEdo2Zk-registerer"
+  "tezos-embedded-protocol-demo-counter"
+  "tezos-embedded-protocol-alpha"
+  "tezos-protocol-plugin-alpha-registerer"
+  "tezos-embedded-protocol-demo-noops"
+  "tezos-embedded-protocol-genesis"
+]
+conflicts: [
+  "tezos-embedded-protocol-001-PtCJ7pwo" { != version }
+  "tezos-embedded-protocol-002-PsYLVpVv" { != version }
+  "tezos-embedded-protocol-003-PsddFKi3" { != version }
+  "tezos-embedded-protocol-004-Pt24m4xi" { != version }
+  "tezos-embedded-protocol-005-PsBABY5H" { != version }
+  "tezos-embedded-protocol-005-PsBabyM1" { != version }
+  "tezos-embedded-protocol-006-PsCARTHA" { != version }
+  "tezos-embedded-protocol-007-PsDELPH1" { != version }
+  "tezos-protocol-plugin-007-PsDELPH1-registerer" { != version }
+  "tezos-embedded-protocol-008-PtEdoTez" { != version }
+  "tezos-embedded-protocol-008-PtEdo2Zk" { != version }
+  "tezos-protocol-plugin-008-PtEdo2Zk-registerer" { != version }
+  "tezos-embedded-protocol-demo-counter" { != version }
+  "tezos-embedded-protocol-alpha" { != version }
+  "tezos-protocol-plugin-alpha-registerer" { != version }
+  "tezos-embedded-protocol-demo-noops" { != version }
+  "tezos-embedded-protocol-genesis" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_node/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-node` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-p2p-services/tezos-p2p-services.9.7/opam
+++ b/packages/tezos-p2p-services/tezos-p2p-services.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_p2p_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-p2p`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-p2p/tezos-p2p.9.7/opam
+++ b/packages/tezos-p2p/tezos-p2p.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-p2p-services" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "lwt-watcher" { = "0.1" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_p2p/%{name}%.install" "./"]
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  not deterministic... again
+]
+synopsis: "Tezos: library for a pool of P2P connections"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.9.7/opam
+++ b/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_000_Ps9mPmXa/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_000_Ps9mPmXa/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000_Ps9mPmXa (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.9.7/opam
+++ b/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_001_PtCJ7pwo/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_001_PtCJ7pwo/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.9.7/opam
+++ b/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_002_PsYLVpVv/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_002_PsYLVpVv/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.9.7/opam
+++ b/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_003_PsddFKi3/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_003_PsddFKi3/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, functor version)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.9.7/opam
+++ b/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_004_Pt24m4xi/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_004_Pt24m4xi/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.9.7/opam
+++ b/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_005_PsBABY5H/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBABY5H/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.9.7/opam
+++ b/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_005_PsBabyM1/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_005_PsBabyM1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-006-PsCARTHA-parameters/tezos-protocol-006-PsCARTHA-parameters.9.7/opam
+++ b/packages/tezos-protocol-006-PsCARTHA-parameters/tezos-protocol-006-PsCARTHA-parameters.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.9.7/opam
+++ b/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_006_PsCARTHA/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_006_PsCARTHA/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-007-PsDELPH1/tezos-protocol-007-PsDELPH1.9.7/opam
+++ b/packages/tezos-protocol-007-PsDELPH1/tezos-protocol-007-PsDELPH1.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_007_PsDELPH1/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-008-PtEdo2Zk-parameters/tezos-protocol-008-PtEdo2Zk-parameters.9.7/opam
+++ b/packages/tezos-protocol-008-PtEdo2Zk-parameters/tezos-protocol-008-PtEdo2Zk-parameters.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-008-PtEdo2Zk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-008-PtEdo2Zk/tezos-protocol-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-protocol-008-PtEdo2Zk/tezos-protocol-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_008_PtEdo2Zk/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-008-PtEdoTez/tezos-protocol-008-PtEdoTez.9.7/opam
+++ b/packages/tezos-protocol-008-PtEdoTez/tezos-protocol-008-PtEdoTez.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_008_PtEdoTez/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdoTez/lib_protocol/%{name}%.install" "./"]
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-009-PsFLoren-parameters/tezos-protocol-009-PsFLoren-parameters.9.7/opam
+++ b/packages/tezos-protocol-009-PsFLoren-parameters/tezos-protocol-009-PsFLoren-parameters.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-009-PsFLoren" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-009-PsFLoren/tezos-protocol-009-PsFLoren.9.7/opam
+++ b/packages/tezos-protocol-009-PsFLoren/tezos-protocol-009-PsFLoren.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_009_PsFLoren/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-010-PtGRANAD-parameters/tezos-protocol-010-PtGRANAD-parameters.9.7/opam
+++ b/packages/tezos-protocol-010-PtGRANAD-parameters/tezos-protocol-010-PtGRANAD-parameters.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-010-PtGRANAD" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-010-PtGRANAD/tezos-protocol-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-protocol-010-PtGRANAD/tezos-protocol-010-PtGRANAD.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_010_PtGRANAD/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-alpha-parameters/tezos-protocol-alpha-parameters.9.7/opam
+++ b/packages/tezos-protocol-alpha-parameters/tezos-protocol-alpha-parameters.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-alpha" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_parameters/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: parameters"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-alpha/tezos-protocol-alpha.9.7/opam
+++ b/packages/tezos-protocol-alpha/tezos-protocol-alpha.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_alpha/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-compiler/tezos-protocol-compiler.9.7/opam
+++ b/packages/tezos-protocol-compiler/tezos-protocol-compiler.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.10.2" & < "4.11" }
+  "dune" { >= "2.5" }
+  "tezos-protocol-environment" { = version }
+  "ocp-ocamlres" { >= "0.4" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_compiler/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol compiler"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.9.7/opam
+++ b/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_demo_counter/lib_protocol/dune.inc"
+  ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/proto_demo_counter/lib_protocol/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.9.7/opam
+++ b/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_demo_noops/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_demo_noops/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-environment-packer/tezos-protocol-environment-packer.9.7/opam
+++ b/packages/tezos-protocol-environment-packer/tezos-protocol-environment-packer.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "ocaml" { >= "4.03" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: sigs/structs packer for economic protocol environment"
+
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-environment-sigs/tezos-protocol-environment-sigs.9.7/opam
+++ b/packages/tezos-protocol-environment-sigs/tezos-protocol-environment-sigs.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "ocaml" { >= "4.8.0" }
+  "tezos-stdlib" { with-test & = version }
+  "tezos-protocol-environment-packer" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: restricted typing environment for the economic protocols"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-environment-structs/tezos-protocol-environment-structs.9.7/opam
+++ b/packages/tezos-protocol-environment-structs/tezos-protocol-environment-structs.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-crypto" { = version }
+  "tezos-protocol-environment-packer" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: restricted typing environment for the economic protocols"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-environment/tezos-protocol-environment.9.7/opam
+++ b/packages/tezos-protocol-environment/tezos-protocol-environment.9.7/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "zarith" { < "1.12"} # the signature of the [Z] module has changed in 1.12
+  "tezos-sapling" { = version }
+  "tezos-base" { = version }
+  "tezos-storage" { = version }
+  "tezos-protocol-environment-sigs" { = version }
+  "tezos-protocol-environment-structs" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "crowbar" { with-test }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: custom economic-protocols environment implementation for `tezos-client` and testing"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-genesis-carthagenet/tezos-protocol-genesis-carthagenet.9.7/opam
+++ b/packages/tezos-protocol-genesis-carthagenet/tezos-protocol-genesis-carthagenet.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_genesis_carthagenet/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis_carthagenet/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis_carthagenet economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-genesis/tezos-protocol-genesis.9.7/opam
+++ b/packages/tezos-protocol-genesis/tezos-protocol-genesis.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [
+    "sed" "-i.back" "-e" "s/-nostdlib//g"
+    "%{build}%/src/proto_genesis/lib_protocol/dune.inc"
+  ]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_genesis/lib_protocol/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis economic-protocol definition"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-007-PsDELPH1-registerer/tezos-protocol-plugin-007-PsDELPH1-registerer.9.7/opam
+++ b/packages/tezos-protocol-plugin-007-PsDELPH1-registerer/tezos-protocol-plugin-007-PsDELPH1-registerer.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-embedded-protocol-007-PsDELPH1" { = version }
+  "tezos-protocol-plugin-007-PsDELPH1" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-007-PsDELPH1/tezos-protocol-plugin-007-PsDELPH1.9.7/opam
+++ b/packages/tezos-protocol-plugin-007-PsDELPH1/tezos-protocol-plugin-007-PsDELPH1.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-007-PsDELPH1" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_007_PsDELPH1/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-008-PtEdo2Zk-registerer/tezos-protocol-plugin-008-PtEdo2Zk-registerer.9.7/opam
+++ b/packages/tezos-protocol-plugin-008-PtEdo2Zk-registerer/tezos-protocol-plugin-008-PtEdo2Zk-registerer.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-embedded-protocol-008-PtEdo2Zk" { = version }
+  "tezos-protocol-plugin-008-PtEdo2Zk" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-008-PtEdo2Zk/tezos-protocol-plugin-008-PtEdo2Zk.9.7/opam
+++ b/packages/tezos-protocol-plugin-008-PtEdo2Zk/tezos-protocol-plugin-008-PtEdo2Zk.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-008-PtEdo2Zk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_008_PtEdo2Zk/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-009-PsFLoren-registerer/tezos-protocol-plugin-009-PsFLoren-registerer.9.7/opam
+++ b/packages/tezos-protocol-plugin-009-PsFLoren-registerer/tezos-protocol-plugin-009-PsFLoren-registerer.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-embedded-protocol-009-PsFLoren" { = version }
+  "tezos-protocol-plugin-009-PsFLoren" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-009-PsFLoren/tezos-protocol-plugin-009-PsFLoren.9.7/opam
+++ b/packages/tezos-protocol-plugin-009-PsFLoren/tezos-protocol-plugin-009-PsFLoren.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-009-PsFLoren" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_009_PsFLoren/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-010-PtGRANAD-registerer/tezos-protocol-plugin-010-PtGRANAD-registerer.9.7/opam
+++ b/packages/tezos-protocol-plugin-010-PtGRANAD-registerer/tezos-protocol-plugin-010-PtGRANAD-registerer.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-embedded-protocol-010-PtGRANAD" { = version }
+  "tezos-protocol-plugin-010-PtGRANAD" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-010-PtGRANAD/tezos-protocol-plugin-010-PtGRANAD.9.7/opam
+++ b/packages/tezos-protocol-plugin-010-PtGRANAD/tezos-protocol-plugin-010-PtGRANAD.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-010-PtGRANAD" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_010_PtGRANAD/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-alpha-registerer/tezos-protocol-plugin-alpha-registerer.9.7/opam
+++ b/packages/tezos-protocol-plugin-alpha-registerer/tezos-protocol-plugin-alpha-registerer.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-embedded-protocol-alpha" { = version }
+  "tezos-protocol-plugin-alpha" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-plugin-alpha/tezos-protocol-plugin-alpha.9.7/opam
+++ b/packages/tezos-protocol-plugin-alpha/tezos-protocol-plugin-alpha.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-alpha" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/proto_alpha/lib_plugin/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-protocol-updater/tezos-protocol-updater.9.7/opam
+++ b/packages/tezos-protocol-updater/tezos-protocol-updater.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-compiler" { = version }
+  "tezos-shell-context" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_updater/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol dynamic loading for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-proxy/tezos-proxy.9.7/opam
+++ b/packages/tezos-proxy/tezos-proxy.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-mockup-proxy" {= version}
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "crowbar" { with-test }
+  "tezos-test-services" { with-test }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_proxy/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: proxy"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-requester/tezos-requester.9.7/opam
+++ b/packages/tezos-requester/tezos-requester.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+  "lwt-watcher"
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "tezos-test-services" { with-test & = version }
+]
+available: [ arch != "x86_32" & arch != "arm32" & arch != "ppc32" ]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_requester/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: generic resource fetching service"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.9.7/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "cohttp-lwt-unix" { >= "2.2.0" }
+  "tezos-rpc-http-client" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: unix implementation of the RPC client"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.9.7/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-rpc-http" { = version }
+  "resto-cohttp-client" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http client)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.9.7/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-rpc-http" { = version }
+  "resto-cohttp-server" { >= "0.6" & < "0.7" }
+  "resto-acl" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-rpc-http/tezos-rpc-http.9.7/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+  "resto-directory" { >= "0.6" & < "0.7" }
+  "resto-cohttp" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc_http/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server and client)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-rpc/tezos-rpc.9.7/opam
+++ b/packages/tezos-rpc/tezos-rpc.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-error-monad" { = version }
+  "resto" { >= "0.6" & < "0.7" }
+  "resto-directory" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_rpc/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (service and hierarchy descriptions)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-sapling/tezos-sapling.9.7/opam
+++ b/packages/tezos-sapling/tezos-sapling.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+authors: [ "Nomadic Labs <contact@nomadic-labs.com>" ]
+maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
+homepage: "https://gitlab.com/tezos/tezos"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "data-encoding" { >= "0.3" & < "0.4" }
+  "tezos-crypto" { = version }
+  "tezos-test-services" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-j" jobs "-p" name "@install" ]
+  ["mv" "src/lib_sapling/%{name}%.install" "./"]
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  requires the "zcash-params" files
+]
+synopsis: "OCaml library for the Sapling protocol, using librustzcash"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-shell-context/tezos-shell-context.9.7/opam
+++ b/packages/tezos-shell-context/tezos-shell-context.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_protocol_environment/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocols environment implementation for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-shell-services/tezos-shell-services.9.7/opam
+++ b/packages/tezos-shell-services/tezos-shell-services.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-workers" { = version }
+  "tezos-p2p-services" { = version }
+  "tezos-version" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_shell_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-shell`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-shell/tezos-shell.9.7/opam
+++ b/packages/tezos-shell/tezos-shell.9.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-p2p" { = version }
+  "tezos-validation" { = version }
+  "tezos-requester" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "crowbar" { with-test }
+  "tezos-test-services" { with-test & = version }
+  "tezos-embedded-protocol-demo-noops" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_shell/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: core of `tezos-node` (gossip, validation scheduling, mempool, ...)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-signer-backends/tezos-signer-backends.9.7/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.9.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-signer-services" { = version }
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+]
+depopts: [
+  "ledgerwallet-tezos"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_signer_backends/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: remote-signature backends for `tezos-client`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-signer-services/tezos-signer-services.9.7/opam
+++ b/packages/tezos-signer-services/tezos-signer-services.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_signer_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-signer`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-signer/tezos-signer.9.7/opam
+++ b/packages/tezos-signer/tezos-signer.9.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-client-base-unix" { = version }
+  "tezos-rpc-http-server" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/bin_signer/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `tezos-signer` binary"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.7/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.7/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "base-unix"
+  "dune" { >= "2.5" }
+  "tezos-event-logging" { = version }
+  "re" { >= "1.7.2" }
+  "ptime" { >= "0.8.4" }
+  "mtime" { >= "1.0.0" }
+  "conf-libev"
+  "ipaddr" { >= "4.0.0" }
+  "ezjsonm" { >= "1.1.0" }
+  "fmt" { >= "0.8.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library (unix-specific fragment)"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-stdlib/tezos-stdlib.9.7/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.7/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "ocaml" { >= "4.8.0" }
+  "hex"
+  "lwt" { >= "5.4.0" }
+  "zarith"
+  "ppx_inline_test"
+  "bigstring" { with-test }
+  "lwt_log" { with-test }
+  "alcotest" { with-test & >= "1.1.0" }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+  "crowbar" { with-test }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_stdlib/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-storage/tezos-storage.9.7/opam
+++ b/packages/tezos-storage/tezos-storage.9.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-lmdb" { = "7.4" }
+  "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7" }
+  "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7" }
+  "digestif" {>= "0.7.3"}
+  "tezos-shell-services" { = version }
+  "alcotest-lwt" { with-test & >= "1.1.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_storage/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: low-level key-value store for `tezos-node`"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-test-helpers/tezos-test-helpers.9.7/opam
+++ b/packages/tezos-test-helpers/tezos-test-helpers.9.7/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "ocaml" { >= "4.8.0" }
+  "qcheck-alcotest"
+  "alcotest"
+  "alcotest-lwt"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_test/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+]
+synopsis: "Tezos-agnostic test helpers"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-test-services/tezos-test-services.9.7/opam
+++ b/packages/tezos-test-services/tezos-test-services.9.7/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+  "alcotest-lwt" { >= "1.1.0" }
+  "tezos-stdlib-unix" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_test_services/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: Alcotest-based test services"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-validation/tezos-validation.9.7/opam
+++ b/packages/tezos-validation/tezos-validation.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-protocol-updater" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_validation/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for blocks validation"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-validator/tezos-validator.9.7/opam
+++ b/packages/tezos-validator/tezos-validator.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["mv" "src/bin_validation/%{name}%.install" "./"]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+synopsis: "Tezos: `tezos-validator` binary for external validation of blocks"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-version/tezos-version.9.7/opam
+++ b/packages/tezos-version/tezos-version.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_version/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: version information generated from Git"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos-workers/tezos-workers.9.7/opam
+++ b/packages/tezos-workers/tezos-workers.9.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "2.5" }
+  "tezos-base" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "src/lib_workers/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: worker library"
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v9.7/tezos-v9.7.tar.bz2"
+  checksum: [
+    "sha256=f7b20fc8052f36c362310bf8947803d1e4b3e62a820a6dff056af576f9e21fe2"
+    "sha512=d352bfe6cc4559f1b7d8a30c343c1fdfe921976f5bde21b20cd4ae20ca51ab65f091fc202e29295884e0931d22de36769e943d780eb68800516a5f2ae3587c06"
+  ]
+}

--- a/packages/tezos/tezos.9.7/opam
+++ b/packages/tezos/tezos.9.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "ledgerwallet-tezos"
+  "tezos-node" { = version }
+  "tezos-client" { = version }
+  "tezos-signer" { = version }
+  "tezos-accuser-009-PsFLoren" { = version }
+  "tezos-baker-009-PsFLoren" { = version }
+  "tezos-endorser-009-PsFLoren" { = version }
+  "tezos-accuser-010-PtGRANAD" { = version }
+  "tezos-baker-010-PtGRANAD" { = version }
+  "tezos-endorser-010-PtGRANAD" { = version }
+  "tezos-codec" { = version }
+
+  "tezos-embedded-protocol-001-PtCJ7pwo" { = version }
+  "tezos-embedded-protocol-002-PsYLVpVv" { = version }
+  "tezos-embedded-protocol-003-PsddFKi3" { = version }
+  "tezos-embedded-protocol-004-Pt24m4xi" { = version }
+  "tezos-embedded-protocol-005-PsBABY5H" { = version }
+  "tezos-embedded-protocol-005-PsBabyM1" { = version }
+  "tezos-embedded-protocol-006-PsCARTHA" { = version }
+  "tezos-embedded-protocol-007-PsDELPH1" { = version }
+  "tezos-embedded-protocol-008-PtEdoTez" { = version }
+  "tezos-embedded-protocol-008-PtEdo2Zk" { = version }
+
+  "tezos-client-001-PtCJ7pwo-commands" { = version }
+  "tezos-client-002-PsYLVpVv-commands" { = version }
+  "tezos-client-003-PsddFKi3-commands" { = version }
+  "tezos-client-004-Pt24m4xi-commands" { = version }
+  "tezos-client-005-PsBabyM1-commands" { = version }
+  "tezos-client-006-PsCARTHA-commands" { = version }
+  "tezos-client-007-PsDELPH1-commands-registration" { = version }
+  "tezos-client-008-PtEdo2Zk-commands-registration" { = version }
+]
+synopsis: "Tezos meta package installing all active binaries"


### PR DESCRIPTION
This a minor yet critical update of the octez distribution (packages are not renamed yet and still called `tezos` :-) ) that allows to run the tezos blockchain with its latest "economic protocol" smoothly.