### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.6)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.6/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.6/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.6/happy-eyeballs-v0.0.6.tbz"
+  checksum: [
+    "sha256=0daaea315ed51c237221a31631b0852f0c3ce53d8f7813dbbc20d477075c6404"
+    "sha512=ddc5c0723281f4ab770399201a47b3cdb852f7b9b85e759f4959337e8f4160684ac6f049485e80a4eb229e81d7cb239f02557b84807d9a90485ffd3be1cb9422"
+  ]
+}
+x-commit-hash: "1e62e62bd0c13bc8838d666c17f1453a5d47bb9b"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.6/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.6/happy-eyeballs-v0.0.6.tbz"
+  checksum: [
+    "sha256=0daaea315ed51c237221a31631b0852f0c3ce53d8f7813dbbc20d477075c6404"
+    "sha512=ddc5c0723281f4ab770399201a47b3cdb852f7b9b85e759f4959337e8f4160684ac6f049485e80a4eb229e81d7cb239f02557b84807d9a90485ffd3be1cb9422"
+  ]
+}
+x-commit-hash: "1e62e62bd0c13bc8838d666c17f1453a5d47bb9b"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.6/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.6/happy-eyeballs-v0.0.6.tbz"
+  checksum: [
+    "sha256=0daaea315ed51c237221a31631b0852f0c3ce53d8f7813dbbc20d477075c6404"
+    "sha512=ddc5c0723281f4ab770399201a47b3cdb852f7b9b85e759f4959337e8f4160684ac6f049485e80a4eb229e81d7cb239f02557b84807d9a90485ffd3be1cb9422"
+  ]
+}
+x-commit-hash: "1e62e62bd0c13bc8838d666c17f1453a5d47bb9b"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* return a variant from timer to indicate whether there are connections pending
  or the timer can be suspended -- this avoids unnecessary busy work (@reynir)
* connect_ip: take list of Ipaddr.t and int pairs instead of separate lists.
  The reason for this change is the dns-client. (@hannesm @reynir)
