### PR TITLE
Fix gappa support on Apple Silicon for 1.3.5 as well

### DIFF
--- a/packages/gappa/gappa.1.3.5/opam
+++ b/packages/gappa/gappa.1.3.5/opam
@@ -15,7 +15,11 @@ build: [
   [ "touch" "stamp-config_h.in" ]
   [ "./configure"
     # If someone knows how to ask MacPorts for the usual include and lib path, please tell me
-    "CXXFLAGS=-I/opt/local/include" "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
+    "CXXFLAGS=-I/opt/local/include" { os-distribution = "macports" & os = "macos" }
+    "LDFLAGS=-L/opt/local/lib" { os-distribution = "macports" & os = "macos" }
+    # Support installing on Apple Silicon with Homebrew
+    "CXXFLAGS=-I/opt/homebrew/include" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
+    "LDFLAGS=-L/opt/homebrew/lib" { os-distribution = "homebrew" & os = "macos" & arch = "arm64"}
     "--build=%{arch}%-pc-cygwin" { os = "win32" & os-distribution = "cygwinports" }
     "--host=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }
     "--target=%{arch}%-w64-mingw32" { os = "win32" & os-distribution = "cygwinports" }


### PR DESCRIPTION
gappa-1.3.5 is included in __coq-platform.2021.09.0~8.12 and fails with the same problem as #19990 