### PR TITLE
[new release] crlibm (0.5)

### DIFF
--- a/packages/crlibm/crlibm.0.5/opam
+++ b/packages/crlibm/crlibm.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["libm" "math" "floating-point" "rounding" "science"]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-crlibm"
+dev-repo: "git+https://github.com/Chris00/ocaml-crlibm.git"
+bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
+doc: "https://Chris00.github.io/ocaml-crlibm/doc"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune-configurator" {>= "2.0"}
+  "dune" {>= "2.0"}
+  "base-bytes" {build}
+  "benchmark" {with-test}
+]
+synopsis: "Binding to CRlibm, a correctly rounded math lib"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-crlibm/releases/download/0.5/crlibm-0.5.tbz"
+  checksum: [
+    "sha256=ac0b9dd06a8842456b5e36551d84d2789c16256446ff2537be9091b1d44b8d27"
+    "sha512=e411323f39cf186f3145a9500c560ac8a94c1ff5fc4e6697067733a750f360404be6916e966c10cdc0bd66b0d6878ab1eadfc5586096226e5fea8b1db51a9e35"
+  ]
+}
+x-commit-hash: "cff684eeb3ab82c3f633fa62e7af5378600f48e8"

--- a/packages/crlibm/crlibm.0.5/opam
+++ b/packages/crlibm/crlibm.0.5/opam
@@ -20,6 +20,7 @@ depends: [
   "benchmark" {with-test}
 ]
 synopsis: "Binding to CRlibm, a correctly rounded math lib"
+available: arch != "x86_32"
 url {
   src:
     "https://github.com/Chris00/ocaml-crlibm/releases/download/0.5/crlibm-0.5.tbz"


### PR DESCRIPTION
Binding to CRlibm, a correctly rounded math lib

- Project page: <a href="https://github.com/Chris00/ocaml-crlibm">https://github.com/Chris00/ocaml-crlibm</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-crlibm/doc">https://Chris00.github.io/ocaml-crlibm/doc</a>

##### CHANGES:

- Rename sub-modules to more standard names.
