### PR TITLE
js_of_ocaml: conflict with base-domains

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.1/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0.2/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.0/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.1.0/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
@@ -26,6 +26,7 @@ depopts: ["ocamlfind"]
 conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
@@ -27,6 +27,7 @@ depopts: ["ocamlfind"]
 conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.0/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.2.1/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.3.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.3.0/opam
@@ -19,6 +19,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 synopsis: "Compiler from OCaml bytecode to Javascript"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.4.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.4.0/opam
@@ -25,6 +25,7 @@ depends: [
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.0/opam
@@ -27,6 +27,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 url {
   src:

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.1/opam
@@ -27,6 +27,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 url {
   src:

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.5.2/opam
@@ -27,6 +27,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 url {
   src:

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.6.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.6.0/opam
@@ -27,6 +27,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 url {
   src:

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
@@ -28,6 +28,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.1/opam
@@ -28,6 +28,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 x-commit-hash: "888697ba6c17051c50839e35d882a8c58fdc69f5"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
@@ -28,6 +28,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
@@ -28,6 +28,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
@@ -28,6 +28,7 @@ depopts: [ "ocamlfind" ]
 conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "base-domains"
 ]
 x-commit-hash: "c97f2543ff7bfa6c8fe683cca7beec884b38f918"
 url {


### PR DESCRIPTION
Currently the multicore compilers have a different bytecode
format which results in an exception:
Js_of_ocaml_compiler.Instr.Bad_instruction(152))

This PR prevents the existing jsoo being selected as an installable
option with the multicore compiler and erroring out on CI.