### PR TITLE
[new release] 8 packages from savonet/ocaml-ffmpeg at 1.0.1

### DIFF
--- a/packages/ffmpeg-av/ffmpeg-av.1.0.1/opam
+++ b/packages/ffmpeg-av/ffmpeg-av.1.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg libraries -- top-level helpers"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "ffmpeg-avutil" {= version}
+  "ffmpeg-avcodec" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg-avcodec/ffmpeg-avcodec.1.0.1/opam
+++ b/packages/ffmpeg-avcodec/ffmpeg-avcodec.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg avcodec library"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "ffmpeg-avutil" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg-avdevice/ffmpeg-avdevice.1.0.1/opam
+++ b/packages/ffmpeg-avdevice/ffmpeg-avdevice.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg avdevice library"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "ffmpeg-av" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg-avfilter/ffmpeg-avfilter.1.0.1/opam
+++ b/packages/ffmpeg-avfilter/ffmpeg-avfilter.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg avfilter library"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "ffmpeg-avutil" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg-avutil/ffmpeg-avutil.1.0.1/opam
+++ b/packages/ffmpeg-avutil/ffmpeg-avutil.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg avutil libraries"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "base-threads"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg-swresample/ffmpeg-swresample.1.0.1/opam
+++ b/packages/ffmpeg-swresample/ffmpeg-swresample.1.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg swresample library"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "ffmpeg-avutil" {= version}
+  "ffmpeg-avcodec" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg-swscale/ffmpeg-swscale.1.0.1/opam
+++ b/packages/ffmpeg-swscale/ffmpeg-swscale.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg swscale library"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "conf-pkg-config" {build}
+  "conf-ffmpeg" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator" {build}
+  "ffmpeg-avutil" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ffmpeg" {< "0.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}

--- a/packages/ffmpeg/ffmpeg.1.0.1/opam
+++ b/packages/ffmpeg/ffmpeg.1.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings for the ffmpeg libraries"
+maintainer: ["Romain Beauxis <toots@rastageeks.org>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only"
+homepage: "https://github.com/savonet/ocaml-ffmpeg"
+bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "ffmpeg-av" {= version}
+  "ffmpeg-avutil" {= version}
+  "ffmpeg-avcodec" {= version}
+  "ffmpeg-avfilter" {= version}
+  "ffmpeg-avdevice" {= version}
+  "ffmpeg-swscale" {= version}
+  "ffmpeg-swresample" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
+url {
+  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.1.tar.gz"
+  checksum: [
+    "md5=f8aaa5d20ea8e0c3784c872455534b06"
+    "sha512=063077f5ccc7da1cf985ef97fb466b2c4caf7c89da7c08098df94a52f62b254e6f146976c80e45f6413a14d966e388beb0519bd2286139e9232925d23787df32"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ffmpeg.1.0.1`: Bindings for the ffmpeg libraries
-`ffmpeg-av.1.0.1`: Bindings for the ffmpeg libraries -- top-level helpers
-`ffmpeg-avcodec.1.0.1`: Bindings for the ffmpeg avcodec library
-`ffmpeg-avdevice.1.0.1`: Bindings for the ffmpeg avdevice library
-`ffmpeg-avfilter.1.0.1`: Bindings for the ffmpeg avfilter library
-`ffmpeg-avutil.1.0.1`: Bindings for the ffmpeg avutil libraries
-`ffmpeg-swresample.1.0.1`: Bindings for the ffmpeg swresample library
-`ffmpeg-swscale.1.0.1`: Bindings for the ffmpeg swscale library



---
* Homepage: https://github.com/savonet/ocaml-ffmpeg
* Source repo: git+https://github.com/savonet/ocaml-ffmpeg.git
* Bug tracker: https://github.com/savonet/ocaml-ffmpeg/issues

---
:camel: Pull-request generated by opam-publish v2.0.3