### PR TITLE
lablgtk3-extra is not compatible with OCaml 4.13 (uses -warn-error)

### DIFF
--- a/packages/lablgtk-extras/lablgtk-extras.1.6/opam
+++ b/packages/lablgtk-extras/lablgtk-extras.1.6/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "lablgtk2-extras"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.13"}
   "ocamlfind"
   "config-file" {>= "1.1"}
   "xmlm" {>= "1.1.1"}

--- a/packages/lablgtk3-extras/lablgtk3-extras.3.0/opam
+++ b/packages/lablgtk3-extras/lablgtk3-extras.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://framagit.org/zoggy/lablgtk-extras/"
 doc: "https://framagit.org/zoggy/lablgtk-extras/"
 bug-reports: "https://framagit.org/zoggy/lablgtk-extras/-/issues"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "4.13"}
   "ocamlfind" {build}
   "ocf" {>= "0.6.0"}
   "xmlm" {>= "1.3.0"}


### PR DESCRIPTION
cc @zoggy 
```
#=== ERROR while compiling lablgtk-extras.1.6 =================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/lablgtk-extras.1.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/lablgtk-extras-19-7f23ce.env
# output-file          ~/.opam/log/lablgtk-extras-19-7f23ce.out
### output ###
# Error (warning 6 [labels-omitted]): labels row, column were omitted in the application of this function.
# File "gdir.ml", line 189, characters 2-27:
# 189 | 	(view#connect#row_expanded
#         ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error (warning 6 [labels-omitted]): label callback was omitted in the application of this function.
# File "gdir.ml", line 196, characters 2-28:
# 196 | 	(view#connect#row_collapsed
#         ^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error (warning 6 [labels-omitted]): label callback was omitted in the application of this function.
# File "gdir.ml", line 203, characters 2-32:
# 203 | 	(view#selection#connect#changed
#         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error (warning 6 [labels-omitted]): label callback was omitted in the application of this function.
# make[1]: *** [../master.Makefile:90: gdir.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.13.0+trunk/.opam-switch/build/lablgtk-extras.1.6/src'
# make: *** [Makefile:36: src] Error 2
```