### PR TITLE
Tezt: fix checksums and install script

### DIFF
--- a/packages/tezt/tezt.1.0.0/opam
+++ b/packages/tezt/tezt.1.0.0/opam
@@ -14,13 +14,14 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
+  ["mv" "tezt/lib/%{name}%.install" "./"]
 ]
 synopsis: "Framework for integration tests with external processes"
 
 url {
   src: "https://gitlab.com/tezos/tezos/-/archive/v10.0-rc1/tezos-v10.0-rc1.tar.bz2"
   checksum: [
-    "sha256=a30b3c2f2945ed4a044419c80907cb962bc2ee9eef8d05e73fb34d163808346c"
-    "sha512=eb975c3d85910f544b8298ab1677793063a4f69e2733b90c0c1e50ba7164c2e5764783ff8321b7495b66aed63e55f6f6e6d77457f87fe6cd035200b6c7b98b0c"
+    "sha256=668cf2199de2507892549d04a3c81dc22f7603900c0a62a1eec955c06b2007d6"
+    "sha512=4afabf8e8bb2b862000e526010bbd9aac677cac2a1b48848deafb096e45e1ebb2a3fad0dcfae136ff93231590cae5484f6515c31557c13aef1e2685b3c02a6ee"
   ]
 }


### PR DESCRIPTION
The checksums for Octez (the Tezos implementation) tarballs changed a while ago. We are working on making them more stable, but in the meantime, here is a patch that fixes them for the `tezt` package (which is part of the source code of Octez).

Additionally, the `opam` file for `tezt` did not have the `["mv" "tezt/lib/%{name}%.install" "./"]` line which is required because the `.opam` file (and thus the `.install`) file is not at the root, so `opam install tezt` did not actually install anything. This patch also fixes that.

I assume there is a policy to not replace existing packages, but is it also the case for this kind of fixes? If so, should I instead push a new version?