### PR TITLE
[new release] ca-certs-nss (3.71)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.71/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.71/opam
@@ -24,6 +24,9 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
CHANGES:

* Update to NSS 3.71 (Sep 30th 2021)
* Remove rresult and hex dependencies