### PR TITLE
Package ocsigen-toolkit.2.13.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.13.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.13.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.13.0.tar.gz"
+  checksum: [
+    "md5=65a8dbf784c7a95b125e8b16c5c4f8c5"
+    "sha512=e2302a9d92a526ecd5d8c48644432938775669d2d19b3047d582aec501e250d5dee8f56bd293839b735cb7bb78133b2650117409b15a75f964e6b897afb72cb8"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.2.13.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0