### PR TITLE
[new release] mirage-flow, mirage-flow-unix and mirage-flow-combinators (3.0.0)

### DIFF
--- a/packages/mirage-flow-combinators/mirage-flow-combinators.3.0.0/opam
+++ b/packages/mirage-flow-combinators/mirage-flow-combinators.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS specialized to lwt"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz"
+  checksum: [
+    "sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc"
+    "sha512=2aeb397799621bc0ea2485b68058949c99b3da8d454939d594a9b2d39ef47aa2c16489f06adfa2dea3b34fd15e60a23abc6b8e214dfbc8b7da2e958de7c36b57"
+  ]
+}
+x-commit-hash: "f5f6c131a9e72ac473719eb8740058385638a524"

--- a/packages/mirage-flow-unix/mirage-flow-unix.3.0.0/opam
+++ b/packages/mirage-flow-unix/mirage-flow-unix.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "mirage-flow" {= version}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+  "mirage-flow-combinators" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS on Unix"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz"
+  checksum: [
+    "sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc"
+    "sha512=2aeb397799621bc0ea2485b68058949c99b3da8d454939d594a9b2d39ef47aa2c16489f06adfa2dea3b34fd15e60a23abc6b8e214dfbc8b7da2e958de7c36b57"
+  ]
+}
+x-commit-hash: "f5f6c131a9e72ac473719eb8740058385638a524"

--- a/packages/mirage-flow/mirage-flow.3.0.0/opam
+++ b/packages/mirage-flow/mirage-flow.3.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Dave Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-flow"
+doc: "https://mirage.github.io/mirage-flow/"
+bug-reports: "https://github.com/mirage/mirage-flow/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-flow.git"
+synopsis: "Flow implementations and combinators for MirageOS"
+description: """
+This repo contains generic operations over Mirage `FLOW` implementations.
+
+Please consult [the API documentation](https://mirage.github.io/mirage-flow/index.html).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-flow/releases/download/v3.0.0/mirage-flow-v3.0.0.tbz"
+  checksum: [
+    "sha256=d70bda6c85ec2747bed88bc4d95f269d2810503b92913f0807be5291696138fc"
+    "sha512=2aeb397799621bc0ea2485b68058949c99b3da8d454939d594a9b2d39ef47aa2c16489f06adfa2dea3b34fd15e60a23abc6b8e214dfbc8b7da2e958de7c36b57"
+  ]
+}
+x-commit-hash: "f5f6c131a9e72ac473719eb8740058385638a524"


### PR DESCRIPTION
Flow implementations and combinators for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-flow">https://github.com/mirage/mirage-flow</a>
- Documentation: <a href="https://mirage.github.io/mirage-flow/">https://mirage.github.io/mirage-flow/</a>

##### CHANGES:

- Remove Mirage_flow_lwt module
- Require fmt 0.8.7, cstruct 6.0.0 and avoid deprecated functions
- Compatibility with alcotest 1.4 (eta expansion of Alcotest.fail)
- Mirage_flow_combinators.forward has an additional unit argument to avoid
  unerasable optional argument warning
