### PR TITLE
OCaml 4.14: dev packages

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -1,13 +1,13 @@
 opam-version: "2.0"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
-synopsis: "Latest 4.14.0 development"
+synopsis: "Current trunk"
 maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
-  "ocaml" {= "4.14.0" & post}
+  "ocaml" {= "5.0.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
@@ -52,16 +52,16 @@ build: [
 ]
 install: [make "install"]
 url {
-  src: "https://github.com/ocaml/ocaml/archive/4.14.tar.gz"
+  src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
 post-messages: [
   "A failure in the middle of the build may be caused by build parallelism
    (enabled by default).
    See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1}
+  {failure & jobs > 1 & os != "cygwin"}
   "You can try installing again including --jobs=1
    to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
+  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "platform@lists.ocaml.org"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {= "5.0.0"} |
+  "ocaml-variants" {>= "5.0.0" & < "5.0.1~"} |
+  "ocaml-system" {>= "5.0.0" & < "5.0.1~"}
+]
+setenv: [
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]


### PR DESCRIPTION
This PR adds the development package for the 4.14 branch of the compiler, update the trunk package to 5.0.0+trunk and add a new ocaml-5.0.0 metapackage as a dependency on the new trunk package.