### PR TITLE
[new release] goblint (1.1.1)

### DIFF
--- a/packages/goblint/goblint.1.1.1/opam
+++ b/packages/goblint/goblint.1.1.1/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "Static analysis framework for C"
+maintainer: [
+  "Michael Schwarz <michael.schwarz93@gmail.com>"
+  "Simmo Saan <simmo.saan@gmail.com>"
+  "Ralf Vogler <ralf.vogler@gmail.com>"
+]
+authors: [
+  "Vesal Vojdani"
+  "Kalmer Apinis"
+  "Ralf Vogler"
+  "Michael Schwarz"
+  "Julian Erhard"
+  "Simmo Saan"
+]
+license: "MIT"
+homepage: "https://goblint.in.tum.de"
+doc: "https://goblint.readthedocs.io/en/latest/"
+bug-reports: "https://github.com/goblint/analyzer/issues"
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune" {>= "2.9.1"}
+  "goblint-cil" {>= "1.8.2"}
+  "batteries" {>= "3.2.0"}
+  "zarith" {>= "1.8"}
+  "qcheck-core"
+  "ppx_distr_guards" {>= "0.2"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ocaml-monadic" {>= "0.5"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+  "dune-site"
+  "sha" {>= "1.12"}
+  "conf-gmp" {>= "3"}
+  "conf-ruby" {with-test}
+  "benchmark" {with-test}
+]
+depopts: ["apron" "z3"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/goblint/analyzer.git"
+url {
+  src:
+    "https://github.com/goblint/analyzer/releases/download/v1.1.1/goblint-1.1.1.tbz"
+  checksum: [
+    "sha256=999272bfbd3b9b96fcd58987b237ac6e9fa6d92ef935cc89f1ea2b4205185141"
+    "sha512=f3bf6ab71cf8c258d3290da4bf9f6fe42d7c671822e0efeb0fc50afdff078ab15e352237e5c1db31c5aa3a9d430691268ed2e5e00da10f2615835f672f91683d"
+  ]
+}
+x-commit-hash: "c35cb34d985a98308e65666cfb547f2447045ce9"
+# on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
+# also remember to generate/adjust goblint.opam.locked!
+# pin-depends: [
+  # the published goblint-cil 1.8.2 is currently up-to-date, so no pin needed
+  # [ "goblint-cil.1.8.1" "git+https://github.com/goblint/cil.git#c16dddf74f6053a8b3fac07ca2feff18d4d56964" ]
+  # TODO: add back after release, only pinned for optimization (https://github.com/ocaml-ppx/ppx_deriving/pull/252)
+  # [ "ppx_deriving.5.2.1" "git+https://github.com/ocaml-ppx/ppx_deriving.git#0a89b619f94cbbfc3b0fb3255ab4fe5bc77d32d6" ]
+  # quoter workaround reverted for release, so no pin needed
+  # [ "ppx_deriving_yojson.3.6.1" "git+https://github.com/ocaml-ppx/ppx_deriving_yojson.git#e030f13a3450e9cf7d2c43fa04e709ef608486cd" ]
+  # TODO: add back after release, only pinned for CI stability
+  # [ "apron.v0.9.13" "git+https://github.com/antoinemine/apron.git#c852ebcc89e5cf4a5a3318e7c13c73e1756abb11"]
+# ]


### PR DESCRIPTION
Static analysis framework for C

- Project page: <a href="https://goblint.in.tum.de">https://goblint.in.tum.de</a>
- Documentation: <a href="https://goblint.readthedocs.io/en/latest/">https://goblint.readthedocs.io/en/latest/</a>

##### CHANGES:

* Added lower bounds to dependencies (zarith, ocaml-monadic, sha, conf-gmp).
* Fixed ounit2 library for unit tests.
* Disabled kernel regression tests when linux-headers couldn't be downloaded (e.g. in opam-repository opam-ci).
* Fixed dune-site in opam install by requiring dune 2.9.1.
