### PR TITLE
Alpine capnproto-dev is now in the main repository

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.2/opam
+++ b/packages/conf-capnproto/conf-capnproto.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "Sandstorm Development Group, Inc."
+  "Cloudflare, Inc."
+  "other contributors"
+]
+homepage: "https://capnproto.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/capnproto/capnproto.git"
+license: "MIT"
+build: [
+  ["capnp" "--version"]
+]
+depexts: [
+  ["capnproto-dev"] {os-distribution = "alpine"}
+  ["capnproto"] {os-distribution = "arch"}
+  ["capnproto" "capnproto-devel" "epel-release"] {os-distribution = "centos"}
+  ["capnproto" "libcapnp-dev"] {os-family = "debian"}
+  ["capnproto" "capnproto-devel"] {os-distribution = "fedora"}
+  ["capnproto"] {os-distribution = "gentoo"}
+  ["capnp"] {os-distribution = "homebrew" & os = "macos"}
+  ["capnproto"] {os-distribution = "macports" & os = "macos"}
+  ["capnproto" "libcapnp-devel"] {os-family = "suse"}
+  ["capnproto"] {os = "freebsd"}
+]
+x-ci-accept-failures: [
+  "alpine-3.13"   # Does not have capnproto in the main repository
+  "oraclelinux-7" # Does not have capnproto
+  "oraclelinux-8" # Does not have capnproto
+]
+synopsis: "Virtual package relying on captnproto installation"
+flags: conf


### PR DESCRIPTION
The old `capnproto-dev@edgecommunity` now fails with:

    command              /usr/bin/capnp --version
    Error relocating /usr/lib/libcapnpc.so.0.9.1: _ZSt28__throw_bad_array_new_lengthv: symbol not found
    Error relocating /usr/bin/capnp: _ZSt28__throw_bad_array_new_lengthv: symbol not found