### PR TITLE
[new release] omigrate (0.1.1)

### DIFF
--- a/packages/omigrate/omigrate.0.1.1/opam
+++ b/packages/omigrate/omigrate.0.1.1/opam
@@ -19,8 +19,11 @@ depends: [
   "pgx"
   "pgx_lwt_unix"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/omigrate/omigrate.0.1.1/opam
+++ b/packages/omigrate/omigrate.0.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Database migrations for Reason and OCaml"
+description: "Database migrations for Reason and OCaml"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/omigrate"
+doc: "https://tmattio.github.io/omigrate/"
+bug-reports: "https://github.com/tmattio/omigrate/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "lwt" {>= "5.3.0"}
+  "uri"
+  "cmdliner"
+  "logs"
+  "fmt"
+  "pgx"
+  "pgx_lwt_unix"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/omigrate.git"
+url {
+  src:
+    "https://github.com/tmattio/omigrate/releases/download/0.1.1/omigrate-0.1.1.tbz"
+  checksum: [
+    "sha256=274a85d581eaccdc291a1cfa7266c8e634e65f32e1c5ac54be3094d3d64ebad2"
+    "sha512=a152330c8003b1ff0bc8c50026ed21c53690b7f935c3150e4c87a19b62c5d9540e4601731414541587ebbd467e80658b211dbf38918b359fc5626c3df7e33365"
+  ]
+}
+x-commit-hash: "5fafde8fd9204cad125aa3f92de6462f517ea9bd"

--- a/packages/omigrate/omigrate.0.1.1/opam
+++ b/packages/omigrate/omigrate.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "uri"
   "cmdliner"
   "logs"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "pgx"
   "pgx_lwt_unix"
 ]


### PR DESCRIPTION
Database migrations for Reason and OCaml

- Project page: <a href="https://github.com/tmattio/omigrate">https://github.com/tmattio/omigrate</a>
- Documentation: <a href="https://tmattio.github.io/omigrate/">https://tmattio.github.io/omigrate/</a>

##### CHANGES:

## Fixed

- Use 1-indexed month number in migration names (tmattio/omigrate#1, @punchagan)
