### PR TITLE
Support installing gappa on Apple Silicon with Homebrew

### DIFF
--- a/packages/gappa/gappa.1.4.0/opam
+++ b/packages/gappa/gappa.1.4.0/opam
@@ -15,6 +15,8 @@ build: [
   [ "./configure"
     # If someone knows how to ask MacPorts for the usual include and lib path, please tell me
     "CXXFLAGS=-I/opt/local/include" "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
+    # Support installing on Apple Silicon with Homebrew
+    "CXXFLAGS=-I/opt/homebrew/include" "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" }
     "--build=%{arch}%-pc-cygwin" { os = "win32" & os-distribution = "cygwinports" }
     "--host=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }
     "--target=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }


### PR DESCRIPTION
This change is needed for Coq Platform to enable support for Apple's arm64 / M1 chips. See: https://github.com/coq/platform/issues/168