### PR TITLE
bap-print.2.0.0: missing dependency

### DIFF
--- a/packages/bap-print/bap-print.2.0.0/opam
+++ b/packages/bap-print/bap-print.2.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "bap-std" {= "2.0.0"}
   "bap-demangle"
   "text-tags"
+  "re"
 ]
 synopsis: "Print plugin - print project in various formats"
 url {


### PR DESCRIPTION
Add dependency on re to fix
```
#=== ERROR while compiling bap-print.2.0.0 ====================================#
# context              2.0.9 | linux/x86_64 | ocaml-base-compiler.4.06.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.06/.opam-switch/build/bap-print.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/bap-print-947-03b880.env
# output-file          ~/.opam/log/bap-print-947-03b880.out
### output ###
# ./setup.exe -quiet -build 
# ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package findlib myocamlbuild.ml /home/opam/.opam/4.06/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# /home/opam/.opam/4.06/bin/ocamlfind ocamldep -package text-tags -package bap-demangle -package bap -modules plugins/print/print_main.ml > plugins/print/print_main.ml.depends
# /home/opam/.opam/4.06/bin/ocamlfind ocamlc -c -g -annot -bin-annot -short-paths -w +a-4-6-7-9-27-29-32..42-44-45-48-50-60 -package text-tags -package bap-demangle -package bap -I plugins/print -o plugins/print/print_main.cmo plugins/print/print_main.ml
# + /home/opam/.opam/4.06/bin/ocamlfind ocamlc -c -g -annot -bin-annot -short-paths -w +a-4-6-7-9-27-29-32..42-44-45-48-50-60 -package text-tags -package bap-demangle -package bap -I plugins/print -o plugins/print/print_main.cmo plugins/print/print_main.ml
# File "plugins/print/print_main.ml", line 60, characters 24-32:
# Error: Unbound module Re
# Command exited with code 2.
# make: *** [Makefile:8: build] Error 1
```

See on https://github.com/ocaml/opam-repository/pull/19651