### PR TITLE
Point opam.ocaml.org sources to GitHub

### DIFF
--- a/packages/bindlib/bindlib.4.0.2/opam
+++ b/packages/bindlib/bindlib.4.0.2/opam
@@ -26,6 +26,6 @@ Authors
 	* Rodolphe Lepigre"""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/6b/6b37b02a6d1c7e5bb51ba96adbf84afc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bindlib-4.0.2.tar.gz"
   checksum: "md5=6b37b02a6d1c7e5bb51ba96adbf84afc"
 }

--- a/packages/bindlib/bindlib.4.0.3/opam
+++ b/packages/bindlib/bindlib.4.0.3/opam
@@ -26,6 +26,6 @@ Authors
 	* Rodolphe Lepigre"""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/49/49f7dcb45ebe49765dc850db7b842e32"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bindlib-4.0.3.tar.gz"
   checksum: "md5=49f7dcb45ebe49765dc850db7b842e32"
 }

--- a/packages/bindlib/bindlib.4.0/opam
+++ b/packages/bindlib/bindlib.4.0/opam
@@ -26,6 +26,6 @@ Authors
 	* Rodolphe Lepigre"""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/ce/ce1ca69a76ba5ecf1735a64ab1c175c9"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/bindlib-4.0.tar.gz"
   checksum: "md5=ce1ca69a76ba5ecf1735a64ab1c175c9"
 }

--- a/packages/camlimages/camlimages.4.0.1/opam
+++ b/packages/camlimages/camlimages.4.0.1/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/d6/d6b9494b56a72b65fd302d1858efff7c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.0.1.tar.gz"
   checksum: "md5=d6b9494b56a72b65fd302d1858efff7c"
 }

--- a/packages/camlimages/camlimages.4.0.2/opam
+++ b/packages/camlimages/camlimages.4.0.2/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/5c/5cfd732034ac7845d0b9e783254f0796"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.0.2.tar.gz"
   checksum: "md5=5cfd732034ac7845d0b9e783254f0796"
 }

--- a/packages/camlimages/camlimages.4.1.0/opam
+++ b/packages/camlimages/camlimages.4.1.0/opam
@@ -44,6 +44,6 @@ extra-files: [
   "camlimages.4.1.0.build_fix.patch" "md5=b355c56cd972562926810de76118221c"
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/e5/e5bded8e500c58a228a021b1377ea5af"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.1.0.tar.gz"
   checksum: "md5=e5bded8e500c58a228a021b1377ea5af"
 }

--- a/packages/camlimages/camlimages.4.1.1/opam
+++ b/packages/camlimages/camlimages.4.1.1/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/41/413645eb35c3b933119ae80279ab4646"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.1.1.tar.gz"
   checksum: "md5=413645eb35c3b933119ae80279ab4646"
 }

--- a/packages/camlimages/camlimages.4.1.2/opam
+++ b/packages/camlimages/camlimages.4.1.2/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/91/91a07717d4682018ee536731078bb453"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.1.2.tar.gz"
   checksum: "md5=91a07717d4682018ee536731078bb453"
 }

--- a/packages/camlimages/camlimages.4.2.0/opam
+++ b/packages/camlimages/camlimages.4.2.0/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/20/2060b7c7f8f8e1863142f0d67edc9926"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.0.tar.gz"
   checksum: "md5=2060b7c7f8f8e1863142f0d67edc9926"
 }

--- a/packages/camlimages/camlimages.4.2.1/opam
+++ b/packages/camlimages/camlimages.4.2.1/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/7c/7ce29544e2a2945b4899f3c6f05859a0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.1.tar.gz"
   checksum: "md5=7ce29544e2a2945b4899f3c6f05859a0"
 }

--- a/packages/camlimages/camlimages.4.2.2/opam
+++ b/packages/camlimages/camlimages.4.2.2/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/3c/3c4aa0153ca2d91ec2a0798d74648581"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.2.tar.gz"
   checksum: "md5=3c4aa0153ca2d91ec2a0798d74648581"
 }

--- a/packages/camlimages/camlimages.4.2.3/opam
+++ b/packages/camlimages/camlimages.4.2.3/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/43/4372729302b029a23246b6299439e040"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.3.tar.gz"
   checksum: "md5=4372729302b029a23246b6299439e040"
 }

--- a/packages/camlimages/camlimages.4.2.4/opam
+++ b/packages/camlimages/camlimages.4.2.4/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/64/64b49a9f869c699aebc517e89373c537"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.4.tar.gz"
   checksum: "md5=64b49a9f869c699aebc517e89373c537"
 }

--- a/packages/camlimages/camlimages.4.2.5/opam
+++ b/packages/camlimages/camlimages.4.2.5/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/2d/2dac146789f8971f0a746b220472f4dc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.5.tar.gz"
   checksum: "md5=2dac146789f8971f0a746b220472f4dc"
 }

--- a/packages/camlimages/camlimages.4.2.6/opam
+++ b/packages/camlimages/camlimages.4.2.6/opam
@@ -38,6 +38,6 @@ also an interface with the freetype library to draw texts using
 truetype fonts."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/1e/1e16ba8381ccec229d128342e58d2f19"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-4.2.6.tar.gz"
   checksum: "md5=1e16ba8381ccec229d128342e58d2f19"
 }

--- a/packages/camlimages/camlimages.5.0.0/opam
+++ b/packages/camlimages/camlimages.5.0.0/opam
@@ -27,6 +27,6 @@ image formats with an interface for the Caml graphics library. It has
 also an interface with the freetype library to draw texts using
 truetype fonts."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/52/521b7dbafd64afcca31dd3a908a5db31"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlimages-5.0.0.tar.gz"
   checksum: "md5=521b7dbafd64afcca31dd3a908a5db31"
 }

--- a/packages/camlon/camlon.1.0.0/opam
+++ b/packages/camlon/camlon.1.0.0/opam
@@ -26,6 +26,6 @@ description: """
 CamlON is JSON in OCaml, a tree like data type structure with OCaml values'
 look and feel.  The library provides the data type and its parser and printer."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/8b/8bd9f6802d221214e1988389cc3d428a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlon-1.0.0.tar.gz"
   checksum: "md5=8bd9f6802d221214e1988389cc3d428a"
 }

--- a/packages/camlon/camlon.1.0.1/opam
+++ b/packages/camlon/camlon.1.0.1/opam
@@ -26,6 +26,6 @@ description: """
 CamlON is JSON in OCaml, a tree like data type structure with OCaml values'
 look and feel.  The library provides the data type and its parser and printer."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/e3/e3e6eb7c8b16e5cf237e21bb5a3a9cec"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlon-1.0.1.tar.gz"
   checksum: "md5=e3e6eb7c8b16e5cf237e21bb5a3a9cec"
 }

--- a/packages/camlon/camlon.1.0.2/opam
+++ b/packages/camlon/camlon.1.0.2/opam
@@ -27,6 +27,6 @@ description: """
 CamlON is JSON in OCaml, a tree like data type structure with OCaml values'
 look and feel.  The library provides the data type and its parser and printer."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0d/0d333e8aac9d4e38ea7418f6b86371b0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlon-1.0.2.tar.gz"
   checksum: "md5=0d333e8aac9d4e38ea7418f6b86371b0"
 }

--- a/packages/camlon/camlon.2.0.0/opam
+++ b/packages/camlon/camlon.2.0.0/opam
@@ -26,6 +26,6 @@ description: """
 CamlON is JSON in OCaml, a tree like data type structure with OCaml values'
 look and feel.  The library provides the data type and its parser and printer."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ef/ef9a16b4fdf64b723426fbf0f035e76f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlon-2.0.0.tar.gz"
   checksum: "md5=ef9a16b4fdf64b723426fbf0f035e76f"
 }

--- a/packages/camlon/camlon.2.0.1/opam
+++ b/packages/camlon/camlon.2.0.1/opam
@@ -16,6 +16,6 @@ description: """
 CamlON is JSON in OCaml, a tree like data type structure with OCaml values'
 look and feel.  The library provides the data type and its parser and printer."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/f3/f30339e7726877f16df691eb00c0bf93"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/camlon-2.0.1.tar.gz"
   checksum: "md5=f30339e7726877f16df691eb00c0bf93"
 }

--- a/packages/charInfo_width/charInfo_width.0.1.0/opam
+++ b/packages/charInfo_width/charInfo_width.0.1.0/opam
@@ -22,6 +22,6 @@ description: """
 This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
 
 url {
-  src: "https://opam.ocaml.org/cache/md5/b1/b1856eb22cafcaf564d2d11be5d522c0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/charInfo_width-0.1.0.tar.gz"
   checksum: "md5=b1856eb22cafcaf564d2d11be5d522c0"
 }

--- a/packages/charInfo_width/charInfo_width.1.0.0/opam
+++ b/packages/charInfo_width/charInfo_width.1.0.0/opam
@@ -22,6 +22,6 @@ description: """
 This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
 
 url {
-  src: "https://opam.ocaml.org/cache/md5/99/999d063b7beb2f082e88d22c354a2b3b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/charInfo_width-1.0.0.tar.gz"
   checksum: "md5=999d063b7beb2f082e88d22c354a2b3b"
 }

--- a/packages/cinaps/cinaps.v0.12.1/opam
+++ b/packages/cinaps/cinaps.v0.12.1/opam
@@ -21,7 +21,7 @@ OCaml code inside special comments and cinaps make sure that what
 follows is what is printed by the OCaml code.
 "
 url {
-  src: "https://opam.ocaml.org/cache/sha256/c6/c644bfc9eaaa61edf97ba791def0ed96fc3aa45ffd604c0fafe8ff62b1d12965"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cinaps-v0.12.1.tbz"
   checksum: [
     "sha256=c644bfc9eaaa61edf97ba791def0ed96fc3aa45ffd604c0fafe8ff62b1d12965"
     "sha512=b5be7a7ff6794e8d514a229dff9f758e59de7cdefa062dd1b1035124648a2d865a7da740943a79c5432bd19657c9b27cbd8a6dc0df12d1f053d8402740040741"

--- a/packages/cubicle/cubicle.1.0.1/opam
+++ b/packages/cubicle/cubicle.1.0.1/opam
@@ -23,6 +23,6 @@ install: [make "install" "MANDIR=%{man}%"]
 synopsis: "SMT based model checker for parameterized systems"
 extra-files: ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/a1/a13b45e48ba6bfa35f38ed52cb639c13"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cubicle-1.0.1.tar.gz"
   checksum: "md5=a13b45e48ba6bfa35f38ed52cb639c13"
 }

--- a/packages/cubicle/cubicle.1.0.2/opam
+++ b/packages/cubicle/cubicle.1.0.2/opam
@@ -29,6 +29,6 @@ extra-files: [
   ["cubicle.install" "md5=ba6d18615d00544948c96638b6c8d900"]
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/08/08a6f19c157037c162bb4a764f2c3747"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cubicle-1.0.2.tar.gz"
   checksum: "md5=08a6f19c157037c162bb4a764f2c3747"
 }

--- a/packages/dtoa/dtoa.0.1/opam
+++ b/packages/dtoa/dtoa.0.1/opam
@@ -22,6 +22,6 @@ A library for converting floats to strings (doubles to ascii, "d to a").
 
 This is a (partial) port of Google's double-conversion library from C++ to C."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/40/40cb786876812a7e70ab5a7cf4094829"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/dtoa-0.1.tar.gz"
   checksum: "md5=40cb786876812a7e70ab5a7cf4094829"
 }

--- a/packages/dune_watch/dune_watch.0.0.1/opam
+++ b/packages/dune_watch/dune_watch.0.0.1/opam
@@ -15,6 +15,6 @@ depends: [
 synopsis:
   "A tool to relaunch jbuilder (or dune) when a file modification is detected via fswatch."
 url {
-  src: "https://opam.ocaml.org/cache/md5/72/72d60c4431014ada08da858fe73e2efe"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/dune_watch-0.0.1.tar.gz"
   checksum: "md5=72d60c4431014ada08da858fe73e2efe"
 }

--- a/packages/dune_watch/dune_watch.0.1.0/opam
+++ b/packages/dune_watch/dune_watch.0.1.0/opam
@@ -17,6 +17,6 @@ depends: [
 synopsis:
   "A tool to relaunch jbuilder (or dune) when a file modification is detected via fswatch."
 url {
-  src: "https://opam.ocaml.org/cache/md5/ff/ff503261958572c7c0f503857bab5a16"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/dune_watch-0.1.0.tar.gz"
   checksum: "md5=ff503261958572c7c0f503857bab5a16"
 }

--- a/packages/genprint/genprint.0.3/opam
+++ b/packages/genprint/genprint.0.3/opam
@@ -26,6 +26,6 @@ depends: [
 ]
 
 url {
-  src: "https://opam.ocaml.org/cache/md5/d5/d5b58cc0aa7e1dd745d94fcc405d9d27"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/genprint-0.3a.tar.gz"
   checksum: "md5=d5b58cc0aa7e1dd745d94fcc405d9d27"
 }

--- a/packages/glMLite/glMLite.0.03.51/opam
+++ b/packages/glMLite/glMLite.0.03.51/opam
@@ -21,6 +21,6 @@ description: """
 Provide bindings for GL, Glu and Glut, GLE, FTGL, and also some
 small image loader modules for different image file formats."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/91/9189dcb5c10a86c8b6b2558e03962a04"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/glMLite-0.03.51.tgz"
   checksum: "md5=9189dcb5c10a86c8b6b2558e03962a04"
 }

--- a/packages/gles3/gles3.20160307.alpha/opam
+++ b/packages/gles3/gles3.20160307.alpha/opam
@@ -53,6 +53,6 @@ Authors
 flags: light-uninstall
 url {
   src:
-    "https://opam.ocaml.org/cache/md5/86/86b0d72e42fd3e7eed18f3ced34de66a"
+    "https://github.com/ocaml/opam-source-archives/raw/main/gles3-20160307.alpha.tar.gz"
   checksum: "md5=86b0d72e42fd3e7eed18f3ced34de66a"
 }

--- a/packages/gles3/gles3.20160505.alpha/opam
+++ b/packages/gles3/gles3.20160505.alpha/opam
@@ -53,6 +53,6 @@ Authors
 flags: light-uninstall
 url {
   src:
-    "https://opam.ocaml.org/cache/md5/f6/f69ee4f6933304ead70b09e5ae5192e9"
+    "https://github.com/ocaml/opam-source-archives/raw/main/gles3-20160505.alpha.tar.gz"
   checksum: "md5=f69ee4f6933304ead70b09e5ae5192e9"
 }

--- a/packages/glsurf/glsurf.3.3.1/opam
+++ b/packages/glsurf/glsurf.3.3.1/opam
@@ -35,6 +35,6 @@ Authors:
 	Christophe Raffalli"""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/f2/f2084bbf0cd0a31dc9c22fe4e9b8b5be"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/glsurf-3.3.1.tar.gz"
   checksum: "md5=f2084bbf0cd0a31dc9c22fe4e9b8b5be"
 }

--- a/packages/glsurf/glsurf.3.3/opam
+++ b/packages/glsurf/glsurf.3.3/opam
@@ -31,6 +31,6 @@ power of OpenGl to animate the surface, use transparency, etc ...
 Authors:
 	Christophe Raffalli"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/af/af1de416d0d51e7be611324383eaf945"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/glsurf-3.3.tar.gz"
   checksum: "md5=af1de416d0d51e7be611324383eaf945"
 }

