### PR TITLE
Add ocaml 5.00 and 4.14.0+domains to base-domains to support the current multicore dev workflow

### DIFF
--- a/packages/base-domains/base-domains.base/opam
+++ b/packages/base-domains/base-domains.base/opam
@@ -4,7 +4,6 @@ description: """
 Domains-based parallelism distributed with the Multicore OCaml compiler"
 """
 depends: [
-  "ocaml" {>= "4.06.0"}
   "ocaml" {>= "5.00"} | 
   "ocaml-variants" {
     = "4.14.0+domains" |


### PR DESCRIPTION
Fixes https://github.com/ocaml-multicore/ocaml-multicore/issues/728