### PR TITLE
Mark re2 unavailable on arm32 architectures (uses g++ -m32)

### DIFF
--- a/packages/re2/re2.v0.10.0/opam
+++ b/packages/re2/re2.v0.10.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-distribution = "ol"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 url {
   src:

--- a/packages/re2/re2.v0.10.1/opam
+++ b/packages/re2/re2.v0.10.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-distribution = "ol"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 url {
   src: "https://github.com/janestreet/re2/archive/v0.10.1.tar.gz"

--- a/packages/re2/re2.v0.11.0/opam
+++ b/packages/re2/re2.v0.11.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-distribution = "ol"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 url {
   src:

--- a/packages/re2/re2.v0.12.0/opam
+++ b/packages/re2/re2.v0.12.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_jane"    {>= "v0.12" & < "v0.13"}
   "dune"        {>= "1.5.1" & < "2.0.0"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 description: "
 "

--- a/packages/re2/re2.v0.12.1/opam
+++ b/packages/re2/re2.v0.12.1/opam
@@ -16,6 +16,7 @@ depends: [
   "dune"        {>= "1.5.1"}
   "conf-g++" {build}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 url {
   src: "https://github.com/janestreet/re2/archive/v0.12.1.tar.gz"

--- a/packages/re2/re2.v0.13.0/opam
+++ b/packages/re2/re2.v0.13.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ppx_jane"    {>= "v0.13" & < "v0.14"}
   "dune"        {>= "1.5.1"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 description: "
 "

--- a/packages/re2/re2.v0.14.0/opam
+++ b/packages/re2/re2.v0.14.0/opam
@@ -16,6 +16,7 @@ depends: [
   "conf-g++"    {build}
   "dune"        {>= "2.0.0"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 description: "
 "

--- a/packages/re2/re2.v0.9.0/opam
+++ b/packages/re2/re2.v0.9.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-distribution = "ol"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 url {
   src: "https://ocaml.janestreet.com/ocaml-core/v0.9/files/re2-v0.9.0.tar.gz"

--- a/packages/re2/re2.v0.9.1/opam
+++ b/packages/re2/re2.v0.9.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["gcc-c++"] {os-distribution = "fedora"}
   ["gcc-c++"] {os-distribution = "ol"}
 ]
+available: arch != "arm32"
 synopsis: "OCaml bindings for RE2, Google's regular expression library"
 url {
   src: "https://github.com/janestreet/re2/archive/v0.9.1.tar.gz"


### PR DESCRIPTION
Upstream issue: https://github.com/janestreet/re2/issues/26

```
#=== ERROR while compiling re2.v0.14.0 ========================================#
# context              2.1.0 | linux/arm32 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/re2.v0.14.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p re2 -j 159
# exit-code            1
# env-file             ~/.opam/log/re2-24-14acdc.env
# output-file          ~/.opam/log/re2-24-14acdc.out
### output ###
#          gcc src/stubs.o
# In file included from stubs.cpp:64:
# util.h:6: warning: "Val_none" redefined
#     6 | #define Val_none (Val_int(0))
#       | 
# In file included from stubs.h:6,
#                  from stubs.cpp:8:
# /home/opam/.opam/4.13/lib/ocaml/caml/mlvalues.h:403: note: this is the location of the previous definition
#   403 | #define Val_none Val_int(0)
#       | 
#       ocamlc src/.re2.objs/byte/re2__Regex.{cmo,cmt}
# File "src/regex.ml", line 156, characters 25-46:
# 156 |       | Invalid_argument "index out of bounds" ->
#                                ^^^^^^^^^^^^^^^^^^^^^
# Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
# this constructor's arguments. They are only for information
# and may change in future versions. (See manual section 11.5)
#     ocamlopt src/.re2.objs/native/re2__Regex.{cmx,o}
# File "src/regex.ml", line 156, characters 25-46:
# 156 |       | Invalid_argument "index out of bounds" ->
#                                ^^^^^^^^^^^^^^^^^^^^^
# Warning 52 [fragile-literal-pattern]: Code should not depend on the actual values of
# this constructor's arguments. They are only for information
# and may change in future versions. (See manual section 11.5)
#         bash src/re2_c/dllre2_c_stubs.so,src/re2_c/libre2_c_stubs.a (exit 2)
# (cd _build/default/src/re2_c && /bin/bash -e -u -o pipefail -c '
# ARFLAGS=rsc
# CXXFLAGS="-Wall -O3 -g -pthread"
# if [ FreeBSD = `uname -s` ]; then
#        CXX=clang++
#        CXXFLAGS="$CXXFLAGS -I /usr/local/lib/re2"
# else
#        CXX=g++
# fi
# if ! false; then
#   CXX="$CXX -m32"
# fi
# /usr/bin/gmake -s -C libre2 clean
# /usr/bin/gmake -s -C libre2 ARFLAGS="$ARFLAGS" CXX="$CXX" CXXFLAGS="$CXXFLAGS" obj/libre2.a obj/so/libre2.so
# cp libre2/obj/libre2.a libre2_c_stubs.a
# cp libre2/obj/so/libre2.so dllre2_c_stubs.so
# /usr/bin/gmake -s -C libre2 clean
# ')
# g++: error: unrecognized command-line option '-m32'; did you mean '-mbe32'?
# gmake: *** [Makefile:161: obj/util/arena.o] Error 1
```

The flag is there since v0.9.0: https://github.com/janestreet/re2/commit/1a33cdc4bab936140be5c1e378c6dd483e5e4100