### PR TITLE
Package ocsipersist-lib.1.0.3

### DIFF
--- a/packages/ocsipersist-lib/ocsipersist-lib.1.0.3/opam
+++ b/packages/ocsipersist-lib/ocsipersist-lib.1.0.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) - support library"
+description:  "This library defines signatures and auxiliary tools for defining backends for the Ocsipersist frontent. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM database, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_ppx" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.3.tar.gz"
+  checksum: [
+    "md5=0c167841a78ae5b46fdbc2f39fefeba9"
+    "sha512=6b86bc1b77ccd5dca4d15bf0a001278b234ad2ad87db95cb884af7cd3c48c0ad8b17e041c5cec29557dbb4c0bcdd21ac7dbc98b38ff3d680c1d6340099e2406d"
+  ]
+}

--- a/packages/ocsipersist-lib/ocsipersist-lib.1.0.3/opam
+++ b/packages/ocsipersist-lib/ocsipersist-lib.1.0.3/opam
@@ -18,7 +18,7 @@ depends: [
 url {
   src: "https://github.com/ocsigen/ocsipersist/archive/1.0.3.tar.gz"
   checksum: [
-    "md5=0c167841a78ae5b46fdbc2f39fefeba9"
-    "sha512=6b86bc1b77ccd5dca4d15bf0a001278b234ad2ad87db95cb884af7cd3c48c0ad8b17e041c5cec29557dbb4c0bcdd21ac7dbc98b38ff3d680c1d6340099e2406d"
+    "md5=363b4c5303785dc164c735e6b5f36a66"
+    "sha512=2a735060f55ebe0143a025b4b72874858d2c63a82ba31323dcf16d0dd2561518f435665c51db4fc3a57f23638a9cdcc747387c672d42b0360d8df8c744906ec8"
   ]
 }


### PR DESCRIPTION
### `ocsipersist-lib.1.0.3`
Persistent key/value storage (for Ocsigen) - support library
This library defines signatures and auxiliary tools for defining backends for the Ocsipersist frontent. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM database, PostgreSQL, SQLite.



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0