### PR TITLE
rdf is not compatible with OCaml 4.13 (uses compiler-libs)

### DIFF
--- a/packages/rdf/rdf.0.12.0/opam
+++ b/packages/rdf/rdf.0.12.0/opam
@@ -24,7 +24,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "4.13"}
   "ocamlfind" {build}
   "ptime" {>= "0.8.5"}
   "re" {>= "1.9.0"}


### PR DESCRIPTION
cc @zoggy 
```
#=== ERROR while compiling rdf.0.12.0 =========================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/rdf.0.12.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/rdf-19-57fea2.env
# output-file          ~/.opam/log/rdf-19-57fea2.out
### output ###
# /home/opam/.opam/4.13.0+trunk/bin/ocamlfind ocamlopt -linkpkg -o ppx_rdf -package compiler-libs.common,str -package ptime,re,uri,uuidm,uutf,xmlm,sedlex,sedlex.ppx,menhirLib,cryptokit,pcre,yojson,iri,jsonm,  -thread -safe-string -g -warn-error +8   rdf.cmxa ppx_rdf.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.13.0+trunk/lib/ocaml/compiler-libs, /home/opam/.opam/4.13.0+trunk/lib/ocaml
# File "ppx_rdf.ml", line 111, characters 16-99:
# 111 |           (Some (Pat.tuple [ Pat.var (Location.mknoloc "eloc") ; Pat.var (Location.mknoloc "msg")]))
#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type Parsetree.pattern
#        but an expression was expected of type
#          Ast_helper.str list * Parsetree.pattern
# make[1]: *** [Makefile:170: ppx_rdf] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.13.0+trunk/.opam-switch/build/rdf.0.12.0/src'
# make: *** [Makefile:33: src] Error 2
```