### PR TITLE
[new release] mirage-fs (4.0.0)

### DIFF
--- a/packages/mirage-fs/mirage-fs.4.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.4.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+homepage:     "https://github.com/mirage/mirage-fs"
+doc:          "https://mirage.github.io/mirage-fs/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-fs.git"
+bug-reports:  "https://github.com/mirage/mirage-fs/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt"
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "4.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+]
+synopsis: "MirageOS signatures for filesystem devices"
+description: """
+mirage-fs provides the `[Mirage_fs.S][fs]` signatures
+the MirageOS filesystem devices should implement.
+
+[fs]: http://mirage.github.io/mirage-fs/Mirage_fs.html
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use mirage-kv instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-fs/releases/download/v4.0.0/mirage-fs-v4.0.0.tbz"
+  checksum: [
+    "sha256=3d86761c23eec4ebf8154ec41f29ac6b5a08654eeaf134b3cd1be59e061d677b"
+    "sha512=d5ce102ae88771cf4a8198c37ba76e6d5ca0a87f4df76d6d7ad2a40c1161b3e731059234aea7fb3db997a9f16d84d8f75a34ff4a6e38765c2499278e5ba94567"
+  ]
+}
+x-commit-hash: "2749c1aa8b2ed541139b88988ef710cb2a77e6d3"


### PR DESCRIPTION
MirageOS signatures for filesystem devices

- Project page: <a href="https://github.com/mirage/mirage-fs">https://github.com/mirage/mirage-fs</a>
- Documentation: <a href="https://mirage.github.io/mirage-fs/">https://mirage.github.io/mirage-fs/</a>

##### CHANGES:

* Remove Mirage_fs_lwt module (mirage/mirage-fs#28 @hannesm)
* remove mirage-device dependency (mirage/mirage-fs#28 @hannesm)
