### PR TITLE
OpenCC 1.1

### DIFF
--- a/packages/conf-opencc1_1/conf-opencc1_1.1/files/test.c
+++ b/packages/conf-opencc1_1/conf-opencc1_1.1/files/test.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return 0;
+}

--- a/packages/conf-opencc1_1/conf-opencc1_1.1/opam
+++ b/packages/conf-opencc1_1/conf-opencc1_1.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-opencc1.1/"
+bug-reports: "https://github.com/kandu/ocaml-opencc1.1/issues"
+license: "MIT"
+tags: [
+  "opencc"
+  "Chinese conversion"
+]
+
+build: [
+  ["sh" "-exec" "cc $CFLAGS test.c -l:libopencc.so.1.1"]
+]
+
+depexts: [
+  ["libopencc1.1"] {os-distribution = "debian"}
+  ["libopencc1.1"] {os-distribution = "ubuntu"}
+  ["opencc"] {os-distribution = "suse"}
+  ["opencc"] {os-distribution = "archlinux"}
+  ["app-i18n/opencc"] {os-distribution = "gentoo"}
+  ["opencc"] {os-distribution = "fedora"}
+  ["opencc"] {os-distribution = "centos"}
+  ["opencc"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+synopsis: "Virtual package relying on opencc v1.1 (libopencc.so.1.1) installation"
+description: "This package can install only if the libopencc v1.1 is available on the system"
+
+extra-files: [
+  "test.c" "md5=9690f46dfbcfc47a300c8cac95f3ded2"
+]
+
+flags: [conf]
+

--- a/packages/conf-opencc1_1/conf-opencc1_1.1/opam
+++ b/packages/conf-opencc1_1/conf-opencc1_1.1/opam
@@ -14,9 +14,8 @@ build: [
 ]
 
 depexts: [
-  ["libopencc1.1"] {os-distribution = "debian"}
-  ["libopencc1.1"] {os-distribution = "ubuntu"}
-  ["opencc"] {os-distribution = "suse"}
+  ["libopencc1.1"] {os-family = "debian"}
+  ["opencc"] {os-family = "suse"}
   ["opencc"] {os-distribution = "archlinux"}
   ["app-i18n/opencc"] {os-distribution = "gentoo"}
   ["opencc"] {os-distribution = "fedora"}

--- a/packages/opencc1_1/opencc1_1.0.1.0/opam
+++ b/packages/opencc1_1/opencc1_1.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-opencc1_1/"
+bug-reports: "https://github.com/kandu/ocaml-opencc1_1/issues"
+license: "MIT"
+tags: [
+  "opencc"
+  "Chinese conversion"
+]
+dev-repo: "git+https://github.com/kandu/ocaml-opencc1.1"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.4"}
+  "ctypes"
+  "ctypes-foreign"
+  "conf-opencc1_1"
+]
+
+post-messages: [
+  "This package requires installation of libopencc (>= 1.1 & < 2.0~)"
+]
+
+synopsis: "Bindings for OpenCC (v1.1) - Open Chinese Convert"
+description:
+  "Open Chinese Convert (OpenCC, 開放中文轉換) is an opensource project for conversion between Traditional Chinese and Simplified Chinese, supporting character-level conversion, phrase-level conversion, variant conversion and regional idioms among Mainland China, Taiwan and Hong kong."
+
+url {
+  src: "https://github.com/kandu/ocaml-opencc1_1/archive/refs/tags/0.1.0.tar.gz"
+  checksum: "md5=32b842d41cc65e462136620d6bc3bd95"
+}


### PR DESCRIPTION
OpenCC had updated its SOVERSION to 1.1, so we need new bindings for the new version.

1. Only the C++ interface of opencc was changed. This package only depends on the C interface, so the ocaml interface is still.
2. opencc in the FreeBSD ports is not updated, so we drop FreeBSD depext item for now.