### PR TITLE
Package ocsipersist-pgsql.1.0.4

### DIFF
--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.4/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.4.tar.gz"
+  checksum: [
+    "md5=e99f5923693f6b8ab9fdd390743629d8"
+    "sha512=adb726404721e0d7d0325b3239c4352d18cc43181e95ab025bdca97f5fdf07ebca97e78959c043ddb45dfd33ba6affad9349f17b04261e97ffa1f80f4317677c"
+  ]
+}


### PR DESCRIPTION
### `ocsipersist-pgsql.1.0.4`
Persistent key/value storage (for Ocsigen) using PostgreSQL
This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library.



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0