--- a/packages/imagelib/imagelib.20160413/opam
+++ b/packages/imagelib/imagelib.20160413/opam
@@ -35,6 +35,6 @@ As imagelib only requires camlzip, it is suitable for compilation to
 javascript using js_of_ocaml (only for operations not requireing the
 convert binary)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/b2/b24402c12c50c8d891735ae3c03ceae9"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/imagelib_20160413.tar.gz"
   checksum: "md5=b24402c12c50c8d891735ae3c03ceae9"
 }

--- a/packages/imagemagick/imagemagick.0.34-1/opam
+++ b/packages/imagemagick/imagemagick.0.34-1/opam
@@ -17,6 +17,6 @@ synopsis: "Bindings for ImageMagick"
 flags: light-uninstall
 extra-files: ["fix_build.patch" "md5=ba5ad56e150b9f685363f59d2a163dea"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/d4/d4e28dce94ccefba878ad31016f05fe4"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/OCaml-ImageMagick-0.34.tgz"
   checksum: "md5=d4e28dce94ccefba878ad31016f05fe4"
 }

--- a/packages/imagemagick/imagemagick.0.34/opam
+++ b/packages/imagemagick/imagemagick.0.34/opam
@@ -14,6 +14,6 @@ install: [make "find_install"]
 synopsis: "Bindings for ImageMagick"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/d4/d4e28dce94ccefba878ad31016f05fe4"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/OCaml-ImageMagick-0.34.tgz"
   checksum: "md5=d4e28dce94ccefba878ad31016f05fe4"
 }

--- a/packages/iri/iri.0.1.0/opam
+++ b/packages/iri/iri.0.1.0/opam
@@ -29,6 +29,6 @@ This implementation does not depend on regular expression library. Is is impleme
 Sedlex, thus it will be usable in Javascript (with Js_of_ocaml)."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/d3/d345a473366c0ce29199188908d711f6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/iri-0.1.0.tar.gz"
   checksum: "md5=d345a473366c0ce29199188908d711f6"
 }

--- a/packages/iri/iri.0.2.0/opam
+++ b/packages/iri/iri.0.2.0/opam
@@ -29,6 +29,6 @@ This implementation does not depend on regular expression library. Is is impleme
 Sedlex, thus it will be usable in Javascript (with Js_of_ocaml)."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/63/633d0e7f23609ce61bdf3804380133d8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/iri-0.2.0.tar.gz"
   checksum: "md5=633d0e7f23609ce61bdf3804380133d8"
 }

--- a/packages/iri/iri.0.3.0/opam
+++ b/packages/iri/iri.0.3.0/opam
@@ -28,6 +28,6 @@ extra-files: [
   "ocaml-before.4.03.0.patch" "md5=f1d93a26710029c3b0f105221e8a51fe"
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/c7/c7473781ec408f1b37d65ded5e932319"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/iri-0.3.0.tar.gz"
   checksum: "md5=c7473781ec408f1b37d65ded5e932319"
 }

