### PR TITLE
[NEW RELEASE] DAGaml.0.02

### DIFF
--- a/packages/DAGaml/DAGaml.0.01/opam
+++ b/packages/DAGaml/DAGaml.0.01/opam
@@ -14,6 +14,7 @@ depends: [
 ]
 build: make
 install: [make "install"]
+available: arch != "arm32" & arch != "x86_32"
 dev-repo: "git+https://gitlab.com/boreal-ldd/dagaml"
 url {
 	src:"https://gitlab.com/boreal-ldd/dagaml/-/archive/v0.01/dagaml-v0.01.tar.gz"

--- a/packages/DAGaml/DAGaml.0.01/opam
+++ b/packages/DAGaml/DAGaml.0.01/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/dagaml"
 bug-reports: "https://gitlab.com/boreal-ldd/dagaml"
 depends: [
-	"ocaml" {>= "4.08.1" & < "4.12"}
+	"ocaml" {>= "4.08.1"}
 	"GuaCaml" {>= "0.03"}
 	"Snowflake" {>= "0.02.02"}
 	"ocamlbuild" {build}

--- a/packages/DAGaml/DAGaml.0.02/opam
+++ b/packages/DAGaml/DAGaml.0.02/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "DAGaml : Abstract DAG manipulation in OCaml"
+maintainer: "Joan Thibault <joan.thibault@ens-rennes.fr>"
+authors: "Joan Thibault <joan.thibault@ens-rennes.fr>"
+license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://gitlab.com/boreal-ldd/dagaml"
+bug-reports: "https://gitlab.com/boreal-ldd/dagaml"
+depends: [
+	"ocaml" {>= "4.08.1" & < "4.12"}
+	"GuaCaml" {>= "0.03"}
+	"Snowflake" {>= "0.02.02"}
+	"ocamlbuild" {build}
+	"ocamlfind" {build}
+]
+build: [make "lib"]
+install: [make "install"]
+dev-repo: "git+https://gitlab.com/boreal-ldd/dagaml"
+url {
+	src:"https://gitlab.com/boreal-ldd/dagaml/-/archive/v0.01/dagaml-v0.02.tar.gz"
+	checksum:"md5=e7744ac85660a981d11772ed70d427ec"
+}

--- a/packages/DAGaml/DAGaml.0.02/opam
+++ b/packages/DAGaml/DAGaml.0.02/opam
@@ -14,6 +14,7 @@ depends: [
 ]
 build: [make "lib"]
 install: [make "install"]
+available: arch != "arm32" & arch != "x86_32"
 dev-repo: "git+https://gitlab.com/boreal-ldd/dagaml"
 url {
 	src:"https://gitlab.com/boreal-ldd/dagaml/-/archive/v0.02/dagaml-v0.02.tar.gz"

--- a/packages/DAGaml/DAGaml.0.02/opam
+++ b/packages/DAGaml/DAGaml.0.02/opam
@@ -16,6 +16,6 @@ build: [make "lib"]
 install: [make "install"]
 dev-repo: "git+https://gitlab.com/boreal-ldd/dagaml"
 url {
-	src:"https://gitlab.com/boreal-ldd/dagaml/-/archive/v0.01/dagaml-v0.02.tar.gz"
+	src:"https://gitlab.com/boreal-ldd/dagaml/-/archive/v0.02/dagaml-v0.02.tar.gz"
 	checksum:"md5=e7744ac85660a981d11772ed70d427ec"
 }

--- a/packages/DAGaml/DAGaml.0.02/opam
+++ b/packages/DAGaml/DAGaml.0.02/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/dagaml"
 bug-reports: "https://gitlab.com/boreal-ldd/dagaml"
 depends: [
-	"ocaml" {>= "4.08.1" & < "4.12"}
+	"ocaml" {>= "4.08.1"}
 	"GuaCaml" {>= "0.03"}
 	"Snowflake" {>= "0.02.02"}
 	"ocamlbuild" {build}

--- a/packages/GuaCaml/GuaCaml.0.03.01/opam
+++ b/packages/GuaCaml/GuaCaml.0.03.01/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/guacaml"
 bug-reports: "https://gitlab.com/boreal-ldd/guacaml"
 depends: [
-	"ocaml" {>= "4.08" & < "4.12" }
+	"ocaml" {>= "4.08"}
 	"ocamlbuild" {build}
 	"ocamlfind" {build}
 ]
@@ -14,6 +14,6 @@ build: make
 install: [make "install"]
 dev-repo: "git+https://gitlab.com/boreal-ldd/guacaml#release"
 url {
-	src:"https://gitlab.com/boreal-ldd/guacaml/-/archive/v0.03/guacaml-v0.03.tar.gz"
-	checksum:"md5=31813763d3683f6291a88c4b66b9df6c"
+	src:"https://gitlab.com/boreal-ldd/guacaml/-/archive/v0.03.01/guacaml-v0.03.01.tar.gz"
+	checksum:"md5=4b92e447de895bad3b9dfdd8a3c024ad"
 }


### PR DESCRIPTION
- **NEW** RBTF, pRBTF, CRBTF, RBTF+max/int
- Upgraded interfaces : OOPS ( cmp, cofactor, id ) and QEOPS ( support )
- **NEW** new module : Support ( interfaced with QEOPS )
- Imported `RBTF_ArgMax_vUInt` from `Snowflake`
- Improved performances of LDD-O-NUCX
- **NEW** Added AQEOPS' library, including : `sat_select_A`, `exists_projA`, `argmaxA`
- **FORMAT** Fixed 'Modele' into 'Model' (spellcheck)