### PR TITLE
Add the torch 0.13 package for PyTorch 1.9.

### DIFF
--- a/packages/torch/torch.0.13/opam
+++ b/packages/torch/torch.0.13/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+bug-reports:  "https://github.com/LaurentMazare/ocaml-torch/issues"
+homepage:     "https://github.com/LaurentMazare/ocaml-torch"
+dev-repo:     "git+https://github.com/LaurentMazare/ocaml-torch.git"
+license:      "Apache-2.0"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "base" {>= "v0.11.0" & < "v0.15"}
+  "cmdliner"
+  "ctypes" {>= "0.5"}
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "dune-configurator"
+  "libtorch" {>= "1.9.0" & < "1.10.0"}
+  "npy"
+  "ocaml" {>= "4.08"}
+  "ocaml-compiler-libs"
+  "ppx_custom_printf" {< "v0.15"}
+  "ppx_expect" {< "v0.15"}
+  "ppx_sexp_conv" {< "v0.15"}
+  "sexplib" {< "v0.15"}
+  "stdio" {< "v0.15"}
+]
+
+available: arch = "x86_64" & (os = "linux" | os = "macos")
+x-ci-accept-failures: [
+  "centos-7" # Requires gcc with -std=c++14
+  "oraclelinux-7" # Requires gcc with -std=c++14
+]
+
+synopsis: "PyTorch bindings for OCaml"
+description: """
+The ocaml-torch project provides some OCaml bindings for the PyTorch library.
+This brings to OCaml NumPy-like tensor computations with GPU acceleration and
+tape-based automatic differentiation.
+"""
+
+url {
+  src: "https://github.com/LaurentMazare/ocaml-torch/archive/0.13.tar.gz"
+  checksum: [
+    "md5=52a70206107b74898c412457132ea7dc"
+    "sha512=2209847a54308144ca255b4b2dbddf64f300b9dad4cd717b6d2db6a6839cad992ef604fe85bf495f772e587656a2b32d1acd002e1cfc9a259927edef0e3b85ae"
+  ]
+}


### PR DESCRIPTION
Now that the libtorch packages have been updated for PyTorch 1.9, update the torch package to use these.