### PR TITLE
Use the archive cache on opam 2.2

### DIFF
--- a/repo
+++ b/repo
@@ -2,5 +2,5 @@ opam-version: "2.0"
 browse: "https://opam.ocaml.org/packages/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
 archive-mirrors: [
-  "https://opam.ocaml.org/cache" {ocaml-version >= "2.2"}
+  "https://opam.ocaml.org/cache" {opam-version >= "2.2"}
 ]

--- a/repo
+++ b/repo
@@ -1,3 +1,6 @@
 opam-version: "2.0"
-browse: "https://opam.ocaml.org/pkg/"
+browse: "https://opam.ocaml.org/packages/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
+archive-mirrors: [
+  "https://opam.ocaml.org/cache" {ocaml-version >= "2.2"}
+]


### PR DESCRIPTION
To merge when https://github.com/ocaml/opam/pull/4830 is merged. See linked issues for previous attempts at doing this 