### PR TITLE
jst-config returns inconsistent configuration on PowerPC and IBM Z

### DIFF
--- a/packages/core/core.v0.12.0/opam
+++ b/packages/core/core.v0.12.0/opam
@@ -30,4 +30,3 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.12/files/core-v0.12.0.tar.gz"
   checksum: "md5=22ea4ee001f178c0f9d878c145530fd3"
 }
-available: arch != "ppc64" 

--- a/packages/core/core.v0.12.1/opam
+++ b/packages/core/core.v0.12.1/opam
@@ -30,4 +30,3 @@ url {
     "https://github.com/janestreet/core/releases/download/v0.12.1/core-v0.12.1.tbz"
   checksum: "md5=3a1b7e7324b9884768eb1f85a3d49ad6"
 }
-available: arch != "ppc64" 

--- a/packages/core/core.v0.12.2/opam
+++ b/packages/core/core.v0.12.2/opam
@@ -30,4 +30,3 @@ url {
     "https://github.com/janestreet/core/archive/v0.12.2.tar.gz"
   checksum: "md5=c521d9ae441683154b0008146c112ff4"
 }
-available: arch != "ppc64" 

--- a/packages/core/core.v0.12.3/opam
+++ b/packages/core/core.v0.12.3/opam
@@ -30,4 +30,3 @@ url {
     "https://github.com/janestreet/core/archive/v0.12.3.tar.gz"
   checksum: "md5=7bd476a69141c1b921dee8c1b4dd6353"
 }
-available: arch != "ppc64" 

--- a/packages/core/core.v0.12.4/opam
+++ b/packages/core/core.v0.12.4/opam
@@ -29,4 +29,3 @@ url {
   src: "https://github.com/janestreet/core/archive/v0.12.4.tar.gz"
   checksum: "md5=85f006b0666f4fe05c566be8fda64cb2"
 }
-available: arch != "ppc64" 

--- a/packages/core/core.v0.13.0/opam
+++ b/packages/core/core.v0.13.0/opam
@@ -30,4 +30,3 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.13/files/core-v0.13.0.tar.gz"
   checksum: "md5=0dedfb21e756427ea39ab4dc173d67a9"
 }
-available: arch != "ppc64" 

--- a/packages/core/core.v0.14.0/opam
+++ b/packages/core/core.v0.14.0/opam
@@ -31,4 +31,3 @@ url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.14/files/core-v0.14.0.tar.gz"
   checksum: "md5=571dc65fff922c86951068d66e4a05ca"
 }
-available: arch != "ppc64"

--- a/packages/core/core.v0.14.1/opam
+++ b/packages/core/core.v0.14.1/opam
@@ -31,4 +31,3 @@ url {
   src: "https://github.com/janestreet/core/archive/v0.14.1.tar.gz"
   checksum: "md5=b11f58205953d84cedb0003efcdab231"
 }
-available: arch != "ppc64"

--- a/packages/jst-config/jst-config.v0.12.0/opam
+++ b/packages/jst-config/jst-config.v0.12.0/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: [
   "base-native-int63"
 ]
+available: arch != "ppc32" & arch != "ppc64" & arch != "s390x" # https://github.com/janestreet/jst-config/pull/3
 synopsis: "Compile-time configuration for Jane Street libraries"
 description: "
 Defines compile-time constants used in Jane Street libraries such as Base, Core, and

--- a/packages/jst-config/jst-config.v0.13.0/opam
+++ b/packages/jst-config/jst-config.v0.13.0/opam
@@ -17,6 +17,7 @@ depends: [
   "dune"       {>= "1.5.1"}
   "dune-configurator"
 ]
+available: arch != "ppc32" & arch != "ppc64" & arch != "s390x" # https://github.com/janestreet/jst-config/pull/3
 synopsis: "Compile-time configuration for Jane Street libraries"
 description: "
 Defines compile-time constants used in Jane Street libraries such as Base, Core, and

--- a/packages/jst-config/jst-config.v0.14.0/opam
+++ b/packages/jst-config/jst-config.v0.14.0/opam
@@ -17,6 +17,7 @@ depends: [
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]
+available: arch != "ppc32" & arch != "ppc64" & arch != "s390x" # https://github.com/janestreet/jst-config/pull/3
 synopsis: "Compile-time configuration for Jane Street libraries"
 description: "
 Defines compile-time constants used in Jane Street libraries such as Base, Core, and


### PR DESCRIPTION
Alternative fix to https://github.com/ocaml/opam-repository/pull/17119 and https://github.com/ocaml/opam-repository/pull/19326

See https://github.com/janestreet/jst-config/pull/3 for the upstream fix