### PR TITLE
[new release] conduit, conduit-mirage, conduit-lwt, conduit-lwt-unix and conduit-async (4.0.2)

### DIFF
--- a/packages/conduit-async/conduit-async.4.0.2/opam
+++ b/packages/conduit-async/conduit-async.4.0.2/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "core"
   "uri" {>= "4.0.0"}
   "ppx_here" {>= "v0.9.0"}
@@ -25,7 +25,7 @@ conflicts: [
   "async_ssl" {< "v0.9.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.4.0.2/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.4.0.2/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "base-unix"
   "logs"
   "ppx_sexp_conv" {>="v0.13.0"}
@@ -29,7 +29,7 @@ conflicts: [
   "ssl" {< "0.5.9"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit-lwt/conduit-lwt.4.0.2/opam
+++ b/packages/conduit-lwt/conduit-lwt.4.0.2/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "base-unix"
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "3.0.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"

--- a/packages/conduit-mirage/conduit-mirage.4.0.2/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.2/opam
@@ -7,10 +7,11 @@ homepage: "https://github.com/mirage/ocaml-conduit"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.07.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "uri" {>= "4.0.0"}
+  "bigarray-compat"
   "cstruct" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
   "mirage-clock" {>= "3.0.0"}
@@ -34,7 +35,7 @@ conflicts: [
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/conduit/conduit.4.0.2/opam
+++ b/packages/conduit/conduit.4.0.2/opam
@@ -10,7 +10,7 @@ doc: "https://mirage.github.io/ocaml-conduit/"
 bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "ppx_sexp_conv" {>="v0.13.0"}
   "sexplib"
   "astring"
@@ -20,7 +20,7 @@ depends: [
   "ipaddr-sexp"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* Adapt conduit-mirage to tls 0.15.0 (@hannesm mirage/ocaml-conduit#404)
* Remove Conduit_mirage.Endpoint.ok_authenticator (@hannesm mirage/ocaml-conduit#404)
* Now Conduit_mirage.Endpoint.server does not use an authenticator - and thus
  not request a client certificate (@hannesm mirage/ocaml-conduit#404)
