### PR TITLE
[new release] mirage-protocols (6.0.0)

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.6.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.6.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "fmt"
+  "duration"
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v6.0.0/mirage-protocols-v6.0.0.tbz"
+  checksum: [
+    "sha256=229b089663b968068a557b4498d14e64c778179e04d3bf888bce64f0184a9725"
+    "sha512=226dc1b1905a1c28d24df3a9c844fb181eebed0081036f2c08fb67ff40f102be53f40b1a2b351c5de63aa50b6e74e5e484796117473f8f791f485ea11aedfd3f"
+  ]
+}
+x-commit-hash: "805461d35799ceecad378c161aa3b7a0e3420e32"

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "5.0.0"}
+  "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "5.0.0"}
+  "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "5.0.0"}
+  "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -34,7 +34,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "5.0.0"}
+  "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}


### PR DESCRIPTION
MirageOS signatures for network protocols

- Project page: <a href="https://github.com/mirage/mirage-protocols">https://github.com/mirage/mirage-protocols</a>
- Documentation: <a href="https://mirage.github.io/mirage-protocols/">https://mirage.github.io/mirage-protocols/</a>

##### CHANGES:

Simplify UDP and TCP module types to set the stage for an alternative TCP stack,
and allow TCP and UDP to hold the listeners internally (instead of hiding them
in a Mirage_stack.S.

- Revise UDP module type:
   - removed type ipinput
   - add a val listen : t -> port:int -> callback -> unit
   - add a val unlisten : t -> port:int -> unit
   - val input is now: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t
- Revise TCP module type
   - removed type ipinput
   - removed type listener
   - add a val listen : t -> port:int -> ?keepalive:Keepalive.t -> (flow -> unit Lwt.t) -> unit
   - add a val unlisten : t -> port:int -> unit
   - val input is now: t -> src:ipaddr -> dst:ipaddr -> Cstruct.t -> unit Lwt.t

In mirage/mirage-protocols#28 by @hannesm
