### PR TITLE
[new release] ppxlib (0.23.0)

### DIFF
--- a/packages/GT/GT.0.4.1/opam
+++ b/packages/GT/GT.0.4.1/opam
@@ -28,7 +28,7 @@ depends: [
   "conf-m4"    { build }
   "dune"       { >= "2.7.1" }
   "ocamlgraph"
-  "ppxlib"     {>= "0.22.0" }
+  "ppxlib"     {>= "0.22.0" & < "0.23.0"}
   "logger-p5"
   "ocaml-migrate-parsetree" { >= "2.1.0" }
   "base"

--- a/packages/GT/GT.0.4.2/opam
+++ b/packages/GT/GT.0.4.2/opam
@@ -29,7 +29,7 @@ depends: [
   "conf-m4"    { build }
   "dune"       { >= "2.7.1" }
   "ocamlgraph"
-  "ppxlib"     {>= "0.22.0" }
+  "ppxlib"     {>= "0.22.0" & < "0.23.0"}
   "logger-p5"
   "ocaml-migrate-parsetree" { >= "2.1.0" }
   "base"

--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.6/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "uutf"
   "menhir" {>= "20180523"}
   "pprint"
-  "ppxlib"
+  "ppxlib" {< "0.23.0"}
   "containers"
   "ppx_inline_test"
 ]

--- a/packages/metaquot/metaquot.0.4.0/opam
+++ b/packages/metaquot/metaquot.0.4.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
   "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "metapp" {>= "0.4.0"}

--- a/packages/metaquot/metaquot.0.4.0/opam
+++ b/packages/metaquot/metaquot.0.4.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/thierry-martinez/metaquot"
 doc: "https://github.com/thierry-martinez/metaquot"
 bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.13"}
   "stdcompat" {>= "12"}
   "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "ocamlfind" {>= "1.8.1"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.18.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.18.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocp-indent" {with-test}
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc" {>= "1.4.2"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "re"
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.17.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.17.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml-migrate-parsetree" {>= "2.1.0"}
   "ocp-indent" {with-test}
   "odoc" {>= "1.4.2"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.18.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.18.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocp-indent" {with-test}
   "bisect_ppx" {with-test & >= "2.5.0"}
   "odoc" {>= "1.4.2"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ppx_accessor/ppx_accessor.v0.14.2/opam
+++ b/packages/ppx_accessor/ppx_accessor.v0.14.2/opam
@@ -14,7 +14,7 @@ depends: [
   "accessor"{>= "v0.14.1" & < "v0.15"}
   "base"{>= "v0.14" & < "v0.15"}
   "dune"  {>= "2.0.0"}
-  "ppxlib"   {>= "0.14.0"}
+  "ppxlib"   {>= "0.14.0" & < "0.23.0"}
 ]
 synopsis: "[@@deriving] plugin to generate accessors for use with the Accessor libraries"
 description: "

--- a/packages/ppx_cstruct/ppx_cstruct.6.0.0/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.6.0.0/opam
@@ -27,6 +27,7 @@ depends: [
   "cppo" {with-test}
   "cstruct-sexp" {with-test & = version}
   "cstruct-unix" {with-test & = version}
+  "ocaml-migrate-parsetree" {>= "2.1.0" & with-test}
 ]
 synopsis: "Access C-like structures directly from OCaml"
 description: """

--- a/packages/ppx_optcomp/ppx_optcomp.v0.14.1/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"   {>= "v0.14" & < "v0.15"}
   "stdio"  {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.23.0"}
 ]
 synopsis: "Optional compilation for OCaml"
 description: "

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.14.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.14.1/opam
@@ -14,7 +14,7 @@ depends: [
   "base"        {>= "v0.14" & < "v0.15"}
   "variantslib" {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
-  "ppxlib"      {>= "0.14.0"}
+  "ppxlib"      {>= "0.14.0" & < "0.23.0"}
 ]
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "

--- a/packages/ppxlib/ppxlib.0.23.0/opam
+++ b/packages/ppxlib/ppxlib.0.23.0/opam
@@ -20,7 +20,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & < "4.13"}
+  "ocaml" {>= "4.04.1" & < "4.14"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}

--- a/packages/ppxlib/ppxlib.0.23.0/opam
+++ b/packages/ppxlib/ppxlib.0.23.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "4.13"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.23.0/ppxlib-0.23.0.tbz"
+  checksum: [
+    "sha256=1b5836c186b9d5a16acf47da94f3968f4f08b519b7729cd86a8fd39971fe12e5"
+    "sha512=00352fe61756f5aad5fd89b3cc596b619e5a5cf6808dcb0c197369bfff9f1ba182b4c6e5ea0e67269c9441b7b9b28f2a70d63fb972dfda64fc1a8404f7924753"
+  ]
+}
+x-commit-hash: "de5b3113f31167d156de7d2caa1a36c04a01dba2"

--- a/packages/ppxlib/ppxlib.0.23.0/opam
+++ b/packages/ppxlib/ppxlib.0.23.0/opam
@@ -34,6 +34,7 @@ depends: [
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
+  "base-effects"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Drop `Parser` from the API (ocaml-ppx/ppxlib#263, @pitag-ha)

- `Location`: add `set_filename` and `Error.get_location` (ocaml-ppx/ppxlib#247, @pitag-ha)

- Drop dependency on OMP2 (ocaml-ppx/ppxlib#187, @pitag-ha)

- Make OMP1 a conflict (ocaml-ppx/ppxlib#255, @kit-ty-kate)

- Drop `Syntaxerr` from the public API. Doesn't affect any user in the
  [ppx universe](https://github.com/ocaml-ppx/ppx_universe) (ocaml-ppx/ppxlib#244, @pitag-ha)

- Add a lower-bound constraint for Sexplib0 (ocaml-ppx/ppxlib#240, @pitag-ha)

- Fix bug due to which unwanted public binaries got installed when installing
  ppxlib (ocaml-ppx/ppxlib#223, @pitag-ha)

- Add `Keyword.is_keyword` to check if a string is an OCaml keyword
  (ocaml-ppx/ppxlib#227, @pitag-ha)

- Remove `Lexer.keyword_table`: use `Keyword.is_keyword` instead
  (ocaml-ppx/ppxlib#227, @pitag-ha)

- Remove `Lexer` from the API: it was the same as the compiler-libs
  `Lexer` (ocaml-ppx/ppxlib#228, @pitag-ha)

- Remove the modules `Ast_magic`, `Compiler_version`, `Js`, `Find_version`,
  `Convert`, `Extra_warnings`, `Location_error`, `Select_ast` and
  `Import_for_core` from the API: they are meant for internal use and
  aren't used by any current downstream user in the
  [ppx universe](https://github.com/ocaml-ppx/ppx_universe) (ocaml-ppx/ppxlib#230, @pitag-ha)

- Remove compiler specific helper functions from `Location`. They aren't used
  by any current downstream user in the
  [ppx universe](https://github.com/ocaml-ppx/ppx_universe) (ocaml-ppx/ppxlib#238, @pitag-ha)

- Allow "%a" when using Location.Error.createf (ocaml-ppx/ppxlib#239, @mlasson)

- Fix in `Location`: make `raise_errorf` exception equivalent to exception
  `Error` (ocaml-ppx/ppxlib#242, @pitag-ha)

- Fix in `Pprintast`: correctly pretty print local type substitutions, e.g.
  type t := ... (ocaml-ppx/ppxlib#261, @matthewelse)

- Add `Ast_pattern.esequence`, for matching on any number of sequenced
  expressions e.g. `do_a (); do_b (); ...`. (ocaml-ppx/ppxlib#264, @matthewelse)

- Expose a part of `Ast_io` in order to allow reading AST values from binary
 files (ocaml-ppx/ppxlib#270, @arozovyk)
