### PR TITLE
[new release] mirage-xen (6.0.1)

### DIFF
--- a/packages/mirage-xen/mirage-xen.6.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.6.0.1/opam
@@ -9,7 +9,7 @@ license:      "ISC"
 tags:         ["org:mirage"]
 
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mirage-xen/mirage-xen.6.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.6.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "io-page" {>= "2.4.0"}
   "mirage-runtime" {>= "3.7.0"}
   "logs"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ocaml-freestanding" {>= "0.6.2"}
   "solo5-bindings-xen" {>= "0.6.7"}
   "bheap" {>= "2.0.0"}

--- a/packages/mirage-xen/mirage-xen.6.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.6.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "conf-pkg-config"
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "3.7.0"}
+  "logs"
+  "fmt"
+  "ocaml-freestanding" {>= "0.6.2"}
+  "solo5-bindings-xen" {>= "0.6.7"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v6.0.1/mirage-xen-v6.0.1.tbz"
+  checksum: [
+    "sha256=520ebbf85f8aeb07d22dbd3ca740f33275bb1ef58f33e7a5fac09e9a12d136b0"
+    "sha512=ddac9804fc66f18fd5a9c5a9200ec791910154efdd1faf76f6597cf666343f1e3703ad66cdc6f32f05308b14f9a2feb7fc3ca458d0236feeac5e878121450a09"
+  ]
+}
+x-commit-hash: "3f19ae991eae5a285c3f4761a214c7ca6eac3659"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Fix OCaml documentation strings (mirage/mirage-xen#30 @hannesm)
* Add caml_get_wall_clock to retrieve the wall clock as int64 (mirage/mirage-xen#31 @hannesm)
* Don't require opam for the bindings compilation (mirage/mirage-xen#32 @sternenseemann)
* Remove checksum_stubs and alloc_pages_stubs (available in mirage-tcpip
  and io-page), to keep in sync with mirage-solo5 (mirage/mirage-xen#33 @dinosaure, adapted
  by @hannesm to mirage-xen)
