### PR TITLE
[new release] pyre-ast (0.1.6)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.6/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.6/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.6/pyre-ast-0.1.6.tbz"
+  checksum: [
+    "sha256=7e688555327e1af8fc9cabd9d6bc07746213bec1376f36ab9072c0aa8df2e8ad"
+    "sha512=6a87e494af4f1f577ab5819fe2ea7753950f93bc18c4f63eca8b79581df29ae17acee47f6a476c7ac29ad9007476e6d68c64ae13e92d2a89bd8ebced4aba2c2b"
+  ]
+}
+x-commit-hash: "154026a36dc7f14bf522ebca241969bee975b70b"


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- Expose 2 additional fields `end_lineno` and `end_offset` from CPython3.10 `SyntaxError`. Fix an error in documentation where column numbers should start from 1 instead of 0.
- Remove the optional `filename` argument from the `parse_module` API. It turns out that this argument is actually dropped when computing error messages so it does not serve any purpose at the moment.
