### PR TITLE
Package ppx_cstubs.0.5.0.2

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.5.0.2/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.5.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "bigarray-compat"
+  "ctypes" {>= "0.13.0" & < "0.20"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3" & < "4.14.0"}
+  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.4.0"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: """
+Preprocessor for easier stub generation with ctypes
+"""
+
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.5.0.2.tar.gz"
+  checksum: [
+    "md5=9121c74ea6598e8e0d77943e99b4cf60"
+    "sha512=2ec6863e5cff3a7d200afc987abd5b15d40d45f33ca8b06e7a6094518232401d0eb9ab3ac537952d030e42cbdb7dac494c69c6398da16d2dbcf0c08222e36fd8"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.5.0.2`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.3