### PR TITLE
2 packages from LexiFi/landmarks at 1.4

### DIFF
--- a/packages/landmarks-ppx/landmarks-ppx.1.4/opam
+++ b/packages/landmarks-ppx/landmarks-ppx.1.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Preprocessor instrumenting code using the landmarks library"
+description: """
+Automatically or semi-automatically instrument your code using
+landmarks library."""
+maintainer: ["Marc Lasson <marc.lasson@lexifi.com>"]
+authors: ["Marc Lasson <marc.lasson@lexifi.com>"]
+license: "MIT"
+homepage: "https://github.com/LexiFi/landmarks"
+bug-reports: "https://github.com/LexiFi/landmarks/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.22"}
+  "landmarks" {= "1.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LexiFi/landmarks.git"
+url {
+  src: "https://github.com/LexiFi/landmarks/archive/v1.4.tar.gz"
+  checksum: [
+    "md5=2ed3e4fd7ee14c195035dedfb730829f"
+    "sha512=5d3ea9ed9519745f153d6cc7700b4e97747bbd285961f4fa964d62e3fc36e9bc63c7f5789df252e9faa05d4bf8ddcec4bdc9898b2381b607d716e1354d156c42"
+  ]
+}

--- a/packages/landmarks/landmarks.1.4/opam
+++ b/packages/landmarks/landmarks.1.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A simple profiling library"
+description: """
+Landmarks is a simple profiling library for OCaml. It provides
+primitives to measure time spent in portion of instrumented code. The
+instrumentation of the code may either done by hand, automatically or
+semi-automatically using the ppx pepreprocessor (see landmarks-ppx package).
+"""
+maintainer: ["Marc Lasson <marc.lasson@lexifi.com>"]
+authors: ["Marc Lasson <marc.lasson@lexifi.com>"]
+license: "MIT"
+homepage: "https://github.com/LexiFi/landmarks"
+bug-reports: "https://github.com/LexiFi/landmarks/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LexiFi/landmarks.git"
+available: arch = "x86_64" | arch = "x86_32"
+url {
+  src: "https://github.com/LexiFi/landmarks/archive/v1.4.tar.gz"
+  checksum: [
+    "md5=2ed3e4fd7ee14c195035dedfb730829f"
+    "sha512=5d3ea9ed9519745f153d6cc7700b4e97747bbd285961f4fa964d62e3fc36e9bc63c7f5789df252e9faa05d4bf8ddcec4bdc9898b2381b607d716e1354d156c42"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`landmarks.1.4`: A simple profiling library
-`landmarks-ppx.1.4`: Preprocessor instrumenting code using the landmarks library



---
* Homepage: https://github.com/LexiFi/landmarks
* Source repo: git+https://github.com/LexiFi/landmarks.git
* Bug tracker: https://github.com/LexiFi/landmarks/issues

---
:camel: Pull-request generated by opam-publish v2.0.3