### PR TITLE
[new release] um-abt (0.1.0)

### DIFF
--- a/packages/um-abt/um-abt.0.1.0/opam
+++ b/packages/um-abt/um-abt.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "An OCaml library implementing abstract binding trees (ABTs)"
+description: """
+An ABT library consistent with the interface defined in Robert Harper's
+   'Practical Foundations for Programming Languages', using immutable
+   pointers to for varibale binding."""
+maintainer: ["shon.feder@gmail.com"]
+authors: ["Shon Feder"]
+license: "MIT"
+homepage: "https://github.com/shonfeder/um-abt"
+doc: "https://shonfeder.github.io/um-abt"
+bug-reports: "https://github.com/shonfeder/um-abt/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_deriving" {>= "5.2.1"}
+  "qcheck" {with-test & >= "0.17"}
+  "mdx" {>= "1.10.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/shonfeder/um-abt.git"
+x-commit-hash: "94ec569d41872f3b15fa300605cd4d2e12309176"
+url {
+  src:
+    "https://github.com/shonfeder/um-abt/releases/download/v0.1.0/um-abt-v0.1.0.tbz"
+  checksum: [
+    "sha256=658725f8c53f38230877405de7684ff1d892b989ce6a96cbe733a2c957767349"
+    "sha512=817b7b13713e5eb2d5f4d845ce769623f06b0a80c90d948c5ad630192833fdef9334cbcffab12299d3c63fc3ab5fe0d33075039c1a73ff9a52de774aa655bd30"
+  ]
+}


### PR DESCRIPTION
An OCaml library implementing abstract binding trees (ABTs)

- Project page: <a href="https://github.com/shonfeder/um-abt">https://github.com/shonfeder/um-abt</a>
- Documentation: <a href="https://shonfeder.github.io/um-abt">https://shonfeder.github.io/um-abt</a>

##### CHANGES:

- Initial release
