### PR TITLE
All current versions of kind2 require zmq < 5.1.4

### DIFF
--- a/packages/kind2/kind2.1.3.0/opam
+++ b/packages/kind2/kind2.1.3.0/opam
@@ -17,9 +17,9 @@ depends: [
   "num"
   "odoc" {with-doc}
   "ounit2" {with-test}
-  "z3" {<= "4.8.8-1" & with-test}
+  "z3" {< "4.8.9" & with-test}
   "yojson"
-  "zmq"
+  "zmq" {>= "5.1.0" & < "5.1.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/kind2/kind2.1.3.1/opam
+++ b/packages/kind2/kind2.1.3.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit2" {with-test}
   "z3" {< "4.8.9" & with-test}
   "yojson"
-  "zmq"
+  "zmq" {>= "5.1.0" & < "5.1.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/kind2/kind2.1.4.0/opam
+++ b/packages/kind2/kind2.1.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ounit2" {with-test}
   "z3" {< "4.8.9" & with-test}
   "yojson"
-  "zmq" {>= "5.0.0"}
+  "zmq" {>= "5.1.0" & < "5.1.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/kind2/kind2.1.5.0/opam
+++ b/packages/kind2/kind2.1.5.0/opam
@@ -23,7 +23,7 @@ depends: [
   "odoc" {with-doc}
   "ounit2" {with-test}
   "yojson"
-  "zmq" {>= "5.0.0"}
+  "zmq" {>= "5.1.0" & < "5.1.4"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
This PR updates version constraints for kind2.