### PR TITLE
[new release] mirage-time and mirage-time-unix (3.0.0)

### DIFF
--- a/packages/mirage-time-unix/mirage-time-unix.3.0.0/opam
+++ b/packages/mirage-time-unix/mirage-time-unix.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-time" {=version}
+  "lwt" {>= "4.0.0"}
+  "duration"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS on Unix"
+description: """
+mirage-time-unix defines `Time`, an implementation of the `Mirage_time.S` signature for the Unix backend.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v3.0.0/mirage-time-v3.0.0.tbz"
+  checksum: [
+    "sha256=0d40949b58e2c7e8b762ccc8ce066345046233c8c95d0e3d17a242ff289cbd7c"
+    "sha512=066f9271c7871eb754cf9b3f8853f4861ce80d1cc31eb9a2384f3cd62441e15aa7636d19cc3bee6d56219fa5653b9f7da7d9b9d659fd1f7cd17326e7ba1715eb"
+  ]
+}
+x-commit-hash: "c68f199b1952f0656526a3212f82afd2a49c1f00"

--- a/packages/mirage-time/mirage-time.3.0.0/opam
+++ b/packages/mirage-time/mirage-time.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: [
+  "Thomas Gazagnaire"
+  "Anil Madhavapeddy"
+  "Gabriel Radanne"
+  "Mindy Preston"
+  "Thomas Leonard"
+  "Nicolas Ojeda Bar"
+  "Dave Scott"
+  "David Kaloper"
+  "Hannes Mehnert"
+  "Richard Mortier"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-time"
+doc: "https://mirage.github.io/mirage-time/"
+bug-reports: "https://github.com/mirage/mirage-time/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-time.git"
+synopsis: "Time operations for MirageOS"
+description: """
+mirage-time defines `Mirage_time.S`, the signature for time-related operations for MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-time/releases/download/v3.0.0/mirage-time-v3.0.0.tbz"
+  checksum: [
+    "sha256=0d40949b58e2c7e8b762ccc8ce066345046233c8c95d0e3d17a242ff289cbd7c"
+    "sha512=066f9271c7871eb754cf9b3f8853f4861ce80d1cc31eb9a2384f3cd62441e15aa7636d19cc3bee6d56219fa5653b9f7da7d9b9d659fd1f7cd17326e7ba1715eb"
+  ]
+}
+x-commit-hash: "c68f199b1952f0656526a3212f82afd2a49c1f00"


### PR DESCRIPTION
Time operations for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-time">https://github.com/mirage/mirage-time</a>
- Documentation: <a href="https://mirage.github.io/mirage-time/">https://mirage.github.io/mirage-time/</a>

##### CHANGES:

* Remove Mirage_time_lwt module (mirage/mirage-time#13 @hannesm)
