### PR TITLE
[release] gmp.6.2.1-2

### DIFF
--- a/packages/gmp/gmp.6.2.1-2/opam
+++ b/packages/gmp/gmp.6.2.1-2/opam
@@ -21,7 +21,7 @@ cross-compilation."""
 url {
   src: "https://github.com/mirage/ocaml-gmp/archive/6.2.1-2.tar.gz"
   checksum: [
-    "md5=e7f879c619b0bd5f4c95661a5cb405f0"
-    "sha512=f87a29a5f631a0e953d5875799043f31775044241e7fd156a1829d3cad2646e29eced121e7ceb89a903cb9f6fa9f409a2443b5dc45b1594608c0a3cc131cd0c8"
+    "md5=367ce7ec00ee8866ad89ad1339f22896"
+    "sha512=0eb8c32fb37ed068ab653884f1afeffcfe9c65f86404de326a2d27fb503a2db2ce1dba79f8cfad2c56647a94ff1e5b02dfd8e0b7cd4154ab15c2717f5f61b0ee"
   ]
 }


### PR DESCRIPTION
# `gmp.6.2.1-2`

**CHANGES:** it should work for MacOS now.

Previous discussions here: https://github.com/ocaml/opam-repository/pull/19745