### PR TITLE
Problem with tezos-lmbd.7.4 checksum

### DIFF
--- a/packages/tezos-lmdb/tezos-lmdb.7.5/files/tezos-lmdb_under_freebsd.diff
+++ b/packages/tezos-lmdb/tezos-lmdb.7.5/files/tezos-lmdb_under_freebsd.diff
@@ -1,0 +1,13 @@
+diff --git a/vendors/ocaml-lmdb/config/discover.ml b/vendors/ocaml-lmdb/config/discover.ml
+index 1b0496ec98..52542cd24e 100644
+--- a/vendors/ocaml-lmdb/config/discover.ml
++++ b/vendors/ocaml-lmdb/config/discover.ml
+@@ -3,6 +3,7 @@ let () =
+   let w = "-W -Wall -Wno-unused-parameter -Wbad-function-cast -Wuninitialized" in
+   let thread = "-pthread" in
+   let opt = "-O2 -g" in
+-  Printf.fprintf oc "(%s %s %s %s)" w thread opt
++  let freebsd_stuff = "-I/usr/local/include -D_WANT_SEMUN" in
++  Printf.fprintf oc "(%s %s %s %s %s)" w thread opt freebsd_stuff
+     (if Sys.word_size = 32 then "-DMDB_VL32" else "") ;
+   close_out oc

--- a/packages/tezos-lmdb/tezos-lmdb.7.5/opam
+++ b/packages/tezos-lmdb/tezos-lmdb.7.5/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: "Vincent Bernardoff <vb@luminar.eu.org>"
+maintainer: "contact@tezos.com"
+license: "ISC"
+synopsis: "Legacy Tezos OCaml binding to LMDB (Consider ocaml-lmdb instead)"
+homepage: "https://gitlab.com/tezos/tezos"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+patches: [
+  "tezos-lmdb_under_freebsd.diff"
+]
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["mv" "vendors/ocaml-lmdb/%{name}%.install" "./"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "tezos-tooling" { with-test & = version }
+  "dune" {>= "1.11"}
+  "rresult" {>= "0.5.0"}
+  "cstruct" {with-test & >= "3.2.1"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+
+url {
+  src: "https://gitlab.com/tezos/tezos/-/archive/v7.5/tezos-v7.5.tar.bz2"
+  checksum: [
+    "sha256=34064994e9ce2c216cca7251de4f7a76cfef9f98740a30b563b17c924e3326a3"
+    "sha512=8b2e9786c2927a70d86f0f4a82d1afdb547ae0b3804e27837e51d54cc4eacb23d954297a53396df35f7ca7e58a0810919d1ba3618135e70028ef64eabce4806d"
+  ]
+}
+extra-files: [
+  [ "tezos-lmdb_under_freebsd.diff" "sha256=5d41a9453e0750bb9cd10094de4280b68b3c9b9bc5e922a7e8c4dba49e0f1929" ]
+]

--- a/packages/tezos-storage/tezos-storage.8.0/opam
+++ b/packages/tezos-storage/tezos-storage.8.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.2.0" & < "2.3"}
   "irmin-pack" { >= "2.1.0" & < "2.3"}
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.8.1/opam
+++ b/packages/tezos-storage/tezos-storage.8.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.2.0" & < "2.3.0" }
   "irmin-pack" { >= "2.1.0" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.8.2/opam
+++ b/packages/tezos-storage/tezos-storage.8.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.2.0" & < "2.3.0" }
   "irmin-pack" { >= "2.1.0" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.8.3/opam
+++ b/packages/tezos-storage/tezos-storage.8.3/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.2.0" & < "2.3.0" }
   "irmin-pack" { >= "2.1.0" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.9.0/opam
+++ b/packages/tezos-storage/tezos-storage.9.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.5.3" }
   "irmin-pack" { >= "2.5.3" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.9.1/opam
+++ b/packages/tezos-storage/tezos-storage.9.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.0" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
   "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.9.2/opam
+++ b/packages/tezos-storage/tezos-storage.9.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.5" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
   "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7.0" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.9.3/opam
+++ b/packages/tezos-storage/tezos-storage.9.3/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.5" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7" }
   "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.9.4/opam
+++ b/packages/tezos-storage/tezos-storage.9.4/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.5" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7" }
   "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7" }
   "digestif" {>= "0.7.3"}

--- a/packages/tezos-storage/tezos-storage.9.7/opam
+++ b/packages/tezos-storage/tezos-storage.9.7/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "2.5" }
-  "tezos-lmdb" { = "7.4" }
+  "tezos-lmdb" { = "7.5" }
   "irmin" { >= "2.5.4" & != "2.6.0" & < "2.7" }
   "irmin-pack" { >= "2.5.4" & != "2.6.0" & < "2.7" }
   "digestif" {>= "0.7.3"}


### PR DESCRIPTION
In between yesterday where we tested and merged tezos.9.7 and today, the sha*sum of the tarball generated by https://gitlab.com/tezos/tezos/-/archive/v7.4/tezos-v7.4.tar.bz2 has changed! In don't really understand this question of stability of the tarball generated by git* but I suspect that our mistake was to not declare on gitlab.com the tag v7.4 as a "release" in the gitlab interface... (I'm reluctant to do it now as it would be displyed on gitlab as a new release which it is not.) 

This MR deals with the emergency: allowing people to install the latest version of tezos. To enable that I packaged tezos-lmbd.7.5 (`v7.5` being a tag declared as a "release" on gitlab so hopefully the tarball will be more stable (tezos.7.5 were not packaged in opam because there are not changes in ocaml code in between 7.4 and 7.5...)) and I updated the reverse dependency to use this new version.

After that will come an other question: what do we do with all the now uninstallable all version of tezos packages because of `Bad checksum`? Do we remove them? Do we update the checksum but it looks like a never ending jobs? ....