### PR TITLE
[conf-zmq] Conforms to macOS M1 with Homebrew

### DIFF
--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -6,10 +6,12 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.0-or-later"
 build: [
   ["cc" "test.c" 
-    "-I/usr/local/include" {os-distribution != "macports"}
-    "-L/usr/local/lib" {os-distribution != "macports"}
     "-I/opt/local/include" {os-distribution = "macports"}
     "-L/opt/local/lib" {os-distribution = "macports"}
+    "-I/opt/homebrew/include" {os-distribution = "homebrew" & arch = "arm64"}
+    "-L/opt/homebrew/lib" {os-distribution = "homebrew" & arch = "arm64"}
+    "-I/usr/local/include" {os-distribution != "macports" & (os-distribution != "homebrew" | arch != "arm64") }
+    "-L/usr/local/lib" {os-distribution != "macports" & (os-distribution != "homebrew" | arch != "arm64") }
     "-lzmq"]
 ]
 depexts: [

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -5,14 +5,7 @@ homepage: "http://zeromq.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.0-or-later"
 build: [
-  ["cc" "test.c" 
-    "-I/opt/local/include" {os-distribution = "macports"}
-    "-L/opt/local/lib" {os-distribution = "macports"}
-    "-I/opt/homebrew/include" {os-distribution = "homebrew" & arch = "arm64"}
-    "-L/opt/homebrew/lib" {os-distribution = "homebrew" & arch = "arm64"}
-    "-I/usr/local/include" {os-distribution != "macports" & (os-distribution != "homebrew" | arch != "arm64") }
-    "-L/usr/local/lib" {os-distribution != "macports" & (os-distribution != "homebrew" | arch != "arm64") }
-    "-lzmq"]
+  ["sh" "-c" "cc test.c $(pkg-config --libs --cflags libzmq)"]
 ]
 depexts: [
   ["libzmq3-dev"] {os-family = "debian"}


### PR DESCRIPTION
Disclaimer : I didn't find any special issue tracker for conf-zmq.

On macOS+M1, Homebrew installs to `/opt/homebrew`.
This fix is a _proposal_ to keep previous behaviors except for this target.
A fix for zmq package is probably also needed.