### PR TITLE
metrics-lwt, metrics-unix: metrics {= version}

### DIFF
--- a/packages/metrics-lwt/metrics-lwt.0.1.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "dune"
-  "metrics"
+  "metrics" {= version}
   "lwt"
 ]
 synopsis: "Lwt backend for the Metrics library"

--- a/packages/metrics-lwt/metrics-lwt.0.1.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.1"}
   "metrics" {= version}
   "lwt"
 ]

--- a/packages/metrics-lwt/metrics-lwt.0.1.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.1.0/opam
@@ -10,12 +10,12 @@ doc:          "https://mirage.github.io/metrics/"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "dune" {>= "1.4"}
-  "metrics" {= version}
+  "metrics" {< "0.5"} # should have been "= version" but to avoid breaking lock files and stuff..
   "lwt"
 ]
 synopsis: "Lwt backend for the Metrics library"

--- a/packages/metrics-lwt/metrics-lwt.0.1.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>= "1.1"}
+  "dune" {>= "1.4"}
   "metrics" {= version}
   "lwt"
 ]

--- a/packages/metrics-lwt/metrics-lwt.0.1.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune" {>= "1.4"}
   "metrics" {< "0.5"} # should have been "= version" but to avoid breaking lock files and stuff..
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "Lwt backend for the Metrics library"
 url {

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -14,7 +14,8 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.1"}
+  "fmt" {>= "0.8.5"}
   "uuidm"
   "metrics" {= version}
   "mtime" {>= "1.0.0"}

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -10,14 +10,14 @@ doc:          "https://mirage.github.io/metrics/"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 
 depends: [
   "dune" {>= "1.4"}
   "fmt" {>= "0.8.5"}
   "uuidm"
-  "metrics" {= version}
+  "metrics" {< "0.5"} # should have been "= version" but to avoid breaking lock files and stuff..
   "mtime" {>= "1.0.0"}
   "lwt"
   "conf-gnuplot"

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune"
   "uuidm"
-  "metrics"
+  "metrics" {= version}
   "mtime"
   "lwt"
   "conf-gnuplot"

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {>= "1.1"}
+  "dune" {>= "1.4"}
   "fmt" {>= "0.8.5"}
   "uuidm"
   "metrics" {= version}

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "uuidm" {>= "0.9.6"}
   "metrics" {< "0.5"} # should have been "= version" but to avoid breaking lock files and stuff..
   "mtime" {>= "1.0.0"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
   "conf-gnuplot"
   "metrics-lwt" {with-test}
 ]

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "uuidm"
   "metrics" {= version}
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "lwt"
   "conf-gnuplot"
   "metrics-lwt" {with-test}

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune" {>= "1.4"}
   "fmt" {>= "0.8.5"}
-  "uuidm"
+  "uuidm" {>= "0.9.6"}
   "metrics" {< "0.5"} # should have been "= version" but to avoid breaking lock files and stuff..
   "mtime" {>= "1.0.0"}
   "lwt"

--- a/packages/metrics/metrics.0.1.0/opam
+++ b/packages/metrics/metrics.0.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "alcotest" {with-test}
 ]
 synopsis: "Metrics infrastructure for OCaml"

--- a/packages/metrics/metrics.0.1.0/opam
+++ b/packages/metrics/metrics.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune"
+  "dune" {>= "1.4"}
   "fmt" {>= "0.8.5"}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
Discovered this missing version constraint in CI lower-bounds check for #19996.