### PR TITLE
Add: uucd.14.0.0, uucp.14.0.0, uunf.14.0.0, uuseg.14.0.0

### DIFF
--- a/packages/uucd/uucd.14.0.0/opam
+++ b/packages/uucd/uucd.14.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: """Unicode character database decoder for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uucd programmers"]
+homepage: "https://erratique.ch/software/uucd"
+doc: "https://erratique.ch/software/uucd/doc/Uucd"
+dev-repo: "git+https://erratique.ch/repos/uucd.git"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+license: ["ISC"]
+tags: ["unicode" "database" "decoder" "org:erratique"]
+depends: ["ocaml" {>= "4.01.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "xmlm"]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/uucd/releases/uucd-14.0.0.tbz"
+  checksum: "sha512=2748ea59440e5379b7a1ed2aed94f1ad0c9f9063ae329a3ac9fc8dc057fa95b4b7c81fc0011eab89af31ddfe8e5562a49476590b36352e62004db476c45a67e1"}
+description: """
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 
+
+Home page: http://erratique.ch/software/uucd"""

--- a/packages/uucp/uucp.14.0.0/opam
+++ b/packages/uucp/uucp.14.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: """Unicode character properties for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uucp programmers"]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/"
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+license: ["ISC"]
+tags: ["unicode" "text" "character" "org:erratique"]
+depends: ["ocaml" {>= "4.03.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "uucd" {with-test}
+          "uunf" {with-test}
+          "uutf" {with-test}]
+depopts: ["uutf"
+          "uunf"
+          "cmdliner"]
+conflicts: ["uutf" {< "1.0.1"}
+            "cmdliner" {< "1.0.0"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+         "--with-uutf" "%{uutf:installed}%"
+         "--with-uunf" "%{uunf:installed}%"
+         "--with-cmdliner" "%{cmdliner:installed}%" ]]
+description: """
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+
+Home page: http://erratique.ch/software/uucp"""
+url {
+  src: "https://erratique.ch/software/uucp/releases/uucp-14.0.0.tbz"
+  checksum: "sha512=2d0224aed5d5accbb121624898f08598e8c74a2415942f159a54221c0cdac62ed64fc70a039c833e50110cefce77754ada9ac2d58f79a6fc9331135326fe6899"}
+post-messages: ["If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+                {failure & (arch = "ppc64" | arch = "arm64")}]

--- a/packages/uunf/uunf.14.0.0/opam
+++ b/packages/uunf/uunf.14.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: """Unicode text normalization for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uunf programmers"]
+homepage: "https://erratique.ch/software/uunf"
+doc: "https://erratique.ch/software/uunf/doc/Uunf"
+dev-repo: "git+https://erratique.ch/repos/uunf.git"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+license: ["ISC"]
+tags: ["unicode" "text" "normalization" "org:erratique"]
+depends: ["ocaml" {>= "4.03.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "uucd" {dev & >= "14.0.0" & < "15.0.0"}]
+depopts: ["uutf"
+          "cmdliner"]
+conflicts: ["uutf" {< "1.0.0"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+         "--with-uutf" "%{uutf:installed}%"
+         "--with-cmdliner" "%{cmdliner:installed}%" ]]
+description: """
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms][nf]. The library is independent from any
+IO mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf has no dependency. It may optionally depend on [Uutf][uutf] for
+support on OCaml UTF-X encoded strings. It is distributed under the
+ISC license.
+
+[nf]: http://www.unicode.org/reports/tr15/
+[uutf]: http://erratique.ch/software/uutf
+
+Home page: http://erratique.ch/software/uunf"""
+url {
+  src: "https://erratique.ch/software/uunf/releases/uunf-14.0.0.tbz"
+  checksum: "sha512=9aac01483abb8a8a5d68832d7f7692909d61559f2c9b0284c1da293f8115d1100df26e9e4cf7280bda6499ba866f5da2c72c4c21ca99a1d594b29d000e9bb051"}
+post-messages: ["If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+                {failure & (arch = "ppc64" | arch = "arm64")}]

--- a/packages/uuseg/uuseg.14.0.0/opam
+++ b/packages/uuseg/uuseg.14.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: """Unicode text segmentation for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uuseg programmers"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg/doc/"
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+license: ["ISC"]
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+depends: ["ocaml" {>= "4.03.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "uucp" {>= "14.0.0" & < "15.0.0"}]
+depopts: ["uutf"
+          "cmdliner"]
+conflicts: ["uutf" {< "1.0.0"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+         "--with-uutf" "%{uutf:installed}%"
+         "--with-cmdliner" "%{cmdliner:installed}%" ]]
+url {
+  src: "https://erratique.ch/software/uuseg/releases/uuseg-14.0.0.tbz"
+  checksum: "sha512=3f089baf95f010663a0c2f060b2911395d9b396f478efb10fd979815f527c9e61e0a70b3192f2e921f59287bfde0da6e25109d4a1825554e2e4a50c0535e97aa"}
+description: """
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+
+Homepage: http://erratique.ch/software/uuseg"""


### PR DESCRIPTION
* Add: `uucd.14.0.0` [home](https://erratique.ch/software/uucd), [doc](https://erratique.ch/software/uucd/doc/Uucd), [issues](https://github.com/dbuenzli/uucd/issues)  
  *Unicode character database decoder for OCaml*
* Add: `uucp.14.0.0` [home](https://erratique.ch/software/uucp), [doc](https://erratique.ch/software/uucp/doc/), [issues](https://github.com/dbuenzli/uucp/issues)  
  *Unicode character properties for OCaml*
* Add: `uunf.14.0.0` [home](https://erratique.ch/software/uunf), [doc](https://erratique.ch/software/uunf/doc/Uunf), [issues](https://github.com/dbuenzli/uunf/issues)  
  *Unicode text normalization for OCaml*
* Add: `uuseg.14.0.0` [home](https://erratique.ch/software/uuseg), [doc](https://erratique.ch/software/uuseg/doc/), [issues](https://github.com/dbuenzli/uuseg/issues)  
  *Unicode text segmentation for OCaml*


---

#### `uucd` v14.0.0 2021-09-17 Zagreb

- Support for Unicode 14.0.0

---

#### `uucp` v14.0.0 2021-09-17 Zagreb

- Unicode 14.0.0 support.
- Tweak `Uucp.Break.tty_width_hint` (09d2186). Thanks to David Kaloper
  Meršinjak.

---

#### `uunf` v14.0.0 2021-09-17 Zagreb

- Unicode 14.0.0 support.

---

#### `uuseg` v14.0.0 2021-09-17 Zagreb

- Unicode 14.0.0 support.

---

Use `b0 cmd -- .opam.publish uucd.14.0.0 uucp.14.0.0 uunf.14.0.0 uuseg.14.0.0` to update the pull request.