### PR TITLE
[new release] odoc (2.0.1)

### DIFF
--- a/packages/odoc/odoc.2.0.1/opam
+++ b/packages/odoc/odoc.2.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.14"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"

--- a/packages/odoc/odoc.2.0.1/opam
+++ b/packages/odoc/odoc.2.0.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "odoc-parser" {>= "0.9.0"}
+  "astring"
+  "cmdliner"
+  "cppo" {build}
+  "dune" {>= "2.7.0"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+  "logs"
+  "re" {>= "1.7.2"}
+
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+
+  "ocaml-version" {with-test & >= "2.3.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test & >= "0.8.3"}
+  "markup" {with-test & >= "1.0.0"}
+  "ocamlfind" {with-test}
+  "yojson" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "bisect_ppx" {with-test & = "2.5.0"}
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
+  "bos" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.0.1/odoc-2.0.1.tbz"
+  checksum: [
+    "sha256=1fdab1d727133998e1ade2cb615af9893dace313ddc8cf562470b215e36fe481"
+    "sha512=884de376164105b7fd25c1efe3780afe04a8635b17909a40a48ce8dfea299c4ca91a1a4755e2f76e13ec413cd6ab86de1dbc761d59cd5dd8318574c4b89e5334"
+  ]
+}
+x-commit-hash: "30b3aafd271a211d8f7d875a2285dfe3758288da"

--- a/packages/odoc/odoc.2.0.1/opam
+++ b/packages/odoc/odoc.2.0.1/opam
@@ -25,9 +25,9 @@ delimited with `(** ... *)`, and outputs HTML.
 depends: [
   "odoc-parser" {>= "0.9.0"}
   "astring"
-  "cmdliner"
-  "cppo" {build}
-  "dune" {>= "2.7.0"}
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "2.9.1"}
   "fpath"
   "ocaml" {>= "4.02.0"}
   "result"
@@ -47,14 +47,14 @@ depends: [
   ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
   "conf-jq" {with-test}
 
-  "bisect_ppx" {with-test & = "2.5.0"}
+  "bisect_ppx" {dev & = "2.5.0"}
   "ppx_expect" {with-test}
   ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
   "bos" {with-test}
 ]
 
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {


### PR DESCRIPTION
OCaml documentation generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

Bugs fixed
- Man page renderer fails to output pages that have children (@jonludlam, @Julow, ocaml/odoc#766)
- Fix resolution of unprefixed references to pages (@Julow, ocaml/odoc#755)
- Fix reporting of ambiguous labels (@Julow, @jonludlam, ocaml/odoc#773, ocaml/odoc#781)
- Allow referencing of labels in the top comment (@jonludlam, ocaml/odoc#771)

Additions
- Strip unquoted spaces in identifiers for a more flexible reference syntax (@lubega-simon, @panglesd, ocaml/odoc#783)
- Add context to messages raised in expansions of includes (@Julow, ocaml/odoc#780)
