### PR TITLE
[new release] x509 (0.15.0)

### DIFF
--- a/packages/x509/x509.0.15.0/opam
+++ b/packages/x509/x509.0.15.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "6.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.1.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-rng"
+  "rresult"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf"
+  "ipaddr" {>= "5.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.15.0/x509-v0.15.0.tbz"
+  checksum: [
+    "sha256=d0971862f1c0f3362eac46691f45130b3517874e0226de44eacefff85f925eb9"
+    "sha512=5fd820271bca45254af055b8c4c62460677a43c8092c3d2b9cfa55ae7e7ad3f00e2616dd90eeadbf17e3441b962774edc0cbf2e562cc9dbb0cd39735cac5704a"
+  ]
+}
+x-commit-hash: "25ca258afcff0e62d40a69d106950fea955bca03"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* FEATURE support validation of an IP address in the leaf certificate
  (mirleft/ocaml-x509#152 mirleft/ocaml-x509#153 @reynir @hannesm)
* FEATURE provide Certificate.ips and Certificate.supports_ip
  (mirleft/ocaml-x509#152 @reynir @hannesm)
* BREAKING revise certificate and public key fingerprint authenticators API:
  now a single fingerprint is supported, previously a list of pairs of
  hostname and fingerprint was used (mirleft/ocaml-x509#153 @hannesm)
* BREAKING The Authenticator.t type has been extended with ?ip:Ipaddr.t
  (mirleft/ocaml-x509#153 @hannesm)
