### PR TITLE
3 packages from gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.10/json-data-encoding-0.10.tar.gz

### DIFF
--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.10/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.10/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.10/json-data-encoding-0.10.tar.gz"
+  checksum: [
+    "md5=5e38f6cfb3dffe652e98b8d38905376f"
+    "sha512=50a7e8bd7036c1c48b4132ba34301df7e4011c619177fed28ec96bffce99acb228dc4fe6fc24bff313b9ae3ba5c6da424189e6a8220b87c918ea20d08e1caca2"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.10/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.10/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.10/json-data-encoding-0.10.tar.gz"
+  checksum: [
+    "md5=5e38f6cfb3dffe652e98b8d38905376f"
+    "sha512=50a7e8bd7036c1c48b4132ba34301df7e4011c619177fed28ec96bffce99acb228dc4fe6fc24bff313b9ae3ba5c6da424189e6a8220b87c918ea20d08e1caca2"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.0.10/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.10/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "uri" {>= "1.9.0" }
+  "crowbar" { with-test }
+  "alcotest" { with-test }
+  "ocamlformat" { = "0.18.0" & dev }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.10/json-data-encoding-0.10.tar.gz"
+  checksum: [
+    "md5=5e38f6cfb3dffe652e98b8d38905376f"
+    "sha512=50a7e8bd7036c1c48b4132ba34301df7e4011c619177fed28ec96bffce99acb228dc4fe6fc24bff313b9ae3ba5c6da424189e6a8220b87c918ea20d08e1caca2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`json-data-encoding.0.10`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.0.10`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.0.10`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://gitlab.com/nomadic-labs/json-data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/json-data-encoding
* Bug tracker: https://gitlab.com/nomadic-labs/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0