### PR TITLE
Package pyml_bindgen.0.1.1

### DIFF
--- a/packages/pyml_bindgen/pyml_bindgen.0.1.1/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.1.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Generate pyml bindings from OCaml value specifications"
+maintainer: "Ryan M. Moore"
+authors: "Ryan M. Moore"
+license: "MIT"
+homepage: "https://github.com/mooreryan/ocaml_python_bindgen"
+doc: "https://mooreryan.github.io/ocaml_python_bindgen/"
+bug-reports: "https://github.com/mooreryan/ocaml_python_bindgen/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "angstrom" {>= "0.15.0"}
+  "base" {>= "v0.12"}
+  "cmdliner"
+  "ppx_jane" {>= "v0.12"}
+  "re2" {>= "v0.12"}
+  "stdio" {>= "v0.12"}
+  "ocaml" {>= "4.08.0"}
+  "core_kernel" {>= "v0.12" & with-test}
+  "ocamlformat" {with-test}
+  "ppx_inline_test" {>= "v0.12" & with-test}
+  "ppx_expect" {>= "v0.12" & with-test}
+  "pyml" {with-test}
+  "bisect_ppx" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mooreryan/ocaml_python_bindgen.git"
+url {
+  src:
+    "https://github.com/mooreryan/ocaml_python_bindgen/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=a0eb69f41243045cf2803e115e525c61"
+    "sha512=09d808052db7b7034863a8ca84ed9a2829bf98c5ae6caa1a83f2758b81af46bc6c80612f59ad94268fb795cc4d80cdf8b7b5b0f8029608e5e34c606252e35dca"
+  ]
+}


### PR DESCRIPTION
### `pyml_bindgen.0.1.1`
Generate pyml bindings from OCaml value specifications



---
* Homepage: https://github.com/mooreryan/ocaml_python_bindgen
* Source repo: git+https://github.com/mooreryan/ocaml_python_bindgen.git
* Bug tracker: https://github.com/mooreryan/ocaml_python_bindgen/issues

---
:camel: Pull-request generated by opam-publish v2.1.0