### PR TITLE
[new release] um-abt (0.1.2)

### DIFF
--- a/packages/um-abt/um-abt.0.1.2/opam
+++ b/packages/um-abt/um-abt.0.1.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "An OCaml library implementing unifiable abstract binding trees (UABTs)"
+description: """
+um-abt provides an abstract binding tree (ABT) library following the
+   principles of Robert Harper's 'Practical Foundations for Programming
+   Languages'.
+
+   The library uses immutable pointers to represent variable binding and extends
+   ABTs with unification, providing unifiable abstract binding trees (UABTs)."""
+maintainer: ["shon.feder@gmail.com"]
+authors: ["Shon Feder"]
+license: "MIT"
+homepage: "https://github.com/shonfeder/um-abt"
+doc: "https://shonfeder.github.io/um-abt"
+bug-reports: "https://github.com/shonfeder/um-abt/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_deriving" {>= "5.2.1"}
+  "logs" {>= "0.7.0"}
+  "logs-ppx" {>= "0.2.0"}
+  "qcheck" {with-test & >= "0.17"}
+  "bos" {with-test & >= "0.2.0"}
+  "mdx" {with-test & >= "1.10.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/shonfeder/um-abt.git"
+url {
+  src:
+    "https://github.com/shonfeder/um-abt/releases/download/v0.1.2/um-abt-v0.1.2.tbz"
+  checksum: [
+    "sha256=ab7be56b4191cfc0ff751a78a9a35c738c6fa9e32257bca2d2a48bb8fa567187"
+    "sha512=5bfd3e66817a21f90d0b910cb923f3e1ba52e71cb30601b78371a52b11d70e4662e00ce10aab3281a2e95cd917d074656651c2188d0900e2c3aa79cc163e5324"
+  ]
+}
+x-commit-hash: "8d243f307a2ae363d162c32745422f5904e64376"


### PR DESCRIPTION
An OCaml library implementing unifiable abstract binding trees (UABTs)

- Project page: <a href="https://github.com/shonfeder/um-abt">https://github.com/shonfeder/um-abt</a>
- Documentation: <a href="https://shonfeder.github.io/um-abt">https://shonfeder.github.io/um-abt</a>

##### CHANGES:

- Fix missing logs dependency
- Fix documentation of `=.=` operator
