### PR TITLE
Add conf-rustup as an alternative package to conf-rust

### DIFF
--- a/packages/conf-rustup/conf-rustup.0.1/opam
+++ b/packages/conf-rustup/conf-rustup.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "lthms@nomadic-labs.com"
+authors: "Thomas Letan"
+homepage: "https://github.com/ocaml/opam-repository"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "MIT"
+build: [
+  ["rustup-init" "--version"] {os-distribution = "alpine"}
+  ["rustup" "--version"] {os-distribution = "arch"}
+  ["rustup" "--version"] {os-distribution = "nixos"}
+  ["rustup" "--version"] {os = "macos" & os-distribution = "homebrew"}
+]
+depexts: [
+  ["rustup"] {os-distribution = "nixos"}
+  ["rustup"] {os-distribution = "arch"}
+  ["rustup"] {os-distribution = "alpine"}
+  ["rustup"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on rustup"
+description:
+  "This package can only install if rustup is installed on the system."
+flags: conf


### PR DESCRIPTION
Most of the time, Rust developers are using `rustup` to manage their installation of Rust. We propose to add a new package, `conf-rustup`, as an alternative of `conf-rust`, that would use `rustup` instead of `rust`.

I have never implemented such a package. Feedback is welcome!