### PR TITLE
Coq.8.13.0/1 disable warn 70

### DIFF
--- a/packages/coq/coq.8.13.0/files/disable_warn_70.patch
+++ b/packages/coq/coq.8.13.0/files/disable_warn_70.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ml b/configure.ml
+index b04834edc6..0ae32dbd62 100644
+--- a/configure.ml
++++ b/configure.ml
+@@ -634,7 +634,7 @@ let camltag = match caml_version_list with
+     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+     67: "unused functor parameter" seems totally bogus
+ *)
+-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67"
++let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-70"
+ let coq_warn_error =
+     if !prefs.warn_error
+     then "-warn-error +a"

--- a/packages/coq/coq.8.13.0/opam
+++ b/packages/coq/coq.8.13.0/opam
@@ -50,8 +50,10 @@ install: [
   [make "COQ_USE_DUNE=" "install-byte"]
 ]
 
+patches: [ "disable_warn_70.patch" ]
 extra-files: [
    ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+   ["disable_warn_70.patch" "sha512=f0446b0624c70bc1806801f1e37148a459a13a1c9539a5fa0aaf00fb36463b7d91a12fe2be417955e149e6abcc0041a059ce22e54303e2092f6892df5522671d"]
 ]
 
 url {

--- a/packages/coq/coq.8.13.1/files/disable_warn_70.patch
+++ b/packages/coq/coq.8.13.1/files/disable_warn_70.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ml b/configure.ml
+index c14a069c49..40c75eb418 100644
+--- a/configure.ml
++++ b/configure.ml
+@@ -634,7 +634,7 @@ let camltag = match caml_version_list with
+     58: "no cmx file was found in path": See https://github.com/ocaml/num/issues/9
+     67: "unused functor parameter" seems totally bogus
+ *)
+-let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67"
++let coq_warnings = "-w +a-4-9-27-41-42-44-45-48-58-67-70"
+ let coq_warn_error =
+     if !prefs.warn_error
+     then "-warn-error +a"

--- a/packages/coq/coq.8.13.1/opam
+++ b/packages/coq/coq.8.13.1/opam
@@ -50,8 +50,10 @@ install: [
   [make "COQ_USE_DUNE=" "install-byte"]
 ]
 
+patches: [ "disable_warn_70.patch" ]
 extra-files: [
    ["coq.install" "sha512=b501737b4dbd22adc1c0377d744448056fb1dc493caf72c05f57c8463cf23f758373605ab3a50b9f505e4c856c41039d0bd7f81f96ed62adc6a674179523e7d2"]
+   ["disable_warn_70.patch" "sha512=b60c151be108b86650417797e82db13460825909b637f56765164e88f20c538a711ca9439bc8c4d91d61aa06ad652f920d9be4a5c14faf52e359a91958d27904"]
 ]
 
 url {


### PR DESCRIPTION
Follow up of https://github.com/ocaml/opam-repository/pull/20025

Removes one warning from Coq to fix many Coq plugins with OCaml 4.13.