### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.1.0

### DIFF
--- a/packages/opam-build/opam-build.0.1.0/opam
+++ b/packages/opam-build/opam-build.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
+  "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
+  "cmdliner" {>= "1.0"}
+]
+available: opam-version >= "2.1" & opam-version < "2.3"
+url {
+  src: "https://github.com/kit-ty-kate/opam-build/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=e9c34359d7c5130164ee7642a9070849"
+    "sha512=64b38dd9a068e37ca2a86c18211c3e7c20f0a8f79442efc9edb71b6d6b24b02904e5633b7d86b2bffcf5ec0561108ebebe4e065e771dab3a271a07b95daeeda8"
+  ]
+}

--- a/packages/opam-test/opam-test.0.1.0/opam
+++ b/packages/opam-test/opam-test.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
+  "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
+  "cmdliner" {>= "1.0"}
+]
+available: opam-version >= "2.1" & opam-version < "2.3"
+url {
+  src: "https://github.com/kit-ty-kate/opam-build/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=e9c34359d7c5130164ee7642a9070849"
+    "sha512=64b38dd9a068e37ca2a86c18211c3e7c20f0a8f79442efc9edb71b6d6b24b02904e5633b7d86b2bffcf5ec0561108ebebe4e065e771dab3a271a07b95daeeda8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`opam-build.0.1.0`: An opam plugin to build projects
-`opam-test.0.1.0`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v2.1.0