### PR TITLE
tar-mirage is not compatible with OCaml 4.13 (opens Int and uses min later)

### DIFF
--- a/packages/tar-mirage/tar-mirage.0.9.0/opam
+++ b/packages/tar-mirage/tar-mirage.0.9.0/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "4.13"}
   "jbuilder" {>= "1.0+beta7"}
   "tar" {< "1.0.0"}
   "cstruct" {>= "1.9.0"}

--- a/packages/tar-mirage/tar-mirage.1.0.0/opam
+++ b/packages/tar-mirage/tar-mirage.1.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "4.13"}
   "dune" {>= "1.0"}
   "tar" {>= "1.0.0"}
   "cstruct" {>= "1.9.0"}

--- a/packages/tar-mirage/tar-mirage.1.0.1/opam
+++ b/packages/tar-mirage/tar-mirage.1.0.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "4.13"}
   "dune" {>= "1.0"}
   "tar" {>= "1.0.0"}
   "cstruct" {>= "1.9.0"}

--- a/packages/tar-mirage/tar-mirage.1.1.0/opam
+++ b/packages/tar-mirage/tar-mirage.1.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "4.13"}
   "dune" {>= "1.0"}
   "tar"
   "cstruct" {>= "1.9.0"}


### PR DESCRIPTION
(fixed in #19627)
```
#=== ERROR while compiling tar-mirage.1.1.0 ===================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.13.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.13.0+trunk/.opam-switch/build/tar-mirage.1.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tar-mirage -j 127
# exit-code            1
# env-file             ~/.opam/log/tar-mirage-19-a14fe2.env
# output-file          ~/.opam/log/tar-mirage-19-a14fe2.out
### output ###
#       ocamlc mirage/.tar_mirage.objs/byte/tar_mirage.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13.0+trunk/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I mirage/.tar_mirage.objs/byte -I /home/opam/.opam/4.13.0+trunk/lib/bigarray-compat -I /home/opam/.opam/4.13.0+trunk/lib/bytes -I /home/opam/.opam/4.13.0+trunk/lib/cstruct -I /home/opam/.opam/4.13.0+trunk/lib/fmt -I /home/opam/.opam/4.13.0+trunk/lib/io-page -I /home/opam/.opam/4.13.0+trunk/lib/logs -I /home/opam/.opam/4.13.0+trunk/lib/lwt -I /home/opam/.opam/4.13.0+trunk/lib/mirage-block -I /home/opam/.opam/4.13.0+trunk/lib/mirage-block-lwt -I /home/opam/.opam/4.13.0+trunk/lib/mirage-device -I /home/opam/.opam/4.13.0+trunk/lib/mirage-kv -I /home/opam/.opam/4.13.0+trunk/lib/mirage-kv-lwt -I /home/opam/.opam/4.13.0+trunk/lib/ptime -I /home/opam/.opam/4.13.0+trunk/lib/re -I /home/opam/.opam/4.13.0+trunk/lib/re/str -I /home/opam/.opam/4.13.0+trunk/lib/result -I /home/opam/.opam/4.13.0+trunk/lib/seq -I /home/opam/.opam/4.13.0+trunk/lib/stdlib-shims -I /home/opam/.opam/4.13.0+trunk/lib/tar -intf-suffix .ml -no-alias-deps -o mirage/.tar_mirage.objs/byte/tar_mirage.cmo -c -impl mirage/tar_mirage.ml)
# File "mirage/tar_mirage.ml", line 124, characters 41-60:
# 124 |       let tmp = Cstruct.sub block 0 (min (Cstruct.len block) Int64.(to_int @@ (sub total_size_bytes (mul start_sector 512L)))) in
#                                                ^^^^^^^^^^^^^^^^^^^
# Error: This expression has type int but an expression was expected of type
#          Int64.t = int64
#     ocamlopt mirage/.tar_mirage.objs/native/tar_mirage.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13.0+trunk/bin/ocamlopt.opt -w -40 -safe-string -g -I mirage/.tar_mirage.objs/byte -I mirage/.tar_mirage.objs/native -I /home/opam/.opam/4.13.0+trunk/lib/bigarray-compat -I /home/opam/.opam/4.13.0+trunk/lib/bytes -I /home/opam/.opam/4.13.0+trunk/lib/cstruct -I /home/opam/.opam/4.13.0+trunk/lib/fmt -I /home/opam/.opam/4.13.0+trunk/lib/io-page -I /home/opam/.opam/4.13.0+trunk/lib/logs -I /home/opam/.opam/4.13.0+trunk/lib/lwt -I /home/opam/.opam/4.13.0+trunk/lib/mirage-block -I /home/opam/.opam/4.13.0+trunk/lib/mirage-block-lwt -I /home/opam/.opam/4.13.0+trunk/lib/mirage-device -I /home/opam/.opam/4.13.0+trunk/lib/mirage-kv -I /home/opam/.opam/4.13.0+trunk/lib/mirage-kv-lwt -I /home/opam/.opam/4.13.0+trunk/lib/ptime -I /home/opam/.opam/4.13.0+trunk/lib/re -I /home/opam/.opam/4.13.0+trunk/lib/re/str -I /home/opam/.opam/4.13.0+trunk/lib/result -I /home/opam/.opam/4.13.0+trunk/lib/seq -I /home/opam/.opam/4.13.0+trunk/lib/stdlib-shims -I /home/opam/.opam/4.13.0+trunk/lib/tar -intf-suffix .ml -no-alias-deps -o mirage/.tar_mirage.objs/native/tar_mirage.cmx -c -impl mirage/tar_mirage.ml)
# File "mirage/tar_mirage.ml", line 124, characters 41-60:
# 124 |       let tmp = Cstruct.sub block 0 (min (Cstruct.len block) Int64.(to_int @@ (sub total_size_bytes (mul start_sector 512L)))) in
#                                                ^^^^^^^^^^^^^^^^^^^
# Error: This expression has type int but an expression was expected of type
#          Int64.t = int64
```