### PR TITLE
Avoid previews when possible

### DIFF
--- a/packages/merlin/merlin.4.3.2~4.13preview/opam
+++ b/packages/merlin/merlin.4.3.2~4.13preview/opam
@@ -10,6 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" jobs] {with-test}
 ]
+flags: avoid-version
 depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.9.0~4.13preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.9.0~4.13preview/opam
@@ -17,6 +17,7 @@ authors: [
 license: "ISC"
 homepage: "https://github.com/ocaml/ocaml-lsp"
 bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+flags: avoid-version
 depends: [
   "dune" {>= "2.9"}
   "yojson"

--- a/packages/ocamlformat/ocamlformat.0.19.0~4.13preview/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0~4.13preview/opam
@@ -7,6 +7,7 @@ authors: ["Josh Berdine <jjb@fb.com>"]
 license: "MIT"
 homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+flags: avoid-version
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.13" & < "4.14"}


### PR DESCRIPTION
Prevents upgrades to OCaml 4.13 while the previews are still the only versions available.
This does not prevent people from installing those preview explicitly nor does this prevent people from installing those packages on 4.13 switches.

Fixes https://discuss.ocaml.org/t/opam-prevent-preview-in-upgrade/8552