### PR TITLE
5 packages from ocsigen/ocsipersist

### DIFF
--- a/packages/ocsipersist-dbm/ocsipersist-dbm.1.0.1/opam
+++ b/packages/ocsipersist-dbm/ocsipersist-dbm.1.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using DBM"
+description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "dbm"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ffbd09c9fe79c0fd9c5013dce0975a7c"
+    "sha512=7b038f35fb93b9983642cbff2f4069cacd5fe9f20118e3cb6aca685a7e2f16f320b73daa13b39dd45429fb6e884699dc7cfca9cfc459c8db86baf4846c9fb7e9"
+  ]
+}

--- a/packages/ocsipersist-lib/ocsipersist-lib.1.0.1/opam
+++ b/packages/ocsipersist-lib/ocsipersist-lib.1.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) - support library"
+description:  "This library defines signatures and auxiliary tools for defining backends for the Ocsipersist frontent. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM database, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ffbd09c9fe79c0fd9c5013dce0975a7c"
+    "sha512=7b038f35fb93b9983642cbff2f4069cacd5fe9f20118e3cb6aca685a7e2f16f320b73daa13b39dd45429fb6e884699dc7cfca9cfc459c8db86baf4846c9fb7e9"
+  ]
+}

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.1/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ffbd09c9fe79c0fd9c5013dce0975a7c"
+    "sha512=7b038f35fb93b9983642cbff2f4069cacd5fe9f20118e3cb6aca685a7e2f16f320b73daa13b39dd45429fb6e884699dc7cfca9cfc459c8db86baf4846c9fb7e9"
+  ]
+}

--- a/packages/ocsipersist/ocsipersist.1.0.1/opam
+++ b/packages/ocsipersist/ocsipersist.1.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using multiple backends"
+description:  "This is an virtual library defining a unified frontend for a number of key/value storage implementations. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM database, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+]
+
+depopts: [
+	"ocsipersist-dbm"
+	"ocsipersist-pgsql"
+	"ocsipersist-sqlite"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ffbd09c9fe79c0fd9c5013dce0975a7c"
+    "sha512=7b038f35fb93b9983642cbff2f4069cacd5fe9f20118e3cb6aca685a7e2f16f320b73daa13b39dd45429fb6e884699dc7cfca9cfc459c8db86baf4846c9fb7e9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocsipersist.1.0.1`: Persistent key/value storage (for Ocsigen) using multiple backends
-`ocsipersist-dbm.1.0.1`: Persistent key/value storage (for Ocsigen) using DBM
-`ocsipersist-lib.1.0.1`: Persistent key/value storage (for Ocsigen) - support library
-`ocsipersist-pgsql.1.0.1`: Persistent key/value storage (for Ocsigen) using PostgreSQL
-`ocsipersist-sqlite.1.0`: Persistent key/value storage (for Ocsigen) using SQLite



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0