### PR TITLE
Update package overview of menhir to move from GForge to GitLab

### DIFF
--- a/packages/menhir/menhir.20140422/opam
+++ b/packages/menhir/menhir.20140422/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   make

--- a/packages/menhir/menhir.20150921/opam
+++ b/packages/menhir/menhir.20150921/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151005/opam
+++ b/packages/menhir/menhir.20151005/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151012/opam
+++ b/packages/menhir/menhir.20151012/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151023/opam
+++ b/packages/menhir/menhir.20151023/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151026/opam
+++ b/packages/menhir/menhir.20151026/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151030/opam
+++ b/packages/menhir/menhir.20151030/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151103/opam
+++ b/packages/menhir/menhir.20151103/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20151112/opam
+++ b/packages/menhir/menhir.20151112/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20160303/opam
+++ b/packages/menhir/menhir.20160303/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20160504/opam
+++ b/packages/menhir/menhir.20160504/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20160526/opam
+++ b/packages/menhir/menhir.20160526/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20160808/opam
+++ b/packages/menhir/menhir.20160808/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20160825/opam
+++ b/packages/menhir/menhir.20160825/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir-list@yquem.inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20161114/opam
+++ b/packages/menhir/menhir.20161114/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir@inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20161115/opam
+++ b/packages/menhir/menhir.20161115/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir@inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]

--- a/packages/menhir/menhir.20170101/opam
+++ b/packages/menhir/menhir.20170101/opam
@@ -5,7 +5,7 @@ authors: [
   "Yann Régis-Gianas <yrg@pps.univ-paris-diderot.fr>"
 ]
 homepage: "http://gallium.inria.fr/~fpottier/menhir/"
-dev-repo: "git+ssh://scm.gforge.inria.fr//gitroot/menhir/menhir.git"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/menhir.git"
 bug-reports: "menhir@inria.fr"
 build: [
   [make "-f" "Makefile" "PREFIX=%{prefix}%" "USE_OCAMLFIND=true" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]


### PR DESCRIPTION
Related issue: #19757 