### PR TITLE
[new release] graphv_webgl_impl, graphv_webgl, graphv_gles2_native_impl, graphv_gles2_native, graphv_gles2, graphv_font_stb_truetype, graphv_font_js, graphv_font, graphv_core_lib, graphv_core and graphv (0.1.1)

### DIFF
--- a/packages/graphv/graphv.0.1.1/opam
+++ b/packages/graphv/graphv.0.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Top_level graphv package, includes all dependencies"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_gles2_native" {= "0.1.1"}
+  "graphv_webgl" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_core/graphv_core.0.1.1/opam
+++ b/packages/graphv_core/graphv_core.0.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Functor for creating a new Graphv library based on a font render and backend renderer"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_core_lib/graphv_core_lib.0.1.1/opam
+++ b/packages/graphv_core_lib/graphv_core_lib.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Primitives for the Graphv vector graphics library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+available:
+    (arch = "x86_64" | arch = "arm64" | arch = "ppc64" | arch = "s390x") & (os != "macos")
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_font/graphv_font.0.1.1/opam
+++ b/packages/graphv_font/graphv_font.0.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Functor for generating the Graphv font library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_font_js/graphv_font_js.0.1.1/opam
+++ b/packages/graphv_font_js/graphv_font_js.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Javascript implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {= "0.1.1"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_webgl_impl" {= "0.1.1"}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_font_stb_truetype/graphv_font_stb_truetype.0.1.1/opam
+++ b/packages/graphv_font_stb_truetype/graphv_font_stb_truetype.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "STB truetype implementation of the font interface for Graphv"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "stb_truetype" {>= "0.6"}
+  "graphv_font" {= "0.1.1"}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_gles2/graphv_gles2.0.1.1/opam
+++ b/packages/graphv_gles2/graphv_gles2.0.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Functor for creating a Graphv renderer based on GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_gles2_native/graphv_gles2_native.0.1.1/opam
+++ b/packages/graphv_gles2_native/graphv_gles2_native.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Full version of the Graphv library based on native GLES2"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {= "0.1.1"}
+  "graphv_font_stb_truetype" {= "0.1.1"}
+  "graphv_gles2_native_impl" {= "0.1.1"}
+  "graphv_gles2" {= "0.1.1"}
+  "graphv_core" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_gles2_native_impl/graphv_gles2_native_impl.0.1.1/opam
+++ b/packages/graphv_gles2_native_impl/graphv_gles2_native_impl.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Native GLES2 implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "conf-gles2" {>= "1"}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_webgl/graphv_webgl.0.1.1/opam
+++ b/packages/graphv_webgl/graphv_webgl.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Full version of the Graphv library based on WebGL"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "graphv_font" {= "0.1.1"}
+  "graphv_font_js" {= "0.1.1"}
+  "graphv_webgl_impl" {= "0.1.1"}
+  "graphv_gles2" {= "0.1.1"}
+  "graphv_core" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"

--- a/packages/graphv_webgl_impl/graphv_webgl_impl.0.1.1/opam
+++ b/packages/graphv_webgl_impl/graphv_webgl_impl.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "WebGL implementation of the backend renderer for the Graphv library"
+maintainer: ["walter@litwinczyk.com"]
+authors: ["Walter Litwinczyk"]
+license: "MIT"
+homepage: "https://github.com/wlitwin/graphv"
+doc: "https://wlitwin.github.io/docs/graphv/graphv"
+bug-reports: "https://github.com/wlitwin/graphv/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppx_expect" {>= "v0.14.1" & with-test}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "graphv_core_lib" {= "0.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/wlitwin/graphv.git"
+url {
+  src:
+    "https://github.com/wlitwin/graphv/releases/download/v0.1.1/graphv-v0.1.1.tbz"
+  checksum: [
+    "sha256=29968fe3169b937224e8b59c644825fb6f48ca6d772f7b1d9a274089f542e89e"
+    "sha512=449bdaffabc61eadd183c16fdf2a0c67bdb0773fc9623c254e71e293ae2c4f182d29b78d746663cc8b01715831b4625e6610295fb7baf321ad148e52d1715ae7"
+  ]
+}
+x-commit-hash: "12fd65f001f7d796b08647e82f9f0201ce7ae884"


### PR DESCRIPTION
WebGL implementation of the backend renderer for the Graphv library

- Project page: <a href="https://github.com/wlitwin/graphv">https://github.com/wlitwin/graphv</a>
- Documentation: <a href="https://wlitwin.github.io/docs/graphv/graphv">https://wlitwin.github.io/docs/graphv/graphv</a>

##### CHANGES:

* Fix stencil path bug when rendering a fill (9ba038d)
* Remove debug assert
