### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.0.7)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.7/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.0.7/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.7/happy-eyeballs-v0.0.7.tbz"
+  checksum: [
+    "sha256=fd4b0e8d8774b6c15323e74167e0195760c45cc7a5283a77fe46638c6ae0f4f4"
+    "sha512=ef426b3adfa9d360da1011f5af4eb46daacfaa5f7197056144e6d2977105627bb7efedbbdfa6ad4fb124276fbbdbca41e7312e14e0405559ff777627c20e5278"
+  ]
+}
+x-commit-hash: "a0076b4c34451ad87f6632bc5ca6ee0a37c11f5f"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.7/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "5.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.7/happy-eyeballs-v0.0.7.tbz"
+  checksum: [
+    "sha256=fd4b0e8d8774b6c15323e74167e0195760c45cc7a5283a77fe46638c6ae0f4f4"
+    "sha512=ef426b3adfa9d360da1011f5af4eb46daacfaa5f7197056144e6d2977105627bb7efedbbdfa6ad4fb124276fbbdbca41e7312e14e0405559ff777627c20e5278"
+  ]
+}
+x-commit-hash: "a0076b4c34451ad87f6632bc5ca6ee0a37c11f5f"

--- a/packages/happy-eyeballs/happy-eyeballs.0.0.7/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt"
+  "logs"
+  "rresult"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.0.7/happy-eyeballs-v0.0.7.tbz"
+  checksum: [
+    "sha256=fd4b0e8d8774b6c15323e74167e0195760c45cc7a5283a77fe46638c6ae0f4f4"
+    "sha512=ef426b3adfa9d360da1011f5af4eb46daacfaa5f7197056144e6d2977105627bb7efedbbdfa6ad4fb124276fbbdbca41e7312e14e0405559ff777627c20e5278"
+  ]
+}
+x-commit-hash: "a0076b4c34451ad87f6632bc5ca6ee0a37c11f5f"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Document changes of the return value of timer (roburio/happy-eyeballs#11 @reynir)
* Pass timeouts as duration into the create functions (roburio/happy-eyeballs#12 @hannesm)
