### PR TITLE
Package opam-depext.1.2.0

### DIFF
--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {dev}
 ]
 available: opam-version >= "2.0.0~beta5"
-post-message: [
+post-messages: [
   "opam-depext is deprecated when used with opam >= 2.1. Please use opam install directly instead" {opam-version >= "2.1"}
 ]
 flags: plugin

--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -23,6 +23,9 @@ depends: [
   "ocamlfind" {dev}
 ]
 available: opam-version >= "2.0.0~beta5"
+post-message: [
+  "opam-depext is deprecated when used with opam >= 2.1. Please use opam install directly instead" {opam-version >= "2.1"}
+]
 flags: plugin
 build: [
   [make] {!pinned}

--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Install OS distribution packages"
+description: """\
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them."""
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+depends: [
+  "ocaml" {>= "4.00"}
+  "base-unix"
+  "cmdliner" {>= "0.9.8" & dev}
+  "ocamlfind" {dev}
+]
+available: opam-version >= "2.0.0~beta5"
+flags: plugin
+build: [
+  [make] {!pinned}
+  [
+    "ocamlfind"
+    "%{ocaml:native?ocamlopt:ocamlc}%"
+    "-package"
+    "unix,cmdliner"
+    "-linkpkg"
+    "-o"
+    "opam-depext"
+    "depext.ml"
+  ] {pinned}
+]
+dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-depext/releases/download/v1.2.0/opam-depext-full-1.2.0.tbz"
+  checksum: [
+    "md5=bb0d9bbf0565dba30d3c8ab8db269118"
+    "sha512=00ab242467552a81ca5ad5c0892315a1b4c44f72d3cf2a29770d5807ee1921914367828e11cb0852ef9c74f406a90af8c9686c8d6f6dcc56c0cd030116081688"
+  ]
+}

--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -28,7 +28,7 @@ post-messages: [
 ]
 flags: plugin
 build: [
-  [make] {!pinned}
+  [make] {!dev}
   [
     "ocamlfind"
     "%{ocaml:native?ocamlopt:ocamlc}%"
@@ -38,7 +38,7 @@ build: [
     "-o"
     "opam-depext"
     "depext.ml"
-  ] {pinned}
+  ] {dev}
 ]
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 url {


### PR DESCRIPTION
### `opam-depext.1.2.0`
Install OS distribution packages
opam-depext is a simple program intended to facilitate the interaction between
OPAM packages and the host package management system. It can query OPAM for the
right external dependencies on a set of packages, depending on the host OS, and
call the OS's package manager in the appropriate way to install them.



---
* Homepage: https://github.com/ocaml/opam-depext
* Source repo: git+https://github.com/ocaml/opam-depext.git#2.0
* Bug tracker: https://github.com/ocaml/opam-depext/issues

---
:camel: Pull-request generated by opam-publish v2.1.0