### PR TITLE
[new release] mirage-block and mirage-block-combinators (3.0.0)

### DIFF
--- a/packages/mirage-block-combinators/mirage-block-combinators.3.0.0/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "io-page"
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "mirage-block" {=version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS using Lwt"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+This package is specialised to the Lwt concurrency library for IO.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v3.0.0/mirage-block-v3.0.0.tbz"
+  checksum: [
+    "sha256=341e67269a6932d762d070e329c080a918cee2f21b00c7e73fddf83fe4a7ce65"
+    "sha512=57826493d421926aa54001c309cea8ef33bbd4ea7c05b35c23ee4483c9ea5ed6baf9ef078a9fbdf298c390b5976025e8875b2ed3ac078a4dee5667af39427291"
+  ]
+}
+x-commit-hash: "f6c65a9520f7b4cb352ae179f189f78acdde82ae"
+

--- a/packages/mirage-block-unix/mirage-block-unix.2.12.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.12.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"
-  "mirage-block" {>= "2.0.0"}
+  "mirage-block" {>= "2.0.0" & < "3.0.0"}
   "rresult"
   "io-page-unix" {>= "2.0.0"}
   "uri" {>= "1.9.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.12.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.12.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"
-  "mirage-block" {>= "2.0.0"}
+  "mirage-block" {>= "2.0.0" & < "3.0.0"}
   "rresult"
   "io-page" {>= "2.0.0"}
   "uri" {>= "1.9.0"}

--- a/packages/mirage-block/mirage-block.3.0.0/opam
+++ b/packages/mirage-block/mirage-block.3.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.7"}
+  "cstruct" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v3.0.0/mirage-block-v3.0.0.tbz"
+  checksum: [
+    "sha256=341e67269a6932d762d070e329c080a918cee2f21b00c7e73fddf83fe4a7ce65"
+    "sha512=57826493d421926aa54001c309cea8ef33bbd4ea7c05b35c23ee4483c9ea5ed6baf9ef078a9fbdf298c390b5976025e8875b2ed3ac078a4dee5667af39427291"
+  ]
+}
+x-commit-hash: "f6c65a9520f7b4cb352ae179f189f78acdde82ae"
+


### PR DESCRIPTION
Block signatures and implementations for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block">https://github.com/mirage/mirage-block</a>
- Documentation: <a href="https://mirage.github.io/mirage-block/">https://mirage.github.io/mirage-block/</a>

##### CHANGES:

* Remove Mirage_block_lwt module (mirage/mirage-block#50 @hannesm)
* Remove dependency of mirage-device (mirage/mirage-block#50 @hannesm)
