### PR TITLE
Tweak depext.1.2.0 metadata

### DIFF
--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -16,7 +16,10 @@ authors: [
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
-depends: ["ocaml" {>= "4.00"}]
+depends: [
+  "ocaml" {>= "4.00"}
+  "base-unix"
+]
 available: opam-version >= "2.0.0~beta5"
 post-messages: [
   "opam-depext is unnecessary when used with opam >= 2.1. Please use opam install directly instead" {opam-version >= "2.1"}

--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -16,30 +16,13 @@ authors: [
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/opam-depext"
 bug-reports: "https://github.com/ocaml/opam-depext/issues"
-depends: [
-  "ocaml" {>= "4.00"}
-  "base-unix"
-  "cmdliner" {>= "0.9.8" & dev}
-  "ocamlfind" {dev}
-]
+depends: ["ocaml" {>= "4.00"}]
 available: opam-version >= "2.0.0~beta5"
 post-messages: [
   "opam-depext is deprecated when used with opam >= 2.1. Please use opam install directly instead" {opam-version >= "2.1"}
 ]
 flags: plugin
-build: [
-  [make] {!dev}
-  [
-    "ocamlfind"
-    "%{ocaml:native?ocamlopt:ocamlc}%"
-    "-package"
-    "unix,cmdliner"
-    "-linkpkg"
-    "-o"
-    "opam-depext"
-    "depext.ml"
-  ] {dev}
-]
+build: make
 dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
 url {
   src:

--- a/packages/opam-depext/opam-depext.1.2.0/opam
+++ b/packages/opam-depext/opam-depext.1.2.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 depends: ["ocaml" {>= "4.00"}]
 available: opam-version >= "2.0.0~beta5"
 post-messages: [
-  "opam-depext is deprecated when used with opam >= 2.1. Please use opam install directly instead" {opam-version >= "2.1"}
+  "opam-depext is unnecessary when used with opam >= 2.1. Please use opam install directly instead" {opam-version >= "2.1"}
 ]
 flags: plugin
 build: make


### PR DESCRIPTION
I didn't review the opam-depext.1.2.0 PR in time to make these as comments there. The development mode of opam-depext only needs to exist in the upstream repo - there's no value in the pinning instructions being in opam-repository (cf. the previous versions).

I tweaked slightly the post-message - at a major version bump of opam the plugin will finally not be supported, but the plugin is not is not itself _deprecated_, it's just _unnecessary_.