### PR TITLE
[new release] mirage-nat (2.2.4)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.2.4/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.4/opam
@@ -26,6 +26,7 @@ depends: [
   "lwt" {with-test}
   "logs" {with-test}
 ]
+conflicts: [ "result" {< "1.5"} ]
 synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
 description: """
 Mirage-nat is a library for [network address


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- avoid deprecated Cstruct.len, use Cstruct.length (mirage/mirage-nat#45 @hannesm)
- remove rresult dependency (mirage/mirage-nat#45 @hannesm)
- raise lower OCaml version to 4.08.0 (mirage/mirage-nat#45 @hannesm)
- remove stdlib-shims dependency (mirage/mirage-nat#45 @hannesm)
