### PR TITLE
bistro: add missing dep on ppxlib

### DIFF
--- a/packages/bistro/bistro.0.5.0/opam
+++ b/packages/bistro/bistro.0.5.0/opam
@@ -36,6 +36,7 @@ depends: [
   "lwt" {>= "3.2.0"}
   "lwt_react"
   "ocamlgraph" {>= "1.8.7"}
+  "ppxlib" {< "0.23.0"}
   "ppx_sexp_conv" {< "v0.13"}
   "rresult"
   "sexplib" {>= "113.24.00" & < "v0.13"}


### PR DESCRIPTION
pveber/bistro#47 mentionned there's an incompatibility with version 0.23.0 of ppxlib, which made me realize that the dep on ppxlib was missing.