### PR TITLE
[new release] tezos-base58 (1.0.0)

### DIFF
--- a/packages/tezos-base58/tezos-base58.1.0.0/opam
+++ b/packages/tezos-base58/tezos-base58.1.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Base58 encoding for Tezos"
+description: """
+Self-contained package for base58 encoding used by Tezos.
+"""
+maintainer: ["Tarides <contact@tarides.com>"]
+authors: [
+  "Tezos devteam"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+]
+license: "MIT"
+homepage: "https://github.com/tarides/tezos-base58"
+bug-reports: "https://github.com/tarides/tezos-base58/issues"
+depends: [ "dune" {>= "2.7"}  "zarith" "digestif" {>= "0.7"} "fmt" ]
+build: [
+  ["dune" "subst"] {dev}
+  [ "dune" "build" "-p" name  "-j" jobs]
+]
+dev-repo: "git+https://github.com/tarides/tezos-base58.git"
+url {
+  src:
+    "https://github.com/tarides/tezos-base58/releases/download/1.0.0/tezos-base58-1.0.0.tbz"
+  checksum: [
+    "sha256=aa99e1c25e3394cc8b01daeba54369f376348553fd2254beedd5f8569cbb8293"
+    "sha512=17415f5731a5e321043b21f67ca541a2ef5fe7e94fa7a7652164324a02176f3abb18163f8954659cd5470611346688f39be1154850e90a8df08f637bbd972ef1"
+  ]
+}
+x-commit-hash: "946930422a5d2e27449d95d65afef9bec47debe9"


### PR DESCRIPTION
Base58 encoding for Tezos

- Project page: <a href="https://github.com/tarides/tezos-base58">https://github.com/tarides/tezos-base58</a>

##### CHANGES:

Initial release
