### PR TITLE
gsl.1.24.3: Disable parallel build (race condition)

### DIFF
--- a/packages/gsl/gsl.1.24.3/opam
+++ b/packages/gsl/gsl.1.24.3/opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "build" "-p" name "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" "1"] # Parallel build disabled due to race-condition
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test}
+  ["dune" "build" "-p" name "@doc" "-j" "1"] {with-doc}
 ]
 maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
 authors: [


### PR DESCRIPTION
```
#=== ERROR while compiling gsl.1.24.3 =========================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/gsl.1.24.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gsl -j 31
# exit-code            1
# env-file             ~/.opam/log/gsl-20-4b94c6.env
# output-file          ~/.opam/log/gsl-20-4b94c6.out
### output ###
#        do_sf src/sf.{ml,mli} (exit 2)
# (cd _build/default/src && config/do_sf.exe)
# Fatal error: exception Sys_error("gsl_include.sexp: No such file or directory")

-        do_sf src/sf.{ml,mli} (exit 2)
- (cd _build/default/src && config/do_sf.exe)
- Fatal error: exception Sys_error("gsl_include.sexp: No such file or directory")
```
cc @mmottl 