### PR TITLE
zarith_stubs_js v0.14.1 and ppx_variants_conv v0.14.2

### DIFF
--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.14.2/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.14.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_variants_conv"
+bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_variants_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"       {>= "4.04.2"}
+  "base"        {>= "v0.14" & < "v0.15"}
+  "variantslib" {>= "v0.14" & < "v0.15"}
+  "dune"        {>= "2.0.0"}
+  "ppxlib"      {>= "0.23.0"}
+]
+synopsis: "Generation of accessor and iteration functions for ocaml variant types"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://github.com/janestreet/ppx_variants_conv/archive/v0.14.2.tar.gz"
+  checksum: "md5=de29f93732da2fad0b221edbd763f5c1"
+}

--- a/packages/zarith_stubs_js/zarith_stubs_js.v0.14.1/opam
+++ b/packages/zarith_stubs_js/zarith_stubs_js.v0.14.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/zarith_stubs_js"
+bug-reports: "https://github.com/janestreet/zarith_stubs_js/issues"
+dev-repo: "git+https://github.com/janestreet/zarith_stubs_js.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/zarith_stubs_js/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"  {>= "2.0.0"}
+]
+synopsis: "Javascripts stubs for the Zarith library"
+description: "
+This library contains no ocaml code, but instead implements
+all of the Zarith C stubs in Javascript for use in Js_of_ocaml
+"
+url {
+  src: "https://github.com/janestreet/zarith_stubs_js/archive/refs/tags/v0.14.1.tar.gz"
+  checksum: "md5=948430731b9e3d0890cfc930b6829c37"
+}


### PR DESCRIPTION
Addresses https://github.com/janestreet/zarith_stubs_js/pull/8 and https://github.com/janestreet/ppx_variants_conv/pull/9

Signed-off-by: Cameron Wong <cwong@janestreet.com>