### PR TITLE
stog is not compatible with OCaml 4.13 (uses ocamldoc's internal functions)

### DIFF
--- a/packages/stog/stog.0.19.0/opam
+++ b/packages/stog/stog.0.19.0/opam
@@ -9,7 +9,7 @@ homepage: "https://www.good-eris.net/stog/"
 doc: "https://www.good-eris.net/stog/doc.html"
 bug-reports: "https://framagit.org/zoggy/stog/issues"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "4.13"}
   "ocamlfind" {build}
   "xtmpl" {>= "0.18.0"}
   "ocf" {>= "0.6.0"}


### PR DESCRIPTION
cc @zoggy 
```
#=== ERROR while compiling stog.0.19.0 ========================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/stog.0.19.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/stog-19-4fa309.env
# output-file          ~/.opam/log/stog-19-4fa309.out
### output ###
# /home/opam/.opam/4.13.0+trunk/bin/ocamlfind ocamlopt -package ,,ppx_blob,xtmpl,ptime,ocf,ocf.ppx,dynlink,unix,str,higlo.lexers,lwt.unix,xtmpl.ppx,uri,uutf  -warn-error F -I +ocamldoc -annot -rectypes -g -safe-string -thread  -shared -o odoc_stog.cmxs odoc_stog.ml
# File "odoc_stog.ml", line 267, characters 23-55:
# 267 |               let s2 = Odoc_html.newline_to_indented_br s in
#                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Odoc_html.newline_to_indented_br
# make[1]: *** [../master.Makefile:95: odoc_stog.cmxs] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.13.0+trunk/.opam-switch/build/stog.0.19.0/src'
# make: *** [Makefile:38: src] Error 2
```