### PR TITLE
[new release] mirage-stack (3.0.0)

### DIFF
--- a/packages/mirage-stack/mirage-stack.3.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.3.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-protocols" {>= "4.0.0"}
+  "fmt"
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used
+as MirageOS network stacks should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v3.0.0/mirage-stack-v3.0.0.tbz"
+  checksum: [
+    "sha256=d222aa0aadbb7287decd8429be01573d876202d8d1399a9fc5e9f8226252fd77"
+    "sha512=638a8603303d7449ace8b70a4927beaf4c49799dca6be2a00f7811aefae4290ad40a960f33a0011a48c4638c4ce348122739f6ebb4d8991e6c4fec0cb26cd795"
+  ]
+}
+x-commit-hash: "4f6d82566ba608cbb084f352749ce241831f2ed3"


### PR DESCRIPTION
MirageOS signatures for network stacks

- Project page: <a href="https://github.com/mirage/mirage-stack">https://github.com/mirage/mirage-stack</a>
- Documentation: <a href="https://mirage.github.io/mirage-stack/">https://mirage.github.io/mirage-stack/</a>

##### CHANGES:

* Remove Mirage_stack_lwt module (mirage/mirage-stack#20 @hannesm)
* mark listen_{tcp(v4),udp(v4)} as deprecated, enow that mirage-protocols 6.0.0
  contains UDP.listen and TCP.listen (mirage/mirage-stack#20 @hannesm)
* Remove mirage-device dependency (mirage/mirage-stack#20 @hannesm)
