### PR TITLE
[new release] cppo_ocamlbuild and cppo (1.6.8)

### DIFF
--- a/packages/cppo/cppo.1.6.8/opam
+++ b/packages/cppo/cppo.1.6.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/cppo"
+doc: "https://ocaml-community.github.io/cppo/"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+  "base-unix"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+synopsis: "Code preprocessor like cpp for OCaml"
+description: """
+Cppo is an equivalent of the C preprocessor for OCaml programs.
+It allows the definition of simple macros and file inclusion.
+
+Cppo is:
+
+* more OCaml-friendly than cpp
+* easy to learn without consulting a manual
+* reasonably fast
+* simple to install and to maintain
+"""
+x-commit-hash: "94b2d0f21fcda5473773518a12afbcff45a52990"
+url {
+  src:
+    "https://github.com/ocaml-community/cppo/archive/refs/tags/v1.6.8.tar.gz"
+  checksum: [
+    "sha256=7e056d50bb194b7f628d2547667262ceb814b1fe9ea666240bfaf1396727be53"
+    "sha512=069bbe0ef09c03b0dc4b5795f909c3ef872fe99c6f1e6704a0fa97594b1570b3579226ec67fe11d696ccc349a4585055bbaf07c65eff423aa45af28abf38c858"
+  ]
+}

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.8/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/cppo"
+doc: "https://ocaml-community.github.io/cppo/"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "ocamlbuild"
+  "ocamlfind"
+]
+conflicts: [
+  "cppo" {< "1.6.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+synopsis: "Plugin to use cppo with ocamlbuild"
+description: """
+This ocamlbuild plugin lets you use cppo in ocamlbuild projects.
+
+To use it, you can call ocamlbuild with the argument `-plugin-tag
+package(cppo_ocamlbuild)` (only since ocaml 4.01 and cppo >= 0.9.4).
+"""
+x-commit-hash: "94b2d0f21fcda5473773518a12afbcff45a52990"
+url {
+  src:
+    "https://github.com/ocaml-community/cppo/archive/refs/tags/v1.6.8.tar.gz"
+  checksum: [
+    "sha256=7e056d50bb194b7f628d2547667262ceb814b1fe9ea666240bfaf1396727be53"
+    "sha512=069bbe0ef09c03b0dc4b5795f909c3ef872fe99c6f1e6704a0fa97594b1570b3579226ec67fe11d696ccc349a4585055bbaf07c65eff423aa45af28abf38c858"
+  ]
+}


### PR DESCRIPTION
CHANGES:

- [feat] Allow version strings without patch numbers, _e.g._ `8.13+beta1`
         The patch number will be set to 0 upon empty, _i.e._ `(8, 13, 0)`