### PR TITLE
conf-python-2-7: Add support for oraclelinux

### DIFF
--- a/packages/conf-python-2-7/conf-python-2-7.1.1/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.1/opam
@@ -10,6 +10,7 @@ depexts: [
   ["python27"] {os-distribution = "nixos"}
   ["python2"] {os-distribution = "alpine"}
   ["python2"] {os-distribution = "centos"}
+  ["python2"] {os-distribution = "ol"}
   ["python2"] {os-distribution = "fedora"}
   ["python2"] {os-distribution = "arch"}
   ["python"] {os-family = "suse"}


### PR DESCRIPTION
Detected in #19397 