### PR TITLE
[new release] domainslib (0.3.2)

### DIFF
--- a/packages/domainslib/domainslib.0.3.2/opam
+++ b/packages/domainslib/domainslib.0.3.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "dune" {>= "1.8"}
+  "base-domains"
+  "mirage-clock-unix" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.3.2.tar.gz"
+  checksum: "md5=b4c1ed2ca16b82c40de9a64989094639"
+}
+


### PR DESCRIPTION
Changes:

Corresponding updates for breaking changes introduced in ocaml-multicore/ocaml-multicore#704

* Updated with the new interface `Domain.cpu_relax`
* `Domain.timer_ticks` replaced with Mirage clock.