### PR TITLE
cudf: update repository url

### DIFF
--- a/packages/cudf/cudf.0.9-1/opam
+++ b/packages/cudf/cudf.0.9-1/opam
@@ -22,6 +22,6 @@ CUDF (for Common Upgradeability Description Format) is a format for
 describing upgrade scenarios in package-based Free and Open Source
 Software distribution."""
 url {
-  src: "https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cudf-0.9.tar.gz"
   checksum: "md5=a4c0e652e56e74c7b388a43f9258d119"
 }

--- a/packages/cudf/cudf.0.9/opam
+++ b/packages/cudf/cudf.0.9/opam
@@ -26,6 +26,6 @@ CUDF (for Common Upgradeability Description Format) is a format for
 describing upgrade scenarios in package-based Free and Open Source
 Software distribution."""
 url {
-  src: "https://gforge.inria.fr/frs/download.php/36602/cudf-0.9.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cudf-0.9.tar.gz"
   checksum: "md5=a4c0e652e56e74c7b388a43f9258d119"
 }


### PR DESCRIPTION
gforge has been deprecated, so archive is now on a repository
under ocaml/opam-source-archives (with the same checksum).

see #19757