### PR TITLE
Package pyml_bindgen.0.1.1

### DIFF
--- a/packages/pyml_bindgen/pyml_bindgen.0.1.1/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.1.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Generate pyml bindings from OCaml value specifications"
+maintainer: "Ryan M. Moore"
+authors: "Ryan M. Moore"
+license: "MIT"
+homepage: "https://github.com/mooreryan/ocaml_python_bindgen"
+doc: "https://mooreryan.github.io/ocaml_python_bindgen/"
+bug-reports: "https://github.com/mooreryan/ocaml_python_bindgen/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "angstrom" {>= "0.15.0"}
+  "base" {>= "v0.12"}
+  "cmdliner" {>= "1.0"}
+  "ppx_let" {>= "v0.12"}
+  "ppx_sexp_conv" {>= "v0.12"}
+  "ppx_string" {>= "v0.12"}
+  "re2" {>= "v0.12"}
+  "stdio" {>= "v0.12"}
+  "ocaml" {>= "4.08.0"}
+  "conf-python-3-dev" {>= "1" & with-test}
+  "core_kernel" {>= "v0.12" & with-test}
+  "ocamlformat" {with-test}
+  "ppx_inline_test" {>= "v0.12" & with-test}
+  "ppx_expect" {>= "v0.12" & with-test}
+  "pyml" {with-test}
+  "bisect_ppx" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mooreryan/ocaml_python_bindgen.git"
+url {
+  src:
+    "https://github.com/mooreryan/ocaml_python_bindgen/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=69d7838ad3a32865974aa911d095e114"
+    "sha512=e84e7028c8bf573748655dd572c24bbe649641bee97c28976a6d9553ed28d5366f76158c191db466318862b4127bdab6efa7779d900639943034de7f7526a490"
+  ]
+}


### PR DESCRIPTION
### `pyml_bindgen.0.1.1`
Generate pyml bindings from OCaml value specifications



---
* Homepage: https://github.com/mooreryan/ocaml_python_bindgen
* Source repo: git+https://github.com/mooreryan/ocaml_python_bindgen.git
* Bug tracker: https://github.com/mooreryan/ocaml_python_bindgen/issues

---
:camel: Pull-request generated by opam-publish v2.1.0