### PR TITLE
Fix #19474 (please do not force-push tags after releases)

### DIFF
--- a/packages/core_kernel/core_kernel.v0.14.2/opam
+++ b/packages/core_kernel/core_kernel.v0.14.2/opam
@@ -44,5 +44,5 @@ Core_kernel is the system-independent part of Core.
 "
 url {
   src: "https://github.com/janestreet/core_kernel/archive/v0.14.2.tar.gz"
-  checksum: "md5=ede2f6d22eaa8320f88bac67d41b5cff"
+  checksum: "md5=1cf251902ba0cc2fb607083a545611e6"
 }

--- a/packages/ppx_optcomp/ppx_optcomp.v0.14.3/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.14.3/opam
@@ -22,5 +22,5 @@ Part of the Jane Street's PPX rewriters collection.
 "
 url {
   src: "https://github.com/janestreet/ppx_optcomp/archive/v0.14.3.tar.gz"
-  checksum: "md5=2d012df62dd0bc82d2ea4ab25b628992"
+  checksum: "md5=47ffbef1fe45cdca7953c81cb2b8f242"
 }


### PR DESCRIPTION
@cwong-ocaml Unless you can fix the tag (force-push back the old archive) quickly, I'm gonna have to push that.
```
diff -ru ppx_optcomp-0.14.3.old/ppx_optcomp.opam ppx_optcomp-0.14.3.new/ppx_optcomp.opam
--- ppx_optcomp-0.14.3.old/ppx_optcomp.opam	2021-09-08 22:34:45.000000000 +0100
+++ ppx_optcomp-0.14.3.new/ppx_optcomp.opam	2021-08-16 11:48:02.000000000 +0100
@@ -11,7 +11,7 @@
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"  {>= "4.04.2"}
+  "ocaml"  {>= "4.08"}
   "base"   {>= "v0.14" & < "v0.15"}
   "stdio"  {>= "v0.14" & < "v0.15"}
   "dune"   {>= "2.0.0"}
```
```
diff -ru core_kernel-0.14.2.old/core_kernel.opam core_kernel-0.14.2.new/core_kernel.opam
--- core_kernel-0.14.2.old/core_kernel.opam	2021-09-08 22:32:54.000000000 +0100
+++ core_kernel-0.14.2.new/core_kernel.opam	2021-08-16 11:56:31.000000000 +0100
@@ -26,7 +26,6 @@
   "ppx_jane"            {>= "v0.14" & < "v0.15"}
   "ppx_sexp_conv"       {>= "v0.14" & < "v0.15"}
   "ppx_sexp_message"    {>= "v0.14" & < "v0.15"}
+  "ppx_optcomp"         {>= "v0.14.3" & < "v0.15"}
   "sexplib"             {>= "v0.14" & < "v0.15"}
   "splittable_random"   {>= "v0.14" & < "v0.15"}
   "stdio"               {>= "v0.14" & < "v0.15"}
```