### PR TITLE
[new release] oniguruma (0.1.1)

### DIFF
--- a/packages/oniguruma/oniguruma.0.1.1/opam
+++ b/packages/oniguruma/oniguruma.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Oniguruma regular expression library"
+description: "Bindings to the Oniguruma regular expression library."
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "BSD-2-Clause"
+tags: ["regex"]
+homepage: "https://github.com/alan-j-hu/ocaml-oniguruma"
+doc: "https://alan-j-hu.github.io/ocaml-oniguruma/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-oniguruma/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "conf-oniguruma" {= "1"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator" {>= "2.9" & build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-oniguruma.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-oniguruma/releases/download/0.1.1/oniguruma-0.1.1.tbz"
+  checksum: [
+    "sha256=5628473f49f1cc3fc41e6e4ef62f006f14b5c593fa9ec223e3e6fdc9dd61ab35"
+    "sha512=a587b76d4130b6b3d308489709702b465133a817cc54b1721d21807476ad12ea84be53b2553b7136a756ba8e781ab67c1b5fa1b342cfab3844d9ccaf9a6a2eee"
+  ]
+}
+x-commit-hash: "b4bedad91a58825dc272f83d07f930dd693704fa"


### PR DESCRIPTION
Bindings to the Oniguruma regular expression library

- Project page: <a href="https://github.com/alan-j-hu/ocaml-oniguruma">https://github.com/alan-j-hu/ocaml-oniguruma</a>
- Documentation: <a href="https://alan-j-hu.github.io/ocaml-oniguruma/">https://alan-j-hu.github.io/ocaml-oniguruma/</a>

##### CHANGES:

- Use pkg-config to determine C flags (fixes alan-j-hu/ocaml-oniguruma#1).
- Explicitly cast between `const char*` and `const UChar*`.
