### PR TITLE
Package sawja.1.5.11

### DIFF
--- a/packages/sawja/sawja.1.5.11/opam
+++ b/packages/sawja/sawja.1.5.11/opam
@@ -28,9 +28,9 @@ Sawja is a library written in OCaml, relying on Javalib to provide a high level 
 Moreover, Sawja provides some stackless intermediate representations of code, called JBir and A3Bir. The transformation algorithm, common to these representations, has been formalized and proved to be semantics-preserving.
 """
 url {
-  src: "https://github.com/javalib-team/sawja/archive/1.5.10.tar.gz"
+  src: "https://github.com/javalib-team/sawja/archive/1.5.11.tar.gz"
   checksum: [
-    "md5=47640ec571b01e759272a66852053fdf"
-    "sha512=aa8ae179f1cce0123d57e391879e2f455cf892ac0a2bb14ac173af54b54a85af2f4b0270709cb1ddae3030af2e47a8541769ba2ace92aa13d88757572f6b5eee"
+    "md5=e9e289fd79f076d4545c3df632ef9fe2"
+    "sha512=013f1cec0e77c6368e2a3e6a77ccb0ec49d3467ffeec179544b6794ca2e7036f6b91667ce1eabee09cf8d1b639f808167e24bb73c95613806bd6be96ab42ab7c"
   ]
 }


### PR DESCRIPTION
### `sawja.1.5.11`
Sawja provides a high level representation of Java bytecode programs and static analysis tools
Sawja is a library written in OCaml, relying on Javalib to provide a high level representation of Java bytecode programs. Its name stands for Static Analysis Workshop for JAva. Whereas Javalib is dedicated to isolated classes, Sawja handles bytecode programs with their class hierarchy and control flow algorithms.
Moreover, Sawja provides some stackless intermediate representations of code, called JBir and A3Bir. The transformation algorithm, common to these representations, has been formalized and proved to be semantics-preserving.



---
* Homepage: http://sawja.inria.fr
* Source repo: git+https://github.com/javalib-team/sawja.git
* Bug tracker: https://github.com/javalib-team/sawja/issues

---
:camel: Pull-request generated by opam-publish v2.1.0