### PR TITLE
mirage-crypto-pk: depend on mirage-runtime package instead of mirage

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.3/opam
@@ -26,7 +26,7 @@ depends: [
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.7"}
   "rresult" {>= "0.6.0"}
-  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage" {>= "4.0.0"})
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0.0"})
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}


### PR DESCRIPTION
`mirage` actually has a lot of dependencies so it's better to depend on `mirage-runtime`. 
The effect is the same, `mirage-crypto-pk` doesn't require `zarith-freestanding` when compiling to `solo5` or `xen` if MirageOS 4 is used.
This dependency was introduced in _Relax bounds to prepare MirageOS 4_ https://github.com/ocaml/opam-repository/pull/19754