### PR TITLE
[new release] um-abt (0.1.1)

### DIFF
--- a/packages/um-abt/um-abt.0.1.1/opam
+++ b/packages/um-abt/um-abt.0.1.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "An OCaml library implementing unifiable abstract binding trees (UABTs)"
+description: """
+um-abt provides an abstract binding tree (ABT) library following the
+   principles of Robert Harper's 'Practical Foundations for Programming
+   Languages'.
+
+   The library uses immutable pointers to represent variable binding and extends
+   ABTs with unification, providing unifiable abstract binding trees (UABTs)."""
+maintainer: ["shon.feder@gmail.com"]
+authors: ["Shon Feder"]
+license: "MIT"
+homepage: "https://github.com/shonfeder/um-abt"
+doc: "https://shonfeder.github.io/um-abt"
+bug-reports: "https://github.com/shonfeder/um-abt/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_deriving" {>= "5.2.1"}
+  "logs-ppx" {>= "0.2.0"}
+  "qcheck" {with-test & >= "0.17"}
+  "bos" {with-test & >= "0.2.0"}
+  "mdx" {with-test & >= "1.10.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/shonfeder/um-abt.git"
+url {
+  src:
+    "https://github.com/shonfeder/um-abt/releases/download/v0.1.1/um-abt-v0.1.1.tbz"
+  checksum: [
+    "sha256=6f5f2be15c6e6fd1ceed1c990e4db263ae0a26598c82fa59cb1e9ca71094c4a0"
+    "sha512=03b1c0ad45cfcb3cb6769c7adf4b3efa0e4bd874bcc40f99805d2bfcad2a9713789dc1e1e152012903c4f760f152a1a8d1ea84323d6221a2fc90f31f53c1e4a4"
+  ]
+}
+x-commit-hash: "e3d4b1f9267aec1a33e5881d9d276ebb2bf18099"


### PR DESCRIPTION
An OCaml library implementing unifiable abstract binding trees (UABTs)

- Project page: <a href="https://github.com/shonfeder/um-abt">https://github.com/shonfeder/um-abt</a>
- Documentation: <a href="https://shonfeder.github.io/um-abt">https://shonfeder.github.io/um-abt</a>

##### CHANGES:

- Fix binding constructor bug
- Fix build failure
- Fix missing dependencies
