### PR TITLE
[new release] mindstorm and mindstorm-lwt (0.8.1)

### DIFF
--- a/packages/mindstorm-lwt/mindstorm-lwt.0.8.1/opam
+++ b/packages/mindstorm-lwt/mindstorm-lwt.0.8.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Julie De Pril"
+           "Marc Ducobu"
+           "Dany Maslowski" ]
+license: "LGPL-2.1" # with OCaml linking exception
+homepage: "https://github.com/Chris00/ocaml-mindstorm"
+dev-repo: "git+https://github.com/Chris00/ocaml-mindstorm.git"
+bug-reports: "https://github.com/Chris00/ocaml-mindstorm/issues"
+doc: "https://Chris00.github.io/ocaml-mindstorm/doc"
+tags: [ "lego" "robotics" "mindstorms"
+        "clib:usb" "clib:bluetooth" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "mindstorm" {= version}
+  "base-threads"
+  "lwt"
+  "dune"
+  "dune-configurator"
+  "cppo" {build}
+  "base-bytes"
+  "base-unix"
+]
+synopsis: "Drive Lego Mindstorms bricks from OCaml (LWT version)"
+description: """
+This library allows you to communicate with your Lego Mindstorms brick
+via bluetooth, enable the motors and retrieve data from various
+sensors.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-mindstorm/releases/download/0.8.1/mindstorm-0.8.1.tbz"
+  checksum: [
+    "sha256=a8df331c4efffe3811b0410898a239c8744050ceb3c771052b79f794f1f6283f"
+    "sha512=f7b065279b76d0b3ba8d713332c8cac8328f2119baaac4c6278803a194faa923d3931b14d01c8097c689076dd9b4af2689ea53d1bca333409b6c5d3909eb0eb9"
+  ]
+}
+x-commit-hash: "dd32130a2446f960fac1f762663ee470e723eaec"

--- a/packages/mindstorm-lwt/mindstorm-lwt.0.8.1/opam
+++ b/packages/mindstorm-lwt/mindstorm-lwt.0.8.1/opam
@@ -23,7 +23,7 @@ depends: [
   "lwt"
   "dune"
   "dune-configurator"
-  "cppo" {build}
+  "cppo" {build & >= "1.3.0"}
   "base-bytes"
   "base-unix"
 ]

--- a/packages/mindstorm/mindstorm.0.8.1/opam
+++ b/packages/mindstorm/mindstorm.0.8.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Julie De Pril"
+           "Marc Ducobu"
+           "Dany Maslowski" ]
+license: "LGPL-2.1" # with OCaml linking exception
+homepage: "https://github.com/Chris00/ocaml-mindstorm"
+dev-repo: "git+https://github.com/Chris00/ocaml-mindstorm.git"
+bug-reports: "https://github.com/Chris00/ocaml-mindstorm/issues"
+doc: "https://Chris00.github.io/ocaml-mindstorm/doc"
+tags: [ "lego" "robotics" "mindstorms"
+        "clib:usb" "clib:bluetooth" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune"
+  "dune-configurator" {>= "2.0"}
+  "cppo" {build}
+  "base-bytes"
+  "base-unix"
+  "conf-bluetooth" {os = "linux"}
+]
+synopsis: "Drive Lego Mindstorms bricks from OCaml"
+description: """
+This library allows you to communicate with your Lego Mindstorms brick
+via bluetooth, enable the motors and retrieve data from various
+sensors.
+"""
+available: os != "macos"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-mindstorm/releases/download/0.8.1/mindstorm-0.8.1.tbz"
+  checksum: [
+    "sha256=a8df331c4efffe3811b0410898a239c8744050ceb3c771052b79f794f1f6283f"
+    "sha512=f7b065279b76d0b3ba8d713332c8cac8328f2119baaac4c6278803a194faa923d3931b14d01c8097c689076dd9b4af2689ea53d1bca333409b6c5d3909eb0eb9"
+  ]
+}
+x-commit-hash: "dd32130a2446f960fac1f762663ee470e723eaec"


### PR DESCRIPTION
Drive Lego Mindstorms bricks from OCaml

- Project page: <a href="https://github.com/Chris00/ocaml-mindstorm">https://github.com/Chris00/ocaml-mindstorm</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-mindstorm/doc">https://Chris00.github.io/ocaml-mindstorm/doc</a>

##### CHANGES:

- Improve the portability on Windows.
