### PR TITLE
Otoml 0.9.2

### DIFF
--- a/packages/otoml/otoml.0.9.2/opam
+++ b/packages/otoml/otoml.0.9.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis:
+  "TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)"
+description: """\
+OTOML is a library for parsing, manipulating, and pretty-printing TOML files.
+
+* Fully 1.0.0-compliant.
+* No extra dependencies: default implementation uses native numbers and represents dates as strings.
+* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
+* Informative parse error reporting.
+* Pretty-printer offers flexible indentation options."""
+maintainer: "daniil+opam@baturin.org"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://github.com/dmbaturin/otoml"
+bug-reports: "https://github.com/dmbaturin/otoml/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "menhir"
+  "menhirLib" {>= "20200525"}
+  "dune" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "ounit2" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dmbaturin/otoml.git"
+url {
+  src: "https://github.com/dmbaturin/otoml/archive/refs/tags/0.9.2.tar.gz"
+  checksum: [
+    "md5=9fe793f78b49843f641118ce5c8aec59"
+    "sha512=3ab1c1128155aa12acf29d455a7fe6d32bba5982ef57dcf6095e6890f913d9663880f308d92e51111c65986f56126daaf575e820b31b15b009b1d824dca81d52"
+  ]
+}

--- a/packages/soupault/soupault.3.0.0/opam
+++ b/packages/soupault/soupault.3.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "lambdasoup" {>= "0.7.2"}
   "markup" {>= "1.0.0-1"}
-  "otoml"
+  "otoml" {< "0.9.2"}
   "fileutils"
   "logs"
   "fmt"

--- a/packages/soupault/soupault.3.1.0/opam
+++ b/packages/soupault/soupault.3.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "lambdasoup" {>= "0.7.2"}
   "markup" {>= "1.0.0-1"}
-  "otoml"
+  "otoml" {< "0.9.2"}
   "fileutils"
   "logs"
   "fmt"

--- a/packages/soupault/soupault.3.2.0/opam
+++ b/packages/soupault/soupault.3.2.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "lambdasoup" {>= "0.7.3"}
   "markup" {>= "1.0.0-1"}
-  "otoml"
+  "otoml" {< "0.9.2"}
   "fileutils" {>= "0.6.3"}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}


### PR DESCRIPTION
Due to a breaking change in this release that affects soupault, I also adjusted dependencies in all affected soupault versions to use `{< "0.9.2"}`. The other dependent package, [dirsift](https://opam.ocaml.org/packages/dirsift/) isn't using the affected function and shouldn't need any adjustments.

I'll make a maintenance release to make soupault buildable with the latest version once this PR is merged.

### Breaking changes

`Otoml.get_array` now has type `?strict:bool -> (t -> 'a) -> t -> 'a list`,
that is, it requires an accessor function that will be applied to every item of the array.

For example, you can use `Otoml.find t (Otoml.get_array Otoml.get_string) ["foo"]` to retrieve
an array of strings from a TOML document's key `foo`.

The motivation for the change is that it allows retrieving arrays of unwrapped OCaml values in one step.
The old behaviour can still be emulated using an identify function for the accessor,
for example the built-in `Otoml.get_value : 'a -> 'a`.

### New features

New `Otoml.path_exists t ["some"; "table"; "key"]` allows checking if a key path exists in a TOML document.

`Otoml.Printer.to_string/to_channel` functions now provide `~force_table_array` option. When set to true,
it forces every array that contains nothing but tables to be rendered using the `[[...]]`` table array syntax.

### Bug fixes

Unicode escape sequences are now printed correctly.

If a table has subtables and non-table items, the non-table items are forcibly moved before the first subtable
for printing. This way the output parses correctly, otherwise the non-table items would be mistakenly treated
as subtable members. This way hand-constructed TOML tables are always formatted correctly even if the user
inserts non-table items after a subtable.

### Testing

Added a minimal test suite for the read-write interface, and a TOML test suite client executable for encoder testing.