### PR TITLE
Package ocsigen-i18n.4.0.0

### DIFF
--- a/packages/eliom/eliom.6.10.1/opam
+++ b/packages/eliom/eliom.6.10.1/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.11.0/opam
+++ b/packages/eliom/eliom.6.11.0/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.12.0/opam
+++ b/packages/eliom/eliom.6.12.0/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.12.1/opam
+++ b/packages/eliom/eliom.6.12.1/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.12.4/opam
+++ b/packages/eliom/eliom.6.12.4/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.5.1" & < "3.9.0"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.4.0" & < "5.0.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.8.0/opam
+++ b/packages/eliom/eliom.6.8.0/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3" & < "3.5.0"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.8.1/opam
+++ b/packages/eliom/eliom.6.8.1/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3" & < "3.5"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.9.1/opam
+++ b/packages/eliom/eliom.6.9.1/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3" & < "3.5"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.9.2/opam
+++ b/packages/eliom/eliom.6.9.2/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/eliom/eliom.6.9.3/opam
+++ b/packages/eliom/eliom.6.9.3/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-tyxml" {>= "3.3"}
   "lwt_log"
   "lwt_ppx"
-  "ppx_tools_versioned"
+  "ppx_tools_versioned" {>= "5.2.3"}
   "tyxml" {>= "4.3.0" & < "4.4.0"}
   "ocsigenserver" {>= "2.10" & < "3.0.0"}
   "ipaddr" {>= "2.1"}

--- a/packages/ocsigen-i18n/ocsigen-i18n.1.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.08.0"}
   "ocamlfind" {build}
 ]
-synopsis: "I18n made easy for web sites written with eliom."
+synopsis: "I18n made easy for web sites written with eliom"
 authors: "Julien Sagot julien.sagot@besport.com"
 flags: light-uninstall
 url {

--- a/packages/ocsigen-i18n/ocsigen-i18n.1.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.1.0.0/opam
@@ -4,6 +4,7 @@ maintainer:   "Julien Sagot julien.sagot@besport.com"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]

--- a/packages/ocsigen-i18n/ocsigen-i18n.2.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.2.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.08.0"}
   "ocamlfind" {build}
 ]
-synopsis: "I18n made easy for web sites written with eliom."
+synopsis: "I18n made easy for web sites written with eliom"
 authors: "Julien Sagot julien.sagot@besport.com"
 url {
   src: "https://github.com/besport/ocsigen-i18n/archive/2.0.0.tar.gz"

--- a/packages/ocsigen-i18n/ocsigen-i18n.2.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.2.0.0/opam
@@ -4,6 +4,7 @@ maintainer:   "Julien Sagot julien.sagot@besport.com"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ make "bindir=%{bin}%" "uninstall" ]

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.0.0/opam
@@ -4,6 +4,7 @@ maintainer:   "Julien Sagot julien.sagot@besport.com"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ make "bindir=%{bin}%" "uninstall" ]

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.08.0"}
   "ocamlfind" {build}
 ]
-synopsis: "I18n made easy for web sites written with eliom."
+synopsis: "I18n made easy for web sites written with eliom"
 authors: "Julien Sagot julien.sagot@besport.com"
 url {
   src: "https://github.com/besport/ocsigen-i18n/archive/3.0.0.tar.gz"

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.1.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.1.0/opam
@@ -4,6 +4,7 @@ maintainer:   "Julien Sagot julien.sagot@besport.com"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ make "bindir=%{bin}%" "uninstall" ]

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.1.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.08.0"}
   "ocamlfind" {build}
 ]
