### PR TITLE
Package sawja.1.5.11

### DIFF
--- a/packages/sawja/sawja.1.5.11/opam
+++ b/packages/sawja/sawja.1.5.11/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "sawja@inria.fr"
+authors: "Sawja development team"
+homepage: "http://sawja.inria.fr"
+bug-reports: "https://github.com/javalib-team/sawja/issues"
+license: "GPL-3.0"
+dev-repo: "git+https://github.com/javalib-team/sawja.git"
+build: [
+  ["./configure.sh"]
+  [make]
+]
+remove: [
+  ["ocamlfind" "remove" "sawja"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlfind" {build}
+  "javalib" {>= "3.2.1" & < "3.3"}
+]
+
+synopsis: "Sawja provides a high level representation of Java bytecode programs and static analysis tools"
+
+description: """
+Sawja is a library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs. Its name stands for Static Analysis Workshop for JAva. Whereas Javalib is dedicated to isolated classes, Sawja handles bytecode programs with their class hierarchy and control flow algorithms.
+Moreover, Sawja provides some stackless intermediate representations of code, called JBir and A3Bir. The transformation algorithm, common to these representations, has been formalized and proved to be semantics-preserving.
+"""
+url {
+  src: "https://github.com/javalib-team/sawja/archive/1.5.10.tar.gz"
+  checksum: [
+    "md5=47640ec571b01e759272a66852053fdf"
+    "sha512=aa8ae179f1cce0123d57e391879e2f455cf892ac0a2bb14ac173af54b54a85af2f4b0270709cb1ddae3030af2e47a8541769ba2ace92aa13d88757572f6b5eee"
+  ]
+}


### PR DESCRIPTION
### `sawja.1.5.11`
Sawja provides a high level representation of Java bytecode programs and static analysis tools
Sawja is a library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs. Its name stands for Static Analysis Workshop for JAva. Whereas Javalib is dedicated to isolated classes, Sawja handles bytecode programs with their class hierarchy and control flow algorithms.
Moreover, Sawja provides some stackless intermediate representations of code, called JBir and A3Bir. The transformation algorithm, common to these representations, has been formalized and proved to be semantics-preserving.



---
* Homepage: http://sawja.inria.fr
* Source repo: git+https://github.com/javalib-team/sawja.git
* Bug tracker: https://github.com/javalib-team/sawja/issues

---
:camel: Pull-request generated by opam-publish v2.1.0