--- a/packages/iri/iri.0.4.0/opam
+++ b/packages/iri/iri.0.4.0/opam
@@ -24,6 +24,6 @@ This implementation does not depend on regular expression library. Is is impleme
 Sedlex, thus it will be usable in Javascript (with Js_of_ocaml)."""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/ec/ec34f9a8d1ee28130bed89ea486cf168"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/iri-0.4.0.tar.gz"
   checksum: "md5=ec34f9a8d1ee28130bed89ea486cf168"
 }

--- a/packages/levenshtein/levenshtein.1.0.0/opam
+++ b/packages/levenshtein/levenshtein.1.0.0/opam
@@ -34,6 +34,6 @@ It provides:
 * Functor to abstact the implementation of the array and cache.
 * Ready-to-use String and StringWithHashtbl modules are provided."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/51/513c55272e1f1809aae4f922705abe70"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/levenshtein-1.0.0.tar.gz"
   checksum: "md5=513c55272e1f1809aae4f922705abe70"
 }

--- a/packages/levenshtein/levenshtein.1.1.0/opam
+++ b/packages/levenshtein/levenshtein.1.1.0/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Levenshtein distance algorithm for general array."
 description: "Levenshtein distance algorithm for general array."
 url {
-  src: "https://opam.ocaml.org/cache/md5/b4/b45583727538cd7b1eb07b4ce3661f79"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/levenshtein-1.1.0.tar.gz"
   checksum: "md5=b45583727538cd7b1eb07b4ce3661f79"
 }

--- a/packages/levenshtein/levenshtein.1.1.1/opam
+++ b/packages/levenshtein/levenshtein.1.1.1/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Levenshtein distance algorithm for general array."
 description: "Levenshtein distance algorithm for general array."
 url {
-  src: "https://opam.ocaml.org/cache/md5/e9/e9d73b014ab154e0ef88065e2998301c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/levenshtein-1.1.1.tar.gz"
   checksum: "md5=e9d73b014ab154e0ef88065e2998301c"
 }

--- a/packages/levenshtein/levenshtein.1.1.2/opam
+++ b/packages/levenshtein/levenshtein.1.1.2/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Levenshtein distance algorithm for general array."
 description: "Levenshtein distance algorithm for general array."
 url {
-  src: "https://opam.ocaml.org/cache/md5/ac/ac0e83b3a27d1b5cb859fb0098e4730b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/levenshtein-1.1.2.tar.gz"
   checksum: "md5=ac0e83b3a27d1b5cb859fb0098e4730b"
 }

--- a/packages/meta_conv/meta_conv.0.10.0/opam
+++ b/packages/meta_conv/meta_conv.0.10.0/opam
@@ -17,6 +17,6 @@ synopsis: "Meta conv, type_conv for various tree data format"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/91/91622ea5ab55328e23c6679fe7b85c15"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-0.10.0.tar.gz"
   checksum: "md5=91622ea5ab55328e23c6679fe7b85c15"
 }

--- a/packages/meta_conv/meta_conv.0.11.0/opam
+++ b/packages/meta_conv/meta_conv.0.11.0/opam
@@ -17,6 +17,6 @@ synopsis: "Meta conv, type_conv for various tree data format"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/1a/1a7a196536cd83af381d741f543d54d1"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-0.11.0.tar.gz"
   checksum: "md5=1a7a196536cd83af381d741f543d54d1"
 }

--- a/packages/meta_conv/meta_conv.0.9.0/opam
+++ b/packages/meta_conv/meta_conv.0.9.0/opam
@@ -16,6 +16,6 @@ synopsis: "Meta conv, type_conv for various tree data format"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/da/da544ec99261b3efd4dd25f3bbdb0aa7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-0.9.0.tar.gz"
   checksum: "md5=da544ec99261b3efd4dd25f3bbdb0aa7"
 }

--- a/packages/meta_conv/meta_conv.1.0.0/opam
+++ b/packages/meta_conv/meta_conv.1.0.0/opam
@@ -17,6 +17,6 @@ synopsis: "Meta conv, type_conv for various tree data format"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/e6/e6d5cb046877c44800a01502b0dc2c3e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.0.0.tar.gz"
   checksum: "md5=e6d5cb046877c44800a01502b0dc2c3e"
 }

--- a/packages/meta_conv/meta_conv.1.1.0/opam
+++ b/packages/meta_conv/meta_conv.1.1.0/opam
@@ -16,6 +16,6 @@ synopsis: "Meta conv, type_conv for various tree data format"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/33/33e4dab87958a59e7e8551fc00cffd01"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.1.0.tar.gz"
   checksum: "md5=33e4dab87958a59e7e8551fc00cffd01"
 }

--- a/packages/meta_conv/meta_conv.1.1.1/opam
+++ b/packages/meta_conv/meta_conv.1.1.1/opam
@@ -16,6 +16,6 @@ synopsis: "Meta conv, type_conv for various tree data formats"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/10/1098a602ab9a73636ee03184a53a89f8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.1.1.tar.gz"
   checksum: "md5=1098a602ab9a73636ee03184a53a89f8"
 }

--- a/packages/meta_conv/meta_conv.1.1.2/opam
+++ b/packages/meta_conv/meta_conv.1.1.2/opam
@@ -16,6 +16,6 @@ synopsis: "Meta conv, type_conv for various tree data formats"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/b9/b907d3219df22204bc5e2885d7f7737c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.1.2.tar.gz"
   checksum: "md5=b907d3219df22204bc5e2885d7f7737c"
 }

--- a/packages/meta_conv/meta_conv.1.1.3/opam
+++ b/packages/meta_conv/meta_conv.1.1.3/opam
@@ -18,6 +18,6 @@ synopsis: "Meta conv, type_conv for various tree data formats"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/09/091be9a7f0bca7659615307b09260ffe"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.1.3.tar.gz"
   checksum: "md5=091be9a7f0bca7659615307b09260ffe"
 }

--- a/packages/meta_conv/meta_conv.1.1.4/opam
+++ b/packages/meta_conv/meta_conv.1.1.4/opam
@@ -19,6 +19,6 @@ synopsis: "Meta conv, type_conv for various tree data formats"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/41/4153d97c591f23c9c6116d3b090e2208"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.1.4.tar.gz"
   checksum: "md5=4153d97c591f23c9c6116d3b090e2208"
 }

--- a/packages/meta_conv/meta_conv.1.1.5/opam
+++ b/packages/meta_conv/meta_conv.1.1.5/opam
@@ -25,6 +25,6 @@ synopsis: "Meta conv, type_conv for various tree data formats"
 description:
   "Meta conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/32/32f2898c0e4c8b18c8efc6af3f571d72"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/meta_conv-1.1.5.tar.gz"
   checksum: "md5=32f2898c0e4c8b18c8efc6af3f571d72"
 }

--- a/packages/minimal/minimal.1.0.0/opam
+++ b/packages/minimal/minimal.1.0.0/opam
@@ -20,6 +20,6 @@ depends: [
 synopsis: "Minima.l, a minimal Lisp"
 description: "Minimalist Lisp interpreter."
 url {
-  src: "https://opam.ocaml.org/cache/md5/eb/eb390419022c23fbf3d0818478b53028"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/minimal-1.0.0.tar.gz"
   checksum: "md5=eb390419022c23fbf3d0818478b53028"
 }

--- a/packages/minimal/minimal.1.1.0/opam
+++ b/packages/minimal/minimal.1.1.0/opam
@@ -21,6 +21,6 @@ depends: [
 synopsis: "Minima.l, a minimal Lisp"
 description: "Minimalist Lisp interpreter."
 url {
-  src: "https://opam.ocaml.org/cache/md5/4f/4f7edc007c651a161b47ea410ce55583"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/minimal-1.1.0.tar.gz"
   checksum: "md5=4f7edc007c651a161b47ea410ce55583"
 }

--- a/packages/mirage-http/mirage-http.1.1.0/opam
+++ b/packages/mirage-http/mirage-http.1.1.0/opam
@@ -20,6 +20,6 @@ dev-repo: "git://github.com/mirage/mirage-http"
 install: [make "install"]
 synopsis: "MirageOS HTTP client and server driver for Unix"
 url {
-  src: "https://opam.ocaml.org/cache/md5/f8/f8ca9f9cb46592682ee571bd124783e6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-1.1.0.tar.gz"
   checksum: "md5=f8ca9f9cb46592682ee571bd124783e6"
 }

--- a/packages/mirage-http/mirage-http.2.0.0/opam
+++ b/packages/mirage-http/mirage-http.2.0.0/opam
@@ -23,6 +23,6 @@ dev-repo: "git://github.com/mirage/mirage-http"
 install: [make "install"]
 synopsis: "MirageOS HTTP client and server driver for Unix"
 url {
-  src: "https://opam.ocaml.org/cache/md5/cf/cf20706f3360eb49fe457628f3b41b8f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.0.0.tar.gz"
   checksum: "md5=cf20706f3360eb49fe457628f3b41b8f"
 }

--- a/packages/mirage-http/mirage-http.2.1.0/opam
+++ b/packages/mirage-http/mirage-http.2.1.0/opam
@@ -24,6 +24,6 @@ dev-repo: "git://github.com/mirage/mirage-http"
 install: [make "install"]
 synopsis: "MirageOS HTTP client and server driver"
 url {
-  src: "https://opam.ocaml.org/cache/md5/0e/0e1d7d00d5f87e8d2c42967fcd346317"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.1.0.tar.gz"
   checksum: "md5=0e1d7d00d5f87e8d2c42967fcd346317"
 }

--- a/packages/mirage-http/mirage-http.2.2.0/opam
+++ b/packages/mirage-http/mirage-http.2.2.0/opam
@@ -23,6 +23,6 @@ depends: [
 synopsis: "MirageOS HTTP client and server driver"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/90/901d47714cb6713a7b3a42bae9749a7c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.2.0.tar.gz"
   checksum: "md5=901d47714cb6713a7b3a42bae9749a7c"
 }

--- a/packages/mirage-http/mirage-http.2.3.0/opam
+++ b/packages/mirage-http/mirage-http.2.3.0/opam
@@ -21,6 +21,6 @@ depends: [
 synopsis: "MirageOS HTTP client and server driver"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/d1/d1968e5bc5aea254b93dc77dc8d79007"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.3.0.tar.gz"
   checksum: "md5=d1968e5bc5aea254b93dc77dc8d79007"
 }

--- a/packages/mirage-http/mirage-http.2.4.0/opam
+++ b/packages/mirage-http/mirage-http.2.4.0/opam
@@ -21,6 +21,6 @@ depends: [
 synopsis: "MirageOS HTTP client and server driver"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/45/45570b5dfb08a8c027e2da4f5edfb095"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.4.0.tar.gz"
   checksum: "md5=45570b5dfb08a8c027e2da4f5edfb095"
 }

--- a/packages/mirage-http/mirage-http.2.5.0/opam
+++ b/packages/mirage-http/mirage-http.2.5.0/opam
@@ -21,6 +21,6 @@ depends: [
 synopsis: "MirageOS HTTP client and server driver"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/d9/d9391f983182c7de9a8e9ddc1275c4cc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.5.0.tar.gz"
   checksum: "md5=d9391f983182c7de9a8e9ddc1275c4cc"
 }

--- a/packages/mirage-http/mirage-http.2.5.1/opam
+++ b/packages/mirage-http/mirage-http.2.5.1/opam
@@ -21,6 +21,6 @@ depends: [
 synopsis: "MirageOS HTTP client and server driver"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/2b/2b603bc6a49e9c5003b749942b9704ba"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.5.1.tar.gz"
   checksum: "md5=2b603bc6a49e9c5003b749942b9704ba"
 }

--- a/packages/mirage-http/mirage-http.2.5.2/opam
+++ b/packages/mirage-http/mirage-http.2.5.2/opam
@@ -21,6 +21,6 @@ depends: [
 synopsis: "MirageOS HTTP client and server driver"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/34/3419cfd4eb377c1a44f9ac94e0034586"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.5.2.tar.gz"
   checksum: "md5=3419cfd4eb377c1a44f9ac94e0034586"
 }

--- a/packages/mirage-http/mirage-http.2.5.3/opam
+++ b/packages/mirage-http/mirage-http.2.5.3/opam
@@ -21,6 +21,6 @@ depends: [
 ]
 synopsis: "MirageOS-compatible implementation of the Cohttp interfaces"
 url {
-  src: "https://opam.ocaml.org/cache/md5/3e/3e83cab7de7cca512bac4f54d485fc0a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-2.5.3.tbz"
   checksum: "md5=3e83cab7de7cca512bac4f54d485fc0a"
 }

--- a/packages/mirage-http/mirage-http.3.0.0/opam
+++ b/packages/mirage-http/mirage-http.3.0.0/opam
@@ -24,6 +24,6 @@ depends: [
 tags: "org:mirage"
 synopsis: "MirageOS HTTP client and server driver"
 url {
-  src: "https://opam.ocaml.org/cache/md5/8c/8ced7b4060c4aecd6f1dacaae42ec56b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-3.0.0.tar.gz"
   checksum: "md5=8ced7b4060c4aecd6f1dacaae42ec56b"
 }

--- a/packages/mirage-http/mirage-http.3.1.0/opam
+++ b/packages/mirage-http/mirage-http.3.1.0/opam
@@ -24,6 +24,6 @@ depends: [
 ]
 synopsis: "MirageOS-compatible implementation of the Cohttp interfaces"
 url {
-  src: "https://opam.ocaml.org/cache/md5/38/389825fad467972644ae953dab57787f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mirage-http-3.1.0.tbz"
   checksum: "md5=389825fad467972644ae953dab57787f"
 }

--- a/packages/nebula/nebula.0.2.1/opam
+++ b/packages/nebula/nebula.0.2.1/opam
@@ -25,6 +25,6 @@ synopsis: "DCPU-16 emulator"
 description:
   "Nebula is a complete DCPU-16 emulator including simulated hardware devices."
 url {
-  src: "https://opam.ocaml.org/cache/md5/50/503062e6e7fd3a2c7dc20a9b21a9ee5f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/nebula-0.2.1.tar.gz"
   checksum: "md5=503062e6e7fd3a2c7dc20a9b21a9ee5f"
 }

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
@@ -17,6 +17,6 @@ depends: [
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings to the NLOpt optimization library"
 url {
-  src: "https://opam.ocaml.org/cache/md5/a5/a5a742f058469438dd45c34356ff9665"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/nlopt-ocaml-0.4.tar.gz"
   checksum: "md5=a5a742f058469438dd45c34356ff9665"
 }

--- a/packages/ocaml-indent/ocaml-indent.1.1.0/opam
+++ b/packages/ocaml-indent/ocaml-indent.1.1.0/opam
@@ -32,6 +32,6 @@ The indentation tries to follow my style as possible. Neither the
 official one (does it exists?) or something already available
 (i.e. ocaml-mode/tuareg)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/26/267e7493f0bc4e974d9c28896560d0a5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocaml-indent-1.1.0.tar.gz"
   checksum: "md5=267e7493f0bc4e974d9c28896560d0a5"
 }

--- a/packages/ocaml-indent/ocaml-indent.1.2.1/opam
+++ b/packages/ocaml-indent/ocaml-indent.1.2.1/opam
@@ -33,6 +33,6 @@ The indentation tries to follow my style as possible. Neither the
 official one (does it exists?) or something already available
 (i.e. ocaml-mode/tuareg)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/55/551bd8b4b5c3de61baf1684c739fe315"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocaml-indent-1.2.1.tar.gz"
   checksum: "md5=551bd8b4b5c3de61baf1684c739fe315"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
@@ -24,7 +24,7 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/58/586fadd27d0a46426c59984f4236056d"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocaml-variants-4.00.1+short-types.tar.gz"
   checksum: "md5=586fadd27d0a46426c59984f4236056d"
 }
 available: !(os = "macos" & arch = "arm64")

--- a/packages/ocamldsort/ocamldsort.0.15.0/opam
+++ b/packages/ocamldsort/ocamldsort.0.15.0/opam
@@ -21,6 +21,6 @@ install: [make "install"]
 synopsis: "Sorts a set of OCaml source files according to their dependencies"
 extra-files: ["ocamldsort.install" "md5=2559d16061178a281cd65ffc5af98243"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/8b/8b7fbdc958c2322f614ef141084df56a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamldsort_0.15.0.orig.tar.gz"
   checksum: "md5=8b7fbdc958c2322f614ef141084df56a"
 }

--- a/packages/ocamlfind-lint/ocamlfind-lint.0.1.0/opam
+++ b/packages/ocamlfind-lint/ocamlfind-lint.0.1.0/opam
@@ -27,6 +27,6 @@ extra-files: [
   "ocamlfind-lint.install" "md5=b0a7863158805e2f08baa791fa4e61ef"
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/74/74b3f70eac0cabcd51b317fc73dbfc69"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlfind-lint-0.1.0.tar.gz"
   checksum: "md5=74b3f70eac0cabcd51b317fc73dbfc69"
 }

--- a/packages/ocamlspot/ocamlspot.4.00.0.2.0.1/opam
+++ b/packages/ocamlspot/ocamlspot.4.00.0.2.0.1/opam
@@ -20,6 +20,6 @@ depends: [
 ]
 extra-files: ["ocamlspot.install" "md5=f43cbca5e0836c5ff9da5bd00d816ac3"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/8a/8af4d270f71402b0b8401845c4f5be44"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.00.0.2.0.1.tar.gz"
   checksum: "md5=8af4d270f71402b0b8401845c4f5be44"
 }

--- a/packages/ocamlspot/ocamlspot.4.00.0.2.1.0/opam
+++ b/packages/ocamlspot/ocamlspot.4.00.0.2.1.0/opam
@@ -20,6 +20,6 @@ depends: [
 ]
 extra-files: ["ocamlspot.install" "md5=f43cbca5e0836c5ff9da5bd00d816ac3"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/49/49f5f4fecccf5640f40780759c996172"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.00.0.2.1.0.tar.gz"
   checksum: "md5=49f5f4fecccf5640f40780759c996172"
 }

--- a/packages/ocamlspot/ocamlspot.4.00.0.2.1.1/opam
+++ b/packages/ocamlspot/ocamlspot.4.00.0.2.1.1/opam
@@ -20,6 +20,6 @@ depends: [
 ]
 extra-files: ["ocamlspot.install" "md5=f43cbca5e0836c5ff9da5bd00d816ac3"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/ff/ff4cb87fff763fbe416e720ba8162276"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.00.0.2.1.1.tar.gz"
   checksum: "md5=ff4cb87fff763fbe416e720ba8162276"
 }

--- a/packages/ocamlspot/ocamlspot.4.00.1.2.1.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.00.1.2.1.2/opam
@@ -19,6 +19,6 @@ depends: [
   "ocaml" {= "4.00.1"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/71/715b29874098c467ab969287f43b47c7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.00.1.2.1.2.tar.gz"
   checksum: "md5=715b29874098c467ab969287f43b47c7"
 }

--- a/packages/ocamlspot/ocamlspot.4.00.1.2.1.4/opam
+++ b/packages/ocamlspot/ocamlspot.4.00.1.2.1.4/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 extra-files: ["ocamlspot.install" "md5=f43cbca5e0836c5ff9da5bd00d816ac3"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/1a/1a713a74884b694af8c86e57636740f1"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.00.1.2.1.4.tar.gz"
   checksum: "md5=1a713a74884b694af8c86e57636740f1"
 }

--- a/packages/ocamlspot/ocamlspot.4.01.0.2.2.0/opam
+++ b/packages/ocamlspot/ocamlspot.4.01.0.2.2.0/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 extra-files: ["ocamlspot.install" "md5=f43cbca5e0836c5ff9da5bd00d816ac3"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/76/7679c9daa1bb248517f0f6b74381fe11"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.01.0.2.2.0.tar.gz"
   checksum: "md5=7679c9daa1bb248517f0f6b74381fe11"
 }

--- a/packages/ocamlspot/ocamlspot.4.02.1.2.3.0/opam
+++ b/packages/ocamlspot/ocamlspot.4.02.1.2.3.0/opam
@@ -28,6 +28,6 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.03.0"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/2a/2a68af48bf52b3b0ab3bc719cd9c611c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.02.1.2.3.0.tar.gz"
   checksum: "md5=2a68af48bf52b3b0ab3bc719cd9c611c"
 }

--- a/packages/ocamlspot/ocamlspot.4.03.0.2.3.1/opam
+++ b/packages/ocamlspot/ocamlspot.4.03.0.2.3.1/opam
@@ -28,6 +28,6 @@ depends: [
   "ocaml" {= "4.03.0"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/d5/d589b51dfe4719dbe2af423d4d57c201"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.03.0.2.3.1.tar.gz"
   checksum: "md5=d589b51dfe4719dbe2af423d4d57c201"
 }

--- a/packages/ocamlspot/ocamlspot.4.04.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.04.0.2.3.2/opam
@@ -28,6 +28,6 @@ depends: [
   "ocaml" {>= "4.04.0" & < "4.05.0"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/7f/7fef29d3dc907c2e7a14ecc5d8cc7e2b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.04.0.2.3.2.tar.gz"
   checksum: "md5=7fef29d3dc907c2e7a14ecc5d8cc7e2b"
 }

--- a/packages/ocamlspot/ocamlspot.4.05.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.05.0.2.3.2/opam
@@ -28,6 +28,6 @@ depends: [
   "ocaml" {>= "4.05.0" & < "4.06.0"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/4d/4dc6d0b880ec437ce90468ad074c665d"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.05.0.2.3.2.tar.gz"
   checksum: "md5=4dc6d0b880ec437ce90468ad074c665d"
 }

--- a/packages/ocamlspot/ocamlspot.4.06.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.06.0.2.3.2/opam
@@ -28,6 +28,6 @@ depends: [
   "ocaml" {>= "4.06.0" & < "4.07.0"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/c7/c76099dac167f86a78edb13827baf83c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocamlspot-4.06.0.2.3.2.tar.gz"
   checksum: "md5=c76099dac167f86a78edb13827baf83c"
 }

--- a/packages/ocp-build/ocp-build.1.99.8-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.8-beta/opam
@@ -36,6 +36,6 @@ install: [make "install"]
 synopsis: "Project manager for OCaml"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/e4/e476608ad528dd60550cda17434c53ea"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocp-build.1.99.8-beta.tar.gz"
   checksum: "md5=e476608ad528dd60550cda17434c53ea"
 }

--- a/packages/ocp-build/ocp-build.1.99.9-beta/opam
+++ b/packages/ocp-build/ocp-build.1.99.9-beta/opam
@@ -25,6 +25,6 @@ conflicts: [ "typerex"  {< "1.99.7"} ]
 install: [make "install"]
 synopsis: "Project manager for OCaml"
 url {
-  src: "https://opam.ocaml.org/cache/md5/75/756bfe6337160693ec52119b400a12c2"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocp-build.1.99.9-beta.tar.gz"
   checksum: "md5=756bfe6337160693ec52119b400a12c2"
 }

--- a/packages/ocp-manager/ocp-manager.0.1.2/opam
+++ b/packages/ocp-manager/ocp-manager.0.1.2/opam
@@ -18,6 +18,6 @@ install: [make "install.opam"]
 synopsis: "Global Manager for OCaml versions and OPAM switches"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/65/652599889ef497ae23fff2a9304cad01"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocp-manager.0.1.2.tar.gz"
   checksum: "md5=652599889ef497ae23fff2a9304cad01"
 }

--- a/packages/ocp-manager/ocp-manager.0.1.3/opam
+++ b/packages/ocp-manager/ocp-manager.0.1.3/opam
@@ -18,6 +18,6 @@ install: [make "install.opam"]
 synopsis: "Global Manager for OCaml versions and OPAM switches"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/fc/fc77ca7a7924c9e147a5dc27cde3eed7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocp-manager.0.1.3.tar.gz"
   checksum: "md5=fc77ca7a7924c9e147a5dc27cde3eed7"
 }

--- a/packages/ocp-pack-split/ocp-pack-split.1.0.1/opam
+++ b/packages/ocp-pack-split/ocp-pack-split.1.0.1/opam
@@ -14,7 +14,7 @@ extra-files: [
   "ocp-pack-split.install" "md5=9d28fabf6e6c72182e0e89c3cdc0b70d"
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/91/9122bc296089330db082965152164ce7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ocp-pack-1.0.1.tar.gz"
   checksum: "md5=9122bc296089330db082965152164ce7"
 }
 tags: ["org:ocamlpro"]

--- a/packages/oni/oni.1.0.10/opam
+++ b/packages/oni/oni.1.0.10/opam
@@ -14,6 +14,6 @@ depends: [
 ]
 synopsis: "Oni - assorted components for low-level networking."
 url {
-  src: "https://opam.ocaml.org/cache/md5/44/44a3e40c6d1a22af1215c945b8d65110"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/oni.1.0.10.tar.xz"
   checksum: "md5=44a3e40c6d1a22af1215c945b8d65110"
 }

--- a/packages/oni/oni.1.0.11/opam
+++ b/packages/oni/oni.1.0.11/opam
@@ -14,6 +14,6 @@ depends: [
 ]
 synopsis: "Oni - assorted components for low-level networking."
 url {
-  src: "https://opam.ocaml.org/cache/md5/df/df8c0ce58e00a6e4b821a282e5e5917a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/oni-1.0.11.tar.bz2"
   checksum: "md5=df8c0ce58e00a6e4b821a282e5e5917a"
 }

--- a/packages/oni/oni.1.0.12/opam
+++ b/packages/oni/oni.1.0.12/opam
@@ -14,6 +14,6 @@ depends: [
 ]
 synopsis: "Oni - assorted components for low-level networking."
 url {
-  src: "https://opam.ocaml.org/cache/md5/c3/c3959a726383d351cbe4fc9471d336d0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/oni.1.0.12.tar.xz"
   checksum: "md5=c3959a726383d351cbe4fc9471d336d0"
 }

--- a/packages/oni/oni.1.0.9/opam
+++ b/packages/oni/oni.1.0.9/opam
@@ -14,6 +14,6 @@ depends: [
 ]
 synopsis: "Oni - assorted components for low-level networking."
 url {
-  src: "https://opam.ocaml.org/cache/md5/c5/c52fcb0353c510c064168c99354c8bc3"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/oni-1.0.9.tar.bz2"
   checksum: "md5=c52fcb0353c510c064168c99354c8bc3"
 }

--- a/packages/opamfind/opamfind.1.0.0/opam
+++ b/packages/opamfind/opamfind.1.0.0/opam
@@ -32,6 +32,6 @@ OPAMFind is a library to analyze the installed OCamlFind and OPAM packages
 and obtain the relationship between them: which OCamlFind package is installed
 by which OPAM package."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0b/0b6cc64460fe8b38a65d3a0519fba69a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/opamfind-1.0.0.tar.gz"
   checksum: "md5=0b6cc64460fe8b38a65d3a0519fba69a"
 }

--- a/packages/opamfind/opamfind.1.1.0/opam
+++ b/packages/opamfind/opamfind.1.1.0/opam
@@ -32,6 +32,6 @@ OPAMFind is a library to analyze the installed OCamlFind and OPAM packages
 and obtain the relationship between them: which OCamlFind package is installed
 by which OPAM package."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/63/63a3bd2ab66c6c1ec46e9c57cb2f9144"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/opamfind-1.1.0.tar.gz"
   checksum: "md5=63a3bd2ab66c6c1ec46e9c57cb2f9144"
 }

--- a/packages/opamfind/opamfind.1.1.1/opam
+++ b/packages/opamfind/opamfind.1.1.1/opam
@@ -32,6 +32,6 @@ OPAMFind is a library to analyze the installed OCamlFind and OPAM packages
 and obtain the relationship between them: which OCamlFind package is installed
 by which OPAM package."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/5e/5e2b83c921ef85c1c5b8b4e537b86159"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/opamfind-1.1.1.tar.gz"
   checksum: "md5=5e2b83c921ef85c1c5b8b4e537b86159"
 }

--- a/packages/opamfind/opamfind.1.1.2/opam
+++ b/packages/opamfind/opamfind.1.1.2/opam
@@ -32,6 +32,6 @@ OPAMFind is a library to analyze the installed OCamlFind and OPAM packages
 and obtain the relationship between them: which OCamlFind package is installed
 by which OPAM package."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/da/daa388e41048a7b145543f4b6fce2354"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/opamfind-1.1.2.tar.gz"
   checksum: "md5=daa388e41048a7b145543f4b6fce2354"
 }

--- a/packages/opamfind/opamfind.1.1.3/opam
+++ b/packages/opamfind/opamfind.1.1.3/opam
@@ -32,6 +32,6 @@ OPAMFind is a library to analyze the installed OCamlFind and OPAM packages
 and obtain the relationship between them: which OCamlFind package is installed
 by which OPAM package."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/6d/6d87b63cde85794f85676fa9373274b0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/opamfind-1.1.3.tar.gz"
   checksum: "md5=6d87b63cde85794f85676fa9373274b0"
 }

--- a/packages/opamfind/opamfind.1.2.0/opam
+++ b/packages/opamfind/opamfind.1.2.0/opam
@@ -32,6 +32,6 @@ OPAMFind is a library to analyze the installed OCamlFind and OPAM packages
 and obtain the relationship between them: which OCamlFind package is installed
 by which OPAM package."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/2f/2f5cc55177bd85325bb6f8a1c41f478a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/opamfind-1.2.0.tar.gz"
   checksum: "md5=2f5cc55177bd85325bb6f8a1c41f478a"
 }

--- a/packages/orakuda/orakuda.1.0.1/opam
+++ b/packages/orakuda/orakuda.1.0.1/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/29/29c082666ffc3ac604f90c61a159191f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.0.1.tar.gz"
   checksum: "md5=29c082666ffc3ac604f90c61a159191f"
 }

--- a/packages/orakuda/orakuda.1.0.2/opam
+++ b/packages/orakuda/orakuda.1.0.2/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/1f/1ff916ca572ea4eae1464a76520f282d"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.0.2.tar.gz"
   checksum: "md5=1ff916ca572ea4eae1464a76520f282d"
 }

--- a/packages/orakuda/orakuda.1.1.0/opam
+++ b/packages/orakuda/orakuda.1.1.0/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/60/6060a174084fac7a82deb6c850231bb8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.1.0.tar.gz"
   checksum: "md5=6060a174084fac7a82deb6c850231bb8"
 }

--- a/packages/orakuda/orakuda.1.1.1/opam
+++ b/packages/orakuda/orakuda.1.1.1/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/f2/f2fbd69a87749cc23b9d1d8220b237a4"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.1.1.tar.gz"
   checksum: "md5=f2fbd69a87749cc23b9d1d8220b237a4"
 }

--- a/packages/orakuda/orakuda.1.2.0/opam
+++ b/packages/orakuda/orakuda.1.2.0/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/f7/f730f9a2bb84b1bfd1be11f8091effc5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.2.0.tar.gz"
   checksum: "md5=f730f9a2bb84b1bfd1be11f8091effc5"
 }

--- a/packages/orakuda/orakuda.1.2.1/opam
+++ b/packages/orakuda/orakuda.1.2.1/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/e4/e46091a25682046c619e6f3cff881a9e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.2.1.tar.gz"
   checksum: "md5=e46091a25682046c619e6f3cff881a9e"
 }

--- a/packages/orakuda/orakuda.1.2.2/opam
+++ b/packages/orakuda/orakuda.1.2.2/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Sub-shell call by back-quotes $`...` or <:qx<...>>
 * Easy hashtbl access tbl${key}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ab/ab77dc713b9fc12ebdc1628e987f1582"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-1.2.2.tar.gz"
   checksum: "md5=ab77dc713b9fc12ebdc1628e987f1582"
 }

--- a/packages/orakuda/orakuda.2.0.0/opam
+++ b/packages/orakuda/orakuda.2.0.0/opam
@@ -32,6 +32,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/91/91f7a4f3bb2ee3bff60307a1b5f894bc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/orakuda-2.0.0.tar.gz"
   checksum: "md5=91f7a4f3bb2ee3bff60307a1b5f894bc"
 }

--- a/packages/pa_monad_custom/pa_monad_custom.v6.0.0/opam
+++ b/packages/pa_monad_custom/pa_monad_custom.v6.0.0/opam
@@ -10,6 +10,6 @@ install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Syntactic Sugar for Monads"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/26/26d988060d5997c6164cb7f209f073ee"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pa_monad_custom-6.0.0.tar.gz"
   checksum: "md5=26d988060d5997c6164cb7f209f073ee"
 }

--- a/packages/pa_ovisitor/pa_ovisitor.1.0.0/opam
+++ b/packages/pa_ovisitor/pa_ovisitor.1.0.0/opam
@@ -17,6 +17,6 @@ synopsis:
 description:
   "CamlP4 type_conv module to auto-generate visitor, folder, mapper from type definitions."
 url {
-  src: "https://opam.ocaml.org/cache/md5/8b/8b780264a3fcc0eaa435393c8c2d1543"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pa_ovisitor-1.0.0.tar.gz"
   checksum: "md5=8b780264a3fcc0eaa435393c8c2d1543"
 }

--- a/packages/patoline/patoline.0.1/opam
+++ b/packages/patoline/patoline.0.1/opam
@@ -29,6 +29,6 @@ install: [make "install"]
 synopsis: "A new typesetting system, programmable in ocaml."
 dev-repo: "git+https://github.com/patoline/patoline.git"
 url {
-  src: "https://opam.ocaml.org/cache/md5/2f/2f7fe33ef6dff305e9a2407696c7a799"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/patoline-0.1.tar.gz"
   checksum: "md5=2f7fe33ef6dff305e9a2407696c7a799"
 }

--- a/packages/planck/planck.1.0.1/opam
+++ b/packages/planck/planck.1.0.1/opam
@@ -29,6 +29,6 @@ Parser LANguage Combinator Kit A LL(n) parser monadic combinator
 library in OCaml. It includes a big example of lexer+parser for OCaml
 syntax."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/e9/e9d371a0d0e5657198d853837ec9b66c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/planck-1.0.1.tar.gz"
   checksum: "md5=e9d371a0d0e5657198d853837ec9b66c"
 }

--- a/packages/planck/planck.2.0.1/opam
+++ b/packages/planck/planck.2.0.1/opam
@@ -30,6 +30,6 @@ Parser LANguage Combinator Kit A LL(n) parser monadic combinator
 library in OCaml. It includes a big example of lexer+parser for OCaml
 syntax."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/a1/a19d9d44d491de4bc98e51fc57e07d74"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/planck-2.0.1.tar.gz"
   checksum: "md5=a19d9d44d491de4bc98e51fc57e07d74"
 }

--- a/packages/planck/planck.2.1.0/opam
+++ b/packages/planck/planck.2.1.0/opam
@@ -30,6 +30,6 @@ Parser LANguage Combinator Kit A LL(n) parser monadic combinator
 library in OCaml. It includes a big example of lexer+parser for OCaml
 syntax."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/38/38cf144fc2c150ff621be397ce65550b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/planck-2.1.0.tar.gz"
   checksum: "md5=38cf144fc2c150ff621be397ce65550b"
 }

--- a/packages/planck/planck.2.1.1/opam
+++ b/packages/planck/planck.2.1.1/opam
@@ -31,6 +31,6 @@ Parser LANguage Combinator Kit A LL(n) parser monadic combinator
 library in OCaml. It includes a big example of lexer+parser for OCaml
 syntax."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/08/0863e39c85d0d12211ff0fed44906017"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/planck-2.1.1.tar.gz"
   checksum: "md5=0863e39c85d0d12211ff0fed44906017"
 }

--- a/packages/planck/planck.2.2.0/opam
+++ b/packages/planck/planck.2.2.0/opam
@@ -37,6 +37,6 @@ library in OCaml. It includes a big example of lexer+parser for OCaml
 syntax."""
 extra-files: ["build_fix.patch" "md5=b1703193e57d813d08167568e5a879d7"]
 url {
-  src: "https://opam.ocaml.org/cache/md5/e3/e31529014eb8d5134b8ad3ebdad197bc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/planck-2.2.0.tar.gz"
   checksum: "md5=e31529014eb8d5134b8ad3ebdad197bc"
 }

