### PR TITLE
Package curses.1.0.8

### DIFF
--- a/packages/curses/curses.1.0.8/opam
+++ b/packages/curses/curses.1.0.8/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "michael.bacarella@gmail.com"
+authors: ["Nicolas George"]
+homepage: "https://github.com/mbacarella/curses"
+bug-reports: "http://github.com/mbacarella/curses/issues"
+dev-repo: "git+https://github.com/mbacarella/curses"
+build: [
+  ["./configure" "--enable-widec"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]
+  [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
+]
+depends: [
+    "ocaml"
+    "ocamlfind" {build}
+    "conf-ncurses"
+]
+install: [make "OCAMLMAKEFILE=OCamlMakefile" "install"]
+synopsis: "Bindings to curses/ncurses"
+description: "Tools for building terminal-based user interfaces"
+url {
+  src: "https://github.com/mbacarella/curses/archive/1.0.8.tar.gz"
+  checksum: [
+    "md5=4a7cb58186a652d15bc1a2066aba5954"
+    "sha512=b0b48b9da3946abc4eb8024365747a58104123c5fc55af2441275fd3127c0860c56bf23a9416767409ce9c1b8ce8f65f809f206fbe6575cd70a04efc01624477"
+  ]
+}

--- a/packages/curses/curses.1.0.8/opam
+++ b/packages/curses/curses.1.0.8/opam
@@ -4,6 +4,7 @@ authors: ["Nicolas George"]
 homepage: "https://github.com/mbacarella/curses"
 bug-reports: "http://github.com/mbacarella/curses/issues"
 dev-repo: "git+https://github.com/mbacarella/curses"
+license: "LGPL-2.1-or-later"
 build: [
   ["./configure" "--enable-widec"]
   [make "OCAMLMAKEFILE=OCamlMakefile" "byte"]


### PR DESCRIPTION
### `curses.1.0.8`
Bindings to curses/ncurses
Tools for building terminal-based user interfaces



---
* Homepage: https://github.com/mbacarella/curses
* Source repo: git+https://github.com/mbacarella/curses
* Bug tracker: http://github.com/mbacarella/curses/issues

---
:camel: Pull-request generated by opam-publish v2.1.0