### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.8.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.8.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.8.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.8.0/jsonrpc-1.8.0.tbz"
+  checksum: [
+    "sha256=90ac8fc3b291bc9c28b93d39fee6c75615f278f70ad795912fa5a47fa1a08c89"
+    "sha512=9460328d2559d86e9d56bcf8a9ef722c57d20a53c41e47398c36401bdc13dd9874e885586f2ad2d0492707bc3a5e7d5393afcebe1cbad1c15fb314884502bd1d"
+  ]
+}
+x-commit-hash: "e0c615b46323daabb9e63320a966802095a5ad1d"

--- a/packages/lsp/lsp.1.8.0/opam
+++ b/packages/lsp/lsp.1.8.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "pp"
+  "csexp" {>= "1.4"}
+  "uutf"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.8.0/jsonrpc-1.8.0.tbz"
+  checksum: [
+    "sha256=90ac8fc3b291bc9c28b93d39fee6c75615f278f70ad795912fa5a47fa1a08c89"
+    "sha512=9460328d2559d86e9d56bcf8a9ef722c57d20a53c41e47398c36401bdc13dd9874e885586f2ad2d0492707bc3a5e7d5393afcebe1cbad1c15fb314884502bd1d"
+  ]
+}
+x-commit-hash: "e0c615b46323daabb9e63320a966802095a5ad1d"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.8.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.8.0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
   "dune" {>= "2.9"}
   "yojson"
-  "re"
+  "re" {>= "1.5.0"}
   "ppx_yojson_conv_lib" {>= "v0.14"}
   "dune-build-info"
   "dot-merlin-reader"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.8.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.8.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "yojson"
+  "re"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-build-info"
+  "dot-merlin-reader"
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.4"}
+  "result" {>= "1.5"}
+  "ocamlformat-rpc-lib" {= "0.18.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12" & < "4.13"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.8.0/jsonrpc-1.8.0.tbz"
+  checksum: [
+    "sha256=90ac8fc3b291bc9c28b93d39fee6c75615f278f70ad795912fa5a47fa1a08c89"
+    "sha512=9460328d2559d86e9d56bcf8a9ef722c57d20a53c41e47398c36401bdc13dd9874e885586f2ad2d0492707bc3a5e7d5393afcebe1cbad1c15fb314884502bd1d"
+  ]
+}
+x-commit-hash: "e0c615b46323daabb9e63320a966802095a5ad1d"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.8.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.8.0/opam
@@ -18,7 +18,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
 depends: [
-  "dune" {>= "2.7"}
+  "dune" {>= "2.9"}
   "yojson"
   "re"
   "ppx_yojson_conv_lib" {>= "v0.14"}
@@ -27,7 +27,7 @@ depends: [
   "pp" {>= "1.1.2"}
   "csexp" {>= "1.4"}
   "result" {>= "1.5"}
-  "ocamlformat-rpc-lib" {= "0.18.0"}
+  "ocamlformat-rpc-lib" {>= "0.18.0" & < "0.19.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.12" & < "4.13"}
 ]


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add a new code action `Add missing rec keyword`, which is available when
  adding a `rec` keyword can fix `Unbound value ...` error, e.g.,

  ```ocaml
  let fact n = if n = 0 then 1 else n * fact (n - 1)
                                     (* ^^^^ Unbound value fact *)
  ```

  Adding `rec` to the definition of `fact` will fix the problem. The new code
  action offers adding `rec`.

- Use ocamlformat to properly format type snippets. This feature requires the
  `ocamlformat-rpc` opam package to be installed. (ocaml/ocaml-lsp#386)

- Add completion support for polymorphic variants, when it is possible to pin
  down the precise type. Examples (`<|>` stands for the cursor) when completion
  will work (ocaml/ocaml-lsp#473)

  Function application:

  ```
  let foo (a: [`Alpha | `Beta]) = ()

  foo `A<|>
  ```

  Type explicitly shown:

  ```
  let a : [`Alpha | `Beta] = `B<|>
  ```

  Note: this is actually a bug fix, since we were ignoring the backtick when
  constructing the prefix for completion.

- Parse merlin errors (best effort) into a more structured form. This allows
  reporting all locations as "related information" (ocaml/ocaml-lsp#475)

- Add support for Merlin `Construct` command as completion suggestions, i.e.,
  show complex expressions that could complete the typed hole. (ocaml/ocaml-lsp#472)

- Add a code action `Construct an expression` that is shown when the cursor is
  at the end of the typed hole, i.e., `_|`, where `|` is the cursor. The code
  action simply triggers the client (currently only VS Code is supported) to
  show completion suggestions. (ocaml/ocaml-lsp#472)

- Change the formatting-on-save error notification to a warning notification
  (ocaml/ocaml-lsp#472)

- Code action to qualify ("put module name in identifiers") and unqualify
  ("remove module name from identifiers") module names in identifiers (ocaml/ocaml-lsp#399)

  Starting from:

  ```ocaml
  open Unix

  let times = Unix.times ()
  let f x = x.Unix.tms_stime, x.Unix.tms_utime
  ```

  Calling "remove module name from identifiers" with the cursor on the open
  statement will produce:

  ```ocaml
  open Unix

  let times = times ()
  let f x = x.tms_stime, x.tms_utime
  ```

  Calling "put module name in identifiers" will restore:

  ```ocaml
  open Unix

  let times = Unix.times ()
  let f x = x.Unix.tms_stime, x.Unix.tms_utime
  ```

## Fixes

- Do not show "random" documentation on hover

  - fixed by [merlin#1364](https://github.com/ocaml/merlin/pull/1364)
  - fixes duplicate:
    - [ocaml-lsp#344](https://github.com/ocaml/ocaml-lsp/issues/344)
    - [vscode-ocaml-platform#111](https://github.com/ocamllabs/vscode-ocaml-platform/issues/111)

- Correctly rename a variable used as a named/optional argument (ocaml/ocaml-lsp#478)

- When reporting an error at the beginning of the file, use the first line not
  the second (ocaml/ocaml-lsp#489)
