### PR TITLE
2 packages from ocaml-sf/learn-ocaml at 0.13.0

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.13.0/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.13.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {>= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "omd" {<= "1.3.1"}
+  "asak"
+  "gg"
+  "vg"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "ssl" {= "0.5.5"}
+  "digestif" {>= "0.7.1"}
+  "dune"
+  "ezjsonm"
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {>= "0.4"}
+  "ocplib-json-typed" {>= "0.7"}
+  "ipaddr" {= "2.8.0"}
+  "cstruct" {>= "3.3.0"}
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "ppx_fields_conv"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/v0.13.0.tar.gz"
+  checksum: [
+    "md5=d05d2c513812eee349b04ac605e41eab"
+    "sha512=0a59b1fb85cc7e8fab64abbed763963992603c6de97dda819e92827cc9644547a72bcdde3b88ae26f8d54d7e63a8f192100da4541d603fcc6d82aa125dcb893d"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.13.0/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.13.0/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "base" {>= "v0.9.4"}
+  "base64"
+  "cmdliner"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "1.11.4"}
+  "easy-format" {>= "1.3.0"}
+  "ipaddr" {>= "2.8.0"}
+  "ezjsonm"
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "ssl" {= "0.5.5"}
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocp-ocamlres" {= "0.4"}
+  "ocplib-json-typed" {>= "0.6"}
+  "ocplib-json-typed-browser" {>= "0.6"}
+  "odoc" {build}
+  "omd"
+  "pprint"
+  "ppx_cstruct"
+  "ppx_tools"
+  "re"
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+  "asak" {>= "0.1"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/v0.13.0.tar.gz"
+  checksum: [
+    "md5=d05d2c513812eee349b04ac605e41eab"
+    "sha512=0a59b1fb85cc7e8fab64abbed763963992603c6de97dda819e92827cc9644547a72bcdde3b88ae26f8d54d7e63a8f192100da4541d603fcc6d82aa125dcb893d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`learn-ocaml.0.13.0`: The learn-ocaml online platform (engine)
-`learn-ocaml-client.0.13.0`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---

### Features

* Port to OCaml 4.12 ([#408](https://www.github.com/ocaml-sf/learn-ocaml/issues/408)) ([34f04af](https://github.com/ocaml-sf/learn-ocaml/commit/34f04af5e0725e524d73d34d6b2b83b25d2777ed))
* Relax the client/server coupling & Add support for API versioning ([#426](https://www.github.com/ocaml-sf/learn-ocaml/issues/426)) ([3113861](https://www.github.com/ocaml-sf/learn-ocaml/commit/31138615d1566f5cd7b7d63484bfe5434a47258c))
* Make server version available to front-ends (`learn-ocaml-client` & `learn-ocaml.el`) ([#429](https://github.com/ocaml-sf/learn-ocaml/pull/429)) ([d607281](https://github.com/ocaml-sf/learn-ocaml/commit/d607281bc7ee6f85fb86c1f242a70a2dc6c7020a))
* Generate static binaries directly from a GitHub Action (Linux, macOS) ([#391](https://github.com/ocaml-sf/learn-ocaml/pull/391)) ([ff9f091](https://github.com/ocaml-sf/learn-ocaml/commit/ff9f091d4af8110bed76c02afcfba66d13f17374))
* Make the prelude available in description page ([#393](https://www.github.com/ocaml-sf/learn-ocaml/issues/393)) ([51ed717](https://www.github.com/ocaml-sf/learn-ocaml/commit/51ed717fb5224aeb53c55b666019d10ceaeb68b6))
* Improve description entrypoint ([#423](https://www.github.com/ocaml-sf/learn-ocaml/issues/423)) ([a825d7e](https://www.github.com/ocaml-sf/learn-ocaml/commit/a825d7ed515fc9cc0dbd74513e902c5f8f828fc1))
* Add a ppx facility to test expressions ([#403](https://github.com/ocaml-sf/learn-ocaml/pull/403)) ([526bc07](https://github.com/ocaml-sf/learn-ocaml/commit/526bc07f47f88d777145c5cb52c97b0456bc4e67))
* Make `find_binding` match annotated declarations ([#425](https://github.com/ocaml-sf/learn-ocaml/pull/425)) ([b277b38](https://github.com/ocaml-sf/learn-ocaml/commit/b277b38167c079f506e3801e7fea36b61f63f710))
* **UI:** Discourage redundant token creation from users ([#410](https://github.com/ocaml-sf/learn-ocaml/pull/410)) ([83630d5](https://github.com/ocaml-sf/learn-ocaml/commit/83630d5fc82f63e1c533a1d5b48e1e854deb7918))
* **UI:** Move the toplevel buttons to the bottom-right ([#409](https://github.com/ocaml-sf/learn-ocaml/pull/409)) ([90066d0](https://github.com/ocaml-sf/learn-ocaml/commit/90066d0fb2ec468d0a211b371f44c59b7ebe4108))
* **UI:** Reset the toplevel every time before evaluating code from the editor ([#411](https://github.com/ocaml-sf/learn-ocaml/pull/411)) ([65ce0c42](https://github.com/ocaml-sf/learn-ocaml/commit/65ce0c42ef2075458f82c5063254b4fe68b641d0))
* **UI:** Improve UX for clickable logo ([#389](https://github.com/ocaml-sf/learn-ocaml/pull/389)) ([c406219](https://www.github.com/ocaml-sf/learn-ocaml/commit/c4062194ce23b14b3fb87198dff3ac6ef53a8ece))
* Add support for exercise code reuse ([#320](https://github.com/ocaml-sf/learn-ocaml/pull/320)) ([42d8127](https://github.com/ocaml-sf/learn-ocaml/commit/42d81279916c70528b42cf0af7eec01cf1adcbcb))
* Add VG in toplevel and exercises ([#352](https://github.com/ocaml-sf/learn-ocaml/pull/352)) ([1add7ba](https://github.com/ocaml-sf/learn-ocaml/commit/1add7babae8a899d066b61122bfe08212bcf4a28)) 


### Bug Fixes

* **CI:** Use OCaml 4.12.1 ([d5ece9b](https://www.github.com/ocaml-sf/learn-ocaml/commit/d5ece9b933bbd0b3dce879f397e1d9929a92bdfb))
* Blacklist jsoo version 3.10.0 ([#420](https://github.com/ocaml-sf/learn-ocaml/pull/420)) ([2696f86](https://github.com/ocaml-sf/learn-ocaml/commit/2696f86f4dad94d6b8645ee1ea2eb416f35e1a80))
* **.ci-macosx.sh:** Avoid `{ set -e; c1 && c2; }` bug & Improve script ([17a6703](https://www.github.com/ocaml-sf/learn-ocaml/commit/17a6703c1d4d2a59d4c0dcb78328f29cfd057add))
* **.ci-macosx.sh:** Install openssl ([0a30b4f](https://www.github.com/ocaml-sf/learn-ocaml/commit/0a30b4fe982bd16131c48b555a2072fbd8f2b277))
* **dune:** Avoid ANSI char issues in `opam show … > VERSION` ([#394](https://github.com/ocaml-sf/learn-ocaml/pull/394)) ([b72fa6c](https://www.github.com/ocaml-sf/learn-ocaml/commit/b72fa6c3047e997bdc513c9957951458cd702e39))
* **UI:** Fix the display of UTF-8 characters in the code editor ([#412](https://github.com/ocaml-sf/learn-ocaml/pull/412)) ([debb635](https://github.com/ocaml-sf/learn-ocaml/commit/debb635f216016372a44b4e18d97b72296038691))
* **omd:** Update the markdown-to-html transformation so links open a new tab ([#392](https://github.com/ocaml-sf/learn-ocaml/pull/392)) ([e0e3f2f](https://github.com/ocaml-sf/learn-ocaml/commit/e0e3f2fe13884bd2482bbe26f78b69048f910532))
* **omd:** Update `override`_url to avoid escape characters problems in URL ([1e87190](https://www.github.com/ocaml-sf/learn-ocaml/commit/1e87190a9de73136dca0b7032267e0f8c2c066e5))
* Fix static deployment ([#356](https://github.com/ocaml-sf/learn-ocaml/pull/356)) ([1332c6e](https://github.com/ocaml-sf/learn-ocaml/commit/1332c6ecb693dc737f835ea201adb7079b5350af))
* Fix & Document static deployment CLI support ([#368](https://github.com/ocaml-sf/learn-ocaml/pull/368)) ([3cc2533](https://github.com/ocaml-sf/learn-ocaml/commit/3cc2533986a608c12108f4feb5fa1754fa9e5a89))
* Fix learn-ocaml-client regression after PR [#320](https://github.com/ocaml-sf/learn-ocaml/pull/320) ([#397](https://github.com/ocaml-sf/learn-ocaml/pull/397)) ([5b16c92](https://github.com/ocaml-sf/learn-ocaml/commit/5b16c92392ac587e2aea5c0f9fb70bb16fe9ba68))
* Better error message for `X-TOKEN` registration ([#406](https://github.com/ocaml-sf/learn-ocaml/pull/406)) ([e27415c](https://www.github.com/ocaml-sf/learn-ocaml/commit/e27415cf67ba4c976f96067fd1d201999b7692af))
* **CI:** Add custom, curl-based `wait_for_it` ([d910a6e](https://www.github.com/ocaml-sf/learn-ocaml/commit/d910a6e5779133c82a0aebb1cf16c11a019eeef0))
* **Docker:** Fix runtime error in Docker packaging ([a697edf](https://www.github.com/ocaml-sf/learn-ocaml/commit/a697edfd44b6d8fdbfc935ad04533de5627022ab))
* **CI:** Bump alpine version & Use `ocaml/opam` instead of `ocaml/opam2` ([7766698](https://www.github.com/ocaml-sf/learn-ocaml/commit/7766698707759739f3893173aa3b876540c344c4))
* **CI:** Workaround the static-bin-macos failure ([#431](https://www.github.com/ocaml-sf/learn-ocaml/issues/431)) ([064dafd](https://www.github.com/ocaml-sf/learn-ocaml/commit/064dafd20d2ec12042f7ddcddaf8549b14176fd6))
* Use HTML5 Doctype ([fe0fe8b](https://www.github.com/ocaml-sf/learn-ocaml/commit/fe0fe8b983b722c685c34aa3f238e46a30dfb17b))


### Performance Improvements

* Remove redundant build step ([2b3f25b](https://www.github.com/ocaml-sf/learn-ocaml/commit/2b3f25b1a68fc21321c3cc044b334717304475e5))
* **Learnocaml_main:** Remove unneeded `Markup.pretty_print` ([e5ce820](https://www.github.com/ocaml-sf/learn-ocaml/commit/e5ce82078f2f5d2663022d9a2dae682601399dda))


### Tests

* **runtests.sh:** Improve the script & Fix all shellcheck issues ([5f4a6ac](https://www.github.com/ocaml-sf/learn-ocaml/commit/5f4a6ac1ea8ec8b0120896a2e89afb88dadb91cb))


### Continuous Integration

* CI/CD using GitHub Actions ([#361](https://github.com/ocaml-sf/learn-ocaml/pull/361)) ([bcecadd](https://github.com/ocaml-sf/learn-ocaml/commit/bcecadd9c01e3ee058a4c944e71af31019e48c78))
* **GHA:** Add a weekly build `https://crontab.guru/#0_8_*_*_6` ([63903f2](https://github.com/ocaml-sf/learn-ocaml/commit/63903f277e6eaa1b08580cbf4e0bb289996f85de))
* **GHA:** Enable cron build for `static-builds.yml` ([6478085](https://github.com/ocaml-sf/learn-ocaml/commit/6478085d72e575e368be50d4b45fc12ab4fa25a2))
* **GHA:** Deploy `ocamlsf/emacs-learn-ocaml-client:{master,$tags}` ([#433](https://github.com/ocaml-sf/learn-ocaml/pull/433)) ([dce8f00](https://github.com/ocaml-sf/learn-ocaml/commit/dce8f00ffcb42f2ac9d6bae08400c8b3ba6872d1))
* **GHA:** Ensure the uploaded artifacts are single `.tar.gz` files ([#432](https://github.com/ocaml-sf/learn-ocaml/pull/432)) ([adbb063](https://github.com/ocaml-sf/learn-ocaml/commit/adbb063e3087ff2d7c3cc04ec26d1b9bf5acc0dd))
* **release.yml:** Add a (3 jobs)-based GHA using release-please ([#434](https://www.github.com/ocaml-sf/learn-ocaml/issues/434)) ([7e389ef](https://www.github.com/ocaml-sf/learn-ocaml/commit/7e389ef22842e95e1b3f4364c19cf657a53ebf01))


### Documentation

* Document student answers classification ([#421](https://github.com/ocaml-sf/learn-ocaml/pull/421)) ([9b1a551](https://github.com/ocaml-sf/learn-ocaml/commit/9b1a55160b5732d0d0125035c841f979286ae7cd))
* Fix docs issue [#399](https://www.github.com/ocaml-sf/learn-ocaml/issues/399) and unify the markdown syntax ([276dac9](https://www.github.com/ocaml-sf/learn-ocaml/commit/276dac96c8d538a97e628e77b162c49642ae519a))
* Make accessible the documentation generated by `odoc` ([#404](https://github.com/ocaml-sf/learn-ocaml/pull/404)) ([e10975f](https://github.com/ocaml-sf/learn-ocaml/commit/e10975fdf5a4f31594f946e0fd00fc6995ba630b))
* **docs/index.md:** Update docker badges & ocaml-sf URL ([7fce8a1](https://www.github.com/ocaml-sf/learn-ocaml/commit/7fce8a1a93deeef69495bdde98a8a504ccb54b17))
* **readme:** s/HTTP/HTTPS/ ([193df99](https://www.github.com/ocaml-sf/learn-ocaml/commit/193df99160ea834b46bafbf82efceb7f6cf64a2e))
* **UI:** Improve text details ([#428](https://github.com/ocaml-sf/learn-ocaml/pull/428)) ([017f049](https://github.com/ocaml-sf/learn-ocaml/commit/017f04960fc1cf7b11f641869082f13556a7c809))

### Miscellaneous Chores

* release 0.13.0 ([f6b3b26](https://www.github.com/ocaml-sf/learn-ocaml/commit/f6b3b2652c8b8cfdc30bb86514f532f5901c660f))


---
:camel: Pull-request generated by opam-publish v2.1.0