### PR TITLE
added packages/fasmifra/fasmifra.1.1.0/opam

### DIFF
--- a/packages/fasmifra/fasmifra.1.1.0/opam
+++ b/packages/fasmifra/fasmifra.1.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/FASMIFRA"
+bug-reports: "https://github.com/UnixJunkie/FASMIFRA/issues"
+dev-repo: "git+https://github.com/UnixJunkie/FASMIFRA.git"
+license: "GPL-3.0-or-later"
+build: ["dune" "build" "-p" name "-j" jobs]
+install: [
+  ["cp" "bin/fasmifra_fragment.py" "%{bin}%/fasmifra_fragment.py"]
+]
+depends: [
+  "base-unix"
+  "batteries" {>= "3.3.0"}
+  "dolog" {>= "6.0.0"}
+  "dune" {>= "1.11"}
+  "minicli" {>= "5.0.0"}
+  "ocaml"
+  "parany" {>= "12.0.0"}
+  "line_oriented" {>= "1.0.0"}
+  "conf-rdkit" {>= "1"}
+  "conf-python-3" {>= "1.0.0"}
+]
+synopsis: "Molecular Generation by Fast Assembly of SMILES Fragments"
+description: """
+Generate molecules fast given a molecular training set.
+
+Properties of the generated molecules might significantly match
+those of the training set (training set distribution matching).
+
+Reference implementation for a submitted manuscript.
+"""
+url {
+  src: "https://github.com/UnixJunkie/FASMIFRA/archive/refs/tags/v1.1.0.tar.gz"
+  checksum: "md5=d12b87ec8a1a361ef4d9fa1c23615869"
+}


### PR DESCRIPTION
faster than previous version in case there are _many_ molecular fragments
(i.e. many molecules were fragmented).
A binary cache of indexed fragments is stored on disk.
Significantly accelerates molecular generation in case the same
collection of fragments is used to generate molecules several times.