### PR TITLE
Fix conf-python-2-7-1.1 for Fedora

### DIFF
--- a/packages/conf-python-2-7/conf-python-2-7.1.2/files/test.py
+++ b/packages/conf-python-2-7/conf-python-2-7.1.2/files/test.py
@@ -1,0 +1,1 @@
+print 'python-2.7 OK'

--- a/packages/conf-python-2-7/conf-python-2-7.1.2/opam
+++ b/packages/conf-python-2-7/conf-python-2-7.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://www.python.org/download/releases/2.7/"
+authors: "Python Software Foundation"
+license: "PSF"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: ["python2.7" "test.py"]
+depexts: [
+  ["python2.7"] {os-family = "debian"}
+  ["python27"] {os-distribution = "nixos"}
+  ["python2"] {os-distribution = "alpine"}
+  ["python2"] {os-distribution = "centos"}
+  ["python2"] {os-distribution = "ol"}
+  ["python2.7"] {os-distribution = "fedora"}
+  ["python2"] {os-distribution = "arch"}
+  ["python"] {os-family = "suse"}
+  ["dev-lang/python:2.7"] {os-distribution = "gentoo"}
+  ["python/2.7"] {os = "openbsd"}
+  ["lang/python27"] {os = "netbsd"}
+  ["lang/python27"] {os = "freebsd"}
+  ["python27"] {os-distribution = "macports" & os = "macos"}
+  ["python"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on Python-2.7 installation"
+description: """
+This package can only install if the Python-2.7 interpreter is available
+on the system."""
+extra-files: ["test.py" "md5=b2b11a2f587814ed4c08b109d9ed949f"]
+flags: conf


### PR DESCRIPTION
The package name for Fedora should be `python2.7`, see https://fedoraproject.org/wiki/Changes/RetirePython2