### PR TITLE
ocigenserver.2.9: Fix constraint

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.2.9/opam
+++ b/packages/ocsigenserver/ocsigenserver.2.9/opam
@@ -48,7 +48,7 @@ depends: [
   "base-threads"
   "react"
   "ssl" {< "0.5.8"}
-  "lwt" {>= "3.0.0" & < "4.0.0"}
+  "lwt" {>= "3.2.0" & < "4.0.0"}
   "lwt_ssl"
   "lwt_react"
   "ocamlnet" {>= "4.0.2"}


### PR DESCRIPTION
Uses Lwt_pool.create with ~dispose only available with Lwt >= 3.2.0

Detected in #19908 

```
# make[3]: Entering directory '/home/opam/.opam/4.03/.opam-switch/build/ocsigenserver.2.9/src/extensions/ocsipersist-pgsql'
# ln -s -f ../ocsipersist.mli .
# ocamlfind ocamlc -g -bin-annot -thread -I ../../baselib -I ../../http -I ../../server -package tyxml.parser -package pgocaml -package lwt -c ocsipersist.mli
# ocamlfind ocamlc -g -bin-annot -thread -I ../../baselib -I ../../http -I ../../server -package tyxml.parser -package pgocaml -package lwt -c ocsipersist.ml
# File "ocsipersist.ml", line 56, characters 34-41:
# Error: The function applied to this argument has type
#          ?check:('a -> (bool -> unit) -> unit) -> 'a Lwt_pool.t
# This argument cannot be applied with label ~dispose
# make[3]: *** [Makefile:46: ocsipersist.cmo] Error 2
# make[3]: Leaving directory '/home/opam/.opam/4.03/.opam-switch/build/ocsigenserver.2.9/src/extensions/ocsipersist-pgsql'
# make[2]: *** [Makefile:52: byte] Error 2
# make[2]: Leaving directory '/home/opam/.opam/4.03/.opam-switch/build/ocsigenserver.2.9/src/extensions'
# make[1]: *** [Makefile:7: all] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.03/.opam-switch/build/ocsigenserver.2.9/src'
# make: *** [Makefile:8: all] Error 2



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build ocsigenserver 2.9
```