### PR TITLE
[new release] pyml.20211015

### DIFF
--- a/packages/pyml/pyml.20211015/opam
+++ b/packages/pyml/pyml.20211015/opam
@@ -33,5 +33,5 @@ depends: [
 depopts: ["utop"]
 url {
   src: "https://github.com/thierry-martinez/pyml/archive/refs/tags/20211015.tar.gz"
-  checksum: "sha512=f44a55196f31e4f9a7e04e589f9ef5613e00373ba955dedddf3b6a68403a89e92df5af6a8b14dd8c1970e59e203927e8d64a08cff49826803f94271edccf5c33"
+  checksum: "sha512=79237ab56a2e439e785f4d873abd603fdaa51dbbb1258efb25102ca897826cf4d5d15e8467f324df85bba3c61995ceee8fb82d0808cda0da8010e024a78307aa"
 }


### PR DESCRIPTION
This PR publishes a new release for pyml. Here is the change log:

- More portable architecture detection
  (inspired by the discussion https://discuss.ocaml.org/t/a-zoo-of-values-for-system/8525
   initiated by Olaf Hering, with helpful comments from Daniel Bünzli,
   @EduardoRFS, David Allsopp, kit-ty-kate and jbeckford)

- Better compatibility with Windows

- Correct version detection for Python 3.10