### PR TITLE
[new release] key-parsers (1.4.0)

### DIFF
--- a/packages/key-parsers/key-parsers.1.4.0/opam
+++ b/packages/key-parsers/key-parsers.1.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Nathan Rebours <nathan.p.rebours@gmail.com>"
+]
+homepage: "https://github.com/cryptosense/key-parsers"
+bug-reports: "https://github.com/cryptosense/key-parsers/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/cryptosense/key-parsers.git"
+doc: "https://cryptosense.github.io/key-parsers/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "asn1-combinators" {>= "0.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "dune" {>= "2.0"}
+  "hex" {>= "1.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "ounit" {with-test & >= "2.0.0"}
+  "ppx_deriving" {>= "4.0"}
+  "result" {>= "1.5"}
+  "zarith" {>= "1.4.1"}
+]
+conflicts: [
+  "ppx_driver" {= "v0.9.1"}
+]
+synopsis: "Parsers for multiple key formats"
+description: """
+This library provides parsers for several encodings of RSA, DSA, Diffie-Hellman or
+Elliptic curve public and private keys.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/key-parsers/releases/download/1.4.0/key-parsers-1.4.0.tbz"
+  checksum: [
+    "sha256=01466350871121b73ae2c23eace1ac6aa883898d7dd0f9ad34c523413d2e67c0"
+    "sha512=3958075aa13bf05a51bf59c2b1d56c7afa404479bb4f23415a9f23582c9bdcf0d91f7f51a3f77f99effc19b0563834c1a83c84f841a8a0406610858db56400f4"
+  ]
+}
+x-commit-hash: "7944dc93538b944a88a0ffe5a177e6a84e5945da"


### PR DESCRIPTION
Parsers for multiple key formats

- Project page: <a href="https://github.com/cryptosense/key-parsers">https://github.com/cryptosense/key-parsers</a>
- Documentation: <a href="https://cryptosense.github.io/key-parsers/doc">https://cryptosense.github.io/key-parsers/doc</a>

##### CHANGES:

*2021-09-14*

### Changed

- Parse Signature packets/Marker packets in the PGP module
