### PR TITLE
[new release] pyml.20210924

### DIFF
--- a/packages/pyml/pyml.20210924/opam
+++ b/packages/pyml/pyml.20210924/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [make "all" "pymltop" "pymlutop" {utop:installed} "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%"]
+run-test: [make "test"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "dune" {build & >= "1.11.3"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "13"}
+  "conf-python-3-dev" {with-test}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/archive/20210924.tar.gz"
+  checksum: "sha512=8affb211ead62933ea67b5a82a81582bf09c9747a1dbc95d619a1eb775aaaded7c7e73e9a6ebd969c7c7e5d8c910a0848b156c675e23751999d906da7ccd7d43"
+}


### PR DESCRIPTION
- Use `dune` as default build system (dunification done by Laurent Mazare,
  https://github.com/thierry-martinez/pyml/pull/28)

  This should in particular fix build problems of reverse dependencies
  with the byte-code compiler
  (reported by @nicoTolly, https://github.com/thierry-martinez/pyml/issues/62)

    - Handle more platforms with dune
      (reported by Olaf Hering, https://github.com/thierry-martinez/pyml/issues/68)

    - pyutils is no longer used by generate and is shipped with pyml package
      as it was the case with Makefile-based build system
      (reported by Olaf Hering, https://github.com/thierry-martinez/pyml/issues/69)

- Support for raising exceptions with traceback from OCaml
  (implemented by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/65)

- Fix soundness bug with numpy
  (reported by Richard Alligier, https://github.com/thierry-martinez/pyml/pull/65)