### PR TITLE
[new release] rpclib, rpclib-lwt, rpclib-js, rpclib-html, rpclib-async, rpc and ppx_deriving_rpc (8.1.1)

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
-  "rresult"
+  "rresult" {>= "0.3.0"}
   "ppxlib" {>= "0.18.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "rresult"
+  "ppxlib" {>= "0.18.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
@@ -31,7 +31,7 @@ as all conversions are from and to strings.
 """
 url {
   src:
-    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
   checksum: [
     "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
     "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.1/opam
@@ -6,6 +6,7 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0.0"}

--- a/packages/rpc/rpc.8.1.1/opam
+++ b/packages/rpc/rpc.8.1.1/opam
@@ -36,7 +36,7 @@ This is a dummy package installing the main library components.
 post-messages: ["DEPRECATED. This package is a virtual package and is outdated, you should consider using directly rpclib, rpclib-lwt, rpclib-async and ppx_deriving_rpc instead"]
 url {
   src:
-    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
   checksum: [
     "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
     "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"

--- a/packages/rpc/rpc.8.1.1/opam
+++ b/packages/rpc/rpc.8.1.1/opam
@@ -6,9 +6,10 @@ tags: ["org:mirage" "org:xapi-project" "deprecated"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml" {>= "4.04.1"}
-  "dune"
+  "dune" {>= "2.0.0"}
   "rpclib" {=version}
   "rpclib-lwt" {=version}
   "ppx_deriving_rpc" {=version}

--- a/packages/rpc/rpc.8.1.1/opam
+++ b/packages/rpc/rpc.8.1.1/opam
@@ -19,8 +19,8 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-    ["dune" "runtest" "-p" name] {with-test}
-    ["dune" "build" "@doc"] {with-doc}
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 description: """

--- a/packages/rpc/rpc.8.1.1/opam
+++ b/packages/rpc/rpc.8.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project" "deprecated"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune"
+  "rpclib" {=version}
+  "rpclib-lwt" {=version}
+  "ppx_deriving_rpc" {=version}
+  "alcotest" {with-test}
+  "md2mld" {with-doc & >= "0.4.0"}
+  "conf-which" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+    ["dune" "runtest" "-p" name] {with-test}
+    ["dune" "build" "@doc"] {with-doc}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+
+This is a dummy package installing the main library components.
+"""
+post-messages: ["DEPRECATED. This package is a virtual package and is outdated, you should consider using directly rpclib, rpclib-lwt, rpclib-async and ppx_deriving_rpc instead"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/rpclib-async/rpclib-async.8.1.1/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.1/opam
@@ -6,10 +6,11 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml"
   "alcotest" {with-test}
-  "dune"
+  "dune" {>= "2.0.0"}
   "rpclib" {=version}
   "async" {>= "v0.9.0"}
   "ppx_deriving_rpc" {with-test & =version}

--- a/packages/rpclib-async/rpclib-async.8.1.1/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune"
+  "rpclib" {=version}
+  "async" {>= "v0.9.0"}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/rpclib-async/rpclib-async.8.1.1/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.1/opam
@@ -30,7 +30,7 @@ as all conversions are from and to strings.
 """
 url {
   src:
-    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
   checksum: [
     "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
     "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"

--- a/packages/rpclib-async/rpclib-async.8.1.1/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.1/opam
@@ -17,7 +17,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 description: """

--- a/packages/rpclib-html/rpclib-html.8.1.1/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.1/opam
@@ -26,7 +26,7 @@ as all conversions are from and to strings.
 """
 url {
   src:
-    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
   checksum: [
     "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
     "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"

--- a/packages/rpclib-html/rpclib-html.8.1.1/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune"
+  "rpclib" {=version}
+  "cow"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/rpclib-html/rpclib-html.8.1.1/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "rpclib" {=version}
-  "cow"
+  "cow" {>= "2.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git://github.com/mirage/ocaml-rpc"

--- a/packages/rpclib-html/rpclib-html.8.1.1/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.1/opam
@@ -7,9 +7,10 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml"
-  "dune"
+  "dune" {>= "2.0.0"}
   "rpclib" {=version}
   "cow" {>= "2.0.0"}
 ]

--- a/packages/rpclib-js/rpclib-js.8.1.1/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "dune"
+  "rpclib" {=version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/rpclib-js/rpclib-js.8.1.1/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.1/opam
@@ -27,7 +27,7 @@ as all conversions are from and to strings.
 """
 url {
   src:
-    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
   checksum: [
     "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
     "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"

--- a/packages/rpclib-js/rpclib-js.8.1.1/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.1/opam
@@ -6,9 +6,10 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml"
-  "dune"
+  "dune" {>= "2.0.0"}
   "rpclib" {=version}
   "js_of_ocaml" {>= "3.5.0"}
   "js_of_ocaml-ppx" {>= "3.5.0"}

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
@@ -18,7 +18,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 description: """

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
@@ -6,10 +6,11 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml"
   "alcotest" {with-test}
-  "dune"
+  "dune" {>= "2.0.0"}
   "rpclib" {=version}
   "lwt" {>= "3.0.0"}
   "alcotest-lwt" {with-test}

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune"
+  "rpclib" {=version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.1/opam
@@ -31,7 +31,7 @@ as all conversions are from and to strings.
 """
 url {
   src:
-    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.1/rpclib-8.1.1.tbz"
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
   checksum: [
     "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
     "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "alcotest" {with-test}
   "dune" {>= "2.0.0"}
   "base64" {>= "3.4.0"}
-  "cmdliner"
+  "cmdliner" {>= "0.9.8"}
   "rresult"
   "xmlm"
   "yojson" {>= "1.7.0"}

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "base64" {>= "3.4.0"}
+  "cmdliner"
+  "rresult"
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/v8.1.1/rpclib-8.1.1.tbz"
+  checksum: [
+    "sha256=7490acef5f0914220cf00f4d7977b29b16c6840a378f515864b5f31b93d0f399"
+    "sha512=7424ac12f5a96207875e0a0eba4f13772c93540e87491232105c7852193a47432b5442f748264bb5cb90dab8b1711b1368e870b3eca083ffff9cf73a27df5ed9"
+  ]
+}
+x-commit-hash: "0f3edef992f241170a12cf9e2e9e118122e6336a"

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "base64" {>= "3.4.0"}
   "cmdliner" {>= "0.9.8"}
-  "rresult"
+  "rresult" {>= "0.3.0"}
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -16,6 +16,9 @@ depends: [
   "xmlm"
   "yojson" {>= "1.7.0"}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -6,6 +6,7 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
 depends: [
   "ocaml" {>= "4.04.0"}
   "alcotest" {with-test}

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -22,7 +22,7 @@ conflicts: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git://github.com/mirage/ocaml-rpc"
 description: """


### PR DESCRIPTION
A library to deal with RPCs in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-rpc">https://github.com/mirage/ocaml-rpc</a>
- Documentation: <a href="https://mirage.github.io/ocaml-rpc/rpclib">https://mirage.github.io/ocaml-rpc/rpclib</a>

##### CHANGES:

* Ignore error about using f-strings in python bindings (@psafont)
* Compatibility with rresult 0.7.0 (@psafont)
