### PR TITLE
[new release] letsencrypt, letsencrypt-dns and letsencrypt-app (0.4.0)

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.0.4.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "letsencrypt-dns" {= version}
+  "cmdliner"
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto-rng"
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.4.0/letsencrypt-v0.4.0.tbz"
+  checksum: [
+    "sha256=bdcc186ebe3e38ecfe38de495637b09c987f7b540a5a975a5982f2ffff0f720a"
+    "sha512=ca15cdf853b5460340f7ee448dc4ef70e1f10b5775e2ca6f7e869c5b0ad7e5b1ecf20c1647705a6662746b2a5805a28255f84f8fe2d0801b956dd82f0064f710"
+  ]
+}
+x-commit-hash: "5f1579db6335744a8e9f39165e7db499cf42d50b"

--- a/packages/letsencrypt-dns/letsencrypt-dns.0.4.0/opam
+++ b/packages/letsencrypt-dns/letsencrypt-dns.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "logs"
+  "fmt"
+  "lwt" {>= "2.6.0"}
+  "dns"
+  "dns-tsig"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.4.0/letsencrypt-v0.4.0.tbz"
+  checksum: [
+    "sha256=bdcc186ebe3e38ecfe38de495637b09c987f7b540a5a975a5982f2ffff0f720a"
+    "sha512=ca15cdf853b5460340f7ee448dc4ef70e1f10b5775e2ca6f7e869c5b0ad7e5b1ecf20c1647705a6662746b2a5805a28255f84f8fe2d0801b956dd82f0064f710"
+  ]
+}
+x-commit-hash: "5f1579db6335744a8e9f39165e7db499cf42d50b"

--- a/packages/letsencrypt/letsencrypt.0.4.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.4.0/opam
@@ -26,6 +26,7 @@ depends: [
   "ounit" {with-test}
   "ptime"
   "domain-name" {>= "0.2.0"}
+  "cstruct" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/letsencrypt/letsencrypt.0.4.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "rresult"
+  "base64" {>= "3.1.0"}
+  "logs"
+  "fmt"
+  "uri"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk"
+  "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "x509" {>= "0.13.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "ptime"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.4.0/letsencrypt-v0.4.0.tbz"
+  checksum: [
+    "sha256=bdcc186ebe3e38ecfe38de495637b09c987f7b540a5a975a5982f2ffff0f720a"
+    "sha512=ca15cdf853b5460340f7ee448dc4ef70e1f10b5775e2ca6f7e869c5b0ad7e5b1ecf20c1647705a6662746b2a5805a28255f84f8fe2d0801b956dd82f0064f710"
+  ]
+}
+x-commit-hash: "5f1579db6335744a8e9f39165e7db499cf42d50b"

--- a/packages/paf-le/paf-le.0.0.4/opam
+++ b/packages/paf-le/paf-le.0.0.4/opam
@@ -14,7 +14,7 @@ depends: [
   "duration"
   "emile" {>= "1.0"}
   "httpaf"
-  "letsencrypt" {>= "0.3.0"}
+  "letsencrypt" {>= "0.3.0" & < "0.4.0"}
   "mirage-stack"
   "mirage-time"
   "tls-mirage"

--- a/packages/paf-le/paf-le.0.0.5/opam
+++ b/packages/paf-le/paf-le.0.0.5/opam
@@ -14,7 +14,7 @@ depends: [
   "duration"
   "emile" {>= "1.1"}
   "httpaf"
-  "letsencrypt" {>= "0.3.0"}
+  "letsencrypt" {>= "0.3.0" & < "0.4.0"}
   "mirage-stack"
   "mirage-time"
   "tls-mirage"


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/mmaker/ocaml-letsencrypt">https://github.com/mmaker/ocaml-letsencrypt</a>
- Documentation: <a href="https://mmaker.github.io/ocaml-letsencrypt">https://mmaker.github.io/ocaml-letsencrypt</a>

##### CHANGES:

* support EC (P-256, P-384, P-521) account keys (@reynir @hannesm)
  (reported in mmaker/ocaml-letsencrypt#24 by @dinosaure)
* allow key_type to be passed into the alpn_solver (@hannesm)
* add RFC 7520 test cases (@reynir @hannesm)
* remove astring dependency (@hannesm)
* bugfix: "orders" field in account is Uri.t option, not a list (@hannesm)
  (reported in mmaker/ocaml-letsencrypt#27 by @torinnd)
