### PR TITLE
[new release] u2f (0.1.2)

### DIFF
--- a/packages/u2f/u2f.0.1.2/opam
+++ b/packages/u2f/u2f.0.1.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage: "https://github.com/roburio/u2f"
+dev-repo: "git+https://github.com/roburio/u2f.git"
+bug-reports: "https://github.com/roburio/u2f/issues"
+doc: "https://roburio.github.io/u2f/doc"
+maintainer: [ "team@robur.coop" ]
+authors: [ "Reynir Björnsson <reynir@reynir.dk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dream" {dev}
+  "ppx_blob" {dev}
+  "cmdliner" {dev}
+  "logs" {dev}
+  "lwt" {dev}
+  "yojson"
+  "ppx_deriving_yojson"
+  "mirage-crypto-ec"
+  "mirage-crypto-rng"
+  "x509" {>= "0.13.0"}
+  "base64" {>= "3.1.0"}
+  "cstruct" {>= "6.0.0"}
+]
+
+synopsis: "Universal Second Factor (U2F) implementation in OCaml"
+description: """
+A server-side implementation of the two-factor authentication standard
+Universal Second Factor (U2F). With special (USB, NFC) devices, a
+challenge-response authentication using public key cryptography is done.
+"""
+url {
+  src:
+    "https://github.com/roburio/u2f/releases/download/v0.1.2/u2f-0.1.2.tbz"
+  checksum: [
+    "sha256=54060ee5ca642758532d32a9f8e44fc6988ad58babb5d11b723602c9bce2f324"
+    "sha512=a47a35cd8c6ec9c1c0cfbbec68fb8e25b8372e0e5f0df637e4599226333b2eae18604b10f3367c34d1151471d6b8ce88aa59931ce845a12ed95b1ac33a167212"
+  ]
+}
+x-commit-hash: "c596c5507d8201f4cbb9676681cd9c695ed8e155"


### PR DESCRIPTION
Universal Second Factor (U2F) implementation in OCaml

- Project page: <a href="https://github.com/roburio/u2f">https://github.com/roburio/u2f</a>
- Documentation: <a href="https://roburio.github.io/u2f/doc">https://roburio.github.io/u2f/doc</a>

##### CHANGES:

* Remove unused reference to Rresult

## v0.1.1 (2021-06-30)

* Add public_name field to dune (roburio/u2f#3 @CraigFE)

## v0.1.0 (2021-06-30)

* Initial release, sponsored by skolem.tech
