### PR TITLE
Package binaryen_dsl.0.5

### DIFF
--- a/packages/binaryen_dsl/binaryen_dsl.0.5/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Writing Webassembly text format in DSL"
+description: """
+This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.
+
+You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).
+"""
+maintainer: "Vincent Chan <okcdz@diverse.space>"
+authors: "Vincent Chan <okcdz@diverse.space>"
+license: "MIT"
+homepage: "https://github.com/vincentdchan/ocaml-binaryen-dsl"
+bug-reports: "https://github.com/vincentdchan/ocaml-binaryen-dsl/issues"
+dev-repo: "git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git"
+depends: [
+  "ocaml"
+  "core"
+  "dune" {>= "2.8"}
+  "ctypes"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/vincentdchan/ocaml-binaryen-dsl/archive/0.5.tar.gz"
+  checksum: [
+    "md5=44c93a58c14cef81c28f196433d58bea"
+    "sha512=fb85673b8aeea9b0d2f84243fd60cf1c7c6c233e24bf9987da7975f1612af54fec07b08f72c7fad9bd5f62ad2fa1db8089d0be0c89a53d4549b1e1dc1cefadae"
+  ]
+}


### PR DESCRIPTION
### `binaryen_dsl.0.5`
Writing Webassembly text format in DSL
This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.

You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).



---
* Homepage: https://github.com/vincentdchan/ocaml-binaryen-dsl
* Source repo: git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git
* Bug tracker: https://github.com/vincentdchan/ocaml-binaryen-dsl/issues

---
:camel: Pull-request generated by opam-publish v2.1.0