### PR TITLE
stdio is not compatible with OCaml 4.14

### DIFF
--- a/packages/stdio/stdio.v0.14.0/opam
+++ b/packages/stdio/stdio.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "4.14"}
   "base"  {>= "v0.14" & < "v0.15"}
   "dune"  {>= "2.0.0"}
 ]


### PR DESCRIPTION
new module name conflict: Stdlib.Out_channel
```
#=== ERROR while compiling stdio.v0.14.0 ======================================#
# context              2.1.1 | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/stdio.v0.14.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p stdio -j 31
# exit-code            1
# env-file             ~/.opam/log/stdio-19-56e1f3.env
# output-file          ~/.opam/log/stdio-19-56e1f3.out
### output ###
#       ocamlc src/.stdio.objs/byte/stdio.{cmi,cmti}
# File "src/stdio.mli", line 4, characters 21-31:
# 4 | module In_channel  = In_channel
#                          ^^^^^^^^^^
# Alert deprecated: module Base.In_channel
# [2016-09] this element comes from the stdlib distributed with OCaml.
# Referring to the stdlib directly is discouraged by Base. You should either
# use the equivalent functionality offered by Base, or if you really want to
# refer to the stdlib, use Caml.In_channel instead
# File "src/stdio.mli", line 5, characters 21-32:
# 5 | module Out_channel = Out_channel
#                          ^^^^^^^^^^^
# Alert deprecated: module Base.Out_channel
# [2016-09] this element comes from the stdlib distributed with OCaml.
# Referring to the stdlib directly is discouraged by Base. You should either
# use the equivalent functionality offered by Base, or if you really want to
# refer to the stdlib, use Caml.Out_channel instead
#       ocamlc src/.stdio.objs/byte/stdio.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.stdio.objs/byte -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Stdio__ -o src/.stdio.objs/byte/stdio.cmo -c -impl src/stdio.ml)
# File "src/stdio.ml", line 4, characters 21-31:
# 4 | module In_channel  = In_channel
#                          ^^^^^^^^^^
# Alert deprecated: module Base.In_channel
# [2016-09] this element comes from the stdlib distributed with OCaml.
# Referring to the stdlib directly is discouraged by Base. You should either
# use the equivalent functionality offered by Base, or if you really want to
# refer to the stdlib, use Caml.In_channel instead
# File "src/stdio.ml", line 5, characters 21-32:
# 5 | module Out_channel = Out_channel
#                          ^^^^^^^^^^^
# Alert deprecated: module Base.Out_channel
# [2016-09] this element comes from the stdlib distributed with OCaml.
# Referring to the stdlib directly is discouraged by Base. You should either
# use the equivalent functionality offered by Base, or if you really want to
# refer to the stdlib, use Caml.Out_channel instead
# File "src/stdio.ml", line 11, characters 20-39:
# 11 | let eprintf       = Out_channel.eprintf
#                          ^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Out_channel.eprintf
#     ocamlopt src/.stdio.objs/native/stdio.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I src/.stdio.objs/byte -I src/.stdio.objs/native -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Stdio__ -o src/.stdio.objs/native/stdio.cmx -c -impl src/stdio.ml)
# File "src/stdio.ml", line 4, characters 21-31:
# 4 | module In_channel  = In_channel
#                          ^^^^^^^^^^
# Alert deprecated: module Base.In_channel
# [2016-09] this element comes from the stdlib distributed with OCaml.
# Referring to the stdlib directly is discouraged by Base. You should either
# use the equivalent functionality offered by Base, or if you really want to
# refer to the stdlib, use Caml.In_channel instead
# File "src/stdio.ml", line 5, characters 21-32:
# 5 | module Out_channel = Out_channel
#                          ^^^^^^^^^^^
# Alert deprecated: module Base.Out_channel
# [2016-09] this element comes from the stdlib distributed with OCaml.
# Referring to the stdlib directly is discouraged by Base. You should either
# use the equivalent functionality offered by Base, or if you really want to
# refer to the stdlib, use Caml.Out_channel instead
# File "src/stdio.ml", line 11, characters 20-39:
# 11 | let eprintf       = Out_channel.eprintf
#                          ^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Out_channel.eprintf
```
cc @aalekseyev