### PR TITLE
PRINGO version 1.2

### DIFF
--- a/packages/pringo/pringo.1.2/opam
+++ b/packages/pringo/pringo.1.2/opam
@@ -4,7 +4,7 @@ description:
   "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
 maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
 authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
-license: "GPL v2 with static linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xavierleroy/pringo"
 bug-reports: "https://github.com/xavierleroy/pringo/issues"
 depends: [

--- a/packages/pringo/pringo.1.2/opam
+++ b/packages/pringo/pringo.1.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Pseudo-random, splittable number generators"
+description:
+  "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "GPL v2 with static linking exception"
+homepage: "https://github.com/xavierleroy/pringo"
+bug-reports: "https://github.com/xavierleroy/pringo/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+]
+build: make
+install: [make "install"]
+dev-repo: "git+https://https://github.com/xavierleroy/pringo"
+url {
+  src: "https://github.com/xavierleroy/pringo/archive/1.2.tar.gz"
+  checksum: [
+    "md5=f8b07c628f19965de66de9d3c64f958b"
+    "sha512=a7ee4769707237b326e0d99de72e1ce16975baac3a4444abb4bc7c8c5e56e2115feb0efd70a169bdc5b0f5fda6a16395f3485fac654cc0ca14bf08b454897a42"
+  ]
+}


### PR DESCRIPTION
Version 1.2 of the PRINGO library: Pseudo-Random, splIttable Number Generators for Ocaml

- PR 3: unbox the argument of the mix30 C stub
- Install .cmti and .mli files for documentation
