### PR TITLE
[new release] caldav (0.1.1)

### DIFF
--- a/packages/caldav/caldav.0.1.1/opam
+++ b/packages/caldav/caldav.0.1.1/opam
@@ -55,6 +55,7 @@ depends: [
   "dispatch" {>= "0.5.0"}
   "uri" {>= "4.0.0"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 synopsis: "A CalDAV server"
 description: """
 A CalDAV server (RFC 4791). Supports everything from the roburio/icalendar

--- a/packages/caldav/caldav.0.1.1/opam
+++ b/packages/caldav/caldav.0.1.1/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/caldav"
+bug-reports: "https://github.com/roburio/caldav/issues"
+dev-repo: "git+https://github.com/roburio/caldav.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/caldav/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test & >= "0.8.5"}
+  "ounit" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test}
+  "tcpip" {with-test & >= "3.7.0"}
+  "mirage-clock-unix" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "fmt" {>= "0.8.7"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "ppx_deriving" {>= "4.3"}
+  "lwt" {>= "4.0"}
+  "ptime" {>= "0.8.5"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {with-test & >= "2.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+  "base64" {>= "3.0.0"}
+  "xmlm" {>= "1.3.0"}
+  "tyxml" {>= "4.3.0"}
+  "icalendar" {>= "0.1.2"}
+  "sexplib" {>= "v0.12.0"}
+  "ppx_sexp_conv" {>= "v0.12.0"}
+  "logs" {>= "0.6.3"}
+  "hex" {>= "1.4.0"}
+  "metrics"
+  "re" {>= "1.7.2"}
+  #from webmachine
+  "dispatch" {>= "0.5.0"}
+  "uri" {>= "4.0.0"}
+]
+synopsis: "A CalDAV server"
+description: """
+A CalDAV server (RFC 4791). Supports everything from the roburio/icalendar
+library. Also includes a partial WebDAV implementation.
+"""
+url {
+  src:
+    "https://github.com/roburio/caldav/releases/download/v0.1.1/caldav-v0.1.1.tbz"
+  checksum: [
+    "sha256=edcd9e1b65b7595e5dde49c1b2aac9cf25c60cd713eb25cbdb80df8fbfb5b80a"
+    "sha512=9537c95e5621eedfe7719fcb7f4b009cfffcd12f518987f645d55ef2e36e3eb928bfb3a48cf93e7cc5234678f6dbffcb1f457c3da2dcce8fd04804d441912993"
+  ]
+}
+x-commit-hash: "0075969af7e1ea677e34b225ea215dfe0a35052f"


### PR DESCRIPTION
A CalDAV server

- Project page: <a href="https://github.com/roburio/caldav">https://github.com/roburio/caldav</a>
- Documentation: <a href="https://roburio.github.io/caldav/">https://roburio.github.io/caldav/</a>

##### CHANGES:

* Drop rresult and astring dependency (roburio/caldav#23 @hannesm).
