### PR TITLE
[new release] index and index-bench (1.5.0)

### DIFF
--- a/packages/index-bench/index-bench.1.5.0/opam
+++ b/packages/index-bench/index-bench.1.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cmdliner"
+  "dune" {>= "2.7.0"}
+  "fmt"
+  "index" {= version}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re" {>= "1.9.0"}
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+  "mtime"
+  "logs" {>= "0.7.0"}
+  "progress" {>= "0.2.1"}
+  "tezos-base58" {>= "1.0.0" & with-test}
+  "digestif" {>= "0.7" & with-test}
+  "optint" {>= "0.1.0" & with-test}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.5.0/index-1.5.0.tbz"
+  checksum: [
+    "sha256=2e311cd0bad5b831ac4cebacc83d319b0bca7d5b713ef42dca2bcc064cda34e0"
+    "sha512=02d9bfe68daba9c857455244708bf7f25aac50a02a3c14b35cc499dd2a0ccfe5fa47016aea783efadc652bd922c6d4216eac8188400617e98ddc3eb98b9c16c3"
+  ]
+}
+x-commit-hash: "98c9315c1116215aa7792544c0fe7bdc764f084d"

--- a/packages/index/index.1.5.0/opam
+++ b/packages/index/index.1.5.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.1.0"}
+  "repr"    {>= "0.5.0"}
+  "ppx_repr"
+  "fmt"     {>= "0.8.5"}
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner"
+  "progress" {>= "0.2.1"}
+  "semaphore-compat" {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+  "lru"      {>= "0.3.0"}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.5.0/index-1.5.0.tbz"
+  checksum: [
+    "sha256=2e311cd0bad5b831ac4cebacc83d319b0bca7d5b713ef42dca2bcc064cda34e0"
+    "sha512=02d9bfe68daba9c857455244708bf7f25aac50a02a3c14b35cc499dd2a0ccfe5fa47016aea783efadc652bd922c6d4216eac8188400617e98ddc3eb98b9c16c3"
+  ]
+}
+x-commit-hash: "98c9315c1116215aa7792544c0fe7bdc764f084d"


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Changed

- The benchmarks now use `tezos-base58` instead of `tezos-context-hash` (mirage/index#367)

- Add an LRU to cache the result of `Index.find` operations. The default LRU
  capacity is 30_000 entries. (mirage/index#366)
