### PR TITLE
Package taglib.0.3.7

### DIFF
--- a/packages/conf-taglib/conf-taglib.1/opam
+++ b/packages/conf-taglib/conf-taglib.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["libtag-devel"] {os-family = "suse"}
   ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
+  ["taglib"] {os = "macos" & os-distribution = "macports"}
   ["taglib-devel"] {os-distribution="centos" | os-family = "fedora"}
 ]
 synopsis: "Virtual package relying on taglib"

--- a/packages/conf-taglib/conf-taglib.1/opam
+++ b/packages/conf-taglib/conf-taglib.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://taglib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "taglib maintainers"
+license: "LGPL-2.1-or-later"
+build: ["pkg-config" "--exists" "taglib"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libtag1-dev" "zlib1g-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["taglib-dev" "zlib-dev"] {os-family = "alpine"}
+  ["libtag-devel"] {os-family = "suse"}
+  ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
+  ["taglib"] {os = "macos" & os-distribution = "homebrew"}
+  ["taglib-devel"] {os-distribution="centos" | os-family = "fedora"}
+]
+synopsis: "Virtual package relying on taglib"
+description:
+  "This package can only install if the taglib library is installed on the system."
+flags: conf

--- a/packages/taglib/taglib.0.3.7/opam
+++ b/packages/taglib/taglib.0.3.7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Bindings for the taglib library"
+description:
+  "Bindings for the taglib library which provides functions for reading tags in headers of audio files"
+maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+authors: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/savonet/ocaml-taglib"
+bug-reports: "https://github.com/savonet/ocaml-taglib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "conf-taglib"
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-taglib.git"
+url {
+  src: "https://github.com/savonet/ocaml-taglib/archive/v0.3.7.tar.gz"
+  checksum: [
+    "md5=4f6df8b09126897a394e9acfc6193d59"
+    "sha512=04e498d1fc2e3937bc25583175436d1cee8a25aabfdf43df4f30d1878aac97fde1d25be8dca44273fb2223785c3872088d667d6ba3e6cc644730b2f9b4d0491f"
+  ]
+}


### PR DESCRIPTION
### `taglib.0.3.7`
Bindings for the taglib library
Bindings for the taglib library which provides functions for reading tags in headers of audio files



---
* Homepage: https://github.com/savonet/ocaml-taglib
* Source repo: git+https://github.com/savonet/ocaml-taglib.git
* Bug tracker: https://github.com/savonet/ocaml-taglib/issues

---
:camel: Pull-request generated by opam-publish v2.0.3