### PR TITLE
new release ocaml-freestanding 0.6.6

### DIFF
--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.6/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [make]
+install: [make "install" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")
+  "ocaml" {>= "4.08.0" & < "4.14.0"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml runtime"
+description:
+  "This package provides a freestanding OCaml runtime (asmrun), suitable for linking with a unikernel base layer."
+url {
+  src: "https://github.com/mirage/ocaml-freestanding/archive/v0.6.6.tar.gz"
+  checksum: "sha512=e7e8180b23d84cec251f6b406c8bee6a530223c68950b4faacd089b8a14e2aaa04bb70ff8adc7b2f0ffc5e1988c1d55f05c55dfc884c577c4f2607565c367f75"
+}


### PR DESCRIPTION
Fix compilation on alpine 3.13+ with OCaml 4.13+ by providing LDFLAGS including -lopenlibm to OCaml's configure (mirage/ocaml-freestanding#99, @dinosaure)
