### PR TITLE
fix url.src for imagemagick

### DIFF
--- a/packages/imagemagick/imagemagick.0.34-1/opam
+++ b/packages/imagemagick/imagemagick.0.34-1/opam
@@ -17,7 +17,6 @@ synopsis: "Bindings for ImageMagick"
 flags: light-uninstall
 extra-files: ["fix_build.patch" "md5=ba5ad56e150b9f685363f59d2a163dea"]
 url {
-  src:
-    "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/downloads/OCaml-ImageMagick-0.34.tgz"
+  src: "https://opam.ocaml.org/cache/md5/d4/d4e28dce94ccefba878ad31016f05fe4"
   checksum: "md5=d4e28dce94ccefba878ad31016f05fe4"
 }

--- a/packages/imagemagick/imagemagick.0.34/opam
+++ b/packages/imagemagick/imagemagick.0.34/opam
@@ -14,7 +14,6 @@ install: [make "find_install"]
 synopsis: "Bindings for ImageMagick"
 flags: light-uninstall
 url {
-  src:
-    "http://www.linux-nantes.org/~fmonnier/OCaml/ImageMagick/downloads/OCaml-ImageMagick-0.34.tgz"
+  src: "https://opam.ocaml.org/cache/md5/d4/d4e28dce94ccefba878ad31016f05fe4"
   checksum: "md5=d4e28dce94ccefba878ad31016f05fe4"
 }


### PR DESCRIPTION
@kit-ty-kate there's something weird with this one: 0.34 and 0.34-1 are exactly the same ! Should we remove 0.34-1 ?

@fccm fyi, your pages on `linux-nantes.org` are down so we can't acess the dev-repo anymore nor the tarballs.

EDIT: OK actually, 0.34-1 seems to contain a patch in `extra-files`, my bad. Yet I'm surprised: why hasn't the patch been added to 0.34 directly ?