### PR TITLE
Package curses.1.0.7

### DIFF
--- a/packages/curses/curses.1.0.7/opam
+++ b/packages/curses/curses.1.0.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "michael.bacarella@gmail.com"
+authors: ["Nicolas George"]
+homepage: "https://github.com/mbacarella/curses"
+bug-reports: "http://github.com/mbacarella/curses/issues"
+dev-repo: "git+https://github.com/mbacarella/curses"
+build: [
+  ["./configure" "--enable-widec"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
+]
+depends: [
+    "ocaml"
+    "ocamlfind" {build}
+    "conf-ncurses"
+]
+install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
+synopsis: "Bindings to curses/ncurses"
+description: "Tools for building terminal-based user interfaces"
+url {
+  src: "https://github.com/mbacarella/curses/archive/1.0.7.tar.gz"
+  checksum: [
+    "md5=64ef65ab73d5a8b9fb18644c9866fc5e"
+    "sha512=3d379b5627fd7c2d7164425bd67cfb7eccb7e2933a6164cec528d301e3510fa9b985bf79e2cba061008246f7e7c1a0516f2baac7218f587934ad471b3be0d063"
+  ]
+}


### PR DESCRIPTION
### `curses.1.0.7`
Bindings to curses/ncurses
Tools for building terminal-based user interfaces



---
* Homepage: https://github.com/mbacarella/curses
* Source repo: git+https://github.com/mbacarella/curses
* Bug tracker: http://github.com/mbacarella/curses/issues

---
:camel: Pull-request generated by opam-publish v2.1.0