### PR TITLE
[new release] ethernet (2.2.1)

### DIFF
--- a/packages/ethernet/ethernet.2.2.1/opam
+++ b/packages/ethernet/ethernet.2.2.1/opam
@@ -29,6 +29,7 @@ depends: [
   "lwt" {>= "3.0.0"}
   "logs" {>= "0.6.0"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
 description: """
 `ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)


### PR DESCRIPTION
OCaml Ethernet (IEEE 802.3) layer, used in MirageOS

- Project page: <a href="https://github.com/mirage/ethernet">https://github.com/mirage/ethernet</a>
- Documentation: <a href="https://mirage.github.io/ethernet/">https://mirage.github.io/ethernet/</a>

##### CHANGES:

* Remove rresult dependency (mirage/ethernet#7 @hannesm)
* Avoid deprecated Cstruct.len, use Cstruct.length (mirage/ethernet#7 @hannesm)
