### PR TITLE
crowbar.0.2: Add missing constraint (uses Cmdliner.Term.const)

### DIFF
--- a/packages/crowbar/crowbar.0.2/opam
+++ b/packages/crowbar/crowbar.0.2/opam
@@ -1,5 +1,6 @@
 opam-version: "2.0"
 maintainer: "stephen.dolan@cl.cam.ac.uk"
+authors: "stephen.dolan@cl.cam.ac.uk"
 homepage: "https://github.com/stedolan/crowbar"
 bug-reports: "https://github.com/stedolan/crowbar/issues"
 dev-repo: "git+https://github.com/stedolan/crowbar.git"

--- a/packages/crowbar/crowbar.0.2/opam
+++ b/packages/crowbar/crowbar.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.1"}
   "ocaml" {>= "4.08"}
   "ocplib-endian"
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "0.9.8"}
   "afl-persistent" {>= "1.1"}
   "calendar" {with-test & >= "2.00"}
   "fpath" {with-test}

--- a/packages/crowbar/crowbar.0.2/opam
+++ b/packages/crowbar/crowbar.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "1.1"}
   "ocaml" {>= "4.08"}
   "ocplib-endian"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "afl-persistent" {>= "1.1"}
   "calendar" {with-test & >= "2.00"}
   "fpath" {with-test}


### PR DESCRIPTION
spotted in https://github.com/ocaml/opam-repository/pull/19299

```
#=== ERROR while compiling crowbar.0.2 ========================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12/.opam-switch/build/crowbar.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p crowbar -j 47
# exit-code            1
# env-file             ~/.opam/log/crowbar-23-013cda.env
# output-file          ~/.opam/log/crowbar-23-013cda.out
### output ###
#       ocamlc src/.crowbar.objs/byte/crowbar.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.crowbar.objs/byte -I /home/opam/.opam/4.12/lib/afl-persistent -I /home/opam/.opam/4.12/lib/bytes -I /home/opam/.opam/4.12/lib/cmdliner -I /home/opam/.opam/4.12/lib/ocplib-endian -intf-suffix .ml -no-alias-deps -o src/.crowbar.objs/byte/crowbar.cmo -c -impl src/crowbar.ml)
# File "src/crowbar.ml", line 576, characters 33-52:
# 576 |         let cmd = Cmdliner.Term.(const run_all_tests $ randomness_file $ verbosity $
#                                        ^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          (string option -> 'a list/2 -> bool -> test list/1 -> int) gen
#        but an expression was expected of type ('b -> 'c) Cmdliner.Term.t
#        File "src/crowbar.ml", line 26, characters 0-58:
#          Definition of type list/1
#        File "_none_", line 1:
#          Definition of type list/2
```