### PR TITLE
Package pprint.20211129

### DIFF
--- a/packages/pprint/pprint.20211129/opam
+++ b/packages/pprint/pprint.20211129/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A pretty-printing combinator library and rendering engine"
+description: """\
+This library offers a set of combinators for building so-called documents as
+well as an efficient engine for converting documents to a textual, fixed-width
+format. The engine takes care of indentation and line breaks, while respecting
+the constraints imposed by the structure of the document and by the text width."""
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Nicolas Pouillard <np@nicolaspouillard.fr>"
+]
+homepage: "https://github.com/fpottier/pprint"
+bug-reports: "francois.pottier@inria.fr"
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.3"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+ssh://git@github.com/fpottier/pprint.git"
+url {
+  src: "https://github.com/fpottier/pprint/archive/20211129.tar.gz"
+  checksum: [
+    "md5=defc647ff0d1cb2afc10d513230724c4"
+    "sha512=12133735f558075f1ecdcec16cc11f7237dd82883c542645c479f534acd8ed6935f05a3f9aad8e330c329520852bdff6d420d632636bd9004a4d0aade762cae6"
+  ]
+}

--- a/packages/pprint/pprint.20211129/opam
+++ b/packages/pprint/pprint.20211129/opam
@@ -10,6 +10,7 @@ authors: [
   "François Pottier <francois.pottier@inria.fr>"
   "Nicolas Pouillard <np@nicolaspouillard.fr>"
 ]
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/fpottier/pprint"
 bug-reports: "francois.pottier@inria.fr"
 depends: [


### PR DESCRIPTION
### `pprint.20211129`
A pretty-printing combinator library and rendering engine
This library offers a set of combinators for building so-called documents as
well as an efficient engine for converting documents to a textual, fixed-width
format. The engine takes care of indentation and line breaks, while respecting
the constraints imposed by the structure of the document and by the text width.



---
* Homepage: https://github.com/fpottier/pprint
* Source repo: git+ssh://git@github.com/fpottier/pprint.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.1.0