### PR TITLE
[new release] clangml.4.5.0

### DIFF
--- a/packages/clangml/clangml.4.5.0/opam
+++ b/packages/clangml/clangml.4.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
+doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
+bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "13"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test & >= "1.0.1"}
+  "pattern" {with-test & >= "0.2.0"}
+  "metapp" {>= "0.4.0"}
+  "metaquot" {>= "0.4.0"}
+  "refl" {>= "0.4.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+  "ppxlib" {>= "0.23"}
+]
+x-ci-accept-failures: [
+   "centos-7" # GCC does not support --std=c++14
+   "archlinux" # LLVM not detected
+   "oraclelinux-7" # LLVM not detected
+]
+available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/uploads/888b796e6a42405e831315d967bf094d/clangml.4.5.0.tar.gz"
+  checksum: "sha512=f0e0da9290a4f7e9a193754236ea028cabf2a0039f3c2e49a85e53a2cd6a2a78eade60f0c0bd73d272cd0e4bc7fba4333a645faaf14f94e4404498e4144306fc"
+}


### PR DESCRIPTION
This PR adds the new release clangml.4.5.0.
The change-log is reproduced below.

- Support for Clang/LLVM 12.0.1 and 13.0.0.

- *[compatibility break]* `initializer_list` for constructors now contains
  items with a dedicated type `constructor_initializer`.

- Fields for anonymous struct/unions and indirect fields can now be represented
  in the AST by disabling `options.ignore_indirect_fields` and
  `options.ignore_anonymous_fields`.
  (reported by Seungwan Kwon)

- Fields for implicit constructors and methods can now be represented in the AST
  by disabling `options.ignore_implicit_constructors` and
  `options.ignore_implicit_methods`.

- Fields for injected class nameds can now be represented in the AST
  by disabling `options.ignore_injected_class_names`.

- Fix segmentation fault issue when accessing `NULL` `TypeInfoLoc*` in attributes