### PR TITLE
Partially Revert "solo5-bindings-* need conf-gcc"

### DIFF
--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.4.1/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.4.1/opam
@@ -10,10 +10,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "genode"]
 install: [make "opam-genode-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-genode-uninstall" "PREFIX=%{prefix}%"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-muen"

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.2/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.2/opam
@@ -16,10 +16,7 @@ remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]
 ]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-spt"

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
@@ -19,7 +19,6 @@ remove: [
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "solo5-bindings-hvt"

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
@@ -12,10 +12,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "hvt"]
 install: [make "opam-hvt-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
@@ -12,10 +12,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "hvt"]
 install: [make "opam-hvt-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
@@ -18,10 +18,7 @@ remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]
 ]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.6/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.6/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.7/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.7/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.8/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.8/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
@@ -13,10 +13,7 @@ build: [make "muen"]
 install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.1/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.1/opam
@@ -13,10 +13,7 @@ build: [make "muen"]
 install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.2/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.2/opam
@@ -19,10 +19,7 @@ remove: [
   [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]
 ]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.4/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.4/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.6/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.6/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.7/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.7/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.8/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.8/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.2/opam
@@ -19,10 +19,7 @@ remove: [
   [make "V=1" "uninstall-opam-spt" "PREFIX=%{prefix}%"]
 ]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.3/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 depexts: [

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.4/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.4/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 depexts: [

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.5/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.6/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.6/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.7/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.7/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.8/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.8/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENOD
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {os = "linux"}
-  "conf-gcc"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
@@ -13,10 +13,7 @@ build: [make "virtio"]
 install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.1/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.1/opam
@@ -13,10 +13,7 @@ build: [make "virtio"]
 install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.2/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.2/opam
@@ -19,10 +19,7 @@ remove: [
   [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]
 ]
 x-ci-accept-failures: ["debian-unstable"]
-depends: [
-  "conf-pkg-config"
-  "conf-gcc"
-]
+depends: "conf-pkg-config"
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-hvt"

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.4/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.4/opam
@@ -22,7 +22,6 @@ x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.6/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.6/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.7/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.7/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.8/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.8/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.6/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.6/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.7/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.7/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.8/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.8/opam
@@ -17,7 +17,6 @@ install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN="
 depends: [
   "conf-pkg-config"
   "conf-libseccomp" {build & os = "linux"}
-  "conf-gcc"
 ]
 conflicts: [
   "ocaml-freestanding" {< "0.6.0"}


### PR DESCRIPTION
This reverts the `conf-gcc` part of commit 2719bc9c4db8d262e13eb1bdd5cfc8de1338ab49
but keeps the `flags: avoid-version` part.