### PR TITLE
Package soupault.3.1.0

### DIFF
--- a/packages/soupault/soupault.3.1.0/opam
+++ b/packages/soupault/soupault.3.1.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
+* Export extracted metadata to JSON.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.app"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.2"}
+  "markup" {>= "1.0.0-1"}
+  "otoml"
+  "fileutils"
+  "logs"
+  "fmt"
+  "re"
+  "ezjsonm"
+  "yaml" {>= "2.0.0"}
+  "containers" {>= "3.4"}
+  "odate"
+  "spelll" {>= "0.3"}
+  "base64" {>= "3.0.0"}
+  "jingoo" {>= "1.4.2"}
+  "tsort" {>= "2.1.0"}
+  "lua-ml" {>= "0.9.2"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/refs/tags/3.1.0.tar.gz"
+  checksum: [
+    "md5=ce0f0cb9557c3f229c3913797b961bc1"
+    "sha512=a8aa4c7d1da2a117ca38075a38735b3d09c142f331fd71322e6a11d789681d114267316aa5dc45f5ecab98eb2e57c4f6f9a75ae65afca55967561e64de929b7d"
+  ]
+}


### PR DESCRIPTION
### `soupault.3.1.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

With soupault you can:

* Generate ToC and footnotes.
* Insert file content or an HTML snippet in any element.
* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
* Export extracted metadata to JSON.

Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
similar to web browsers.

The website generator mode is optional, you can use it as post-processor for existing sites.



---
* Homepage: https://www.soupault.app
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.1.0