### PR TITLE
[new release] curses (1.0.10)

### DIFF
--- a/packages/curses/curses.1.0.10/opam
+++ b/packages/curses/curses.1.0.10/opam
@@ -3,7 +3,7 @@ synopsis: "Bindings to ncurses"
 description: "Tools for building terminal-based user interfaces"
 maintainer: ["Michael Bacarella <m@bacarella.com>"]
 authors: ["Nicolas George"]
-license: "LGPL-2.1-or-later WITH OCaml-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/mbacarella/curses"
 bug-reports: "https://github.com/mbacarella/curses/issues"
 depends: [

--- a/packages/curses/curses.1.0.10/opam
+++ b/packages/curses/curses.1.0.10/opam
@@ -8,8 +8,9 @@ homepage: "https://github.com/mbacarella/curses"
 bug-reports: "https://github.com/mbacarella/curses/issues"
 depends: [
   "dune" {>= "2.7"}
-  "conf-ncurses"
-  "dune-configurator"
+  "conf-ncurses" {build}
+  "conf-pkg-config" {build}
+  "dune-configurator" {build}
   "ocaml" {>= "4.02.0"}
   "odoc" {with-doc}
 ]

--- a/packages/curses/curses.1.0.10/opam
+++ b/packages/curses/curses.1.0.10/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bindings to ncurses"
+description: "Tools for building terminal-based user interfaces"
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: ["Nicolas George"]
+license: "LGPL-2.1-or-later WITH OCaml-linking-exception"
+homepage: "https://github.com/mbacarella/curses"
+bug-reports: "https://github.com/mbacarella/curses/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "conf-ncurses"
+  "dune-configurator"
+  "ocaml" {>= "4.02.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/curses.git"
+url {
+  src:
+    "https://github.com/mbacarella/curses/releases/download/1.0.10/curses-1.0.10.tbz"
+  checksum: [
+    "sha256=c9126f9798f0c5b3beb05efe89c7713cf655c1ffbe040a52f218aeba291922af"
+    "sha512=158626f3fd6931f30482a47ab149990ff49334c8c0dc966eb07d92f22e87faaab3fd48ed7788bbc5a77f82cb6163520588ce55ab53456bca22994f147c7e00c5"
+  ]
+}
+x-commit-hash: "a23a03d06206d85f53938c196b2a258ed1e4ef2e"


### PR DESCRIPTION
Bindings to ncurses

- Project page: <a href="https://github.com/mbacarella/curses">https://github.com/mbacarella/curses</a>

##### CHANGES:

* Updated to dune-lang 2.7, so that we don't have that generated .opam file
  bug anymore.
