### PR TITLE
Orsetto: update dependencies.

### DIFF
--- a/packages/orsetto/orsetto.1.0.1/opam
+++ b/packages/orsetto/orsetto.1.0.1/opam
@@ -10,7 +10,7 @@ license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
-    "conjury" { build & >= "2.0" }
+    "conjury" { build & >= "2.0" & < "3.0~" }
     "uucd" { build & = "12.0.0" }
     "ounit" { build & with-test & >= "2.0.7" }
 ]

--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -10,7 +10,7 @@ license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
-    "conjury" { build & >= "2.0" }
+    "conjury" { build & >= "2.0" & < "3.0~" }
     "uucd" { build & = "12.0.0" }
     "ounit" { build & with-test & >= "2.0.7" }
 ]

--- a/packages/orsetto/orsetto.1.0.3/opam
+++ b/packages/orsetto/orsetto.1.0.3/opam
@@ -10,7 +10,7 @@ license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
-    "conjury" { build & >= "2.0.1" }
+    "conjury" { build & >= "2.0.1" & < "3.0~" }
     "uucd" { build & = "13.0.0" }
     "ounit2" { build & with-test & >= "2.2" }
 ]

--- a/packages/orsetto/orsetto.1.0/opam
+++ b/packages/orsetto/orsetto.1.0/opam
@@ -10,7 +10,7 @@ license: "BSD-2-Clause"
 depends: [
     ("ocaml" { >= "4.07" & < "4.09" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
-    "conjury" { build & >= "2.0" }
+    "conjury" { build & >= "2.0" & < "3.0~" }
     "uucd" { build & = "12.0.0" }
     "ounit" { build & with-test & >= "2.0.7" }
 ]

--- a/packages/orsetto/orsetto.1.1/opam
+++ b/packages/orsetto/orsetto.1.1/opam
@@ -9,7 +9,7 @@ tags: [ "org:conjury.org" ]
 license: "BSD-2-Clause"
 depends: [
     "ocaml" { >= "4.08.1" }
-    "conjury" { build & >= "2.0.1" }
+    "conjury" { build & >= "2.0.1" & < "3.0~" }
     "omake" { build & >= "0.10.3" }
     "uucd" { build & = "13.0.0" }
     "ounit2" { build & with-test & >= "2.2" }


### PR DESCRIPTION
- Conjury 3.0 will drop support for its 2.0 programming interfaces.