### PR TITLE
Package pyml_bindgen.0.1.0

### DIFF
--- a/packages/pyml_bindgen/pyml_bindgen.0.1.0/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Generate pyml bindings from OCaml value specifications"
+maintainer: "Ryan M. Moore"
+authors: "Ryan M. Moore"
+license: "MIT"
+homepage: "https://github.com/mooreryan/ocaml_python_bindgen"
+doc: "https://mooreryan.github.io/ocaml_python_bindgen/"
+bug-reports: "https://github.com/mooreryan/ocaml_python_bindgen/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "angstrom"
+  "base"
+  "cmdliner"
+  "ppx_jane"
+  "re2"
+  "stdio"
+  "ocaml"
+  "core_kernel" {with-test}
+  "ocamlformat" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "pyml" {with-test}
+  "bisect_ppx" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mooreryan/ocaml_python_bindgen.git"
+url {
+  src:
+    "https://github.com/mooreryan/ocaml_python_bindgen/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=0fc328f1bd5dc5425fea269f25b86616"
+    "sha512=8468355c7b63acfc86fccbd88cc095260a6efd6fad9936c46e0799483558f8a548265d9d3c954014fd41502cf3282390aa3135887459fc1da899c1bce0058be8"
+  ]
+}


### PR DESCRIPTION
### `pyml_bindgen.0.1.0`
Generate pyml bindings from OCaml value specifications



---
* Homepage: https://github.com/mooreryan/ocaml_python_bindgen
* Source repo: git+https://github.com/mooreryan/ocaml_python_bindgen.git
* Bug tracker: https://github.com/mooreryan/ocaml_python_bindgen/issues

---
:camel: Pull-request generated by opam-publish v2.1.0