### PR TITLE
Fix dependency about logs.0.6.3 and cmdliner.1.0.4

### DIFF
--- a/packages/logs/logs.0.6.3/opam
+++ b/packages/logs/logs.0.6.3/opam
@@ -16,7 +16,7 @@ depends: [
 depopts: [
   "js_of_ocaml"
   "fmt"
-  "cmdliner"
+  "cmdliner" {>= "1.0.4."}
   "lwt" ]
 conflicts: [
   "js_of_ocaml" { < "3.3.0" } ]


### PR DESCRIPTION
`odoc.2.0.1` got an error about logs/cmdliner:
```
#=== ERROR while compiling logs.0.6.3 =========================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/logs.0.6.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --with-js_of_ocaml false --with-fmt true --with-cmdliner true --with-lwt false
# exit-code            1
# env-file             ~/.opam/log/logs-25-65298e.env
# output-file          ~/.opam/log/logs-25-65298e.out
### output ###
# ocamlfind ocamldep -modules src/logs.ml > src/logs.ml.depends
# ocamlfind ocamldep -modules src/logs.mli > src/logs.mli.depends
# ocamlfind ocamlc -c -bin-annot -safe-string -I src -I test -o src/logs.cmi src/logs.mli
# ocamlfind ocamlopt -c -bin-annot -safe-string -I src -I test -o src/logs.cmx src/logs.ml
# ocamlfind ocamlopt -a src/logs.cmx -o src/logs.cmxa
# ocamlfind ocamlopt -shared src/logs.cmx -o src/logs.cmxs
# ocamlfind ocamlc -c -bin-annot -safe-string -I src -I test -o src/logs.cmo src/logs.ml
# ocamlfind ocamlc -a src/logs.cmo -o src/logs.cma
# ocamlfind ocamldep -package fmt -modules src/logs_fmt.ml > src/logs_fmt.ml.depends
# ocamlfind ocamldep -package fmt -modules src/logs_fmt.mli > src/logs_fmt.mli.depends
# ocamlfind ocamlc -c -bin-annot -safe-string -package fmt -I src -I test -o src/logs_fmt.cmi src/logs_fmt.mli
# ocamlfind ocamlopt -c -bin-annot -safe-string -package fmt -I src -I test -o src/logs_fmt.cmx src/logs_fmt.ml
# ocamlfind ocamlopt -a -package fmt src/logs_fmt.cmx -o src/logs_fmt.cmxa
# ocamlfind ocamlopt -shared -package fmt src/logs_fmt.cmx -o src/logs_fmt.cmxs
# ocamlfind ocamlc -c -bin-annot -safe-string -package fmt -I src -I test -o src/logs_fmt.cmo src/logs_fmt.ml
# ocamlfind ocamlc -a -package fmt src/logs_fmt.cmo -o src/logs_fmt.cma
# ocamlfind ocamldep -package cmdliner -modules src/logs_cli.ml > src/logs_cli.ml.depends
# ocamlfind ocamldep -package cmdliner -modules src/logs_cli.mli > src/logs_cli.mli.depends
# ocamlfind ocamlc -c -bin-annot -safe-string -package cmdliner -I src -I test -o src/logs_cli.cmi src/logs_cli.mli
# + ocamlfind ocamlc -c -bin-annot -safe-string -package cmdliner -I src -I test -o src/logs_cli.cmi src/logs_cli.mli
# File "src/logs_cli.mli", line 15, characters 17-33:
# Error: Unbound type constructor Cmdliner.Arg.env
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ["ocamlbuild"; "-use-ocamlfind"; "-classic-display"; "-build-dir";
#      "_build"; "opam"; "pkg/META"; "CHANGES.md"; "LICENSE.md"; "README.md";
#      "src/logs.a"; "src/logs.cmxs"; "src/logs.cmxa"; "src/logs.cma";
#      "src/logs.cmx"; "src/logs.cmi"; "src/logs.mli"; "src/logs_fmt.a";
#      "src/logs_fmt.cmxs"; "src/logs_fmt.cmxa"; "src/logs_fmt.cma";
#      "src/logs_fmt.cmx"; "src/logs_fmt.cmi"; "src/logs_fmt.mli";
#      "src/logs_cli.a"; "src/logs_cli.cmxs"; "src/logs_cli.cmxa";
#      "src/logs_cli.cma"; "src/logs_cli.cmx"; "src/logs_cli.cmi";
#      "src/logs_cli.mli"; "src/logs_top.a"; "src/logs_top.cmxs";
#      "src/logs_top.cmxa"; "src/logs_top.cma"; "src/logs_top.cmx";
#      "src/logs_top_init.ml"; "src/logs_fmt_top_init.ml"; "test/tool.ml";
#      "test/tags.ml"]: exited with 10
```

This PR wants to put a lower bounds on `logs` to fix the compilation of it.