### PR TITLE
[new release] http-lwt-client (0.0.4)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.4/opam
@@ -23,6 +23,7 @@ depends: [
   "happy-eyeballs-lwt"
   "h2" {>= "0.8.0"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/http-lwt-client/http-lwt-client.0.0.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.8.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.4/http-lwt-client-v0.0.4.tbz"
+  checksum: [
+    "sha256=dcbfdd5dda3b43a22c288a84df81370cd0b9b26bc7f0fdfb4c54b998356caaf8"
+    "sha512=f7e7f7fe14c01482904c62341332931f48d12078f3e482657ece34e14733d9861f62e127b90f4230b3549a1843b431b9cf22f3f22fe00eec73d0c2dee08d2a6c"
+  ]
+}
+x-commit-hash: "eedc4e1fc9f369d1e169735eb286cf3b6baeb2b4"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Add ?happy_eyeballs to Http_lwt_client.one_request to allow reusing this
  state across requests
* Initialize Ca_certs.authenticator only once (lazily) to avoid decoding
  trust anchors multiple times
* Fix Http_lwt_unix.Buffer for resizing on put (to avoid errors with H2)
* Avoid exceptions from Lwt.wakeup_later by calling it at most once
