### PR TITLE
OCaml 4.13.0~rc1 packages

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "First release candidate of OCaml 4.13.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git://github.com/ocaml/ocaml#4.13"
+depends: [
+  "ocaml" {= "4.13.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.13.0-rc1.tar.gz"
+  checksum: "sha256=19d79c91c51e01050b97601831111ca3d10cd6c0a1a382d943011eecdf734c53"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate of OCaml 4.13.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.13"
+depends: [
+  "ocaml" {= "4.13.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version hidden-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.13.0-rc1.tar.gz"
+  checksum: "sha256=19d79c91c51e01050b97601831111ca3d10cd6c0a1a382d943011eecdf734c53"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]


### PR DESCRIPTION
This is the first release candidate for OCaml 4.13.0. Compared to the last beta, this version includes two more safe bug fixes in flambda and compiler-libs, a small regression fix when compiling C file with ocaml{c,opt}, and mostly internal configuration and build improvements.

## Changes since the beta release

### Bug fixes

- [#10593](https://github.com/ocaml/ocaml/issues/10593): Fix untyping of patterns without named existential quantifiers. This
  bug was only present in the beta version of OCaml 4.13.0.
  (Ulysse Gérard, review by Florian Angeletti)

- [#10603](https://github.com/ocaml/ocaml/issues/10603), [#10611](https://github.com/ocaml/ocaml/issues/10611): Fix if condition marked as inconstant in flambda
  (Vincent Laviron and Pierre Chambart, report by Marcello Seri)

### Regression fix

+ [#9960](https://github.com/ocaml/ocaml/issues/9960), [#10619(*new in rc1*)](https://github.com/ocaml/ocaml/issues/10619): extend ocamlc/ocamlopt's -o option to work when
  compiling C files
  (Sébastien Hinderer, reported by Daniel Bünzli, review by
  Florian Angeletti and Gabriel Scherer)

### Internal configuration and build system

- [#10451](https://github.com/ocaml/ocaml/issues/10451): Replace the use of iconv with a C utility to convert $(LIBDIR) to a
  C string constant on Windows when building the runtime. Hardens the generation
  of the constant on Unix for paths with backslashes, double-quotes and
  newlines.
  (David Allsopp, review by Florian Angeletti and Sébastien Hinderer)

- [#10471](https://github.com/ocaml/ocaml/issues/10471): Fix detection of arm32 architectures with musl in configure.
  (Louis Gesbert, review by David Allsopp)

- [#10511](https://github.com/ocaml/ocaml/issues/10511): Cygwin ports now correctly configure when flexdll is not available.
  (David Allsopp, review by Florian Angeletti)

- [#10584](https://github.com/ocaml/ocaml/issues/10584), [#10856](https://github.com/ocaml/ocaml/issues/10856): Standard Library documentation build no longer fails if
  optional libraries have been disabled.
  (David Allsopp, report by Yuri Victorovich review by Florian Angeletti)

### Manual
- [#10605](https://github.com/ocaml/ocaml/issues/10605): manual, name few css classes to ease styling and maintainability.
  (Florian Angeletti, review by Wiktor Kuchta and Gabriel Scherer)
