### PR TITLE
coq is not compatible with no-naked-pointers

### DIFF
--- a/packages/coq/coq.8.13.0/opam
+++ b/packages/coq/coq.8.13.0/opam
@@ -27,6 +27,9 @@ depends: [
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]
+conflicts: [
+  "ocaml-option-nnp"
+]
 build: [
   [
     "./configure"

--- a/packages/coq/coq.8.13.1/opam
+++ b/packages/coq/coq.8.13.1/opam
@@ -27,6 +27,9 @@ depends: [
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]
+conflicts: [
+  "ocaml-option-nnp"
+]
 build: [
   [
     "./configure"

--- a/packages/coq/coq.8.13.2/opam
+++ b/packages/coq/coq.8.13.2/opam
@@ -27,6 +27,9 @@ depends: [
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]
+conflicts: [
+  "ocaml-option-nnp"
+]
 build: [
   [
     "./configure"


### PR DESCRIPTION
cc @ejgallego 
```
#=== ERROR while compiling coq.8.13.2 =========================================#
# context              2.1.0 | linux/x86_64 | ocaml-options-only-nnp.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12/.opam-switch/build/coq.8.13.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j31
# exit-code            2
# env-file             ~/.opam/log/coq-19-b76bba.env
# output-file          ~/.opam/log/coq-19-b76bba.out
### output ###
# COQC -noinit theories/Init/Notations.v
# make[1]: *** [Makefile.build:863: theories/Init/Notations.vo] Segmentation fault
```