### PR TITLE
Make cppo_ocamlbuild and cppo < 1.6.0 incompatible

### DIFF
--- a/packages/cppo/cppo.0.9.4/opam
+++ b/packages/cppo/cppo.0.9.4/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 install: [make "install-lib"]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall

--- a/packages/cppo/cppo.1.0.0/opam
+++ b/packages/cppo/cppo.1.0.0/opam
@@ -12,6 +12,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 install: [make "install-lib"]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall

--- a/packages/cppo/cppo.1.0.1/opam
+++ b/packages/cppo/cppo.1.0.1/opam
@@ -12,6 +12,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 install: [make "install-lib"]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall

--- a/packages/cppo/cppo.1.1.0/opam
+++ b/packages/cppo/cppo.1.1.0/opam
@@ -12,6 +12,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 install: [make "install-lib"]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall

--- a/packages/cppo/cppo.1.1.1/opam
+++ b/packages/cppo/cppo.1.1.1/opam
@@ -12,6 +12,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 install: [make "install-lib"]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall

--- a/packages/cppo/cppo.1.1.2/opam
+++ b/packages/cppo/cppo.1.1.2/opam
@@ -12,6 +12,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 install: [make "install-lib"]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall

--- a/packages/cppo/cppo.1.2.2/opam
+++ b/packages/cppo/cppo.1.2.2/opam
@@ -20,6 +20,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo/cppo.1.3.0/opam
+++ b/packages/cppo/cppo.1.3.0/opam
@@ -20,6 +20,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo/cppo.1.3.1/opam
+++ b/packages/cppo/cppo.1.3.1/opam
@@ -20,6 +20,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo/cppo.1.3.2/opam
+++ b/packages/cppo/cppo.1.3.2/opam
@@ -20,6 +20,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo/cppo.1.4.0/opam
+++ b/packages/cppo/cppo.1.4.0/opam
@@ -20,6 +20,9 @@ depends: [
   "ocamlfind"
   "ocamlbuild"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo/cppo.1.4.1/opam
+++ b/packages/cppo/cppo.1.4.1/opam
@@ -24,6 +24,9 @@ depends: [
   "ocamlbuild"
   "base-bytes"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo/cppo.1.5.0/opam
+++ b/packages/cppo/cppo.1.5.0/opam
@@ -24,6 +24,9 @@ depends: [
   "ocamlbuild"
   "base-bytes"
 ]
+conflicts: [
+  "cppo_ocamlbuild"
+]
 synopsis: "Equivalent of the C preprocessor for OCaml programs"
 flags: light-uninstall
 extra-files: ["cppo.install" "md5=17d87ee306893c194f9fc7045c0bf717"]

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.8/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.8/opam
@@ -11,6 +11,9 @@ depends: [
   "ocamlbuild"
   "ocamlfind"
 ]
+conflicts: [
+  "cppo" {< "1.6.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Both install the cppo_ocamlbuild library since cppo 0.9.4

```
#=== ERROR while installing cppo.1.2.2 ========================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.04.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.04/.opam-switch/build/cppo.1.2.2
# command              ~/.opam/opam-init/hooks/sandbox.sh install make install-lib
# exit-code            2
# env-file             ~/.opam/log/cppo-1109-a390b9.env
# output-file          ~/.opam/log/cppo-1109-a390b9.out
### output ###
# ocamlfind install -patch-version 1.1.2 "cppo_ocamlbuild" \
# 	META ocamlbuild_plugin/_build/ocamlbuild_cppo.cmi ocamlbuild_plugin/_build/ocamlbuild_cppo.cma ocamlbuild_plugin/_build/ocamlbuild_cppo.cmxa ocamlbuild_plugin/_build/ocamlbuild_cppo.a ocamlbuild_plugin/_build/ocamlbuild_cppo.cmxs
# ocamlfind: Package cppo_ocamlbuild is already installed
#  - (file /home/opam/.opam/4.04/lib/cppo_ocamlbuild/META already exists)
# make: *** [Makefile:79: install-lib] Error 2
```