### PR TITLE
fix url.src for chamo

### DIFF
--- a/packages/chamo/chamo.2.01/opam
+++ b/packages/chamo/chamo.2.01/opam
@@ -18,6 +18,6 @@ synopsis:
   "A source code editor, even if it can be used to edit any text file."
 extra-files: ["chamo.install" "md5=61635a19e58f6af4d4587471c79bef4a"]
 url {
-  src: "http://zoggy.github.com/chamo/chamo-2.01.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/e9/e9e2047c929680884c35cee6a973735c"
   checksum: "md5=e9e2047c929680884c35cee6a973735c"
 }

--- a/packages/chamo/chamo.2.02/opam
+++ b/packages/chamo/chamo.2.02/opam
@@ -22,6 +22,6 @@ synopsis:
   "A source code editor, even if it can be used to edit any text file."
 extra-files: ["chamo.install" "md5=61635a19e58f6af4d4587471c79bef4a"]
 url {
-  src: "http://zoggy.github.com/chamo/chamo-2.02.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/ef/efedc2453f1ca3e24c9de93f236db578"
   checksum: "md5=efedc2453f1ca3e24c9de93f236db578"
 }

--- a/packages/chamo/chamo.2.03/opam
+++ b/packages/chamo/chamo.2.03/opam
@@ -28,6 +28,6 @@ synopsis:
   "A source code editor, even if it can be used to edit any text file."
 extra-files: ["chamo.install" "md5=61635a19e58f6af4d4587471c79bef4a"]
 url {
-  src: "http://zoggy.github.com/chamo/chamo-2.03.tar.gz"
+  src: "https://opam.ocaml.org/cache/md5/f2/f2dc1e57c4205349796a8745065f5e95"
   checksum: "md5=f2dc1e57c4205349796a8745065f5e95"
 }


### PR DESCRIPTION
@zoggy I tried to use the tarball from gitlab but the md5sum wasn't matching (at least for 2.01) so I went with opam's cache