### PR TITLE
[new release] mirage-random (3.0.0)

### DIFF
--- a/packages/mirage-random/mirage-random.3.0.0/opam
+++ b/packages/mirage-random/mirage-random.3.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:    "thomas@gazagnaire.org"
+homepage:      "https://github.com/mirage/mirage-random"
+bug-reports:   "https://github.com/mirage/mirage-random/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-random.git"
+doc:           "https://mirage.github.io/mirage-random/"
+authors:       ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+tags:          [ "org:mirage"]
+license:       "ISC"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune" {>="1.1.0"}
+  "cstruct" {>= "4.0.0"}
+  "ocaml" {>= "4.08.0"}
+]
+
+synopsis: "Random-related devices for MirageOS"
+description: """
+mirage-random defines `Mirage_random.S` the signature for random-related devices for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-random/releases/download/v3.0.0/mirage-random-v3.0.0.tbz"
+  checksum: [
+    "sha256=49fe3f281d6430cc1723ecabe47fc9b8e9b29d83cd5f0964f5d000fa014066cf"
+    "sha512=5d16855740e04f8efe5bcd5a7596ccffb5b927a616c5e6de4a5f5bd96e2f9f8f3b030d8b216156cac897d49a64b0f5bd7f89c30c787c3d9be63ab952c9984160"
+  ]
+}
+x-commit-hash: "2f2434c30cedb476b44b10c55cec0052f1eaa1f4"


### PR DESCRIPTION
Random-related devices for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-random">https://github.com/mirage/mirage-random</a>
- Documentation: <a href="https://mirage.github.io/mirage-random/">https://mirage.github.io/mirage-random/</a>

##### CHANGES:

* Remove Mirage_random.C (@hannesm)
