### PR TITLE
conf-zlib: fix depext typo

### DIFF
--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["zlib-devel"] {os-distribution = "fedora"}
   ["zlib-devel"] {os-distribution = "ol"}
   ["zlib"] {os-distribution = "nixos"}
-  ["lzlib"] {os-distribution = "homebrew" & os = "macos"}
+  ["zlib"] {os-distribution = "homebrew" & os = "macos"}
   ["zlib"] {os-family = "arch"}
 ]
 synopsis: "Virtual package relying on zlib"


### PR DESCRIPTION
[lzlib](https://formulae.brew.sh/formula/lzlib) is lzma, must be [zlib](https://formulae.brew.sh/formula/zlib) I believe