### PR TITLE
Fix `ffmpeg` versioning in liquidsoap.2.0.0~rc1

### DIFF
--- a/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
@@ -87,14 +87,14 @@ conflicts: [
   "dssi" {< "0.1.3"}
   "faad" {< "0.5.0"}
   "fdkaac" {< "0.3.1"}
-  "ffmpeg" {< "1.0.0~beta2"}
-  "ffmpeg-avutil" {< "1.0.0~beta2"}
-  "ffmpeg-av" {< "1.0.0~beta2"}
-  "ffmpeg-avcodec" {< "1.0.0~beta2"}
-  "ffmpeg-avdevice" {< "1.0.0~beta2"}
-  "ffmpeg-avfilter" {< "1.0.0~beta2"}
-  "ffmpeg-swresample" {< "1.0.0~beta2"}
-  "ffmpeg-swscale" {< "1.0.0~beta2"}
+  "ffmpeg" {< "1.0.0~rc1"}
+  "ffmpeg-avutil" {< "1.0.0~rc1"}
+  "ffmpeg-av" {< "1.0.0~rc1"}
+  "ffmpeg-avcodec" {< "1.0.0~rc1"}
+  "ffmpeg-avdevice" {< "1.0.0~rc1"}
+  "ffmpeg-avfilter" {< "1.0.0~rc1"}
+  "ffmpeg-swresample" {< "1.0.0~rc1"}
+  "ffmpeg-swscale" {< "1.0.0~rc1"}
   "flac" {< "0.3.0"}
   "frei0r" {< "0.1.0"}
   "gstreamer" {< "0.3.1"}


### PR DESCRIPTION
The versioning for `ffmpeg` packages is wrong, sorry about that. This PR fixes it.