### PR TITLE
gappa 1.4.0: fix os-dependent flags

### DIFF
--- a/packages/gappa/gappa.1.4.0/opam
+++ b/packages/gappa/gappa.1.4.0/opam
@@ -16,9 +16,12 @@ build: [
     # If someone knows how to ask MacPorts for the usual include and lib path, please tell me
     "CXXFLAGS=-I/opt/local/include" { os-distribution = "macports" & os = "macos" }
     "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
+    # Support installing on x86 with Homebrew
+    "CXXFLAGS=-I/usr/local/include" { os-distribution = "homebrew" & os = "macos" & arch = "x86_64"}
+    "LDFLAGS=-L/usr/local/lib" { os-distribution = "homebrew" & os = "macos" & arch = "x86_64"}
     # Support installing on Apple Silicon with Homebrew
-    "CXXFLAGS=-I/opt/homebrew/include" { os-distribution = "homebrew" & os = "macos" }
-    "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" }
+    "CXXFLAGS=-I/opt/homebrew/include" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
+    "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
     # Support for windows
     "--build=%{arch}%-pc-cygwin" { os = "win32" & os-distribution = "cygwinports" }
     "--host=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }

--- a/packages/gappa/gappa.1.4.0/opam
+++ b/packages/gappa/gappa.1.4.0/opam
@@ -14,9 +14,12 @@ build: [
   [ "touch" "stamp-config_h.in" ]
   [ "./configure"
     # If someone knows how to ask MacPorts for the usual include and lib path, please tell me
-    "CXXFLAGS=-I/opt/local/include" "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
+    "CXXFLAGS=-I/opt/local/include" { os-distribution = "macports" & os = "macos" }
+    "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
     # Support installing on Apple Silicon with Homebrew
-    "CXXFLAGS=-I/opt/homebrew/include" "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" }
+    "CXXFLAGS=-I/opt/homebrew/include" { os-distribution = "homebrew" & os = "macos" }
+    "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" }
+    # Support for windows
     "--build=%{arch}%-pc-cygwin" { os = "win32" & os-distribution = "cygwinports" }
     "--host=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }
     "--target=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }

--- a/packages/gappa/gappa.1.4.0/opam
+++ b/packages/gappa/gappa.1.4.0/opam
@@ -16,9 +16,6 @@ build: [
     # If someone knows how to ask MacPorts for the usual include and lib path, please tell me
     "CXXFLAGS=-I/opt/local/include" { os-distribution = "macports" & os = "macos" }
     "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
-    # Support installing on x86 with Homebrew
-    "CXXFLAGS=-I/usr/local/include" { os-distribution = "homebrew" & os = "macos" & arch = "x86_64"}
-    "LDFLAGS=-L/usr/local/lib" { os-distribution = "homebrew" & os = "macos" & arch = "x86_64"}
     # Support installing on Apple Silicon with Homebrew
     "CXXFLAGS=-I/opt/homebrew/include" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
     "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}


### PR DESCRIPTION
The filter was only applied to a part of the flags.
See #19990