### PR TITLE
Add ez_subst.0.2.0

### DIFF
--- a/packages/ez_subst/ez_subst.0.2.0/opam
+++ b/packages/ez_subst/ez_subst.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis: "Ez_subst is a simple module to perform string substitutions"
+description: """
+Ez_subst is a simple module to perform string substitutions, like
+${brace}, $(paren), $[bracket] or $alpha. It provides many options
+to configure the substitutions.
+"""
+authors: ["Fabrice LE FESSANT <fabrice.le_fessant@origin-labs.com>"]
+maintainer: ["Fabrice LE FESSANT <fabrice.le_fessant@origin-labs.com>"]
+homepage: "https://ocamlpro.github.io/ez_subst"
+doc: "https://ocamlpro.github.io/ez_subst/sphinx"
+bug-reports: "https://github.com/ocamlpro/ez_subst/issues"
+dev-repo: "git+https://github.com/ocamlpro/ez_subst.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh build '%{name}%'"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["sh" "-c" "./scripts/after.sh build '%{name}%'"]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
+]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.6.0"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+
+url {
+    src: "https://github.com/ocamlpro/ez_subst/archive/v0.2.0.tar.gz"
+    checksum: [ "sha256=64610b261c88be22ceef0d3d667b076664db54c3d005ee1f83077bac6b966a2c" ]
+}


### PR DESCRIPTION
`Ez_subst` is a simple library to replace variables within strings by other strings. It can be configured to use different characters ('%', '$', etc.), and use different substitutions depending on the format used (`$X`, `${X}`, `$(X)` and `$[X]` can be processed by different substitutions), and recursive ones.