### PR TITLE
[new release] 1.0.0 release of ppx_inline_alcotest

### DIFF
--- a/packages/ppx_inline_alcotest/ppx_inline_alcotest.1.0.0/opam
+++ b/packages/ppx_inline_alcotest/ppx_inline_alcotest.1.0.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Inline tests backend for alcotest"
+description: "Run inline tests in the style of Alcotest."
+maintainer: ["kirang@comp.nus.edu.sg"]
+authors: ["Kiran Gopinathan"]
+license: "ISC"
+homepage: "https://gitlab.com/gopiandcode/ppx-inline-alcotest"
+bug-reports: "https://gitlab.com/gopiandcode/ppx-inline-alcotest/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ppxlib" {>= "0.22.0"}
+  "ocaml" {>= "4.05.0"}
+  "alcotest" {>= "1.0.0"}
+]
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+dev-repo: "git+https://gitlab.com/gopiandcode/ppx-inline-alcotest.git"
+url {
+  src: "https://gitlab.com/gopiandcode/ppx-inline-alcotest/-/archive/1.0.0/ppx-inline-alcotest-1.0.0.tar.gz"
+  checksum: "md5=4a89e24597d249ec8d3d91449785295b"
+}


### PR DESCRIPTION
Initial release of ppx_inline_alcotest - adds an alcotest inline test backend: https://discuss.ocaml.org/t/any-interest-in-inline-test-alcotest-backend/8351