### PR TITLE
[new release] http-lwt-client (0.0.2)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.2/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.2/http-lwt-client-v0.0.2.tbz"
+  checksum: [
+    "sha256=6e7c53ddd702700a8c128ae3b1b50c821f81b1bdda632c67332cbae7a61401d0"
+    "sha512=92c20d84d66e5ad3a85238f242d7f9e2ef46030e69a4301e7de9d009f60e32ca4c803e659755e591f325f9fbb0b5926291c56157cd3141e579e856c158155c5b"
+  ]
+}
+x-commit-hash: "a1adf1d28751476babcb46dc4150ce30cb0dbb1d"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Unify response API between HTTP1 and HTTP2 requests and responses (issue roburio/http-lwt-client#5)
