### PR TITLE
2 packages from c-cube/ezcurl at 0.2.1

### DIFF
--- a/packages/ezcurl-lwt/ezcurl-lwt.0.2.1/opam
+++ b/packages/ezcurl-lwt/ezcurl-lwt.0.2.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl, Lwt version"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "ezcurl" { = version }
+  "lwt"
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "mdx" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" "lwt" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.2.1.tar.gz"
+  checksum: [
+    "md5=2255e9953d8b1dba7601d300631ea023"
+    "sha512=c3429bff46980e684d93c7e6b69ea39dd5f56a6f27e5b811e9f8433632ef312d1ff123759fa69aca8508d54f5597dffdaff41f1ab9ef3cf0a83a9ece100d5763"
+  ]
+}

--- a/packages/ezcurl/ezcurl.0.2.1/opam
+++ b/packages/ezcurl/ezcurl.0.2.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.2.1.tar.gz"
+  checksum: [
+    "md5=2255e9953d8b1dba7601d300631ea023"
+    "sha512=c3429bff46980e684d93c7e6b69ea39dd5f56a6f27e5b811e9f8433632ef312d1ff123759fa69aca8508d54f5597dffdaff41f1ab9ef3cf0a83a9ece100d5763"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezcurl.0.2.1`: Friendly wrapper around OCurl
-`ezcurl-lwt.0.2.1`: Friendly wrapper around OCurl, Lwt version



---
* Homepage: https://github.com/c-cube/ezcurl/
* Source repo: git+https://github.com/c-cube/ezcurl.git
* Bug tracker: https://github.com/c-cube/ezcurl/issues

---
:camel: Pull-request generated by opam-publish v2.1.0