### PR TITLE
bouguee.20210514

### DIFF
--- a/packages/bogue/bogue.20210514/opam
+++ b/packages/bogue/bogue.20210514/opam
@@ -26,7 +26,7 @@ bug-reports: "https://github.com/sanette/bogue/issues"
 depends: [
   "dune" {>= "1.11"}
   "tsdl-image" {= "0.1.2"}
-  "tsdl-ttf" {>= "0.2"}
+  "tsdl-ttf" {>= "0.2" & < "0.3"}
   "ocaml" {>= "4.08.0"}
   "tsdl" {>= "0.9.0"}
 ]


### PR DESCRIPTION
Fixes
```
#=== ERROR while compiling bogue.20210514 =====================================#
# context              2.0.9 | linux/x86_64 | ocaml-base-compiler.4.12.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12/.opam-switch/build/bogue.20210514
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bogue -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/bogue-9913-0a5907.env
# output-file          ~/.opam/log/bogue-9913-0a5907.out
### output ###
# File "lib/dune", line 4, characters 32-40:
# 4 |  (libraries str tsdl tsdl_image tsdl_ttf))
```