### PR TITLE
Package glfw-ocaml (3.3.1)

### DIFF
--- a/packages/glfw-ocaml/glfw-ocaml.3.3.1/opam
+++ b/packages/glfw-ocaml/glfw-ocaml.3.3.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "A GLFW binding for OCaml"
+maintainer: "Sylvain BOILARD <boilard@crans.org>"
+authors: "Sylvain BOILARD <boilard@crans.org>"
+license: "Zlib"
+homepage: "https://github.com/SylvainBoilard/GLFW-OCaml"
+bug-reports: "https://github.com/SylvainBoilard/GLFW-OCaml/issues"
+depends: [
+  "conf-glfw3"
+  "base-bigarray"
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.02.0"}
+]
+x-ci-accept-failures: [
+  "debian-10" # default version of this library is too old
+  "ubuntu-16.04" # default version of this library is too old
+  "ubuntu-18.04" # default version of this library is too old
+  "centos-7" # default version of this library is too old
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/SylvainBoilard/GLFW-OCaml.git"
+url {
+  src:
+    "https://github.com/SylvainBoilard/GLFW-OCaml/archive/3.3.1.tar.gz"
+  checksum: [
+    "md5=be77a305cf56fbe9992b6f28b5a52307"
+    "sha512=b9333eeef5d3fd5e5f5d850d72a6afe2c7fb90828a71f7b7838b4e24d59c63cdc804afc79a4cc8e22e87383581da936cfa48359031899ebd13ba1601d9ee5012"
+  ]
+}


### PR DESCRIPTION
CHANGES:

* Added support for glfwExtensionSupported.
* Added support for no-naked-pointers mode (see the OCaml 4.12 manual in section 18.2.3)
* Fixed getGammaRamp returning a bigarray that was backed by GLFW internal const-qualified memory.
* Upgrade build system to Dune 2.0.