### PR TITLE
[new release] Initial release of GopCaml-Mode-Merlin (0.0.4)

### DIFF
--- a/packages/gopcaml-mode-merlin/gopcaml-mode-merlin.0.0.4/opam
+++ b/packages/gopcaml-mode-merlin/gopcaml-mode-merlin.0.0.4/opam
@@ -20,9 +20,9 @@ depends: [
   "ppx_let" {>= "v0.14.0"}
   "ppx_here" {>= "v0.14.0"}
   "ocaml" {>= "4.12.0"}
-  "core" {>= "0.13.0"}
+  "core" {>= "v0.13.0"}
   "ppx_deriving" {>= "4.4"}
-  "ecaml" {>= "0.13.0"}
+  "ecaml" {>= "v0.13.0"}
 ]
 conflicts: [
   "gopcaml-mode"

--- a/packages/gopcaml-mode-merlin/gopcaml-mode-merlin.0.0.4/opam
+++ b/packages/gopcaml-mode-merlin/gopcaml-mode-merlin.0.0.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Ultimate Ocaml editing plugin, providing advanced structural editing, movement and analysis in Emacs (uses Merlin parser)"
+description:
+  "Gopcaml-mode is a plugin for emacs for editing OCaml code. It aims to extend existing Emacs editing experience to closer match the features in modern IDEs (uses Merlin's error tolerant parser)."
+maintainer: ["kirang@comp.nus.edu.sg"]
+authors: ["Kiran Gopinathan"]
+license: "GPL-3.0-only"
+homepage: "https://gitlab.com/gopiandcode/gopcaml-mode"
+bug-reports: "https://gitlab.com/gopiandcode/gopcaml-mode/issues"
+depends: [
+  "merlin" {>= "3.6.0"}
+  "ocp-indent" {>= "1.0.0"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "ppx_sexp_conv" {>= "v0.14.3"}
+  "ppx_let" {>= "v0.14.0"}
+  "ppx_here" {>= "v0.14.0"}
+  "ocaml" {>= "4.12.0"}
+  "core" {>= "0.13.0"}
+  "ppx_deriving" {>= "4.4"}
+  "ecaml" {>= "0.13.0"}
+]
+conflicts: [
+  "gopcaml-mode"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/gopiandcode/gopcaml-mode.git"
+url {
+  src: "https://gitlab.com/gopiandcode/gopcaml-mode/uploads/baa1e6a4bc822774118919181f9e879e/gopcaml-mode-0.0.4-merlin.tar.gz"
+  checksum: "md5=c23e5a1a559ecfcf924ecae0ba13f002"
+}
+
+  


### PR DESCRIPTION
# Initial Release of GopCaml-mode-Merlin (0.0.4)

  - Switches OCaml parser to use merlin's parser, thereby allowing for
    robustness to invalid syntax.

