### PR TITLE
Revise awa and paf-le conflicts with domain-name

### DIFF
--- a/packages/awa/awa.0.0.1/opam
+++ b/packages/awa/awa.0.0.1/opam
@@ -35,6 +35,7 @@ depends: [
   "hacl_x25519" {>= "0.2.0"}
   "zarith"
 ]
+conflicts: [ "domain-name" {>= "0.3.1"} ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""
 x-commit-hash: "870f3f55fe6fe9125798cb9894bb98186e535a68"

--- a/packages/awa/awa.0.0.2/opam
+++ b/packages/awa/awa.0.0.2/opam
@@ -35,6 +35,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "zarith"
 ]
+conflicts: [ "domain-name" {>= "0.3.1"} ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""
 x-commit-hash: "a29cca7141580660ab4b2150f575c747ca182516"

--- a/packages/awa/awa.0.0.3/opam
+++ b/packages/awa/awa.0.0.3/opam
@@ -35,6 +35,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "zarith"
 ]
+conflicts: [ "domain-name" {>= "0.3.1"} ]
 synopsis: "SSH implementation in OCaml"
 description: """The OpenSSH protocol implemented in OCaml."""
 x-commit-hash: "200091e42500f79f4ccb399ac685987638be64af"

--- a/packages/paf-le/paf-le.0.0.6/opam
+++ b/packages/paf-le/paf-le.0.0.6/opam
@@ -20,6 +20,7 @@ depends: [
   "tls-mirage"
   "x509" {>= "0.13.0"}
 ]
+conflicts: [ "domain-name" {>= "0.3.1"} ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"


### PR DESCRIPTION
partially reverts #19886 (as questioned in https://github.com/ocaml/opam-repository/pull/19886#pullrequestreview-792913837), uses conflicts instead.