### PR TITLE
Coq 8.13.2: disable warn 70 for OCaml 4.13

### DIFF
--- a/packages/coq/coq.8.13.2/files/disable_warn_70.patch
+++ b/packages/coq/coq.8.13.2/files/disable_warn_70.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ml b/configure.ml
+index 26511e0f8f..3ae125f1b7 100644
+--- a/configure.ml
++++ b/configure.ml
+@@ -634,7 +634,7 @@ let camltag = match caml_version_list with
+     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+     67: "unused functor parameter" seems totally bogus
+ *)
+-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67"
++let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-70"
+ let coq_warn_error =
+     if !prefs.warn_error
+     then "-warn-error +a"

--- a/packages/coq/coq.8.13.2/opam
+++ b/packages/coq/coq.8.13.2/opam
@@ -50,8 +50,10 @@ install: [
   [make "COQ_USE_DUNE=" "install-byte"]
 ]
 
+patches: [ "disable_warn_70.patch" ]
 extra-files: [
    ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+   ["disable_warn_70.patch" "sha512=f4bcf3d4b7700c021d05da978995fdaea63571db76d0d2caeb1a0093d0c2898a278770e40c7621114a215d293434c7b173801167b81c362d3797bca382c38d41"]
 ]
 
 url {


### PR DESCRIPTION
This PR is a follow-up of https://github.com/ocaml/opam-repository/pull/19903 It removes one warning from Coq to fix many Coq plugins with OCaml 4.13.