### PR TITLE
[new release] um-abt (0.1.5)

### DIFF
--- a/packages/um-abt/um-abt.0.1.5/opam
+++ b/packages/um-abt/um-abt.0.1.5/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis:
+  "An OCaml library implementing unifiable abstract binding trees (UABTs)"
+description: """
+um-abt provides an abstract binding tree (ABT) library following the
+   principles of Robert Harper's 'Practical Foundations for Programming
+   Languages'.
+
+   The library uses immutable pointers to represent variable binding and extends
+   ABTs with unification, providing unifiable abstract binding trees (UABTs)."""
+maintainer: ["shon.feder@gmail.com"]
+authors: ["Shon Feder"]
+license: "MIT"
+homepage: "https://github.com/shonfeder/um-abt"
+doc: "https://shonfeder.github.io/um-abt"
+bug-reports: "https://github.com/shonfeder/um-abt/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_deriving" {>= "5.2.1"}
+  "logs" {>= "0.7.0"}
+  "logs-ppx" {>= "0.2.0"}
+  "qcheck" {with-test & >= "0.17"}
+  "bos" {with-test & >= "0.2.0"}
+  "mdx" {with-test & >= "1.10.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/shonfeder/um-abt.git"
+url {
+  src:
+    "https://github.com/shonfeder/um-abt/releases/download/v0.1.5/um-abt-v0.1.5.tbz"
+  checksum: [
+    "sha256=d22a7c70f310a58c38906164fc8cef10b72da7989cf2686a51d6b75cf041e041"
+    "sha512=2fdc2823fe5d0d5a123e3daa7cc3c5e06b226caa2cbf3e8f824f24e87d595260b31787faa11961a1fb0f806fa0911894b31625daea2e6b980bb6a3b9330b9523"
+  ]
+}
+x-commit-hash: "71f39b19ec1da8cef2ee904a8ad9c8100ea68cd9"


### PR DESCRIPTION
An OCaml library implementing unifiable abstract binding trees (UABTs)

- Project page: <a href="https://github.com/shonfeder/um-abt">https://github.com/shonfeder/um-abt</a>
- Documentation: <a href="https://shonfeder.github.io/um-abt">https://shonfeder.github.io/um-abt</a>

##### CHANGES:

- Fix bug in ɑ-equivalence algorithm (See f89271)
