### PR TITLE
iso639: Disable tests (non-deterministic due to uninitialized bytes)

### DIFF
--- a/packages/iso639/iso639.0.0.4/opam
+++ b/packages/iso639/iso639.0.0.4/opam
@@ -11,7 +11,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test} # Non-deterministic (uninitialized bytes)
 ]
 dev-repo: "git+https://github.com/paurkedal/ocaml-iso639.git"
 synopsis: "Language Codes for OCaml"

--- a/packages/iso639/iso639.0.0.4/opam
+++ b/packages/iso639/iso639.0.0.4/opam
@@ -7,7 +7,7 @@ doc: "http://paurkedal.github.io/ocaml-iso639/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-iso639/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune"
+  "dune" {>= "1.1"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
```
#=== ERROR while compiling iso639.0.0.4 =======================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0/.opam-switch/build/iso639.0.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p iso639 -j 31
# exit-code            1
# env-file             ~/.opam/log/iso639-1796-5b354b.env
# output-file          ~/.opam/log/iso639-1796-5b354b.out
### output ###
#  test_iso639 alias tests/runtest (exit 2)
# (cd _build/default/tests && ./test_iso639.exe)
# Fatal error: exception Assert_failure("tests/test_iso639.ml", 56, 10)
```
cc @paurkedal 