### PR TITLE
2 packages from ocaml-sf/learn-ocaml at 0.13.1

### DIFF
--- a/packages/learn-ocaml-client/learn-ocaml-client.0.13.1/opam
+++ b/packages/learn-ocaml-client/learn-ocaml-client.0.13.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml client"
+description: """\
+This contains the binaries to interact with the learn-ocaml
+platform from the command line."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak"
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "cstruct" {>= "3.3.0"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "ezjsonm"
+  "gg"
+  "ipaddr" {= "2.8.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ssl"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "omd" {<= "1.3.1"}
+  "ppx_fields_conv"
+  "ppxlib"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ssl" {= "0.5.5"}
+  "vg"
+]
+build: ["dune" "build" "@install" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/v0.13.1.tar.gz"
+  checksum: [
+    "md5=c1b66e42e49e9628756608026f4ec06e"
+    "sha512=e9ee208cea4504dec1ba18c868878f88018d6472f8cb272cda397f32106c2dd77ec9ebb0af80ff2efd34fff25d4f1e00ea88413dd02d89653646db5106946218"
+  ]
+}

--- a/packages/learn-ocaml/learn-ocaml.0.13.1/opam
+++ b/packages/learn-ocaml/learn-ocaml.0.13.1/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+synopsis: "The learn-ocaml online platform (engine)"
+description: """\
+This contains the binaries forming the engine for the learn-ocaml platform, and
+the common files. A demo exercise repository is also provided as example."""
+maintainer: "Yann Régis-Gianas"
+authors: [
+  "Benjamin Canou (OCamlPro)"
+  "Çağdaş Bozman (OCamlPro)"
+  "Grégoire Henry (OCamlPro)"
+  "Louis Gesbert (OCamlPro)"
+  "Pierrick Couderc (OCamlPro)"
+]
+license: "MIT"
+homepage: "https://github.com/ocaml-sf/learn-ocaml"
+bug-reports: "https://github.com/ocaml-sf/learn-ocaml/issues"
+depends: [
+  "asak"
+  "base64"
+  "base" {>= "v0.9.4"}
+  "cmdliner"
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conf-git"
+  "decompress" {= "0.8.1"}
+  "digestif" {>= "0.7.1"}
+  "dune" {>= "2.3.0"}
+  "easy-format" {>= "1.3.0"}
+  "ezjsonm"
+  "ipaddr" {>= "2.8.0"}
+  "js_of_ocaml" {>= "3.3.0" & != "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.3.0"}
+  "js_of_ocaml-lwt"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-toplevel"
+  "js_of_ocaml-tyxml"
+  "lwt" {>= "4.0.0"}
+  "lwt_react"
+  "lwt_ssl"
+  "magic-mime"
+  "markup"
+  "markup-lwt"
+  "ocaml" {(>= "4.12") & (< "4.13~")}
+  "ocamlfind" {build}
+  "ocp-indent-nlfork"
+  "ocplib-json-typed" {>= "0.7"}
+  "ocplib-json-typed-browser" {>= "0.7"}
+  "ocp-ocamlres" {>= "0.4"}
+  "odoc" {build}
+  "omd" {<= "1.3.1"}
+  "pprint"
+  "ppx_cstruct"
+  "ppxlib"
+  "ppx_sexp_conv"
+  "ppx_tools"
+  "ppx_tools_versioned"
+  "re"
+  "ssl" {= "0.5.5"}
+  "uutf" {>= "1.0"}
+  "vg"
+  "yojson" {>= "1.4.0"}
+]
+build: [
+  [make "static"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  ["mkdir" "-p" "%{_:share}%"]
+  ["cp" "-r" "demo-repository" "%{_:share}%/repository"]
+]
+dev-repo: "git+https://github.com/ocaml-sf/learn-ocaml"
+url {
+  src: "https://github.com/ocaml-sf/learn-ocaml/archive/v0.13.1.tar.gz"
+  checksum: [
+    "md5=c1b66e42e49e9628756608026f4ec06e"
+    "sha512=e9ee208cea4504dec1ba18c868878f88018d6472f8cb272cda397f32106c2dd77ec9ebb0af80ff2efd34fff25d4f1e00ea88413dd02d89653646db5106946218"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`learn-ocaml.0.13.1`: The learn-ocaml online platform (engine)
-`learn-ocaml-client.0.13.1`: The learn-ocaml client



---
* Homepage: https://github.com/ocaml-sf/learn-ocaml
* Source repo: git+https://github.com/ocaml-sf/learn-ocaml
* Bug tracker: https://github.com/ocaml-sf/learn-ocaml/issues

---


### Bug Fixes

* ***.opam:** Make common deps constraints uniform & Add missing deps ([26a50ef](https://www.github.com/ocaml-sf/learn-ocaml/commit/26a50ef1ef4c37ddb990f9d7ebb71da6896cfc1a))
* **API:** Fix listing exercise status when the status list hasn't been initialized; Fix [#314](https://www.github.com/ocaml-sf/learn-ocaml/issues/314) ([3c781cb](https://www.github.com/ocaml-sf/learn-ocaml/commit/3c781cb3f9605176c915da825be877c70cfceb41))
* **grader:** Display negative numbers with mandatory parens; Fix [#440](https://www.github.com/ocaml-sf/learn-ocaml/issues/440) ([35941b5](https://www.github.com/ocaml-sf/learn-ocaml/commit/35941b5ebe8cb2b947cd6010118050a79c6e36f8))
* **UI:** Cleanup duplicate, inconsistent camel logos ([03d871a](https://www.github.com/ocaml-sf/learn-ocaml/commit/03d871ad0a70c4c50849166dd2b2f3d95ae3913a))
* **UI:** Display Actions=teacher_menubar properly in responsive mode; Fix [#444](https://www.github.com/ocaml-sf/learn-ocaml/issues/444) ([#450](https://www.github.com/ocaml-sf/learn-ocaml/issues/450)) ([b6d44db](https://www.github.com/ocaml-sf/learn-ocaml/commit/b6d44db7504e9b74169cbb69e9ae08b60a1aed01))
* **UI:** Fix CSS bug regarding the loading animation ([#445](https://www.github.com/ocaml-sf/learn-ocaml/issues/445)) ([881982a](https://www.github.com/ocaml-sf/learn-ocaml/commit/881982a8f0ec5b03b4f8c85d8ea38790ac804012))
* **UI:** Increase timeout during grading ([3cb9dd1](https://www.github.com/ocaml-sf/learn-ocaml/commit/3cb9dd1f0460b9c5d91e8c42c3bba9b23091c0e7))
* **UI:** Update one fr translation ([06a71ae](https://www.github.com/ocaml-sf/learn-ocaml/commit/06a71aec5af76e421c5e654d213fb77450eae82a))


### Dependencies

* Fix version of dune package (w.r.t. that of dune-project file) ([7c11083](https://www.github.com/ocaml-sf/learn-ocaml/commit/7c110834d9647beb80ce59d976a18efe712d5393))


### Documentation

* **tests/README.md:** Add hint for test case generation ([19477a5](https://www.github.com/ocaml-sf/learn-ocaml/commit/19477a51327ed749bc0f7cf0ad9195e1b401c5f8))


### Tests

* Add Dockefile.test-server to repro issue with learn-ocaml.opam ([6d86ce6](https://www.github.com/ocaml-sf/learn-ocaml/commit/6d86ce6a7c40b3098336315d3f4cbd4b89ace9c8))
* Add test to repro issue [#440](https://www.github.com/ocaml-sf/learn-ocaml/issues/440) ([07033c9](https://www.github.com/ocaml-sf/learn-ocaml/commit/07033c98b3e73630a4472125673dc386687bc2b1))


### CI/CD

* **build-and-test.yml:** Add ocamlsf/learn-ocaml:0.13.0 in client test matrix ([6c21d9c](https://www.github.com/ocaml-sf/learn-ocaml/commit/6c21d9c58a36364f52ac731b28b9e1622a1348dc))
* Ensure release-please triggers docker/build-push-action jobs ([#443](https://www.github.com/ocaml-sf/learn-ocaml/issues/443)) ([71c3590](https://www.github.com/ocaml-sf/learn-ocaml/commit/71c3590e46ad48269834dbaf1a3b634ec35b91b4))
* Ensure the CD-related workflows won't run on forks ([#446](https://www.github.com/ocaml-sf/learn-ocaml/issues/446)) ([6b8c49b](https://www.github.com/ocaml-sf/learn-ocaml/commit/6b8c49b36a8e2c2bd729cd0acc8f9cefde38ec2a))


---
:camel: Pull-request generated by opam-publish v2.1.0