### PR TITLE
Make batteries conflict with multicore (interface of Stdlib.Gc changed)

### DIFF
--- a/packages/batteries/batteries.3.3.0/opam
+++ b/packages/batteries/batteries.3.3.0/opam
@@ -26,6 +26,9 @@ depends: [
   "benchmark" {with-test & >= "1.6"}
   "num"
 ]
+conflicts: [
+  "base-domains"
+]
 url {
   src: "https://github.com/ocaml-batteries-team/batteries-included/archive/v3.3.0.tar.gz"
   checksum: "md5=fe4da12b678a82faaeda4e58492ea871"


### PR DESCRIPTION
```
#=== ERROR while compiling batteries.3.3.0 ====================================#
# context              2.1.1 | linux/x86_64 | ocaml-variants.4.12.0+domains | file:///home/opam/opam-repository
# path                 ~/.opam/4.12/.opam-switch/build/batteries.3.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/batteries-20-962ee5.env
# output-file          ~/.opam/log/batteries-20-962ee5.out
### output ###
# ocamlfind ocamlc -c -g -annot -bin-annot -safe-string -no-alias-deps -strict-sequence -w -3 -w -29 -package bigarray,num,str -warn-error -50 -package bytes -I src -I toplevel -I testsuite -I qtest -I build -I benchsuite -I benchsuite/lib -o src/batGc.cmo src/batGc.ml
# + ocamlfind ocamlc -c -g -annot -bin-annot -safe-string -no-alias-deps -strict-sequence -w -3 -w -29 -package bigarray,num,str -warn-error -50 -package bytes -I src -I toplevel -I testsuite -I qtest -I build -I benchsuite -I benchsuite/lib -o src/batGc.cmo src/batGc.ml
# File "src/batGc.ml", line 1:
# Error: The implementation src/batGc.ml
#        does not match the interface src/batGc.cmi:
#        The value `huge_fallback_count' is required but not provided
#        File "src/batGc.mliv", line 289, characters 0-74: Expected declaration
#        The value `get_credit' is required but not provided
#        File "src/batGc.mliv", line 283, characters 0-71: Expected declaration
#        The value `get_bucket' is required but not provided
#        File "src/batGc.mliv", line 276, characters 0-70: Expected declaration
#        The value `get_minor_free' is required but not provided
#        File "src/batGc.mliv", line 270, characters 0-61: Expected declaration
# Command exited with code 2.
# make: *** [Makefile:107: all] Error 10
```