### PR TITLE
Package libbinaryen.101.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.101.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.101.0.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {= "1"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v101.0.0/libbinaryen-v101.0.0.tar.gz"
+  checksum: [
+    "md5=97a51833781c781385f81d356cd3b26e"
+    "sha512=303e3630ee834b3dae80eff5fb74c0d0042a43423b1096cf84f7c206aa64a6bb9052c00fd87862e6b806e205ec4f240854346fb79605d5ef8a905b8cee9181db"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.101.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
### Features

* Initial implementation ([#1](https://www.github.com/grain-lang/libbinaryen/issues/1)) ([9da8c77](https://www.github.com/grain-lang/libbinaryen/commit/9da8c770c7ead5b74bab70efbd94c8e763716ec3))


### Miscellaneous Chores

* **ci:** Fix release branch name ([#2](https://www.github.com/grain-lang/libbinaryen/issues/2)) ([a543459](https://www.github.com/grain-lang/libbinaryen/commit/a543459cc7f2313318e0b5ec7f48bb901f67dbfb))


---
:camel: Pull-request generated by opam-publish v2.1.0