### PR TITLE
[new release] http-cookie (4.1.0)

### DIFF
--- a/packages/http-cookie/http-cookie.4.1.0/opam
+++ b/packages/http-cookie/http-cookie.4.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTTP cookie library for OCaml"
+description: "OCaml library to manipulate HTTP cookie. Adheres to RFC 6265."
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/http-cookie"
+bug-reports: "https://github.com/lemaetech/http-cookie/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.10.0"}
+  "fmt" {>= "0.8.9"}
+  "angstrom" {>= "0.15.0"}
+  "ppx_expect" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-cookie/releases/download/v4.1.0/http-cookie-v4.1.0.tbz"
+  checksum: [
+    "sha256=d8dd3505bee94e38d731cae08b7a33a5be3d8ed625c0c47f657d8784e633be02"
+    "sha512=1118980e056bece4ebf6ecf24bd6eaa575c8cda1ae37b921ddb044f30cdc42a77c98cf99763a808b45fbb84a55d4abdd1b41a1def6aa037ee7dd797b17365ac6"
+  ]
+}
+x-commit-hash: "64b55753043977052d7ce81f1113ccc526b65c7e"


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- [Change] `of_cookie` now validates duplicate cookie keys.
- [Change] slightly improve error message for `of_cookie` and `of_set_cookie`
- [Fix]    Fix IPv6 parsing for H16 values.
