### PR TITLE
Package chick.0.2

### DIFF
--- a/packages/chick/chick.0.2/opam
+++ b/packages/chick/chick.0.2/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+synopsis: "Help package in writing mathematics documents under Jupyter."
+description: "Toolbox to make mathematical statements and demonstrations more readable and reliable. The enrichment of the text is carried out from routine Ocaml that produce latex."
+license: "LGPL"
+maintainer: "VMichelRene <michelorange024@gmail.com>"
+authors: "VMichelRene <michelorange024@gmail.com>"
+dev-repo: "git+https://github.com/VMichelRene/chick"
+install: [make "install"]
+depends: ["ocaml" "ocamlfind" "zarith"]
+build: [make]
+url {
+  src: "https://github.com/VMichelRene/chick/archive/refs/tags/0.2.tar.gz"
+  checksum: "md5=3ed271e5557675ae912affd224e3e636"
+}
+


### PR DESCRIPTION
### `chick.0.2`
Help package in writing mathematics documents under Jupyter.
Toolbox to make mathematical statements and demonstrations more readable and reliable. The enrichment of the text is carried out from routine Ocaml that produce latex.



---
* Source repo: git+https://github.com/VMichelRene/chick

---
:camel: Pull-request generated by opam-publish v2.1.0