### PR TITLE
[new release] graphv_webgl_impl, graphv_webgl, graphv_gles2_native_impl, graphv_gles2_native, graphv_gles2, graphv_font_stb_truetype, graphv_font_js, graphv_font, graphv_core_lib, graphv_core and graphv (0.1.0)

### DIFF
--- a/packages/graphv/graphv.0.1.0/opam
+++ b/packages/graphv/graphv.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Top_level graphv package, includes all dependencies"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_gles2_native" {>= "0.1"}
+  "graphv_webgl" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_core/graphv_core.0.1.0/opam
+++ b/packages/graphv_core/graphv_core.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Functor for creating a new Graphv library based on a font render and backend renderer"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_core_lib/graphv_core_lib.0.1.0/opam
+++ b/packages/graphv_core_lib/graphv_core_lib.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Primitives for the Graphv vector graphics library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+available:
+    arch = "x86_64" | arch = "arm64"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_font/graphv_font.0.1.0/opam
+++ b/packages/graphv_font/graphv_font.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Functor for generating the Graphv font library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_font_js/graphv_font_js.0.1.0/opam
+++ b/packages/graphv_font_js/graphv_font_js.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Javascript implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_font_stb_truetype/graphv_font_stb_truetype.0.1.0/opam
+++ b/packages/graphv_font_stb_truetype/graphv_font_stb_truetype.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "STB truetype implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "stb_truetype" {>= "0.6"}
+  "graphv_font" {>= "0.1"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_gles2/graphv_gles2.0.1.0/opam
+++ b/packages/graphv_gles2/graphv_gles2.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Functor for creating a Graphv renderer based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_gles2_native/graphv_gles2_native.0.1.0/opam
+++ b/packages/graphv_gles2_native/graphv_gles2_native.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Full version of the Graphv library based on native GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1"}
+  "graphv_font_stb_truetype" {>= "0.1"}
+  "graphv_gles2_native_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_gles2_native_impl/graphv_gles2_native_impl.0.1.0/opam
+++ b/packages/graphv_gles2_native_impl/graphv_gles2_native_impl.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Native GLES2 implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "conf-gles2" {>= "1"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_webgl/graphv_webgl.0.1.0/opam
+++ b/packages/graphv_webgl/graphv_webgl.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Full version of the Graphv library based on WebGL"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {>= "0.1"}
+  "graphv_font_js" {>= "0.1"}
+  "graphv_webgl_impl" {>= "0.1"}
+  "graphv_gles2" {>= "0.1"}
+  "graphv_core" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"

--- a/packages/graphv_webgl_impl/graphv_webgl_impl.0.1.0/opam
+++ b/packages/graphv_webgl_impl/graphv_webgl_impl.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "WebGL implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_core_lib" {>= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.0/graphv-v0.1.0.tbz"
+  checksum: [
+    "sha256=67e0f626216d1e2b812a9509c09c365b409efed99db2d775aa8cd3862fc584e0"
+    "sha512=cbced35fa29fb6c614f006ab0ed6a5d666dd19a9f244c9b7914d8fee9fdff9533223517044487ebc31acfe2a73a8d39f31de58abca3b0714724f78d84810aa94"
+  ]
+}
+x-commit-hash: "193171c97c4defb8bbad4e46153175518a6325e0"


### PR DESCRIPTION
WebGL implementation of the backend renderer for the Graphv library

- Project page: <a href="https://github.com/wlitwin/graphv">https://github.com/wlitwin/graphv</a>
- Documentation: <a href="https://wlitwin.github.io/docs/graphv/graphv">https://wlitwin.github.io/docs/graphv/graphv</a>

##### CHANGES:

* Initial Release
