### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.0.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.0.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.0.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "io-page"
+  "lwt"
+  "mirage-block"
+  "mirage-kv" {>= "3.0.0"}
+  "ptime"
+  "re" {>= "1.7.2"}
+  "tar" {= version}
+  "io-page-unix" {with-test}
+  "mirage-block-unix" {with-test & >= "2.5.0"}
+  "ounit2" {with-test}
+  "ounit2-lwt" {with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.0.0/tar-mirage-v2.0.0.tbz"
+  checksum: [
+    "sha256=0b204f1f565cf762d89ebfbb5a7823e53acaa57834fa3fb5944399367afc4a29"
+    "sha512=83c8a214cb9ad1987d062b3503089ab0492e2ec3d3636d54e20f8b73733e40a618190aeae0498d71fdc3fa9c42e6f08b1b31acefdeb1be60419cd37fd86e7f4e"
+  ]
+}
+x-commit-hash: "344bd51aef93d92784077c9bf7f2f5d1db11569a"

--- a/packages/tar-unix/tar-unix.2.0.0/opam
+++ b/packages/tar-unix/tar-unix.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.03.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "re" {>= "1.7.2"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.0.0/tar-mirage-v2.0.0.tbz"
+  checksum: [
+    "sha256=0b204f1f565cf762d89ebfbb5a7823e53acaa57834fa3fb5944399367afc4a29"
+    "sha512=83c8a214cb9ad1987d062b3503089ab0492e2ec3d3636d54e20f8b73733e40a618190aeae0498d71fdc3fa9c42e6f08b1b31acefdeb1be60419cd37fd86e7f4e"
+  ]
+}
+x-commit-hash: "344bd51aef93d92784077c9bf7f2f5d1db11569a"

--- a/packages/tar/tar.2.0.0/opam
+++ b/packages/tar/tar.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "re" {>= "1.7.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.0.0/tar-mirage-v2.0.0.tbz"
+  checksum: [
+    "sha256=0b204f1f565cf762d89ebfbb5a7823e53acaa57834fa3fb5944399367afc4a29"
+    "sha512=83c8a214cb9ad1987d062b3503089ab0492e2ec3d3636d54e20f8b73733e40a618190aeae0498d71fdc3fa9c42e6f08b1b31acefdeb1be60419cd37fd86e7f4e"
+  ]
+}
+x-commit-hash: "344bd51aef93d92784077c9bf7f2f5d1db11569a"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Bump lower-bound on Cstruct to 6.0.0 (@MisterDA, @djs55, @dinosaure, mirage/ocaml-tar#74)
- Update to Dune 2.9 and generate opam files (@MisterDA, @djs55, @dinosaure, mirage/ocaml-tar#74)
- Support only OCaml versions 4.08 and higher. (@MisterDA, @dinosaure, mirage/ocaml-tar#77)
- Don't print any logging to stdout or stderr (@MisterDA, @djs55, @dinosaure, mirage/ocaml-tar#74)
- Remove `Tar.Make.Header`, `Tar_cstruct.Header`, `Tar_unix.Header`, and
  `Tar_lwt_unix.Header` to keep only Tar.Header and use it everywhere.
  - `Tar.Make.Header.get_next_header` becomes `Tar.Make.get_next_header`;
  - `Tar_cstruct.Header.get_next_header` becomes `Tar_cstruct.get_next_header`;
  - `Tar_lwt_unix.Header.get_next_header` becomes `Tar_lwt_unix.get_next_header`;
  - `Tar_lwt_unix.Header.of_file` becomes `Tar_lwt_unix.header_of_file`;
  - `Tar_unix.Header.get_next_header` becomes `Tar_unix.get_next_header`;
  - `Tar_unix.Header.of_file` becomes `Tar_unix.header_of_file`;
  - All the `Tar_*.Header.t` values have to be changed to `Tar.Header.t`.
  (@MisterDA, @dinosaure, mirage/ocaml-tar#77)
- Fix parsing of pax Extended Header File Times with sub-second
  granularity. (@MisterDA, @dinosaure, mirage/ocaml-tar#77)
- Add `Tar_unix.transform` and `Tar_lwt_unix.transform` to help
  transforming headers of a streamed tar archive between two file
  descriptors. (@MisterDA, @dinosaure, mirage/ocaml-tar#77)
- Remove `{build}` tag on the `dune` dependency (@CraigFe, @hannesm, mirage/ocaml-tar#72)
- Adapt `ocaml-tar` to newer MirageOS interfaces (@hannesm, @dinosaure, mirage/ocaml-tar#73)
- Update gnu.org link (@reynir, @dinosaure, mirage/ocaml-tar#79)
- `file_mode` defaults to `0o400` (@reynir, @MisterDA, @dinosaure, mirage/ocaml-tar#78)
