### PR TITLE
[new release] redirect.0.2.1

### DIFF
--- a/packages/redirect/redirect.0.2.1/opam
+++ b/packages/redirect/redirect.0.2.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Redirect channels"
+description: """
+Redirect channels to files, strings...
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/redirect"
+doc: "https://github.com/thierry-martinez/redirect"
+bug-reports: "https://github.com/thierry-martinez/redirect"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "10"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/redirect"
+url {
+  src: "https://github.com/thierry-martinez/redirect/releases/download/v0.2.1/redirect-0.2.1.tar.gz"
+  checksum: "sha512=4f10adc54ff6b6274b7373ca90e0e1a6a15aa9d097f2c8d303672c4963e1b963174809103415739868828a8328315762cdab143fbb99c88ec4071859b895c77c"
+}


### PR DESCRIPTION
This PR adds the new release for redirect.0.2.1:

- Fix `with_channel_from_string` for long strings that do not fit in
  pipe, by using a thread for outputing the string.

- Some minor optimizations, using the fact that re-raising an exception
  preserves the backtrace and the constraint on OCaml version (>=4.03)
  ensures that match-with-exception is available.