### PR TITLE
[new release] ocaml-r (OCaml-R)

### DIFF
--- a/packages/ocaml-r/ocaml-r.0.5.0/opam
+++ b/packages/ocaml-r/ocaml-r.0.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Objective Caml bindings for the R interpreter"
+description: """
+
+OCaml-R is a library that can be used to construct R values in memory,
+convert them to OCaml values, and build clean wrappers to R
+functions. It provide a simple means to develop bindings to any R
+package."""
+maintainer: ["philippe.veber@gmail.com"]
+authors: ["Guillaume Yzyquel" "Maxence Guesdon" "Philippe Veber"]
+license: "GPL-3.0-only"
+tags: ["R" "statistics"]
+homepage: "https://github.com/pveber/ocaml-r/"
+doc: "https://pveber.github.io/ocaml-r/ocaml-r/index.html"
+bug-reports: "https://github.com/pveber/ocaml-r/issues"
+depends: [
+  "alcotest" {with-test}
+  "base" {build & >= "v0.14"}
+  "conf-r" {build}
+  "conf-r-mathlib" {build}
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.08"}
+  "stdio" {>= "v0.14" & build}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pveber/ocaml-r.git"
+url {
+  src:
+    "https://github.com/pveber/ocaml-r/releases/download/v0.5.0/ocaml-r-0.5.0.tbz"
+  checksum: [
+    "sha256=35fc05e7852e18309df75caaeb61d466d2eeaeee13bc31e509576da040b3606e"
+    "sha512=5b4ad4e76fe2239acc50edd8b6a3636434111af78d2279fa1f818c8127ebe72262d421d8488adfd15466d1893d9e5a05a5aa754bcbe68a32ecd8b0e4a4b2c19a"
+  ]
+}
+x-commit-hash: "d9c80f09f6f029398bff6164dfb541a6acdc8c49"


### PR DESCRIPTION
Objective Caml bindings for the R interpreter

- Project page: <a href="https://github.com/pveber/ocaml-r/">https://github.com/pveber/ocaml-r/</a>
- Documentation: <a href="https://pveber.github.io/ocaml-r/ocaml-r/index.html">https://pveber.github.io/ocaml-r/ocaml-r/index.html</a>

##### CHANGES:

ocaml-r-0.5.0 2021-11-01
------------------------

- added graphics functions (axis, text, points, smooth_scatter,
  boxplot)
- added base function (c, list creation)
- fixed interaction with pkg-config (by @drjdn)



ocaml-r-0.4.0 2020-10-15
------------------------

This version implements a massive API refactoring, which generalizes
and amplifies the design experimented in version 0.2.0. Each R
datatype is represented as an abstract type of a dedicated module. The
`t` type of the module is a bare SEXP (or at rather a custom block
wrapping a bare SEXP). S3 inheritance is represented by module (type)
inclusion.

- addition of an (alco)test suite
- (typed) matrices for logical, character and int types
- row and column access for data.frame and matrix
- access to factor values
- safer interface for list and data.frame components
- modular interface for statistical tests

ocaml-r-0.3.1 2020-07-29
------------------------

- replaced configurator by dune.configurator
- fixed compilation warnings

ocaml-r-0.3.0 2020-05-07
------------------------

- base: added readRDS, saveRDS, cbind, rbind
- graphics: abline
- stats: ecdf
- fixed compilation bug

ocaml-r-0.2.0 2019-06-07
------------------------

- experimented modular (instead of object) interfaces
- a few more wrappers in base, stats and graphics
- improved stub generation
- API documentation

ocaml-r-0.1.1 2018-11-18
------------------------

jbuilder-to-dune transition

ocaml-r-0.1.0 2018-06-06
------------------------

First formal release
