### PR TITLE
Correct conf-postgresql for EL 8.

### DIFF
--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -9,12 +9,15 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 
 depexts: [
   ["libpq-dev"] {os-family = "debian"}
+  ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
+  ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
+  ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
   ["postgresql96-client"] {os-distribution = "freebsd"}
   ["postgresql96-client"] {os-distribution = "openbsd"}
-  ["postgresql-devel"] {os-distribution = "centos"}
-  ["postgresql-devel"] {os-distribution = "rhel"}
+  ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
+  ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "fedora"}
-  ["postgresql-devel"] {os-distribution = "ol"}
+  ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
   ["postgresql-server-devel"] {os-family = "suse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-libs"] {os-family = "arch"}

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -12,12 +12,13 @@ depexts: [
   ["libpq-devel"] {os-distribution = "centos" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "rhel" & os-version >= "8"}
   ["libpq-devel"] {os-distribution = "ol" & os-version >= "8"}
+  ["libpq-devel"] {os-distribution = "fedora" & os-version >= "30"}
   ["postgresql96-client"] {os-distribution = "freebsd"}
   ["postgresql96-client"] {os-distribution = "openbsd"}
   ["postgresql-devel"] {os-distribution = "centos" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "rhel" & os-version < "8"}
-  ["postgresql-devel"] {os-distribution = "fedora"}
   ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
+  ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
   ["postgresql-server-devel"] {os-family = "suse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
   ["postgresql-libs"] {os-family = "arch"}


### PR DESCRIPTION
On CentOS 8, the PostgreSQL client library package is called libpq-devel. I presume the same is the case for RHEL and for the distribution with the identifier "os", which seems to be in the family judging from other conf-* packages.