### PR TITLE
[new release] jwto (0.4.0)

### DIFF
--- a/packages/jwto/jwto.0.4.0/opam
+++ b/packages/jwto/jwto.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "JWT encoding, decoding and verification"
+description: "JWT encoding, decoding and verification"
+maintainer: ["Sebastian Porto"]
+authors: ["Sebastian Porto"]
+license: "MIT"
+homepage: "https://github.com/sporto/jwto"
+bug-reports: "https://github.com/sporto/jwto"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8"}
+  "yojson" {>= "1.6"}
+  "base64" {>= "3.1"}
+  "re" {>= "1.8"}
+  "ppx_deriving" {>= "4.2"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sporto/jwto.git"
+url {
+  src:
+    "https://github.com/sporto/jwto/releases/download/0.4.0/jwto-0.4.0.tbz"
+  checksum: [
+    "sha256=d77316759763070495e6484eb1226d936eb6d3d1aa1126187f512f2efdc86ca3"
+    "sha512=4daa12af774b69bf46fe1d61982c3ceba8c4cef08319926b9f639334f12c1624ea1eebe51208f8d5d8d32ea48935eb48e0db1d8679242479e5565e0b2626dcce"
+  ]
+}
+x-commit-hash: "13b4b53cc4ec433e0881f68ef8f97c1e224ca61a"


### PR DESCRIPTION
JWT encoding, decoding and verification

- Project page: <a href="https://github.com/sporto/jwto">https://github.com/sporto/jwto</a>

##### CHANGES:

- Use `digestif` instead of `cryptokit`
