### PR TITLE
[new release] opam-grep (0.2.0)

### DIFF
--- a/packages/opam-grep/opam-grep.0.2.0/opam
+++ b/packages/opam-grep/opam-grep.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "An opam plugin that greps anything in the sources of every opam packages"
+license: "MIT"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+homepage: "https://github.com/kit-ty-kate/opam-grep"
+dev-repo: "git://github.com/kit-ty-kate/opam-grep.git"
+bug-reports: "https://github.com/kit-ty-kate/opam-grep/issues"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "progress" {>= "0.2.1"}
+  "cmdliner" {>= "1.0.4"}
+  "fpath" {>= "0.7.3"}
+  "bos" {>= "0.2.0"}
+]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-grep/releases/download/v0.2.0/opam-grep-v0.2.0.tbz"
+  checksum: [
+    "sha256=7ffa5acaa2853b7ebb3b481824314fa9c5fe3962393153ef4bb1554b246ae604"
+    "sha512=909b4f96d869f31188bd2b74843c670439f46bba24e7136592e558322f41a8e91e61e63cb92aace7fc1ea351ff18869b7a08eb067310d8fffd84fc5c180e6f68"
+  ]
+}
+x-commit-hash: "eefb9a14e286511d62d140d2cdff079a74de0abb"


### PR DESCRIPTION
An opam plugin that greps anything in the sources of every opam packages

- Project page: <a href="https://github.com/kit-ty-kate/opam-grep">https://github.com/kit-ty-kate/opam-grep</a>

##### CHANGES:

- Complete rewrite from POSIX shell script to OCaml, making it more portable
- Use the faster `ripgrep` and `ugrep` over `grep` when available (suggestion from @Engil)
- Ignore read failures from grep (symlinks to unreachable files can make it fail)
- Use `$XDG_CACHE_HOME` when available to store the archives instead of just `~/.cache`
- Use the `progress` library to show progress instead of a non-portable/DIY spinner
- Use the `cmdliner` library to handle arguments and produce a manpage via --help
