### PR TITLE
[new release] sha (1.15)

### DIFF
--- a/packages/sha/sha.1.15/opam
+++ b/packages/sha/sha.1.15/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Binding to the SHA cryptographic functions"
+description: """
+This is the binding for SHA interface code in OCaml. Offering the same
+interface than the MD5 digest included in the OCaml standard library.
+It's currently providing SHA1, SHA256 and SHA512 hash functions."""
+maintainer: ["dave@recoil.org"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Goswin von Brederlow"
+  "Eric Cooper"
+  "Florent Monnier"
+  "Forrest L Norvell"
+  "Vincent Bernadoff"
+  "David Scott"
+  "Olaf Hering"
+  "Arthur Teisseire"
+  "Nicolás Ojeda Bär"
+  "Christopher Zimmermann"
+  "Thomas Leonard"
+  "Antonin Décimo"
+]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-sha"
+bug-reports: "https://github.com/djs55/ocaml-sha/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "stdlib-shims" {>= "0.3.0"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/djs55/ocaml-sha.git"
+url {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.15/sha-v1.15.tbz"
+  checksum: [
+    "sha256=8a930fcc83a804d0279c4a3dfbe2c8332363970280465843af26fbebb37078b6"
+    "sha512=55c0f90ad05d638c8e2aa871a7519e3f936746c946647e2d05d492111f98e2b516df51e78a0ec7f4bcaf6b5e3371f7e9ab1c468c5a5089c68343d3fcd740884d"
+  ]
+}
+x-commit-hash: "223483b25304566310274ca897294ef7cb0ea706"


### PR DESCRIPTION
Binding to the SHA cryptographic functions

- Project page: <a href="https://github.com/djs55/ocaml-sha">https://github.com/djs55/ocaml-sha</a>

##### CHANGES:

- Add `equal` function to compare digests by @MisterDA (djs55/ocaml-sha#52)
- Improve documentation formatting by @MisterDA (djs55/ocaml-sha#51)
- Add `of_hex` and `of_bin` functions to unserialise `ShaX.t` values by @MisterDA (djs55/ocaml-sha#50)
