### PR TITLE
[new release] ca-certs (0.2.2)

### DIFF
--- a/packages/ca-certs/ca-certs.0.2.2/opam
+++ b/packages/ca-certs/ca-certs.0.2.2/opam
@@ -26,6 +26,7 @@ depends: [
   "alcotest" {with-test}
   "fmt" {with-test & >= "0.8.7"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 dev-repo: "git+https://github.com/mirage/ca-certs.git"
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Detect root CA certificates from the operating system

- Project page: <a href="https://github.com/mirage/ca-certs">https://github.com/mirage/ca-certs</a>
- Documentation: <a href="https://mirage.github.io/ca-certs/doc">https://mirage.github.io/ca-certs/doc</a>

##### CHANGES:

* Filter trailing certificate (if the data does not contain
  "-----BEGIN CERTIFICATE-----", it won't be a certificate) (mirage/ca-certs#19 @hannesm)
* Avoid deprecated functions from fmt (mirage/ca-certs#19 @hannesm)
* Remove rresult dependency (mirage/ca-certs#19 @hannesm)
* Update GitHub actions (mirage/ca-certs#19 @hannesm)
