### PR TITLE
gsl: Make unavailable on arm32

### DIFF
--- a/packages/gsl/gsl.1.18.5/opam
+++ b/packages/gsl/gsl.1.18.5/opam
@@ -31,6 +31,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocamlfind" "remove" "gsl"]
 ]
+available: arch != "arm32"
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "ocaml" {>= "3.12"}

--- a/packages/gsl/gsl.1.19.1/opam
+++ b/packages/gsl/gsl.1.19.1/opam
@@ -31,6 +31,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocamlfind" "remove" "gsl"]
 ]
+available: arch != "arm32"
 depends: [
   "ocaml" {>= "3.12"}
   "base-bigarray"

--- a/packages/gsl/gsl.1.19.3/opam
+++ b/packages/gsl/gsl.1.19.3/opam
@@ -31,6 +31,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: [
   ["ocamlfind" "remove" "gsl"]
 ]
+available: arch != "arm32"
 depends: [
   "ocaml" {>= "3.12"}
   "base-bigarray"

--- a/packages/gsl/gsl.1.20.0/opam
+++ b/packages/gsl/gsl.1.20.0/opam
@@ -24,6 +24,7 @@ depends: [
   "configurator" {build & < "v0.13"}
   "jbuilder" {>= "1.0+beta10"}
 ]
+available: arch != "arm32"
 synopsis: "GSL - Bindings to the GNU Scientific Library"
 description: """
 gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the

--- a/packages/gsl/gsl.1.20.2/opam
+++ b/packages/gsl/gsl.1.20.2/opam
@@ -24,6 +24,7 @@ depends: [
   "configurator" {build & < "v0.13"}
   "jbuilder" {>= "1.0+beta10"}
 ]
+available: arch != "arm32"
 synopsis: "GSL - Bindings to the GNU Scientific Library"
 description: """
 gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the

--- a/packages/gsl/gsl.1.21.0/opam
+++ b/packages/gsl/gsl.1.21.0/opam
@@ -24,6 +24,7 @@ depends: [
   "configurator" {build & < "v0.13"}
   "jbuilder" {>= "1.0+beta10"}
 ]
+available: arch != "arm32"
 synopsis: "GSL - Bindings to the GNU Scientific Library"
 description: """
 gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the

--- a/packages/gsl/gsl.1.22.0/opam
+++ b/packages/gsl/gsl.1.22.0/opam
@@ -24,6 +24,7 @@ depends: [
   "configurator" {build & < "v0.15"}
   "jbuilder" {>= "1.0+beta10"}
 ]
+available: arch != "arm32"
 synopsis: "GSL - Bindings to the GNU Scientific Library"
 description: """
 gsl-ocaml interfaces the GSL (GNU Scientific Library), providing many of the

--- a/packages/gsl/gsl.1.24.0/opam
+++ b/packages/gsl/gsl.1.24.0/opam
@@ -24,6 +24,7 @@ depends: [
   "base" {build & < "v0.15"}
   "stdio" {build & < "v0.15"}
 ]
+available: arch != "arm32"
 
 synopsis: "GSL - Bindings to the GNU Scientific Library"
 

--- a/packages/gsl/gsl.1.24.1/opam
+++ b/packages/gsl/gsl.1.24.1/opam
@@ -23,6 +23,7 @@ depends: [
   "base" {build & < "v0.15"}
   "stdio" {build & < "v0.15"}
 ]
+available: arch != "arm32"
 
 synopsis: "GSL - Bindings to the GNU Scientific Library"
 

--- a/packages/gsl/gsl.1.24.2/opam
+++ b/packages/gsl/gsl.1.24.2/opam
@@ -30,6 +30,7 @@ depends: [
   "base" {build}
   "stdio" {build}
 ]
+available: arch != "arm32"
 url {
   src:
     "https://github.com/mmottl/gsl-ocaml/releases/download/1.24.2/gsl-1.24.2.tbz"

--- a/packages/gsl/gsl.1.24.3/opam
+++ b/packages/gsl/gsl.1.24.3/opam
@@ -28,6 +28,7 @@ depends: [
   "conf-gsl" {build}
   "conf-pkg-config" {build}
 ]
+available: arch != "arm32"
 url {
   src:
     "https://github.com/mmottl/gsl-ocaml/releases/download/1.24.3/gsl-1.24.3.tbz"


### PR DESCRIPTION
Architectures with double-word alignment for doubles are not supported, see ARCH_ALIGN_DOUBLE
```
#=== ERROR while compiling gsl.1.24.3 =========================================#
# context              2.1.1 | linux/arm32 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/gsl.1.24.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gsl -j 1
# exit-code            1
# env-file             ~/.opam/log/gsl-23-f1ee31.env
# output-file          ~/.opam/log/gsl-23-f1ee31.out
### output ###
#          gcc src/mlgsl_blas.o (exit 1)
# (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -fPIC -DPIC -Wno-unused-parameter -g -I /home/opam/.opam/4.13/lib/ocaml -o mlgsl_blas.o -c mlgsl_blas.c)
# In file included from mlgsl_vector.h:9,
#                  from mlgsl_vector_double.h:9,
#                  from mlgsl_blas.c:8:
# wrappers.h:13:2: error: #error "Architectures with double-word alignment for doubles are not supported"
#    13 | #error "Architectures with double-word alignment for doubles are not supported"
#       |  ^~~~~
#          gcc src/mlgsl_blas_complex.o (exit 1)
```
cc @mmottl 