### PR TITLE
[new release] mirage-solo5 (0.6.5)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.6.5/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.5/opam
@@ -13,7 +13,7 @@ tags: [
   "org:mirage"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/packages/mirage-solo5/mirage-solo5.0.6.5/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.6.5/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.6.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "ocaml-freestanding" {>= "0.4.5"}
+  "metrics"
+  "mirage-runtime" {>= "3.7.0"}
+  "duration"
+  ("solo5-bindings-hvt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-spt" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-virtio" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-muen" {>= "0.6.0" & < "0.7.0"} | "solo5-bindings-genode" {>= "0.6.0" & < "0.7.0"})
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.6.5/mirage-solo5-v0.6.5.tbz"
+  checksum: [
+    "sha256=0aa506012fd60027990406cbd622facb4ef8a5320ee8190a189f467b9706001d"
+    "sha512=8a33d063acf1cd94dba22a6fcf759a718550fa02b95f6c29fc2e1a04e8587ac96a32cca1f5429142f106ad66958c98fab774edc241da044fbb5c116fdce36a8b"
+  ]
+}
+x-commit-hash: "c8a2dc62d2de5ea631241238ff32d8c08b8229ee"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Add caml_get_wall_clock to retrieve the wall clock as int64 (mirage/mirage-solo5#73 @hannesm)
* Remove checksum_stubs, now available through tcpip (mirage/mirage-solo5#75 @dinosaure)
* Remove alloc_pages_stubs, now available through io-page (mirage/mirage-solo5#76 @dinosaure)
* Don't require opam for the bindings compilation (mirage/mirage-solo5#79 @hannesm)
