### PR TITLE
[new release] http-lwt-client (0.0.4)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner"
+  "logs"
+  "lwt"
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.8.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.4/http-lwt-client-v0.0.4.tbz"
+  checksum: [
+    "sha256=948df1c8382d3f37b75dcb064aafaaae15232cc0b149afe907cbee8674808d30"
+    "sha512=e78d0efd8e8fb8944aaf8b9d248189ac8396351477ad4f4c262f4968d5a9c892bdda76e92a20390490b14d22ab84b103c6a0823628fe96ec1aa48c9c7a75e943"
+  ]
+}
+x-commit-hash: "ae79cbc8c3eb12e73c3f8dc1bb310a0e9020d52d"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Add ?tls_config to Http_lwt_client.one_request to enable passing an entire
  TLS configuration
* Avoid exception in resolve_location
* Add ?happy_eyeballs to Http_lwt_client.one_request to allow reusing this
  state across requests
* Initialize Ca_certs.authenticator only once (lazily) to avoid decoding
  trust anchors multiple times
* Fix Http_lwt_unix.Buffer for resizing on put (to avoid errors with H2)
* Avoid exceptions from Lwt.wakeup_later by calling it at most once
