### PR TITLE
gopcaml-mode: add missing upper bounds

### DIFF
--- a/packages/gopcaml-mode-merlin/gopcaml-mode-merlin.0.0.4/opam
+++ b/packages/gopcaml-mode-merlin/gopcaml-mode-merlin.0.0.4/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.14.3"}
   "ppx_let" {>= "v0.14.0"}
   "ppx_here" {>= "v0.14.0"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "4.13"}
   "core" {>= "v0.13.0"}
   "ppx_deriving" {>= "4.4"}
   "ecaml" {>= "v0.13.0"}

--- a/packages/gopcaml-mode/gopcaml-mode.0.0.3/opam
+++ b/packages/gopcaml-mode/gopcaml-mode.0.0.3/opam
@@ -9,7 +9,7 @@ license: "GPL-3.0-only"
 homepage: "https://gitlab.com/gopiandcode/gopcaml-mode"
 bug-reports: "https://gitlab.com/gopiandcode/gopcaml-mode/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.13"}
   "dune" {>= "1.10"}
   "core" {>= "v0.13.0"}
   "ppx_deriving" {>= "4.4.0"}


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/20126

the `#` have been interpreted as comments 🤦 

The failures are:
```

#=== ERROR while compiling gopcaml-mode-merlin.0.0.4 ==========================#
# context              2.0.10 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/gopcaml-mode-merlin.0.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gopcaml-mode-merlin -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/gopcaml-mode-merlin-30601-865888.env
# output-file          ~/.opam/log/gopcaml-mode-merlin-30601-865888.out
### output ###
#       ocamlc vendor/merlin/src/config/.config.objs/byte/my_config.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -w -a -g -bin-annot -I vendor/merlin/src/config/.config.objs/byte -no-alias-deps -o vendor/merlin/src/config/.config.objs/byte/my_config.cmo -c -impl vendor/merlin/src/config/my_config.ml)
# File "vendor/merlin/src/config/my_config.ml", line 7, characters 54-67:
# 7 |   | `OCaml_4_10_0 | `OCaml_4_11_0 | `OCaml_4_12_0 ] = `OCaml_4_13_0
#                                                           ^^^^^^^^^^^^^
# Error: This expression has type [> `OCaml_4_13_0 ]
#        but an expression was expected of type
#          [ `OCaml_4_02_0
#          | `OCaml_4_02_1
#          | `OCaml_4_02_2
#          | `OCaml_4_02_3
#          | `OCaml_4_03_0
#          | `OCaml_4_04_0
#          | `OCaml_4_05_0
#          | `OCaml_4_06_0
#          | `OCaml_4_07_0
#          | `OCaml_4_07_1
#          | `OCaml_4_08_0
#          | `OCaml_4_09_0
#          | `OCaml_4_10_0
#          | `OCaml_4_11_0
#          | `OCaml_4_12_0 ]
#        The second variant type does not allow tag(s) `OCaml_4_13_0
```
[source](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/207e5f0919ce08eb408a4a911562da1494f5ac2c/variant/opam-2.0,compilers,4.13,menhir.20211128,revdeps,gopcaml-mode-merlin.0.0.4)
and 
```

#=== ERROR while compiling gopcaml-mode.0.0.3 =================================#
# context              2.0.10 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/gopcaml-mode.0.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gopcaml-mode -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/gopcaml-mode-31261-865888.env
# output-file          ~/.opam/log/gopcaml-mode-31261-865888.out
### output ###
#        ocaml (internal)
# File "/home/opam/.opam/4.13/.opam-switch/build/gopcaml-mode.0.0.3/_build/.dune/default/parser/dune.ml", line 28, characters 14-37:
# 28 |   Hashtbl.add Toploop.directive_table "require"
#                    ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# File "/home/opam/.opam/4.13/.opam-switch/build/gopcaml-mode.0.0.3/_build/.dune/default/parser/dune.ml", line 30, characters 14-37:
# 30 |   Hashtbl.add Toploop.directive_table "use"
#                    ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# File "/home/opam/.opam/4.13/.opam-switch/build/gopcaml-mode.0.0.3/_build/.dune/default/parser/dune.ml", line 34, characters 14-37:
# 34 |   Hashtbl.add Toploop.directive_table "use_mod"
#                    ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# File "_build/.dune/default/parser/dune", line 2, characters 13-25:
# 2 | (copy_files# 413/*.ml{,i})
#                  ^^^^^^^^^^^^
# Error: Cannot find directory: parser/413
```
[source](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/207e5f0919ce08eb408a4a911562da1494f5ac2c/variant/opam-2.0,compilers,4.13,menhir.20211128,revdeps,gopcaml-mode.0.0.3)