--- a/packages/ppx_curried_constr/ppx_curried_constr.1.0.0/opam
+++ b/packages/ppx_curried_constr/ppx_curried_constr.1.0.0/opam
@@ -112,6 +112,6 @@ Do you use REPL?  Personally, I use it only as a calculator.
 Cons constructor `(::)` is specially handled in OCaml
 and it is outside of the support of `ppx_curried_constr`."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/53/5360d9f6c68056c66a46ccf9c680d4e1"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_curried_constr-1.0.0.tar.gz"
   checksum: "md5=5360d9f6c68056c66a46ccf9c680d4e1"
 }

--- a/packages/ppx_dotbracket/ppx_dotbracket.1.0.0/opam
+++ b/packages/ppx_dotbracket/ppx_dotbracket.1.0.0/opam
@@ -25,6 +25,6 @@ depends: [
 synopsis:
   "ppx extension for rebinding dot-bracket expressions such as a.[x], a.(x), a.{x}"
 url {
-  src: "https://opam.ocaml.org/cache/md5/bf/bf72213cae0a9a140fa2831e9c390544"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_dotbracket-1.0.0.tar.gz"
   checksum: "md5=bf72213cae0a9a140fa2831e9c390544"
 }

--- a/packages/ppx_implicits/ppx_implicits.0.0.1/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.0.1/opam
@@ -31,6 +31,6 @@ ppx_implicits  is a PPX syntax extension for
 
 Note: ppx_implicits works only with `ocamlc` and `ocamlopt`. It does not work with REPL (`ocaml`)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/13/1394f9d8e528f12b403319f23deca660"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_implicits-0.0.1.tar.gz"
   checksum: "md5=1394f9d8e528f12b403319f23deca660"
 }

--- a/packages/ppx_implicits/ppx_implicits.0.1.0/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.1.0/opam
@@ -38,6 +38,6 @@ ppx_implicits  is a PPX syntax extension for
 
 Note: ppx_implicits works only with `ocamlc` and `ocamlopt`. It does not work with REPL (`ocaml`)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/20/20387c4b55a60b8574ecc56703674f00"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_implicits-0.1.0.tar.gz"
   checksum: "md5=20387c4b55a60b8574ecc56703674f00"
 }

--- a/packages/ppx_implicits/ppx_implicits.0.2.0/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.2.0/opam
@@ -44,6 +44,6 @@ ppx_implicits  is a PPX syntax extension for
 
 Note: ppx_implicits works only with `ocamlc` and `ocamlopt`. It does not work with REPL (`ocaml`)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d9/d9ee745c9a09cb5a6c867ada3710cef4"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_implicits-0.2.0.tar.gz"
   checksum: "md5=d9ee745c9a09cb5a6c867ada3710cef4"
 }

--- a/packages/ppx_implicits/ppx_implicits.0.3.0/opam
+++ b/packages/ppx_implicits/ppx_implicits.0.3.0/opam
@@ -42,6 +42,6 @@ ppx_implicits  is a PPX syntax extension for
 
 Note: ppx_implicits works only with `ocamlc` and `ocamlopt`. It does not work with REPL (`ocaml`)."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/1d/1d76385c74289fea9af8ee205b10e317"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_implicits-0.3.0.tar.gz"
   checksum: "md5=1d76385c74289fea9af8ee205b10e317"
 }

--- a/packages/ppx_integer/ppx_integer.0.1.0/opam
+++ b/packages/ppx_integer/ppx_integer.0.1.0/opam
@@ -21,6 +21,6 @@ ppx_integer
 ppx_integer is a PPX syntax extension to write integer suffix with
 non standard suffix characters of `[g-zG-Z]`."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/4d/4d851c089fc25dcef71a4c9ea16d55b8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_integer-0.1.0.tar.gz"
   checksum: "md5=4d851c089fc25dcef71a4c9ea16d55b8"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.0.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.0.0/opam
@@ -21,6 +21,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/53/534cde50c25710e145280f1e77ee3acb"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.0.0.tar.gz"
   checksum: "md5=534cde50c25710e145280f1e77ee3acb"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.0.1/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.0.1/opam
