### PR TITLE
Package soupault.3.2.1

### DIFF
--- a/packages/soupault/soupault.3.2.1/opam
+++ b/packages/soupault/soupault.3.2.1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
+* Export extracted metadata to JSON.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.app"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.3"}
+  "markup" {>= "1.0.0-1"}
+  "otoml" {>= "0.9.2"}
+  "fileutils" {>= "0.6.3"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "re" {>= "1.9.0"}
+  "ezjsonm" {>= "1.2.0"}
+  "yaml" {>= "2.0.0"}
+  "containers" {>= "3.6"}
+  "odate" {>= "0.6"}
+  "spelll" {>= "0.3"}
+  "base64" {>= "3.0.0"}
+  "jingoo" {>= "1.4.2"}
+  "tsort" {>= "2.1.0"}
+  "lua-ml" {>= "0.9.3"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src: "https://github.com/dmbaturin/soupault/archive/refs/tags/3.2.1.zip"
+  checksum: [
+    "md5=ac62be950df7fa84ae534d1387ab3106"
+    "sha512=9fc6e21446132c1879ec12dda153b096b034101299d2aebdcc4940b4a9a1bba6630af73fc244e125b72e429492258f45b87a10dfc4a4ab554011dc157a27755a"
+  ]
+}

--- a/packages/soupault/soupault.3.2.1/opam
+++ b/packages/soupault/soupault.3.2.1/opam
@@ -51,9 +51,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/dmbaturin/soupault"
 url {
-  src: "https://github.com/dmbaturin/soupault/archive/refs/tags/3.2.1.zip"
+  src: "https://github.com/dmbaturin/soupault/archive/refs/tags/3.2.1.tar.gz"
   checksum: [
-    "md5=ac62be950df7fa84ae534d1387ab3106"
-    "sha512=9fc6e21446132c1879ec12dda153b096b034101299d2aebdcc4940b4a9a1bba6630af73fc244e125b72e429492258f45b87a10dfc4a4ab554011dc157a27755a"
+    "md5=c1f1b1dfcde00dadf98c826b2fb03afa"
+    "sha512=3254a205d67f76bc856fb043796ee87861e9232b230315bf346aed4496fa917677c4c9bfb8f9ec048e2f7b0c2b92fd5a02c24b60896d52686076f3171a85afda"
   ]
 }


### PR DESCRIPTION
### `soupault.3.2.1`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

With soupault you can:

* Generate ToC and footnotes.
* Insert file content or an HTML snippet in any element.
* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
* Export extracted metadata to JSON.

Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
similar to web browsers.

The website generator mode is optional, you can use it as post-processor for existing sites.



---
* Homepage: https://www.soupault.app
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.1.0