### PR TITLE
Add missing constraint for ocamlformat.0.15.0 on odoc

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.15.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.15.0/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {>= "20181006"}
   "ocaml-migrate-parsetree" {>= "1.7.3" & < "2.0.0"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/19694/files. Done for >= 0.16.0. I didn't try the other versions.