@@ -21,6 +21,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/0c/0cb2337d7b6c8967f1caa294645caf94"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.0.1.tar.gz"
   checksum: "md5=0cb2337d7b6c8967f1caa294645caf94"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.0.2/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.0.2/opam
@@ -32,6 +32,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/f7/f7aa888fca3ec2b98aff1dfdc3d3c87a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.0.2.tar.gz"
   checksum: "md5=f7aa888fca3ec2b98aff1dfdc3d3c87a"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.1.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.1.0/opam
@@ -34,6 +34,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/15/15ea1cc1e93bf3f465196c5c89c2686f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.1.0.tar.gz"
   checksum: "md5=15ea1cc1e93bf3f465196c5c89c2686f"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.2.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.2.0/opam
@@ -34,6 +34,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/2e/2ea868f984364525c247193fc9cdb56e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.2.0.tar.gz"
   checksum: "md5=2ea868f984364525c247193fc9cdb56e"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.3.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.3.0/opam
@@ -35,6 +35,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/fa/fa6c852eec4959ef687f6f174d1ec9c7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.3.0.tar.gz"
   checksum: "md5=fa6c852eec4959ef687f6f174d1ec9c7"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.4.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.4.0/opam
@@ -35,6 +35,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/ed/ed5f3a1094ea846869de634ffb905ec8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.4.0.tar.gz"
   checksum: "md5=ed5f3a1094ea846869de634ffb905ec8"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.4.1/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.4.1/opam
@@ -35,6 +35,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/36/3691b020bdbcda135c8c138ada2d9c42"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.4.1.tar.gz"
   checksum: "md5=3691b020bdbcda135c8c138ada2d9c42"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.5.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.5.0/opam
@@ -29,6 +29,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/6f/6fc5428ec4d8d9a12128f9a3f0d254dc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.5.0.tar.gz"
   checksum: "md5=6fc5428ec4d8d9a12128f9a3f0d254dc"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.5.1/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.5.1/opam
@@ -35,6 +35,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/e2/e238e811764cc10d89eed13ea3381dcd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.5.1.tar.gz"
   checksum: "md5=e238e811764cc10d89eed13ea3381dcd"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.6.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.6.0/opam
@@ -37,6 +37,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/d7/d714e4f7b2e44edbc8648da4efe6b046"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.6.0.tar.gz"
   checksum: "md5=d714e4f7b2e44edbc8648da4efe6b046"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.7.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.7.0/opam
@@ -37,6 +37,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/9e/9ea8ae343b201430aee9a3184f856971"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.7.0.tar.gz"
   checksum: "md5=9ea8ae343b201430aee9a3184f856971"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.2.8.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.2.8.0/opam
@@ -37,6 +37,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/54/542c5e397f705b2fee7b9e746aa79f2d"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-2.8.0.tar.gz"
   checksum: "md5=542c5e397f705b2fee7b9e746aa79f2d"
 }

--- a/packages/ppx_meta_conv/ppx_meta_conv.3.0.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.3.0.0/opam
@@ -37,6 +37,6 @@ synopsis: "ppx_meta_conv, ppx based type_conv for various tree data formats."
 description:
   "ppx_meta_conv provides an easier way to auto-generate decoder and encoder between OCaml data types and various tree form data such as JSON, XML, Sexp, etc."
 url {
-  src: "https://opam.ocaml.org/cache/md5/d4/d4d0490dedac20d7299354d2c963ab57"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_meta_conv-3.0.0.tar.gz"
   checksum: "md5=d4d0490dedac20d7299354d2c963ab57"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.0/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.0/opam
@@ -26,6 +26,6 @@ ppx_monadic follows the tradition of pa_monad, a CamlP4 syntax extension
 for `do` notation. Basically code with pa_monad should work with ppx_monadic
 only by replacing `perform` by `do_;`. (I find `perform` is bit too long to type.)"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/4a/4ab1137697d8ed02ff42e9e00c5dc619"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.0.tar.gz"
   checksum: "md5=4ab1137697d8ed02ff42e9e00c5dc619"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.1/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.1/opam
@@ -26,6 +26,6 @@ ppx_monadic follows the tradition of pa_monad, a CamlP4 syntax extension
 for `do` notation. Basically code with pa_monad should work with ppx_monadic
 only by replacing `perform` by `do_;`. (I find `perform` is bit too long to type.)"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ea/eab0e620d00d5b5c15c750fa443c273c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.1.tar.gz"
   checksum: "md5=eab0e620d00d5b5c15c750fa443c273c"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.2/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.2/opam
@@ -28,6 +28,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/69/6972c5eb08d02e96357f9bf102ef1f0a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.2.tar.gz"
   checksum: "md5=6972c5eb08d02e96357f9bf102ef1f0a"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.3/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.3/opam
@@ -32,6 +32,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/c9/c9188bf1b22c5f828a18f5ab469c4d12"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.3.tar.gz"
   checksum: "md5=c9188bf1b22c5f828a18f5ab469c4d12"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.4/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.4/opam
@@ -36,6 +36,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/da/da8892d01ceb05ddd0be94b377603612"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.4.tar.gz"
   checksum: "md5=da8892d01ceb05ddd0be94b377603612"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.5/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.5/opam
@@ -35,6 +35,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/25/25fbbc720d3195adafa2eb52eaac3d85"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.5.tar.gz"
   checksum: "md5=25fbbc720d3195adafa2eb52eaac3d85"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.0.6/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.0.6/opam
@@ -35,6 +35,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/5e/5e500ac86308888ed93487c41f3431c3"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.0.6.tar.gz"
   checksum: "md5=5e500ac86308888ed93487c41f3431c3"
 }

--- a/packages/ppx_monadic/ppx_monadic.1.1.0/opam
+++ b/packages/ppx_monadic/ppx_monadic.1.1.0/opam
@@ -35,6 +35,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/6f/6f67c80ba1b4d14412910538b3dec8dd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-1.1.0.tar.gz"
   checksum: "md5=6f67c80ba1b4d14412910538b3dec8dd"
 }

--- a/packages/ppx_monadic/ppx_monadic.2.2.2/opam
+++ b/packages/ppx_monadic/ppx_monadic.2.2.2/opam
@@ -35,6 +35,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/31/31c22d8b1fe87f5aacd7a7d91f977bb6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-2.2.2.tar.gz"
   checksum: "md5=31c22d8b1fe87f5aacd7a7d91f977bb6"
 }

--- a/packages/ppx_monadic/ppx_monadic.2.3.0/opam
+++ b/packages/ppx_monadic/ppx_monadic.2.3.0/opam
@@ -25,6 +25,6 @@ The sugar is supported inside the following constructs:
 * `when` clause for pattern guards
 * `[%comp e || ..]` for list (and other monadic) comprehensions"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ac/acabe9d688bd3b9f80d7120699ee0a1f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_monadic-2.3.0.tar.gz"
   checksum: "md5=acabe9d688bd3b9f80d7120699ee0a1f"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.2.0.1/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.2.0.1/opam
@@ -32,6 +32,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d5/d54c7a13de164721576ab114c597e5cd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-2.0.1.tar.gz"
   checksum: "md5=d54c7a13de164721576ab114c597e5cd"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.0/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/2b/2b215f64380b864a0a2eb40f06984192"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.0.0.tar.gz"
   checksum: "md5=2b215f64380b864a0a2eb40f06984192"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.1/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.1/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d6/d65ca1ef61d8231a627b73f05788b912"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.0.1.tar.gz"
   checksum: "md5=d65ca1ef61d8231a627b73f05788b912"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.2/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.2/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/9c/9ce5afb6d105be1d86024ca176ed0bd6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.0.2.tar.gz"
   checksum: "md5=9ce5afb6d105be1d86024ca176ed0bd6"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.0.3/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.0.3/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0a/0ad5ef928e834bf700e78e981fe09a1b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.0.3.tar.gz"
   checksum: "md5=0ad5ef928e834bf700e78e981fe09a1b"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.1.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.1.0/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/e2/e23701dcc37c83987b96d3527fed4dd0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.1.0.tar.gz"
   checksum: "md5=e23701dcc37c83987b96d3527fed4dd0"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.1.1/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.1.1/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/64/649997864eee9d35986ad60b31d168c7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.1.1.tar.gz"
   checksum: "md5=649997864eee9d35986ad60b31d168c7"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.2.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.2.0/opam
@@ -34,6 +34,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/fd/fd893cb0ea82507a5e44271a9603085f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.2.0.tar.gz"
   checksum: "md5=fd893cb0ea82507a5e44271a9603085f"
 }

--- a/packages/ppx_orakuda/ppx_orakuda.3.3.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.3.0/opam
@@ -24,6 +24,6 @@ Perl (or other scripting language). It provides syntax like:
 * Variable and expression references in string {qq|...|qq}
 * Sub-shell call by back-quotes {qx|...|qx}"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/67/67878f8d12afedeb1d692ad3c6d71c08"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_orakuda-3.3.0.tar.gz"
   checksum: "md5=67878f8d12afedeb1d692ad3c6d71c08"
 }

--- a/packages/ppx_overload/ppx_overload.1.0.0/opam
+++ b/packages/ppx_overload/ppx_overload.1.0.0/opam
@@ -58,6 +58,6 @@ Limitation
 
 ppx_overload does not work with toplevel."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/3c/3c8074cb48bc0bc5bccadb46654355c5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_overload-1.0.0.tar.gz"
   checksum: "md5=3c8074cb48bc0bc5bccadb46654355c5"
 }

--- a/packages/ppx_overload/ppx_overload.1.0.1/opam
+++ b/packages/ppx_overload/ppx_overload.1.0.1/opam
@@ -59,6 +59,6 @@ Limitation
 
 ppx_overload does not work with toplevel."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ae/ae9d28330b4c7b4e0feec2edf814a8a7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_overload-1.0.1.tar.gz"
   checksum: "md5=ae9d28330b4c7b4e0feec2edf814a8a7"
 }

--- a/packages/ppx_pattern_guard/ppx_pattern_guard.1.0.0/opam
+++ b/packages/ppx_pattern_guard/ppx_pattern_guard.1.0.0/opam
@@ -47,6 +47,6 @@ match e with
 | (x, y) when [%guard let w = x + y;; w = 5] -> prerr_endline "3"
 ```"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/17/176b8c2d67669c436a77531815282b6e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_pattern_guard-1.0.0.tar.gz"
   checksum: "md5=176b8c2d67669c436a77531815282b6e"
 }

--- a/packages/ppx_pattern_guard/ppx_pattern_guard.1.0.1/opam
+++ b/packages/ppx_pattern_guard/ppx_pattern_guard.1.0.1/opam
@@ -47,6 +47,6 @@ match e with
 | (x, y) when [%guard let w = x + y;; w = 5] -> prerr_endline "3"
 ```"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/6e/6e2902dfa2fe8d0e7ccaebba9ce867b6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_pattern_guard-1.0.1.tar.gz"
   checksum: "md5=6e2902dfa2fe8d0e7ccaebba9ce867b6"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.0.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.0.0/opam
@@ -35,6 +35,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/14/143ddde1e09f64d4514070191d7d3bf6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.0.0.tar.gz"
   checksum: "md5=143ddde1e09f64d4514070191d7d3bf6"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.0.1/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.0.1/opam
@@ -91,6 +91,6 @@ Todo
 * let [%poly_record] = true in ... or something equivalent
 * Patterns: `{ x = p }`. This is diffcult and probably requires ppx_pattern_guard"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/14/14347831b78638f6e36aba0b6d4dc276"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.0.1.tar.gz"
   checksum: "md5=14347831b78638f6e36aba0b6d4dc276"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.0/opam
@@ -41,6 +41,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/2a/2ac8140bc737e49be892f9009e191944"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.1.0.tar.gz"
   checksum: "md5=2ac8140bc737e49be892f9009e191944"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.1/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.1/opam
@@ -42,6 +42,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/c7/c77c69e8e501cd539eab00cbd8b2d355"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.1.1.tar.gz"
   checksum: "md5=c77c69e8e501cd539eab00cbd8b2d355"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.2/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.2/opam
@@ -42,6 +42,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/6a/6a9a807939c1941d602bb56ae1b1526c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.1.2.tar.gz"
   checksum: "md5=6a9a807939c1941d602bb56ae1b1526c"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.1.3/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.1.3/opam
@@ -42,6 +42,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/55/55d77b34dac40c566875d5e220e04a74"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.1.3.tar.gz"
   checksum: "md5=55d77b34dac40c566875d5e220e04a74"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.2.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.2.0/opam
@@ -42,6 +42,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/4f/4fc67e8d9c0c362d0b4546f1502bf290"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.2.0.tar.gz"
   checksum: "md5=4fc67e8d9c0c362d0b4546f1502bf290"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.2.1/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.2.1/opam
@@ -42,6 +42,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/9a/9a5b0c232de9ce77da23089054f83633"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.2.1.tar.gz"
   checksum: "md5=9a5b0c232de9ce77da23089054f83633"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.2.2/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.2.2/opam
@@ -42,6 +42,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/81/8122c8398d94b4e72e5fb99f7b9a97c8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.2.2.tar.gz"
   checksum: "md5=8122c8398d94b4e72e5fb99f7b9a97c8"
 }

--- a/packages/ppx_poly_record/ppx_poly_record.1.3.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.3.0/opam
@@ -32,6 +32,6 @@ Implementation of `_ PPx_poly_record.Poly_record.t` is not by OCaml objects:
 it has no method table inside therefore safely serializable between different
 programs if its fields have no functional value."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/3d/3dff075d8caf67d771efa6afa8391a26"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_poly_record-1.3.0.tar.gz"
   checksum: "md5=3dff075d8caf67d771efa6afa8391a26"
 }

--- a/packages/ppx_sexp/ppx_sexp.0.3.0/opam
+++ b/packages/ppx_sexp/ppx_sexp.0.3.0/opam
@@ -44,6 +44,6 @@ If you are embedding atoms, there is a streamlined syntax:
 
 Unquote-splicing is also supported."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/af/afbfb6e6c9eca9032234464703b83588"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_sexp-0.3.0.tar.gz"
   checksum: "md5=afbfb6e6c9eca9032234464703b83588"
 }

--- a/packages/ppx_test/ppx_test.0.0.1/opam
+++ b/packages/ppx_test/ppx_test.0.0.1/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/27/27395baf72ee855c2ff23cf2be686f9b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-0.0.1.tar.gz"
   checksum: "md5=27395baf72ee855c2ff23cf2be686f9b"
 }

--- a/packages/ppx_test/ppx_test.1.0.1/opam
+++ b/packages/ppx_test/ppx_test.1.0.1/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d9/d92c407be0625e4aaa4a193a5dd0e388"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.0.1.tar.gz"
   checksum: "md5=d92c407be0625e4aaa4a193a5dd0e388"
 }

