### PR TITLE
[new release] nuscr (2.0.0)

### DIFF
--- a/packages/nuscr/nuscr.2.0.0/opam
+++ b/packages/nuscr/nuscr.2.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "A tool to manipulate and validate Scribble-style multiparty protocols"
+description:
+  "A toolkit to manipulate Scribble-style multiparty protocols, based on classical multiparty session type theory. The toolkit provides means to define global protocols, project to local protocols, convert local protocols to a CFSM representation, and generate OCaml code for protocol implementations."
+maintainer: ["Francisco Ferreira"]
+authors: [
+  "Francisco Ferreira" "Fangyi Zhou" "Simon Castellan" "Benito Echarren"
+]
+license: "GPL-3.0-or-later"
+homepage: "https://nuscr.dev/"
+doc: "https://nuscr.dev/nuscr/docs/"
+bug-reports: "https://github.com/nuscr/nuscr/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "menhir" {>= "20190924"}
+  "ppx_deriving" {>= "5.2"}
+  "dune" {>= "2.8"}
+  "base" {>= "v0.12.0"}
+  "stdio" {>= "v0.12.0"}
+  "ppx_sexp_conv" {>= "v0.12.0"}
+  "z3" {with-test}
+  "odoc" {with-doc}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppxlib" {>= "0.22.0"}
+  "cmdliner" {>= "1.0.4"}
+  "process" {>= "0.2.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/nuscr/nuscr.git"
+url {
+  src: "https://github.com/nuscr/nuscr/releases/download/2.0.0/nuscr-web-2.0.0.tbz"
+  checksum: [
+    "sha256=fbd17793416c225702a93f52e200e48faa37721cab4d16c3d997500407c6fede"
+    "sha512=da005593f3ae30c2566121452535c2405508f197f26962ac25d402e40245b3c8344d5a654cd3e3069f85458b232a845bc4a0371bacc59741dfb067e88cd3d6d0"
+  ]
+}
+x-commit-hash: "376b3b0af868aea0a7be12423b9724afdec21154"


### PR DESCRIPTION
CHANGES:

## Added

- A new pragma system for extensions:
  `(*# PRAGMA #*)` at the beginning of the input file can enable theory
  extensions.
- Nested Protocol extension, via `NestedProtocols` pragma (by Benito Echarren Serrano)
- Refinement Type extension, via `RefinementTypes` pragma (by Fangyi Zhou)

## Changed

- New, improved command line interface with cmdliner
- Reorganise code layout
- Recursions immediately after a choice is permitted under some circumstances

## Fixed

- Non-distinct choice prefixes now raise an error
- Degenerate recursions in protocols will be removed
- Catch an uncaught exception when user enters a non-existent protocol from CLI
- Merging [end] and [\mu t.t] after projection is now possible