### PR TITLE
reverse dependency of tls: prepare those failing for upcoming release

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "fmt"
   "logs"
   "dns-client" {>= "5.0.0"}
-  "tls-mirage"
+  "tls-mirage" {< "0.15.0"}
   "mirage-stack" {>= "2.0.0"}
   "arp" {>= "2.3.0" & with-test}
   "alcotest" {>= "1.0.1" & with-test}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2/opam
@@ -17,7 +17,7 @@ depends: [
   "fmt"
   "logs"
   "dns-client" {>= "5.0.0"}
-  "tls-mirage"
+  "tls-mirage" {< "0.15.0"}
   "mirage-stack" {>= "2.0.0"}
   "arp" {>= "2.3.0" & with-test}
   "alcotest" {>= "1.0.1" & with-test}

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "asetmap"
   "mirage-flow" {>="2.0.0"}
-  "tls" {>= "0.13.1"}
+  "tls" {>= "0.13.1" & < "0.15.0"}
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "asetmap"
   "mirage-flow" {>="2.0.0"}
-  "tls" {>= "0.13.1"}
+  "tls" {>= "0.13.1" & < "0.15.0"}
   "base64" {>= "3.0.0"}
   "uri" {>= "1.6.0"}
   "ptime"

--- a/packages/conduit-mirage/conduit-mirage.2.1.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "conduit-lwt"
   "vchan" {>= "5.0.0"}
   "xenstore"
-  "tls" {>= "0.11.0"}
+  "tls" {>= "0.11.0" & < "0.15.0"}
   "tls-mirage" {>= "0.11.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"

--- a/packages/conduit-mirage/conduit-mirage.2.2.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.2.1/opam
@@ -21,8 +21,8 @@ depends: [
   "conduit-lwt"
   "vchan" {>= "5.0.0"}
   "xenstore"
-  "tls" {>= "0.11.0"}
-  "tls-mirage" {>= "0.11.0"}
+  "tls" {>= "0.11.0" & < "0.15.0"}
+  "tls-mirage" {>= "0.11.0" & < "0.15.0"}
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
 ]

--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -89,6 +89,7 @@ depends: [
   "faraday-lwt-unix"
   "psq"  # h2.
   "result"  # http/af, websocket/af.
+  "tls" {< "0.15.0"}
 
   # Testing, development.
   "alcotest" {with-test}

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -90,6 +90,7 @@ depends: [
   "faraday-lwt-unix"
   "psq"  # h2.
   "result"  # http/af, websocket/af.
+  "tls" {< "0.15.0"}
 
   # Testing, development.
   "alcotest" {with-test}

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.2.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.2.0/opam
@@ -21,6 +21,7 @@ depopts: [
   "tls"
   "lwt_ssl"
 ]
+conflicts: [ "tls" {>= "0.15.0"} ]
 synopsis: "Lwt + Unix support for gluten"
 url {
   src:

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.2.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.2.1/opam
@@ -21,6 +21,7 @@ depopts: [
   "tls"
   "lwt_ssl"
 ]
+conflicts: [ "tls" {>= "0.15.0"} ]
 synopsis: "Lwt + Unix support for gluten"
 url {
   src:

--- a/packages/irc-client-tls/irc-client-tls.0.7.0/opam
+++ b/packages/irc-client-tls/irc-client-tls.0.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.6"}
   "irc-client" {= version}
   "lwt"
-  "tls"
+  "tls" {< "0.15.0"}
   "x509" {>= "0.10.0"}
   "odoc" {with-doc}
   "ocaml"

--- a/packages/paf-cohttp/paf-cohttp.0.0.5/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.5/opam
@@ -15,6 +15,7 @@ depends: [
   "domain-name"
   "httpaf"
   "ipaddr"
+  "tls" {with-test & < "0.15.0"}
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}

--- a/packages/paf/paf.0.0.5/opam
+++ b/packages/paf/paf.0.0.5/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "mirage-stack" {>= "2.2.0"}
   "mirage-time"
-  "tls-mirage" {>= "0.14.0"}
+  "tls-mirage" {>= "0.14.0" & < "0.15.0"}
   "mimic"
   "ke" {>= "0.4"}
   "lwt" {with-test}
@@ -29,7 +29,7 @@ depends: [
   "httpaf" {>= "0.7.1"}
   "h2" {>= "0.7.0"}
   "faraday" {>= "0.7.2"}
-  "tls" {>= "0.14.0"}
+  "tls" {>= "0.14.0" & < "0.15.0"}
   "cstruct" {>= "6.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
upper bounds for the failures observed in https://github.com/ocaml/opam-repository/pull/19716
- capnp-rpc-mirage/net @talex5 
- conduit-mirage @talex5 @samoht @avsm 
- dream (via vendor of gluten) @aantron
- gluten-lwt-unix @anmonteiro 
- irc-client-tls @c-cube @johnelse 
- paf / paf-cohttp @dinosaure 

The change is actually in X509 0.15.0 that modified the type Authenticator.t (used to be:
```OCaml
type t = host:[`host] Domain_name.t option -> Certificate.t list -> Validation.r
```

now it is:
```OCaml
type t = ?ip:Ipaddr.t -> host:[`host] Domain_name.t option -> Certificate.t list -> Validation.r
```

This means the leaf certificate can be validated based on an IP address in the subjectAlternativeName extension instead of a hostname (this is crucial for DNS-over-TLS). In all the above packages you seem to have copied over the type for an authenticator -- the easy fix is to add `?ip:_` to your function.