### PR TITLE
[new release] dkim and dkim-mirage (0.3.0)

### DIFF
--- a/packages/dkim-mirage/dkim-mirage.0.3.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.3.0/opam
@@ -20,6 +20,7 @@ depends: [
   "dune"       {>= "2.0.0"}
   "dkim"       {= version}
   "dns-client" {>= "6.0.0"}
+  "rresult"    {>= "0.7.0"}
   "mirage-time"
   "mirage-random"
   "mirage-clock"

--- a/packages/dkim-mirage/dkim-mirage.0.3.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/ocaml-dkim"
+bug-reports:  "https://github.com/dinosaure/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/dinosaure/ocaml-dkim.git"
+doc:          "https://dinosaure.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml for MirageOS"
+description: """A light layer of the dkim library for MirageOS"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "dkim"       {= version}
+  "dns-client" {>= "6.0.0"}
+  "mirage-time"
+  "mirage-random"
+  "mirage-clock"
+  "mirage-stack"
+  "lwt"
+  "alcotest"   {with-test}
+  "digestif"   {with-test}
+  "fmt"        {with-test}
+  "logs"       {with-test}
+  "mirage-crypto-rng" {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/ocaml-dkim/releases/download/v0.3.0/dkim-0.3.0.tbz"
+  checksum: [
+    "sha256=887c87e54ffbba2119cacba4337e3b7abbebaf900099ffeffa372347f9316112"
+    "sha512=232f1b7ec7555338e4cef0d81de5f3da083e8afaba0e374581b933ad3dcf3ef635206041621f3e980d78da877d40693f15fb54c9e2f7b0197bd9762ebc16f9b1"
+  ]
+}
+x-commit-hash: "a9e6041b64614100052bfb93435696f3bb289cb0"

--- a/packages/dkim/dkim.0.3.0/opam
+++ b/packages/dkim/dkim.0.3.0/opam
@@ -30,6 +30,7 @@ depends: [
   "cmdliner"
   "logs"
   "fmt"        {>= "0.8.7"}
+  "rresult"    {>= "0.7.0"}
   "fpath"
   "base64"     {>= "3.0.0"}
   "mirage-crypto" {>= "0.9.2"}

--- a/packages/dkim/dkim.0.3.0/opam
+++ b/packages/dkim/dkim.0.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/ocaml-dkim"
+bug-reports:  "https://github.com/dinosaure/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/dinosaure/ocaml-dkim.git"
+doc:          "https://dinosaure.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "mrmime"     {>= "0.3.1"}
+  "digestif"   {>= "0.9.0"}
+  "ipaddr"
+  "astring"
+  "base-unix"
+  "hmap"
+  "domain-name"
+  "dns-client" {>= "6.0.0"}
+  "cmdliner"
+  "logs"
+  "fmt"        {>= "0.8.7"}
+  "fpath"
+  "base64"     {>= "3.0.0"}
+  "mirage-crypto" {>= "0.9.2"}
+  "mirage-crypto-pk" {>= "0.9.2"}
+  "x509" {>= "0.6.3"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest"   {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/ocaml-dkim/releases/download/v0.3.0/dkim-0.3.0.tbz"
+  checksum: [
+    "sha256=887c87e54ffbba2119cacba4337e3b7abbebaf900099ffeffa372347f9316112"
+    "sha512=232f1b7ec7555338e4cef0d81de5f3da083e8afaba0e374581b933ad3dcf3ef635206041621f3e980d78da877d40693f15fb54c9e2f7b0197bd9762ebc16f9b1"
+  ]
+}
+x-commit-hash: "a9e6041b64614100052bfb93435696f3bb289cb0"

--- a/packages/dkim/dkim.0.3.0/opam
+++ b/packages/dkim/dkim.0.3.0/opam
@@ -7,8 +7,10 @@ dev-repo:     "git+https://github.com/dinosaure/ocaml-dkim.git"
 doc:          "https://dinosaure.github.io/ocaml-dkim/"
 license:      "MIT"
 synopsis:     "Implementation of DKIM in OCaml"
-description: """A library and a binary to verify and sign an email
-with the DKIM mechanism described by the RFC 6376"""
+description: """
+A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376
+"""
 
 build: [
   [ "dune" "subst" ] {dev}

--- a/packages/dkim/dkim.0.3.0/opam
+++ b/packages/dkim/dkim.0.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mrmime"     {>= "0.5.0"}
   "digestif"   {>= "0.9.0"}
   "ipaddr"
-  "astring"
+  "astring"    {>= "0.8.5"}
   "base-unix"
   "hmap"
   "domain-name"

--- a/packages/dkim/dkim.0.3.0/opam
+++ b/packages/dkim/dkim.0.3.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0.0"}
-  "mrmime"     {>= "0.3.1"}
+  "mrmime"     {>= "0.5.0"}
   "digestif"   {>= "0.9.0"}
   "ipaddr"
   "astring"

--- a/packages/hxd/hxd.0.2.0/opam
+++ b/packages/hxd/hxd.0.2.0/opam
@@ -25,10 +25,10 @@ depends: [
   "base-unix"
   "angstrom" {>= "0.14.0"}
   "stdlib-shims"
-  "rresult"
-  "fmt"      {>= "0.8.0" & < "0.8.7"}
+  "fmt"      {>= "0.8.0"}
   "cmdliner"
   "fpath"    {>= "0.7.3"}
+  "rresult"  {< "0.7.0"}
 ]
 url {
   src:

--- a/packages/hxd/hxd.0.2.0/opam
+++ b/packages/hxd/hxd.0.2.0/opam
@@ -28,7 +28,7 @@ depends: [
   "rresult"
   "fmt"
   "cmdliner"
-  "fpath"
+  "fpath"    {>= "0.7.3"}
 ]
 url {
   src:

--- a/packages/hxd/hxd.0.2.0/opam
+++ b/packages/hxd/hxd.0.2.0/opam
@@ -11,7 +11,7 @@ description: """Please, help me to debug ocaml-git
 """
 
 build: [
-  [ "dune" "subst" ]
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
@@ -26,7 +26,7 @@ depends: [
   "angstrom" {>= "0.14.0"}
   "stdlib-shims"
   "rresult"
-  "fmt"
+  "fmt"      {>= "0.8.0" & < "0.8.7"}
   "cmdliner"
   "fpath"    {>= "0.7.3"}
 ]


### PR DESCRIPTION
Implementation of DKIM in OCaml

- Project page: <a href="https://github.com/dinosaure/ocaml-dkim">https://github.com/dinosaure/ocaml-dkim</a>
- Documentation: <a href="https://dinosaure.github.io/ocaml-dkim/">https://dinosaure.github.io/ocaml-dkim/</a>

##### CHANGES:

- Upgrade to the new interface of `mrmime` (dinosaure/ocaml-dkim#15, @dinosaure)
- Fix how we parse AUID (dinosaure/ocaml-dkim#16, @dinosaure)
- Implement a real memory bounded verify function (dinosaure/ocaml-dkim#19, @dinosaure)
- Homogeneize DNS interface (with `ocaml-spf`) (dinosaure/ocaml-dkim#20, @dinosaure)
- Add some accessors to be able to get some info from DMARC (dinosaure/ocaml-dkim#21, dinosaure/ocaml-dkim#22, @dinosaure)
- Add a comparison function on server values (dinosaure/ocaml-dkim#24, @dinosaure)
- Fix stream implementation on `dkim-mirage` (dinosaure/ocaml-dkim#26, @dinosaure)
- Upgrade to the new DNS interface (dinosaure/ocaml-dkim#25, @dinosaure)
- Fix when we got an empty prelude (and don't raise end-of-stream in that case) (dinosaure/ocaml-dkim#27, @dinosaure)
- Upgrade ocamlformat and fmt.0.8.7 (dinosaure/ocaml-dkim#28, @dinosaure)
- Use the lastest version of DNS (with DNS-over-TLS) (dinosaure/ocaml-dkim#30, @dinosaure)
