### PR TITLE
[new release] builder (0.3.0)

### DIFF
--- a/packages/builder/builder.0.3.0/opam
+++ b/packages/builder/builder.0.3.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/builder"
+dev-repo: "git+https://github.com/roburio/builder.git"
+bug-reports: "https://github.com/roburio/builder/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "asn1-combinators"
+  "bheap" {>= "2.0.0"}
+  "bos"
+  "cmdliner"
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "fmt" {>= "0.8.7"}
+  "fpath"
+  "logs"
+  "lwt"
+  "ptime"
+  "uuidm"
+  "http-lwt-client" {>= "0.0.4"}
+  "base64"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+
+synopsis: "Scheduling and executing shell jobs"
+description: """
+The builder server has a schedule of jobs to be executed, stored persistently
+on disk. Any number of workers can connect via TCP (using ASN.1 encoded
+messages) that execute a single job -- usually contained in a sandbox (FreeBSD
+jail or Docker container). A client is a command-line interface to modify the
+schedule. Access control is out of scope - run it locally on your build host.
+The server receives the output artifacts of each job, and either stores them
+on the local file system or upload them to a remote server via http.
+
+See https://builds.robur.coop for the live web frontend (builder-web).
+"""
+url {
+  src:
+    "https://github.com/roburio/builder/releases/download/v0.3.0/builder-0.3.0.tbz"
+  checksum: [
+    "sha256=0e823f6ab0084ab21f4ee44ca2f2aa7d001d3d55970cab58791fbc13022691ea"
+    "sha512=9d7359402eafd997db0b6b71ba49e49961d554c706717632d75f611924ab1cfa9f4ecd11a4a89adc46d3cce0b49c64bba360462be3e3a6694f4e64fce07d27fd"
+  ]
+}
+x-commit-hash: "1fd69b050e17aa40ab35e8cf0324afe2ce0589ed"


### PR DESCRIPTION
Scheduling and executing shell jobs

- Project page: <a href="https://github.com/roburio/builder">https://github.com/roburio/builder</a>

##### CHANGES:

* server: unstuck waiting workers when a new queue is created for a platform
* server: warn when a worker requests a job for a new platform when a template
  does not exist
* server: improve logging of workers (always prefix uuid)
* worker: kill process group when server communication fails
* worker: collect output on any exit code
* client: observe-latest has optional platform and job_name arguments
* client: execute has an optional platform argument
* Debian and FreeBSD packaging improvements
