### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-ocamlbuild, js_of_ocaml-lwt and js_of_ocaml-compiler (3.10.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04" & < "4.14"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.12.0" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner"
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04" & < "4.14"}

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.10.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.10.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.10.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.10.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.10.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "ocamlbuild"
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.10.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.10.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.10.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.10.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.10.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.10.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.10.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.10.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.10.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.10.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.10.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.10.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.10.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml/js_of_ocaml.3.10.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.10.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "uchar"
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.10.0/js_of_ocaml-3.10.0.tbz"
+  checksum: [
+    "sha256=7bfe95c283e30a53df9364555517aa4ea614876be566a86b33e6d0fefc4a6126"
+    "sha512=1815f0bfcea65a28082293756350a9365304584d3a19af0983e1498c6f8d7d25a751aec18560aa7b633b64b8adfb4417e9647cdf703bedcb7aaf316abf9a3243"
+  ]
+}
+x-commit-hash: "41ca9c4aa3004e11803c1e49d3ad77ec799bf853"

--- a/packages/js_of_ocaml/js_of_ocaml.3.10.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.10.0/opam
@@ -7,6 +7,7 @@ authors: ["Ocsigen team <dev@ocsigen.org>"]
 homepage: "https://ocsigen.github.io/js_of_ocaml"
 doc: "https://ocsigen.github.io/js_of_ocaml"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+license: "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.04"}


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.github.io/js_of_ocaml">https://ocsigen.github.io/js_of_ocaml</a>
- Documentation: <a href="https://ocsigen.github.io/js_of_ocaml">https://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Compiler: add support for OCaml 4.13
* Compiler: new tool to check for missing primitives
* Compiler: drop support for OCaml 4.03 and bellow
* Lib: add offsetX and offsetY to Dom_html.mouseEvent
* Lib: add innerText property for Dom_html
* Runtime: add dummy implementation for many dummy primitives
* Runtime: add runtime for new float operation in 4.13 ocsigen/js_of_ocaml#1113 (by pmwhite)

## Misc
* manual/rev_bindings.wiki: fix compilation error
