### PR TITLE
uri.2.2.1: Disable build parallelism (non-deterministic failures)

### DIFF
--- a/packages/uri/uri.2.2.1/opam
+++ b/packages/uri/uri.2.2.1/opam
@@ -23,8 +23,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" "1"] # Does not support parallel build
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 url {
   src:


### PR DESCRIPTION
```
#=== ERROR while compiling uri.2.2.1 ==========================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.12.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12.0/.opam-switch/build/uri.2.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p uri -j 31
# exit-code            1
# env-file             ~/.opam/log/uri-20-332c21.env
# output-file          ~/.opam/log/uri-20-332c21.out
### output ###
#       ocamlc lib/.uri.objs/byte/uri_re.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.uri.objs/byte -no-alias-deps -o lib/.uri.objs/byte/uri_re.cmo -c -impl lib/.wrapped_compat/Uri_re.ml-gen)
# File "lib/.wrapped_compat/Uri_re.ml-gen", line 1, characters 99-110:
# 1 | [@@@deprecated "Please switch to using Uri.Re instead of Uri_re. Use Uri.Uri_re instead."] include Uri__Uri_re
#                                                                                                        ^^^^^^^^^^^
# Error: Unbound module Uri__Uri_re
```