### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.3)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.3/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.3/happy-eyeballs-v0.0.3.tbz"
+  checksum: [
+    "sha256=03907738c696f6d941d1406a766d09b4770a8dbedd3a9388775c084754e62421"
+    "sha512=682bdab64007784569aa0dc17eaadab7b3e9017f02f28d273df4ccbfea1d7ae6443cb487f7709dee30693038b9236a8da63ee0df880e38979aef66ae27614bc5"
+  ]
+}
+x-commit-hash: "c5edc8bbb5df2b08e6d8f4ab31de4e1e28103e6b"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.3/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.3/happy-eyeballs-v0.0.3.tbz"
+  checksum: [
+    "sha256=03907738c696f6d941d1406a766d09b4770a8dbedd3a9388775c084754e62421"
+    "sha512=682bdab64007784569aa0dc17eaadab7b3e9017f02f28d273df4ccbfea1d7ae6443cb487f7709dee30693038b9236a8da63ee0df880e38979aef66ae27614bc5"
+  ]
+}
+x-commit-hash: "c5edc8bbb5df2b08e6d8f4ab31de4e1e28103e6b"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.3/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "4.0.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.3/happy-eyeballs-v0.0.3.tbz"
+  checksum: [
+    "sha256=03907738c696f6d941d1406a766d09b4770a8dbedd3a9388775c084754e62421"
+    "sha512=682bdab64007784569aa0dc17eaadab7b3e9017f02f28d273df4ccbfea1d7ae6443cb487f7709dee30693038b9236a8da63ee0df880e38979aef66ae27614bc5"
+  ]
+}
+x-commit-hash: "c5edc8bbb5df2b08e6d8f4ab31de4e1e28103e6b"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>

##### CHANGES:

* BUGFIX: Avoid exception if expand_list is called with an empty list
