### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.3.1)

### DIFF
--- a/packages/shuttle/shuttle.0.3.1/opam
+++ b/packages/shuttle/shuttle.0.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.14" & < "v0.15"}
+  "core" {>= "v0.14" & < "v0.15"}
+  "ppx_jane" {>= "v0.14" & < "v0.15"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.3.1/shuttle-0.3.1.tbz"
+  checksum: [
+    "sha256=98511a712a0c761d1470653d6a34040dbeae8436a74460cb53522194029b7814"
+    "sha512=2ff9938064d86802a06475ccd7a412c4fd2a901e7aeacbb82e00135bd729c61cc15052adb39d562a29bf89a43dc6a80d77b45bf5ce1ba4c60cead5db7923cc31"
+  ]
+}
+x-commit-hash: "97de4726902fa056b505f4ea13cf87c8d1bc5334"

--- a/packages/shuttle_http/shuttle_http.0.3.1/opam
+++ b/packages/shuttle_http/shuttle_http.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "HTTP codec for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "http"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.14" & < "v0.15"}
+  "core" {>= "v0.14" & < "v0.15"}
+  "ppx_jane" {>= "v0.14" & < "v0.15"}
+  "shuttle" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.3.1/shuttle-0.3.1.tbz"
+  checksum: [
+    "sha256=98511a712a0c761d1470653d6a34040dbeae8436a74460cb53522194029b7814"
+    "sha512=2ff9938064d86802a06475ccd7a412c4fd2a901e7aeacbb82e00135bd729c61cc15052adb39d562a29bf89a43dc6a80d77b45bf5ce1ba4c60cead5db7923cc31"
+  ]
+}
+x-commit-hash: "97de4726902fa056b505f4ea13cf87c8d1bc5334"

--- a/packages/shuttle_ssl/shuttle_ssl.0.3.1/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.3.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.14" & < "v0.15"}
+  "async_ssl" {>= "v0.14" & < "v0.15"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.3.1/shuttle-0.3.1.tbz"
+  checksum: [
+    "sha256=98511a712a0c761d1470653d6a34040dbeae8436a74460cb53522194029b7814"
+    "sha512=2ff9938064d86802a06475ccd7a412c4fd2a901e7aeacbb82e00135bd729c61cc15052adb39d562a29bf89a43dc6a80d77b45bf5ce1ba4c60cead5db7923cc31"
+  ]
+}
+x-commit-hash: "97de4726902fa056b505f4ea13cf87c8d1bc5334"


### PR DESCRIPTION
Reasonably performant channels for async
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Add support for using format strings for writing to an output channel.
* Remove support for deferred responses from chunked reader callbacks.
* Add a new `shuttle_http` library that implements a driver for httpaf server_connection.
* Support creating a reader pipe from `Input_channel`.
* Support creating a writer pipe from `Output_channel`.
* Support encrypted channels using `async_ssl`.
