### PR TITLE
Package ocsipersist-pgsql.1.0.5

### DIFF
--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.5/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.5/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib"
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.0.5.tar.gz"
+  checksum: [
+    "md5=445d551d6a515961d24592b0790e1808"
+    "sha512=b19719e3bc1897e1766bb0a72b31c702b90d3ab4969118c31578923b1c831e38fce35c8224bda96c786551965469a93c893db0e3c6dadffbd5fd886576e6d991"
+  ]
+}


### PR DESCRIPTION
### `ocsipersist-pgsql.1.0.5`
Persistent key/value storage (for Ocsigen) using PostgreSQL
This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library.



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0