### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.4)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.4/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.4/happy-eyeballs-v0.0.4.tbz"
+  checksum: [
+    "sha256=be1bb277a757acd1a21eb86f9670a724e3c6c8bd40cec2362f61b5731848fe99"
+    "sha512=2444ec232652ec790e5552e1b0d64b28755a65541c673b54a4168ca1cea8ca9ad1d31029287186c9d5ca682b45adabefb1f9c817a17919b44f03df99d08a95d4"
+  ]
+}
+x-commit-hash: "0a9d099b893071ebfc392df42d0aa88b406b685c"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.4/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.4/happy-eyeballs-v0.0.4.tbz"
+  checksum: [
+    "sha256=be1bb277a757acd1a21eb86f9670a724e3c6c8bd40cec2362f61b5731848fe99"
+    "sha512=2444ec232652ec790e5552e1b0d64b28755a65541c673b54a4168ca1cea8ca9ad1d31029287186c9d5ca682b45adabefb1f9c817a17919b44f03df99d08a95d4"
+  ]
+}
+x-commit-hash: "0a9d099b893071ebfc392df42d0aa88b406b685c"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.4/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.4/happy-eyeballs-v0.0.4.tbz"
+  checksum: [
+    "sha256=be1bb277a757acd1a21eb86f9670a724e3c6c8bd40cec2362f61b5731848fe99"
+    "sha512=2444ec232652ec790e5552e1b0d64b28755a65541c673b54a4168ca1cea8ca9ad1d31029287186c9d5ca682b45adabefb1f9c817a17919b44f03df99d08a95d4"
+  ]
+}
+x-commit-hash: "0a9d099b893071ebfc392df42d0aa88b406b685c"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>

##### CHANGES:

* Use set from ipaddr (>= 5.2.0) instead providing these
