### PR TITLE
Constrain every packages using tsdl-ttf or tsdl-image

### DIFF
--- a/packages/bogue/bogue.20190717/opam
+++ b/packages/bogue/bogue.20190717/opam
@@ -30,8 +30,8 @@ Programming with bogue is easy if you're used to GUIs with widgets,
 layouts, callbacks, and of course it has a functional flavor. It uses
 Threads when non-blocking reactions are needed."""
 depends: [
-  "tsdl-image" {>= "0.2"}
-  "tsdl-ttf" {>= "0.2"}
+  "tsdl-image" {>= "0.2" & < "0.3"}
+  "tsdl-ttf" {>= "0.2" & < "0.3"}
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.10"}
   "tsdl" {>= "0.9.0" & < "0.9.7"}

--- a/packages/bogue/bogue.20190920/opam
+++ b/packages/bogue/bogue.20190920/opam
@@ -30,8 +30,8 @@ Programming with bogue is easy if you're used to GUIs with widgets,
 layouts, callbacks, and of course it has a functional flavor. It uses
 Threads when non-blocking reactions are needed."""
 depends: [
-  "tsdl-image" {>= "0.2"}
-  "tsdl-ttf" {>= "0.2"}
+  "tsdl-image" {>= "0.2" & < "0.3"}
+  "tsdl-ttf" {>= "0.2" & < "0.3"}
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.10"}
   "tsdl" {>= "0.9.0" & < "0.9.7"}

--- a/packages/bogue/bogue.20200630/opam
+++ b/packages/bogue/bogue.20200630/opam
@@ -32,8 +32,8 @@ layouts, callbacks, and of course it has a functional flavor. It uses
 Threads when non-blocking reactions are needed."""
 depends: [
   "stdlib-shims" {>= "0.1.0"}
-  "tsdl-image" {>= "0.2"}
-  "tsdl-ttf" {>= "0.2"}
+  "tsdl-image" {>= "0.2" & < "0.3"}
+  "tsdl-ttf" {>= "0.2" & < "0.3"}
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.10"}
   "tsdl" {>= "0.9.0" & < "0.9.7"}

--- a/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.0~rc1/opam
@@ -118,7 +118,7 @@ conflicts: [
   "srt" {< "0.1.2"}
   "ssl" {< "0.5.2"}
   "taglib" {< "0.3.0"}
-  "tsdl-image" {< "0.2.0"}
+  "tsdl-image" {< "0.2.0" | >= "0.3"}
   "theora" {< "0.4.0"}
   "vorbis" {< "0.8.0"}
   "xmlplaylist" {< "0.1.3"}

--- a/packages/sdl-liquidsoap/sdl-liquidsoap.2/opam
+++ b/packages/sdl-liquidsoap/sdl-liquidsoap.2/opam
@@ -5,5 +5,5 @@ authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 synopsis: "Virtual package installing liquidsoap's sdl dependencies"
 description:
   "This package installs SDL dependencies for liquidsoap."
-depends: ["tsdl-image" "tsdl-ttf"]
+depends: ["tsdl-image" {< "0.3"} "tsdl-ttf"]
 bug-reports: "https://github.com/savonet/liquidsoap/issues"


### PR DESCRIPTION
changed the library name from tsdl_{ttf,image} to tsdl-{ttf,image}

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>