### PR TITLE
[release] gmp.6.2.1-1

### DIFF
--- a/packages/gmp/gmp.6.2.1-1/opam
+++ b/packages/gmp/gmp.6.2.1-1/opam
@@ -25,3 +25,4 @@ url {
     "sha512=83601526fd2c6ad181fb60353d75fd0c44ce0bd010324f16c14d9019f64e16c0496b9fbbba6f4f5b4eb55e5584ff9e65ce16aa3f016e905cfa5bc91b9876c1a3"
   ]
 }
+available: [ os != "macos" ]


### PR DESCRIPTION
## `gmp.6.2.1-1`

`gmp` is a small package wrapping the `gmp` library build system inside the `dune` build system. 

It statically builds `gmp` from source and allows, when built using the _dune workspace_ feature, ✨cross-compilation✨.
See https://github.com/mirage/ocaml-gmp

**CHANGES:**
This release incorporates a set of patches in the build system to fix cross-compilation issues.
