### PR TITLE
Restrict menhir to OCaml >= 4.11

### DIFF
--- a/packages/menhir/menhir.20211125/opam
+++ b/packages/menhir/menhir.20211125/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.11.0"}
   "dune" {>= "2.8.0"}
   "menhirLib" {= version}
   "menhirSdk" {= version}


### PR DESCRIPTION
OCaml’s type-checker is having issues with the generated code in earlier versions
It looks wide-spread enough to require a restriction in `menhir` instead of all the packages that use menhir on these versions.

Fixes https://github.com/ocaml/opam-repository/issues/20107
cc @fpottier 

Example of issues:
```
#=== ERROR while compiling js_of_ocaml-compiler.3.7.1 =========================#
# context     2.0.8 | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path        ~/.opam/4.03/.opam-switch/build/js_of_ocaml-compiler.3.7.1
# command     ~/.opam/4.03/bin/dune build -p js_of_ocaml-compiler -j 31
# exit-code   1
# env-file    ~/.opam/log/js_of_ocaml-compiler-54-75a799.env
# output-file ~/.opam/log/js_of_ocaml-compiler-54-75a799.out
### output ###
#       ocamlc compiler/lib/.js_of_ocaml_compiler.objs/byte/js_of_ocaml_compiler__Annot_parser.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlc.opt -w -40 -w -7-37 -safe-string -g -bin-annot -I compiler/lib/.js_of_ocaml_compiler.objs/byte -I /home/opam/.opam/4.03/lib/biniou -I /home/opam/.opam/4.03/lib/bytes -I /home/opam/.opam/4.03/lib/easy-format -I /home/opam/.opam/4.03/lib/menhirLib -I /home/opam/.opam/4.03/lib/ocaml/compiler-libs -I /home/opam/.opam/4.03/lib/yojson -intf-suffix .ml -no-alias-deps -open Js_of_ocaml_compiler -o compiler/lib/.js_of_ocaml_compiler.objs/byte/js_of_ocaml_compiler__Annot_parser.cmo -c -impl compiler/lib/annot_parser.pp.ml)
# File "annot_parser.ml", line 76, characters 2-1980:
# Error: This definition has type
#          'ttv_tail.
#            _menhir_env ->
#            'ttv_tail -> _menhir_state -> 'tv_arg_annot list -> 'freshtv208
#        which is less general than
#          'ttv_tail 'ttv_return.
#            _menhir_env ->
#            'ttv_tail -> _menhir_state -> 'tv_arg_annot list -> 'ttv_return
#     ocamlopt compiler/lib/.js_of_ocaml_compiler.objs/native/js_of_ocaml_compiler__Annot_parser.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlopt.opt -w -40 -w -7-37 -safe-string -g -I compiler/lib/.js_of_ocaml_compiler.objs/byte -I compiler/lib/.js_of_ocaml_compiler.objs/native -I /home/opam/.opam/4.03/lib/biniou -I /home/opam/.opam/4.03/lib/bytes -I /home/opam/.opam/4.03/lib/easy-format -I /home/opam/.opam/4.03/lib/menhirLib -I /home/opam/.opam/4.03/lib/ocaml/compiler-libs -I /home/opam/.opam/4.03/lib/yojson -intf-suffix .ml -no-alias-deps -open Js_of_ocaml_compiler -o compiler/lib/.js_of_ocaml_compiler.objs/native/js_of_ocaml_compiler__Annot_parser.cmx -c -impl compiler/lib/annot_parser.pp.ml)
# File "annot_parser.ml", line 76, characters 2-1980:
# Error: This definition has type
#          'ttv_tail.
#            _menhir_env ->
#            'ttv_tail -> _menhir_state -> 'tv_arg_annot list -> 'freshtv208
#        which is less general than
#          'ttv_tail 'ttv_return.
#            _menhir_env ->
#            'ttv_tail -> _menhir_state -> 'tv_arg_annot list -> 'ttv_return
```