### PR TITLE
release ocaml-freestanding 0.6.5

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.5/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
+  "ocaml" {>= "4.08.0" & < "4.14.0"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml runtime"
+description:
+  "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."
+url {
+  src: "https://github.com/mirage/ocaml-freestanding/archive/v0.6.5.tar.gz"
+  checksum: "sha512=d54cd9cc9f9c63c3f58a1082b1b4ede5bbf7441e4eb5741bfc907440f9a515d4989fb80076d3291d76a7b69d171a98b07691f946e2610e93c30ef36fa126864e"
+}


### PR DESCRIPTION
* Add support for OCaml 4.13 (mirage/ocaml-freestanding#95 mirage/ocaml-freestanding#94, @kit-ty-kate @dra27)
* Remove cflags and libs flags that are no longer used in the MirageOS-with-dune development (mirage/ocaml-freestanding#91 @hannesm, reverts mirage/ocaml-freestanding#50 @TheLortex). These were introduced in version 0.4.4.
