### PR TITLE
solo5-bindings-* < 0.6.5: mark unavailable since they need gcc < 10

### DIFF
--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
@@ -25,7 +25,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
@@ -25,7 +25,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
@@ -32,7 +32,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
+  false &
   (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
@@ -35,7 +35,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
+  false &
   (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
@@ -36,7 +36,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
+  false &
   (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
@@ -19,7 +19,9 @@ conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.1/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.1/opam
@@ -19,7 +19,9 @@ conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.2/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.2/opam
@@ -26,7 +26,9 @@ conflicts: [
   "solo5-bindings-spt"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
@@ -29,7 +29,9 @@ conflicts: [
   "solo5-bindings-spt"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.4/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.4/opam
@@ -29,7 +29,9 @@ conflicts: [
   "solo5-bindings-spt"
   "solo5-bindings-virtio"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
@@ -37,8 +37,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
-  (arch = "x86_64" | arch = "arm64") & os = "linux"
+  false & (arch = "x86_64" | arch = "arm64") & os = "linux"
 ]
 synopsis: "Solo5 sandboxed execution environment (spt target)"
 description: """

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
@@ -35,8 +35,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
-  (arch = "x86_64" | arch = "arm64") & os = "linux"
+  false & (arch = "x86_64" | arch = "arm64") & os = "linux"
 ]
 synopsis: "Solo5 sandboxed execution environment (spt target)"
 description: """

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.4/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.4/opam
@@ -36,8 +36,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
-  (arch = "x86_64" | arch = "arm64") & os = "linux"
+  false & (arch = "x86_64" | arch = "arm64") & os = "linux"
 ]
 synopsis: "Solo5 sandboxed execution environment (spt target)"
 description: """

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
@@ -19,7 +19,9 @@ conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-muen"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.1/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.1/opam
@@ -19,7 +19,9 @@ conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-muen"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.2/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.2/opam
@@ -26,7 +26,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
@@ -29,7 +29,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.4/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.4/opam
@@ -29,7 +29,9 @@ conflicts: [
   "solo5-bindings-muen"
   "solo5-bindings-genode"
 ]
+# requires gcc < 10
 available: [
+  false &
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]


### PR DESCRIPTION
as suggested in https://github.com/ocaml/opam-repository/pull/19655#issuecomment-927702506