### PR TITLE
Package ocsigen-toolkit.3.0.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.0.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/3.0.1.tar.gz"
+  checksum: [
+    "md5=99334c92b41884cc4c2c48f9de1aa2c2"
+    "sha512=58744d01289290f3be3a3828e53ec992c7e26cfde9b869bc10395e6487d064d167a87ee1510cca4d24723ca34ec8d23badedc14ed1204540477220fccbcf4214"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.0.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0