### PR TITLE
Hide dune.2.9.0 as much as possible (generates broken dune files)

### DIFF
--- a/packages/dune/dune.2.9.0/opam
+++ b/packages/dune/dune.2.9.0/opam
@@ -48,6 +48,7 @@ depends: [
   "base-unix"
   "base-threads"
 ]
+flags: avoid-version
 x-commit-hash: "641a95d2254ca7c51c97f07f2eed85b7a95db954"
 url {
   src: "https://github.com/ocaml/dune/releases/download/2.9.0/dune-2.9.0.tbz"


### PR DESCRIPTION
We can't remove it (as it would break lock files) but we can "hide" it for opam >= 2.1 users. It will still be available but will only be taken on the very last resort.
Now that 2.9.1 is release this won't change the users' installation too much.

cc @ejgallego 