### PR TITLE
4 packages from sneeuwballen/zipperposition at 2.1

### DIFF
--- a/packages/libzipperposition/libzipperposition.2.1/opam
+++ b/packages/libzipperposition/libzipperposition.2.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2.17@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+license: "BSD-2-Clause"
+synopsis: "Library for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  "logtk" { = version }
+  "containers" { >= "3.1" & < "4.0" }
+  "containers-data" { >= "3.1" & < "4.0" }
+  "iter" { >= "1.2" }
+  "oseq"
+  "dune" { >= "1.11" }
+  "msat" { >= "0.8.1" < "0.10" }
+  "menhir" {build}
+  "logtk" { = version }
+  "ocaml" {>= "4.07"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.1.tar.gz"
+  checksum: [
+    "md5=e72de75e9f0f87da9e6e8c0a4d4c89f9"
+    "sha512=81becfc9badd686ab3692cd9312172aa4c4e3581b110e81770bb01e0ffbc1eb8495d0dd6d43b98f3d06e6b8c8a338174c13ebafb4e9849a3ddf89f9a3a72c287"
+  ]
+}
+

--- a/packages/logtk/logtk.2.1/opam
+++ b/packages/logtk/logtk.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2.17@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+license: "BSD-2-Clause"
+synopsis: "Core types and algorithms for logic"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base-bytes"
+  "base-unix"
+  ("zarith" | "num")
+  "oseq" { >= "0.3" & < "0.4" }
+  "containers" { >= "3.0" & < "4.0" }
+  "containers-data" { >= "3.0" & < "4.0" }
+  "mtime" { >= "1.0" }
+  "iter" { >= "1.2" }
+  "menhir" {build}
+  "dune" { >= "1.11" }
+  "alcotest" {with-test}
+  "qcheck-core" {with-test & >= "0.9"}
+  "qcheck-alcotest" {with-test & >= "0.9"}
+  "ocaml" {>= "4.07"}
+]
+depopts: [
+  "msat"
+]
+conflicts: [
+  "msat" { < "0.8.1" }
+  "msat" { >= "0.10" }
+  "zarith" { < "1.7" }
+]
+tags: [ "logic" "unification" "term" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.1.tar.gz"
+  checksum: [
+    "md5=e72de75e9f0f87da9e6e8c0a4d4c89f9"
+    "sha512=81becfc9badd686ab3692cd9312172aa4c4e3581b110e81770bb01e0ffbc1eb8495d0dd6d43b98f3d06e6b8c8a338174c13ebafb4e9849a3ddf89f9a3a72c287"
+  ]
+}
+

--- a/packages/zipperposition-tools/zipperposition-tools.2.1/opam
+++ b/packages/zipperposition-tools/zipperposition-tools.2.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2.17@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+license: "BSD-2-Clause"
+synopsis: "Support tools for Zipperposition"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.11" }
+  "containers" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.2" }
+  "oseq" { >= "0.2" }
+  "msat" { >= "0.8" < "0.10" }
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "ocaml" {>= "4.07"}
+]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.1.tar.gz"
+  checksum: [
+    "md5=e72de75e9f0f87da9e6e8c0a4d4c89f9"
+    "sha512=81becfc9badd686ab3692cd9312172aa4c4e3581b110e81770bb01e0ffbc1eb8495d0dd6d43b98f3d06e6b8c8a338174c13ebafb4e9849a3ddf89f9a3a72c287"
+  ]
+}

--- a/packages/zipperposition/zipperposition.2.1/opam
+++ b/packages/zipperposition/zipperposition.2.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2.17@m4x.org"
+authors: ["Simon Cruanes" "Petar Vukmirovic" "Alexander Bentkamp" "Sophie Tourret" "Visa Nummelin"]
+homepage: "https://github.com/sneeuwballen/zipperposition"
+license: "BSD-2-Clause"
+synopsis: "A fully automatic theorem prover for typed higher-order and beyond"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "base-unix"
+  "logtk" { = version }
+  "libzipperposition" { = version }
+  "containers" { >= "3.0" & < "4.0" }
+  "iter" { >= "1.2" }
+  "oseq"
+  "dune" { >= "1.11" }
+  "msat" { >= "0.8" < "0.10" }
+  "menhir" {build}
+  "ocaml" {>= "4.07"}
+]
+tags: [ "logic" "unification" "term" "superposition" "prover" ]
+bug-reports: "https://github.com/sneeuwballen/zipperposition/issues"
+dev-repo: "git+https://github.com/sneeuwballen/zipperposition.git"
+url {
+  src: "https://github.com/sneeuwballen/zipperposition/archive/2.1.tar.gz"
+  checksum: [
+    "md5=e72de75e9f0f87da9e6e8c0a4d4c89f9"
+    "sha512=81becfc9badd686ab3692cd9312172aa4c4e3581b110e81770bb01e0ffbc1eb8495d0dd6d43b98f3d06e6b8c8a338174c13ebafb4e9849a3ddf89f9a3a72c287"
+  ]
+}
+


### PR DESCRIPTION
This pull-request concerns:
-`libzipperposition.2.1`: Library for Zipperposition
-`logtk.2.1`: Core types and algorithms for logic
-`zipperposition.2.1`: A fully automatic theorem prover for typed higher-order and beyond
-`zipperposition-tools.2.1`: Support tools for Zipperposition



---
* Homepage: https://github.com/sneeuwballen/zipperposition
* Source repo: git+https://github.com/sneeuwballen/zipperposition.git
* Bug tracker: https://github.com/sneeuwballen/zipperposition/issues

---
:camel: Pull-request generated by opam-publish v2.1.0