### PR TITLE
cloudi < 2.0.2 is not compatible with OCaml 4.13 (uses -warn-error)

### DIFF
--- a/packages/cloudi/cloudi.1.8.0/opam
+++ b/packages/cloudi/cloudi.1.8.0/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.13"}
   "base-unix"
   "num"
 ]

--- a/packages/cloudi/cloudi.2.0.0/opam
+++ b/packages/cloudi/cloudi.2.0.0/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.13"}
   "base-unix"
   "num"
 ]

--- a/packages/cloudi/cloudi.2.0.1/opam
+++ b/packages/cloudi/cloudi.2.0.1/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.13"}
   "base-unix"
   "num"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling cloudi.2.0.1 =======================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/cloudi.2.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/cloudi-19-5f2435.env
# output-file          ~/.opam/log/cloudi-19-5f2435.out
### output ###
# ocamlopt -safe-string -w @A -o cloudi.cmx -c cloudi.ml
# File "cloudi.ml", line 62, characters 6-25:
# 62 |       mutable state : 's;
#            ^^^^^^^^^^^^^^^^^^^
# Error (warning 69 [unused-field]): mutable record field state is never mutated.
# make: *** [makefile:78: cloudi.cmx] Error 2
```