### PR TITLE
[new release] plotkicadsch and kicadsch (0.9.0)

### DIFF
--- a/packages/kicadsch/kicadsch.0.9.0/opam
+++ b/packages/kicadsch/kicadsch.0.9.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Library to read and convert Kicad Sch files"
+description: """
+Library able to read Kicad libraries and sch file and
+drive a painter to paint the schematics.
+"""
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+  "ocaml" {>="4.07"}
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/0.9.0/plotkicadsch-0.9.0.tbz"
+  checksum: [
+    "sha256=07ebe710fc9ddd2533be24dd368caf624d29ec7ae0fd74c99bc2b1b18f00e234"
+    "sha512=85daa669c9d77c941dce3e351487f41695c85283d38cc53b745cc3b97cfa57d56049c92478c2bf6059cb1633db619baf227d387737a53bab2cf826c053c438a1"
+  ]
+}
+x-commit-hash: "649864bc92eacf77bf9800a0ee55f98dab1e634d"

--- a/packages/kicadsch/kicadsch.0.9.0/opam
+++ b/packages/kicadsch/kicadsch.0.9.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
@@ -23,7 +23,7 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/jnavila/plotkicadsch/releases/download/0.9.0/plotkicadsch-0.9.0.tbz"
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.9.0/plotkicadsch-0.9.0.tbz"
   checksum: [
     "sha256=07ebe710fc9ddd2533be24dd368caf624d29ec7ae0fd74c99bc2b1b18f00e234"
     "sha512=85daa669c9d77c941dce3e351487f41695c85283d38cc53b745cc3b97cfa57d56049c92478c2bf6059cb1633db619baf227d387737a53bab2cf826c053c438a1"

--- a/packages/kicadsch/kicadsch.0.9.0/opam
+++ b/packages/kicadsch/kicadsch.0.9.0/opam
@@ -21,6 +21,7 @@ depends: [
   "ounit" {with-test}
   "ocaml" {>="4.07"}
 ]
+available: arch != "arm32" & arch != "x86_32"
 url {
   src:
     "https://github.com/jnavila/plotkicadsch/releases/download/v0.9.0/plotkicadsch-0.9.0.tbz"

--- a/packages/kicadsch/kicadsch.0.9.0/opam
+++ b/packages/kicadsch/kicadsch.0.9.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
-authors: "Jean-Noel Avila <jn.avila@free.fr>"
+maintainer: "Jean-Noël Avila <jn.avila@free.fr>"
+authors: "Jean-Noël Avila <jn.avila@free.fr>"
 homepage: "https://jnavila.github.io/plotkicadsch/"
 doc: "https://jnavila.github.io/plotkicadsch/index"
 synopsis: "Library to read and convert Kicad Sch files"

--- a/packages/plotkicadsch/plotkicadsch.0.9.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.9.0/opam
@@ -13,7 +13,7 @@ Two utilities:
 license: "ISC"
 dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
@@ -31,7 +31,7 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/jnavila/plotkicadsch/releases/download/0.9.0/plotkicadsch-0.9.0.tbz"
+    "https://github.com/jnavila/plotkicadsch/releases/download/v0.9.0/plotkicadsch-0.9.0.tbz"
   checksum: [
     "sha256=07ebe710fc9ddd2533be24dd368caf624d29ec7ae0fd74c99bc2b1b18f00e234"
     "sha512=85daa669c9d77c941dce3e351487f41695c85283d38cc53b745cc3b97cfa57d56049c92478c2bf6059cb1633db619baf227d387737a53bab2cf826c053c438a1"

--- a/packages/plotkicadsch/plotkicadsch.0.9.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Jean-Noel Avila <jn.avila@free.fr>"
+authors: "Jean-Noel Avila <jn.avila@free.fr>"
+homepage: "https://jnavila.github.io/plotkicadsch/"
+bug-reports: "https://github.com/jnavila/plotkicadsch/issues"
+doc: "https://jnavila.github.io/plotkicadsch/index"
+synopsis: "Utilities to print and compare version of Kicad schematics"
+description: """
+Two utilities:
+ * plotkicadsch is able to plot schematic sheets to SVG files
+ * plotgitsch is able to compare git revisions of schematics
+"""
+license: "ISC"
+dev-repo: "git+https://github.com/jnavila/plotkicadsch.git"
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.09"}
+  "dune" {>= "1.0"}
+  "kicadsch" {= version}
+  "tyxml" {>= "4.0.0"}
+  "lwt"
+  "lwt_ppx" {build}
+  "sha"
+  "git" {>= "3.4.0"}
+  "git-unix"
+  "base64" {>= "3.0.0"}
+  "cmdliner"
+]
+url {
+  src:
+    "https://github.com/jnavila/plotkicadsch/releases/download/0.9.0/plotkicadsch-0.9.0.tbz"
+  checksum: [
+    "sha256=07ebe710fc9ddd2533be24dd368caf624d29ec7ae0fd74c99bc2b1b18f00e234"
+    "sha512=85daa669c9d77c941dce3e351487f41695c85283d38cc53b745cc3b97cfa57d56049c92478c2bf6059cb1633db619baf227d387737a53bab2cf826c053c438a1"
+  ]
+}
+x-commit-hash: "649864bc92eacf77bf9800a0ee55f98dab1e634d"


### PR DESCRIPTION
Utilities to print and compare version of Kicad schematics

- Project page: <a href="https://jnavila.github.io/plotkicadsch/">https://jnavila.github.io/plotkicadsch/</a>
- Documentation: <a href="https://jnavila.github.io/plotkicadsch/index">https://jnavila.github.io/plotkicadsch/index</a>

##### CHANGES:

 - plotgitsch: introduce alpha channel for background in internal diff
 - plotgitsch: add revisions in diff plots
 - plotgitsch: allow missing components in libs
 - plotgitsch: add --relative option
