### PR TITLE
[Why3] why3-coq 1.4.0 supports coq 8.13*

### DIFF
--- a/packages/why3-coq/why3-coq.1.4.0/opam
+++ b/packages/why3-coq/why3-coq.1.4.0/opam
@@ -37,7 +37,7 @@ install: [make "install-coq"]
 
 depends: [
   "conf-autoconf" {build & dev}
-  "coq" {>= "8.6" & < "8.13~"}
+  "coq" {>= "8.6" & < "8.14~"}
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
   "why3" {= version}


### PR DESCRIPTION
The support of coq 8.13 was added in why3-coq version 1.4.0

@silene @vprevosto 