### PR TITLE
Tezos-stdlib-unix needs fmt (used to be transitively provided)

### DIFF
--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.10.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.10.2/opam
@@ -13,6 +13,7 @@ depends: [
   "ptime" { >= "0.8.4" }
   "mtime" { >= "1.0.0" }
   "conf-libev"
+  "domain-name" { < "0.3.1" }
   "ipaddr" { >= "4.0.0" }
   "ezjsonm" { >= "1.1.0" }
   "fmt" { >= "0.8.7" }


### PR DESCRIPTION
We forgot to declare the dependency toward `fmt` of `tezos-stdlib-unix` in the dune file (but not in the opam file!) because up to `domain-name.0.3.0`, `domain-name` brought `fmt` and we were saved by the dependency chain `domain-name` -> `ipaddr` -> `tezos-stdlib-unix`...

Of course, there is an alternative fix which is to declare `"domain-name" { < "0.3.1" }` as a dependency constraint but is it really less ugly then the patch?