### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.2)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.2/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.2/happy-eyeballs-v0.0.2.tbz"
+  checksum: [
+    "sha256=c58e83c6d62393797d751cf17f833c310df7970cefe404d8d935b209fc5f0ea8"
+    "sha512=68f00d9f9f1fa23468f7d32e71ddf0bc6b1ddcad12a0e08259a1ee5e58d9d0889fa71ec08f531e4eab172dd40cb4efdd2f7f5dd96333abf010ed140f92737c2f"
+  ]
+}
+x-commit-hash: "b0bf35a98cced23ebac594dfe5c427fa0748d8f8"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.2/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.2/happy-eyeballs-v0.0.2.tbz"
+  checksum: [
+    "sha256=c58e83c6d62393797d751cf17f833c310df7970cefe404d8d935b209fc5f0ea8"
+    "sha512=68f00d9f9f1fa23468f7d32e71ddf0bc6b1ddcad12a0e08259a1ee5e58d9d0889fa71ec08f531e4eab172dd40cb4efdd2f7f5dd96333abf010ed140f92737c2f"
+  ]
+}
+x-commit-hash: "b0bf35a98cced23ebac594dfe5c427fa0748d8f8"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.2/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "4.0.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.2/happy-eyeballs-v0.0.2.tbz"
+  checksum: [
+    "sha256=c58e83c6d62393797d751cf17f833c310df7970cefe404d8d935b209fc5f0ea8"
+    "sha512=68f00d9f9f1fa23468f7d32e71ddf0bc6b1ddcad12a0e08259a1ee5e58d9d0889fa71ec08f531e4eab172dd40cb4efdd2f7f5dd96333abf010ed140f92737c2f"
+  ]
+}
+x-commit-hash: "b0bf35a98cced23ebac594dfe5c427fa0748d8f8"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>

##### CHANGES:

* Delay connect failure if v6 resolution and connection attempt fails before
  v4 resolution had a chance to succeed or fail (issue roburio/happy-eyeballs#9).
