### PR TITLE
[new release] http-cookie (3.1.0)

### DIFF
--- a/packages/http-cookie/http-cookie.3.1.0/opam
+++ b/packages/http-cookie/http-cookie.3.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "HTTP cookie library for OCaml"
+description: "OCaml library to manipulate HTTP cookie. Adheres to RFC 6265."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/http-cookie"
+bug-reports: "https://github.com/lemaetech/http-cookie/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-cookie/releases/download/v3.1.0/http-cookie-v3.1.0.tbz"
+  checksum: [
+    "sha256=bd3fe88bf73482c9f0c4be2a69977675d615cda856f2dc5498cd94ce27277aa5"
+    "sha512=2f16c29ed6d870114a54f3ad2f4d470a593dfd645f8d89a0db93ed524a2fe341025065ff00217afb3e5035f6d79a2c35bf9c5618d2404f1dcd0aaffcc718164a"
+  ]
+}
+x-commit-hash: "01578e05f239c2463f0f0bb9dc4beb6a18c528c7"


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- Add `update_*` functions.
