### PR TITLE
[opam-source-archives] Relocate old pyml archives on gforge.inria.fr

### DIFF
--- a/packages/pyml/pyml.20161224/opam
+++ b/packages/pyml/pyml.20161224/opam
@@ -55,6 +55,6 @@ Bindings are split in three modules:
   bindings."""
 flags: light-uninstall
 url {
-  src: "http://pyml.gforge.inria.fr/pyml-20161224.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pyml-20161224.tar.gz"
   checksum: "md5=ea8f445792ba5c8a7d5b6f4bf6bb31cd"
 }

--- a/packages/pyml/pyml.20170730/opam
+++ b/packages/pyml/pyml.20170730/opam
@@ -15,6 +15,6 @@ depends: [
 depopts: ["utop"]
 synopsis: "OCaml bindings for Python"
 url {
-  src: "http://pyml.gforge.inria.fr/pyml-20170730.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pyml-20170730.tar.gz"
   checksum: "md5=468e86155b28dc02d9acf0c8cc61e4b0"
 }

--- a/packages/pyml/pyml.20170807/opam
+++ b/packages/pyml/pyml.20170807/opam
@@ -15,6 +15,6 @@ depends: [
 depopts: ["utop"]
 synopsis: "OCaml bindings for Python"
 url {
-  src: "http://pyml.gforge.inria.fr/pyml-20170807.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pyml-20170807.tar.gz"
   checksum: "md5=b4d56646df336f83ecae295794524970"
 }

--- a/packages/pyml/pyml.20171117/opam
+++ b/packages/pyml/pyml.20171117/opam
@@ -16,6 +16,6 @@ depends: [
 depopts: ["utop"]
 synopsis: "OCaml bindings for Python"
 url {
-  src: "http://pyml.gforge.inria.fr/pyml-20171117.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pyml-20171117.tar.gz"
   checksum: "md5=285ba07b973f713c66991faf5382814d"
 }

--- a/packages/pyml/pyml.20180530/opam
+++ b/packages/pyml/pyml.20180530/opam
@@ -17,6 +17,6 @@ depends: [
 depopts: ["utop"]
 synopsis: "OCaml bindings for Python"
 url {
-  src: "http://pyml.gforge.inria.fr/pyml-20180530.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pyml-20180530.tar.gz"
   checksum: "md5=c4984df264751168e9017c05bee0d5e6"
 }


### PR DESCRIPTION
This PR fixes broken URLs for old pyml archives pointing to gforge.inria.fr (which is now down, #19757).
These pyml archives have been kindly uploaded to https://github.com/ocaml/opam-source-archives (https://github.com/ocaml/opam-source-archives/commit/7a651a9f55ab23a9858d517bd6efde6fd0499763). Thanks!