### PR TITLE
Package ocsigen-toolkit.2.12.2

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
@@ -1,26 +1,26 @@
 opam-version: "2.0"
+synopsis:
+  "Reusable UI components for Eliom applications (client only, or client-server)"
+description:
+  "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
 maintainer: "dev@ocsigen.org"
-synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
-description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
 authors: "dev@ocsigen.org"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 homepage: "http://www.ocsigen.org"
 bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
-dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
-license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-build: [ make "-j%{jobs}%" ]
-install: [ make "install" ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "eliom" {>= "6.12.1"}
-  "calendar" {>= "2.0.0"}
+  "calendar"
 ]
-depexts: [
-  ["libgdbm-dev"] {os-family = "debian"}
-]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+depexts: ["libgdbm-dev"] {os-family = "debian"}
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
 url {
-  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.12.2.tar.gz"
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.13.0.tar.gz"
   checksum: [
-    "md5=858dbbbcb856d02fda7d2851cc3afecc"
-    "sha512=ceb18e7483df78bef903e5898678d74fbe02170d05d5bdf97957d98decf3b687ba4756d786f16bc54b6ea2eb8504d463b6d10f72a959cf1715f5fa2ff98129c3"
+    "md5=4ef1def8ec59e588ccdbafb825d74d2d"
+    "sha512=c7d55a1e06d2f9430fabdf32d96477aa68c7862768eaa0d7f5c60a5be653626a7ab8520c3c0762611cc4724604f3ced4454ebcecf5b50a4201b4cc18d49ab9db"
   ]
 }


### PR DESCRIPTION
### `ocsigen-toolkit.2.12.2`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0