--- a/packages/ppx_test/ppx_test.1.1.0/opam
+++ b/packages/ppx_test/ppx_test.1.1.0/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/42/42daac2991bfa5ed88547643c3a3bb30"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.1.0.tar.gz"
   checksum: "md5=42daac2991bfa5ed88547643c3a3bb30"
 }

--- a/packages/ppx_test/ppx_test.1.2.0/opam
+++ b/packages/ppx_test/ppx_test.1.2.0/opam
@@ -30,6 +30,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/e4/e4ae09ecdd365b43e90d06339b0dad80"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.2.0.tar.gz"
   checksum: "md5=e4ae09ecdd365b43e90d06339b0dad80"
 }

--- a/packages/ppx_test/ppx_test.1.2.1/opam
+++ b/packages/ppx_test/ppx_test.1.2.1/opam
@@ -30,6 +30,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/35/359a33d7488bed0211372b0c6a292eb7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.2.1.tar.gz"
   checksum: "md5=359a33d7488bed0211372b0c6a292eb7"
 }

--- a/packages/ppx_test/ppx_test.1.3.0/opam
+++ b/packages/ppx_test/ppx_test.1.3.0/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/7a/7aef9bcf3c3a14cc105af272f852f191"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.3.0.tar.gz"
   checksum: "md5=7aef9bcf3c3a14cc105af272f852f191"
 }

--- a/packages/ppx_test/ppx_test.1.3.1/opam
+++ b/packages/ppx_test/ppx_test.1.3.1/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ff/ffdf9b6f108aeea2a407a78f175b1ef4"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.3.1.tar.gz"
   checksum: "md5=ffdf9b6f108aeea2a407a78f175b1ef4"
 }

--- a/packages/ppx_test/ppx_test.1.4.0/opam
+++ b/packages/ppx_test/ppx_test.1.4.0/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/dd/dda3fcc1748c5b0cf5bdbd5d407d36a2"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.4.0.tar.gz"
   checksum: "md5=dda3fcc1748c5b0cf5bdbd5d407d36a2"
 }

--- a/packages/ppx_test/ppx_test.1.4.1/opam
+++ b/packages/ppx_test/ppx_test.1.4.1/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/a2/a2058cc11704aee241bb9537620a4bb2"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.4.1.tar.gz"
   checksum: "md5=a2058cc11704aee241bb9537620a4bb2"
 }

--- a/packages/ppx_test/ppx_test.1.4.2/opam
+++ b/packages/ppx_test/ppx_test.1.4.2/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/e9/e91cbb5626d292ca4431154fa54571b0"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.4.2.tar.gz"
   checksum: "md5=e91cbb5626d292ca4431154fa54571b0"
 }

--- a/packages/ppx_test/ppx_test.1.5.0/opam
+++ b/packages/ppx_test/ppx_test.1.5.0/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/8c/8c852e5a3c5201783150730833fd7d58"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.5.0.tar.gz"
   checksum: "md5=8c852e5a3c5201783150730833fd7d58"
 }

--- a/packages/ppx_test/ppx_test.1.5.2/opam
+++ b/packages/ppx_test/ppx_test.1.5.2/opam
@@ -31,6 +31,6 @@ ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
 * let %TEST name = e, a replacement of TEST name = e
 * let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
 url {
-  src: "https://opam.ocaml.org/cache/md5/b0/b0c735a9508f3b66d5c842d6b12b34d9"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppx_test-1.5.2.tar.gz"
   checksum: "md5=b0c735a9508f3b66d5c842d6b12b34d9"
 }

--- a/packages/ppxx/ppxx.1.0.0/opam
+++ b/packages/ppxx/ppxx.1.0.0/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/84/84c6a889457dcfe20f8dbac5be9d52e7"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.0.0.tar.gz"
   checksum: "md5=84c6a889457dcfe20f8dbac5be9d52e7"
 }

--- a/packages/ppxx/ppxx.1.1.0/opam
+++ b/packages/ppxx/ppxx.1.1.0/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d6/d61d5d2784d9b1b7932105e1f556be44"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.1.0.tar.gz"
   checksum: "md5=d61d5d2784d9b1b7932105e1f556be44"
 }

--- a/packages/ppxx/ppxx.1.2.0/opam
+++ b/packages/ppxx/ppxx.1.2.0/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/82/82a755f9923514f529b5ed33aee76369"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.2.0.tar.gz"
   checksum: "md5=82a755f9923514f529b5ed33aee76369"
 }

--- a/packages/ppxx/ppxx.1.2.1/opam
+++ b/packages/ppxx/ppxx.1.2.1/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/20/200af7ddfd8100160eed312bd9c4dc8e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.2.1.tar.gz"
   checksum: "md5=200af7ddfd8100160eed312bd9c4dc8e"
 }

--- a/packages/ppxx/ppxx.1.3.0/opam
+++ b/packages/ppxx/ppxx.1.3.0/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/93/938fa0db49e6e0ff7d7b11b9ecd4fb01"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.3.0.tar.gz"
   checksum: "md5=938fa0db49e6e0ff7d7b11b9ecd4fb01"
 }

--- a/packages/ppxx/ppxx.1.3.1/opam
+++ b/packages/ppxx/ppxx.1.3.1/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/bd/bd8ee112707425bb4be5bda7896c1d55"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.3.1.tar.gz"
   checksum: "md5=bd8ee112707425bb4be5bda7896c1d55"
 }

--- a/packages/ppxx/ppxx.1.3.2/opam
+++ b/packages/ppxx/ppxx.1.3.2/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/04/042e3b6a40e69ca037a638dfef8d9b69"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.3.2.tar.gz"
   checksum: "md5=042e3b6a40e69ca037a638dfef8d9b69"
 }

--- a/packages/ppxx/ppxx.1.4.0/opam
+++ b/packages/ppxx/ppxx.1.4.0/opam
@@ -27,6 +27,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/13/1308eededf2811917cd5e92845f809d5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-1.4.0.tar.gz"
   checksum: "md5=1308eededf2811917cd5e92845f809d5"
 }

--- a/packages/ppxx/ppxx.2.0.0/opam
+++ b/packages/ppxx/ppxx.2.0.0/opam
@@ -29,6 +29,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/27/27f76a103e6562e6932d99db4c5ce8bb"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-2.0.0.tar.gz"
   checksum: "md5=27f76a103e6562e6932d99db4c5ce8bb"
 }

--- a/packages/ppxx/ppxx.2.1.0/opam
+++ b/packages/ppxx/ppxx.2.1.0/opam
@@ -30,6 +30,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/76/766940542728a3d38c3a58be73bdad54"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-2.1.0.tar.gz"
   checksum: "md5=766940542728a3d38c3a58be73bdad54"
 }

--- a/packages/ppxx/ppxx.2.2.0/opam
+++ b/packages/ppxx/ppxx.2.2.0/opam
@@ -30,6 +30,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/3f/3fcfb2a84345f22c70838005a078219c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-2.2.0.tar.gz"
   checksum: "md5=3fcfb2a84345f22c70838005a078219c"
 }

--- a/packages/ppxx/ppxx.2.3.0/opam
+++ b/packages/ppxx/ppxx.2.3.0/opam
@@ -29,6 +29,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/34/34ce9212ce93a1341675966065c84c15"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-2.3.0.tar.gz"
   checksum: "md5=34ce9212ce93a1341675966065c84c15"
 }

--- a/packages/ppxx/ppxx.2.3.1/opam
+++ b/packages/ppxx/ppxx.2.3.1/opam
@@ -20,6 +20,6 @@ description: """
 
 PPXX contains several utility functions to make PPX preprocessors easier."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/bd/bdbaade4cf0c5b4bd0bd1a8c4d917677"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ppxx-2.3.1.tar.gz"
   checksum: "md5=bdbaade4cf0c5b4bd0bd1a8c4d917677"
 }

--- a/packages/psyche/psyche.0.0.1/opam
+++ b/packages/psyche/psyche.0.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "base" {< "v0.15"}
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/43/43785b1a9d362576fab512dd842653dd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/psyche-0.0.1.tar.gz"
   checksum: [
     "md5=43785b1a9d362576fab512dd842653dd"
     "sha512=280311728f70f343ad2ab56d1e1834676391f231038651971e866146638e5b59425ae07132475e7bcf095691c89be1ec946e66c413c68c4f3c0b81aafda5a2f7"

--- a/packages/qcheck/qcheck.0.2/opam
+++ b/packages/qcheck/qcheck.0.2/opam
@@ -29,6 +29,6 @@ randomly generated instances of the type. Also contains Gabriel Scherer's
 random value generator library, https://github.com/gasche/random-generator"""
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/20/20cd905282925a476d0016f5b4578b5b"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/qcheck-0.2.tar.gz"
   checksum: "md5=20cd905282925a476d0016f5b4578b5b"
 }

--- a/packages/r2pipe/r2pipe.0.0.1/opam
+++ b/packages/r2pipe/r2pipe.0.0.1/opam
@@ -18,6 +18,6 @@ messages: ["DEPRECATED. r2pipe is outdated, you should consider using radare2 in
 post-messages: ["DEPRECATED. r2pipe is outdated, you should consider using radare2 instead"]
 synopsis: "Deprecated: use radare2 instead"
 url {
-  src: "https://opam.ocaml.org/cache/md5/3c/3c9ccfdf81a10d3e865b50bf5e9cf97a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/r2pipe-0.0.2.zip"
   checksum: "md5=3c9ccfdf81a10d3e865b50bf5e9cf97a"
 }

--- a/packages/rdbg/rdbg.1.65/opam
+++ b/packages/rdbg/rdbg.1.65/opam
@@ -39,6 +39,6 @@ extra-files: [
   ["_oasis_remove_.ml" "md5=6100ca146fa97d2196eb49a2631d0796"]
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/bc/bc242ad397aaaab380c84510cf41612f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/rdbg.1.65.tgz"
   checksum: "md5=bc242ad397aaaab380c84510cf41612f"
 }

--- a/packages/rdbg/rdbg.1.70/opam
+++ b/packages/rdbg/rdbg.1.70/opam
@@ -40,6 +40,6 @@ extra-files: [
   ["_oasis_remove_.ml" "md5=6100ca146fa97d2196eb49a2631d0796"]
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/92/92a16d3ede61f83cc2e4e7b5be1c1798"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/rdbg.1.70.tgz"
   checksum: "md5=92a16d3ede61f83cc2e4e7b5be1c1798"
 }

--- a/packages/rfsm/rfsm.1.4.2/opam
+++ b/packages/rfsm/rfsm.1.4.2/opam
@@ -26,6 +26,6 @@ depends: [
 synopsis:
   "A toolset for describing and simulating StateChart-like state diagrams"
 url {
-  src: "https://opam.ocaml.org/cache/md5/2f/2febda48d5fed77b887778f65d4c2685"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/rfsm-1.4.2.tar.gz"
   checksum: "md5=2febda48d5fed77b887778f65d4c2685"
 }

--- a/packages/sedlex/sedlex.1.99/opam
+++ b/packages/sedlex/sedlex.1.99/opam
@@ -18,6 +18,6 @@ synopsis:
   "unicode-friendly lexer generator (successor of ulex, now based on -ppx instead of camlp4)"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/eb/ebf0cd8b18ffde5546273dfdae35ed66"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/sedlex-1.99.1.tar.gz"
   checksum: "md5=ebf0cd8b18ffde5546273dfdae35ed66"
 }

--- a/packages/sibylfs-lem/sibylfs-lem.0.4.0/opam
+++ b/packages/sibylfs-lem/sibylfs-lem.0.4.0/opam
@@ -54,6 +54,6 @@ extra-files: [
   ["generate_install_manifest.sh" "md5=b00e2b11d8713deba697852a958889dd"]
 ]
 url {
-  src: "https://opam.ocaml.org/cache/md5/93/9306b3bdc99638d5895156c840033b86"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/sibylfs-lem-0.4.0.tar.gz"
   checksum: "md5=9306b3bdc99638d5895156c840033b86"
 }

--- a/packages/spotinstall/spotinstall.1.0.0/opam
+++ b/packages/spotinstall/spotinstall.1.0.0/opam
@@ -52,6 +52,6 @@ or included in this source package, ocaml-annot-<version>.patch.
 
 For the second one, you can use SpotInstall. This tool."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/c1/c1124aea9674cf327a75e85456b8f704"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotinstall-1.0.0.tar.gz"
   checksum: "md5=c1124aea9674cf327a75e85456b8f704"
 }

--- a/packages/spotinstall/spotinstall.1.0.1/opam
+++ b/packages/spotinstall/spotinstall.1.0.1/opam
@@ -52,6 +52,6 @@ or included in this source package, ocaml-annot-<version>.patch.
 
 For the second one, you can use SpotInstall. This tool."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/2f/2fcc310ced15dd5ceb187e68d3275b23"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotinstall-1.0.1.tar.gz"
   checksum: "md5=2fcc310ced15dd5ceb187e68d3275b23"
 }

--- a/packages/spotinstall/spotinstall.1.1.0/opam
+++ b/packages/spotinstall/spotinstall.1.1.0/opam
@@ -53,6 +53,6 @@ or included in this source package, ocaml-annot-<version>.patch.
 
 For the second one, you can use SpotInstall. This tool."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/81/814bdd644b9413c839da41af9d6973b5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotinstall-1.1.0.tar.gz"
   checksum: "md5=814bdd644b9413c839da41af9d6973b5"
 }

--- a/packages/spotinstall/spotinstall.1.1.1/opam
+++ b/packages/spotinstall/spotinstall.1.1.1/opam
@@ -53,6 +53,6 @@ or included in this source package, ocaml-annot-<version>.patch.
 
 For the second one, you can use SpotInstall. This tool."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/97/97feae7a34f470033a44f391939a7344"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotinstall-1.1.1.tar.gz"
   checksum: "md5=97feae7a34f470033a44f391939a7344"
 }

--- a/packages/spotinstall/spotinstall.1.2.0/opam
+++ b/packages/spotinstall/spotinstall.1.2.0/opam
@@ -53,6 +53,6 @@ or included in this source package, ocaml-annot-<version>.patch.
 
 For the second one, you can use SpotInstall. This tool."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/00/00d96fb110e1c569191e685c3073a89f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotinstall-1.2.0.tar.gz"
   checksum: "md5=00d96fb110e1c569191e685c3073a89f"
 }

--- a/packages/spotinstall/spotinstall.1.2.1/opam
+++ b/packages/spotinstall/spotinstall.1.2.1/opam
@@ -53,6 +53,6 @@ or included in this source package, ocaml-annot-<version>.patch.
 
 For the second one, you can use SpotInstall. This tool."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/34/34ef371edfdcfe8b5e8f85c707bf4d05"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotinstall-1.2.1.tar.gz"
   checksum: "md5=34ef371edfdcfe8b5e8f85c707bf4d05"
 }

