### PR TITLE
Only permit result 1.5+ on OCaml 4.14 and later

### DIFF
--- a/packages/result/result.1.0/opam
+++ b/packages/result/result.1.0/opam
@@ -12,7 +12,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "4.14"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.0.tar.gz"
   checksum: "md5=01391a66385ab1a43f90455dfb5c6843"

--- a/packages/result/result.1.1/opam
+++ b/packages/result/result.1.1/opam
@@ -11,7 +11,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "4.14"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.1.tar.gz"
   checksum: "md5=1e0005783d4f70e1a9772723fa0e846b"

--- a/packages/result/result.1.2/opam
+++ b/packages/result/result.1.2/opam
@@ -14,7 +14,7 @@ description: """
 Projects that want to use the new result type defined in OCaml >= 4.03
 while staying compatible with older version of OCaml should use the
 Result module defined in this library."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "4.14"}]
 url {
   src: "https://github.com/janestreet/result/archive/1.2.tar.gz"
   checksum: "md5=3d5b66c5526918f0f2ca9d6811ef09c8"

--- a/packages/result/result.1.3/opam
+++ b/packages/result/result.1.3/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.14"}
   "jbuilder" {>= "1.0+beta11"}
 ]
 synopsis: "Compatibility Result module"

--- a/packages/result/result.1.4/opam
+++ b/packages/result/result.1.4/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/janestreet/result/issues"
 license: "BSD-3-Clause"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.14"}
   "dune" {>= "1.0"}
 ]
 synopsis: "Compatibility Result module"


### PR DESCRIPTION
Apropos https://github.com/ocaml/opam-repository/issues/19880#issuecomment-954121920, this takes @hannesm's original suggestion and shifts it from rewriting the past to prewriting the future 🙂

This is a slightly unusual constraining, because we're prohibiting packages which _may_ compile on 4.14, but this stops a bug from 1.0-1.4 from continuing to permeate the ecosystem.