### PR TITLE
[new release] icalendar (0.1.5)

### DIFF
--- a/packages/caldav/caldav.0.1.0/opam
+++ b/packages/caldav/caldav.0.1.0/opam
@@ -43,7 +43,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "xmlm" {>= "1.3.0"}
   "tyxml" {>= "4.3.0"}
-  "icalendar" {>= "0.1.2"}
+  "icalendar" {>= "0.1.2" & < "0.1.5"}
   "rresult" {>= "0.6.0"}
   "sexplib" {>= "v0.12.0"}
   "ppx_sexp_conv" {>= "v0.12.0"}

--- a/packages/icalendar/icalendar.0.1.5/opam
+++ b/packages/icalendar/icalendar.0.1.5/opam
@@ -25,7 +25,7 @@ depends: [
   "alcotest" {with-test}
   "fmt"
   "angstrom" {>= "0.14.0"}
-  "re"
+  "re" {>= "1.7.2"}
   "uri"
   "ptime"
   "ppx_deriving"

--- a/packages/icalendar/icalendar.0.1.5/opam
+++ b/packages/icalendar/icalendar.0.1.5/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re"
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/v0.1.5/icalendar-v0.1.5.tbz"
+  checksum: [
+    "sha256=934327b0c361e04e0931b48e40bea7cd3bfdabb2663b0ed06a2e04f86ff873a6"
+    "sha512=ed3ea6a25d97a2e847c49425b20d4bed480df237589b0cc302e1c3cbb4d8fc8291cfb5e225e082b58c8bdbf43a969a9991915ac55c1e6122754751f0091558c3"
+  ]
+}
+x-commit-hash: "5766347a86a6f6e5f33927b61b722bceb2cdab9c"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/roburio/icalendar">https://github.com/roburio/icalendar</a>
- Documentation: <a href="https://roburio.github.io/icalendar/">https://roburio.github.io/icalendar/</a>

##### CHANGES:

* Drop astring, rresult, stdlib-shims dependencies
* Require OCaml 4.08 as lower bound
