### PR TITLE
5 packages from ocsigen/lwt

### DIFF
--- a/packages/lwt/lwt.5.5.0/opam
+++ b/packages/lwt/lwt.5.5.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.8.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0" & "os" != "win32"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0" & "os" != "win32 " | >= "4.06.0"}
+  ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
+  "ocplib-endian"
+  "result" {os != "win32"} # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  # Until https://github.com/aantron/bisect_ppx/pull/327.
+  # "bisect_ppx" {dev & >= "2.0.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+build: [
+  ["dune" "exec" "-p" name "src/unix/config/discover.exe" "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.5.0.tar.gz"
+  checksum: [
+    "md5=94272fac89c5bf21a89c102b8a8f35a5"
+    "sha512=8951b94555e930634375816d71815b9d85daad6ffb7dab24864661504d11be26575ab0b237196c54693efa372a9b69cdc1d5068a20a250dc0bbb4a3c03c5fda1"
+  ]
+}

--- a/packages/lwt_domain/lwt_domain.0.1.0/opam
+++ b/packages/lwt_domain/lwt_domain.0.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using Domainslib with Lwt"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Lwt_domain"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Sudha Parimala"
+]
+maintainer: [
+  "Sudha Parimala"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "domainslib" {>= "0.3.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.5.0.tar.gz"
+  checksum: [
+    "md5=94272fac89c5bf21a89c102b8a8f35a5"
+    "sha512=8951b94555e930634375816d71815b9d85daad6ffb7dab24864661504d11be26575ab0b237196c54693efa372a9b69cdc1d5068a20a250dc0bbb4a3c03c5fda1"
+  ]
+}

--- a/packages/lwt_ppx/lwt_ppx.2.0.3/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt"
+  "ocaml" {>= "4.02.0"}
+  "ppxlib" {>= "0.16.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.5.0.tar.gz"
+  checksum: [
+    "md5=94272fac89c5bf21a89c102b8a8f35a5"
+    "sha512=8951b94555e930634375816d71815b9d85daad6ffb7dab24864661504d11be26575ab0b237196c54693efa372a9b69cdc1d5068a20a250dc0bbb4a3c03c5fda1"
+  ]
+}

--- a/packages/lwt_ppx_let/lwt_ppx_let.5.5.0/opam
+++ b/packages/lwt_ppx_let/lwt_ppx_let.5.5.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+
+synopsis: "Dummy package context for ppx_let tests"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt"
+  "ppx_let" {with-test}
+]
+
+description: "Internal package used to partition ppx_let tests."
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.5.0.tar.gz"
+  checksum: [
+    "md5=94272fac89c5bf21a89c102b8a8f35a5"
+    "sha512=8951b94555e930634375816d71815b9d85daad6ffb7dab24864661504d11be26575ab0b237196c54693efa372a9b69cdc1d5068a20a250dc0bbb4a3c03c5fda1"
+  ]
+}

--- a/packages/lwt_react/lwt_react.1.1.5/opam
+++ b/packages/lwt_react/lwt_react.1.1.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using React with Lwt"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Lwt_react"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "react" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.5.0.tar.gz"
+  checksum: [
+    "md5=94272fac89c5bf21a89c102b8a8f35a5"
+    "sha512=8951b94555e930634375816d71815b9d85daad6ffb7dab24864661504d11be26575ab0b237196c54693efa372a9b69cdc1d5068a20a250dc0bbb4a3c03c5fda1"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`lwt.5.5.0`: Promises and event-driven I/O
-`lwt_domain.0.1.0`: Helpers for using Domainslib with Lwt
-`lwt_ppx.2.0.3`: PPX syntax for Lwt, providing something similar to async/await from JavaScript
-`lwt_ppx_let.5.5.0`: Dummy package context for ppx_let tests
-`lwt_react.1.1.5`: Helpers for using React with Lwt



---
* Homepage: https://github.com/ocsigen/lwt
* Source repo: git+https://github.com/ocsigen/lwt.git
* Bug tracker: https://github.com/ocsigen/lwt/issues

---
:camel: Pull-request generated by opam-publish v2.1.0