### PR TITLE
[new release] mirage-clock, mirage-clock-unix and mirage-clock-freestanding (4.0.0)

### DIFF
--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.4.0.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.4.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "mirage-clock" {= version}
+]
+conflicts: [
+  "mirage-solo5" {<= "0.6.4"}
+  "mirage-xen" {<= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git://github.com/mirage/mirage-clock"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.0.0/mirage-clock-v4.0.0.tbz"
+  checksum: [
+    "sha256=77c5faa1e30588d4e287fcf32c21dc1460611eba03515a860526c7097c2a9678"
+    "sha512=7600a0fbcc88637ef09242283bec80fc68f95340fd671abcec663a34041cf98b17e31fe4ee2f6d33dfab1a806049f22863ed5b76c9e2e40d0c6a0b1262f17329"
+  ]
+}
+x-commit-hash: "5c1fa5e5818d1a5d8600894e95f07d48ad705c6f"

--- a/packages/mirage-clock-unix/mirage-clock-unix.4.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "dune-configurator"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.0.0/mirage-clock-v4.0.0.tbz"
+  checksum: [
+    "sha256=77c5faa1e30588d4e287fcf32c21dc1460611eba03515a860526c7097c2a9678"
+    "sha512=7600a0fbcc88637ef09242283bec80fc68f95340fd671abcec663a34041cf98b17e31fe4ee2f6d33dfab1a806049f22863ed5b76c9e2e40d0c6a0b1262f17329"
+  ]
+}
+x-commit-hash: "5c1fa5e5818d1a5d8600894e95f07d48ad705c6f"

--- a/packages/mirage-clock/mirage-clock.4.0.0/opam
+++ b/packages/mirage-clock/mirage-clock.4.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.0.0/mirage-clock-v4.0.0.tbz"
+  checksum: [
+    "sha256=77c5faa1e30588d4e287fcf32c21dc1460611eba03515a860526c7097c2a9678"
+    "sha512=7600a0fbcc88637ef09242283bec80fc68f95340fd671abcec663a34041cf98b17e31fe4ee2f6d33dfab1a806049f22863ed5b76c9e2e40d0c6a0b1262f17329"
+  ]
+}
+x-commit-hash: "5c1fa5e5818d1a5d8600894e95f07d48ad705c6f"


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-clock">https://github.com/mirage/mirage-clock</a>
- Documentation: <a href="https://mirage.github.io/mirage-clock/">https://mirage.github.io/mirage-clock/</a>

##### CHANGES:

* Remove Mirage_clock_lwt module (mirage/mirage-clock#48 @hannesm)
* Use caml_get_wall_clock instead of unix_gettime to avoid floating point
  conversion roundtrip (mirage/mirage-clock#47 @hannesm)
