### PR TITLE
[updated] conf-libclang.12 and [new release] conf-libclang.13

### DIFF
--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -10,7 +10,7 @@ homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
 doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
 bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
 depends: [
-  "conf-libclang" {= "12"}
+  "conf-libclang" {<= "12"}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}

--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -10,7 +10,7 @@ homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
 doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
 bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
 depends: [
-  "conf-libclang"
+  "conf-libclang" {= "12"}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
@@ -35,7 +35,7 @@ x-ci-accept-failures: [
 available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}% --with-llvm-version=%{conf-libclang:clangml440_compatible_version}%"]
   ["dune" "build" "-p" name "-j" jobs "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}]]

--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -35,7 +35,7 @@ x-ci-accept-failures: [
 available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" %{conf-libclang:clangml440_configure_options}"]
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" %{conf-libclang:clangml440_configure_options}%]
   ["dune" "build" "-p" name "-j" jobs "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}]]

--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -35,7 +35,7 @@ x-ci-accept-failures: [
 available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" "--with-llvm-version=%{conf-libclang:clangml440_compatible_version}%"]
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" %{conf-libclang:clangml440_configure_options}"]
   ["dune" "build" "-p" name "-j" jobs "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}]]

--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -35,7 +35,7 @@ x-ci-accept-failures: [
 available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}% --with-llvm-version=%{conf-libclang:clangml440_compatible_version}%"]
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" "--with-llvm-version=%{conf-libclang:clangml440_compatible_version}%"]
   ["dune" "build" "-p" name "-j" jobs "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}]]

--- a/packages/clangml/clangml.4.4.0/opam
+++ b/packages/clangml/clangml.4.4.0/opam
@@ -35,7 +35,7 @@ x-ci-accept-failures: [
 available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
 build: [
-  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" %{conf-libclang:clangml440_configure_options}%]
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%" conf-libclang:clangml440_configure_options]
   ["dune" "build" "-p" name "-j" jobs "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}]]

--- a/packages/conf-libclang/conf-libclang.12/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.12/files/configure.sh
@@ -35,9 +35,9 @@ for version in default 12 11 10 9 8 7 6 5 4 3; do
     fi
 
     if [ "$llvm_version" = "12.0.1" ]; then
-        clangml440_compatible_version=12.0.0 # clangml.4.4.0 does not recognize 12.0.1
+        clangml440_configure_options="--with-llvm-version=12.0.0" # clangml.4.4.0 does not recognize 12.0.1
     else
-        clangml440_compatible_version="" # rely on clangml's ./configure autodetection
+        clangml440_configure_options="" # rely on clangml's ./configure autodetection
     fi
 
     LLVM_CFLAGS="$($llvm_config --cflags)"
@@ -87,7 +87,7 @@ EOF
     
     echo "config: \"$llvm_config\"" >> conf-libclang.config
     echo "version: \"$llvm_version\"" >> conf-libclang.config
-    echo "clangml440_compatible_version: \"$clangml440_compatible_version\"" >> conf-libclang.config
+    echo "clangml440_configure_options: \"$clangml440_configure_options\"" >> conf-libclang.config
     exit 0
 done
 

--- a/packages/conf-libclang/conf-libclang.12/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.12/files/configure.sh
@@ -11,7 +11,7 @@ for version in default 12 11 10 9 8 7 6 5 4 3; do
     if [ "$version" = default ]; then
         llvm_config=llvm-config
         llvm_version="$($llvm_config --version)" || continue
-        if [ $(printf "$llvm_version\n13" | sort | head -n1) = 13 ]; then
+        if [ $(printf "${llvm_version%%.*}\n13" | sort -n | head -n1) = 13 ]; then
             continue
         fi
     else

--- a/packages/conf-libclang/conf-libclang.12/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.12/files/configure.sh
@@ -37,7 +37,7 @@ for version in default 12 11 10 9 8 7 6 5 4 3; do
     if [ "$llvm_version" = "12.0.1" ]; then
         clangml440_compatible_version=12.0.0 # clangml.4.4.0 does not recognize 12.0.1
     else
-        clangml440_compatible_version="$llvm_version"
+        clangml440_compatible_version="" # rely on clangml's ./configure autodetection
     fi
 
     LLVM_CFLAGS="$($llvm_config --cflags)"

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -29,7 +29,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
 ]
 extra-files: [[
-  "configure.sh" "sha512=46358a4f18a53c87947355ed4d72c57ed85a7f2965564fa75592abab0dddaad2eb1b6f0940228e4230516fa043a772da44cbd176f2b274a07364bfae2cbae268"
+  "configure.sh" "sha512=6a5b8a76cbe7215e34db82a7d9df4b6138491b4ad2fcbf7c6d68b726f732cfdf3dd7a3e45af228ff4970d58d18b157b3b011c2580dd5c74a0cf4b236bdcf74af"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 12.0.x)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -8,8 +8,7 @@ build: [
   ["bash" "-ex" "configure.sh" version]
 ]
 depexts: [
-  # Brew already has a package for llvm@13
-  ["llvm@12"] {os = "macos"}
+  ["llvm@12"] {os = "macos"} # Brew already has a package for llvm@13
   ["llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -24,6 +24,9 @@ depexts: [
 ]
 x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
+  "alpine-3.13" # unavailable system package 'llvm-dev'
+  "alpine-3.14" # unavailable system package 'llvm-dev'
+  "opensuse-15.3" # unavailable system package 'llvm-clang-devel'
 ]
 extra-files: [[
   "configure.sh" "sha512=db02fc6eee598041fd019679337eab74dc4180f6e94cfe6099a0b76ca2b10f9695079696ff4ee1b41692db46601211335fda83481dadb33ee65895a3a1369bdd"

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -8,8 +8,11 @@ build: [
   ["bash" "-ex" "configure.sh" version]
 ]
 depexts: [
-  ["llvm"] {os = "macos"}
-  ["glibc=2.33" "llvm" "clang"] {os-distribution = "arch"} # needs GLIBC_2.33
+  # Brew already has a package for llvm@13
+  ["llvm@12"] {os = "macos"}
+  # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
+  # to know it.
+  ["libffi" "llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
@@ -26,7 +29,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
 ]
 extra-files: [[
-  "configure.sh" "sha512=0237ec1078edf2218258b86d98beaad2cac9cf97698bbe486d92542b860d5b7228904128eed24462448436b7f2f58c8bfe359aa00b2acc366f66ced2345f9d6a"
+  "configure.sh" "sha512=46358a4f18a53c87947355ed4d72c57ed85a7f2965564fa75592abab0dddaad2eb1b6f0940228e4230516fa043a772da44cbd176f2b274a07364bfae2cbae268"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 12.0.x)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -11,8 +11,9 @@ depexts: [
   # Brew already has a package for llvm@13
   ["llvm@12"] {os = "macos"}
   # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
-  # to know it.
-  ["libffi=3.4.2" "llvm" "clang"] {os-distribution = "arch"}
+  # to know it. llvm-config needs libffi.so.8 provided by libffi=3.4.2 requiring
+  # glib2=2.70.0
+  ["libffi=3.4.2""glib2=2.70.0" "llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
@@ -29,7 +30,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
 ]
 extra-files: [[
-  "configure.sh" "sha512=6a5b8a76cbe7215e34db82a7d9df4b6138491b4ad2fcbf7c6d68b726f732cfdf3dd7a3e45af228ff4970d58d18b157b3b011c2580dd5c74a0cf4b236bdcf74af"
+  "configure.sh" "sha512=0c398f5d8bd32dd9b39953c2cf8861ace50a7ce6ef572e469a11b4e9c10723579bb0c8737066ffada68fecde56a1065094cd8166ac5273a1bff8a019e887a854"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 12.0.x)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -12,7 +12,7 @@ depexts: [
   ["llvm@12"] {os = "macos"}
   # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
   # to know it.
-  ["libffi" "llvm" "clang"] {os-distribution = "arch"}
+  ["libffi=3.4.2" "llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -10,10 +10,7 @@ build: [
 depexts: [
   # Brew already has a package for llvm@13
   ["llvm@12"] {os = "macos"}
-  # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
-  # to know it. llvm-config needs libffi.so.8 provided by libffi=3.4.2 requiring
-  # glib2=2.70.0
-  ["libffi=3.4.2""glib2=2.70.0" "llvm" "clang"] {os-distribution = "arch"}
+  ["llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
@@ -30,7 +27,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
 ]
 extra-files: [[
-  "configure.sh" "sha512=0c398f5d8bd32dd9b39953c2cf8861ace50a7ce6ef572e469a11b4e9c10723579bb0c8737066ffada68fecde56a1065094cd8166ac5273a1bff8a019e887a854"
+  "configure.sh" "sha512=db02fc6eee598041fd019679337eab74dc4180f6e94cfe6099a0b76ca2b10f9695079696ff4ee1b41692db46601211335fda83481dadb33ee65895a3a1369bdd"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 12.0.x)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.13/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.13/files/configure.sh
@@ -11,7 +11,7 @@ for version in default 13 12 11 10 9 8 7 6 5 4 3; do
     if [ "$version" = default ]; then
         llvm_config=llvm-config
         llvm_version="$($llvm_config --version)" || continue
-        if [ $(printf "$llvm_version\n14" | sort | head -n1) = 14 ]; then
+        if [ $(printf "${llvm_version%%.*}\n14" | sort -n | head -n1) = 14 ]; then
             continue
         fi
     else

--- a/packages/conf-libclang/conf-libclang.13/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.13/files/configure.sh
@@ -7,11 +7,11 @@ clean_tempdir () {
 }
 
 shopt -s nullglob
-for version in default 12 11 10 9 8 7 6 5 4 3; do
+for version in default 13 12 11 10 9 8 7 6 5 4 3; do
     if [ "$version" = default ]; then
         llvm_config=llvm-config
         llvm_version="$($llvm_config --version)" || continue
-        if [ $(printf "$llvm_version\n13" | sort | head -n1) = 13 ]; then
+        if [ $(printf "$llvm_version\n14" | sort | head -n1) = 14 ]; then
             continue
         fi
     else
@@ -32,12 +32,6 @@ for version in default 12 11 10 9 8 7 6 5 4 3; do
         if [ -z "$llvm_version" ]; then
             continue
         fi
-    fi
-
-    if [ "$llvm_version" = "12.0.1" ]; then
-        clangml440_compatible_version=12.0.0 # clangml.4.4.0 does not recognize 12.0.1
-    else
-        clangml440_compatible_version="$llvm_version"
     fi
 
     LLVM_CFLAGS="$($llvm_config --cflags)"
@@ -87,10 +81,9 @@ EOF
     
     echo "config: \"$llvm_config\"" >> conf-libclang.config
     echo "version: \"$llvm_version\"" >> conf-libclang.config
-    echo "clangml440_compatible_version: \"$clangml440_compatible_version\"" >> conf-libclang.config
     exit 0
 done
 
-echo "Error: No usable version of LLVM <=12.0.x found."
+echo "Error: No usable version of LLVM <=13.0.x found."
 exit 1
 

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -10,8 +10,9 @@ build: [
 depexts: [
   ["llvm"] {os = "macos"}
   # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
-  # to know it.
-  ["libffi=3.4.2" "llvm" "clang"] {os-distribution = "arch"}
+  # to know it. llvm-config needs libffi.so.8 provided by libffi=3.4.2 requiring
+  # glib2=2.70.0
+  ["libffi=3.4.2""glib2=2.70.0" "llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -9,10 +9,7 @@ build: [
 ]
 depexts: [
   ["llvm"] {os = "macos"}
-  # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
-  # to know it. llvm-config needs libffi.so.8 provided by libffi=3.4.2 requiring
-  # glib2=2.70.0
-  ["libffi=3.4.2""glib2=2.70.0" "llvm" "clang"] {os-distribution = "arch"}
+  ["llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -24,6 +24,9 @@ depexts: [
 ]
 x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
+  "alpine-3.13" # unavailable system package 'llvm-dev'
+  "alpine-3.14" # unavailable system package 'llvm-dev'
+  "opensuse-15.3" # unavailable system package 'llvm-clang-devel'
 ]
 extra-files: [[
   "configure.sh" "sha512=39710d395a437c0cb057180ed604e606d4aa3414bf164517fa42a38ffb79a6300406be3591ad1de1bb0779a5058773be0aa381e5dfe2ec670afed2d81ac14739"

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -9,7 +9,9 @@ build: [
 ]
 depexts: [
   ["llvm"] {os = "macos"}
-  ["glibc=2.33" "llvm" "clang"] {os-distribution = "arch"} # needs GLIBC_2.33
+  # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
+  # to know it.
+  ["libffi" "llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
@@ -26,7 +28,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
 ]
 extra-files: [[
-  "configure.sh" "sha512=38f964ca68526c45ffac194eaa494018c6b2260641ecfcda19c509471de98cf8362f40ba199aed31cab9b9753466e341d32e7aee51bb74897b3ebf9cead66a0d"
+  "configure.sh" "sha512=39710d395a437c0cb057180ed604e606d4aa3414bf164517fa42a38ffb79a6300406be3591ad1de1bb0779a5058773be0aa381e5dfe2ec670afed2d81ac14739"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 13.0.x)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -19,14 +19,14 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "ol" & os-version >= "8"}
   ["llvm-clang-devel"] {os-family = "suse"}
-  ["devel/llvm12"] {os = "freebsd"}
+  ["devel/llvm13"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7" # clang-devel is not available
 ]
 extra-files: [[
-  "configure.sh" "sha512=0237ec1078edf2218258b86d98beaad2cac9cf97698bbe486d92542b860d5b7228904128eed24462448436b7f2f58c8bfe359aa00b2acc366f66ced2345f9d6a"
+  "configure.sh" "sha512=38f964ca68526c45ffac194eaa494018c6b2260641ecfcda19c509471de98cf8362f40ba199aed31cab9b9753466e341d32e7aee51bb74897b3ebf9cead66a0d"
 ]]
-synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 12.0.x)"
+synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 13.0.x)"
 flags: conf

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -11,7 +11,7 @@ depexts: [
   ["llvm"] {os = "macos"}
   # LLVM package depends on libffi on arch, but mirrors used by opam CI seem not
   # to know it.
-  ["libffi" "llvm" "clang"] {os-distribution = "arch"}
+  ["libffi=3.4.2" "llvm" "clang"] {os-distribution = "arch"}
   ["libclang-dev" "llvm-dev"] {os-family = "debian"}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]


### PR DESCRIPTION
This PR adds the version conf-libclang.13 to detect libclang <=13.0.x.

The logic of conf-libclang.12 is modified such that if a given version of clang is installed but cannot be compiled with, the script continues finding if an older version is available (in Ubuntu 21.10, clang is packaged such a way that headers of clang 10, clang 11 and clang 12 are missing). conf-libclang.13 implements the same logic.

Moreover, conf-libclang.12 is modified such that clangml.4.4.0 can be used on systems where llvm 12.0.1 is installed even if clangml.4.4.0 does only recognize llvm 12.0.0.