### PR TITLE
[new release] graphv_webgl_impl, graphv_webgl, graphv_gles2_native_impl, graphv_gles2_native, graphv_gles2, graphv_font_stb_truetype, graphv_font_js, graphv_font, graphv_core_lib, graphv_core and graphv (0.1.0)

### DIFF
--- a/packages/graphv/graphv.0.1.0/opam
+++ b/packages/graphv/graphv.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Top_level graphv package, includes all dependencies"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_gles2_native" {>= "0.1"}
+  "graphv_webgl" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_core/graphv_core.0.1.0/opam
+++ b/packages/graphv_core/graphv_core.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Functor for creating a new Graphv library based on a font render and backend renderer"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_core_lib/graphv_core_lib.0.1.0/opam
+++ b/packages/graphv_core_lib/graphv_core_lib.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Primitives for the Graphv vector graphics library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_font/graphv_font.0.1.0/opam
+++ b/packages/graphv_font/graphv_font.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Functor for generating the Graphv font library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_font_js/graphv_font_js.0.1.0/opam
+++ b/packages/graphv_font_js/graphv_font_js.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Javascript implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_font" {>= "0.1"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_font_stb_truetype/graphv_font_stb_truetype.0.1.0/opam
+++ b/packages/graphv_font_stb_truetype/graphv_font_stb_truetype.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "STB truetype implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "stb_truetype" {>= "0.6"}
+  "graphv_font" {>= "0.1"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_gles2/graphv_gles2.0.1.0/opam
+++ b/packages/graphv_gles2/graphv_gles2.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Functor for creating a Graphv renderer based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_gles2_native/graphv_gles2_native.0.1.0/opam
+++ b/packages/graphv_gles2_native/graphv_gles2_native.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Full version of the Graphv library based on native GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_font" {>= "0.1"}
+  "graphv_font_stb_truetype" {>= "0.1"}
+  "graphv_gles2_native_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_gles2_native_impl/graphv_gles2_native_impl.0.1.0/opam
+++ b/packages/graphv_gles2_native_impl/graphv_gles2_native_impl.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Native GLES2 implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_webgl/graphv_webgl.0.1.0/opam
+++ b/packages/graphv_webgl/graphv_webgl.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Full version of the Graphv library based on WebGL"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "graphv_font" {>= "0.1"}
+  "graphv_font_js" {>= "0.1"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"

--- a/packages/graphv_webgl_impl/graphv_webgl_impl.0.1.0/opam
+++ b/packages/graphv_webgl_impl/graphv_webgl_impl.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "WebGL implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=807aab5e0c9780536bdbe00aa845b2862d91da8ef6250e559d1178d3a9d876c4"
+    "sha512=2c32770348ae04e37f92410e406074216824c31c6f79a2080ca2832a6432247380e02fdadc05a3f23634a2b14cb999e9f19e12236080bef233a9b2998a52c7dc"
+  ]
+}
+x-commit-hash: "fb22067fce263482a13d35956e8b055345f89341"


### PR DESCRIPTION
Graphv library 2D renderer for OCaml

- Project page: <a href="https://github.com/wlitwin/graphv">https://github.com/wlitwin/graphv</a>
- Documentation: <a href="https://wlitwin.github.io/docs/graphv/graphv">https://wlitwin.github.io/docs/graphv/graphv</a>

##### CHANGES:

* Initial Release
