### PR TITLE
Fix the upper boundary on ptime for asn1-combinators

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.2/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "zarith"
   "bigarray-compat"
   "stdlib-shims"
-  "ptime"
+  "ptime" {< "0.8.6"}
   "alcotest" {with-test}
 ]
 description: """

--- a/packages/asn1-combinators/asn1-combinators.0.2.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.3/opam
@@ -17,7 +17,7 @@ depends: [
   "zarith"
   "bigarray-compat"
   "stdlib-shims"
-  "ptime"
+  "ptime" {< "0.8.6"}
   "alcotest" {with-test}
 ]
 description: """

--- a/packages/asn1-combinators/asn1-combinators.0.2.4/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.4/opam
@@ -17,7 +17,7 @@ depends: [
   "zarith"
   "bigarray-compat"
   "stdlib-shims"
-  "ptime"
+  "ptime" {< "0.8.6"}
   "alcotest" {with-test}
 ]
 description: """

--- a/packages/asn1-combinators/asn1-combinators.0.2.5/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.5/opam
@@ -17,7 +17,7 @@ depends: [
   "zarith"
   "bigarray-compat"
   "stdlib-shims"
-  "ptime"
+  "ptime" {< "0.8.6"}
   "alcotest" {with-test}
 ]
 description: """


### PR DESCRIPTION
v0.8.6 removed the dependency to `result` which means packages that use `result` that they accidentally inherited from `ptime` on OCaml <4.07 break. Such as asn1-combinators.

The newer asn1-combinators release is not affected since it requires 4.08 anyway.