### PR TITLE
[new release] prettym (0.0.2)

### DIFF
--- a/packages/prettym/prettym.0.0.2/opam
+++ b/packages/prettym/prettym.0.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "bigarray-overlap"
   "fmt"              {>= "0.8.7"}
   "ke"               {>= "0.4"}
-  "bigstringaf"
+  "bigstringaf"      {>= "0.2"}
   "bigarray-compat"
   "ptime"            {with-test}
   "alcotest"         {with-test}


### PR DESCRIPTION
An memory-bounded encoder according to RFC 822

- Project page: <a href="https://github.com/dinosaure/prettym">https://github.com/dinosaure/prettym</a>
- Documentation: <a href="https://dinosaure.github.io/prettym/">https://dinosaure.github.io/prettym/</a>

##### CHANGES:

- Upgrade to `fmt.0.8.7` (@dinosaure, 5068eea)
