### PR TITLE
[new release] cohttp, cohttp-top, cohttp-mirage, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and cohttp-async (4.1.0)

### DIFF
--- a/packages/cohttp-async/cohttp-async.4.1.0/opam
+++ b/packages/cohttp-async/cohttp-async.4.1.0/opam
@@ -52,7 +52,7 @@ available: arch != "s390x"
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
   checksum: [
     "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
     "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"

--- a/packages/cohttp-async/cohttp-async.4.1.0/opam
+++ b/packages/cohttp-async/cohttp-async.4.1.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "async_kernel" {>= "v0.14.0"}
+  "async_unix" {>= "v0.14.0"}
+  "async" {>= "v0.14.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "cohttp" {= version}
+  "conduit-async" {>= "1.2.0"}
+  "magic-mime"
+  "mirage-crypto" {with-test}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "ipaddr"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+available: arch != "s390x"
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.4.1.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.4.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "logs"
+  "lwt" {>= "3.0.0"}
+  "lwt_ppx" {with-test}
+  "conf-npm" {with-test}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.4.1.0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.4.1.0/opam
@@ -42,7 +42,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
   checksum: [
     "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
     "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.4.1.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.4.1.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "conduit-lwt" {>= "5.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0"}
+  "cmdliner"
+  "magic-mime"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "cohttp-lwt" {= version}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.4.1.0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.4.1.0/opam
@@ -47,7 +47,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
   checksum: [
     "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
     "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"

--- a/packages/cohttp-lwt/cohttp-lwt.4.1.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.4.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt
+concurrency library to multiplex IO.  It implements as much of the
+logic in an OS-independent way as possible, so that more specialised
+modules can be tailored for different targets.  For example, you
+can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo` for a Unix or
+JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same
+IO logic from this module."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "cohttp" {= version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+  "uri" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"

--- a/packages/cohttp-lwt/cohttp-lwt.4.1.0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.4.1.0/opam
@@ -42,7 +42,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
   checksum: [
     "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
     "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"

--- a/packages/cohttp-mirage/cohttp-mirage.4.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Gazagnaire"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2"}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "magic-mime"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"

--- a/packages/cohttp-mirage/cohttp-mirage.4.1.0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.4.1.0/opam
@@ -41,7 +41,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
   checksum: [
     "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
     "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"

--- a/packages/cohttp-top/cohttp-top.4.1.0/opam
+++ b/packages/cohttp-top/cohttp-top.4.1.0/opam
@@ -33,7 +33,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
   checksum: [
     "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
     "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"

--- a/packages/cohttp-top/cohttp-top.4.1.0/opam
+++ b/packages/cohttp-top/cohttp-top.4.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "cohttp" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"

--- a/packages/cohttp/cohttp.4.1.0/opam
+++ b/packages/cohttp/cohttp.4.1.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+]
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value."""
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "fmt" {with-test}
+  "jsonm" {build}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v4.1.0/cohttp-4.1.0.tbz"
+  checksum: [
+    "sha256=60d76205cc7dc0597ed7ef6f2de7d53506480516d1b28da9d0e8ef87a055afb3"
+    "sha512=95ae2f746430fa40b417b23b65664c48ded3383a989909566b2887fbe61980e3fe9622313a7f1a62074e9e9078971afb94ee0dbbfdd6f8293a169e0cce88ff3b"
+  ]
+}
+x-commit-hash: "c0716f5eb56fc3120b273e82ac93588e3cef88a2"


### PR DESCRIPTION
An OCaml library for HTTP clients and servers

- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cohttp/">https://mirage.github.io/ocaml-cohttp/</a>

##### CHANGES:

- cohttp-lwt-unix: Adopt ocaml-conduit 5.0.0 (smorimoto mirage/ocaml-cohttp#787)
- cohttp-mirage: fix deprecated fmt usage (tmcgilchrist mirage/ocaml-cohttp#783)
- lwt_jsoo: Use logs for the warnings and document it (mseri mirage/ocaml-cohttp#776)
- lwt: Use logs to warn users about leaked bodies and document it (mseri mirage/ocaml-cohttp#771)
- lwt, lwt_unix: Improve use of logs and the documentation, fix bug in the Debug.enable_debug function (mseri mirage/ocaml-cohttp#772)
- lwt_jsoo: Fix exception on connection errors in chrome (mefyl mirage/ocaml-cohttp#761)
- lwt_jsoo: Fix `Lwt.wakeup_exn` `Invalid_arg` exception when a js
  stack overflow happens in the XHR completion handler (mefyl mirage/ocaml-cohttp#762).
- lwt_jsoo: Add test suite (mefyl mirage/ocaml-cohttp#764).
