### PR TITLE
Package ocsipersist-pgsql.1.0.3

### DIFF
--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.3/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.3.tar.gz"
+  checksum: [
+    "md5=8cc3ff678d0a73b8505fab69a39b2394"
+    "sha512=f31f91e909248a2067a0cde3aace5d039322a3bceb763ae3c29f1da379408fbae8f043c2d5234558a75402409f636ec656775922e9e4087155f40d5f6f89db0e"
+  ]
+}


### PR DESCRIPTION
### `ocsipersist-pgsql.1.0.3`
Persistent key/value storage (for Ocsigen) using PostgreSQL
This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library.



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0