### PR TITLE
make ezjs_min.0.2.2 not available

### DIFF
--- a/packages/ezjs_min/ezjs_min.0.2.2/opam
+++ b/packages/ezjs_min/ezjs_min.0.2.2/opam
@@ -39,3 +39,4 @@ url {
     "sha512=b0b94f5bdd8dadf7bacf6cbb6fcd78885f9762bc9a3e8b1d5b866a1251e00b0f893dbff5d84987203cfdf9ac1fd43f542f328e8b9f9d8333949c1aaf0d5681ea"
   ]
 }
+available: false


### PR DESCRIPTION
the tarball is not even in the cache so there's nothing we can do here...

@maxtori 