### PR TITLE
switches to the released files in bap-emacs-goodies

### DIFF
--- a/packages/bap-emacs-dot/bap-emacs-dot.0.1/opam
+++ b/packages/bap-emacs-dot/bap-emacs-dot.0.1/opam
@@ -16,5 +16,6 @@ synopsis:
 depends: ["ocaml"]
 flags: light-uninstall
 url {
-  src: "git+https://github.com/ivg/emacs-dot.git"
+  checksum: "md5=8096913c841b50e599ea611647992aad"
+  src: "https://github.com/ivg/emacs-dot/archive/refs/tags/v0.1.0.tar.gz"
 }

--- a/packages/bap-emacs-mode/bap-emacs-mode.0.1/opam
+++ b/packages/bap-emacs-mode/bap-emacs-mode.0.1/opam
@@ -19,5 +19,6 @@ https://github.com/fkie-cad/bap-mode"""
 depends: ["ocaml"]
 flags: light-uninstall
 url {
-  src: "git+https://github.com/fkie-cad/bap-mode.git"
+  checksum: "md5=6575008a9c8feebb3f4f8f4bda360886"
+  src: "https://github.com/ivg/bap-mode/archive/refs/tags/v0.1.0.tar.gz"
 }


### PR DESCRIPTION
Uses the release URLs with checksums for the bap-emacs-goodies. Fixes #19871 and also does the same for the bap-emacs-mode package. 

I was thinking about whether it should be a new version or I can update the old version and decided to do the destructive update because the installed files are exactly the same, we change only the delivery method. At least from the user perspective.