### PR TITLE
Package ocamlog.0.11

### DIFF
--- a/packages/ocamlog/ocamlog.0.11/opam
+++ b/packages/ocamlog/ocamlog.0.11/opam
@@ -1,0 +1,22 @@
+
+opam-version: "2.0"
+synopsis: "Simple Logger for OCaml"
+description: "Able to print with different colors, levels, trace out caller, etc."
+maintainer: "paulpatault <p.patault@gmail.com>"
+authors: "paulpatault <p.patault@gmail.com>"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.8"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paulpatault/OcamLog"
+homepage: "https://www.github.com/paulpatault/OcamLog"
+bug-reports: "https://www.github.com/paulpatault/OcamLog/issues"
+license: "MIT"
+url {
+  src: "https://github.com/paulpatault/ocamlog/archive/0.2.tar.gz"
+  checksum: [
+    "md5=33e4bc9d00f66812f951bc210f70e9b3"
+    "sha512=236874e08ceaa3fca411e2d2be48b8c67f901e2bf624722cd38e0f64c5abe9a4fe4a9a3ad0126f0b5ee1211b3b46622abaa5ac9a8b1d23d000704c509ef9369a"
+  ]
+}


### PR DESCRIPTION
### `ocamlog.0.11`
Simple Logger for OCaml
Able to print with different colors, levels, trace out caller, etc.



---
* Homepage: https://www.github.com/paulpatault/OcamLog
* Source repo: git+https://github.com/paulpatault/OcamLog
* Bug tracker: https://www.github.com/paulpatault/OcamLog/issues

---
:camel: Pull-request generated by opam-publish v2.1.0