### PR TITLE
[new release] index and index-bench (1.4.2)

### DIFF
--- a/packages/index-bench/index-bench.1.4.2/opam
+++ b/packages/index-bench/index-bench.1.4.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cmdliner"
+  "dune" {>= "2.7.0"}
+  "fmt"
+  "index" {= version}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re" {>= "1.9.0"}
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+  "tezos-context-hash" {>= "1.0.0"}
+  "mtime"
+  "logs" {>= "0.7.0"}
+  "optint" {>= "0.1.0" & with-test}
+  "progress" {>= "0.2.1"}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.2/index-1.4.2.tbz"
+  checksum: [
+    "sha256=7dfd0632cbd7f167629ac635f94a510f4dcfa6cce7f1245ebe67ef43e0e1e290"
+    "sha512=51fae46d7bade9b1ffd07254fb7f9c0a8e4bfe72500c8b4e237d1c8d0e20745de96ce131a8432adbfd8629c152ea9b3341d5c1b66a00f27edc28cd17981ba0a4"
+  ]
+}
+x-commit-hash: "ee8a1f2093b67eda6c2b3b328d5fb86de672b408"

--- a/packages/index/index.1.4.2/opam
+++ b/packages/index/index.1.4.2/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.1.0"}
+  "repr"    {>= "0.5.0"}
+  "ppx_repr"
+  "fmt"     {>= "0.8.5"}
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner"
+  "progress" {>= "0.2.1"}
+  "semaphore-compat" {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.2/index-1.4.2.tbz"
+  checksum: [
+    "sha256=7dfd0632cbd7f167629ac635f94a510f4dcfa6cce7f1245ebe67ef43e0e1e290"
+    "sha512=51fae46d7bade9b1ffd07254fb7f9c0a8e4bfe72500c8b4e237d1c8d0e20745de96ce131a8432adbfd8629c152ea9b3341d5c1b66a00f27edc28cd17981ba0a4"
+  ]
+}
+x-commit-hash: "ee8a1f2093b67eda6c2b3b328d5fb86de672b408"


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Fixed

- Fix stats recording in `Raw.unsafe_write` (mirage/index#351)

## Changed

- Changed the implementation of the write-ahead log to significantly reduce its
  memory usage (at the cost of some additional disk IO). (mirage/index#355)
