### PR TITLE
Package ocsipersist-pgsql.1.0.2

### DIFF
--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.2/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.2.tar.gz"
+  checksum: [
+    "md5=0d6a62bc59454aac2f077189a628f078"
+    "sha512=fbf043df65c37587a198947323d13256dfcd25d847ff33037e42df7b28423a87cee6a5b7c6264cb2b0c159b88fc6e3f095ed46ed3fe49fa57287e0825c263e85"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocsipersist-pgsql.1.0.2`: Persistent key/value storage (for Ocsigen) using PostgreSQL



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0