### PR TITLE
[new release] mirage-kv (4.0.0)

### DIFF
--- a/packages/mirage-kv/mirage-kv.4.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.4.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v4.0.0/mirage-kv-v4.0.0.tbz"
+  checksum: [
+    "sha256=352d87a479f1bbda9aa358aa732a66b813c242e63e9998589d6e818960b63d3a"
+    "sha512=d6f98085539e764be19bb544070a701e7b50983075ebd5462063f37c5f0a1c828b6f81f2b9337a1e1ea0718a2f99efb685dc17419b774f110d83446d4b24abb7"
+  ]
+}
+x-commit-hash: "5c2c75e5a0efc0c9390b11fab75b1e706ea8d4ab"


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Remove Mirage_kv_lwt module (mirage/mirage-kv#24 @hannesm)
* remove mirage-device dependency (mirage/mirage-kv#24 @hannesm)
* Adapt to fmt 0.8.7 dependency (mirage/mirage-kv#23 @MisterDA)
