### PR TITLE
Add missing spawn.v0.14.0 (jst's v prefix was missing and thus wasn't taken as latest version)

### DIFF
--- a/packages/spawn/spawn.v0.14.0/opam
+++ b/packages/spawn/spawn.v0.14.0/opam
@@ -29,9 +29,6 @@ depends: [
   "ppx_expect" {with-test}
   "ocaml" {>= "4.02.3"}
 ]
-# TODO: Uncomment (should be something similar) when opam 2.2.0 (hopefully) is around
-# See https://github.com/ocaml/opam/wiki/Spec-for-Extended-package-specific-variables
-# available: opam-version < "2.2" | _:manual
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/pull/18474#issuecomment-899417259