### PR TITLE
bos.0.2.1 requires at least fpath.0.7.3 due to rresult/result packages

### DIFF
--- a/packages/bos/bos.0.2.1/opam
+++ b/packages/bos/bos.0.2.1/opam
@@ -16,7 +16,7 @@ depends: ["ocaml" {>= "4.08.0"}
           "base-unix"
           "rresult" {>= "0.7.0"}
           "astring"
-          "fpath"
+          "fpath" {>= "0.7.3"}
           "fmt" {>= "0.8.10"}
           "logs"
           "mtime" {with-test}]


### PR DESCRIPTION
An error appears on `bos.0.2.1` when we want to downgrade `fpath` from `0.7.3` to `0.7.0`. The error is about the `rresult`/`result` package when, at one point, `fpath.0.7.0` uses `Rresult.result` type and `bos.0.2.1` expects a `result` type. See this error:
```
#=== ERROR while compiling bos.0.2.1 ==========================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/bos.0.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false
# exit-code            1
# env-file             ~/.opam/log/bos-23-4cf4c7.env
# output-file          ~/.opam/log/bos-23-4cf4c7.out
### output ###
# ocamlfind ocamldep -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_base.ml > src/bos_base.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_base.cmo src/bos_base.ml
# ocamlfind ocamldep -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_pat.ml > src/bos_pat.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_pat.cmo src/bos_pat.ml
# ocamlfind ocamldep -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_log.ml > src/bos_log.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_log.cmo src/bos_log.ml
# ocamlfind ocamldep -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_cmd.ml > src/bos_cmd.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_cmd.cmo src/bos_cmd.ml
# ocamlfind ocamldep -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_os_u.ml > src/bos_os_u.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_os_u.cmo src/bos_os_u.ml
# ocamlfind ocamldep -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_os_tmp.ml > src/bos_os_tmp.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_os_tmp.cmo src/bos_os_tmp.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_os_tmp.cmo src/bos_os_tmp.ml
# File "src/bos_os_tmp.ml", line 16, characters 10-17:
# 16 |         | Error _ -> absent (* FIXME log something ? *)
#                ^^^^^^^
# Error: This pattern matches values of type ('a, 'b) result
#        but a pattern was expected which matches values of type
#          (Fpath.t, [ `Msg of string ]) Result.result
#        Result.result is abstract because no corresponding cmi file was found in path.
````

This is a possible fix when we we should not allow `opam` to downgrade `fpath` to `fpath.0.7.0` when we want to install `bos.0.2.1`. WDYT?