### PR TITLE
[new release] http-cookie (4.2.0)

### DIFF
--- a/packages/http-cookie/http-cookie.4.2.0/opam
+++ b/packages/http-cookie/http-cookie.4.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "HTTP cookie library for OCaml"
+description: """
+A comprehensive and strict standards compliant HTTP cookies library for ocaml. 
+
+   http-cookie supports consuming and creating HTTP cookies found in HTTP request Cookie header 
+   and in Set-Cookie header in HTTP response. The library validates all cookie attributes, 
+   cookie name and cookie value for standards conformance and correct usage. The validation 
+   suite is comprehensive and includes validation of domain name, IPv4, IPv6 and HTTP 
+   date-time formats.
+
+   The RFC standards/validations implemented by the library are:
+   - RFC 6265
+   - RFC 1123
+   - RFC 1034
+   - IPV4/IPV6 address validation
+   """
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem <gbikal@gmail.com>"]
+license: "MPL-2.0"
+homepage: "https://github.com/lemaetech/http-cookie"
+bug-reports: "https://github.com/lemaetech/http-cookie/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.10.0"}
+  "fmt" {>= "0.8.9"}
+  "angstrom" {>= "0.15.0"}
+  "ppx_expect" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lemaetech/http-cookie.git"
+url {
+  src:
+    "https://github.com/lemaetech/http-cookie/releases/download/v4.2.0/http-cookie-v4.2.0.tbz"
+  checksum: [
+    "sha256=cdb91d7ee5420c38503fd3b333d0349a2c6689166b8c17f95fda8cd1c2454ed6"
+    "sha512=2f024dfaa1062e5701e811f933ce84ec674b579a3cded8a5279fc34366a4de360cd5f0ca3f68311f6ff527ec8a8a5c71325f8849bb05b8e98bf467bd33762191"
+  ]
+}
+x-commit-hash: "c3a09b5f537af2d1c2ecd2d5d1904b5224d2e8e6"


### PR DESCRIPTION
HTTP cookie library for OCaml

- Project page: <a href="https://github.com/lemaetech/http-cookie">https://github.com/lemaetech/http-cookie</a>

##### CHANGES:

- [Change] makes `http_only` true by default in `create` function. This makes the cookie more secure by default.
- Use mdx in README.md
- Update tests
