### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.3.1)

### DIFF
--- a/packages/shuttle/shuttle.0.3.1/opam
+++ b/packages/shuttle/shuttle.0.3.1/opam
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "b1369c87b7a1c695c880bd5df78471123ecdb951"
+available: [ arch != "s390x" ]

--- a/packages/shuttle_http/shuttle_http.0.3.1/opam
+++ b/packages/shuttle_http/shuttle_http.0.3.1/opam
@@ -40,3 +40,4 @@ url {
   ]
 }
 x-commit-hash: "b1369c87b7a1c695c880bd5df78471123ecdb951"
+available: [ arch != "s390x" ]

--- a/packages/shuttle_ssl/shuttle_ssl.0.3.1/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.3.1/opam
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "b1369c87b7a1c695c880bd5df78471123ecdb951"
+available: [ arch != "s390x" ]


### PR DESCRIPTION
Reasonably performant channels for async
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Add support for using format strings for writing to an output channel.
* Remove support for deferred responses from chunked reader callbacks.
* Add a new `shuttle_http` library that implements a driver for httpaf server_connection.
* Support creating a reader pipe from `Input_channel`.
* Support creating a writer pipe from `Output_channel`.
* Support encrypted channels using `async_ssl`.