### PR TITLE
Add: brr.0.0.2

### DIFF
--- a/packages/brr/brr.0.0.2/opam
+++ b/packages/brr/brr.0.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: """Browser programming toolkit for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The brr programmers"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "js_of_ocaml-compiler" {>= "3.7.1"}
+          "js_of_ocaml-toplevel" {>= "3.7.1"}
+          "note"]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.2.tbz"
+  checksum: "sha512=038e864ee718531ddf7a85166c9fec747eef20e55cdaf6610807275775d54ea1d3139ecc73afd4922ae2927c6e9ea367de93fdb3d9d369e848c69e9d8ccf8607"}
+description: """
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* Note based reactive support (optional and experimental).
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on [Note][note]
+and on the `js_of_ocaml` compiler and runtime – but not on its
+libraries or syntax extension.
+
+[note]: https://erratique.ch/software/note
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: https://erratique.ch/software/brr"""


### PR DESCRIPTION
* Add: `brr.0.0.2` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.2 2020-09-23 Zagreb

- Change the `Brr.Base64` module (`atob`, `bota`) to make it more
  useful and less error prone ([#18](https://github.com/dbuenzli/brr/issues/18)). 
  Thanks to Armaël Guéneau for shooting himself in the foot.
- Add `Brr.Window.open'` ([#20](https://github.com/dbuenzli/brr/issues/20)). 
  Thanks to Boris Dob for the suggestion and the patch.
- Rename `Brr_webcrypto.Crypto_algo.rsassa_pks1_v1_5` to `rsassa_pkcs1_v1_5`. 
  Thanks to Hannes Mehnert for the report and the fix.
- Add `Brr.El.parent` ([#10](https://github.com/dbuenzli/brr/issues/10)).
  Thanks to Sébastien Dailly for the suggestion and the patch.
- Add `Brr.El.{find_first_by_selector,fold_find_by_selector}` to 
  lookup elements by CSS selectors.
- `Jstr.{starts_with,ends_with}`, change labels to follow Stdlib labelling. 
- Add optional `base` argument to `Brr.Uri.{v,of_jstr}`.
- Add `Brr.Uri.Params.is_empty`.
- Add `Brr_io.Form.Data.{is_empty,has_file_entry,of_uri_params,to_uri_params}`.
- Tweak interfaces of `Brr_canvas.Image_data.create`, 
  `Brr_webaudio.Node.connect_node`, `Brr_webaudio.Node.connect_param` to
  not trigger the 4.12 definition of the warning 
  `unerasable-optional-argument`. 
- Fix for uncaught JavaScript exceptions in the OCaml console ([#21](https://github.com/dbuenzli/brr/issues/21)). 
  The fix is brittle, the right fix is to solve ([#2](https://github.com/dbuenzli/brr/issues/2)).
- Fix `Brr_canvas.Gl` for browsers that do not support GL2 contexts.
  On these browsers this would lead to obscure failures in separate
  compilation mode. 
  Thanks to Duncan Holm for the report ([#9](https://github.com/dbuenzli/brr/issues/9)).
- Fix wrong value of `Request.Credentials.include`.
- Fix `Blob.of_array_buffer` ([#23](https://github.com/dbuenzli/brr/issues/23)). Didn't work at all. 
  Thanks to Armaël Guéneau for the report and the fix.
- Fix `Jstr.concat` when `sep` is unspecified ([#14](https://github.com/dbuenzli/brr/issues/14)).
  Thanks to Sébastien Dailly for the report.
- Fix signature of `Brr_webcrypto.Subtle_crypto.{export,import}_key`. 
  Thanks to Romain Calascibetta for the report and the fix.

---

Use `b0 cmd -- .opam.publish brr.0.0.2` to update the pull request.