### PR TITLE
Package ocamlog.0.1

### DIFF
--- a/packages/ocamlog/ocamlog.0.1/opam
+++ b/packages/ocamlog/ocamlog.0.1/opam
@@ -5,7 +5,7 @@ description: "Able to print with different colors, levels, trace out caller, etc
 maintainer: "paulpatault <p.patault@gmail.com>"
 authors: "paulpatault <p.patault@gmail.com>"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.04"}
   "dune" {>= "2.8"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ocamlog/ocamlog.0.1/opam
+++ b/packages/ocamlog/ocamlog.0.1/opam
@@ -1,0 +1,22 @@
+
+opam-version: "2.0"
+synopsis: "Simple Logger for OCaml"
+description: "Able to print with different colors, levels, trace out caller, etc."
+maintainer: "paulpatault <p.patault@gmail.com>"
+authors: "paulpatault <p.patault@gmail.com>"
+depends: [
+  "ocaml"
+  "dune" {>= "2.8"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paulpatault/OcamLog"
+homepage: "https://www.github.com/paulpatault/OcamLog"
+bug-reports: "https://www.github.com/paulpatault/OcamLog/issues"
+license: "MIT"
+url {
+  src: "https://github.com/paulpatault/ocamlog/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=1e14b6596988792264bbeca76830558a"
+    "sha512=e638151fa9250fc1aeca2ebee24ca20bde75deef9045ff77e41b75b6b6ce91c9b4994235a3817e5091b8c0ee3feffab7790d8210cae9e4682ee6f68485812ace"
+  ]
+}


### PR DESCRIPTION
### `ocamlog.0.1`
Simple Logger for OCaml
Able to print with different colors, levels, trace out caller, etc.



---
* Homepage: https://www.github.com/paulpatault/OcamLog
* Source repo: git+https://github.com/paulpatault/OcamLog
* Bug tracker: https://www.github.com/paulpatault/OcamLog/issues

---
:camel: Pull-request generated by opam-publish v2.1.0