### PR TITLE
Package ocsipersist-pgsql.1.0.3

### DIFF
--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.3/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.3.tar.gz"
+  checksum: [
+    "md5=363b4c5303785dc164c735e6b5f36a66"
+    "sha512=2a735060f55ebe0143a025b4b72874858d2c63a82ba31323dcf16d0dd2561518f435665c51db4fc3a57f23638a9cdcc747387c672d42b0360d8df8c744906ec8"
+  ]
+}


### PR DESCRIPTION
### `ocsipersist-pgsql.1.0.3`
Persistent key/value storage (for Ocsigen) using PostgreSQL
This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library.



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0