### PR TITLE
Package ocamlog.0.2

### DIFF
--- a/packages/ocamlog/ocamlog.0.2/opam
+++ b/packages/ocamlog/ocamlog.0.2/opam
@@ -1,0 +1,22 @@
+
+opam-version: "2.0"
+synopsis: "Simple Logger for OCaml"
+description: "Able to print with different colors, levels, trace out caller, etc."
+maintainer: "paulpatault <p.patault@gmail.com>"
+authors: "paulpatault <p.patault@gmail.com>"
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.8"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paulpatault/OcamLog"
+homepage: "https://www.github.com/paulpatault/OcamLog"
+bug-reports: "https://www.github.com/paulpatault/OcamLog/issues"
+license: "MIT"
+url {
+  src: "https://github.com/paulpatault/ocamlog/archive/v0.2.tar.gz"
+  checksum: [
+    "md5=093992b1204fb4759541a2331808351c"
+    "sha512=e55521d9eec0204f88f6c811f57d112f67f5d001efbb3e7880baaf81a724b8cdf82887465de6b84a91b84e5664c5d47835a4bc889de137e8d692aab0957ad18d"
+  ]
+}


### PR DESCRIPTION
### `ocamlog.0.2`
Simple Logger for OCaml
Able to print with different colors, levels, trace out caller, etc.



---
* Homepage: https://www.github.com/paulpatault/OcamLog
* Source repo: git+https://github.com/paulpatault/OcamLog
* Bug tracker: https://www.github.com/paulpatault/OcamLog/issues

---
:camel: Pull-request generated by opam-publish v2.1.0