### PR TITLE
[new release] builder (0.1.2)

### DIFF
--- a/packages/builder/builder.0.1.2/opam
+++ b/packages/builder/builder.0.1.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/builder"
+dev-repo: "git+https://github.com/roburio/builder.git"
+bug-reports: "https://github.com/roburio/builder/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "asn1-combinators"
+  "bheap" {>= "2.0.0"}
+  "bos"
+  "cmdliner"
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "fmt" {>= "0.8.7"}
+  "fpath"
+  "logs"
+  "lwt"
+  "ptime"
+  "uuidm"
+  "http-lwt-client" {>= "0.0.4"}
+  "base64"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+
+synopsis: "Scheduling and executing shell jobs"
+description: """
+The builder server has a schedule of jobs to be executed, stored persistently
+on disk. Any number of workers can connect via TCP (using ASN.1 encoded
+messages) that execute a single job -- usually contained in a sandbox (FreeBSD
+jail or Docker container). A client is a command-line interface to modify the
+schedule. Access control is out of scope - run it locally on your build host.
+The server receives the output artifacts of each job, and either stores them
+on the local file system or upload them to a remote server via http.
+
+See https://builds.robur.coop for the live web frontend (builder-web).
+"""
+url {
+  src:
+    "https://github.com/roburio/builder/releases/download/v0.1.2/builder-v0.1.2.tbz"
+  checksum: [
+    "sha256=f65ca9e3cd8a18d487ef9ccaa509ea2d4237540956bbf74414c8cfe7a17a260d"
+    "sha512=3fbd88c4dd98db9172c6e9437f45292e3da78b06b0bee10d08f466e1a704a553311a53720a31862988ab0bb47ee4483208c7afbc4a3aa70fac0288631c5798c4"
+  ]
+}
+x-commit-hash: "94a7530e925b1b0cc17e6fef06b4a5780da2a316"


### PR DESCRIPTION
Scheduling and executing shell jobs

- Project page: <a href="https://github.com/roburio/builder">https://github.com/roburio/builder</a>

##### CHANGES:

* Avoid deprecated functions of Fmt (roburio/builder#14 @hannesm)
* Drop rresult dependency (roburio/builder#14 @hannesm)
