### PR TITLE
Allow ocamlformat.0.19.0 to be compiled on OCaml 4.14

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.19.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.19.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/ocaml-ppx/ocamlformat"
 bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.08" & < "4.14"}
+  "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "base-unix"


### PR DESCRIPTION
cc @gpetiot does that looks ok to you? I’m not seeing any errors or warnings when compiling and the [changelog](https://github.com/ocaml/ocaml/blob/trunk/Changes) only lists things that should not require special code in ocamlformat (at least from what I can guess):
```
### Language features:

- #10462: Add attribute to produce a compiler error for polls.

- #10437: Allow explicit binders for type variables.

- #10441: Remove unnecessary parentheses surrounding immediate objects.
  Allow 'object ... end # f', 'f object ... end', etc.

- #181, #9760: opt-in tail-modulo-cons (TMC) transformation
    let[@tail_mod_cons] rec map f li = ...
 ```