### PR TITLE
[new release] builder (0.2.0)

### DIFF
--- a/packages/builder/builder.0.2.0/opam
+++ b/packages/builder/builder.0.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/builder"
+dev-repo: "git+https://github.com/roburio/builder.git"
+bug-reports: "https://github.com/roburio/builder/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+  "asn1-combinators"
+  "bheap" {>= "2.0.0"}
+  "bos"
+  "cmdliner"
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "fmt" {>= "0.8.7"}
+  "fpath"
+  "logs"
+  "lwt"
+  "ptime"
+  "uuidm"
+  "http-lwt-client" {>= "0.0.4"}
+  "base64"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+
+synopsis: "Scheduling and executing shell jobs"
+description: """
+The builder server has a schedule of jobs to be executed, stored persistently
+on disk. Any number of workers can connect via TCP (using ASN.1 encoded
+messages) that execute a single job -- usually contained in a sandbox (FreeBSD
+jail or Docker container). A client is a command-line interface to modify the
+schedule. Access control is out of scope - run it locally on your build host.
+The server receives the output artifacts of each job, and either stores them
+on the local file system or upload them to a remote server via http.
+
+See https://builds.robur.coop for the live web frontend (builder-web).
+"""
+url {
+  src:
+    "https://github.com/roburio/builder/releases/download/v0.2.0/builder-v0.2.0.tbz"
+  checksum: [
+    "sha256=66b3f31634388f0f7ee98d39bf7c40a7998decd3362de2d724f4d3d789cbef79"
+    "sha512=0cc681261864bdb692cfcb7a0b1ab433d38d03d30df011e1f9ba994f4577e24b38a50ed2e16abfd03da6485db3222cab074138fbf7a090b3118f300bcb59e284"
+  ]
+}
+x-commit-hash: "9b7933ab017aef1196388851731fa6de8d64bd98"


### PR DESCRIPTION
Scheduling and executing shell jobs

- Project page: <a href="https://github.com/roburio/builder">https://github.com/roburio/builder</a>

##### CHANGES:

* Client: print relative timestamp for worker output
* Client: report result of command execution
* Add platform string to jobs (supporting one server for
  multiple heterogenous workers)
* Debian packaging: add "builder" user, create /var/lib/builder,
  use 0644 for service scripts and metadata
* Worker: simplify and unify failure behaviour (exit on error)
* Revise communication protocol (breaks backwards compatibility)
