### PR TITLE
Package eliom.8.8.1

### DIFF
--- a/packages/eliom/eliom.8.6.0/opam
+++ b/packages/eliom/eliom.8.6.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "4.0.1"}
+  "ocsigenserver" {>= "4.0.1" & < "4.0.2"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "dbm" | "sqlite3"

--- a/packages/eliom/eliom.8.8.0/opam
+++ b/packages/eliom/eliom.8.8.0/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt_log"
   "lwt_ppx" {>= "1.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
-  "ocsigenserver" {>= "4.0.1" & < "5.0.0"}
+  "ocsigenserver" {>= "4.0.1" & < "4.0.2"}
   "ipaddr" {>= "2.1"}
   "reactiveData" {>= "0.2.1"}
   "dbm" | "sqlite3"

--- a/packages/eliom/eliom.8.8.1/opam
+++ b/packages/eliom/eliom.8.8.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: "Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml."
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppx_tools" {>= "5.2"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "4.0.1" & < "5.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+  "ppx_tools_versioned" {>= "5.2.3"}
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/8.8.1.tar.gz"
+  checksum: [
+    "md5=86a836ca14a9a0af9b12a2bfdd44e9d0"
+    "sha512=34150e008ad953b7bfaa7492255ded0e8f5034373cf98757461e5500678da3f9e029deb58d7e53b79ea4480200e00f9bd1577bbb9c26906a9b8a8c5ccc3a7792"
+  ]
+}


### PR DESCRIPTION
### `eliom.8.8.1`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications. It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time. Eliom allows implementing the whole application as a single program that includes both the client and the server code. We use a syntax extension to distinguish between the two sides. The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0