### PR TITLE
Update package overview of mlcuddidl to move from GForge to GitLab

### DIFF
--- a/packages/mlcuddidl/mlcuddidl.3.0.2/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.2/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Bertrand Jeannet" "Nicolas Berthier"]
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcuddidl/index.html"
-bug-reports: "https://gforge.inria.fr/projects/mlxxxidl/"
+bug-reports: "https://framagit.org/nberth/mlcuddidl/-/issues"
 # SVN repositories not supported (yet).
-# dev-repo: "svn://scm.gforge.inria.fr/svnroot/mlxxxidl/mlcuddidl/"
+# dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 license: "LGPL-2.1-only"
 build: [
   ["./configure"]

--- a/packages/mlcuddidl/mlcuddidl.3.0.3/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.3/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Bertrand Jeannet" "Nicolas Berthier"]
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcuddidl/index.html"
-bug-reports: "https://gforge.inria.fr/projects/mlxxxidl/"
+bug-reports: "https://framagit.org/nberth/mlcuddidl/-/issues"
 dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 license: "LGPL-2.1-only"
 build: [

--- a/packages/mlcuddidl/mlcuddidl.3.0.4/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.4/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Bertrand Jeannet" "Nicolas Berthier"]
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcuddidl/index.html"
-bug-reports: "https://gforge.inria.fr/projects/mlxxxidl/"
+bug-reports: "https://framagit.org/nberth/mlcuddidl/-/issues"
 # SVN repositories not supported (yet).
-# dev-repo: "svn://scm.gforge.inria.fr/svnroot/mlxxxidl/mlcuddidl/"
+# dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 license: "LGPL-2.1-only"
 build: [

--- a/packages/mlcuddidl/mlcuddidl.3.0.5/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.5/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Bertrand Jeannet" "Nicolas Berthier"]
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcuddidl/index.html"
-bug-reports: "https://gforge.inria.fr/projects/mlxxxidl/"
+bug-reports: "https://framagit.org/nberth/mlcuddidl/-/issues"
 # SVN repositories not supported (yet).
-# dev-repo: "svn://scm.gforge.inria.fr/svnroot/mlxxxidl/mlcuddidl/"
+# dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 license: "LGPL-2.1-only"
 build: [

--- a/packages/mlcuddidl/mlcuddidl.3.0.6/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.6/opam
@@ -2,9 +2,9 @@ opam-version: "2.0"
 maintainer: "Nicolas Berthier <m@nberth.space>"
 authors: ["Bertrand Jeannet" "Nicolas Berthier"]
 homepage: "https://www.inrialpes.fr/pop-art/people/bjeannet/mlxxxidl-forge/mlcuddidl/index.html"
-bug-reports: "https://gforge.inria.fr/projects/mlxxxidl/"
+bug-reports: "https://framagit.org/nberth/mlcuddidl/-/issues"
 # SVN repositories not supported (yet).
-# dev-repo: "svn://scm.gforge.inria.fr/svnroot/mlxxxidl/mlcuddidl/"
+# dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 dev-repo: "git+https://framagit.org/nberth/mlcuddidl.git"
 license: "LGPL-2.1-only"
 build: [


### PR DESCRIPTION
Related issue: #19757 