--- a/packages/spotlib/spotlib.1.0.0/opam
+++ b/packages/spotlib/spotlib.1.0.0/opam
@@ -25,6 +25,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/29/29b04f6898428dd3e2648b2c71989ccd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-1.0.0.tar.gz"
   checksum: "md5=29b04f6898428dd3e2648b2c71989ccd"
 }

--- a/packages/spotlib/spotlib.2.0.1/opam
+++ b/packages/spotlib/spotlib.2.0.1/opam
@@ -25,6 +25,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/5d/5d9ba6b6b3389b9ac6a4ceb868ad2863"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.0.1.tar.gz"
   checksum: "md5=5d9ba6b6b3389b9ac6a4ceb868ad2863"
 }

--- a/packages/spotlib/spotlib.2.1.0/opam
+++ b/packages/spotlib/spotlib.2.1.0/opam
@@ -25,6 +25,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/58/58e170e0137137783ce63f4cf7050b02"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.1.0.tar.gz"
   checksum: "md5=58e170e0137137783ce63f4cf7050b02"
 }

--- a/packages/spotlib/spotlib.2.1.1/opam
+++ b/packages/spotlib/spotlib.2.1.1/opam
@@ -25,6 +25,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d4/d4d25f82710616f282567b44b4ceb236"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.1.1.tar.gz"
   checksum: "md5=d4d25f82710616f282567b44b4ceb236"
 }

--- a/packages/spotlib/spotlib.2.1.2/opam
+++ b/packages/spotlib/spotlib.2.1.2/opam
@@ -25,6 +25,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/87/879baaebf734378c1a2f8e98ba16ce92"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.1.2.tar.gz"
   checksum: "md5=879baaebf734378c1a2f8e98ba16ce92"
 }

--- a/packages/spotlib/spotlib.2.2.0/opam
+++ b/packages/spotlib/spotlib.2.2.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d7/d7d87563fada5b85b22ee820b0c89e71"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.2.0.tar.gz"
   checksum: "md5=d7d87563fada5b85b22ee820b0c89e71"
 }

--- a/packages/spotlib/spotlib.2.3.0/opam
+++ b/packages/spotlib/spotlib.2.3.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/05/05aac3e07559d97b240462243f94f3a5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.3.0.tar.gz"
   checksum: "md5=05aac3e07559d97b240462243f94f3a5"
 }

--- a/packages/spotlib/spotlib.2.4.0/opam
+++ b/packages/spotlib/spotlib.2.4.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/b4/b4560a160ed6f2a1ac1d575d44073eb1"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.4.0.tar.gz"
   checksum: "md5=b4560a160ed6f2a1ac1d575d44073eb1"
 }

--- a/packages/spotlib/spotlib.2.4.1/opam
+++ b/packages/spotlib/spotlib.2.4.1/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0b/0b4e7dc83cee701752c3f5187c98da3a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.4.1.tar.gz"
   checksum: "md5=0b4e7dc83cee701752c3f5187c98da3a"
 }

--- a/packages/spotlib/spotlib.2.5.0/opam
+++ b/packages/spotlib/spotlib.2.5.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/2a/2a75107d504e6c6bb048cab5814ffe4a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.5.0.tar.gz"
   checksum: "md5=2a75107d504e6c6bb048cab5814ffe4a"
 }

--- a/packages/spotlib/spotlib.2.5.1/opam
+++ b/packages/spotlib/spotlib.2.5.1/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/df/df9342fe31e9a10f332b5686d818867f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.5.1.tar.gz"
   checksum: "md5=df9342fe31e9a10f332b5686d818867f"
 }

--- a/packages/spotlib/spotlib.2.5.2/opam
+++ b/packages/spotlib/spotlib.2.5.2/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/a6/a6db69db71619322556ab64ccb438a32"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.5.2.tar.gz"
   checksum: "md5=a6db69db71619322556ab64ccb438a32"
 }

--- a/packages/spotlib/spotlib.2.5.3/opam
+++ b/packages/spotlib/spotlib.2.5.3/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/8a/8afa2635a6141b25e1c942a1b4aa039d"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-2.5.3.tar.gz"
   checksum: "md5=8afa2635a6141b25e1c942a1b4aa039d"
 }

--- a/packages/spotlib/spotlib.3.0.0/opam
+++ b/packages/spotlib/spotlib.3.0.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/94/9482af4c08faa5df32cb47283209920c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-3.0.0.tar.gz"
   checksum: "md5=9482af4c08faa5df32cb47283209920c"
 }

--- a/packages/spotlib/spotlib.3.1.0/opam
+++ b/packages/spotlib/spotlib.3.1.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/fb/fb973cb0ca224bcf33a107f7000a0f6a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-3.1.0.tar.gz"
   checksum: "md5=fb973cb0ca224bcf33a107f7000a0f6a"
 }

--- a/packages/spotlib/spotlib.3.1.2/opam
+++ b/packages/spotlib/spotlib.3.1.2/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ba/ba343c44ca722aeb5b40b1ba2bed7096"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-3.1.2.tar.gz"
   checksum: "md5=ba343c44ca722aeb5b40b1ba2bed7096"
 }

--- a/packages/spotlib/spotlib.4.0.0/opam
+++ b/packages/spotlib/spotlib.4.0.0/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ca/cabb34691dc4559cbb5b94f01fbed328"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-4.0.0.tar.gz"
   checksum: "md5=cabb34691dc4559cbb5b94f01fbed328"
 }

--- a/packages/spotlib/spotlib.4.0.1/opam
+++ b/packages/spotlib/spotlib.4.0.1/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ba/ba9978d6b414f486c36c3c9bc635b006"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-4.0.1.tar.gz"
   checksum: "md5=ba9978d6b414f486c36c3c9bc635b006"
 }

--- a/packages/spotlib/spotlib.4.0.2/opam
+++ b/packages/spotlib/spotlib.4.0.2/opam
@@ -26,6 +26,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/24/24f9c10a5760af1f38feb89f7c691c83"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib-4.0.2.tar.gz"
   checksum: "md5=24f9c10a5760af1f38feb89f7c691c83"
 }

--- a/packages/spotlib_js/spotlib_js.2.2.0_js/opam
+++ b/packages/spotlib_js/spotlib_js.2.2.0_js/opam
@@ -17,6 +17,6 @@ description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.
 It is almost a poor replication of Jane Street Core, but it is small."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/56/56f7747d922aee2371122433d7312f08"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/spotlib_js-2.2.0_js.tar.gz"
   checksum: "md5=56f7747d922aee2371122433d7312f08"
 }

--- a/packages/statverif/statverif.1.97pl1/opam
+++ b/packages/statverif/statverif.1.97pl1/opam
@@ -18,6 +18,6 @@ synopsis:
   "StatVerif: automated verifier for cryptographic protocols with state, based on ProVerif."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/6e/6e4ab2c56c4af4cb001c8e6353ad00d5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/statverif-1.97pl1.tar.gz"
   checksum: "md5=6e4ab2c56c4af4cb001c8e6353ad00d5"
 }

--- a/packages/tcx/tcx.0.25.0/opam
+++ b/packages/tcx/tcx.0.25.0/opam
@@ -15,6 +15,6 @@ depends: [
 synopsis:
   "OCaml library for parsing and formatting Training Center XML files."
 url {
-  src: "https://opam.ocaml.org/cache/md5/b0/b01f089da78e3c110767c73e877fd519"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tcx-0.25.0.tar.gz"
   checksum: "md5=b01f089da78e3c110767c73e877fd519"
 }

--- a/packages/tidy/tidy.0-2009-0.1.1/opam
+++ b/packages/tidy/tidy.0-2009-0.1.1/opam
@@ -33,6 +33,6 @@ synopsis: "bindings for tidy - HTML Tidy Library"
 description: "HTML parser, syntax checker and reformatter"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/b2/b2528479f6acd0b00c5185b124311614"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tidy-2009-0.1.1.tar.gz"
   checksum: "md5=b2528479f6acd0b00c5185b124311614"
 }

--- a/packages/tidy/tidy.1-4.9.30-0.1.1/opam
+++ b/packages/tidy/tidy.1-4.9.30-0.1.1/opam
@@ -32,6 +32,6 @@ synopsis: "bindings for tidy5 - HTML Tidy with HTML5 support"
 description: "HTML parser, syntax checker and reformatter"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/54/547e329166ed612acb088a864c072283"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tidy-4.9.30-0.1.1.tar.gz"
   checksum: "md5=547e329166ed612acb088a864c072283"
 }

