### PR TITLE
colombe: Fix constraint

### DIFF
--- a/packages/colombe/colombe.0.1.0/opam
+++ b/packages/colombe/colombe.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.3"}
   "angstrom" {< "0.14.0"}
   "ipaddr" {>= "2.9.0"}
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "tls" {< "0.13.0"}
   "logs"
   "base64"

--- a/packages/colombe/colombe.0.1.0/opam
+++ b/packages/colombe/colombe.0.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "tls" {< "0.13.0"}
   "cstruct" {>= "3.3.0"}
   "logs"
-  "base64"
+  "base64" {>= "3.0.0"}
   "rresult"
   "hxd" {< "0.3.0"}
   "domain-name" {>= "0.2.1"}

--- a/packages/colombe/colombe.0.1.0/opam
+++ b/packages/colombe/colombe.0.1.0/opam
@@ -21,6 +21,7 @@ depends: [
   "ipaddr" {>= "2.9.0"}
   "fmt" {>= "0.8.5"}
   "tls" {< "0.13.0"}
+  "cstruct" {>= "3.3.0"}
   "logs"
   "base64"
   "rresult"

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.8.0"}
   "fmt"
-  "ipaddr" {>= "2.9.0"}
+  "ipaddr" {>= "3.0.0"}
   "angstrom" {< "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "fmt" {>= "0.8.5"}
   "ipaddr" {>= "3.0.0"}
-  "angstrom" {>= "0.8.0" & < "0.14.0"}
+  "angstrom" {>= "0.10.0" & < "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}
 ]

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.8.0"}
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ipaddr" {>= "3.0.0"}
   "angstrom" {< "0.14.0"}
   "ocaml-syntax-shims"

--- a/packages/colombe/colombe.0.2.0/opam
+++ b/packages/colombe/colombe.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "fmt" {>= "0.8.5"}
   "ipaddr" {>= "3.0.0"}
-  "angstrom" {< "0.14.0"}
+  "angstrom" {>= "0.8.0" & < "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}
 ]

--- a/packages/colombe/colombe.0.3.0/opam
+++ b/packages/colombe/colombe.0.3.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.8.0"}
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ipaddr" {>= "3.0.0"}
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"

--- a/packages/colombe/colombe.0.3.0/opam
+++ b/packages/colombe/colombe.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.8.0"}
   "fmt"
-  "ipaddr" {>= "2.9.0"}
+  "ipaddr" {>= "3.0.0"}
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}

--- a/packages/colombe/colombe.0.4.0/opam
+++ b/packages/colombe/colombe.0.4.0/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.8.0"}
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ipaddr" {>= "3.0.0"}
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"

--- a/packages/colombe/colombe.0.4.0/opam
+++ b/packages/colombe/colombe.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.8.0"}
   "fmt"
-  "ipaddr" {>= "2.9.0"}
+  "ipaddr" {>= "3.0.0"}
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}

--- a/packages/colombe/colombe.0.4.1/opam
+++ b/packages/colombe/colombe.0.4.1/opam
@@ -17,7 +17,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.8.0"}
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ipaddr" {>= "3.0.0"}
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"

--- a/packages/colombe/colombe.0.4.1/opam
+++ b/packages/colombe/colombe.0.4.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.8.0"}
   "fmt"
-  "ipaddr" {>= "2.9.0"}
+  "ipaddr" {>= "3.0.0"}
   "angstrom" {>= "0.14.0"}
   "ocaml-syntax-shims"
   "alcotest" {with-test}


### PR DESCRIPTION
Detected in #19372 
```
#=== ERROR while compiling colombe.0.4.0 ======================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/colombe.0.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p colombe -j 47
# exit-code            1
# env-file             ~/.opam/log/colombe-28-d7aaf0.env
# output-file          ~/.opam/log/colombe-28-d7aaf0.out
### output ###
# File "/home/opam/.opam/4.08/lib/bigstringaf/bigstringaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
#       ocamlc src/.colombe.objs/byte/colombe__Request.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.colombe.objs/byte -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/base/caml -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/fmt -I /home/opam/.opam/4.08/lib/ipaddr -I /home/opam/.opam/4.08/lib/parsexp -I /home/opam/.opam/4.08/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib -I /home/opam/.opam/4.08/lib/sexplib0 -I /home/opam/.opam/4.08/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -open Colombe__ -o src/.colombe.objs/byte/colombe__Request.cmo -c -impl src/request.ml)
# File "src/request.ml", line 182, characters 10-12:
# 182 |         | Ok (Ipaddr.V4 ipv4) -> Ok (Domain.IPv4 ipv4)
#                 ^^
# Error: This variant pattern is expected to have type Ipaddr.t option
#        The constructor Ok does not belong to type option
#     ocamlopt src/.colombe.objs/native/colombe__Request.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlopt.opt -w -40 -g -I src/.colombe.objs/byte -I src/.colombe.objs/native -I /home/opam/.opam/4.08/lib/angstrom -I /home/opam/.opam/4.08/lib/base/caml -I /home/opam/.opam/4.08/lib/bigstringaf -I /home/opam/.opam/4.08/lib/fmt -I /home/opam/.opam/4.08/lib/ipaddr -I /home/opam/.opam/4.08/lib/parsexp -I /home/opam/.opam/4.08/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.08/lib/seq -I /home/opam/.opam/4.08/lib/sexplib -I /home/opam/.opam/4.08/lib/sexplib0 -I /home/opam/.opam/4.08/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -open Colombe__ -o src/.colombe.objs/native/colombe__Request.cmx -c -impl src/request.ml)
# File "src/request.ml", line 182, characters 10-12:
# 182 |         | Ok (Ipaddr.V4 ipv4) -> Ok (Domain.IPv4 ipv4)
#                 ^^
# Error: This variant pattern is expected to have type Ipaddr.t option
#        The constructor Ok does not belong to type option
```