### PR TITLE
[new release] http-lwt-client (0.0.4)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.8.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.4/http-lwt-client-v0.0.4.tbz"
+  checksum: [
+    "sha256=ac3a55dc42d584e41506e0197ef52ae1dcfb902c463bd72d61a1a7af803cb430"
+    "sha512=00ef84031d153cc206894ea30dd616b1f7e1220b220e89ec804dbbfa01239d7a0e81385e015601bc6535e490e192b3fb0faf603098e1204d0209bcd13a084f6b"
+  ]
+}
+x-commit-hash: "586316168df71d89c51bc0d42c8f1f017e6bae52"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Avoid exception in resolve_location
* Add ?happy_eyeballs to Http_lwt_client.one_request to allow reusing this
  state across requests
* Initialize Ca_certs.authenticator only once (lazily) to avoid decoding
  trust anchors multiple times
* Fix Http_lwt_unix.Buffer for resizing on put (to avoid errors with H2)
* Avoid exceptions from Lwt.wakeup_later by calling it at most once
