### PR TITLE
[new release] wayland (1.0)

### DIFF
--- a/packages/wayland/wayland.1.0/opam
+++ b/packages/wayland/wayland.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Wayland protocol library"
+description:
+  "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0 (excluding schema files)"
+homepage: "https://github.com/talex5/ocaml-wayland"
+doc: "https://talex5.github.io/ocaml-wayland/"
+bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "ocaml" {>= "4.08.0"}
+  "xmlm" {>= "1.3.0"}
+  "lwt" {>= "5.4.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cstruct" {>= "6.0.0"}
+  "cmdliner" {>= "1.0.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/ocaml-wayland.git"
+url {
+  src:
+    "https://github.com/talex5/ocaml-wayland/releases/download/v1.0/wayland-1.0.tbz"
+  checksum: [
+    "sha256=bf8fd0057242d11f1c265c11cfa5de3c517ec0ad5994eae45e1efe3aac034510"
+    "sha512=da639e0903325e124933a03156ffd76188d2dfa2a9a61c5cee808fc8783833b81bb68ab59364ccc7c54a98bafa45d5b5a6c0571179f48178b5667b180a6d5a73"
+  ]
+}
+x-commit-hash: "fba7b1aa964b4d20952dbbacf92b79ed654b72a5"


### PR DESCRIPTION
Pure OCaml Wayland protocol library

- Project page: <a href="https://github.com/talex5/ocaml-wayland">https://github.com/talex5/ocaml-wayland</a>
- Documentation: <a href="https://talex5.github.io/ocaml-wayland/">https://talex5.github.io/ocaml-wayland/</a>

##### CHANGES:

- Improve connection shutdown (talex5/ocaml-wayland#22).
  Add `shutdown` and `up` methods to the transport API.
  Call `shutdown` to start a clean shutdown of the connection.
  Use `up` to detect that a connection is shutting down (to avoid logging pointless errors).
  Add `close` and `socket` methods to `unix_transport`.

- Log exceptions handling messages instead of aborting the connection (talex5/ocaml-wayland#21).
  Most errors are not fatal, and closing the connection means the application can't even e.g. prompt the user to save their work.

- Add `Client.dump` and `Server.dump` (talex5/ocaml-wayland#20). Useful for finding object reference leaks.

- Add `Proxy.pp_transport` (talex5/ocaml-wayland#19). Useful for logging when you have multiple connections.

- Also call `on_delete` handlers when the connection ends (talex5/ocaml-wayland#18).
  Allows them to be used for cleaning up resources.

- Add `set_paused` to pause processing of incoming messages (talex5/ocaml-wayland#17).

- Add `Proxy.can_send` (talex5/ocaml-wayland#16).
  This is useful to check whether a proxy has been destroyed.

- Raise `Invalid_argument` on `Proxy.id` if the proxy is destroyed.

- Add `wp_primary_selection_unstable_v1`.
  This appears to be identical to gtk-primary-selection except for the name and that it's marked as unstable.
  But sway has dropped support for the old name (see https://github.com/swaywm/sway/pull/5788).

- Update to latest Fmt API.

- Fix deprecation warning with cstruct 6.0.1.
