### PR TITLE
Add torch 0.14.

### DIFF
--- a/packages/torch/torch.0.14/opam
+++ b/packages/torch/torch.0.14/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+bug-reports:  "https://github.com/LaurentMazare/ocaml-torch/issues"
+homepage:     "https://github.com/LaurentMazare/ocaml-torch"
+dev-repo:     "git+https://github.com/LaurentMazare/ocaml-torch.git"
+license:      "Apache-2.0"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "base" {>= "v0.11.0" & < "v0.15"}
+  "cmdliner"
+  "ctypes" {>= "0.11"}
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "dune-configurator"
+  "libtorch" {>= "1.10.0" & < "1.11.0"}
+  "npy"
+  "ocaml" {>= "4.08"}
+  "ocaml-compiler-libs"
+  "ppx_custom_printf" {< "v0.15"}
+  "ppx_expect" {< "v0.15"}
+  "ppx_sexp_conv" {< "v0.15"}
+  "sexplib" {< "v0.15"}
+  "stdio" {< "v0.15"}
+]
+
+available: arch = "x86_64" & (os = "linux" | os = "macos")
+x-ci-accept-failures: [
+  "centos-7" # Requires gcc with -std=c++14
+  "oraclelinux-7" # Requires gcc with -std=c++14
+]
+
+synopsis: "PyTorch bindings for OCaml"
+description: """
+The ocaml-torch project provides some OCaml bindings for the PyTorch library.
+This brings to OCaml NumPy-like tensor computations with GPU acceleration and
+tape-based automatic differentiation.
+"""
+
+url {
+  src: "https://github.com/LaurentMazare/ocaml-torch/archive/0.14.tar.gz"
+  checksum: [
+    "md5=7a712ae0e8c7f5452f628377d80a5bb4"
+    "sha512=22314b655bc6b5e5c970cbab8d132eae36ee0b8fb0a96b63727899442eb70fe00bd1895d7cc718a85b58bc2b2b4ea6820fa288a19346f095e5de18f7e47c2d02"
+  ]
+}


### PR DESCRIPTION
This new package update the OCaml PyTorch bindings to work with the newly released 1.10 PyTorch version.