### PR TITLE
Package binaryen_dsl.0.7

### DIFF
--- a/packages/binaryen_dsl/binaryen_dsl.0.7/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Writing Webassembly text format in DSL"
+description: """
+This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.
+
+You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).
+"""
+maintainer: "Vincent Chan <okcdz@diverse.space>"
+authors: "Vincent Chan <okcdz@diverse.space>"
+license: "MIT"
+homepage: "https://github.com/vincentdchan/ocaml-binaryen-dsl"
+bug-reports: "https://github.com/vincentdchan/ocaml-binaryen-dsl/issues"
+dev-repo: "git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git"
+depends: [
+  "ocaml"
+  "core"
+  "dune" {>= "2.8"}
+  "ctypes"
+  "libbinaryen"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/vincentdchan/ocaml-binaryen-dsl/archive/0.6.tar.gz"
+  checksum: [
+    "md5=f12f0fbf36f4f69d0a18430b542ee118"
+    "sha512=c6d32c989aed719388c9332757848202a2222a70f0ee3c65bb9a1ea52dde2bceab977da93b0a5dabec6e0701ce50b3b438175162eaa343427a8702f8357543a0"
+  ]
+}

--- a/packages/binaryen_dsl/binaryen_dsl.0.7/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.7/opam
@@ -21,6 +21,7 @@ depends: [
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
+available: arch != "arm32" & arch !="ppc64" & arch != "s390x" & arch != "x86_32"
 url {
   src:
     "https://github.com/vincentdchan/ocaml-binaryen-dsl/archive/0.6.tar.gz"

--- a/packages/binaryen_dsl/binaryen_dsl.0.7/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.7/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml"
   "core"
   "dune" {>= "2.8"}
-  "ctypes"
+  "ctypes" {>= "0.14.0"}
   "libbinaryen"
 ]
 build: [


### PR DESCRIPTION
### `binaryen_dsl.0.7`
Writing Webassembly text format in DSL
This library helps you to write Webassembly text format(WAT) in OCaml source code with DSL. It helps you to write a code generator for your language to WASM.

You can generate it with [Binaryen](https://github.com/WebAssembly/binaryen).



---
* Homepage: https://github.com/vincentdchan/ocaml-binaryen-dsl
* Source repo: git+https://github.com/vincentdchan/ocaml-binaryen-dsl.git
* Bug tracker: https://github.com/vincentdchan/ocaml-binaryen-dsl/issues

---
:camel: Pull-request generated by opam-publish v2.1.0