### PR TITLE
[new release] index and index-bench (1.4.3)

### DIFF
--- a/packages/index-bench/index-bench.1.4.3/opam
+++ b/packages/index-bench/index-bench.1.4.3/opam
@@ -30,7 +30,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/index.git"
 url {

--- a/packages/index-bench/index-bench.1.4.3/opam
+++ b/packages/index-bench/index-bench.1.4.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cmdliner"
+  "dune" {>= "2.7.0"}
+  "fmt"
+  "index" {= version}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re" {>= "1.9.0"}
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+  "mtime"
+  "logs" {>= "0.7.0"}
+  "progress" {>= "0.2.1"}
+  "tezos-base58" {>= "1.0.0" & with-test}
+  "digestif" {>= "0.7" & with-test}
+  "optint" {>= "0.1.0" & with-test}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.3/index-1.4.3.tbz"
+  checksum: [
+    "sha256=b0701f6e4809041f6b7121e48dcae973455e042cc6fb79377a0b8604f8cfd155"
+    "sha512=62c835aacf0b9d8923f3b03388457ed828027a7ac342f5a4b9a42652259785fd451a7824956a44f8c677a5c234e775a1ce6d8318eb20c433e5e339453ece9a81"
+  ]
+}
+x-commit-hash: "b68077912cd8ae86841314a227f0ca335d908eb7"

--- a/packages/index-bench/index-bench.1.4.3/opam
+++ b/packages/index-bench/index-bench.1.4.3/opam
@@ -27,6 +27,9 @@ depends: [
   "repr" {>= "0.2.1" & with-test}
   "rusage" {>= "1.0.0" & with-test}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/index/index.1.4.3/opam
+++ b/packages/index/index.1.4.3/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.1.0"}
+  "repr"    {>= "0.5.0"}
+  "ppx_repr"
+  "fmt"     {>= "0.8.5"}
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner"
+  "progress" {>= "0.2.1"}
+  "semaphore-compat" {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+  "lru"      {>= "0.3.0"}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.4.3/index-1.4.3.tbz"
+  checksum: [
+    "sha256=b0701f6e4809041f6b7121e48dcae973455e042cc6fb79377a0b8604f8cfd155"
+    "sha512=62c835aacf0b9d8923f3b03388457ed828027a7ac342f5a4b9a42652259785fd451a7824956a44f8c677a5c234e775a1ce6d8318eb20c433e5e339453ece9a81"
+  ]
+}
+x-commit-hash: "b68077912cd8ae86841314a227f0ca335d908eb7"

--- a/packages/index/index.1.4.3/opam
+++ b/packages/index/index.1.4.3/opam
@@ -15,7 +15,7 @@ doc:          "https://mirage.github.io/index/"
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Changed

- The benchmarks now use `tezos-base58` instead of `tezos-context-hash` (mirage/index#367)

- Add an LRU to cache the result of `Index.find` operations. The default LRU
  capacity is 30_000 entries. (mirage/index#366)
