### PR TITLE
Release trax 0.4.0

### DIFF
--- a/packages/trax/trax.0.4.0/opam
+++ b/packages/trax/trax.0.4.0/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.12.0"}
-  "dune" {build}
+  "dune" {>= "2.8"}
 ]
 synopsis: "Stack-independent exception tracing"
 description:

--- a/packages/trax/trax.0.4.0/opam
+++ b/packages/trax/trax.0.4.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "martin@mjambon.com"
+authors: ["Martin Jambon"]
+homepage: "https://github.com/mjambon/trax"
+bug-reports: "https://github.com/mjambon/trax/issues"
+dev-repo: "git+https://github.com/mjambon/trax.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {build}
+]
+synopsis: "Stack-independent exception tracing"
+description:
+  "Trax defines a special exception, which is used to store a trace of where the exception was raised and re-raised. This is done independently from the state of the call stack. It can be used with Lwt or other asynchronous computations in which exceptions no longer propagate simply to the calling function but may be caught, stored, and re-raised after a while and after other exceptions have occurred in unrelated computations."
+url {
+  src: "https://github.com/mjambon/trax/archive/v0.4.0.tar.gz"
+  checksum: "md5=7e056778b183bce0924def2d7722c313"
+}

--- a/packages/trax/trax.0.4.0/opam
+++ b/packages/trax/trax.0.4.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "martin@mjambon.com"
 authors: ["Martin Jambon"]
+license: "BSD-3-Clause"
 homepage: "https://github.com/mjambon/trax"
 bug-reports: "https://github.com/mjambon/trax/issues"
 dev-repo: "git+https://github.com/mjambon/trax.git"

--- a/packages/trax/trax.0.4.0/opam
+++ b/packages/trax/trax.0.4.0/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.12.0"}
   "dune" {build}
 ]
 synopsis: "Stack-independent exception tracing"


### PR DESCRIPTION
This now uses alcotest for tests, but it's not used for building and installing the library so I didn't add it as a dependency in the opam file.
