### PR TITLE
[new release] re (1.10.0)

### DIFF
--- a/packages/re/re.1.10.0/opam
+++ b/packages/re/re.1.10.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+maintainer: "rudi.grinberg@gmail.com"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Rudi Grinberg"
+  "Gabriel Radanne"
+]
+license: "LGPL-2.0 with OCaml linking exception"
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "ounit" {with-test}
+  "seq"
+]
+
+synopsis: "RE is a regular expression library for OCaml"
+description: """
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)
+"""
+url {
+  src:
+    "https://github.com/ocaml/ocaml-re/releases/download/1.10.0/re-1.10.0.tbz"
+  checksum: [
+    "sha256=e83d59ec816b56c08a136f579a162d24839902c675ee596a144899f254109690"
+    "sha512=1a18e46079a9a69f2b536a0a52448b3c679f3d8a195076008380a52ad5ff6ba1d4a072f8678f6b6c7e3bcec2b326c91719ea01923362dcd52c229c98e3eba554"
+  ]
+}
+x-commit-hash: "8a59309051ec573d3090d2550cb61b415a4c6837"


### PR DESCRIPTION
RE is a regular expression library for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-re">https://github.com/ocaml/ocaml-re</a>

##### CHANGES:

* Add the `[:alpha:]` character class in `Re.Perl` (ocaml/ocaml-re#169)
* Double asterisk (`**`) in `Re.Glob` (ocaml/ocaml-re#172)
  Like `*` but also match `/` characters when `pathname` is set.
* Double asterisk should match 0 or more directories unless in trailing
  position. (ocaml/ocaml-re#192, fixes ocaml/ocaml-re#185)
