### PR TITLE
[new release] mirage-net (4.0.0)

### DIFF
--- a/packages/mirage-net/mirage-net.4.0.0/opam
+++ b/packages/mirage-net/mirage-net.4.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-net"
+bug-reports:   "https://github.com/mirage/mirage-net/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net.git"
+doc:           "https://mirage.github.io/mirage-net/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "fmt"
+  "macaddr" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "Network signatures for MirageOS"
+description: """
+mirage-net defines `Mirage_net.S`, the signature for network operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net/releases/download/v4.0.0/mirage-net-v4.0.0.tbz"
+  checksum: [
+    "sha256=668effd187b81a0ab32450870c15dbb89ff911397ff338a8951807e250e194ce"
+    "sha512=52064dc704ebd0d305fd234b6d89fc313d5a80016d8875ef93212a1962ad8b1f332f7b0338244afbb2d2f207a28d476e7d7639be9dc607d95145afee7fccc483"
+  ]
+}
+x-commit-hash: "f440f203ed2d1653f11d6c0b184dbbdfb94ef723"


### PR DESCRIPTION
Network signatures for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-net">https://github.com/mirage/mirage-net</a>
- Documentation: <a href="https://mirage.github.io/mirage-net/">https://mirage.github.io/mirage-net/</a>

##### CHANGES:

- remove dependency on mirage-device (mirage/mirage-net#24 @hannesm)
- remove Mirage_net_lwt module (mirage/mirage-net#24 @hannesm)
