### PR TITLE
Package otoml.0.9.3

### DIFF
--- a/packages/otoml/otoml.0.9.3/opam
+++ b/packages/otoml/otoml.0.9.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)"
+description: """\
+OTOML is a library for parsing, manipulating, and pretty-printing TOML files.
+
+* Fully 1.0.0-compliant.
+* No extra dependencies: default implementation uses native numbers and represents dates as strings.
+* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
+* Informative parse error reporting.
+* Pretty-printer offers flexible indentation options."""
+maintainer: "daniil+opam@baturin.org"
+authors: "Daniil Baturin <daniil@baturin.org>"
+license: "MIT"
+homepage: "https://github.com/dmbaturin/otoml"
+bug-reports: "https://github.com/dmbaturin/otoml/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "menhir"
+  "menhirLib" {>= "20200525"}
+  "dune" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/dmbaturin/otoml.git"
+url {
+  src: "https://github.com/dmbaturin/otoml/archive/refs/tags/0.9.3.tar.gz"
+  checksum: [
+    "md5=bc5b13ea6047165ada9e7696979d8ff6"
+    "sha512=43e06d1f36870983002c4ae98f4dcfe7305d78e750ff246c19c21583e4f7d1cd7bb84a90036d178c92f038a064ec9648d8103a6aeeddd2979965bfc91c8c3d1e"
+  ]
+}


### PR DESCRIPTION
### `otoml.0.9.3`
TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)
OTOML is a library for parsing, manipulating, and pretty-printing TOML files.

* Fully 1.0.0-compliant.
* No extra dependencies: default implementation uses native numbers and represents dates as strings.
* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
* Informative parse error reporting.
* Pretty-printer offers flexible indentation options.



---
* Homepage: https://github.com/dmbaturin/otoml
* Source repo: git+https://github.com/dmbaturin/otoml.git
* Bug tracker: https://github.com/dmbaturin/otoml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0