### PR TITLE
[new release] mirage-protocols (7.0.0)

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.7.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.7.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "fmt"
+  "duration"
+  "lwt" {>= "4.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v7.0.0/mirage-protocols-v7.0.0.tbz"
+  checksum: [
+    "sha256=5659c450015b05b97448f1ee394858e383d62e26ffd88fd4fd0c5c4cd376c0f0"
+    "sha512=fd0ab477605933fbab6693b83067d64196ba52e4e968cc5a5449e059e65dde12bfba543eeb39f2562bfe5d5c25b5268e73dee24fd55e0ad390a6c6795d932ac4"
+  ]
+}
+x-commit-hash: "66f4b686639731e6ddc93be61e399d76f3407056"


### PR DESCRIPTION
MirageOS signatures for network protocols

- Project page: <a href="https://github.com/mirage/mirage-protocols">https://github.com/mirage/mirage-protocols</a>
- Documentation: <a href="https://mirage.github.io/mirage-protocols/">https://mirage.github.io/mirage-protocols/</a>

##### CHANGES:

* Remove Mirage_protocols_lwt module (mirage/mirage-protocols#29 @hannesm)
* Remove mirage-device dependency (mirage/mirage-protocols#29 @hannesm)
