### PR TITLE
Update conf-bap-llvm to use llvm-9-dev in Debian bullseye.

### DIFF
--- a/packages/conf-bap-llvm/conf-bap-llvm.1.6/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.6/opam
@@ -15,7 +15,8 @@ depends: [
 depexts: [
 
   # debian
-  ["llvm-7-dev"] {os-distribution = "debian"}
+  ["llvm-7-dev"] {os-distribution = "debian" & os-version < "11"}
+  ["llvm-9-dev"] {os-distribution = "debian" & os-version >= "11"}
 
   # ubuntu
   ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty


### PR DESCRIPTION
Debian Bullseye was [released this month](https://www.debian.org/releases/bullseye/) and includes [LLVM 9](https://packages.debian.org/bullseye/llvm-9-dev).  Some parts of BAP (e.g. Aarch64 loading/disassembly) seem to work better with LLVM 9 than LLVM 7, so this patch updates the config package to support LLVM 9 in Debian where available.

This shouldn't be merged before it's been reviewed by someone from the BAP team (/cc @ivg)