### PR TITLE
[new release] crlibm (0.5.1)

### DIFF
--- a/packages/crlibm/crlibm.0.5.1/opam
+++ b/packages/crlibm/crlibm.0.5.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+tags: ["libm" "math" "floating-point" "rounding" "science"]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-crlibm"
+dev-repo: "git+https://github.com/Chris00/ocaml-crlibm.git"
+bug-reports: "https://github.com/Chris00/ocaml-crlibm/issues"
+doc: "https://Chris00.github.io/ocaml-crlibm/doc"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune-configurator" {>= "2.0"}
+  "dune" {>= "2.0"}
+  "base-bytes" {build}
+  "benchmark" {with-test}
+]
+synopsis: "Binding to CRlibm, a correctly rounded math lib"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-crlibm/releases/download/0.5.1/crlibm-0.5.1.tbz"
+  checksum: [
+    "sha256=fcc6ff4497eb168a91bac7967316164ff0d3e1ee776fed958718a9cd7c49983b"
+    "sha512=1b62bde2d45b74ef4b15b015c90bb0f0a292180b6436f8deab81d54ab08b9cede9265c82b309a4e5377f97181049d1430bce8867df025a09859f503de0eb8032"
+  ]
+}
+x-commit-hash: "67336ec53500b92312cb7add796c2c8503b0b445"


### PR DESCRIPTION
Binding to CRlibm, a correctly rounded math lib

- Project page: <a href="https://github.com/Chris00/ocaml-crlibm">https://github.com/Chris00/ocaml-crlibm</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-crlibm/doc">https://Chris00.github.io/ocaml-crlibm/doc</a>

##### CHANGES:

- Fix compilation on the Intel 32 bits platform.
