### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.5)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.5/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.5/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.5/happy-eyeballs-v0.0.5.tbz"
+  checksum: [
+    "sha256=58596df95f623d79feef051ef9a31243da03bfc544d0fe0e6426ed16cac672fe"
+    "sha512=77fcfdae997a3f710fe56bc5ba8e2f5f4535405246c66463f118de804931f40be0d0a2ed498c5a9d5c6bf0d364295f9b062dd08cc561f8f4a279fc63214490b5"
+  ]
+}
+x-commit-hash: "745ba4839a6d71e104f88387f258938ef08ef166"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.5/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.5/happy-eyeballs-v0.0.5.tbz"
+  checksum: [
+    "sha256=58596df95f623d79feef051ef9a31243da03bfc544d0fe0e6426ed16cac672fe"
+    "sha512=77fcfdae997a3f710fe56bc5ba8e2f5f4535405246c66463f118de804931f40be0d0a2ed498c5a9d5c6bf0d364295f9b062dd08cc561f8f4a279fc63214490b5"
+  ]
+}
+x-commit-hash: "745ba4839a6d71e104f88387f258938ef08ef166"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.5/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.5/happy-eyeballs-v0.0.5.tbz"
+  checksum: [
+    "sha256=58596df95f623d79feef051ef9a31243da03bfc544d0fe0e6426ed16cac672fe"
+    "sha512=77fcfdae997a3f710fe56bc5ba8e2f5f4535405246c66463f118de804931f40be0d0a2ed498c5a9d5c6bf0d364295f9b062dd08cc561f8f4a279fc63214490b5"
+  ]
+}
+x-commit-hash: "745ba4839a6d71e104f88387f258938ef08ef166"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>

##### CHANGES:

* connect_ip: take an optional shuffle argument and an ordered list of ips to
  attempt connections to. The reason for this change is that /etc/resolv.conf
  specifies an ordering.
