### PR TITLE
[new release] 0.0.6 Release of ego - fixes some bugs

### DIFF
--- a/packages/ego/ego.0.0.6/opam
+++ b/packages/ego/ego.0.0.6/opam
@@ -4,7 +4,7 @@ description:
   "Ego is an exensible egraph library for OCaml loosely based on the egg library in Rust."
 maintainer: ["kirang@comp.nus.edu.sg"]
 authors: ["Kiran Gopinathan"]
-license: "GPL-3.0+"
+license: "GPL-3.0-or-later"
 homepage: "https://gitlab.com/gopiandcode/ego"
 bug-reports: "https://gitlab.com/gopiandcode/ego/issues"
 depends: [
@@ -30,8 +30,7 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files"
-    "false"
+    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}

--- a/packages/ego/ego.0.0.6/opam
+++ b/packages/ego/ego.0.0.6/opam
@@ -10,8 +10,8 @@ bug-reports: "https://gitlab.com/gopiandcode/ego/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.0.8"}
-  "containers" {>= "3.3"}
-  "containers-data" {>= "3.3"}
+  "containers" {>= "3.4"}
+  "containers-data" {>= "3.4"}
   "iter" {>= "1.2.1"}
   "ppx_deriving" {>= "4.4"}
   "ppx_inline_alcotest" {>= "1.0.0"}

--- a/packages/ego/ego.0.0.6/opam
+++ b/packages/ego/ego.0.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Ego (EGraphs OCaml) is extensible EGraph library for OCaml"
+description:
+  "Ego is an exensible egraph library for OCaml loosely based on the egg library in Rust."
+maintainer: ["kirang@comp.nus.edu.sg"]
+authors: ["Kiran Gopinathan"]
+license: "GPL-3.0+"
+homepage: "https://gitlab.com/gopiandcode/ego"
+bug-reports: "https://gitlab.com/gopiandcode/ego/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.0.8"}
+  "containers" {>= "3.3"}
+  "containers-data" {>= "3.3"}
+  "iter" {>= "1.2.1"}
+  "ppx_deriving" {>= "4.4"}
+  "ppx_inline_alcotest" {>= "1.0.0"}
+  "ppx_inline_alcotest" {>= "1.0.0"}
+  "ocamldot" {>= "1.1"}
+  "sexplib" {>= "v0.14.0"}
+  "ppxlib" {>= "0.22.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files"
+    "false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://gitlab.com/gopiandcode/ego.git"
+url {
+  src: "https://github.com/verse-lab/ego/archive/refs/tags/0.0.6.tar.gz"
+  checksum: "md5=bb48de9f1c477103d77215a40ce84d6f"
+}

--- a/packages/ego/ego.0.0.6/opam
+++ b/packages/ego/ego.0.0.6/opam
@@ -40,5 +40,5 @@ build: [
 dev-repo: "git+https://gitlab.com/gopiandcode/ego.git"
 url {
   src: "https://github.com/verse-lab/ego/archive/refs/tags/0.0.6.tar.gz"
-  checksum: "md5=bb48de9f1c477103d77215a40ce84d6f"
+  checksum: "md5=016028a0dcd7a8cef864b20879baf9dd"
 }


### PR DESCRIPTION
Latest release of ego, fixes usage of `Option.get_exn` to use `Option.get_exn_or` and updated BackoffScheduler to correctly decrement ban duration.