### PR TITLE
[new release] um-abt (0.1.3)

### DIFF
--- a/packages/um-abt/um-abt.0.1.3/opam
+++ b/packages/um-abt/um-abt.0.1.3/opam
@@ -26,6 +26,9 @@ depends: [
   "mdx" {with-test & >= "1.10.1"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/um-abt/um-abt.0.1.3/opam
+++ b/packages/um-abt/um-abt.0.1.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis:
+  "An OCaml library implementing unifiable abstract binding trees (UABTs)"
+description: """
+um-abt provides an abstract binding tree (ABT) library following the
+   principles of Robert Harper's 'Practical Foundations for Programming
+   Languages'.
+
+   The library uses immutable pointers to represent variable binding and extends
+   ABTs with unification, providing unifiable abstract binding trees (UABTs)."""
+maintainer: ["shon.feder@gmail.com"]
+authors: ["Shon Feder"]
+license: "MIT"
+homepage: "https://github.com/shonfeder/um-abt"
+doc: "https://shonfeder.github.io/um-abt"
+bug-reports: "https://github.com/shonfeder/um-abt/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_deriving" {>= "5.2.1"}
+  "logs" {>= "0.7.0"}
+  "logs-ppx" {>= "0.2.0"}
+  "qcheck" {with-test & >= "0.17"}
+  "bos" {with-test & >= "0.2.0"}
+  "mdx" {with-test & >= "1.10.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/shonfeder/um-abt.git"
+url {
+  src:
+    "https://github.com/shonfeder/um-abt/releases/download/v0.1.3/um-abt-v0.1.3.tbz"
+  checksum: [
+    "sha256=454f85bde8c196e2ea7abd05a593155c3fea3de4c456d6142a56b161e8726b49"
+    "sha512=cbb2425262c392b760f270174fedbadc86af2a9af5cecf95ec02a7bcca36921dda163a0407f32b5ce6eb6843364a187698af8e642d5e2cfaf87ae3086f4b211d"
+  ]
+}
+x-commit-hash: "18284ee993b19127e3f41d9509097f8d1e128a5e"


### PR DESCRIPTION
An OCaml library implementing unifiable abstract binding trees (UABTs)

- Project page: <a href="https://github.com/shonfeder/um-abt">https://github.com/shonfeder/um-abt</a>
- Documentation: <a href="https://shonfeder.github.io/um-abt">https://shonfeder.github.io/um-abt</a>

##### CHANGES:

- Put lower bound of 4.08.0 on ocaml compiler
