### PR TITLE
Package chick.0.9

### DIFF
--- a/packages/chick/chick.0.9/opam
+++ b/packages/chick/chick.0.9/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Help package in writing mathematics documents under Jupyter"
+description: """\
+Toolbox to make mathematical statements and demonstrations more 
+readable and reliable.
+The enrichment of the text is carried out from routine Ocaml that produce latex.
+This package is intended to contain the demo production tools and documentation 
+of these same demos.
+These Ocaml tools can be integrated under Jupyter. 
+"""
+license: "LGPL-3.0-or-later"
+maintainer: "VMichelRene <michelorange024@gmail.com>"
+bug-reports: "https://github.com/VMichelRene/chick/issues"
+homepage: "https://github.com/VMichelRene/chick"
+authors: "VMichelRene <michelorange024@gmail.com>"
+dev-repo: "git+https://github.com/VMichelRene/chick"
+depends: ["ocaml" "ocamlfind" "ocamlbuild" "zarith"]
+run-test: [make "test"]
+build: [make "lib"]
+url {
+  src: "https://github.com/VMichelRene/chick/archive/refs/tags/0.9.tar.gz"
+  checksum: "md5=1c2b8d0cb84702929b3d7b3b877dcb3d"
+}
+


### PR DESCRIPTION
### `chick.0.9`
Help package in writing mathematics documents under Jupyter
Toolbox to make mathematical statements and demonstrations more 
readable and reliable.
The enrichment of the text is carried out from routine Ocaml that produce latex.
This package is intended to contain the demo production tools and documentation 
of these same demos.
These Ocaml tools can be integrated under Jupyter.



---
* Homepage: https://github.com/VMichelRene/chick
* Source repo: git+https://github.com/VMichelRene/chick
* Bug tracker: https://github.com/VMichelRene/chick/issues

---
:camel: Pull-request generated by opam-publish v2.1.0