### PR TITLE
[new release] mirage-console, mirage-console-xen, mirage-console-xen-proto, mirage-console-xen-backend and mirage-console-unix (5.0.0)

### DIFF
--- a/packages/mirage-console-unix/mirage-console-unix.5.0.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.5.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt" {>= "6.0.0"}
+  "mirage-console" {=version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.0.0/mirage-console-v5.0.0.tbz"
+  checksum: [
+    "sha256=8d9a29ebf6ac6b9abddb8203de7b62ad611fa4d42c36549b85ab3e7f9af3e5ce"
+    "sha512=0e429c963fa5a418b4304dd501733fdf54c810579b396c743ba7bbef60fb3a6e777fdf6f8357ebbb1a30fe650a12fb7afe701048fa02d02403260fed168207bb"
+  ]
+}
+x-commit-hash: "24ee07f439a2cb1a851f076459a9108d7f5a9145"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.0.0/opam
@@ -18,6 +18,7 @@ depends: [
   "xenstore"
   "shared-memory-ring"
   "shared-memory-ring-lwt"
+  "cstruct" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "6.0.0"}
+  "io-page" {>= "2.0.0"}
+  "lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.7"}
+  "xenstore"
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.0.0/mirage-console-v5.0.0.tbz"
+  checksum: [
+    "sha256=8d9a29ebf6ac6b9abddb8203de7b62ad611fa4d42c36549b85ab3e7f9af3e5ce"
+    "sha512=0e429c963fa5a418b4304dd501733fdf54c810579b396c743ba7bbef60fb3a6e777fdf6f8357ebbb1a30fe650a12fb7afe701048fa02d02403260fed168207bb"
+  ]
+}
+x-commit-hash: "24ee07f439a2cb1a851f076459a9108d7f5a9145"

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.5.0.0/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.5.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {= version}
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.0.0/mirage-console-v5.0.0.tbz"
+  checksum: [
+    "sha256=8d9a29ebf6ac6b9abddb8203de7b62ad611fa4d42c36549b85ab3e7f9af3e5ce"
+    "sha512=0e429c963fa5a418b4304dd501733fdf54c810579b396c743ba7bbef60fb3a6e777fdf6f8357ebbb1a30fe650a12fb7afe701048fa02d02403260fed168207bb"
+  ]
+}
+x-commit-hash: "24ee07f439a2cb1a851f076459a9108d7f5a9145"

--- a/packages/mirage-console-xen/mirage-console-xen.5.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.5.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "io-page" {>= "2.0.0"}
+  "xenstore"
+  "shared-memory-ring"
+  "lwt"
+  "mirage-flow"
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.0.0/mirage-console-v5.0.0.tbz"
+  checksum: [
+    "sha256=8d9a29ebf6ac6b9abddb8203de7b62ad611fa4d42c36549b85ab3e7f9af3e5ce"
+    "sha512=0e429c963fa5a418b4304dd501733fdf54c810579b396c743ba7bbef60fb3a6e777fdf6f8357ebbb1a30fe650a12fb7afe701048fa02d02403260fed168207bb"
+  ]
+}
+x-commit-hash: "24ee07f439a2cb1a851f076459a9108d7f5a9145"

--- a/packages/mirage-console-xen/mirage-console-xen.5.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.5.0.0/opam
@@ -17,6 +17,7 @@ depends: [
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
   "mirage-xen" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mirage-console/mirage-console.5.0.0/opam
+++ b/packages/mirage-console/mirage-console.5.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.0.0/mirage-console-v5.0.0.tbz"
+  checksum: [
+    "sha256=8d9a29ebf6ac6b9abddb8203de7b62ad611fa4d42c36549b85ab3e7f9af3e5ce"
+    "sha512=0e429c963fa5a418b4304dd501733fdf54c810579b396c743ba7bbef60fb3a6e777fdf6f8357ebbb1a30fe650a12fb7afe701048fa02d02403260fed168207bb"
+  ]
+}
+x-commit-hash: "24ee07f439a2cb1a851f076459a9108d7f5a9145"


### PR DESCRIPTION
Implementations of Mirage console devices

- Project page: <a href="https://github.com/mirage/mirage-console">https://github.com/mirage/mirage-console</a>
- Documentation: <a href="https://mirage.github.io/mirage-console/">https://mirage.github.io/mirage-console/</a>

##### CHANGES:

* Remove Mirage_console_lwt module (mirage/mirage-console#86 @hannesm)
* Remove mirage-device dependency (mirage/mirage-console#86 @hannesm)
* Remove rresult dependency (mirage/mirage-console#86 @hannesm)
* Update to fmt 0.8.7 and cstruct 6.0.0 API (mirage/mirage-console#86 @hannesm)
