### PR TITLE
[new release] ocaml-version (3.3.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.3.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.3.0/ocaml-version-v3.3.0.tbz"
+  checksum: [
+    "sha256=36d0e8d73e5ea1aec1e3f2ce23bd1c1370f4182a2361b6b65390252046c4262d"
+    "sha512=593419ac45eee1fda403bb80d77378bc8e7c6a9def98be33d6409243468e0e9736f7c990e94301cede156144d6ab38e71827fbaca889eac4b4a1c99ca87a551f"
+  ]
+}
+x-commit-hash: "70d79c7cd69a93eeca0a9ed295fc555069994445"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add 4.13.0 and 4.12.1 entries (@Octachron)
