### PR TITLE
[new release] pyast.0.1.1

### DIFF
--- a/packages/pyast/pyast.0.1.1/opam
+++ b/packages/pyast/pyast.0.1.1/opam
@@ -12,7 +12,7 @@ doc: "https://github.com/thierry.martinez/pyast"
 bug-reports: "https://github.com/thierry.martinez/pyast"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "2.8" & >= "1.11.3"}
+  "dune" {>= "2.8"}
   "pyml" {>= "20210226"}
   "refl" {>= "0.4.0"}
   "cmdliner" {>= "1.0.4"}


### PR DESCRIPTION
This PR adds a bugfix release of pyast:

- pyast.0.1.1: Fix conversion bug with ExtSlice
  (when converting Python <3.9.0 to Python >=3.9.0)