### PR TITLE
PRINGO version 1.3

### DIFF
--- a/packages/pringo/pringo.1.3/opam
+++ b/packages/pringo/pringo.1.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Pseudo-random, splittable number generators"
+description:
+  "Pseudo-random number generators that support splitting and two interfaces: one stateful, one purely functional"
+maintainer: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+authors: "Xavier Leroy <xavier.leroy@college-de-france.fr>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xavierleroy/pringo"
+bug-reports: "https://github.com/xavierleroy/pringo/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind"
+  "testu01" {with-test}
+]
+build: make
+install: [make "install"]
+run-test: [make "smalltest"]
+dev-repo: "git+https://https://github.com/xavierleroy/pringo"
+url {
+  src: "https://github.com/xavierleroy/pringo/archive/1.3.tar.gz"
+  checksum: [
+    "md5=0312dd42b01e3a884649625fef64777c"
+    "sha512=6a44adbf0980415cc1c899f351add6094b947043000223b58b226f5d0b4d926c8c8cd39c9336f8ccffb565fd5f8bf23263f465dcd3143488f53241f9e9d440b1"
+  ]
+}

--- a/packages/pringo/pringo.1.3/opam
+++ b/packages/pringo/pringo.1.3/opam
@@ -14,7 +14,7 @@ depends: [
 ]
 build: make
 install: [make "install"]
-run-test: [make "smalltest"]
+run-test: [make "smalltest"] {ocaml:version >= "4.08"}
 dev-repo: "git+https://https://github.com/xavierleroy/pringo"
 url {
   src: "https://github.com/xavierleroy/pringo/archive/1.3.tar.gz"


### PR DESCRIPTION
- Add `uniform` function producing a random floating-point number in (0.0, 1.0) 
- Add the LXM generator (the L64X128 variant)
- New test infrastructure based on TestU01
- Add Schaathun's "split sequences" to the tests
