### PR TITLE
OCaml 4.13.0, first beta release

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 4.13.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.13"
+depends: [
+  "ocaml" {= "4.13.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.13.0-beta1.tar.gz"
+  checksum: "sha256=b130031d46767c5d5641bc6f3e223e6bb1ab812956b9997e0e135b988334412c"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 4.13.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
+depends: [
+  "ocaml" {= "4.13.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.13.0-beta1.tar.gz"
+  checksum: "sha256=b130031d46767c5d5641bc6f3e223e6bb1ab812956b9997e0e135b988334412c"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]


### PR DESCRIPTION
The packages for the first beta release of OCaml 4.13.0 .

Compared to the last alpha, we have two backward compatibility fixes (one for %apply and %revapply  another `#directory`), more Stack_overflow exceptions for ARM64, a Windows filename fix and few compiler-libs fixes.


------


## Changes

- [#10549](https://github.com/ocaml/ocaml/issues/10549): Stack overflow detection and naked pointers checking for ARM64
  (Xavier Leroy, review by Stephen Dolan)

- [#10497](https://github.com/ocaml/ocaml/issues/10497): Styling changes in the post-processed HTML manual (webman)
  (Wiktor Kuchta, review by Florian Angeletti)

- [#10543](https://github.com/ocaml/ocaml/issues/10543): Fix Ast_mapper to apply the mapping function to the constants in
  "interval" patterns `c1..c2`.
  (Guillaume Petiot, review by Gabriel Scherer and Nicolás Ojeda Bär)

- [#10380](https://github.com/ocaml/ocaml/issues/10380): Correct handling of UTF-8 paths in configure on Windows
  (David Allsopp, review by Sébastien Hinderer)

- [#10450](https://github.com/ocaml/ocaml/issues/10450), [#10558](https://github.com/ocaml/ocaml/issues/10558): keep %apply and %revapply primitives working with abstract
  types. This breach of backward compatibility was only present in the alpha
  releases of OCaml 4.13.0 .
  (Florian Angeletti, review by Thomas Refis and Leo White)

- [#10550](https://github.com/ocaml/ocaml/issues/10550), [#10551](https://github.com/ocaml/ocaml/issues/10551): fix pretty-print of gadt-pattern-with-type-vars
  (Chet Murthy, review by Gabriel Scherer)

- [#10442](https://github.com/ocaml/ocaml/issues/10442), [#10446](https://github.com/ocaml/ocaml/issues/10446): Fix regression in the toplevel to #directory caused by
  corrections and improvements to the Load_path in [#9611](https://github.com/ocaml/ocaml/issues/9611). #directory now
  adds the path to the start of the load path again (so files in the newly
  added directory take priority).
  (David Allsopp, report by Vasile Rotaru, review by Florian Angeletti
   and Nicolás Ojeda Bär)
