### PR TITLE
data-encoding: loosen cersion constraints on json-data-encoding

### DIFF
--- a/packages/data-encoding/data-encoding.0.4/opam
+++ b/packages/data-encoding/data-encoding.0.4/opam
@@ -11,8 +11,8 @@ depends: [
   "ezjsonm"
   "zarith" {>= "1.4"}
   "hex" {>= "1.3.0"}
-  "json-data-encoding" { = "0.9.1" }
-  "json-data-encoding-bson" { = "0.9.1" }
+  "json-data-encoding" { >= "0.9.1" }
+  "json-data-encoding-bson" { >= "0.9.1" }
   "alcotest" { with-test }
   "crowbar" { >= "0.2" & with-test }
   "ocamlformat" { = "0.15.0" & dev }


### PR DESCRIPTION
Loosen package constraints on data-encoding's dependency to json-data-encoding (changes `=` constraint to `>=` constraint)

I should have made these changes along with https://github.com/ocaml/opam-repository/pull/19381 directly. Next time I'll try to do so.