### PR TITLE
Package spectrum.0.1.0

### DIFF
--- a/packages/spectrum/spectrum.0.1.0/opam
+++ b/packages/spectrum/spectrum.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Library for colour and formatting in the terminal"
+description:
+  "Using OCaml Format module's 'semantic tags' with named colours and CSS-style hex colours."
+maintainer: "ego@anentropic"
+authors: "Anentropic"
+license: "MIT"
+homepage: "https://github.com/anentropic/ocaml-spectrum"
+bug-reports: "https://github.com/anentropic/ocaml-spectrum/issues"
+depends: [
+  "dune" {>= "2.8" & >= "2.8" & < "2.9"}
+  "color" {>= "0.2" & < "0.3"}
+  "alcotest" {with-test & >= "1.4" & < "1.5"}
+  "junit_alcotest" {with-test & >= "2.0" & < "2.1"}
+  "utop" {dev}
+  "ocp-indent" {dev}
+  "ocaml-lsp-server" {dev}
+  "opam-format" {dev}
+  "opam-publish" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anentropic/ocaml-spectrum.git"
+url {
+  src:
+    "https://github.com/anentropic/ocaml-spectrum/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=fb6b15039facc38397c5eb1a0552b3d2"
+    "sha512=888ba6f708e0eea5341186b2df65b72f524c772971306141c5316e337063e65a18f8a7d35a14ddc8c400a81dd7af16cbd2d8ce047d97a887fe81ec3db0e36208"
+  ]
+}


### PR DESCRIPTION
### `spectrum.0.1.0`
Library for colour and formatting in the terminal
Using OCaml Format module's 'semantic tags' with named colours and CSS-style hex colours.



---
* Homepage: https://github.com/anentropic/ocaml-spectrum
* Source repo: git+https://github.com/anentropic/ocaml-spectrum.git
* Bug tracker: https://github.com/anentropic/ocaml-spectrum/issues

---
:camel: Pull-request generated by opam-publish v2.1.0