### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-ocamlbuild, js_of_ocaml-lwt and js_of_ocaml-compiler (3.11.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04" & < "4.14"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.12.0" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner"
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.11.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.3.11.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.11.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.3.11.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "ocamlbuild"
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.11.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.3.11.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.11.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.3.11.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.11.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.3.11.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.11.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.3.11.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"

--- a/packages/js_of_ocaml/js_of_ocaml.3.11.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.3.11.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.github.io/js_of_ocaml"
+doc: "https://ocsigen.github.io/js_of_ocaml"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "uchar"
+  "num" {with-test}
+  "ppx_expect" {with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/3.11.0/js_of_ocaml-3.11.0.tbz"
+  checksum: [
+    "sha256=158dafe7271ac79157981d1c3f5f177ec78a0099c38f861ae14e7ac06bd29c3a"
+    "sha512=d83f0988aa1089fa01a0a693d7e6a832018c5a8ce707f44685809769377ef7ef59ce48229b1612966bd9166b610d66ddff8f2606f6c3f09c49f601b74842fde1"
+  ]
+}
+x-commit-hash: "4572278dea9cc8a7d44d65b440004a2ec3bce7a7"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.github.io/js_of_ocaml">https://ocsigen.github.io/js_of_ocaml</a>
- Documentation: <a href="https://ocsigen.github.io/js_of_ocaml">https://ocsigen.github.io/js_of_ocaml</a>

##### CHANGES:

## Features/Changes
* Compiler: setting tc_depth to 0 remove direct call from the tc optimization.
* Lib: add hidden, onfullscreenchange and onwebkitfullscreenchange to document
* Runtime: fixes for Windows, all tests pass
* Runtime: make all windows drive available on nodejs.
* Runtime: add support for Sys.mkdir and Sys.rmdir
* Runtime: make stdin work on nodejs
* Runtime: add support for Unix(stat,lstat,mkdir,rmdir,symlink,readlink,unlink,getuid) on nodejs.
* Runtime: add caml_raise_with_args

## Bug fixes
* Compiler: fix toplevel generation (ocsigen/js_of_ocaml#1129, ocsigen/js_of_ocaml#1130, ocsigen/js_of_ocaml#1131)
* Compiler: fix predefined exn id with separate compilation
* Compiler: js stubs without 'Provides' should still allow 'Require'
* Runtime: fix handling of uncaugh exceptions
* Runtime: fix error handling of Sys.readdir
* Dune: make git version lookup more resilient
