### PR TITLE
[new release] ocaml-version (3.4.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.4.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.4.0/ocaml-version-v3.4.0.tbz"
+  checksum: [
+    "sha256=d8c1beb5e8d8ebb7710b5f434ce66a3ec8b752b1e4d6ba87c4fe27452bdb8a25"
+    "sha512=215e5b0c4ea5fa5461cdc0fc81fbd84a2a319a246a19504d0a0abc8c891e252a9e41644356150a1dc25d56b3f7e084db7a0b15becab4e1339992e645fc3d8ef1"
+  ]
+}
+x-commit-hash: "c535ad2f463664b31001888fc99495dd01632747"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add 4.13.1 entry (@Octachron ocurrent/ocaml-version#42)
