### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.0.6)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.0.6/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-commit-hash: "37eccf2b54c980d8f6e02bc9300afeed4d543197"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.6/paf-0.0.6.tbz"
+  checksum: [
+    "sha256=21adbe0f7f9c0242354fa996468d01bf21d5cbcbdd978c911df8e2e299e8f9ae"
+    "sha512=314a9c652b056baf4c8b5874b2f60935a3c9e15463b04cde6d0c8e30ec5acb355170576526af0ed29a8d24492e5d170afa5883b18c5b9f6eaa3298ce9565f6ac"
+  ]
+}

--- a/packages/paf-le/paf-le.0.0.6/opam
+++ b/packages/paf-le/paf-le.0.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-stack"
+  "mirage-time"
+  "tls-mirage"
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-commit-hash: "37eccf2b54c980d8f6e02bc9300afeed4d543197"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.6/paf-0.0.6.tbz"
+  checksum: [
+    "sha256=21adbe0f7f9c0242354fa996468d01bf21d5cbcbdd978c911df8e2e299e8f9ae"
+    "sha512=314a9c652b056baf4c8b5874b2f60935a3c9e15463b04cde6d0c8e30ec5acb355170576526af0ed29a8d24492e5d170afa5883b18c5b9f6eaa3298ce9565f6ac"
+  ]
+}

--- a/packages/paf/paf.0.0.6/opam
+++ b/packages/paf/paf.0.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-time"
+  "tls-mirage" {>= "0.15.0"}
+  "mimic"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "tcpip" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+x-commit-hash: "37eccf2b54c980d8f6e02bc9300afeed4d543197"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.6/paf-0.0.6.tbz"
+  checksum: [
+    "sha256=21adbe0f7f9c0242354fa996468d01bf21d5cbcbdd978c911df8e2e299e8f9ae"
+    "sha512=314a9c652b056baf4c8b5874b2f60935a3c9e15463b04cde6d0c8e30ec5acb355170576526af0ed29a8d24492e5d170afa5883b18c5b9f6eaa3298ce9565f6ac"
+  ]
+}


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Use `tls.0.15.0`, `x509.0.15.0` and `letsencrypt.0.4.0` (@hannesm, @dinosaure, dinosaure/paf-le-chien#42)
- Fix the documentation (@dinosaure, dinosaure/paf-le-chien#43)
