### PR TITLE
[new release] routes (1.0.0)

### DIFF
--- a/packages/routes/routes.1.0.0/opam
+++ b/packages/routes/routes.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Typed routing for OCaml applications"
+description:
+  "routes provides combinators for adding typed routing to OCaml applications. The core library will be independent of any particular web framework or runtime. It does path based dispatch from a target url to a user provided handler."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "BSD-3-clause"
+tags: ["router" "http"]
+homepage: "https://github.com/anuragsoni/routes"
+doc: "https://anuragsoni.github.io/routes/"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.05.0"}
+  "alcotest" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/1.0.0/routes-1.0.0.tbz"
+  checksum: [
+    "sha256=5929404834c0d545fe3615b7f3f5ee2e43a47708c8c73d0e5245fa35dda244e8"
+    "sha512=3e7afe9d01822e8c5c3c77b2f7ea989a2bc7ee7f8b55c1401d81950d7a245c7486279c5a6f6584a79254ce839fb361b402774941a9d4558fff2f11af75d4f339"
+  ]
+}
+x-commit-hash: "b9bb8a0f50b7bd9fbd0c79113142ea82830ce2bb"


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* First major release. No changes from 0.9.1

##### Changes since last release

* Add a labelled function to create custom patterns
* Add support for union operation for two routers (@Chattered)
* Use dune language 2.0
* Support wildcard pattern at the end of a route (@Lupus)
* Add map and path prefix to route targets (@Chattered)
* Make ksprintf visible in the public api (@Chattered)
