### PR TITLE
Accept failures in conf-oniguruma

### DIFF
--- a/packages/conf-oniguruma/conf-oniguruma.1/opam
+++ b/packages/conf-oniguruma/conf-oniguruma.1/opam
@@ -19,6 +19,10 @@ depexts: [
   ["oniguruma"] {os = "freebsd"}
   ["oniguruma"] {os = "netbsd"}
 ]
+x-ci-accept-failures: [
+  "centos-7"
+  "oraclelinux-8"
+]
 synopsis: "Virtual package relying on an Oniguruma system installation"
 description:
   "This package can only install if the Oniguruma development package is installed on the system."


### PR DESCRIPTION
This should ignore some failures in which the Oniguruma package isn't available for certain distributions. See the conversation at https://github.com/ocaml/opam-repository/pull/19064.

Note that the CI failure for Oracle Linux 7 is not because of conf-oniguruma. A package exists, but the version is too old.