### PR TITLE
Make patdiff.v0.14.0 unavailable on s390x until janestreet/core#145 gets fixed

### DIFF
--- a/packages/patdiff/patdiff.v0.14.0/opam
+++ b/packages/patdiff/patdiff.v0.14.0/opam
@@ -20,7 +20,7 @@ depends: [
   "re"            {>= "1.8.0"}
 ]
 conflicts: [
-  "core" {< "v0.14.2" & arch = "s390x"} # https://github.com/janestreet/core/issues/145
+  "jst-config" {< "v0.14.1" & arch = "s390x"} # https://github.com/janestreet/core/issues/145
 ]
 synopsis: "File Diff using the Patience Diff algorithm"
 description: "

--- a/packages/patdiff/patdiff.v0.14.0/opam
+++ b/packages/patdiff/patdiff.v0.14.0/opam
@@ -19,6 +19,9 @@ depends: [
   "pcre"
   "re"            {>= "1.8.0"}
 ]
+conflicts: [
+  "core" {< "v0.14.2" & arch = "s390x"} # https://github.com/janestreet/core/issues/145
+]
 synopsis: "File Diff using the Patience Diff algorithm"
 description: "
 "


### PR DESCRIPTION
I'm not sure this is the right fix so I'm making it a draft for the moment until we know for sure it's an issue in core and not down the chain (e.g. `jst-config`)