### PR TITLE
bastet.2.0.0: uncomment test dependencies

### DIFF
--- a/packages/bastet/bastet.2.0.0/opam
+++ b/packages/bastet/bastet.2.0.0/opam
@@ -9,10 +9,10 @@ doc: "https://risto-stevcev.github.io/bastet"
 bug-reports: "https://github.com/Risto-Stevcev/bastet/issues"
 depends: [
   "ocaml" {>= "4.08"}
-#  "alcotest" {>= "1.0.1" & with-test}
-#  "qcheck" {>= "0.13" & with-test}
-#  "qcheck-alcotest" {>= "0.13" & with-test}
-#  "mdx" {>= "1.6.0" & with-test}
+  "alcotest" {>= "1.0.1" & with-test}
+  "qcheck" {>= "0.13" & with-test}
+  "qcheck-alcotest" {>= "0.13" & with-test}
+  "mdx" {>= "1.6.0" & with-test}
   "bisect_ppx" {>= "2.1.0"}
   "odoc" {>= "1.5.0" & with-doc}
   "mustache" {>= "3.1.0" & with-doc}


### PR DESCRIPTION
Per discussion in https://github.com/ocaml/opam-repository/pull/19292