### PR TITLE
Add capnproto-devel to centos, fedora and suse

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["capnproto" "capnproto-devel" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}
   ["capnproto" "capnproto-devel"] {os-distribution = "fedora"}
+  ["capnproto" "capnproto-devel"] {os-distribution = "ol"}
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}

--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -18,12 +18,15 @@ depexts: [
   ["capnproto" "capnproto-devel" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}
   ["capnproto" "capnproto-devel"] {os-distribution = "fedora"}
-  ["capnproto" "capnproto-devel"] {os-distribution = "ol"}
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
   ["capnproto" "libcapnp-devel"] {os-family = "suse"}
   ["capnproto"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # Does not have capnproto
+  "oraclelinux-8" # Does not have capnproto
 ]
 synopsis: "Virtual package relying on captnproto installation"
 flags: conf

--- a/packages/conf-capnproto/conf-capnproto.1/opam
+++ b/packages/conf-capnproto/conf-capnproto.1/opam
@@ -15,13 +15,13 @@ build: [
 depexts: [
   ["capnproto-dev@edgecommunity"] {os-distribution = "alpine"}
   ["capnproto"] {os-distribution = "arch"}
-  ["capnproto" "epel-release"] {os-distribution = "centos"}
+  ["capnproto" "capnproto-devel" "epel-release"] {os-distribution = "centos"}
   ["capnproto" "libcapnp-dev"] {os-family = "debian"}
-  ["capnproto"] {os-distribution = "fedora"}
+  ["capnproto" "capnproto-devel"] {os-distribution = "fedora"}
   ["capnproto"] {os-distribution = "gentoo"}
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
-  ["capnproto"] {os-family = "suse"}
+  ["capnproto" "libcapnp-devel"] {os-family = "suse"}
   ["capnproto"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on captnproto installation"


### PR DESCRIPTION
Debian already had libcapnp-dev so presumably the dev files should be provided on all platforms.

I'm hoping this will fix the `Import failed: /capnp/c++.capnp` errors at https://ci.ocamllabs.io/github/capnproto/capnp-ocaml/commit/dda3d811aa7734110d7af051465011f1f823ffb9.