### PR TITLE
Mistake in tezos.11.0

### DIFF
--- a/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.11.0/opam
+++ b/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.11.0/opam
@@ -8,7 +8,7 @@ license: "MIT"
 depends: [
   "dune" {>= "2.7"}
   "tezos-signer-backends" { = version }
-  "tezos-protocol-006-PsCARTHA-parameters" { = version }
+  "tezos-protocol-006-PsCARTHA" { = version }
 ]
 build: [
   ["rm" "-r" "vendors"]


### PR DESCRIPTION
I don't really understand why the CI didn't caught that but there were a deprecated leftover that made the meta package `tezos` uninstallble...