### PR TITLE
Fix constraints of packages depending on safepass

### DIFF
--- a/packages/links/links.0.7.2/opam
+++ b/packages/links/links.0.7.2/opam
@@ -60,7 +60,7 @@ depends: [
   "lwt"
   "cohttp" {< "0.99.0"}
   "websocket-lwt"
-  "safepass"
+  "safepass" {>= "1.1"}
 ]
 synopsis: "Linking Theory to Practice for the Web"
 description: """

--- a/packages/links/links.0.7.3/opam
+++ b/packages/links/links.0.7.3/opam
@@ -60,7 +60,7 @@ depends: [
   "lwt" {>= "3.1.0"}
   "cohttp"
   "websocket-lwt"
-  "safepass"
+  "safepass" {>= "1.1"}
   "ocamlfind"
 ]
 synopsis: "Linking Theory to Practice for the Web"

--- a/packages/links/links.0.8/opam
+++ b/packages/links/links.0.8/opam
@@ -60,7 +60,7 @@ depends: [
   "lwt" {>= "3.1.0"}
   "cohttp"
   "websocket-lwt"
-  "safepass"
+  "safepass" {>= "1.1"}
   "ocamlfind"
 ]
 synopsis: "Linking Theory to Practice for the Web"

--- a/packages/links/links.0.9.1/opam
+++ b/packages/links/links.0.9.1/opam
@@ -31,7 +31,7 @@ depends: [
   "uri"
   "websocket"
   "websocket-lwt-unix"
-  "safepass"
+  "safepass" {>= "1.1"}
   "result"
   "ocamlfind"
   "menhir"

--- a/packages/links/links.0.9.2/opam
+++ b/packages/links/links.0.9.2/opam
@@ -29,7 +29,7 @@ depends: [
   "uri"
   "websocket"
   "websocket-lwt-unix"
-  "safepass"
+  "safepass" {>= "1.1"}
   "result"
   "ocamlfind"
   "menhir"

--- a/packages/links/links.0.9.3/opam
+++ b/packages/links/links.0.9.3/opam
@@ -29,7 +29,7 @@ depends: [
   "uri"
   "websocket"
   "websocket-lwt-unix"
-  "safepass"
+  "safepass" {>= "1.1"}
   "result"
   "ocamlfind"
   "menhir"

--- a/packages/links/links.0.9.4/opam
+++ b/packages/links/links.0.9.4/opam
@@ -31,7 +31,7 @@ depends: [
   "uri"
   "websocket"
   "websocket-lwt-unix"
-  "safepass"
+  "safepass" {>= "1.1"}
   "result"
   "ocamlfind"
   "menhir" {>= "20210419"}

--- a/packages/links/links.0.9/opam
+++ b/packages/links/links.0.9/opam
@@ -32,7 +32,7 @@ depends: [
   "uri"
   "websocket"
   "websocket-lwt-unix"
-  "safepass"
+  "safepass" {>= "1.1"}
   "result"
   "ocamlfind"
   "menhir"

--- a/packages/ocsigen-start/ocsigen-start.1.0.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
-  "safepass"
+  "safepass" {>= "1.1"}
   "ocsigen-i18n" {>= "3.1.0"}
   "eliom" {= "6.2.0"}
   "ocsigen-toolkit" {>= "0.99" & <= "1.0.0"}

--- a/packages/ocsigen-start/ocsigen-start.1.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.1.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.03"}
   "pgocaml" {>= "2.3"}
   "macaque" {>= "0.7.4"}
-  "safepass"
+  "safepass" {>= "1.1"}
   "ocsigen-i18n" {>= "3.1.0"}
   "eliom" {= "6.3.0"}
   "ocsigen-toolkit" {>= "1.1"}


### PR DESCRIPTION
before 1.1 the library was called ocaml-safepass, not safepass.