### PR TITLE
[new release] dune-release (1.5.1)

### DIFF
--- a/packages/dune-release/dune-release.1.5.1/opam
+++ b/packages/dune-release/dune-release.1.5.1/opam
@@ -36,6 +36,9 @@ depends: [
   "mdx" {with-test & >= "1.6.0"}
   "yojson" {>= "1.6"}
 ]
+conflicts: [
+  "opam-file-format" {< "2.1.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/ocamllabs/dune-release">https://github.com/ocamllabs/dune-release</a>

##### CHANGES:

### Added

- Added support for creating releases from unannotated Git tags. `dune-release`
  supported unannotated tags in a few places already, now it supports using
  them for creating a release. (ocamllabs/dune-release#383, @Leonidas-from-XIV)

### Fixed

- Change the `---V` command option to be `-V` (ocamllabs/dune-release#388, @Leonidas-from-XIV)
- Infer release versions are inferred from VCS tags. This change allows using
  `dune-release` on projects that do not use the changelog or have it in a
  different format.  (ocamllabs/dune-release#381, ocamllabs/dune-release#383 @Leonidas-from-XIV)
- Fix a bug where `dune-release` couldn't retrieve a release on GitHub if the
  tag and project version don't match (e.g. `v1.0` vs `1.0`). `dune-release`
  would in such case believe the release doesn't exist, attempt to create it
  and subsequently fail. (ocamllabs/dune-release#387, ocamllabs/dune-release#395, @Leonidas-from-XIV)
