### PR TITLE
Package libbinaryen.101.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.101.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.101.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v101.0.1/libbinaryen-v101.0.1.tar.gz"
+  checksum: [
+    "md5=3f2fab345e351321edae3d4e268d817d"
+    "sha512=b30a5ea1f293911748774125741a6bcc41c0e17aa9054bfe5799987068d92c9647e901e478523004e5d5c52d84a1c223c330ef9e6808c217b7f25e003c666412"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.101.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
### Features

- Initial implementation ([#1](https://www.github.com/grain-lang/libbinaryen/issues/1)) ([9da8c77](https://www.github.com/grain-lang/libbinaryen/commit/9da8c770c7ead5b74bab70efbd94c8e763716ec3))

### Bug Fixes

- Build binaryen in source & avoid cmake --install ([4f67d9a](https://www.github.com/grain-lang/libbinaryen/commit/4f67d9a849b172874a52dcfddf691efc274cb044))
- **opam:** Add conf-python-3 & ocaml ([4f67d9a](https://www.github.com/grain-lang/libbinaryen/commit/4f67d9a849b172874a52dcfddf691efc274cb044))

### Miscellaneous Chores

- **ci:** Fix release branch name ([#2](https://www.github.com/grain-lang/libbinaryen/issues/2)) ([a543459](https://www.github.com/grain-lang/libbinaryen/commit/a543459cc7f2313318e0b5ec7f48bb901f67dbfb))


---
:camel: Pull-request generated by opam-publish v2.0.3