-synopsis: "I18n made easy for web sites written with eliom."
+synopsis: "I18n made easy for web sites written with eliom"
 authors: "Julien Sagot julien.sagot@besport.com"
 url {
   src: "https://github.com/besport/ocsigen-i18n/archive/3.1.0.tar.gz"

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis:     "I18n made easy for web sites written with eliom."
+synopsis:     "I18n made easy for web sites written with eliom"
 maintainer:   "Jan Rochel <jan@besport.com>"
 
 homepage: "https://github.com/besport/ocsigen-i18n"

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.2.0/opam
@@ -5,6 +5,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
@@ -6,6 +6,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.3.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis:     "I18n made easy for web sites written with eliom."
+synopsis:     "I18n made easy for web sites written with eliom"
 description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
 maintainer:   "Jan Rochel <jan@besport.com>"
 

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.4.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.4.0/opam
@@ -6,6 +6,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 remove:  [ ["rm" "-f" "%{bin}%/ocsigen-i18n-generator"]

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.5.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.5.0/opam
@@ -6,6 +6,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.6.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.6.0/opam
@@ -6,6 +6,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 

--- a/packages/ocsigen-i18n/ocsigen-i18n.3.7.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.3.7.0/opam
@@ -6,6 +6,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ make "build" ]
 install: [ make "bindir=%{bin}%" "install" ]
 

--- a/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis:     "I18n made easy for web sites written with eliom"
+description:  "Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file"
+maintainer:   "Jan Rochel <jan@besport.com>"
+
+homepage: "https://github.com/besport/ocsigen-i18n"
+bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
+dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "ppxlib" {> "0.20"}
+]
+authors: "Julien Sagot"
+url {
+  src: "https://github.com/besport/ocsigen-i18n/archive/4.0.0.tar.gz"
+  checksum: [
+    "md5=47c31fd818ba4d5ecffddf717a88c115"
+    "sha512=3ef8b1d55e8957177b243528fc134a98702e69ed1c0ff7e108a47f730a678fae6ace83c0a64768f92eef70511f95da6e283d24d2d9bcd14374e3ed49751e0d3b"
+  ]
+}

--- a/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
@@ -18,7 +18,7 @@ authors: "Julien Sagot"
 url {
   src: "https://github.com/besport/ocsigen-i18n/archive/4.0.0.tar.gz"
   checksum: [
-    "md5=47c31fd818ba4d5ecffddf717a88c115"
-    "sha512=3ef8b1d55e8957177b243528fc134a98702e69ed1c0ff7e108a47f730a678fae6ace83c0a64768f92eef70511f95da6e283d24d2d9bcd14374e3ed49751e0d3b"
+    "md5=d750bb93432ee60d97b92b0539c95db8"
+    "sha512=f39fdcd4f1b4457b3398384743ab60edbd018b4f727c8d293e57d9a8d3ee7a925f009c7ccfe7be66833f3bb658d1b3275087e771472884505a4395d1fec96673"
   ]
 }

--- a/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
@@ -10,7 +10,7 @@ build:   [ "dune" "build" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.08"}
-  "ocamlfind" {build}
+  "dune" {>= "2.7"}
   "ppxlib" {> "0.20"}
 ]
 authors: "Julien Sagot"

