### PR TITLE
owl.1.0.0: Disable the tests (non-deterministic)

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/files/test.c
+++ b/packages/conf-openblas/conf-openblas.0.2.1/files/test.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <cblas.h>
 #include <lapacke.h>
 

--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -38,5 +38,5 @@ x-ci-accept-failures: [
 synopsis: "Virtual package to install OpenBLAS and LAPACKE"
 description:
   "The package prepares OpenBLAS (CBLAS) and LAPACKE backend for Owl (OCaml numerical library). It can only be installed if OpenBLAS and LAPACKE are installed on the system."
-extra-files: ["test.c" "md5=dcf8ee02542457dde43e1e4917897416"]
+extra-files: ["test.c" "md5=8eb3463bce56366f0506721ca5c4e29c"]
 flags: conf

--- a/packages/owl/owl.0.9.0/opam
+++ b/packages/owl/owl.0.9.0/opam
@@ -18,12 +18,12 @@ Recently, Owl has implemented algorithmic differentiation which essentially make
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+#  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test} # non-deterministic
 ]
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "alcotest" {with-test}
+#  "alcotest" {with-test}
   "base" {build & < "v0.15"}
   "base-bigarray"
   "conf-openblas" {>= "0.2.0"}

--- a/packages/owl/owl.0.9.0/opam
+++ b/packages/owl/owl.0.9.0/opam
@@ -36,6 +36,7 @@ depends: [
   "stdlib-shims"
   "npy"
 ]
+available: arch != "arm64" & arch != "arm32" & arch != "s390x"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/0.9.0/owl-0.9.0.tbz"
   checksum: [

--- a/packages/owl/owl.1.0.0/opam
+++ b/packages/owl/owl.1.0.0/opam
@@ -18,12 +18,12 @@ Recently, Owl has implemented algorithmic differentiation which essentially make
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+#  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test} # Non-deterministic
 ]
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "alcotest" {with-test}
+#  "alcotest" {with-test}
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.1"}

--- a/packages/owl/owl.1.0.0/opam
+++ b/packages/owl/owl.1.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "stdio" {build}
   "npy"
 ]
-available: arch != "arm64" & arch != "arm32"
+available: arch != "arm64" & arch != "arm32" & arch != "s390x"
 x-commit-hash: "f164864baf68f94a19a09b19ed377db433d7aa2a"
 url {
   src: "https://github.com/owlbarn/owl/releases/download/1.0.0/owl-1.0.0.tbz"


### PR DESCRIPTION
cc @ryanrhymes 
```
#=== ERROR while compiling owl.1.0.0 ==========================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0/.opam-switch/build/owl.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p owl -j 31
# exit-code            1
# env-file             ~/.opam/log/owl-7762-904dc9.env
# output-file          ~/.opam/log/owl-7762-904dc9.out
### output ###
#  test_runner alias test/runtest (exit 1)
# (cd _build/default/test && ./test_runner.exe)
[...]
# > [FAIL]        algodiff matrix              0   reverse mode.
#   [OK]          algodiff matrix              1   forward mode.
# 
# ┌──────────────────────────────────────────────────────────────────────────────┐
# │ [FAIL]        algodiff matrix              0   reverse mode.                 │
# └──────────────────────────────────────────────────────────────────────────────┘
# [failure] 
# failed reverse mode operations
#        lyapunov (1/20)
# 
# Logs saved to `~/.opam/4.12.0/.opam-switch/build/owl.1.0.0/_build/default/test/_build/_tests/Owl/algodiff matrix.000.output'.
#  ──────────────────────────────────────────────────────────────────────────────
# 
# Full test results in `~/.opam/4.12.0/.opam-switch/build/owl.1.0.0/_build/default/test/_build/_tests/Owl'.
# 1 failure! in 3.309s. 1396 tests run.
```