### PR TITLE
[new release] sendmail, sendmail-lwt, received and colombe (0.5.0)

### DIFF
--- a/packages/colombe/colombe.0.5.0/opam
+++ b/packages/colombe/colombe.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}
-  "crowbar" {with-test}
+  "crowbar" {>= "0.2" & with-test}
 ]
 depopts: [ "emile" ]
 conflicts: [ "emile" {< "0.8"} ]

--- a/packages/colombe/colombe.0.5.0/opam
+++ b/packages/colombe/colombe.0.5.0/opam
@@ -1,15 +1,13 @@
 opam-version: "2.0"
 license:      "MIT"
-authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
-maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/mirage/colombe"
 bug-reports:  "https://github.com/mirage/colombe/issues"
 dev-repo:     "git+https://github.com/mirage/colombe.git"
-synopsis:     "Received field according RFC5321"
+synopsis:     "SMTP protocol in OCaml"
 doc:          "https://mirage.github.io/colombe/"
-description: """A little library to parse or emit a Received field according
-RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
-on which way - TLS or not - the email was transmitted)."""
+description: """SMTP protocol according RFC5321 without extension."""
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
@@ -17,17 +15,17 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.03.0"}
-  "dune"     {>= "1.8.0"}
-  "mrmime"   {>= "0.4.0"}
-  "emile"    {>= "0.8"}
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8.0"}
+  "fmt"
+  "ipaddr" {>= "2.9.0"}
   "angstrom" {>= "0.14.0"}
-  "colombe"  {>= "0.4.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {with-test}
 ]
-
-pin-depends: [
-  [ "mrmime.dev" "git+https://github.com/mirage/mrmime.git#cb9b1fd598ba1efbed4ad1672bff228de6dcfdac" ]
-]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
 url {
   src:
     "https://github.com/mirage/colombe/releases/download/v0.5.0/colombe-v0.5.0.tbz"

--- a/packages/sendmail-lwt/sendmail-lwt.0.5.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.5.0/opam
@@ -1,15 +1,13 @@
 opam-version: "2.0"
 license:      "MIT"
-authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
-maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/mirage/colombe"
 bug-reports:  "https://github.com/mirage/colombe/issues"
 dev-repo:     "git+https://github.com/mirage/colombe.git"
-synopsis:     "Received field according RFC5321"
 doc:          "https://mirage.github.io/colombe/"
-description: """A little library to parse or emit a Received field according
-RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
-on which way - TLS or not - the email was transmitted)."""
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
@@ -17,16 +15,14 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.03.0"}
-  "dune"     {>= "1.8.0"}
-  "mrmime"   {>= "0.4.0"}
-  "emile"    {>= "0.8"}
-  "angstrom" {>= "0.14.0"}
-  "colombe"  {>= "0.4.0"}
-]
-
-pin-depends: [
-  [ "mrmime.dev" "git+https://github.com/mirage/mrmime.git#cb9b1fd598ba1efbed4ad1672bff228de6dcfdac" ]
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
 ]
 url {
   src:

--- a/packages/sendmail/sendmail.0.5.0/opam
+++ b/packages/sendmail/sendmail.0.5.0/opam
@@ -1,15 +1,13 @@
 opam-version: "2.0"
 license:      "MIT"
-authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
-maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
 homepage:     "https://github.com/mirage/colombe"
 bug-reports:  "https://github.com/mirage/colombe/issues"
 dev-repo:     "git+https://github.com/mirage/colombe.git"
-synopsis:     "Received field according RFC5321"
 doc:          "https://mirage.github.io/colombe/"
-description: """A little library to parse or emit a Received field according
-RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
-on which way - TLS or not - the email was transmitted)."""
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
@@ -17,16 +15,16 @@ build: [
 ]
 
 depends: [
-  "ocaml"    {>= "4.03.0"}
-  "dune"     {>= "1.8.0"}
-  "mrmime"   {>= "0.4.0"}
-  "emile"    {>= "0.8"}
-  "angstrom" {>= "0.14.0"}
-  "colombe"  {>= "0.4.0"}
-]
-
-pin-depends: [
-  [ "mrmime.dev" "git+https://github.com/mirage/mrmime.git#cb9b1fd598ba1efbed4ad1672bff228de6dcfdac" ]
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8"}
+  "colombe" {= version}
+  "tls" {>= "0.13.0"}
+  "base64" {>= "3.0.0"}
+  "logs"
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
 ]
 url {
   src:


### PR DESCRIPTION
Implementation of the sendmail command

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Use `Cstruct.length` instead of `Cstruct.len` (@dinosaure, mirage/colombe#45)
- Let the user to emit the end of the stream (spotted by @jsthomas, @dinosaure, review @mikonieminen)
