### PR TITLE
Package ocamlog.0.0.1

### DIFF
--- a/packages/ocamlog/ocamlog.0.0.1/opam
+++ b/packages/ocamlog/ocamlog.0.0.1/opam
@@ -1,0 +1,21 @@
+
+opam-version: "2.0"
+synopsis: "Simple Logger for OCaml"
+description: "Able to print with different colors, levels, trace out caller, etc."
+maintainer: "paulpatault <p.patault@gmail.com>"
+authors: "paulpatault <p.patault@gmail.com>"
+depends: [
+  "ocaml"
+  "dune" {>= "2.8"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paulpatault/OcamLog"
+homepage: "https://www.github.com/paulpatault/OcamLog"
+bug-reports: "https://www.github.com/paulpatault/OcamLog/issues"
+url {
+  src: "https://github.com/paulpatault/ocamlog/archive/v0.0.1.tar.gz"
+  checksum: [
+    "md5=c2fac248393dbaefe2246cbd673cb280"
+    "sha512=49ae7fc3384cdcf4849036bd343b00776280a5930ae83a93da45bde14d95dedb2890ee5f53586a5d854fd3c5a8df3bafa09f17b1dad5cac29721f6c16a06bd55"
+  ]
+}


### PR DESCRIPTION
### `ocamlog.0.0.1`
Simple Logger for OCaml
Able to print with different colors, levels, trace out caller, etc.



---
* Homepage: https://www.github.com/paulpatault/OcamLog
* Source repo: git+https://github.com/paulpatault/OcamLog
* Bug tracker: https://www.github.com/paulpatault/OcamLog/issues

---
:camel: Pull-request generated by opam-publish v2.1.0