### PR TITLE
[new release] spdx_licenses (1.1.0)

### DIFF
--- a/packages/spdx_licenses/spdx_licenses.1.1.0/opam
+++ b/packages/spdx_licenses/spdx_licenses.1.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A library providing a strict SPDX License Expression parser"
+description: """
+An OCaml library aiming to provide an up-to-date and strict SPDX License Expression parser.
+It implements the format described in: https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
+See https://spdx.org/licenses/ for more details.
+"""
+maintainer: ["Kate <kit.ty.kate@disroot.org>"]
+authors: ["Kate <kit.ty.kate@disroot.org>"]
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/spdx_licenses"
+bug-reports: "https://github.com/kit-ty-kate/spdx_licenses/issues"
+dev-repo: "git+https://github.com/kit-ty-kate/spdx_licenses.git"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.3"}
+  "alcotest" {with-test & >= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.1.0/spdx_licenses-v1.1.0.tbz"
+  checksum: [
+    "sha256=3d9c67dd43ff572f790c75fe132f8c0c4236e02454d39ed89732d34e0346411e"
+    "sha512=ca8c8ed3a6e7857fc60b5d6f8ba1ca05dac5fde1904aacdf1fcb941d1101f720e78e00e1369057c60a1946e5db9940600b2e006564e6aae01af4274e2c30f9c5"
+  ]
+}
+x-commit-hash: "c6ba0493c25ce4d9ff8cb45b228ce412f4444aa0"


### PR DESCRIPTION
A library providing a strict SPDX License Expression parser

- Project page: <a href="https://github.com/kit-ty-kate/spdx_licenses">https://github.com/kit-ty-kate/spdx_licenses</a>

##### CHANGES:

- Increase the minimal required version of OCaml from 4.03 to 4.08 (@kit-ty-kate)
