### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.1.1)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.1/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.1/happy-eyeballs-v0.1.1.tbz"
+  checksum: [
+    "sha256=534f2213209dce1bdff2ae5a5d9cdd1ae5fa1f75ac2cee953dbd19213904fc62"
+    "sha512=c0be3672d7a7833771a3f6e309796b1fef8768efb78208c0649047c4ded3344767818e8c5dd463b1ad969e37ccd64937eb864f829da2395bdce1d061e5ff6daf"
+  ]
+}
+x-commit-hash: "74eb7acb2ff8ca7dcb85c5fdf6f751ee0951260a"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.1/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.1/happy-eyeballs-v0.1.1.tbz"
+  checksum: [
+    "sha256=534f2213209dce1bdff2ae5a5d9cdd1ae5fa1f75ac2cee953dbd19213904fc62"
+    "sha512=c0be3672d7a7833771a3f6e309796b1fef8768efb78208c0649047c4ded3344767818e8c5dd463b1ad969e37ccd64937eb864f829da2395bdce1d061e5ff6daf"
+  ]
+}
+x-commit-hash: "74eb7acb2ff8ca7dcb85c5fdf6f751ee0951260a"

--- a/packages/happy-eyeballs/happy-eyeballs.0.1.1/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.1/happy-eyeballs-v0.1.1.tbz"
+  checksum: [
+    "sha256=534f2213209dce1bdff2ae5a5d9cdd1ae5fa1f75ac2cee953dbd19213904fc62"
+    "sha512=c0be3672d7a7833771a3f6e309796b1fef8768efb78208c0649047c4ded3344767818e8c5dd463b1ad969e37ccd64937eb864f829da2395bdce1d061e5ff6daf"
+  ]
+}
+x-commit-hash: "74eb7acb2ff8ca7dcb85c5fdf6f751ee0951260a"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Happy_eyeballs_lwt.create and Happy_eyeballs_mirage.create now take an
  optional ?happy_eyeballs:Happy_eyeballs.t argument, and also an optional
  ?dns:Dns_client_lwt.t/DNS.t argument. This avoids the need to forward all
  potential creation arguments of Happy_eyeballs and DNS. (roburio/happy-eyeballs#91 @hannesm)
* Fix state machine: if Connecting fails, and resolved is not yet both, return
  to Resolving (instead of Error) (roburio/happy-eyeballs#13 @hannesm,
  similar to d0d4ef5ea2aaf2de407ba84742c5648489c47e1f roburio/happy-eyeballs#9)
* Add a state machine diagram (happy_eyeballs.dot) (roburio/happy-eyeballs#13 @hannesm)
