### PR TITLE
js_of_ocaml-compiler.3.9.1 is not compatible with OCaml 4.13

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
@@ -14,7 +14,7 @@ environment like browsers and Node.js
 build: [["dune" "build" "-p" name "-j" jobs]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.13.0"}
   "dune" {>= "2.5"}
   "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/19623