### PR TITLE
adds a proper constraint to the bap-std package (continues #19749)

### DIFF
--- a/packages/bap-std/bap-std.2.0.0/opam
+++ b/packages/bap-std/bap-std.2.0.0/opam
@@ -43,7 +43,7 @@ depends: [
   "ocamlfind" {>= "1.5.6" & < "2.0"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}
   "regular"
-  "uri"
+  "uri" {<= "3.1.0"}
   "utop" {build & >= "2.0.0"}
   "uuidm"
   "zarith"

--- a/packages/bap-std/bap-std.2.1.0/opam
+++ b/packages/bap-std/bap-std.2.1.0/opam
@@ -43,7 +43,7 @@ depends: [
   "ocamlfind" {>= "1.5.6" & < "2.0"}
   "ppx_jane" {>= "v0.12" & < "v0.13"}
   "regular"
-  "uri"
+  "uri" {<= "3.1.0"}
   "utop" {build & >= "2.0.0"}
   "uuidm"
   "zarith"


### PR DESCRIPTION
In BAP 2.0.0 and 2.1.0 some of the packages were not specifying
correctly the set of dependencies neither in the oasis file nor in the
opam file and were building succesfully because of transitive
depedencies that were brought from other packages, sometimes even
third-party.

In this case `bap-print` is an example of such package, it is failing
with the missing dependency on `re`, which was previously brought by a
dependency on `bap-std`, which, in turn, was depending on the uri
package, which was finally responsible for getting the re module into
scope. The uri package dropped the `re` dependency in versions bigger
than 3.1.0 (by splitting into two subpackages).

I know that the right fix would be to properly specify all depedencies
and do not depend on them, and this is implemented since 2.2.0, more
than a year ago. This fix, albeit quite indirect, is minimal and is a
good showcase that transitive dependencies is a very bad thing.

CC @mseri 