### PR TITLE
mrmime: Add missing constraint

### DIFF
--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.0"}
   "uutf"
   "ke" {>= "0.4"}
-  "ptime"
+  "ptime" {>= "0.8.2"}
   "ipaddr"
   "uutf"
   "rosetta"

--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -21,6 +21,7 @@ depends: [
   "ipaddr"
   "uutf"
   "rosetta"
+  "bigstringaf" {>= "0.2.0"}
   "base64" {>= "3.1.0"}
   "pecu" {>= "0.3" & < "0.5"}
   "rresult"

--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "uutf"
   "ke" {>= "0.4"}
   "ptime" {>= "0.8.2"}
-  "ipaddr"
+  "ipaddr" {>= "2.9.0"}
   "uutf"
   "rosetta"
   "bigstringaf" {>= "0.2.0"}

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "emile"           {>= "0.8" & < "1.0"}
   "base64"          {>= "3.1.0"}
   "pecu"            {= "0.4"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "bigarray-compat"
   "bigarray-overlap"
   "angstrom"        {>= "0.11.0" & < "0.14.0"}

--- a/packages/mrmime/mrmime.0.2.0/opam
+++ b/packages/mrmime/mrmime.0.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "ke"              {>= "0.4"}
   "unstrctrd"
-  "ptime"
+  "ptime" {>= "0.8.2"}
   "uutf"
   "rosetta"         {>= "0.3.0"}
   "ipaddr"

--- a/packages/mrmime/mrmime.0.3.0/opam
+++ b/packages/mrmime/mrmime.0.3.0/opam
@@ -28,7 +28,7 @@ depends: [
   "emile"            {>= "0.8" & < "1.0"}
   "base64"           {>= "3.1.0"}
   "pecu"             {= "0.4"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}

--- a/packages/mrmime/mrmime.0.3.0/opam
+++ b/packages/mrmime/mrmime.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "ke"               {>= "0.4"}
   "unstrctrd"
-  "ptime"
+  "ptime" {>= "0.8.2"}
   "uutf"
   "rosetta"          {>= "0.3.0"}
   "ipaddr"

--- a/packages/mrmime/mrmime.0.3.1/opam
+++ b/packages/mrmime/mrmime.0.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "ke"               {>= "0.4"}
   "unstrctrd"        {>= "0.2"}
-  "ptime"
+  "ptime" {>= "0.8.2"}
   "uutf"
   "rosetta"          {>= "0.3.0"}
   "ipaddr"

--- a/packages/mrmime/mrmime.0.3.1/opam
+++ b/packages/mrmime/mrmime.0.3.1/opam
@@ -28,7 +28,7 @@ depends: [
   "emile"            {>= "1.0"}
   "base64"           {>= "3.1.0"}
   "pecu"             {= "0.4"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}

--- a/packages/mrmime/mrmime.0.3.2/opam
+++ b/packages/mrmime/mrmime.0.3.2/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "ke"               {>= "0.4"}
   "unstrctrd"        {>= "0.2"}
-  "ptime"
+  "ptime" {>= "0.8.2"}
   "uutf"
   "rosetta"          {>= "0.3.0"}
   "ipaddr"

--- a/packages/mrmime/mrmime.0.3.2/opam
+++ b/packages/mrmime/mrmime.0.3.2/opam
@@ -28,7 +28,7 @@ depends: [
   "emile"            {>= "1.0"}
   "base64"           {>= "3.1.0"}
   "pecu"             {>= "0.5"}
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}

--- a/packages/mrmime/mrmime.0.4.0/opam
+++ b/packages/mrmime/mrmime.0.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt"
   "ke"               {>= "0.4"}
   "unstrctrd"        {>= "0.2"}
-  "ptime"
+  "ptime" {>= "0.8.2"}
   "uutf"
   "rosetta"          {>= "0.3.0"}
   "ipaddr"

--- a/packages/mrmime/mrmime.0.4.0/opam
+++ b/packages/mrmime/mrmime.0.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "base64"           {>= "3.1.0"}
   "pecu"             {>= "0.5"}
   "prettym"
-  "bigstringaf"
+  "bigstringaf" {>= "0.5.0"}
   "bigarray-compat"
   "bigarray-overlap" {>= "0.2.0"}
   "angstrom"         {>= "0.14.0"}


### PR DESCRIPTION
Detected in #19372 
```
#=== ERROR while compiling mrmime.0.3.1 =======================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/mrmime.0.3.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mrmime -j 47
# exit-code            1
# env-file             ~/.opam/log/mrmime-28-3b827d.env
# output-file          ~/.opam/log/mrmime-28-3b827d.out
### output ###
# File "/home/opam/.opam/4.08/lib/bigstringaf/bigstringaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
#       ocamlc lib/.mrmime.objs/byte/mrmime__Hd.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.mrmime.objs/byte -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/base/caml -I /home/opam/.opam/4.08/lib/base64 -I /home/opam/.opam/4.08/lib/base64/rfc2045 -I /home/opam/.opam/4.08/lib/bigarray-compat -I /home/opam/.opam/4.08/lib/bigarray-overlap -I /home/opam/.opam/4.08/lib/bigarray-overlap/stubs -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/coin -I /home/opam/.opam/4.08/lib/emile -I /home/opam/.opam/4.08/lib/fmt -I /home/opam/.opam/4.08/lib/ipaddr -I /home/opam/.opam/4.08/lib/ke -I /home/opam/.opam/4.08/lib/parsexp -I /home/opam/.opam/4.08/lib/pecu -I /home/opam/.opam/4.08/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.08/lib/ptime -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/rosetta -I /home/opam/.opam/4.08/lib/rresult -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib -I /home/opam/.opam/4.08/lib/sexplib0 -I /home/opam/.opam/4.08/lib/stdlib-shims -I /home/opam/.opam/4.08/lib/uchar -I /home/opam/.opam/4.08/lib/unstrctrd -I /home/opam/.opam/4.08/lib/unstrctrd/parser -I /home/opam/.opam/4.08/lib/uutf -I /home/opam/.opam/4.08/lib/uuuu -I /home/opam/.opam/4.08/lib/yuscii -I lib/prettym/.prettym.objs/byte -I lib/prettym/.prettym.objs/native -intf-suffix .ml -no-alias-deps -open Mrmime__ -o lib/.mrmime.objs/byte/mrmime__Hd.cmo -c -impl lib/hd.ml)
# File "lib/hd.ml", line 69, characters 23-44:
# 69 |       | [ x ] -> `End (Bigstringaf.to_string x)
#                             ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Bigstringaf.to_string
# Hint: Did you mean of_string?
#     ocamlopt lib/.mrmime.objs/native/mrmime__Hd.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlopt.opt -w -40 -g -I lib/.mrmime.objs/byte -I lib/.mrmime.objs/native -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/base/caml -I /home/opam/.opam/4.08/lib/base64 -I /home/opam/.opam/4.08/lib/base64/rfc2045 -I /home/opam/.opam/4.08/lib/bigarray-compat -I /home/opam/.opam/4.08/lib/bigarray-overlap -I /home/opam/.opam/4.08/lib/bigarray-overlap/stubs -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/bytes -I /home/opam/.opam/4.08/lib/coin -I /home/opam/.opam/4.08/lib/emile -I /home/opam/.opam/4.08/lib/fmt -I /home/opam/.opam/4.08/lib/ipaddr -I /home/opam/.opam/4.08/lib/ke -I /home/opam/.opam/4.08/lib/parsexp -I /home/opam/.opam/4.08/lib/pecu -I /home/opam/.opam/4.08/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.08/lib/ptime -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/rosetta -I /home/opam/.opam/4.08/lib/rresult -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib -I /home/opam/.opam/4.08/lib/sexplib0 -I /home/opam/.opam/4.08/lib/stdlib-shims -I /home/opam/.opam/4.08/lib/uchar -I /home/opam/.opam/4.08/lib/unstrctrd -I /home/opam/.opam/4.08/lib/unstrctrd/parser -I /home/opam/.opam/4.08/lib/uutf -I /home/opam/.opam/4.08/lib/uuuu -I /home/opam/.opam/4.08/lib/yuscii -I lib/prettym/.prettym.objs/byte -I lib/prettym/.prettym.objs/native -intf-suffix .ml -no-alias-deps -open Mrmime__ -o lib/.mrmime.objs/native/mrmime__Hd.cmx -c -impl lib/hd.ml)
# File "lib/hd.ml", line 69, characters 23-44:
# 69 |       | [ x ] -> `End (Bigstringaf.to_string x)
#                             ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Bigstringaf.to_string
# Hint: Did you mean of_string?
```