### PR TITLE
Package ocsigenserver.5.0.0

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.5.0.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.5.0.0/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "A full-featured and extensible Web server"
+description: "Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc."
+authors: "dev@ocsigen.org"
+homepage: "http://ocsigen.org/ocsigenserver/"
+bug-reports: "https://github.com/ocsigen/ocsigenserver/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/ocsigenserver.git"
+build: [
+  [
+    "sh"
+    "configure"
+    "--prefix"
+    "%{prefix}%"
+    "--ocsigen-user"
+    "%{user}%"
+    "--ocsigen-group"
+    "%{group}%"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--logdir"
+    "%{lib}%/ocsigenserver/var/log/ocsigenserver"
+    "--mandir"
+    "%{man}%/man1"
+    "--docdir"
+    "%{lib}%/ocsigenserver/share/doc/ocsigenserver"
+    "--commandpipe"
+    "%{lib}%/ocsigenserver/var/run/ocsigenserver_command"
+    "--staticpagesdir"
+    "%{lib}%/ocsigenserver/var/www"
+    "--datadir"
+    "%{lib}%/ocsigenserver/var/lib/ocsigenserver"
+    "--temproot"
+    ""
+    "--sysconfdir"
+    "%{lib}%/ocsigenserver/etc/ocsigenserver"
+  ]
+  [make "-C" "src" "confs"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install:[make "install.files"]
+depends: [
+  "ocaml" {>= "4.08.1"}
+  "dune" {>= "2.7"}
+  "ocamlfind"
+  "base-unix"
+  "base-threads"
+  "react"
+  "ssl" {>= "0.5.8"}
+  "lwt" {>= "3.0.0"}
+  "lwt_ssl"
+  "lwt_react"
+  "lwt_log"
+  "pcre"
+  "cryptokit"
+  "dbm" | "sqlite3" | "pgocaml"
+  "ipaddr" {>= "2.1"}
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix" {>= "2.0.0"}
+  "hmap"
+  "xml-light"
+  "conf-which"
+  "camlzip"
+]
+conflicts: [
+  "camlzip" {< "1.04"}
+  "pgocaml" {< "2.2"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigenserver/archive/5.0.0.tar.gz"
+  checksum: [
+    "md5=ac7f9fcf1aced530061ceb4c76efe475"
+    "sha512=5691d1cc53725466bf0548fdaa8b4b624b9ac20aa41152f61020da05696a2d0e3cd010d9d72aa60d55216ca4b1b3938573e00c7d922e034d1080508ec46b47dd"
+  ]
+}


### PR DESCRIPTION
### `ocsigenserver.5.0.0`
A full-featured and extensible Web server
Ocsigen Server implements most features of the HTTP protocol, and has a very powerful extension mechanism that makes it very easy to plug your own OCaml modules for generating pages. Many extensions are already implemented, like a reverse proxy, content compression, access control, authentication, etc.



---
* Homepage: http://ocsigen.org/ocsigenserver/
* Source repo: git+https://github.com/ocsigen/ocsigenserver.git
* Bug tracker: https://github.com/ocsigen/ocsigenserver/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0