### PR TITLE
[coq] Fix the compilation of many Coq plugins for OCaml 4.13

### DIFF
--- a/packages/coq/coq.8.14.0/files/disable_warn_70.patch
+++ b/packages/coq/coq.8.14.0/files/disable_warn_70.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/configure/configure.ml b/tools/configure/configure.ml
+index 6f4787269b..ff83872f5e 100644
+--- a/tools/configure/configure.ml
++++ b/tools/configure/configure.ml
+@@ -616,7 +616,7 @@ let camltag = match caml_version_list with
+     67: "unused functor parameter" seems totally bogus
+     68: "This pattern depends on mutable state" no idea what it means, dune builds don't display it
+ *)
+-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-68"
++let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-68-70"
+ let coq_warn_error =
+     if !prefs.warn_error
+     then "-warn-error +a"

--- a/packages/coq/coq.8.14.0/opam
+++ b/packages/coq/coq.8.14.0/opam
@@ -49,10 +49,11 @@ install: [
   [ make "COQ_USE_DUNE=" "install" ]
 ]
 
-patches: [ "dune-install-set-root.patch" "ld_stricter.patch" ]
+patches: [ "dune-install-set-root.patch" "ld_stricter.patch" "disable_warn_70.patch" ]
 extra-files:
   [ [ "dune-install-set-root.patch" "sha256=e3071578fdddc45873fdc78446b1044c3ba8b1031bd05bbc901234cc1ebcceba" ]
-    [ "ld_stricter.patch" "sha256=a5cd1fe65889bb908e1194c37de428266b422f6040b5d729611eb100f054b591" ] ]
+    [ "ld_stricter.patch" "sha256=a5cd1fe65889bb908e1194c37de428266b422f6040b5d729611eb100f054b591" ]
+    [ "disable_warn_70.patch" "sha256=b305336e5103be6540519e6e6b67178e825f998c0f691553c2be1b5abb5a507d" ] ]
 
 url {
   src: "https://github.com/coq/coq/archive/refs/tags/V8.14.0.tar.gz"


### PR DESCRIPTION
Coq imposes a very strict set of default warnings for plugins plus
`-warn-error`. This was meant to be done only for Coq's CI and
development setup, but this setting wrongly leaked into the release
setup of Coq Opam archive.

We fixup things for OCaml 4.13 while a more complete solution is being
worked on.