### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.6)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.6/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.6/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.6/happy-eyeballs-v0.0.6.tbz"
+  checksum: [
+    "sha256=22f8ca31a21921797a7435657472a00cba23b6b60bf11cd992a3e37344e69d88"
+    "sha512=ffeb86b008edf0a42a5db05e284b0f29c38320699537b94d7b1b6d7d11543b604dc4a464e469bdc027239d28524b4663e16aa2078076b60823d5d57df773ce52"
+  ]
+}
+x-commit-hash: "4da50c5dece3709a98cce5ceaf6b9c7b4b593c5a"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.6/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.6/happy-eyeballs-v0.0.6.tbz"
+  checksum: [
+    "sha256=22f8ca31a21921797a7435657472a00cba23b6b60bf11cd992a3e37344e69d88"
+    "sha512=ffeb86b008edf0a42a5db05e284b0f29c38320699537b94d7b1b6d7d11543b604dc4a464e469bdc027239d28524b4663e16aa2078076b60823d5d57df773ce52"
+  ]
+}
+x-commit-hash: "4da50c5dece3709a98cce5ceaf6b9c7b4b593c5a"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.6/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.6/happy-eyeballs-v0.0.6.tbz"
+  checksum: [
+    "sha256=22f8ca31a21921797a7435657472a00cba23b6b60bf11cd992a3e37344e69d88"
+    "sha512=ffeb86b008edf0a42a5db05e284b0f29c38320699537b94d7b1b6d7d11543b604dc4a464e469bdc027239d28524b4663e16aa2078076b60823d5d57df773ce52"
+  ]
+}
+x-commit-hash: "4da50c5dece3709a98cce5ceaf6b9c7b4b593c5a"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>

##### CHANGES:

* connect_ip: take list of Ipaddr.t and int pairs instead of separate lists.
  The reason for this change is the dns-client.
