### PR TITLE
rm dolog dependency version upper bound

### DIFF
--- a/packages/lz4_chans/lz4_chans.3.0.1/opam
+++ b/packages/lz4_chans/lz4_chans.3.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "base-unix"
   "conf-lz4"
-  "dolog" {>= "4.0.0" & < "5.0.0"}
+  "dolog" {>= "4.0.0"}
   "dune" {>= "1.6"}
 ]
 synopsis: "LZ4-compressed binary channels"


### PR DESCRIPTION
because it compiles just fine with dolog-6.0.0