### PR TITLE
[new release] http-cookie (4.0.0)

### DIFF
--- a/packages/http-cookie/http-cookie.4.0.0/opam
+++ b/packages/http-cookie/http-cookie.4.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "HTTP cookie library for OCaml"
+description: "OCaml library to manipulate HTTP cookie. Adheres to RFC 6265."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/http-cookie"
+bug-reports: "https://github.com/lemaetech/http-cookie/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.10.0"}
+  "fmt" {>= "0.8.9"}
+  "angstrom" {>= "0.15.0"}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst" "--root" "."] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files"
+    "false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-cookie/releases/download/v4.0.0/http-cookie-v4.0.0.tbz"
+  checksum: [
+    "sha256=4c02689804446e1240de8eb3fe9344ca256aab5aa7143516c086553006b6c6d6"
+    "sha512=0a9f26e2ed68c9d3596212ad091d98cefb0c41292dc1dd7e27cb6e3da5994e420f3ccbf528ee07c4cc42d220d942c9ffaa70dd9d213ec8cf94241315b2d821bc"
+  ]
+}
+x-commit-hash: "d69e4c4cffe44f852cbfd93ae48da7fed17d2c60"

--- a/packages/http-cookie/http-cookie.4.0.0/opam
+++ b/packages/http-cookie/http-cookie.4.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst" "--root" "."] {dev}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- [BREAKING-CHANGE] remove module `Same_site`. Use `same_site` type instead.
- [New] introduce type `same_site` to replace `Same_site` module and to better conform to RFC 6265.
- [New] add `of_cookie` features an angstrom parser to parse 'Cookie' header value as specified by RFC 6265.
- [New] add `pp`, `pp_date_time` and `pp_same_site` pretty prints type `t`, `date_time` and `same_site` respectively. Useful for debugging pruposes.
- [New] add `date_time` function to create valid `date_time` value.
- [BREAKING-CHANGE] make `date_time` type abstract
- [BREAKING-CHANGE] `to_set_cookie_header_value` has been removed. Use `to_set_cookie` instead.
- [BREAKING-CHANGE] `to_cookie_header_value` has been removed. Use `to_cookie` instead.
- [BREAKING-CHANGE] `of_cookie_header` has been removed, Use`of_cookie` instead.
- [BREAKING-CHANGE] remove `Cookie` exception. The library is now exception less, i.e. uses `result` type to denote error scenarios.
- [New] add `of_set_cookie` to parse HTTP `Set-Cookie` header
- Add expect tests
