### PR TITLE
Package eliom.9.0.0

### DIFF
--- a/packages/eliom/eliom.9.0.0/opam
+++ b/packages/eliom/eliom.9.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: """
+Eliom is a framework for implementing client/server Web applications.
+It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
+Eliom allows implementing the whole application as a single program that includes both the client and the server code.
+We use a syntax extension to distinguish between the two sides.
+The client-side code is compiled to JS using Ocsigen Js_of_ocaml.
+"""
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "base-bytes"
+  "ocsipersist" {>= "1.0" & < "2.0"}
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/9.0.0.tar.gz"
+  checksum: [
+    "md5=db78a1e917834a690f93dc6970a5f31d"
+    "sha512=39a7dfd581521473725a98f591b86b0a5f96628275270cf21179579c569c44994ecc4dd7273e64b796aa5689b7e38ca6df649888d5fa2c1fc3cb708d42655109"
+  ]
+}


### PR DESCRIPTION
### `eliom.9.0.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications.
It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
Eliom allows implementing the whole application as a single program that includes both the client and the server code.
We use a syntax extension to distinguish between the two sides.
The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0