### PR TITLE
[new release] re (1.10.1)

### DIFF
--- a/packages/re/re.1.10.1/opam
+++ b/packages/re/re.1.10.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+maintainer: "rudi.grinberg@gmail.com"
+authors: [
+  "Jerome Vouillon"
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Rudi Grinberg"
+  "Gabriel Radanne"
+]
+license: "LGPL-2.0 with OCaml linking exception"
+homepage: "https://github.com/ocaml/ocaml-re"
+bug-reports: "https://github.com/ocaml/ocaml-re/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "ounit" {with-test}
+  "seq"
+]
+
+synopsis: "RE is a regular expression library for OCaml"
+description: """
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)
+"""
+url {
+  src:
+    "https://github.com/ocaml/ocaml-re/releases/download/1.10.1/re-1.10.1.tbz"
+  checksum: [
+    "sha256=e0c1b03477c46ca7c0256c0d43fb5f1c5d5c38bb5e3c4e40296f6a1a4d7c7733"
+    "sha512=cf92897a4fa7d65d388044fff23b45fb77835b30460826ad148d1b85a58e7ee21de91a5d2bd9223929b46bc48c12e9345563cfb6c89b9c7e0486e5ba6928c8a2"
+  ]
+}
+x-commit-hash: "f7737dfba30dc69794afe0efe1046ed77cd8bd1f"


### PR DESCRIPTION
RE is a regular expression library for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-re">https://github.com/ocaml/ocaml-re</a>

##### CHANGES:

* Glob: add optional argument `?backslash_escapes` to control interpretation of
  backslashes (useful under Windows) (ocaml/ocaml-re#197, ocaml/ocaml-re#198)

* Restore accidentally deleted `*_seq` deprecated aliases.
