### PR TITLE
Add: b0.0.0.3, odig.0.0.7

### DIFF
--- a/packages/b0/b0.0.0.3/opam
+++ b/packages/b0/b0.0.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: """Software construction and deployment kit"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The b0 programmers"]
+homepage: "https://erratique.ch/software/b0"
+doc: "https://erratique.ch/software/b0/doc"
+dev-repo: "git+https://erratique.ch/repos/b0.git"
+bug-reports: "https://github.com/b0-system/b0/issues"
+license: ["ISC" "BSD-2-Clause"]
+tags: ["dev" "org:erratique" "org:b0-system" "build"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "cmdliner" {>= "1.0.2"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/b0/releases/b0-0.0.3.tbz"
+  checksum: "sha512=d24b09eb520b8b91a1e5715badc9f5bcd6a6ec49c047f719a07afef6b835c128dc63e00c3be73d5353b037f4c3c9f2889e40666b30e297e872e4d011f098394c"}
+description: """
+WARNING this package is unstable and work in progress, do not depend on it. 
+
+B0 describes software construction and deployments using modular and
+customizable definitions written in OCaml.
+
+B0 describes:
+
+* Build environments.
+* Software configuration, build and testing.
+* Source and binary deployments.
+* Software life-cycle procedures.
+
+B0 also provides the B00 build library which provides abitrary build
+abstraction with reliable and efficient incremental rebuilds. The B00
+library can be – and has been – used on its own to devise domain
+specific build systems.
+
+B0 is distributed under the ISC license. It depends on [cmdliner][cmdliner].
+
+[cmdliner]: https://erratique.ch/software/cmdliner"""

--- a/packages/odig/odig.0.0.7/opam
+++ b/packages/odig/odig.0.0.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: """Lookup documentation of installed OCaml packages"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The odig programmers"]
+homepage: "https://erratique.ch/software/odig"
+doc: "https://erratique.ch/software/odig/doc"
+dev-repo: "git+https://erratique.ch/repos/odig.git"
+bug-reports: "https://github.com/b0-system/odig/issues"
+license: ["ISC" "LicenseRef-ParaType-Free-Font-License"
+          "LicenseRef-DejaVu-fonts"]
+tags: ["build" "dev" "doc" "meta" "packaging" "org:erratique"
+       "org:b0-system"]
+depends: ["ocaml" {>= "4.08"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "cmdliner" {>= "1.0.0"}
+          "odoc" {>= "2.0.0" }
+          "b0" {= "0.0.3"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/odig/releases/odig-0.0.7.tbz"
+  checksum: "sha512=1398656a8719a37db3f47083a08ab7124ec51bd1df5fe0e4b65410088267f21eccb096ea7494237c411a68e17c44c27d3789f1c8835dcb533c921391425f4def"}
+description: """
+odig is a command line tool to lookup documentation of installed OCaml
+packages. It shows package metadata, readmes, change logs, licenses,
+cross-referenced `odoc` API documentation and manuals.
+
+odig is distributed under the ISC license. The theme fonts have their
+own [licenses](LICENSE.md).
+
+Homepage: https://erratique.ch/software/odig"""


### PR DESCRIPTION
* Add: `b0.0.0.3` [home](https://erratique.ch/software/b0), [doc](https://erratique.ch/software/b0/doc), [issues](https://github.com/b0-system/b0/issues)  
  *Software construction and deployment kit*
* Add: `odig.0.0.7` [home](https://erratique.ch/software/odig), [doc](https://erratique.ch/software/odig/doc), [issues](https://github.com/b0-system/odig/issues)  
  *Lookup documentation of installed OCaml packages*


---

#### `b0` v0.0.3 2021-10-09 Zagreb

Fourth release to support `odig`.

---

#### `odig` v0.0.7 2021-10-09 Zagreb

- Stylesheet support for odoc 2.0.0.
- `--index-intro` option. Fix option no longer interpreting 
  relative files w.r.t. the cwd.
- Add `--index-toc` option, to specify the package index table of
  content.  If you used to define a table of contents in the
  `--index-intro` fragment you now need to define it via this
  option. The contents goes into the `odoc-toc` `nav` element.

---

Use `b0 cmd -- .opam.publish b0.0.0.3 odig.0.0.7` to update the pull request.