### PR TITLE
Add llvm and conf-llvm for 13.0.0.

### DIFF
--- a/packages/conf-llvm/conf-llvm.13.0.0/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.13.0.0/files/configure.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+version=${1/%.?.?/}
+
+if hash brew 2>/dev/null; then
+    brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+fi
+
+shopt -s nullglob
+for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${version}0 llvm-config-mp-$version llvm-config-mp-${version}.0 llvm${version}-config llvm-config-${version}-32 llvm-config-${version}-64 llvm-config $brew_llvm_config; do
+    llvm_version="`$llvm_config --version`" || true
+    case $llvm_version in
+    $version*)
+        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "version: \"$llvm_version\"" >> conf-llvm.config
+        exit 0;;
+    *)
+        echo "Note: '$llvm_config' doesn't match the required version. Got '$llvm_version' but required '$version'."
+        continue;;
+    esac
+done
+
+echo "Error: LLVM ${version} is not installed."
+exit 1

--- a/packages/conf-llvm/conf-llvm.13.0.0/opam
+++ b/packages/conf-llvm/conf-llvm.13.0.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "-ex" "configure.sh" version]
+]
+depexts: [
+  ["llvm@13"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm-13"] {os-distribution = "macports" & os = "macos"}
+  ["llvm-13-dev"] {os-family = "debian"}
+  ["llvm13-dev"] {os-distribution = "alpine"}
+  ["llvm13-devel"] {os-family = "suse"}
+  ["llvm13-devel"] {os-distribution = "fedora"}
+  ["llvm13-devel" "epel-release"] {os-distribution = "centos"}
+  ["devel/llvm13"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on llvm library installation"
+extra-files: ["configure.sh" "md5=2750506041c4edef4482ce9fb5f30aa1"]
+flags: conf

--- a/packages/llvm/llvm.13.0.0/files/META.patch
+++ b/packages/llvm/llvm.13.0.0/files/META.patch
@@ -1,0 +1,199 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/bindings/ocaml/backends/META.llvm_backend.in
++++ b/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,8 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte, -llvm.static) = "shared/llvm_@TARGET@.cma"
++archive(native, -llvm.static) = "shared/llvm_@TARGET@.cmxa"
++archive(byte, llvm.static) = "static/llvm_@TARGET@.cma"
++archive(native, llvm.static) = "static/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index 991bbc0600..a118933875 100644
+--- a/bindings/ocaml/llvm/META.llvm.in
++++ b/bindings/ocaml/llvm/META.llvm.in
+@@ -1,118 +1,148 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte, -llvm.static) = "shared/llvm.cma"
++archive(native, -llvm.static) = "shared/llvm.cmxa"
++archive(byte, llvm.static) = "static/llvm.cma"
++archive(native, llvm.static) = "static/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_analysis.cma"
++    archive(native, -llvm.static) = "shared/llvm_analysis.cmxa"
++    archive(byte, llvm.static) = "static/llvm_analysis.cma"
++    archive(native, llvm.static) = "static/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitreader.cma"
++    archive(native, llvm.static) = "static/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitwriter.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitwriter.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitwriter.cma"
++    archive(native, llvm.static) = "static/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_executionengine.cma"
++    archive(native, -llvm.static) = "shared/llvm_executionengine.cmxa"
++    archive(byte, llvm.static) = "static/llvm_executionengine.cma"
++    archive(native, llvm.static) = "static/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_ipo.cma"
++    archive(native, -llvm.static) = "shared/llvm_ipo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_ipo.cma"
++    archive(native, llvm.static) = "static/llvm_ipo.cmxa"
+ )
+ 
+ package "debuginfo" (
+     requires = "llvm"
+-    version = "@PACKAGE_VERSION@"
++    version  = "@PACKAGE_VERSION@"
+     description = "DebugInfo support for LLVM"
+-    archive(byte) = "llvm_debuginfo.cma"
+-    archive(native) = "llvm_debuginfo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_debuginfo.cma"
++    archive(native, -llvm.static) = "shared/llvm_debuginfo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_debuginfo.cma"
++    archive(native, llvm.static) = "static/llvm_debuginfo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_irreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_irreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_irreader.cma"
++    archive(native, llvm.static) = "static/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_scalar_opts.cma"
++    archive(native, -llvm.static) = "shared/llvm_scalar_opts.cmxa"
++    archive(byte, llvm.static) = "static/llvm_scalar_opts.cma"
++    archive(native, llvm.static) = "static/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_transform_utils.cma"
++    archive(native, -llvm.static) = "shared/llvm_transform_utils.cmxa"
++    archive(byte, llvm.static) = "static/llvm_transform_utils.cma"
++    archive(native, llvm.static) = "static/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_vectorize.cma"
++    archive(native, -llvm.static) = "shared/llvm_vectorize.cmxa"
++    archive(byte, llvm.static) = "static/llvm_vectorize.cma"
++    archive(native, llvm.static) = "static/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_passmgr_builder.cma"
++    archive(native, -llvm.static) = "shared/llvm_passmgr_builder.cmxa"
++    archive(byte, llvm.static) = "static/llvm_passmgr_builder.cma"
++    archive(native, llvm.static) = "static/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_target.cma"
++    archive(native, -llvm.static) = "shared/llvm_target.cmxa"
++    archive(byte, llvm.static) = "static/llvm_target.cma"
++    archive(native, llvm.static) = "static/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_linker.cma"
++    archive(native, -llvm.static) = "shared/llvm_linker.cmxa"
++    archive(byte, llvm.static) = "static/llvm_linker.cma"
++    archive(native, llvm.static) = "static/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_all_backends.cma"
++    archive(native, -llvm.static) = "shared/llvm_all_backends.cmxa"
++    archive(byte, llvm.static) = "static/llvm_all_backends.cma"
++    archive(native, llvm.static) = "static/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.13.0.0/files/add-cmt-for-llvm-13.patch
+++ b/packages/llvm/llvm.13.0.0/files/add-cmt-for-llvm-13.patch
@@ -1,0 +1,23 @@
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index b27cbd3..d69b1da 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -110,6 +110,8 @@ function(add_ocaml_library name)
+     list(APPEND ocaml_inputs "${bin}/${ocaml_file}.mli" "${bin}/${ocaml_file}.ml")
+ 
+     list(APPEND ocaml_outputs "${bin}/${ocaml_file}.cmi" "${bin}/${ocaml_file}.cmo")
++
++    list(APPEND ocaml_outputs "${bin}/${ocaml_file}.cmti" "${bin}/${ocaml_file}.cmt")
+     if( HAVE_OCAMLOPT )
+       list(APPEND ocaml_outputs
+            "${bin}/${ocaml_file}.cmx"
+@@ -159,7 +161,8 @@ function(add_ocaml_library name)
+ 
+   add_custom_command(
+     OUTPUT ${ocaml_outputs}
+-    COMMAND "${OCAMLFIND}" "ocamlmklib" "-o" "${name}" ${ocaml_flags} ${ocaml_params}
++    COMMAND "${OCAMLFIND}" "ocamlmklib" "-ocamlcflags" "-bin-annot"
++      "-o" "${name}" ${ocaml_flags} ${ocaml_params}
+     DEPENDS ${ocaml_inputs} ${c_outputs}
+     COMMENT "Building OCaml library ${name}"
+     VERBATIM)

--- a/packages/llvm/llvm.13.0.0/files/fix-shared.patch
+++ b/packages/llvm/llvm.13.0.0/files/fix-shared.patch
@@ -1,0 +1,24 @@
+diff --git a/cmake/modules/AddOCaml.cmake b/cmake/modules/AddOCaml.cmake
+index 554046b20..b27cbd36c 100644
+--- a/cmake/modules/AddOCaml.cmake
++++ b/cmake/modules/AddOCaml.cmake
+@@ -70,9 +70,16 @@ function(add_ocaml_library name)
+     list(APPEND ocaml_flags "-lLLVM")
+   else()
+     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-    foreach( llvm_lib ${llvm_libs} )
+-      list(APPEND ocaml_flags "-l${llvm_lib}" )
+-    endforeach()
++    if( BUILD_SHARED_LIBS )
++      list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
++    else()
++      foreach( llvm_lib ${llvm_libs} )
++        list(APPEND ocaml_flags "-l${llvm_lib}" )
++      endforeach()
++    endif()
++    if(LLVM_OCAML_OUT_OF_TREE)
++      list(APPEND ocaml_flags "-ccopt" "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
++    endif()
+ 
+     get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+     foreach(system_lib ${system_libs})

--- a/packages/llvm/llvm.13.0.0/files/install.sh
+++ b/packages/llvm/llvm.13.0.0/files/install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -ex
+
+llvm_config="$1"
+libdir="$2"
+cmake="$3"
+make="$4"
+
+function filter_experimental_targets {
+    sed 's/AVR//g' | sed 's/M68k//g' | sed 's/Nios2//g' | xargs
+}
+
+function llvm_install {
+    mkdir build
+    cd build
+
+    "$cmake" \
+        -DCMAKE_BUILD_TYPE="`"$llvm_config" --build-mode`" \
+        -DLLVM_TARGETS_TO_BUILD="`"$llvm_config" --targets-built | filter_experimental_targets | sed 's/ /;/g'`" \
+        -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR="`"$llvm_config" --libdir`" \
+        -DBUILD_SHARED_LIBS=`[ $1 = "shared" ] && echo TRUE || echo FALSE` \
+        -DLLVM_OCAML_OUT_OF_TREE=TRUE \
+        -DLLVM_OCAML_INSTALL_PATH="${libdir}" \
+        ..
+    $make ocaml_all
+    "$cmake" -P bindings/ocaml/cmake_install.cmake
+
+    mkdir "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cma "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cmxa "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/llvm*.a "${libdir}"/llvm/$1
+
+    cd ..
+    rm -rf build
+}
+
+if "$llvm_config" --link-static --libs && "$llvm_config" --link-shared --libs; then
+    patch -p1 < META.patch
+    llvm_install static
+    llvm_install shared
+elif "$llvm_config" --link-static --libs; then
+    sed "s,%%LINKAGE%%,static," link-META.patch | patch -p1
+    llvm_install static
+elif "$llvm_config" --link-shared --libs; then
+    sed "s,%%LINKAGE%%,shared," link-META.patch | patch -p1
+    llvm_install shared
+else
+    echo "WTF..."
+    exit 1
+fi

--- a/packages/llvm/llvm.13.0.0/files/link-META.patch
+++ b/packages/llvm/llvm.13.0.0/files/link-META.patch
@@ -1,0 +1,166 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/bindings/ocaml/backends/META.llvm_backend.in
++++ b/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,6 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm_@TARGET@.cma"
++archive(native) = "%%LINKAGE%%/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index 991bbc0600..255be6dfa3 100644
+--- a/bindings/ocaml/llvm/META.llvm.in
++++ b/bindings/ocaml/llvm/META.llvm.in
+@@ -1,118 +1,118 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm.cma"
++archive(native) = "%%LINKAGE%%/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_analysis.cma"
++    archive(native) = "%%LINKAGE%%/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitwriter.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_executionengine.cma"
++    archive(native) = "%%LINKAGE%%/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_ipo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_ipo.cmxa"
+ )
+ 
+ package "debuginfo" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "DebugInfo support for LLVM"
+-    archive(byte) = "llvm_debuginfo.cma"
+-    archive(native) = "llvm_debuginfo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_debuginfo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_debuginfo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_irreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_scalar_opts.cma"
++    archive(native) = "%%LINKAGE%%/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_transform_utils.cma"
++    archive(native) = "%%LINKAGE%%/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_vectorize.cma"
++    archive(native) = "%%LINKAGE%%/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_passmgr_builder.cma"
++    archive(native) = "%%LINKAGE%%/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_target.cma"
++    archive(native) = "%%LINKAGE%%/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_linker.cma"
++    archive(native) = "%%LINKAGE%%/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_all_backends.cma"
++    archive(native) = "%%LINKAGE%%/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.13.0.0/opam
+++ b/packages/llvm/llvm.13.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+doc: "http://llvm.moe/ocaml"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "git+http://llvm.org/git/llvm.git"
+homepage: "http://llvm.moe"
+install: [
+  ["bash" "-ex" "install.sh" "%{conf-llvm:config}%" lib "%{conf-cmake:cmd}%" make]
+]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "ctypes" {>= "0.4"}
+  "ounit" {with-test}
+  "ocamlfind" {build}
+  "conf-llvm" {build & = version}
+  "conf-python-3" {build}
+  "conf-cmake" {build}
+]
+patches: [
+  "fix-shared.patch"
+  "add-cmt-for-llvm-13.patch"
+]
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+extra-files: [
+  ["link-META.patch" "md5=53dc8e72917585d235b9bbb3e06eed2b"]
+  ["install.sh" "md5=fb51c3d8bc987acac39927c2abd84bcd"]
+  ["fix-shared.patch" "md5=dce86b1db352332968ceb6d042b408a8"]
+  ["add-cmt-for-llvm-13.patch" "md5=248ec7d17ebd1592fc99848016d9452b"]
+  ["META.patch" "md5=4c3cf99d06d2044e2ce5a853e5a16d5e"]
+]
+url {
+  src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/llvm-13.0.0.src.tar.xz"
+  checksum: "sha256=408d11708643ea826f519ff79761fcdfc12d641a2510229eec459e72f8163020"
+}


### PR DESCRIPTION
I make the `llvm.13.0.0` for the llvm binding package. The LLVM 13 is [released](https://github.com/llvm/llvm-project/releases/tag/llvmorg-13.0.0) recently.

Here are some changes:

The OCaml binding has a new library `debuginfo`. To adapt this, I update the `META.patch` and `link-META.patch` to include this library.

In the `install.sh`, I add to filter out a new experiential platform `M68k` to satisfy the building.

`conf-llvm` is unchanged except for the version number.

I add a one-time patch `add-cmt-for-llvm-13.patch`, to build `cmt` and `cmti` files. It is already [merged](https://reviews.llvm.org/D110983) to the llvm-truck (so it will be in llvm-14).

I update one requirement of `llvm` from `conf-python-2-7` to `conf-python-3`.
