### PR TITLE
Package ocsigen-start.4.5.0

### DIFF
--- a/packages/ocsigen-start/ocsigen-start.4.1.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.7.0" & < "4.0.0"}
-  "eliom" {>= "7.0.0"}
+  "eliom" {>= "7.0.0" & < "9.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.3.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "3.7.0"}
-  "eliom" {>= "7.0.0"}
+  "eliom" {>= "7.0.0" & < "9.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0" & < "4.0.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.4.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "pgocaml_ppx" {>= "4.0"}
   "safepass" {>= "3.0"}
   "ocsigen-i18n" {>= "4.0.0"}
-  "eliom" {>= "7.0.0"}
+  "eliom" {>= "7.0.0" & < "9.0.0"}
   "ocsigen-toolkit" {>= "2.7.0"}
   "ocsigen-i18n" {>= "3.7.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.5.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.5.0/opam
@@ -13,8 +13,8 @@ homepage: "https://ocsigen.org/ocsigen-start/"
 bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
 dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-build: [ make "-j%{jobs}%" ]
-install: [ make "install" ]
+build: [make "-j%{jobs}%"]
+install: [make "install"]
 depends: [
   "ocaml" {>= "4.06.1"}
   "pgocaml" {>= "4.0"}

--- a/packages/ocsigen-start/ocsigen-start.4.5.0/opam
+++ b/packages/ocsigen-start/ocsigen-start.4.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+synopsis: "An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc"
+description: """
+Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom).
+It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
+Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
+This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users.
+The goal is to enable the programmer to concentrate on the core of the app, and not on user management.
+"""
+homepage: "https://ocsigen.org/ocsigen-start/"
+bug-reports: "https://github.com/ocsigen/ocsigen-start/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-start.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "pgocaml" {>= "4.0"}
+  "pgocaml_ppx" {>= "4.0"}
+  "safepass" {>= "3.0"}
+  "ocsigen-i18n" {>= "4.0.0"}
+  "eliom" {>= "9.0.0" & < "10.0.0"}
+  "ocsigen-toolkit" {>= "2.7.0"}
+  "ocsigen-i18n" {>= "3.7.0"}
+  "yojson" {>= "1.6.0"}
+  "resource-pooling" {>= "1.0" & < "2.0"}
+  "cohttp-lwt-unix"
+  "conf-npm" {>= "1"}
+  "ocamlnet"
+  "re" {>= "1.7.2"}
+]
+depexts: [
+  ["imagemagick" "ruby-sass" "postgresql" "postgresql-common"] {os-family = "debian"}
+  ["postgresql" "md5sha1sum" "sassc"] {os = "macos" & os-distribution = "homebrew"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-start/archive/4.5.0.tar.gz"
+  checksum: [
+    "md5=3c84a72260d485adadb224f9014940df"
+    "sha512=42f5e01c029b1ef030e09d00925129cda8b396ff9e46f59998e3688a16d05c2252ca3a2f452c4c2e981e9a43bcb9e0c151eb4c0942bddd5b8f5271a5f672fdce"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-start.4.5.0`
An Eliom application skeleton ready to use to build your own application with users, (pre)registration, notifications, etc
Ocsigen Start is a set of higher-level libraries for building client-server web applications with Ocsigen (Js_of_ocaml and Eliom).
It provides modules for user management (session management, registration, activation keys, ...), managing groups of users, displaying tips, and easily sending notifications to the users.
Ocsigen Start comes with an eliom-distillery template for an app with a database, user management, and session management.
This template is intended to serve as a basis for quickly building the Minimum Viable Product for web applications with users.
The goal is to enable the programmer to concentrate on the core of the app, and not on user management.



---
* Homepage: https://ocsigen.org/ocsigen-start/
* Source repo: git+https://github.com/ocsigen/ocsigen-start.git
* Bug tracker: https://github.com/ocsigen/ocsigen-start/issues

---
:camel: Pull-request generated by opam-publish v2.1.0