### PR TITLE
Package ppx_cstubs.0.6.1.2

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.6.1.2/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.6.1.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "bigarray-compat"
+  "ctypes" {>= "0.13.0" & < "0.20"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.04.2" & < "4.14.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.6.1.2.tar.gz"
+  checksum: [
+    "md5=ac074618acdfed418dc576c384aea63c"
+    "sha512=ce12f36d63a9fbc9cfed85fa8b8d1ace9c3e4f97e617a5e6f0dadafdbcd436f499ba344c2caf40464ee0316818aaa0509ff6c29697a1339cfde9a525dfa8c81d"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.6.1.2`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.3