### PR TITLE
[new release] domainslib (0.3.1)

### DIFF
--- a/packages/domainslib/domainslib.0.3.1/opam
+++ b/packages/domainslib/domainslib.0.3.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "dune" {>= "1.8"}
+  "base-domains"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.1.tar.gz"
+  checksum: "md5=29f8df695dfd8f0b87742c3f45cedecf"
+}
+


### PR DESCRIPTION
Changes:

* https://github.com/ocaml-multicore/domainslib/pull/45 adds support for named pools. This is a breaking change with setup_pool taking an optional name parameter and an extra unit parameter.

* A minor bug fix in `parallel_for_reduce`.
