### PR TITLE
[new release] otr (0.3.10)

### DIFF
--- a/packages/otr/otr.0.3.10/opam
+++ b/packages/otr/otr.0.3.10/opam
@@ -15,6 +15,7 @@ depends: [
   "astring"
   "base64" {>= "3.1.0"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Off the record implementation purely in OCaml

- Project page: <a href="https://github.com/hannesm/ocaml-otr">https://github.com/hannesm/ocaml-otr</a>
- Documentation: <a href="https://hannesm.github.io/ocaml-otr/doc">https://hannesm.github.io/ocaml-otr/doc</a>

##### CHANGES:

* remove rresult dependency
* use sexplib0 instead of sexplib for mirage-crypto 0.10.4+ compatibility
  (the dependency stated sexplib0 since some time, but sexplib was inherited
   via mirage-crypto-pk)
