### PR TITLE
[new release] albatross (1.3.1)

### DIFF
--- a/packages/albatross/albatross.1.3.1/opam
+++ b/packages/albatross/albatross.1.3.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "jsonm"
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.3.1/albatross-v1.3.1.tbz"
+  checksum: [
+    "sha256=3e13603493084d636ae712366011cbce9b53a96764d5dfa3b845bd6e95b2d2a9"
+    "sha512=b45b4350aef4dbda3eeeb91c865b1f8979feabd611fc1ceceb692f51a6f6987c3393de54558db70b3f2388c6b41c9ddac06956c392c2bb0b74f7abcfadee9694"
+  ]
+}
+x-commit-hash: "ecf199416b0d0bcb43d7216df0ac522740115b99"

--- a/packages/albatross/albatross.1.3.1/opam
+++ b/packages/albatross/albatross.1.3.1/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/roburio/albatross"
 dev-repo: "git+https://github.com/roburio/albatross.git"
 bug-reports: "https://github.com/roburio/albatross/issues"
 license: "ISC"
-
+available: os != "macos"
 depends: [
   "ocaml" {>= "4.10.0"}
   "dune"
@@ -43,9 +43,8 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
-  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
 ]
 synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
 description: """
@@ -55,7 +54,7 @@ by albatross are network interfaces of kind `tap`, which are connected to
 already existing bridges, block devices, memory, and CPU. Each unikernel is
 pinned (`cpuset` / `taskset`) to a specific core.
 """
-depexts: ["linux-headers"] {os-distribution = "alpine"}
+depexts: ["linux-headers"] {os-family = "alpine"}
 url {
   src:
     "https://github.com/roburio/albatross/releases/download/v1.3.1/albatross-v1.3.1.tbz"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- Linux: install binaries into /usr/sbin, adjust systemd scripts
  (roburio/albatross#89 by @reynir, fixed by @hannesm)
- remove rresult dependency (@hannesm)
- remove deprecated Fmt functions (@dinosaure)