--- a/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
@@ -11,7 +11,7 @@ build:   [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
-  "ppxlib" {> "0.20"}
+  "ppxlib" {>= "0.21.0"}
 ]
 authors: "Julien Sagot"
 url {

--- a/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
+++ b/packages/ocsigen-i18n/ocsigen-i18n.4.0.0/opam
@@ -6,6 +6,7 @@ maintainer:   "Jan Rochel <jan@besport.com>"
 homepage: "https://github.com/besport/ocsigen-i18n"
 bug-reports: "https://github.com/besport/ocsigen-i18n/issues"
 dev-repo: "git+https://github.com/besport/ocsigen-i18n.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build:   [ "dune" "build" "-p" name "-j" jobs ]
 
 depends: [

--- a/packages/ocsigen-start/ocsigen-start.1.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "1.1"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {= "6.2.0"}
   "ocsigen-toolkit" {>= "0.99" & <= "1.0.0"}
   "yojson"

--- a/packages/ocsigen-start/ocsigen-start.1.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.0.0/opam
@@ -4,6 +4,7 @@ maintainer: "dev@ocsigen.org"
 homepage: "https://ocsigen.org/ocsigen-start/"
 bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [ make ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "1.1"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {= "6.3.0"}
   "ocsigen-toolkit" {>= "1.1"}
   "js_of_ocaml-camlp4"

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -4,6 +4,7 @@ maintainer: "dev@ocsigen.org"
 homepage: "https://ocsigen.org/ocsigen-start/"
 bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [ make ]
 install: [ make "install" ]
 remove: [ make "uninstall" ]

--- a/packages/ocsigen-start/ocsigen-start.1.2.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {< "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {< "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {< "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.5.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {< "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.6.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {< "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.7.0/opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
 ]
 depexts: [

--- a/packages/ocsigen-start/ocsigen-start.1.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.7.0/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.1.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.0.0"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.8.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.8.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.8.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.8.0/opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
 ]
 depexts: [

--- a/packages/ocsigen-start/ocsigen-start.1.8.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.8.0/opam
@@ -22,6 +22,7 @@ depends: [
   "js_of_ocaml-ppx" {< "3.6.0"}
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "conf-npm" {>= "1"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "conf-npm" {>= "1"}
 ]

--- a/packages/ocsigen-start/ocsigen-start.2.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.1/opam
@@ -23,6 +23,7 @@ depends: [
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "conf-npm" {>= "1"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "conf-npm" {>= "1"}
 ]

--- a/packages/ocsigen-start/ocsigen-start.2.11.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.11.0/opam
@@ -28,6 +28,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.11.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.11.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.11.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.11.0/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.12.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.12.0/opam
@@ -28,6 +28,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.12.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.12.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.12.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.12.0/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.13.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.13.0/opam
@@ -28,6 +28,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.13.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.13.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.13.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.13.0/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.0/opam
@@ -26,6 +26,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.0/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.1/opam
@@ -23,6 +23,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "js_of_ocaml-ppx" {< "3.6.0"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.1/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.2/opam
@@ -26,6 +26,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.2/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.15.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.15.2/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.0/opam
@@ -23,6 +23,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "js_of_ocaml-ppx" {< "3.6.0"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.1/opam
@@ -23,6 +23,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "js_of_ocaml-ppx" {< "3.6.0"}
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.16.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.16.1/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.18.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.18.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.18.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.18.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.10.1" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.18.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.18.0/opam
@@ -22,6 +22,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.2/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.2/opam
@@ -22,6 +22,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.3/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.3/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "yojson" {>= "1.4.1"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.3/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.3/opam
@@ -22,6 +22,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.19.3/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.19.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.2.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.2.2/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "6.8.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.2.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.2.2/opam
@@ -20,7 +20,7 @@ depends: [
   "js_of_ocaml" {>= "3.4.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.2.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.2.2/opam
@@ -25,6 +25,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.21.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.21.1/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.21.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.21.1/opam
@@ -18,7 +18,7 @@ depends: [
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.21.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.21.1/opam
@@ -23,6 +23,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.3.0/opam
@@ -27,6 +27,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "0.5.2" & < "1.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.4.0/opam
@@ -27,6 +27,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "3.1"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.7.0/opam
@@ -21,7 +21,7 @@ depends: [
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
   "js_of_ocaml-ppx_deriving_json" {< "3.5.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.7.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.7.0/opam
@@ -27,6 +27,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.1/opam
@@ -28,6 +28,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.1/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.2/opam
@@ -28,6 +28,7 @@ depends: [
   "conf-npm" {>= "1"}
   "ocamlnet"
   "lwt_camlp4"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.2/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "macaque" {>= "0.7.4"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.4.0" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.3.1"}
   "js_of_ocaml" {>= "3.4.0"}

--- a/packages/ocsigen-start/ocsigen-start.2.9.2/opam
+++ b/packages/ocsigen-start/ocsigen-start.2.9.2/opam
@@ -22,7 +22,7 @@ depends: [
   "js_of_ocaml-compiler" {>= "3.4.0" & < "3.5.0"}
   "js_of_ocaml-camlp4" {>= "3.1.0"}
   "js_of_ocaml-ppx" {< "3.6.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.1.0"}
+  "ocsigen-i18n" {>= "3.1.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.7.0"}
+  "ocsigen-i18n" {>= "3.7.0" & < "4.0.0"}
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "eliom" {>= "6.12.4" & < "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.4.0.1/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.0.1/opam
@@ -23,6 +23,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
 	["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "eliom" {>= "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}

--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "pgocaml" {>= "4.0"}
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
-  "ocsigen-i18n" {>= "3.7.0"}
+  "ocsigen-i18n" {>= "3.7.0" & < "4.0.0"}
   "eliom" {>= "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -23,6 +23,7 @@ depends: [
   "cohttp-lwt-unix"
   "conf-npm" {>= "1"}
   "ocamlnet"
+  "re" {>= "1.7.2"}
 ]
 depexts: [
   ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}

--- a/packages/ocsigen-start/ocsigen-start.4.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocsigen-i18n" {>= "3.7.0"}
   "eliom" {>= "7.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
-  "ocsigen-i18n" {>= "3.7.0"}
+  "ocsigen-i18n" {>= "3.7.0" & < "4.0.0"}
   "yojson" {>= "1.6.0"}
   "resource-pooling" {>= "1.0" & < "2.0"}
   "cohttp-lwt-unix"


### PR DESCRIPTION
### `ocsigen-i18n.4.0.0`
I18n made easy for web sites written with eliom
Provides executables: ocsigen-i18n-generator for generating an eliom file from a file containing tab-separated values; ocsigen-i18n-rewriter for implementing a PPX syntax for referencing entries in the generated eliom file



---
* Homepage: https://github.com/besport/ocsigen-i18n
* Source repo: git+https://github.com/besport/ocsigen-i18n.git
* Bug tracker: https://github.com/besport/ocsigen-i18n/issues

---
:camel: Pull-request generated by opam-publish v2.1.0