### PR TITLE
Package binaryen_dsl.0.3

### DIFF
--- a/packages/binaryen_dsl/binaryen_dsl.0.3/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Writing Webassembly text format in DSL"
+description: """
+This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.
+
+You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).
+"""
+maintainer: "Vincent Chan <okcdz@diverse.space>"
+authors: "Vincent Chan <okcdz@diverse.space>"
+license: "MIT"
+homepage: "https://github.com/vincentdchan/ocaml-binaryen-dsl"
+bug-reports: "https://github.com/vincentdchan/ocaml-binaryen-dsl/issues"
+dev-repo: "git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git"
+depends: [ "ocaml" "dune" ]
+build: [
+  ["dune" "build" "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/vincentdchan/ocaml-binaryen-dsl/archive/0.3.tar.gz"
+  checksum: [
+    "md5=a3760ba123d3cfb34544566fb6417c70"
+    "sha512=7bdb4f86cfe6859e58b9c578656def58f75a8926792e0de9ce851a18b3e9ef2dbbd9c63fa7986d2db412277a803ca0fe908c440fb1595ddb9cc0977aae9f04f6"
+  ]
+}


### PR DESCRIPTION
### `binaryen_dsl.0.3`
Writing Webassembly text format in DSL
This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.

You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).



---
* Homepage: https://github.com/vincentdchan/ocaml-binaryen-dsl
* Source repo: git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git
* Bug tracker: https://github.com/vincentdchan/ocaml-binaryen-dsl/issues

---
:camel: Pull-request generated by opam-publish v2.1.0