### PR TITLE
[new release] shuttle_ssl and shuttle (0.3.0)

### DIFF
--- a/packages/shuttle/shuttle.0.3.0/opam
+++ b/packages/shuttle/shuttle.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.14" & < "v0.15"}
+  "core" {>= "v0.14" & < "v0.15"}
+  "ppx_jane" {>= "v0.14" & < "v0.15"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.3.0/shuttle-0.3.0.tbz"
+  checksum: [
+    "sha256=ff02d6354ecba38761424e5820417626789749210acbebd79b525537ee0ec66b"
+    "sha512=d3548b97896d17cc960b969a834b2b534791a8c2abbd1b43b29148db02a7878b0ecba7471cfae521656b0849625bf65fd2982d46ef6da52c8a6156eab7798e38"
+  ]
+}
+x-commit-hash: "b4eb1b50e1cc8b2506c2522e9e17a2fb44d33c53"

--- a/packages/shuttle_ssl/shuttle_ssl.0.3.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.14" & < "v0.15"}
+  "async_ssl" {>= "v0.14" & < "v0.15"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.3.0/shuttle-0.3.0.tbz"
+  checksum: [
+    "sha256=ff02d6354ecba38761424e5820417626789749210acbebd79b525537ee0ec66b"
+    "sha512=d3548b97896d17cc960b969a834b2b534791a8c2abbd1b43b29148db02a7878b0ecba7471cfae521656b0849625bf65fd2982d46ef6da52c8a6156eab7798e38"
+  ]
+}
+x-commit-hash: "b4eb1b50e1cc8b2506c2522e9e17a2fb44d33c53"


### PR DESCRIPTION
Async_ssl support for shuttle

- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Support creating a reader pipe from `Input_channel`.
* Support creating a writer pipe from `Output_channel`.
* Support encrypted channels using `async_ssl`.
