### PR TITLE
Update package overview of coq to move from GForge to GitHub

### DIFF
--- a/packages/coq/coq.8.4.5/opam
+++ b/packages/coq/coq.8.4.5/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://coq.inria.fr/"
-dev-repo: "git://scm.gforge.inria.fr/coq/coq.git"
+dev-repo: "git+https://github.com/coq/coq.git"
 bug-reports: "https://coq.inria.fr/bugs/"
 build: [
   [

--- a/packages/coq/coq.8.4.6/opam
+++ b/packages/coq/coq.8.4.6/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
 homepage: "https://coq.inria.fr/"
-dev-repo: "git://scm.gforge.inria.fr/coq/coq.git"
+dev-repo: "git+https://github.com/coq/coq.git"
 bug-reports: "https://coq.inria.fr/bugs/"
 build: [
   [

--- a/packages/coq/coq.8.4.6~camlp4/opam
+++ b/packages/coq/coq.8.4.6~camlp4/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
 homepage: "https://coq.inria.fr/"
-dev-repo: "git://scm.gforge.inria.fr/coq/coq.git"
+dev-repo: "git+https://github.com/coq/coq.git"
 bug-reports: "https://coq.inria.fr/bugs/"
 build: [
   [


### PR DESCRIPTION
Related issue: #19757 