### PR TITLE
Package cps_toolbox.0.2

### DIFF
--- a/packages/cps_toolbox/cps_toolbox.0.2/opam
+++ b/packages/cps_toolbox/cps_toolbox.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A partial OCaml standard library replacement written with continuation passing style in mind"
+maintainer: "Soren Norbaek <sorennorbaek@gmail.com>"
+authors: "Soren Norbaek <sorennorbaek@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/soren-n/cps-toolbox"
+bug-reports: "https://github.com/soren-n/cps-toolbox/issues"
+dev-repo: "git+https://github.com/soren-n/cps-toolbox.git"
+build: [
+  "dune" "build" "-p" name "-j" jobs "@install"
+  "@runtest" {with-test}
+]
+depends: [
+  "dune" {>= "2.8"}
+  "qcheck" {>= "0.17"}
+]
+url {
+  src: "https://github.com/soren-n/cps-toolbox/archive/0.2.tar.gz"
+  checksum: [
+    "md5=7b822f75e2e8412647fc666798d710d4"
+    "sha512=48d306dbbbda359c60a6f09f9254114aa0736961216089dba19ae607bf917db41e9a1fdff54fa50b558b6349911ef5359c7d83a7db64f442a3d277a395888745"
+  ]
+}

--- a/packages/cps_toolbox/cps_toolbox.0.2/opam
+++ b/packages/cps_toolbox/cps_toolbox.0.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "dune" {>= "2.8"}
-  "qcheck" {>= "0.17"}
+  "qcheck" {with-test & >= "0.17"}
 ]
 url {
   src: "https://github.com/soren-n/cps-toolbox/archive/0.2.tar.gz"


### PR DESCRIPTION
### `cps_toolbox.0.2`
A partial OCaml standard library replacement written with continuation passing style in mind



---
* Homepage: https://github.com/soren-n/cps-toolbox
* Source repo: git+https://github.com/soren-n/cps-toolbox.git
* Bug tracker: https://github.com/soren-n/cps-toolbox/issues

---
:camel: Pull-request generated by opam-publish v2.1.0