### PR TITLE
ppx_pbt, ppx_deriving_qcheck: deprecate

### DIFF
--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
@@ -24,7 +24,7 @@ depends: [
 build: ["dune" "build" "-p" name "-j" jobs]
 
 flags: deprecated
-post-message: "This package is deprecated and to be considered experimental and unsupported."
+post-messages: "This package is deprecated and to be considered experimental and unsupported."
 
 dev-repo: "git+https://github.com/vch9/ppx_deriving_qcheck.git"
 url {

--- a/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
+++ b/packages/ppx_deriving_qcheck/ppx_deriving_qcheck.0.1.0/opam
@@ -15,13 +15,16 @@ authors: [
 
 depends: [
   "dune" {>= "2.8.0"}
-  "ocaml" {>= "4.10.2"}
+  "ocaml" {>= "4.10.2" &  < "4.14"}
   "qcheck" {>= "0.17"}
   "ppxlib" {>= "0.22.0"}
   "alcotest" {with-test & >= "1.4.0"}
 ]
 
 build: ["dune" "build" "-p" name "-j" jobs]
+
+flags: deprecated
+post-message: "This package is deprecated and to be considered experimental and unsupported."
 
 dev-repo: "git+https://github.com/vch9/ppx_deriving_qcheck.git"
 url {

--- a/packages/ppx_pbt/ppx_pbt.0.1.0/opam
+++ b/packages/ppx_pbt/ppx_pbt.0.1.0/opam
@@ -15,7 +15,7 @@ authors: [
 
 depends: [
   "dune" {>= "2.8.0"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "4.14"}
   "menhir" {>= "20180523"}
   "qcheck" {>= "0.17"}
   "metaquot" {>= "0.4"}
@@ -23,6 +23,8 @@ depends: [
 
 build: ["dune" "build" "-p" name "-j" jobs]
 
+flags: deprecated
+post-message: "This package is deprecated and to be considered experimental and unsupported."
 
 dev-repo: "git+https://gitlab.com/vch9/ppx_pbt.git"
 url {

--- a/packages/ppx_pbt/ppx_pbt.0.1.0/opam
+++ b/packages/ppx_pbt/ppx_pbt.0.1.0/opam
@@ -24,7 +24,7 @@ depends: [
 build: ["dune" "build" "-p" name "-j" jobs]
 
 flags: deprecated
-post-message: "This package is deprecated and to be considered experimental and unsupported."
+post-messages: "This package is deprecated and to be considered experimental and unsupported."
 
 dev-repo: "git+https://gitlab.com/vch9/ppx_pbt.git"
 url {

--- a/packages/ppx_pbt/ppx_pbt.0.2.1/opam
+++ b/packages/ppx_pbt/ppx_pbt.0.2.1/opam
@@ -16,7 +16,7 @@ authors: [
 depends: [
   "dune" {>= "2.8.0"}
   "menhir" {>= "20210419"}
-  "ocaml" {>= "4.10.2"}
+  "ocaml" {>= "4.10.2" & < "4.14"}
   "qcheck" {>= "0.17"}
   "data-encoding" {>= "0.4"}
   "zarith" {>= "1.12"}
@@ -24,6 +24,9 @@ depends: [
   "ppx_deriving_qcheck" {>= "0.1"}
   "ppx_deriving" {>= "5.0"}
 ]
+
+flags: deprecated
+post-message: "This package is deprecated and to be considered experimental and unsupported."
 
 build: ["dune" "build" "-p" name "-j" jobs]
 

--- a/packages/ppx_pbt/ppx_pbt.0.2.1/opam
+++ b/packages/ppx_pbt/ppx_pbt.0.2.1/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 
 flags: deprecated
-post-message: "This package is deprecated and to be considered experimental and unsupported."
+post-messages: "This package is deprecated and to be considered experimental and unsupported."
 
 build: ["dune" "build" "-p" name "-j" jobs]
 


### PR DESCRIPTION
This supersedes https://github.com/ocaml/opam-repository/pull/19962

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>