### PR TITLE
biocaml 0.11.0: not compatible with 32 bits systems

### DIFF
--- a/packages/biocaml/biocaml.0.11.0/opam
+++ b/packages/biocaml/biocaml.0.11.0/opam
@@ -45,6 +45,9 @@ depopts: [
   "core"
   "lwt"
 ]
+
+available: arch != "x86_32" & arch != "arm32"
+
 url {
   src: "https://github.com/biocaml/biocaml/archive/v0.11.0.tar.gz"
   checksum: [


### PR DESCRIPTION
```
#=== ERROR while compiling biocaml.0.11.0 =====================================#
# context              2.1.1 | linux/x86_32 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/biocaml.0.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p biocaml -j 31
# exit-code            1
# env-file             ~/.opam/log/biocaml-25-1e576a.env
# output-file          ~/.opam/log/biocaml-25-1e576a.out
### output ###
#     ocamlopt .ppx/57ef275c515ec1fe105f6ff0979f5a61/ppx.exe
# /usr/bin/ld: /home/opam/.opam/4.13/lib/ppx_stable/ppx_stable.a(ppx_stable.o): warning: relocation in read-only section `.text'
# /usr/bin/ld: warning: creating DT_TEXTREL in a PIE
#     ocamlopt .ppx/bb6621892267006351fe0f10b906f9c5/ppx.exe
# /usr/bin/ld: /home/opam/.opam/4.13/lib/ppx_sexp_conv/ppx_sexp_conv.a(ppx_sexp_conv.o): warning: relocation in read-only section `.text'
# /usr/bin/ld: warning: creating DT_TEXTREL in a PIE
#     ocamlopt .ppx/8e3fb1120ce661745e7ed68a70958f84/ppx.exe
# /usr/bin/ld: /home/opam/.opam/4.13/lib/ppx_stable/ppx_stable.a(ppx_stable.o): warning: relocation in read-only section `.text'
# /usr/bin/ld: warning: creating DT_TEXTREL in a PIE
#     ocamlopt lib/base/biocaml_base.cmxs
# /usr/bin/ld: lib/base/biocaml_base.a(biocaml_base__Ucsc_genome_browser.o): warning: relocation in read-only section `.text'
# /usr/bin/ld: warning: creating DT_TEXTREL in a shared object
#       ocamlc lib/unix/.biocaml_unix.objs/byte/biocaml_unix__Bam.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -short-paths -open Core_kernel -g -bin-annot -I lib/unix/.biocaml_unix.objs/byte -I /home/opam/.opam/4.13/lib/angstrom -I /home/opam/.opam/4.13/lib/base -I /home/opam/.opam/4.13/lib/base/base_internalhash_types -I /home/opam/.opam/4.13/lib/base/caml -I /home/opam/.opam/4.13/lib/base/md5 -I /home/opam/.opam/4.13/lib/base/shadow_stdlib -I /home/opam/.opam/4.13/lib/base64 -I /home/opam/.opam/4.13/lib/base_bigstring -I /home/opam/.opam/4.13/lib/base_quickcheck -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/bigstringaf -I /home/opam/.opam/4.13/lib/bin_prot -I /home/opam/.opam/4.13/lib/bin_prot/shape -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/cfstream -I /home/opam/.opam/4.13/lib/core_kernel -I /home/opam/.opam/4.13/lib/core_kernel/base_for_tests -I /home/opam/.opam/4.13/lib/core_kernel/binary_packing -I /home/opam/.opam/4.13/lib/fieldslib -I /home/opam/.opam/4.13/lib/jane-street-headers -I /home/opam/.opam/4.13/lib/parsexp -I /home/opam/.opam/4.13/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_expect/collector -I /home/opam/.opam/4.13/lib/ppx_expect/common -I /home/opam/.opam/4.13/lib/ppx_expect/config -I /home/opam/.opam/4.13/lib/ppx_expect/config_types -I /home/opam/.opam/4.13/lib/ppx_expect/evaluator -I /home/opam/.opam/4.13/lib/ppx_expect/matcher -I /home/opam/.opam/4.13/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_inline_test/config -I /home/opam/.opam/4.13/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.13/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.13/lib/ppxlib/print_diff -I /home/opam/.opam/4.13/lib/re -I /home/opam/.opam/4.13/lib/re/perl -I /home/opam/.opam/4.13/lib/rresult -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/sexplib -I /home/opam/.opam/4.13/lib/sexplib0 -I /home/opam/.opam/4.13/lib/splittable_random -I /home/opam/.opam/4.13/lib/stdio -I /home/opam/.opam/4.13/lib/stringext -I /home/opam/.opam/4.13/lib/time_now -I /home/opam/.opam/4.13/lib/typerep -I /home/opam/.opam/4.13/lib/uri -I /home/opam/.opam/4.13/lib/variantslib -I /home/opam/.opam/4.13/lib/xmlm -I /home/opam/.opam/4.13/lib/zip -I lib/base/.biocaml_base.objs/byte -intf-suffix .ml -no-alias-deps -open Biocaml_unix -o lib/unix/.biocaml_unix.objs/byte/biocaml_unix__Bam.cmo -c -impl lib/unix/bam.pp.ml)
# File "lib/unix/bam.ml", line 627, characters 13-23:
# 627 |       | Some 2147483647 (* POS in BAM is 0-based *)
#                    ^^^^^^^^^^
# Error: Integer literal exceeds the range of representable integers of type int
#       ocamlc lib/unix/.biocaml_unix.objs/byte/biocaml_unix__Sam.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -short-paths -open Core_kernel -g -bin-annot -I lib/unix/.biocaml_unix.objs/byte -I /home/opam/.opam/4.13/lib/angstrom -I /home/opam/.opam/4.13/lib/base -I /home/opam/.opam/4.13/lib/base/base_internalhash_types -I /home/opam/.opam/4.13/lib/base/caml -I /home/opam/.opam/4.13/lib/base/md5 -I /home/opam/.opam/4.13/lib/base/shadow_stdlib -I /home/opam/.opam/4.13/lib/base64 -I /home/opam/.opam/4.13/lib/base_bigstring -I /home/opam/.opam/4.13/lib/base_quickcheck -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/bigstringaf -I /home/opam/.opam/4.13/lib/bin_prot -I /home/opam/.opam/4.13/lib/bin_prot/shape -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/cfstream -I /home/opam/.opam/4.13/lib/core_kernel -I /home/opam/.opam/4.13/lib/core_kernel/base_for_tests -I /home/opam/.opam/4.13/lib/core_kernel/binary_packing -I /home/opam/.opam/4.13/lib/fieldslib -I /home/opam/.opam/4.13/lib/jane-street-headers -I /home/opam/.opam/4.13/lib/parsexp -I /home/opam/.opam/4.13/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_expect/collector -I /home/opam/.opam/4.13/lib/ppx_expect/common -I /home/opam/.opam/4.13/lib/ppx_expect/config -I /home/opam/.opam/4.13/lib/ppx_expect/config_types -I /home/opam/.opam/4.13/lib/ppx_expect/evaluator -I /home/opam/.opam/4.13/lib/ppx_expect/matcher -I /home/opam/.opam/4.13/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_inline_test/config -I /home/opam/.opam/4.13/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.13/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.13/lib/ppxlib/print_diff -I /home/opam/.opam/4.13/lib/re -I /home/opam/.opam/4.13/lib/re/perl -I /home/opam/.opam/4.13/lib/rresult -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/sexplib -I /home/opam/.opam/4.13/lib/sexplib0 -I /home/opam/.opam/4.13/lib/splittable_random -I /home/opam/.opam/4.13/lib/stdio -I /home/opam/.opam/4.13/lib/stringext -I /home/opam/.opam/4.13/lib/time_now -I /home/opam/.opam/4.13/lib/typerep -I /home/opam/.opam/4.13/lib/uri -I /home/opam/.opam/4.13/lib/variantslib -I /home/opam/.opam/4.13/lib/xmlm -I /home/opam/.opam/4.13/lib/zip -I lib/base/.biocaml_base.objs/byte -intf-suffix .ml -no-alias-deps -open Biocaml_unix -o lib/unix/.biocaml_unix.objs/byte/biocaml_unix__Sam.cmo -c -impl lib/unix/sam.pp.ml)
# File "lib/unix/sam.ml", line 216, characters 34-44:
# 216 |   (if (1 <= length) && (length <= 2147483647) then
#                                         ^^^^^^^^^^
# Error: Integer literal exceeds the range of representable integers of type int
#     ocamlopt lib/unix/.biocaml_unix.objs/native/biocaml_unix__Sam.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlopt.opt -w -40 -short-paths -open Core_kernel -g -I lib/unix/.biocaml_unix.objs/byte -I lib/unix/.biocaml_unix.objs/native -I /home/opam/.opam/4.13/lib/angstrom -I /home/opam/.opam/4.13/lib/base -I /home/opam/.opam/4.13/lib/base/base_internalhash_types -I /home/opam/.opam/4.13/lib/base/caml -I /home/opam/.opam/4.13/lib/base/md5 -I /home/opam/.opam/4.13/lib/base/shadow_stdlib -I /home/opam/.opam/4.13/lib/base64 -I /home/opam/.opam/4.13/lib/base_bigstring -I /home/opam/.opam/4.13/lib/base_quickcheck -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/bigstringaf -I /home/opam/.opam/4.13/lib/bin_prot -I /home/opam/.opam/4.13/lib/bin_prot/shape -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/cfstream -I /home/opam/.opam/4.13/lib/core_kernel -I /home/opam/.opam/4.13/lib/core_kernel/base_for_tests -I /home/opam/.opam/4.13/lib/core_kernel/binary_packing -I /home/opam/.opam/4.13/lib/fieldslib -I /home/opam/.opam/4.13/lib/jane-street-headers -I /home/opam/.opam/4.13/lib/parsexp -I /home/opam/.opam/4.13/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_expect/collector -I /home/opam/.opam/4.13/lib/ppx_expect/common -I /home/opam/.opam/4.13/lib/ppx_expect/config -I /home/opam/.opam/4.13/lib/ppx_expect/config_types -I /home/opam/.opam/4.13/lib/ppx_expect/evaluator -I /home/opam/.opam/4.13/lib/ppx_expect/matcher -I /home/opam/.opam/4.13/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_inline_test/config -I /home/opam/.opam/4.13/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.13/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.13/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.13/lib/ppxlib/print_diff -I /home/opam/.opam/4.13/lib/re -I /home/opam/.opam/4.13/lib/re/perl -I /home/opam/.opam/4.13/lib/rresult -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/sexplib -I /home/opam/.opam/4.13/lib/sexplib0 -I /home/opam/.opam/4.13/lib/splittable_random -I /home/opam/.opam/4.13/lib/stdio -I /home/opam/.opam/4.13/lib/stringext -I /home/opam/.opam/4.13/lib/time_now -I /home/opam/.opam/4.13/lib/typerep -I /home/opam/.opam/4.13/lib/uri -I /home/opam/.opam/4.13/lib/variantslib -I /home/opam/.opam/4.13/lib/xmlm -I /home/opam/.opam/4.13/lib/zip -I lib/base/.biocaml_base.objs/byte -I lib/base/.biocaml_base.objs/native -intf-suffix .ml -no-alias-deps -open Biocaml_unix -o lib/unix/.biocaml_unix.objs/native/biocaml_unix__Sam.cmx -c -impl lib/unix/sam.pp.ml)
# File "lib/unix/sam.ml", line 216, characters 34-44:
# 216 |   (if (1 <= length) && (length <= 2147483647) then
#                                         ^^^^^^^^^^
# Error: Integer literal exceeds the range of representable integers of type int
```