### PR TITLE
Bisect_ppx 2.7.0: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.7.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.02.0"}
+  "ppxlib" {>= "0.21.0"}
+
+  "ocamlformat" {with-test & = "0.16.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@compatible"] {with-test}
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.7.0.tar.gz"
+  checksum: "md5=73cddd4025cff329b52b93bb663927f8"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.7.0):

> Additions
>
> - Reports in Cobertura XML format, used on GitLab (aantron/bisect_ppx#383, Valentin Chaboche).
> - `.coverage` file merging (aantron/bisect_ppx#389, Valentin Chaboche).
> - Environment variable `BISECT_SIGTERM` and PPX option `--bisect-sigterm`, which cause the runtime to write `.coverage` files upon receiving SIGTERM (aantron/bisect_ppx#390, Arvid Jakobsson).
> - `bisect-ppx-report`: verbose logging now hidden behind new `--verbose` flag (aantron/bisect_ppx@4b36eb4).
> - HTML: minimal metadata so that links to reports are decorated by social media platforms (aantron/bisect_ppx#373).
>
> Bugs fixed
>
> - Adapt to change in how ReScript represents `->` (aantron/bisect_ppx#382, reported by Danni Friedland).
> - Broken installation on pnpm (aantron/bisect_ppx#381, reported by Tillmann Rendel).
> - `bisect-ppx-report`: clearer error messages (aantron/bisect_ppx#386, aantron/bisect_ppx@6327d04).
> - HTML: visit count tooltip not visible on last line of report (aantron/bisect_ppx#374).