### PR TITLE
Package ppx_units.1.0.0

### DIFF
--- a/packages/ppx_units/ppx_units.1.0.0/opam
+++ b/packages/ppx_units/ppx_units.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Generate unit types for every record field"
+description: """
+ppx_units is a simple deriver to automatically generate single variant types from record type definitions
+"""
+license: "MPL-2.0"
+homepage: "https://github.com/SGrondin/ppx_units"
+dev-repo: "git://github.com/SGrondin/ppx_units"
+doc: "https://github.com/SGrondin/ppx_units"
+bug-reports: "https://github.com/SGrondin/ppx_units/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.0.0"}
+
+  "ppxlib" { >= "0.14.0" }
+
+  "alcotest" { with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/ppx_units/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=ae627f403e258a49dba179bfca0b631c"
+    "sha512=ed057812b22bc1edda39091801c4229babdc2708d3a629d1d896ab0cb4e651dea3c9db32a9ed9d69fa2058677a0f5d9921546b92e7e32d3f6626825191553e11"
+  ]
+}


### PR DESCRIPTION
### `ppx_units.1.0.0`
Generate unit types for every record field
ppx_units is a simple deriver to automatically generate single variant types from record type definitions



---
* Homepage: https://github.com/SGrondin/ppx_units
* Source repo: git://github.com/SGrondin/ppx_units
* Bug tracker: https://github.com/SGrondin/ppx_units/issues

---
:camel: Pull-request generated by opam-publish v2.1.0