### PR TITLE
[new release] coq-serapi (8.14.0+0.14.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.14.0+0.14.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.14.0+0.14.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.14" & < "8.15"     }
+  "cmdliner"            {           >= "1.0.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.14.0%2B0.14.0/coq-serapi-8.14.0.0.14.0.tbz"
+  checksum: [
+    "sha256=1c16d8e37b0970f97313d99b57456013ff5ec94135dffc7a3d6d15c2f23b5dfe"
+    "sha512=e2a2b6f7cba9f31aed022058718efe3b5233b6f67a4a8aa79470697c640986053e19508866cf886318f2cc4f26e067583a908fad8c9655aa309ad359000abf1e"
+  ]
+}
+x-commit-hash: "9801d2be6842434d511d8d30f0a01b9c30836555"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serapi] (!) support for Coq 8.14, see upstream changes; nothing
            too remarkable other than `NewDoc` will now ignore
            loadpaths due to new init setup upstream.
            (ejgallego/coq-serapi#253, @ejgallego)
 - [ci]     SerAPI branches should be able to build now against Coq rc
            packages as to better integrate with Coq's platform beta
            release; thanks to Érik Martin-Dorel, Karl Palmskog and Théo
            Zimmermann for feedback.
