### PR TITLE
Package ocplib-endian.1.2

### DIFF
--- a/packages/ocplib-endian/ocplib-endian.1.2/opam
+++ b/packages/ocplib-endian/ocplib-endian.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Optimised functions to read and write int16/32/64 from strings and bigarrays"
+description: """\
+The library implements three modules:
+* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts."""
+maintainer: "pierre.chambart@ocamlpro.com"
+authors: "Pierre Chambart"
+homepage: "https://github.com/OCamlPro/ocplib-endian"
+doc: "https://ocamlpro.github.io/ocplib-endian/ocplib-endian/"
+bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
+depends: [
+  "base-bytes"
+  "ocaml" {>= "4.03.0"}
+  "cppo" {>= "1.1.0" & build}
+  "dune" {>= "1.0"}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/OCamlPro/ocplib-endian.git"
+url {
+  src:
+    "https://github.com/OCamlPro/ocplib-endian/archive/refs/tags/1.2.tar.gz"
+  checksum: [
+    "md5=8d5492eeb7c6815ade72a7415ea30949"
+    "sha512=2e70be5f3d6e377485c60664a0e235c3b9b24a8d6b6a03895d092c6e40d53810bfe1f292ee69e5181ce6daa8a582bfe3d59f3af889f417134f658812be5b8b85"
+  ]
+}

--- a/packages/ocplib-endian/ocplib-endian.1.2/opam
+++ b/packages/ocplib-endian/ocplib-endian.1.2/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis:
   "Optimised functions to read and write int16/32/64 from strings and bigarrays"
 description: """\


### PR DESCRIPTION
### `ocplib-endian.1.2`
Optimised functions to read and write int16/32/64 from strings and bigarrays
The library implements three modules:
* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts.



---
* Homepage: https://github.com/OCamlPro/ocplib-endian
* Source repo: git+https://github.com/OCamlPro/ocplib-endian.git
* Bug tracker: https://github.com/OCamlPro/ocplib-endian/issues

---
:camel: Pull-request generated by opam-publish v2.1.0