### PR TITLE
[new release] sha (1.15.1)

### DIFF
--- a/packages/sha/sha.1.15.1/opam
+++ b/packages/sha/sha.1.15.1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Binding to the SHA cryptographic functions"
+description: """
+This is the binding for SHA interface code in OCaml. Offering the same
+interface than the MD5 digest included in the OCaml standard library.
+It's currently providing SHA1, SHA256 and SHA512 hash functions."""
+maintainer: ["dave@recoil.org"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Goswin von Brederlow"
+  "Eric Cooper"
+  "Florent Monnier"
+  "Forrest L Norvell"
+  "Vincent Bernadoff"
+  "David Scott"
+  "Olaf Hering"
+  "Arthur Teisseire"
+  "Nicolás Ojeda Bär"
+  "Christopher Zimmermann"
+  "Thomas Leonard"
+  "Antonin Décimo"
+]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-sha"
+bug-reports: "https://github.com/djs55/ocaml-sha/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.02"}
+  "stdlib-shims" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/djs55/ocaml-sha.git"
+url {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.15.1/sha-v1.15.1.tbz"
+  checksum: [
+    "sha256=711b63c9dbf08178229a2e85dc2e3c8fb2eb5a07cc3ba9bd5092a32a5c6fa744"
+    "sha512=6c18039bac7fb420c918217c3119f3913235e4ca1846818b6b7d6a8df24221aef32f9c6ccf1c235a499d296d76471b0709b73faf4b3c525ffbf814f96d557b66"
+  ]
+}
+x-commit-hash: "af5c7b1c7d3b8f9492038b7b40ba9cad82fb4ee8"


### PR DESCRIPTION
Binding to the SHA cryptographic functions

- Project page: <a href="https://github.com/djs55/ocaml-sha">https://github.com/djs55/ocaml-sha</a>

##### CHANGES:

Opam CI fixes by @MisterDA (djs55/ocaml-sha#54):

- update to Dune 2.9 to fix [lint warning](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/8cf1e193733c6d6c0330b46c1a7b7a2819e9a977/variant/(lint));
  > (lint) (failed: Warning in sha.1.15: Dubious use of 'dune subst'. 'dune subst' should always only be called with {dev} (i.e. ["dune" "subst"] {dev}) If your opam file has been autogenerated by dune, you need to upgrade your dune-project to at least (lang dune 2.7).)
- define `Bytes_val` ourselves before OCaml 4.06;
- add setup-ocaml GitHub action to catch mistakes earlier.
