### PR TITLE
Add bls12-381-legacy.0.4.3

### DIFF
--- a/packages/bls12-381-legacy/bls12-381-legacy.0.4.3/opam
+++ b/packages/bls12-381-legacy/bls12-381-legacy.0.4.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis:
+  "UNIX version of BLS12-381 primitives. Not implementating the virtual package bls12-381"
+description:
+  "This package should only be used if newer versions of bls12-381 conflict with this version. This package should be considered as legacy and should never be used."
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "conf-rust" {build}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.18.0" & < "0.19.0"}
+  "ctypes-foreign"
+  "bls12-381-gen" {= version}
+  "tezos-rust-libs" {= "1.1"}
+  "alcotest" {with-test}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3-legacy/ocaml-bls12-381-0.4.3-legacy.tar.bz2"
+  checksum: [
+    "md5=93c29b93494f59a46c7a356df951a2af"
+    "sha512=0102db9dcab07c788291e9f799a4cf7a480716f18da6833587381e88ecc699d6e6bb0f44afef0ec7cd14a742d8ec6efc7900b45b0bcdeba409a89420465c0a25"
+  ]
+}


### PR DESCRIPTION
This release does exist only for supporting the Rust backend without considering it as an implementation of a virtual package. The package `Bls12_381_legacy` is exactly the same package than `bls12-381-unix.0.4.3`.

This release has been specifically requested by Octez/Tezos (https://gitlab.com/tezos/tezos). The implementation package `bls12-381-unix` and the new one `bls12-381-legacy` can be used together without any conflict.
Octez/Tezos has already a branch using this package (see [here](https://gitlab.com/tezos/tezos/-/merge_requests/3296/diffs?commit_id=4803a5c40b9ab3953daa4455a61552eb87d915fb)), and might be the only one to use it.

No release of this package is expected in the future, except if dependencies must be updated.