### PR TITLE
[new release] camyll (0.4.0)

### DIFF
--- a/packages/camyll/camyll.0.4.0/opam
+++ b/packages/camyll/camyll.0.4.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "A static site generator"
+description: """
+Camyll is a static site generator.
+
+Features:
+
+- Conversion from Markdown to HTML
+- Syntax highlighting of any language via user-provided TextMate grammars
+- Post tagging
+- Processing of literate Agda"""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+tags: ["blog" "web" "website"]
+homepage: "https://alan-j-hu.github.io/camyll"
+bug-reports: "https://github.com/alan-j-hu/camyll/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "angstrom" {>= "0.15" & < "0.16"}
+  "calendar" {>= "2.01" & < "3"}
+  "cmdliner" {>= "1.0" & < "2"}
+  "httpaf" {>= "0.7.1" & < "0.8"}
+  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
+  "jingoo" {>= "1.4" & < "2"}
+  "lambdasoup" {>= "0.7" & < "0.8"}
+  "markup" {>= "0.8" & < "2"}
+  "ocaml" {>= "4.12"}
+  "omd" {= "2.0.0~alpha2"}
+  "otoml" {>= "0.9.3"}
+  "plist-xml" {< "0.4"}
+  "re" {>= "1.9" & < "2"}
+  "slug" {>= "1.0" & < "2"}
+  "textmate-language" {>= "0.3.1" & < "0.4"}
+  "uri" {>= "4.2" & < "5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/camyll.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/camyll/releases/download/0.4.0/camyll-0.4.0.tbz"
+  checksum: [
+    "sha256=e7ba81564b549b27853b01df56fd4058a5087a38bfcfcd59f5846517554dafc4"
+    "sha512=0d08039f30ba6b86689d8e330c1e806ce6f0344601edaf90989588a89b3cca97f015a9189b425d36fc4c6a4979ee374d431a1ee79835cb64186a0eb0a16217d8"
+  ]
+}
+x-commit-hash: "f8bd06fc6a76a4811bfeb593eebce4c23bcea025"


### PR DESCRIPTION
A static site generator

- Project page: <a href="https://alan-j-hu.github.io/camyll">https://alan-j-hu.github.io/camyll</a>

##### CHANGES:

- Switch from To.ml to OTOML library (alan-j-hu/camyll#1, Daniil Baturin).
- Close a leaked file handle.
- Use `slug` library instead of handrolled function for generating slugs.
