### PR TITLE
Package catala.0.5.0

### DIFF
--- a/packages/catala/catala.0.5.0/opam
+++ b/packages/catala/catala.0.5.0/opam
@@ -12,9 +12,9 @@ homepage: "https://github.com/CatalaLang/catala"
 bug-reports: "https://github.com/CatalaLang/catala/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.11.0"}
   "ANSITerminal" {>= "0.8.2"}
-  "sedlex" {>= "2.1"}
+  "sedlex" {>= "2.4"}
   "menhir" {>= "20200211"}
   "menhirLib" {>= "20200211"}
   "unionFind" {>= "20200320"}
@@ -50,7 +50,7 @@ dev-repo: "git+https://github.com/CatalaLang/catala.git"
 url {
   src: "https://github.com/CatalaLang/catala/archive/0.5.0.tar.gz"
   checksum: [
-    "md5=5d08d2b7750781c303fb40ccd9d791c4"
-    "sha512=022de0081db4a3268290b5683dcb415f76c8c944b111df17f73a472917ae9ad0fef82787c69197316681529390c7b4a94eadbf623e0f1d1058921d1f0461fd0a"
+    "md5=41b0317af37925b16ae7aedfddbcc8b4"
+    "sha512=f02c4e4c7d8ca92c4c2100d1dfc31c56218a8fae3760135335c9cdd10d9edbeb6eb5e407b430c095f579ce2226c3fe4c314788af5aa35c37d04e4dee5f459cb8"
   ]
 }

--- a/packages/catala/catala.0.5.0/opam
+++ b/packages/catala/catala.0.5.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description: """
+Catala is a domain-specific language for deriving faithful-by-construction
+algorithms from legislative texts. See https://catala-lang.org for more information
+"""
+maintainer: ["contact@catala-lang.org"]
+authors: ["Denis Merigoux, Nicolas Chataing"]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.0"}
+  "ANSITerminal" {>= "0.8.2"}
+  "sedlex" {>= "2.1"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "unionFind" {>= "20200320"}
+  "bindlib" {>= "5.0.1"}
+  "cmdliner" {>= "1.0.4"}
+  "re" {>= "1.9.0"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "calendar" {>= "2.04"}
+  "visitors" {>= "20200210"}
+  "benchmark" {>= "1.6"}
+  "js_of_ocaml-ppx" {>= "3.8.0"}
+  "camomile" {>= "1.0.2"}
+  "cppo" {>= "1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.5.0.tar.gz"
+  checksum: [
+    "md5=5d08d2b7750781c303fb40ccd9d791c4"
+    "sha512=022de0081db4a3268290b5683dcb415f76c8c944b111df17f73a472917ae9ad0fef82787c69197316681529390c7b4a94eadbf623e0f1d1058921d1f0461fd0a"
+  ]
+}


### PR DESCRIPTION
### `catala.0.5.0`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction
algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.0.3