### PR TITLE
Fix opus depext on macOS

### DIFF
--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -12,7 +12,8 @@ depexts: [
   ["libopus-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["opus-dev"] {os-family = "alpine"}
   ["opus"] {os-family = "arch"}
-  ["libopus"] {os = "freebsd" | os-distribution = "nixos" | os-family = "suse" | os = "macos" & os-distribution = "homebrew"}
+  ["libopus"] {os = "freebsd" | os-distribution = "nixos" | os-family = "suse"}
+  ["libopusenc"] {os = "macos" & os-distribution = "homebrew"}
   ["opus-devel"] {os-distribution="centos" | os-family = "fedora"}
 ]
 synopsis: "Virtual package relying on libopus"


### PR DESCRIPTION
Sidenote: `opam` `2.1.0` will keep failing even if the depext is installed with the fixed name. This is not really robust as depext do change over OS release. Maybe `--assume-depext` should be implicitly tried at least once?