### PR TITLE
Package opam-custom-install.0.1

### DIFF
--- a/packages/opam-custom-install/opam-custom-install.0.1/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+synopsis: "An opam plugin to install a package using a custom command"
+description: """
+Provides the `opam custom-install` command, which allows to wrap a custom install command, and make opam register it as the installation of a given package. This is a prototype provided for the moment as a plugin, but might get integrated into opam if useful.
+"""
+tags: ["org:ocamlpro" "org:opam"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+depends: [
+  "dune" {>= "1.5"}
+  "opam-client" {>= "2.1.0"}
+]
+homepage: "https://gitlab.ocamlpro.com/louis/opam-custom-install"
+dev-repo: "git+https://gitlab.ocamlpro.com/louis/opam-custom-install.git"
+bug-reports: "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/issues"
+build: ["dune" "build" "-p" name "-j" jobs]
+flags: plugin
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+url {
+  src:
+    "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/archive/0.1/opam-custom-install-0.1.tar.gz"
+  checksum: [
+    "md5=10b50105cc11e93efb9654c73e0db3f1"
+    "sha512=87638e6da2963d7892f2b386a333f65ed769169267f9a6919dfa2a359b260c47a399969bb49f7948776553eb53f6159dabc4e160a90691cdc73b9861d5458eab"
+  ]
+}


### PR DESCRIPTION
### `opam-custom-install.0.1`
An opam plugin to install a package using a custom command
Provides the `opam custom-install` command, which allows to wrap a custom install command, and make opam register it as the installation of a given package. This is a prototype provided for the moment as a plugin, but might get integrated into opam if useful.



---
* Homepage: https://gitlab.ocamlpro.com/louis/opam-custom-install
* Source repo: git+https://gitlab.ocamlpro.com/louis/opam-custom-install.git
* Bug tracker: https://gitlab.ocamlpro.com/louis/opam-custom-install/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0