### PR TITLE
Camlzip 1.11

### DIFF
--- a/packages/camlzip/camlzip.1.11/opam
+++ b/packages/camlzip/camlzip.1.11/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis:
-  "Accessing compressed files in ZIP, GZIP and JAR format."
+  "Accessing compressed files in ZIP, GZIP and JAR format"
 description:
   "The Camlzip library provides easy access to compressed files in ZIP and GZIP format, as well as to Java JAR files.  It provides functions for reading from and writing to compressed files in these formats."
 maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]

--- a/packages/camlzip/camlzip.1.11/opam
+++ b/packages/camlzip/camlzip.1.11/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis:
+  "Accessing compressed files in ZIP, GZIP and JAR format."
+description:
+  "The Camlzip library provides easy access to compressed files in ZIP and GZIP format, as well as to Java JAR files.  It provides functions for reading from and writing to compressed files in these formats."
+maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/camlzip"
+bug-reports: "https://github.com/xavierleroy/camlzip/issues"
+dev-repo: "git+https://github.com/xavierleroy/camlzip.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  [make "all"]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ocamlfind" {build}
+  "conf-zlib"
+]
+url {
+  src: "https://github.com/xavierleroy/camlzip/archive/rel111.tar.gz"
+  checksum: [
+    "sha256=ffbbc5de3e1c13dc0e59272376d232d2ede91b327551063d47fddb74f1d5ed37"
+    "sha512=4d69ef900437e66e00cd345497ec70f407f28cd8344ee5f2fad685d3bfe356924597d1854b752f2841b4007f96d6e0307cfae7e13cfb6f74951ae3eba5198a06"
+  ]
+}


### PR DESCRIPTION
- Zip.add_entry_generator ~level:0 was missing a CRC update
- GPR 28: fix build on platforms with no shared libs
- GPR 33: update META files to use plugin convention
- Use Stdlib.xxx instead of Pervasives.xxx. OCaml >= 4.07 is required.
- make all automatically builds in native-code if supported
- Added local .opam file
- Updated tests and added automatic test harness
- Generate and install .mli, .cmt, and .cmti files
