### PR TITLE
[new release] odoc (2.0.0)

### DIFF
--- a/packages/odoc/odoc.2.0.0/opam
+++ b/packages/odoc/odoc.2.0.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "odoc-parser" {>= "0.9.0"}
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune" {>= "2.7.0"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+  "logs"
+  "re" {>= "1.7.2"}
+
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+
+  "ocaml-version" {with-test & >= "2.3.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test & >= "0.8.3"}
+  "markup" {with-test & >= "1.0.0"}
+  "ocamlfind" {with-test}
+  "yojson" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "bisect_ppx" {with-test & = "2.5.0"}
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
+  "bos" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.0.0/odoc-2.0.0.tbz"
+  checksum: [
+    "sha256=8c31eb2aff18b4b90898afa341f4457cc7a29658caacf9cc9594bdc8120cd007"
+    "sha512=8649ae418877a1b85c74369e3c6897a3d38f8f237e37b8fa6050ce8f9edf6faf92427dbf3d915412c86d2fa777bfc901867ffa793b05ecd08e676f280c5fb60a"
+  ]
+}
+x-commit-hash: "34ef06a986a291c8338e62f8de517a1d7ed63e0a"


### PR DESCRIPTION
OCaml documentation generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

Breaking changes
- Remove odoc-parser into a separate repository (@jonludlam, ocaml/odoc#700)

Additions
- OCaml 4.13 support (@octachron, ocaml/odoc#687, ocaml/odoc#689)
- Better errors/warnings (@Julow, ocaml/odoc#692, ocaml/odoc#717, ocaml/odoc#720, ocaml/odoc#732)
- ModuleType 'Alias' support (@jonludlam, ocaml/odoc#703)
- Improved test suite (@lubega-simon, ocaml/odoc#697)
- Improved documentation (@lubega-simon, @jonludlam, ocaml/odoc#702, ocaml/odoc#733)
- Strengthen module types (@jonludlam, ocaml/odoc#731)

Bugs fixed
- `uwt` now can be documented (@jonludlam, ocaml/odoc#708)
- Fix resolution involving deeply nested substitutions (@jonludlam, ocaml/odoc#727)
- Fix off-by-one error in error reporting (@asavahista, ocaml/odoc#736)
