### PR TITLE
u2f.0.1.{0,1}: depend on rresult

### DIFF
--- a/packages/u2f/u2f.0.1.0/opam
+++ b/packages/u2f/u2f.0.1.0/opam
@@ -27,6 +27,7 @@ depends: [
   "mirage-crypto-rng"
   "x509" {>= "0.13.0" & < "0.15.1"}
   "base64" {>= "3.1.0"}
+  "rresult"
 ]
 
 synopsis: "Universal Second Factor (U2F) implementation in OCaml"

--- a/packages/u2f/u2f.0.1.1/opam
+++ b/packages/u2f/u2f.0.1.1/opam
@@ -27,6 +27,7 @@ depends: [
   "mirage-crypto-rng"
   "x509" {>= "0.13.0" & < "0.15.1"}
   "base64" {>= "3.1.0"}
+  "rresult"
 ]
 
 synopsis: "Universal Second Factor (U2F) implementation in OCaml"


### PR DESCRIPTION
u2f.ml has a line `let open Rresult.R.Infix in` that could be removed just fine, but since it's there we should depend on rresult. Some dependencies pulled in rresult in earlier versions, but not anymore.