### PR TITLE
[new release] albatross (1.3.0)

### DIFF
--- a/packages/albatross/albatross.1.3.0/opam
+++ b/packages/albatross/albatross.1.3.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "rresult"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt"
+  "astring"
+  "jsonm"
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.3.0/albatross-v1.3.0.tbz"
+  checksum: [
+    "sha256=719e46a97cb32d9d6033946ea1846684dcef1418f5ecaa6fc826864354d5f92e"
+    "sha512=1aff6d4c91432607f19f90bb264df74b02b9c9f8f325c01926398d50ae96932af61420c16a77b80f6e0e3514c920c2fcfb21d96e27ff94683070afd2b564f08f"
+  ]
+}
+x-commit-hash: "5817c38472d2dc7b519276da991e2047b0a134aa"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- provide arguments for public-key-type and bits, the default is now
  Ed25519 (used to be RSA) (@hannesm)
- use happy-eyeballs for name resolution and connection setup (@hannesm)
- converge albatross-client-* semantics (@hannesm)
- Implement block_set and block_dump subcommands, also block_add is extended
  to include the block device data (@hannesm, inspired by @dinosaure)
- Implement update subcommand for albatross-client-{local,bistro}, which
  (a) retrieves the digest of a running unikernel (b) looks up that hash
  on http://builds.robur.coop (a repository of reproducible built unikernels)
  (c) does a unikernel update (with same arguments and configuration)
  (@reynir @hannesm)
- Debian and FreeBSD packaging via orb, available on https://builds.robur.coop
  (roburio/albatross#80 @hannesm @reynir)
- Linux: add albatross user and group, as done on FreeBSD (roburio/albatross#79 roburio/albatross#81 @dinosaure)
- Fixes to README (roburio/albatross#78 @yomimono)
