### PR TITLE
[new release] x509 (0.15.1)

### DIFF
--- a/packages/certify/certify.0.3.3/opam
+++ b/packages/certify/certify.0.3.3/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "1.0"}
   "mirage-crypto-pk"
   "mirage-crypto-rng"
-  "x509" {>= "0.12.1"}
+  "x509" {>= "0.12.1" & < "0.15.1"}
   "cstruct" {>= "3.2.0"}
   "ptime"
   "ocaml" {>= "4.07.0"}

--- a/packages/u2f/u2f.0.1.0/opam
+++ b/packages/u2f/u2f.0.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_deriving_yojson"
   "mirage-crypto-ec"
   "mirage-crypto-rng"
-  "x509" {>= "0.13.0"}
+  "x509" {>= "0.13.0" & < "0.15.1"}
   "base64" {>= "3.1.0"}
 ]
 

--- a/packages/u2f/u2f.0.1.1/opam
+++ b/packages/u2f/u2f.0.1.1/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_deriving_yojson"
   "mirage-crypto-ec"
   "mirage-crypto-rng"
-  "x509" {>= "0.13.0"}
+  "x509" {>= "0.13.0" & < "0.15.1"}
   "base64" {>= "3.1.0"}
 ]
 

--- a/packages/x509/x509.0.15.1/opam
+++ b/packages/x509/x509.0.15.1/opam
@@ -17,7 +17,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "asn1-combinators" {>= "0.2.0"}
   "ptime"
-  "base64" {>= "3.1.0"}
+  "base64" {>= "3.3.0"}
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* avoid usae of deprecated functions of fmt (@hannesm)
* remove rresult dependency (@hannesm)
