### PR TITLE
2 packages from c-cube/calculon at 0.7

### DIFF
--- a/packages/calculon-web/calculon-web.0.7/opam
+++ b/packages/calculon-web/calculon-web.0.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+license: "MIT"
+synopsis: "A collection of web plugins for Calculon"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "calculon" { = version }
+  "re" { >= "1.7.2" }
+  "uri"
+  "curly"
+  "atdgen"
+  "lambdasoup"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=6bb91cdc5cd1b5958144faf9b4ae27c3"
+    "sha512=40fe8bdf5389fdb85869e41c24dbbbaafb8f07d026fcb7db2c2a94c1072a6d47a00708b0b0909e509b40325481198e6e45a4a205c92e090bf47eeccd4fbf99ab"
+  ]
+}

--- a/packages/calculon/calculon.0.7/opam
+++ b/packages/calculon/calculon.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license: "MIT"
+synopsis: "Library for writing IRC bots in OCaml and a collection of plugins"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "lwt"
+  "irc-client" { >= "0.7.0"}
+  "irc-client-lwt"
+  "irc-client-lwt-ssl"
+  "logs" {>= "0.5.0"}
+  "yojson" { >= "1.7" }
+  "containers" { >= "3.0" & < "4.0" }
+  "ISO8601"
+  "stringext"
+  "re" { >= "1.7.2" & < "2.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.08.0" }
+]
+depopts: [
+  "iter"
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.7.tar.gz"
+  checksum: [
+    "md5=6bb91cdc5cd1b5958144faf9b4ae27c3"
+    "sha512=40fe8bdf5389fdb85869e41c24dbbbaafb8f07d026fcb7db2c2a94c1072a6d47a00708b0b0909e509b40325481198e6e45a4a205c92e090bf47eeccd4fbf99ab"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.7`: Library for writing IRC bots in OCaml and a collection of plugins
-`calculon-web.0.7`: A collection of web plugins for Calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.1.0