### PR TITLE
[new release] graphv.webgl, graphv, graphv.gles2-native, graphv-gles2.webgl-impl, graphv-gles2, graphv-gles2.native-impl, graphv-font.stb-truetype, graphv-font, graphv-font.js and graphv-core-lib (0.1.0)

### DIFF
--- a/packages/graphv-core-lib/graphv-core-lib.0.1.0/opam
+++ b/packages/graphv-core-lib/graphv-core-lib.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Primitives for the Graphv vector graphics library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv-font.js/graphv-font.js.0.1.0/opam
+++ b/packages/graphv-font.js/graphv-font.js.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Javascript implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "js_of_ocaml" {>= "3.9"}
+  "graphv_core_lib" {>= "0.1"}
+  "graphv_font" {>= "0.1"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv-font.stb-truetype/graphv-font.stb-truetype.0.1.0/opam
+++ b/packages/graphv-font.stb-truetype/graphv-font.stb-truetype.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "STB truetype implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "stb_truetype" {>= "0.6"}
+  "graphv_font" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv-font/graphv-font.0.1.0/opam
+++ b/packages/graphv-font/graphv-font.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Functor for generating the Graphv font library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv-gles2.native-impl/graphv-gles2.native-impl.0.1.0/opam
+++ b/packages/graphv-gles2.native-impl/graphv-gles2.native-impl.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Native GLES2 implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "conf-gles2" {>= "1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv-gles2.webgl-impl/graphv-gles2.webgl-impl.0.1.0/opam
+++ b/packages/graphv-gles2.webgl-impl/graphv-gles2.webgl-impl.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "WebGL implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "js_of_ocaml" {>= "3.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv-gles2/graphv-gles2.0.1.0/opam
+++ b/packages/graphv-gles2/graphv-gles2.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Functor for creating a Graphv renderer based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv.gles2-native/graphv.gles2-native.0.1.0/opam
+++ b/packages/graphv.gles2-native/graphv.gles2-native.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Native version of the Graphv library based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_font" {>= "0.1"}
+  "graphv_font_stb_truetype" {>= "0.1"}
+  "graphv_gles2_native_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv.webgl/graphv.webgl.0.1.0/opam
+++ b/packages/graphv.webgl/graphv.webgl.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "WebGL version of the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_font" {>= "0.1"}
+  "graphv_font_js" {>= "0.1"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"

--- a/packages/graphv/graphv.0.1.0/opam
+++ b/packages/graphv/graphv.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Top-level graphv package"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=4caa1e316b14fd51a81c805057ef0ebeecae448205de06ad824e4ee37013a0ea"
+    "sha512=09c2f8c0802b9b953508019537721416afb55f8882aca39f7046b3433ca2809cbe4d24d19743d0ca5d1ccf6199108e05012d703c8baea84495ec8e1a3c8c5c07"
+  ]
+}
+x-commit-hash: "8dfb2ccb7b6e42c89fd652f532464318f689c36d"


### PR DESCRIPTION
WebGL version of the Graphv library

- Project page: <a href="https://github.com/wlitwin/graphv">https://github.com/wlitwin/graphv</a>
- Documentation: <a href="https://wlitwin.github.io/docs/graphv/graphv">https://wlitwin.github.io/docs/graphv/graphv</a>

##### CHANGES:

* Initial Release
