### PR TITLE
3 packages from c-cube/ocaml-containers at 3.5.1

### DIFF
--- a/packages/containers-data/containers-data.3.5.1/opam
+++ b/packages/containers-data/containers-data.3.5.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+license: "BSD-2"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.5.1.tar.gz"
+  checksum: [
+    "md5=2c4ada818bacf65c893aa7792a8d7abc"
+    "sha512=309856cc438367ff962ea1bddeb4a0a6cce5b3d32bf482e148276d17022b3549e809d5ceb0a441bd649feaf4d90aa0b16c97e4d241d1d21bb3a07834a963eb1b"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.5.1/opam
+++ b/packages/containers-thread/containers-thread.3.5.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.5.1.tar.gz"
+  checksum: [
+    "md5=2c4ada818bacf65c893aa7792a8d7abc"
+    "sha512=309856cc438367ff962ea1bddeb4a0a6cce5b3d32bf482e148276d17022b3549e809d5ceb0a441bd649feaf4d90aa0b16c97e4d241d1d21bb3a07834a963eb1b"
+  ]
+}

--- a/packages/containers/containers.3.5.1/opam
+++ b/packages/containers/containers.3.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "1.1" }
+  "dune-configurator"
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "csexp" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.5.1.tar.gz"
+  checksum: [
+    "md5=2c4ada818bacf65c893aa7792a8d7abc"
+    "sha512=309856cc438367ff962ea1bddeb4a0a6cce5b3d32bf482e148276d17022b3549e809d5ceb0a441bd649feaf4d90aa0b16c97e4d241d1d21bb3a07834a963eb1b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.5.1`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.5.1`: A set of advanced datatypes for containers
-`containers-thread.3.5.1`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0