### PR TITLE
Constrain older odigs on odoc < 2.0.0

### DIFF
--- a/packages/odig/odig.0.0.4/opam
+++ b/packages/odig/odig.0.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1"}
   "cmdliner" {>= "1.0.0"}
-  "odoc" {>= "1.4.0"}
+  "odoc" {>= "1.4.0" & < "2.0.0"}
   "b0" {<= "0.0.0"}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]

--- a/packages/odig/odig.0.0.5/opam
+++ b/packages/odig/odig.0.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1"}
   "cmdliner" {>= "1.0.0"}
-  "odoc" {>= "1.5.0"}
+  "odoc" {>= "1.5.0" & < "2.0.0"}
   "b0" {= "0.0.1"}
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]


### PR DESCRIPTION
As it should be. https://github.com/ocaml/odoc/issues/748