### PR TITLE
[new release] win-eventlog (0.4)

### DIFF
--- a/packages/win-eventlog/win-eventlog.0.4/opam
+++ b/packages/win-eventlog/win-eventlog.0.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Log via the Windows event log from OCaml programs"
+description: """
+A low-level example:
+
+```ocaml
+let log = Eventlog.register "Mirage.exe" in
+let category = 0 and event = 1 in
+Eventlog.report log `Success category event [|
+  "insertion string 1";
+  "insertion string 2";
+|]
+```
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["David Scott"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-win-eventlog"
+doc: "https://mirage.github.io/ocaml-win-eventlog/"
+bug-reports: "https://github.com/mirage/ocaml-win-eventlog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "result"
+  "logs"
+  "base-unix"
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files"
+    "false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-win-eventlog.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-win-eventlog/releases/download/0.4/win-eventlog-0.4.tbz"
+  checksum: [
+    "sha256=f67b192436e2716eaab0396643a73ca8b3af92f22510d6a5f3f43080dcdb0169"
+    "sha512=8e5de12612c2d686e9ae2961283df002c5ed8b071c19f13792b36aa3d704ca6328f25adc4e7e0e30d37c36d05a13ec7e88a6ca313a24a086846b52ec8c265485"
+  ]
+}
+x-commit-hash: "f5b56aeec6eeae4e91ff3c787cd390f8e337d5e9"


### PR DESCRIPTION
Log via the Windows event log from OCaml programs

- Project page: <a href="https://github.com/mirage/ocaml-win-eventlog">https://github.com/mirage/ocaml-win-eventlog</a>
- Documentation: <a href="https://mirage.github.io/ocaml-win-eventlog/">https://mirage.github.io/ocaml-win-eventlog/</a>

##### CHANGES:

- Wrap the library (@MisterDA)
- Bunch of minor fixes (@MisterDA)
- Switch to dune 2.9 and lower bound on OCaml 4.08 (@MisterDA)
