### PR TITLE
Add: bos.0.2.1, fmt.0.8.10, rresult.0.7.0, topkg.1.0.4, topkg-care.1.0.4

### DIFF
--- a/packages/bos/bos.0.1.0/opam
+++ b/packages/bos/bos.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.5"}
   "base-unix"
-  "rresult" {>= "0.3.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.1.1/opam
+++ b/packages/bos/bos.0.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.7.5"}
   "conf-which"
   "base-unix"
-  "rresult" {>= "0.3.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.1.2/opam
+++ b/packages/bos/bos.0.1.2/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.7.4"}
   "conf-which"
   "base-unix"
-  "rresult" {>= "0.3.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.1.3/opam
+++ b/packages/bos/bos.0.1.3/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.7.4"}
   "conf-which"
   "base-unix"
-  "rresult" {>= "0.3.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.1.4/opam
+++ b/packages/bos/bos.0.1.4/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.7.4"}
   "conf-which"
   "base-unix"
-  "rresult" {>= "0.3.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.1.5/opam
+++ b/packages/bos/bos.0.1.5/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.9.0"}
   "conf-which"
   "base-unix"
-  "rresult" {>= "0.4.0"}
+  "rresult" {>= "0.4.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.1.6/opam
+++ b/packages/bos/bos.0.1.6/opam
@@ -14,7 +14,7 @@ depends: [
   "topkg" {build & >= "0.9.0"}
   "conf-which"
   "base-unix"
-  "rresult" {>= "0.4.0"}
+  "rresult" {>= "0.4.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.2.0/opam
+++ b/packages/bos/bos.0.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
   "base-unix"
-  "rresult" {>= "0.4.0"}
+  "rresult" {>= "0.4.0" & < "0.7.0"}
   "astring"
   "fpath"
   "fmt" {>= "0.8.0"}

--- a/packages/bos/bos.0.2.1/opam
+++ b/packages/bos/bos.0.2.1/opam
@@ -19,7 +19,7 @@ depends: ["ocaml" {>= "4.08.0"}
           "fpath"
           "fmt" {>= "0.8.10"}
           "logs"
-          "mtime" {test}]
+          "mtime" {with-test}]
 build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
 url {
   src: "https://erratique.ch/software/bos/releases/bos-0.2.1.tbz"

--- a/packages/bos/bos.0.2.1/opam
+++ b/packages/bos/bos.0.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: """Basic OS interaction for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The bos programmers"]
+homepage: "https://erratique.ch/software/bos"
+doc: "https://erratique.ch/software/bos/doc"
+dev-repo: "git+https://erratique.ch/repos/bos.git"
+bug-reports: "https://github.com/dbuenzli/bos/issues"
+license: ["ISC"]
+tags: ["os" "system" "cli" "command" "file" "path" "log" "unix"
+       "org:erratique"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "base-unix"
+          "rresult" {>= "0.7.0"}
+          "astring"
+          "fpath"
+          "fmt" {>= "0.8.10"}
+          "logs"
+          "mtime" {test}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/bos/releases/bos-0.2.1.tbz"
+  checksum: "sha512=8daeb8a4c2dd1f2460f6274ada19f4f1b6ebe875ff83a938c93418ce0e6bdb74b8afc5c9a7d410c1c9df2dad030e4fa276b6ed2da580639484e8b5bc92610b1d"}
+description: """
+Bos provides support for basic and robust interaction with the
+operating system in OCaml. It has functions to access the process
+environment, parse command line arguments, interact with the file
+system and run command line programs.
+
+Bos works equally well on POSIX and Windows operating systems.
+
+Bos depends on [Rresult][rresult], [Astring][astring], [Fmt][fmt],
+[Fpath][fpath] and [Logs][logs] and the OCaml Unix library. It is
+distributed under the ISC license.
+
+[rresult]: http://erratique.ch/software/rresult
+[astring]: http://erratique.ch/software/astring
+[fmt]: http://erratique.ch/software/fmt
+[fpath]: http://erratique.ch/software/fpath
+[logs]: http://erratique.ch/software/logs
+
+Home page: http://erratique.ch/software/bos  
+Contact: Daniel Bünzli `<daniel.buenzl i@erratique.ch>`"""

--- a/packages/dune-release/dune-release.1.3.0/opam
+++ b/packages/dune-release/dune-release.1.3.0/opam
@@ -23,7 +23,7 @@ depends: [
   "opam-format"
   "opam-state"
   "opam-core"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "logs"
   "odoc"
   "alcotest" {with-test}

--- a/packages/dune-release/dune-release.1.3.1/opam
+++ b/packages/dune-release/dune-release.1.3.1/opam
@@ -23,7 +23,7 @@ depends: [
   "opam-format"
   "opam-state"
   "opam-core"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "logs"
   "odoc"
   "alcotest" {with-test}

--- a/packages/dune-release/dune-release.1.3.2/opam
+++ b/packages/dune-release/dune-release.1.3.2/opam
@@ -23,7 +23,7 @@ depends: [
   "opam-format"
   "opam-state"
   "opam-core"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "logs"
   "odoc"
   "alcotest" {with-test}

--- a/packages/dune-release/dune-release.1.3.3/opam
+++ b/packages/dune-release/dune-release.1.3.3/opam
@@ -23,7 +23,7 @@ depends: [
   "opam-format"
   "opam-state"
   "opam-core"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "logs"
   "odoc"
   "alcotest" {with-test}

--- a/packages/fmt/fmt.0.8.10/opam
+++ b/packages/fmt/fmt.0.8.10/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: """OCaml Format pretty-printer combinators"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The fmt programmers"]
+homepage: "https://erratique.ch/software/fmt"
+doc: "https://erratique.ch/software/fmt/doc/"
+dev-repo: "git+https://erratique.ch/repos/fmt.git"
+bug-reports: "https://github.com/dbuenzli/fmt/issues"
+license: ["ISC"]
+tags: ["string" "format" "pretty-print" "org:erratique"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}]
+depopts: ["base-unix"
+          "cmdliner"]
+conflicts: ["cmdliner" {< "0.9.8"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+          "--with-base-unix" "%{base-unix:installed}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"]]
+url {
+  src: "https://erratique.ch/software/fmt/releases/fmt-0.8.10.tbz"
+  checksum: "sha512=ee35fd2d89b1efb7a59b191b07fb160dcccf0fc1d7fdee6a67508a06c39c5048ba18a210cef4b7f6e80d05e808e70fc40b6fff54ab38db3a982eb2af79e34cb7"}
+description: """
+Fmt exposes combinators to devise `Format` pretty-printing functions.
+
+Fmt depends only on the OCaml standard library. The optional `Fmt_tty`
+library that allows to setup formatters for terminal color output
+depends on the Unix library. The optional `Fmt_cli` library that
+provides command line support for Fmt depends on [`Cmdliner`][cmdliner].
+
+Fmt is distributed under the ISC license.
+
+[cmdliner]: http://erratique.ch/software/cmdliner
+
+Home page: http://erratique.ch/software/fmt"""

--- a/packages/jekyll-format/jekyll-format.0.2.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "astring"
   "omd"
   "fmt"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "ptime"
   "fpath"
   "yaml" {< "3.0.0"}

--- a/packages/jekyll-format/jekyll-format.0.3.0/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "astring"
   "omd"
   "fmt"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "ptime"
   "fpath"
   "ezjsonm" {>="1.1.0"}

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.3"}
-  "fmt"
+  "fmt" {< "0.8.10"}
   "lwt"
   "cstruct" {>= "2.0.0" & < "6.0.1"}
   "cstruct-lwt"

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.2.0/opam
@@ -39,7 +39,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
   "alcotest" {with-test}
-  "fmt"
+  "fmt" {< "0.8.10"}
   "mirage-flow" {>= "1.2.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "lwt"

--- a/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.1.3.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta7"}
-  "fmt"
+  "fmt" {< "0.8.10"}
   "mirage-flow" {>= "1.3.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.3.0"}
   "lwt"

--- a/packages/mirage-flow/mirage-flow.1.2.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.3"}
-  "fmt"
+  "fmt" {< "0.8.10"}
   "result"
 ]
 synopsis: "Various implementations of the MirageOS FLOW interface"

--- a/packages/mirage-flow/mirage-flow.1.3.0/opam
+++ b/packages/mirage-flow/mirage-flow.1.3.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta7"}
-  "fmt"
+  "fmt" {< "0.8.10"}
   "result"
 ]
 synopsis: "Flow implementations and combinators for MirageOS"

--- a/packages/opam-ci/opam-ci.1.0.0/opam
+++ b/packages/opam-ci/opam-ci.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "cmdliner"
   "fmt"
   "logs"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "textwrap"
 ]
 build: [

--- a/packages/osc/osc.0.1.4/opam
+++ b/packages/osc/osc.0.1.4/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ocplib-endian"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "ounit" {with-test}
 ]
 depopts: [

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "ppxlib" {>= "0.18.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppxlib" {>= "0.14.0"}
   "yaml"
   "yaml" {with-test & >= "2.0.0"}
-  "rresult"
+  "rresult" {< "0.7.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/rpclib/rpclib.6.1.0/opam
+++ b/packages/rpclib/rpclib.6.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "alcotest" {with-test & < "1.0.0"}
   "dune" {>= "1.5.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rpclib/rpclib.7.0.0/opam
+++ b/packages/rpclib/rpclib.7.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "alcotest" {with-test & < "1.0.0"}
   "dune" {>= "1.5.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rpclib/rpclib.7.1.0/opam
+++ b/packages/rpclib/rpclib.7.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "base64" {>= "3.4.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rpclib/rpclib.7.2.0/opam
+++ b/packages/rpclib/rpclib.7.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "base64" {>= "3.4.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rpclib/rpclib.8.0.0/opam
+++ b/packages/rpclib/rpclib.8.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "base64" {>= "3.4.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rpclib/rpclib.8.1.0/opam
+++ b/packages/rpclib/rpclib.8.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "base64" {>= "3.4.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rresult/rresult.0.7.0/opam
+++ b/packages/rresult/rresult.0.7.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: """Result value combinators for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The rresult programmers"]
+homepage: "https://erratique.ch/software/rresult"
+doc: "https://erratique.ch/software/rresult/doc/Rresult"
+dev-repo: "git+https://erratique.ch/repos/rresult.git"
+bug-reports: "https://github.com/dbuenzli/rresult/issues"
+license: ["ISC"]
+tags: ["result" "error" "org:erratique"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/rresult/releases/rresult-0.7.0.tbz"
+  checksum: "sha512=f1bb631c986996388e9686d49d5ae4d8aaf14034f6865c62a88fb58c48ce19ad2eb785327d69ca27c032f835984e0bd2efd969b415438628a31f3e84ec4551d3"}
+description: """
+Rresult is an OCaml module for handling computation results and errors
+in an explicit and declarative manner, without resorting to
+exceptions. It defines combinators to operate on the `result` type
+available from OCaml 4.03 in the standard library.
+
+OCaml 4.08 provides the `Stdlib.Result` module which you should prefer
+to Rresult.
+
+Rresult is distributed under the ISC license.
+
+Home page: http://erratique.ch/software/rresult  
+Contact: Daniel Bünzli `<daniel.buenzl i@erratique.ch>`"""

--- a/packages/topkg-care/topkg-care.1.0.4/opam
+++ b/packages/topkg-care/topkg-care.1.0.4/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: """The transitory OCaml software packager"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The topkg programmers"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+license: ["ISC"]
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: ["ocaml" {>= "4.03.0"}
+          "ocamlfind" {build & >= "1.6.1"}
+          "ocamlbuild"
+          "topkg" {= version}
+          "fmt"
+          "logs"
+          "bos" {>= "0.1.5"}
+          "cmdliner" {>= "1.0.0"}
+          "webbrowser"
+          "opam-format" {>= "2.0.0"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
+                                      "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.0.4.tbz"
+  checksum: "sha512=5baa1bf0105397589b741acd0195069823548b2051e453dffd641e5d00536b7a5f41b38d005b2b063f9e7cfb9a3b627bec3e6ad48e56769cc35a71f97a897f1b"}
+description: """
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: http://erratique.ch/software/topkg"""

--- a/packages/topkg/topkg.1.0.4/opam
+++ b/packages/topkg/topkg.1.0.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: """The transitory OCaml software packager"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The topkg programmers"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+license: ["ISC"]
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: ["ocaml" {>= "4.03.0"}
+          "ocamlfind" {build & >= "1.6.1"}
+          "ocamlbuild"]
+build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
+                                      "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.0.4.tbz"
+  checksum: "sha512=5baa1bf0105397589b741acd0195069823548b2051e453dffd641e5d00536b7a5f41b38d005b2b063f9e7cfb9a3b627bec3e6ad48e56769cc35a71f97a897f1b"}
+description: """
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: http://erratique.ch/software/topkg"""

--- a/packages/yaml/yaml.0.2.0/opam
+++ b/packages/yaml/yaml.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "sexplib" {< "v0.15"}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "fmt"
   "logs"
   "bos"

--- a/packages/yaml/yaml.1.0.0/opam
+++ b/packages/yaml/yaml.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ctypes" {>= "0.13.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "sexplib" {< "v0.15"}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "fmt"
   "logs"
   "bos"

--- a/packages/yaml/yaml.2.0.0/opam
+++ b/packages/yaml/yaml.2.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ctypes" {>= "0.13.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "sexplib" {< "v0.15"}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "fmt"
   "logs"
   "bos"

--- a/packages/yaml/yaml.2.0.1/opam
+++ b/packages/yaml/yaml.2.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ctypes" {>= "0.13.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "sexplib" {< "v0.15"}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "fmt"
   "logs"
   "bos"

--- a/packages/yaml/yaml.2.1.0/opam
+++ b/packages/yaml/yaml.2.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ctypes" {>= "0.14.0"}
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
   "sexplib" {< "v0.15"}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "fmt"
   "logs"
   "bos"

--- a/packages/yaml/yaml.3.0.0/opam
+++ b/packages/yaml/yaml.3.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dune" {>= "1.3"}
   "dune-configurator"
   "ctypes" {>= "0.14.0"}
-  "rresult"
+  "rresult" {< "0.7.0"}
   "bos"
   "fmt" {with-test}
   "logs" {with-test}


### PR DESCRIPTION
* Add: `bos.0.2.1` [home](https://erratique.ch/software/bos), [doc](https://erratique.ch/software/bos/doc), [issues](https://github.com/dbuenzli/bos/issues)  
  *Basic OS interaction for OCaml*
* Add: `fmt.0.8.10` [home](https://erratique.ch/software/fmt), [doc](https://erratique.ch/software/fmt/doc/), [issues](https://github.com/dbuenzli/fmt/issues)  
  *OCaml Format pretty-printer combinators*
* Add: `rresult.0.7.0` [home](https://erratique.ch/software/rresult), [doc](https://erratique.ch/software/rresult/doc/Rresult), [issues](https://github.com/dbuenzli/rresult/issues)  
  *Result value combinators for OCaml*
* Add: `topkg.1.0.4` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*
* Add: `topkg-care.1.0.4` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*


---

#### `bos` v0.2.1 2021-10-04 Zagreb

- Require OCaml >= 4.08.
- `OS.Dir.create` fix function result on existing files. It returned
  non-sensical results. The function now errors as it should
  be. Thanks to Léo Andrès for the report.
- `OS.Dir.create` fix function returning `false` instead of 
  `true` when the directory is created with `~path:false`.
  Thanks to Léo Andrès for the report and patch.
- `OS.File.read` support for reading character devices and named
  pipes. Thanks to Rizo Isrof for the patch.

---

#### `fmt` v0.8.10 2021-10-04 Zagreb

* Require OCaml >= 4.08. This drops the dependency on the 
  `stdlib-shims` and `seq` packages.
* Add the `[@@ocaml.deprecated]` annotation to deprecated 
  functions. Thanks to Antonin Décimo for the patch.

---

#### `rresult` v0.7.0 2021-10-04 Zagreb

* Require OCaml >= 4.08. This drops the dependency on the `result`
  compatibility package.
* Users are encouraged to move the the `Stdlib.Result` module 
  available in OCaml 4.08.

---

#### `topkg-care`, `topkg` v1.0.4 2021-10-04 Zagreb

- Remove mentions of `Result.result` in the code base. We got the
  dependency indirectly through `bos` and the latest version of the
  latter no longer depends on it.

---

Use `b0 cmd -- .opam.publish bos.0.2.1 fmt.0.8.10 rresult.0.7.0 topkg.1.0.4 topkg-care.1.0.4` to update the pull request.