### PR TITLE
 [new package] pyast.0.1.0 and [new release] metapp.0.4.1 and metaquot.0.5.0 and pattern.0.3.1

### DIFF
--- a/packages/metapp/metapp.0.4.1/opam
+++ b/packages/metapp/metapp.0.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Meta-preprocessor for OCaml"
+description: """
+Meta-preprocessor for OCaml: extends the language with [%meta ... ]
+construction where ... stands for OCaml code evaluated at
+compile-time.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/metapp"
+doc: "https://github.com/thierry-martinez/metapp"
+bug-reports: "https://github.com/thierry-martinez/metapp"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "stdcompat" {>= "12"}
+  "ppxlib" {>= "0.18.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
+url {
+  src: "https://github.com/thierry-martinez/metapp/archive/v0.4.1.tar.gz"
+  checksum: "sha512=b363c2309c0bf78cbce6a934dbfa1d18c3cdfbee1f15c0cb31b533ff758fc7c6ecff74769577f9969338c5528decf84cbbf49ff61671fdeb20bb284d18e9b25f"
+}

--- a/packages/metapp/metapp.0.4.1/opam
+++ b/packages/metapp/metapp.0.4.1/opam
@@ -36,5 +36,5 @@ build: [
 dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
 url {
   src: "https://github.com/thierry-martinez/metapp/archive/v0.4.1.tar.gz"
-  checksum: "sha512=b363c2309c0bf78cbce6a934dbfa1d18c3cdfbee1f15c0cb31b533ff758fc7c6ecff74769577f9969338c5528decf84cbbf49ff61671fdeb20bb284d18e9b25f"
+  checksum: "sha512=359a2a3b5f8a774bae194e63ec32a61a51ce6c9b047690e973ea8aa457f23843741ccd249cc9d734774c22b24e67001a3dc1d6e14eb763eae41e4f4a2adc6279"
 }

--- a/packages/metaquot/metaquot.0.5.0/opam
+++ b/packages/metaquot/metaquot.0.5.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/thierry-martinez/metaquot"
 doc: "https://github.com/thierry-martinez/metaquot"
 bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
-  "ocaml" {>= "4.08.0" & < "4.13"}
+  "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
   "ppxlib" {>= "0.22.0" & < "0.23.0"}
   "ocamlfind" {>= "1.8.1"}
@@ -35,5 +35,5 @@ build: [
 dev-repo: "git+https://github.com/thierry-martinez/metaquot.git"
 url {
   src: "https://github.com/thierry-martinez/metaquot/archive/v0.5.0.tar.gz"
-  checksum: "sha512=30a9cb179723576138798722ede657df6d1914c41b61d6abe4cfcad7e7accafaa0de5dff3bed713e6f21495d84c802a3e85b75bac57e9d7271aa67de74d5f98e"
+  checksum: "sha512=278c5f1b36424368e202b97e9a8921ca4343094c11f85c3b024f85b470006868a7509df89bc088f9b13dab9b79bfb546d7297cc24d16cffbd2b7e84356c1cf48"
 }

--- a/packages/metaquot/metaquot.0.5.0/opam
+++ b/packages/metaquot/metaquot.0.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OCaml syntax extension for quoting code"
+description: """
+metaquot allows to quote OCaml code.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/metaquot"
+doc: "https://github.com/thierry-martinez/metaquot"
+bug-reports: "https://github.com/thierry-martinez/metaquot"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.13"}
+  "stdcompat" {>= "12"}
+  "ppxlib" {>= "0.22.0" & < "0.23.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+  "metapp" {>= "0.4.1"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/metaquot.git"
+url {
+  src: "https://github.com/thierry-martinez/metaquot/archive/v0.5.0.tar.gz"
+  checksum: "sha512=30a9cb179723576138798722ede657df6d1914c41b61d6abe4cfcad7e7accafaa0de5dff3bed713e6f21495d84c802a3e85b75bac57e9d7271aa67de74d5f98e"
+}

--- a/packages/pattern/pattern.0.3.1/opam
+++ b/packages/pattern/pattern.0.3.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+bug-reports: "https://github.com/thierry-martinez/pattern"
+homepage: "https://github.com/thierry-martinez/pattern"
+doc: "https://github.com/thierry-martinez/pattern"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pattern.git"
+synopsis: "Run-time patterns that explain match failures"
+description: """
+pattern is a PPX extension that generates functions from patterns
+that explain match failures by returning the common context and
+the list of differences between a pattern and a value.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "metapp" {>= "0.3.0"}
+  "metaquot" {>= "0.3.0"}
+  "refl" {>= "0.3.0"}
+  "ocaml-migrate-parsetree" {>= "1.5.0"}
+  "stdcompat" {>= "10"}
+]
+url {
+  src: "https://github.com/thierry-martinez/pattern/archive/v0.3.1.tar.gz"
+  checksum: "sha512=7aca3237073dd353c728e38c075946e57eb9d9a4440221e240509ceac96172d2e37d99c95d7a80865a9525e9e575e1fcc6e7b149a2311c5dc657341ed0901784"
+}

--- a/packages/pyast/pyast.0.1.0/opam
+++ b/packages/pyast/pyast.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1.0"
+synopsis: "Python AST"
+description: """
+This library provides versioned abstract syntax tree for all Python
+versions from Python 2.5 to Python 3.9.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry.martinez/pyast"
+doc: "https://github.com/thierry.martinez/pyast"
+bug-reports: "https://github.com/thierry.martinez/pyast"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.8" & >= "1.11.3"}
+  "pyml" {>= "20210226"}
+  "refl" {>= "0.4.0"}
+  "cmdliner" {>= "1.0.4"}
+  "redirect" {>= "0.2.0"}
+  "stdcompat" {>= "10"}
+  "menhir" {>= "20210419"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry.martinez/pyast.git"
+url {
+  src: "https://github.com/thierry-martinez/pyast/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: "sha512=9e4317274dd45d67c94f852ae7450085e614b660c02e13ac709c4254c02684fe96bc984473fa39b94f064f38b62079a2637a0cff39f31a0e6fcef25cd139495e"
+}

--- a/packages/pyast/pyast.0.1.0/opam
+++ b/packages/pyast/pyast.0.1.0/opam
@@ -19,6 +19,7 @@ depends: [
   "redirect" {>= "0.2.0"}
   "stdcompat" {>= "10"}
   "menhir" {>= "20210419"}
+  "pattern" {with-test & >= "0.3.0"}
   "odoc" {with-doc & >= "1.5.1"}
 ]
 build: [

--- a/packages/pyast/pyast.0.1.0/opam
+++ b/packages/pyast/pyast.0.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "0.1.0"
 synopsis: "Python AST"
 description: """
 This library provides versioned abstract syntax tree for all Python

--- a/packages/pyast/pyast.0.1.0/opam
+++ b/packages/pyast/pyast.0.1.0/opam
@@ -38,5 +38,5 @@ build: [
 dev-repo: "git+https://github.com/thierry.martinez/pyast.git"
 url {
   src: "https://github.com/thierry-martinez/pyast/archive/refs/tags/v0.1.0.tar.gz"
-  checksum: "sha512=9e4317274dd45d67c94f852ae7450085e614b660c02e13ac709c4254c02684fe96bc984473fa39b94f064f38b62079a2637a0cff39f31a0e6fcef25cd139495e"
+  checksum: "sha512=7ac0ad1c6d010e4053801c26972748a3dfb1886907906b6d87d767cd0cee7d433fc5f79b514003063d83ea184d62aea5f6c3eded7baccb47b7f2e60fb9f79775"
 }


### PR DESCRIPTION
This PR adds the new package pyast.0.1.0 and new release metapp.0.4.1, metaquot.0.5.0 and pattern.0.3.1 to add support for OCaml 4.13. This library provides versioned abstract syntax tree for all Python versions.