### PR TITLE
Package binaryen_dsl.0.4

### DIFF
--- a/packages/binaryen_dsl/binaryen_dsl.0.4/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.4/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Writing Webassembly text format in DSL"
+description: """
+This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.
+
+You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).
+"""
+maintainer: "Vincent Chan <okcdz@diverse.space>"
+authors: "Vincent Chan <okcdz@diverse.space>"
+license: "MIT"
+homepage: "https://github.com/vincentdchan/ocaml-binaryen-dsl"
+bug-reports: "https://github.com/vincentdchan/ocaml-binaryen-dsl/issues"
+dev-repo: "git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git"
+depends: [ "ocaml" "dune" "ctypes" ]
+build: [
+  ["dune" "build" "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/vincentdchan/ocaml-binaryen-dsl/archive/0.4.tar.gz"
+  checksum: [
+    "md5=07a71d1259d845b19af619f186acbe20"
+    "sha512=8f444fed31d457130b53485ee15115c23a06498d51db55b1ddfdbaa758b1dab88f0a61aacee8420154f542e2d76dd8dd1e82e67ba4c2bee24318d563d5c5a34d"
+  ]
+}


### PR DESCRIPTION
### `binaryen_dsl.0.4`
Writing Webassembly text format in DSL
This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.

You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).



---
* Homepage: https://github.com/vincentdchan/ocaml-binaryen-dsl
* Source repo: git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git
* Bug tracker: https://github.com/vincentdchan/ocaml-binaryen-dsl/issues

---
:camel: Pull-request generated by opam-publish v2.1.0