### PR TITLE
obytelib is not compatible with OCaml 4.13 (uses -warn-error)

### DIFF
--- a/packages/obytelib/obytelib.1.3/opam
+++ b/packages/obytelib/obytelib.1.3/opam
@@ -13,7 +13,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.13"}
   "ocamlbuild" {build}
 ]
 install: [make "install"]

--- a/packages/obytelib/obytelib.1.4/opam
+++ b/packages/obytelib/obytelib.1.4/opam
@@ -14,7 +14,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.13"}
   "ocamlbuild" {build}
 ]
 install: [make "install"]

--- a/packages/obytelib/obytelib.1.5/opam
+++ b/packages/obytelib/obytelib.1.5/opam
@@ -14,7 +14,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.13"}
   "ocamlbuild" {build}
 ]
 install: [make "install"]


### PR DESCRIPTION
cc @bvaugon 
```
#=== ERROR while compiling obytelib.1.5 =======================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/obytelib.1.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/obytelib-19-826daf.env
# output-file          ~/.opam/log/obytelib-19-826daf.out
### output ###
- + /home/opam/.opam/4.13.0+trunk/bin/ocamlc.opt -c -w Ae-44 -warn-error A -safe-string -strict-formats -strict-sequence -g -o astack.cmo astack.ml
- File "_none_", line 1:
- Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
- like 'Ae', is deprecated.
- Use the equivalent signed form: +A-e-44.
- Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
- File "astack.ml", line 1:
- Error (warning 70 [missing-mli]): Cannot find interface file.
- Command exited with code 2.
- make[1]: *** [Makefile:25: _build/oByteLib.cmx] Error 10
- make: *** [Makefile:15: all] Error 2
```