### PR TITLE
Package eliom.8.9.0

### DIFF
--- a/packages/eliom/eliom.8.9.0/opam
+++ b/packages/eliom/eliom.8.9.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: """
+Eliom is a framework for implementing client/server Web applications.
+It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
+Eliom allows implementing the whole application as a single program that includes both the client and the server code.
+We use a syntax extension to distinguish between the two sides.
+The client-side code is compiled to JS using Ocsigen Js_of_ocaml.
+"""
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "4.0.1" & < "5.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "dbm" | "sqlite3"
+  "base-bytes"
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/8.9.0.tar.gz"
+  checksum: [
+    "md5=a3cedcf506cada1b4ddc8f16dfc59560"
+    "sha512=5596e8a4aaae823f05fb593f4c0f971589f1cf6c1d38aeafc7108d9ba31b2d93ac82f45a399f7e8dad6565d6f7c178b98385c444bd97c8b4dfe26b2d98464257"
+  ]
+}


### PR DESCRIPTION
### `eliom.8.9.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications.
It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
Eliom allows implementing the whole application as a single program that includes both the client and the server code.
We use a syntax extension to distinguish between the two sides.
The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0