### PR TITLE
tezos-stdlib-unix: add domain-name conflict

### DIFF
--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.0/opam
@@ -21,6 +21,7 @@ depends: [
 conflicts: [
   "domain-name" {>= "0.3.1"}
   "ezjsonm" {< "1.1.0"}
+  "fmt" {< "0.8.7"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.1/opam
@@ -21,6 +21,7 @@ depends: [
 conflicts: [
   "domain-name" {>= "0.3.1"}
   "ezjsonm" {< "1.1.0"}
+  "fmt" {< "0.8.7"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.2/opam
@@ -21,6 +21,7 @@ depends: [
 conflicts: [
   "domain-name" {>= "0.3.1"}
   "ezjsonm" {< "1.1.0"}
+  "fmt" {< "0.8.7"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.3/opam
@@ -21,6 +21,7 @@ depends: [
 conflicts: [
   "domain-name" {>= "0.3.1"}
   "ezjsonm" {< "1.1.0"}
+  "fmt" {< "0.8.7"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/opam
@@ -21,6 +21,7 @@ depends: [
 conflicts: [
   "domain-name" {>= "0.3.1"}
   "ezjsonm" {< "1.1.0"}
+  "fmt" {< "0.8.7"}
 ]
 patches: [ "with-re.patch" ]
 build: [


### PR DESCRIPTION
It currently uses `fmt`, which is obtained transitively via some dependency which, in turns, depends on `domain-name-conflict`.

Seen on: https://github.com/ocaml/opam-repository/pull/19881#issuecomment-953116207