### PR TITLE
wxOCaml: repo was renamed from ocplib-wxOCaml to wxOCaml.

### DIFF
--- a/packages/wxOCaml/wxOCaml.1.0.1/opam
+++ b/packages/wxOCaml/wxOCaml.1.0.1/opam
@@ -22,6 +22,7 @@ flags: light-uninstall
 url {
   src: "https://github.com/OCamlPro/wxOCaml/archive/1.0.1.tar.gz"
   checksum: [
-  "md5=dd08ff9cfd13b3bd396429b7cc8affbf"
-  "sha512=0a5511c30006fb082289424cad5941bfa93b6849035e4bdd25a4b027386858460f0ce00352b56850d1b4b4ce097816c88247cd3b31bae05c92ecebd21a617cd0"
+    "md5=dd08ff9cfd13b3bd396429b7cc8affbf"
+    "sha512=0a5511c30006fb082289424cad5941bfa93b6849035e4bdd25a4b027386858460f0ce00352b56850d1b4b4ce097816c88247cd3b31bae05c92ecebd21a617cd0"
+  ]
 }


### PR DESCRIPTION
Fix the opam URLs, and add a sha512.