### PR TITLE
[new release] graphv, graphv-webgl, graphv-gles2, graphv-gles2-webgl-impl, graphv-gles2-native, graphv-gles2-native-impl, graphv-font, graphv-font-stb-truetype, graphv-font-js and graphv-core-lib (0.1.0)

### DIFF
--- a/packages/graphv-core-lib/graphv-core-lib.0.1.0/opam
+++ b/packages/graphv-core-lib/graphv-core-lib.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Primitives for the Graphv vector graphics library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1" & with-test}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-font-js/graphv-font-js.0.1.0/opam
+++ b/packages/graphv-font-js/graphv-font-js.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Javascript implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "js_of_ocaml" {>= "3.9"}
+  "graphv_core_lib" {with-test & >= "0.1"}
+  "graphv_font" {with-test & >= "0.1"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-font-stb-truetype/graphv-font-stb-truetype.0.1.0/opam
+++ b/packages/graphv-font-stb-truetype/graphv-font-stb-truetype.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "STB truetype implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {with-test & >= "0.1"}
+  "stb_truetype" {>= "0.6"}
+  "graphv_font" {with-test & >= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-font/graphv-font.0.1.0/opam
+++ b/packages/graphv-font/graphv-font.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Functor for generating the Graphv font library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "stb_truetype" {>= "0.6"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_webgl_impl" {>= "0"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-gles2-native-impl/graphv-gles2-native-impl.0.1.0/opam
+++ b/packages/graphv-gles2-native-impl/graphv-gles2-native-impl.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Native GLES2 implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1" & with-test}
+  "graphv_core_lib" {with-test & >= "0.1"}
+  "conf-gles2" {>= "1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-gles2-native/graphv-gles2-native.0.1.0/opam
+++ b/packages/graphv-gles2-native/graphv-gles2-native.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Native version of the Graphv library based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {>= "0.1" & with-test}
+  "graphv_font" {with-test & >= "0.1"}
+  "graphv_font_stb_truetype" {>= "0.1"}
+  "graphv_gles2_native_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-gles2-webgl-impl/graphv-gles2-webgl-impl.0.1.0/opam
+++ b/packages/graphv-gles2-webgl-impl/graphv-gles2-webgl-impl.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "WebGL implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1" & with-test}
+  "graphv_core_lib" {with-test & >= "0.1"}
+  "js_of_ocaml" {>= "3.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-gles2/graphv-gles2.0.1.0/opam
+++ b/packages/graphv-gles2/graphv-gles2.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Functor for creating a Graphv renderer based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1" & with-test}
+  "ppx_jane" {>= "v0.14.0"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv-webgl/graphv-webgl.0.1.0/opam
+++ b/packages/graphv-webgl/graphv-webgl.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "WebGL version of the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {>= "0.1" & with-test}
+  "graphv_font" {with-test & >= "0.1"}
+  "graphv_font_js" {>= "0.1"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"

--- a/packages/graphv/graphv.0.1.0/opam
+++ b/packages/graphv/graphv.0.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Top-level graphv package, includes all dependencies"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=73073e8db3ebf5703b40321ec443c67faeada97b0422dbd6defef1db791e0e29"
+    "sha512=44e4805e73f184adb42c3b635e1e25f057003c035a3b50efc14ef55b9c43cdca015081dba3bea4c40009df23aae129a62e9661ed77e12e7675c0967f9435b2f3"
+  ]
+}
+x-commit-hash: "1c50cc074be62c3fe8bbdc98b98eff2cf768ff11"


### PR DESCRIPTION
Top-level graphv package, includes all dependencies

- Project page: <a href="https://github.com/wlitwin/graphv">https://github.com/wlitwin/graphv</a>
- Documentation: <a href="https://wlitwin.github.io/docs/graphv/graphv">https://wlitwin.github.io/docs/graphv/graphv</a>

##### CHANGES:

* Initial Release