--- a/packages/tidy/tidy.5-0.2/opam
+++ b/packages/tidy/tidy.5-0.2/opam
@@ -22,6 +22,6 @@ and upgrading legacy code to modern standards. Tidy is a product of the
 World Wide Web Consortium and the HTML Tidy Advocacy Community Group."""
 
 url {
-  src: "https://opam.ocaml.org/cache/md5/0d/0dee7b084cfd5be14e340e8fbb8e5913"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tidy-5-0.2.tar.gz"
   checksum: "md5=0dee7b084cfd5be14e340e8fbb8e5913"
 }

--- a/packages/tiny_json/tiny_json.1.0.0/opam
+++ b/packages/tiny_json/tiny_json.1.0.0/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/c7/c7f7f381f4a57f0c2395d028166867cf"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.0.0.tar.gz"
   checksum: "md5=c7f7f381f4a57f0c2395d028166867cf"
 }

--- a/packages/tiny_json/tiny_json.1.0.1/opam
+++ b/packages/tiny_json/tiny_json.1.0.1/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/db/dbb3b56ba9b832cfaffba26301c9c55a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.0.1.tar.gz"
   checksum: "md5=dbb3b56ba9b832cfaffba26301c9c55a"
 }

--- a/packages/tiny_json/tiny_json.1.1.0/opam
+++ b/packages/tiny_json/tiny_json.1.1.0/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/4b/4b6516008beafa9bca1b72e18779de06"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.1.0.tar.gz"
   checksum: "md5=4b6516008beafa9bca1b72e18779de06"
 }

--- a/packages/tiny_json/tiny_json.1.1.1/opam
+++ b/packages/tiny_json/tiny_json.1.1.1/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/94/94a5f4f5a6851149e19820824ed054cd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.1.1.tar.gz"
   checksum: "md5=94a5f4f5a6851149e19820824ed054cd"
 }

--- a/packages/tiny_json/tiny_json.1.1.2/opam
+++ b/packages/tiny_json/tiny_json.1.1.2/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/85/85de5705bb6bda5d5f35267347b3799e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.1.2.tar.gz"
   checksum: "md5=85de5705bb6bda5d5f35267347b3799e"
 }

--- a/packages/tiny_json/tiny_json.1.1.3/opam
+++ b/packages/tiny_json/tiny_json.1.1.3/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/78/78d20fda7bf0c3ca7af35a9a40011398"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.1.3.tar.gz"
   checksum: "md5=78d20fda7bf0c3ca7af35a9a40011398"
 }

--- a/packages/tiny_json/tiny_json.1.1.4/opam
+++ b/packages/tiny_json/tiny_json.1.1.4/opam
@@ -24,6 +24,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/5a/5a82e7ff7e06d0d2ed2db53bad5816bf"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.1.4.tar.gz"
   checksum: "md5=5a82e7ff7e06d0d2ed2db53bad5816bf"
 }

--- a/packages/tiny_json/tiny_json.1.1.5/opam
+++ b/packages/tiny_json/tiny_json.1.1.5/opam
@@ -15,6 +15,6 @@ synopsis: "A small Json library from OCAMLTTER"
 description:
   "This is a small Json printer/parser library extracted Yoshihiro IMAI's OCAMLTTER twitter client."
 url {
-  src: "https://opam.ocaml.org/cache/md5/f7/f7cb8db579dc148b40300a4149654ee3"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json-1.1.5.tar.gz"
   checksum: "md5=f7cb8db579dc148b40300a4149654ee3"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.0.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.0.0/opam
@@ -28,6 +28,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/b5/b58883bec47cceccae7439d106136ca2"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.0.0.tar.gz"
   checksum: "md5=b58883bec47cceccae7439d106136ca2"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.0.1/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.0.1/opam
@@ -28,6 +28,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/ca/cac7cc1c72cb3c7610029d957104f305"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.0.1.tar.gz"
   checksum: "md5=cac7cc1c72cb3c7610029d957104f305"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.1.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.1.0/opam
@@ -28,6 +28,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/65/655e254679a91ddc440610e8b6620e36"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.1.0.tar.gz"
   checksum: "md5=655e254679a91ddc440610e8b6620e36"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.2.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.2.0/opam
@@ -28,6 +28,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/61/618a9588be637a668cdee1ee8dc19831"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.2.0.tar.gz"
   checksum: "md5=618a9588be637a668cdee1ee8dc19831"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.3.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.3.0/opam
@@ -17,6 +17,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/2d/2dd468ec719224ea201b8d8cacae736f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.3.0.tar.gz"
   checksum: "md5=2dd468ec719224ea201b8d8cacae736f"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.4.0/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.4.0/opam
@@ -25,6 +25,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/55/5536cd44067bbd29a92c6a2b6c2a69dc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.4.0.tar.gz"
   checksum: "md5=5536cd44067bbd29a92c6a2b6c2a69dc"
 }

--- a/packages/tiny_json_conv/tiny_json_conv.1.4.1/opam
+++ b/packages/tiny_json_conv/tiny_json_conv.1.4.1/opam
@@ -23,6 +23,6 @@ synopsis: "Meta conv for Tiny Json"
 description: "Converters for meta_conv + tiny_json"
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/3b/3b9eb319c57f0678e0c4e93ead1f1e94"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/tiny_json_conv-1.4.1.tar.gz"
   checksum: "md5=3b9eb319c57f0678e0c4e93ead1f1e94"
 }

--- a/packages/treeprint/treeprint.1.0.1/opam
+++ b/packages/treeprint/treeprint.1.0.1/opam
@@ -27,6 +27,6 @@ Treeprint is a small printer combinator library for ASTs with infix,
 prefix and postfix operators with associativity and precedence.
 It provides abstract printing with minimum parentheses insertion."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/cd/cdb905f7127c440fcbeb07bc02442f92"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/treeprint-1.0.1.tar.gz"
   checksum: "md5=cdb905f7127c440fcbeb07bc02442f92"
 }

--- a/packages/treeprint/treeprint.1.0.2/opam
+++ b/packages/treeprint/treeprint.1.0.2/opam
@@ -28,6 +28,6 @@ Treeprint is a small printer combinator library for ASTs with infix,
 prefix and postfix operators with associativity and precedence.
 It provides abstract printing with minimum parentheses insertion."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0a/0a6ab4e50558e3ec5e512ce7c961a91f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/treeprint-1.0.2.tar.gz"
   checksum: "md5=0a6ab4e50558e3ec5e512ce7c961a91f"
 }

--- a/packages/treeprint/treeprint.1.0.3/opam
+++ b/packages/treeprint/treeprint.1.0.3/opam
@@ -29,6 +29,6 @@ Treeprint is a small printer combinator library for ASTs with infix,
 prefix and postfix operators with associativity and precedence.
 It provides abstract printing with minimum parentheses insertion."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/0a/0a5550dc0e9143bf55be8a94aaf4755f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/treeprint-1.0.3.tar.gz"
   checksum: "md5=0a5550dc0e9143bf55be8a94aaf4755f"
 }

--- a/packages/treeprint/treeprint.2.0.0/opam
+++ b/packages/treeprint/treeprint.2.0.0/opam
@@ -29,6 +29,6 @@ Treeprint is a small printer combinator library for ASTs with infix,
 prefix and postfix operators with associativity and precedence.
 It provides abstract printing with minimum parentheses insertion."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/ed/edcf8c2102e84bbc231851d8dec10b08"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/treeprint-2.0.0.tar.gz"
   checksum: "md5=edcf8c2102e84bbc231851d8dec10b08"
 }

--- a/packages/treeprint/treeprint.2.1.0/opam
+++ b/packages/treeprint/treeprint.2.1.0/opam
@@ -29,6 +29,6 @@ Treeprint is a small printer combinator library for ASTs with infix,
 prefix and postfix operators with associativity and precedence.
 It provides abstract printing with minimum parentheses insertion."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/9e/9e5b555018789f0de7a48c9440e5d1ff"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/treeprint-2.1.0.tar.gz"
   checksum: "md5=9e5b555018789f0de7a48c9440e5d1ff"
 }

--- a/packages/treeprint/treeprint.2.1.1/opam
+++ b/packages/treeprint/treeprint.2.1.1/opam
@@ -29,6 +29,6 @@ Treeprint is a small printer combinator library for ASTs with infix,
 prefix and postfix operators with associativity and precedence.
 It provides abstract printing with minimum parentheses insertion."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/6d/6d820e4fa72c1a8bbe96de8424557897"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/treeprint-2.1.1.tar.gz"
   checksum: "md5=6d820e4fa72c1a8bbe96de8424557897"
 }

--- a/packages/typpx/typpx.1.0.2/opam
+++ b/packages/typpx/typpx.1.0.2/opam
@@ -27,6 +27,6 @@ typpx is a library to build PPX'es with types.  Typing the input Parsetree
 by the vanilla or modified OCaml compiler's type inference, you can perform
 AST transformation with type information over Typedtree."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/09/098e4c4374f8f3415d6960335beb97d9"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.0.2.tar.gz"
   checksum: "md5=098e4c4374f8f3415d6960335beb97d9"
 }

--- a/packages/typpx/typpx.1.1.1/opam
+++ b/packages/typpx/typpx.1.1.1/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/04/042d534dcd1751e2f07d3d6cb289c77c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.1.1.tar.gz"
   checksum: "md5=042d534dcd1751e2f07d3d6cb289c77c"
 }

--- a/packages/typpx/typpx.1.1.2/opam
+++ b/packages/typpx/typpx.1.1.2/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/00/00b5e281b1f8d6b919de75ef5bb329ab"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.1.2.tar.gz"
   checksum: "md5=00b5e281b1f8d6b919de75ef5bb329ab"
 }

--- a/packages/typpx/typpx.1.1.3/opam
+++ b/packages/typpx/typpx.1.1.3/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/c8/c881c154b830f201a684a2b4186cdf8a"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.1.3.tar.gz"
   checksum: "md5=c881c154b830f201a684a2b4186cdf8a"
 }

--- a/packages/typpx/typpx.1.2.0/opam
+++ b/packages/typpx/typpx.1.2.0/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d9/d97cd01b381f433b265400141016490e"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.2.0.tar.gz"
   checksum: "md5=d97cd01b381f433b265400141016490e"
 }

--- a/packages/typpx/typpx.1.2.1/opam
+++ b/packages/typpx/typpx.1.2.1/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/22/22031e086987928bc0ffddc44a160fd5"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.2.1.tar.gz"
   checksum: "md5=22031e086987928bc0ffddc44a160fd5"
 }

--- a/packages/typpx/typpx.1.2.2/opam
+++ b/packages/typpx/typpx.1.2.2/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/7d/7d0a9fc2d1b91e92e14488d693f1e005"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.2.2.tar.gz"
   checksum: "md5=7d0a9fc2d1b91e92e14488d693f1e005"
 }

--- a/packages/typpx/typpx.1.3.0/opam
+++ b/packages/typpx/typpx.1.3.0/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/6a/6a98975c1d29416bbe758b89090c0cd1"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.3.0.tar.gz"
   checksum: "md5=6a98975c1d29416bbe758b89090c0cd1"
 }

--- a/packages/typpx/typpx.1.4.0/opam
+++ b/packages/typpx/typpx.1.4.0/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/03/034c31f54f0e4aba46cd8c943031f486"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.4.0.tar.gz"
   checksum: "md5=034c31f54f0e4aba46cd8c943031f486"
 }

--- a/packages/typpx/typpx.1.4.1/opam
+++ b/packages/typpx/typpx.1.4.1/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/7f/7fb058c88cd68d4e7baff4d825ff26ab"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.4.1.tar.gz"
   checksum: "md5=7fb058c88cd68d4e7baff4d825ff26ab"
 }

--- a/packages/typpx/typpx.1.4.2/opam
+++ b/packages/typpx/typpx.1.4.2/opam
@@ -32,6 +32,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/09/09d55c844bf60f057f1574d3939ea847"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.4.2.tar.gz"
   checksum: "md5=09d55c844bf60f057f1574d3939ea847"
 }

--- a/packages/typpx/typpx.1.4.3/opam
+++ b/packages/typpx/typpx.1.4.3/opam
@@ -22,6 +22,6 @@ For examples, it includes:
 * ppx_curried_constr, which makes variant constructors curried functions
 * ppx_type_of, a function to get the type name of argument."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/38/38b04223addfaadb72fa2c689080c798"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/typpx-1.4.3.tar.gz"
   checksum: "md5=38b04223addfaadb72fa2c689080c798"
 }

--- a/packages/unmagic/unmagic.0.9.0/opam
+++ b/packages/unmagic/unmagic.0.9.0/opam
@@ -30,6 +30,6 @@ Unmagic is a small library to runtime tag-check Obj.t values for type-secure
 Obj.magic, input_value, Marshal.from_channel.  It uses typerep to give
 the target type, and follows the same limitations of it."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/d6/d66048abe7125c283f3d0183b46dd864"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/unmagic-0.9.0.tar.gz"
   checksum: "md5=d66048abe7125c283f3d0183b46dd864"
 }

--- a/packages/unmagic/unmagic.1.0.0/opam
+++ b/packages/unmagic/unmagic.1.0.0/opam
@@ -30,6 +30,6 @@ Unmagic is a small library to runtime tag-check Obj.t values for type-secure
 Obj.magic, input_value, Marshal.from_channel.  It uses typerep to give
 the target type, and follows the same limitations of it."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/5e/5e51eb8dadd4a836f762b570b8a94fe8"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/unmagic-1.0.0.tar.gz"
   checksum: "md5=5e51eb8dadd4a836f762b570b8a94fe8"
 }

--- a/packages/unmagic/unmagic.1.0.1/opam
+++ b/packages/unmagic/unmagic.1.0.1/opam
@@ -30,6 +30,6 @@ Unmagic is a small library to runtime tag-check Obj.t values for type-secure
 Obj.magic, input_value, Marshal.from_channel.  It uses typerep to give
 the target type, and follows the same limitations of it."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/7c/7c1a5c774c8c66c468ba5b492e20cdfc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/unmagic-1.0.1.tar.gz"
   checksum: "md5=7c1a5c774c8c66c468ba5b492e20cdfc"
 }

--- a/packages/unmagic/unmagic.1.0.2/opam
+++ b/packages/unmagic/unmagic.1.0.2/opam
@@ -30,6 +30,6 @@ Unmagic is a small library to runtime tag-check Obj.t values for type-secure
 Obj.magic, input_value, Marshal.from_channel.  It uses typerep to give
 the target type, and follows the same limitations of it."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/57/57d315be2bf7241517ff67bd5bfcb816"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/unmagic-1.0.2.tar.gz"
   checksum: "md5=57d315be2bf7241517ff67bd5bfcb816"
 }

--- a/packages/unmagic/unmagic.1.0.3/opam
+++ b/packages/unmagic/unmagic.1.0.3/opam
@@ -21,6 +21,6 @@ Unmagic is a small library to runtime tag-check Obj.t values for type-secure
 Obj.magic, input_value, Marshal.from_channel.  It uses typerep to give
 the target type, and follows the same limitations of it."""
 url {
-  src: "https://opam.ocaml.org/cache/md5/93/9378b07b1b08e86875f96893df711f12"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/unmagic-1.0.3.tar.gz"
   checksum: "md5=9378b07b1b08e86875f96893df711f12"
 }

--- a/packages/xtmpl/xtmpl.0.10/opam
+++ b/packages/xtmpl/xtmpl.0.10/opam
@@ -23,6 +23,6 @@ depends: [
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/32/3229a1a6d4098fd6f6c945bd9c2e60be"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.10.tar.gz"
   checksum: "md5=3229a1a6d4098fd6f6c945bd9c2e60be"
 }

--- a/packages/xtmpl/xtmpl.0.11/opam
+++ b/packages/xtmpl/xtmpl.0.11/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "XML templating library and ppx."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/87/87fdedecd1f2e83f89c7858490394ce3"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.11.tar.gz"
   checksum: "md5=87fdedecd1f2e83f89c7858490394ce3"
 }

--- a/packages/xtmpl/xtmpl.0.12/opam
+++ b/packages/xtmpl/xtmpl.0.12/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "XML templating library and ppx."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/55/55701024603bb8f8243dabc0a42ae452"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.12.tar.gz"
   checksum: "md5=55701024603bb8f8243dabc0a42ae452"
 }

--- a/packages/xtmpl/xtmpl.0.13.0/opam
+++ b/packages/xtmpl/xtmpl.0.13.0/opam
@@ -25,6 +25,6 @@ depends: [
 synopsis: "XML templating library and ppx."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/52/522f0f113fea8b6e9da72cacefb654f6"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.13.0.tar.gz"
   checksum: "md5=522f0f113fea8b6e9da72cacefb654f6"
 }

--- a/packages/xtmpl/xtmpl.0.14.0/opam
+++ b/packages/xtmpl/xtmpl.0.14.0/opam
@@ -27,6 +27,6 @@ description:
   "Provide an XML parser, templating and rewrite engine for XML documents."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/2a/2a6d32ff75c29736839d91b932b1ab14"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.14.0.tar.gz"
   checksum: "md5=2a6d32ff75c29736839d91b932b1ab14"
 }

--- a/packages/xtmpl/xtmpl.0.15.0/opam
+++ b/packages/xtmpl/xtmpl.0.15.0/opam
@@ -23,6 +23,6 @@ description:
   "Provide an XML parser, templating and rewrite engine for XML documents."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/8b/8bb344f7391c884b44166d907d41d7dd"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.15.0.tar.gz"
   checksum: "md5=8bb344f7391c884b44166d907d41d7dd"
 }

--- a/packages/xtmpl/xtmpl.0.16.0/opam
+++ b/packages/xtmpl/xtmpl.0.16.0/opam
@@ -23,6 +23,6 @@ description:
   "Provide an XML parser, templating and rewrite engine for XML documents."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/01/015643924a70789f8ff062f5a211a449"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.16.0.tar.gz"
   checksum: "md5=015643924a70789f8ff062f5a211a449"
 }

--- a/packages/xtmpl/xtmpl.0.3/opam
+++ b/packages/xtmpl/xtmpl.0.3/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "https://opam.ocaml.org/cache/md5/ce/ce84ec66ef3198a036e0d2b01ecc1015"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.3.tar.gz"
   checksum: "md5=ce84ec66ef3198a036e0d2b01ecc1015"
 }

--- a/packages/xtmpl/xtmpl.0.4/opam
+++ b/packages/xtmpl/xtmpl.0.4/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "https://opam.ocaml.org/cache/md5/62/62b7b6984f595364c8230297ef56b00c"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.4.tar.gz"
   checksum: "md5=62b7b6984f595364c8230297ef56b00c"
 }

--- a/packages/xtmpl/xtmpl.0.5/opam
+++ b/packages/xtmpl/xtmpl.0.5/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "https://opam.ocaml.org/cache/md5/33/338b6fb96ad409fe31b0ed8b094da26f"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.5.tar.gz"
   checksum: "md5=338b6fb96ad409fe31b0ed8b094da26f"
 }

--- a/packages/xtmpl/xtmpl.0.6/opam
+++ b/packages/xtmpl/xtmpl.0.6/opam
@@ -10,6 +10,6 @@ depends: [
 install: [make "install"]
 synopsis: "Small XML templating library."
 url {
-  src: "https://opam.ocaml.org/cache/md5/1d/1d2810d26fb11a5d4a803de4733b71fc"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.6.tar.gz"
   checksum: "md5=1d2810d26fb11a5d4a803de4733b71fc"
 }

--- a/packages/xtmpl/xtmpl.0.7/opam
+++ b/packages/xtmpl/xtmpl.0.7/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/98/98172c98b16828b89d17db66f958b0db"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.7.tar.gz"
   checksum: "md5=98172c98b16828b89d17db66f958b0db"
 }

--- a/packages/xtmpl/xtmpl.0.8/opam
+++ b/packages/xtmpl/xtmpl.0.8/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/d6/d6a15094ee7defbd1a767b60bc764efe"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.8.tar.gz"
   checksum: "md5=d6a15094ee7defbd1a767b60bc764efe"
 }

--- a/packages/xtmpl/xtmpl.0.9/opam
+++ b/packages/xtmpl/xtmpl.0.9/opam
@@ -15,6 +15,6 @@ install: [make "install"]
 synopsis: "Small XML templating library."
 flags: light-uninstall
 url {
-  src: "https://opam.ocaml.org/cache/md5/86/8659b35b25966363e9f7ed5df6f43866"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/xtmpl-0.9.tar.gz"
   checksum: "md5=8659b35b25966363e9f7ed5df6f43866"
 }


### PR DESCRIPTION
The cache is opam.ocaml.org is trying to go back to being a cache, so the archives which were being relied on are now in ocaml/opam-source-archives.

This PR (hopefully correctly) updates all the packages to point to them.