### PR TITLE
Package eliom.9.2.1

### DIFF
--- a/packages/eliom/eliom.9.2.1/opam
+++ b/packages/eliom/eliom.9.2.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: """
+Eliom is a framework for implementing client/server Web applications.
+It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
+Eliom allows implementing the whole application as a single program that includes both the client and the server code.
+We use a syntax extension to distinguish between the two sides.
+The client-side code is compiled to JS using Ocsigen Js_of_ocaml.
+"""
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "base-bytes"
+  "ocsipersist" {>= "1.0" & < "2.0"}
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/9.2.1.tar.gz"
+  checksum: [
+    "md5=950572d87f741beb305cf464bc45bce4"
+    "sha512=e29460bd3068f0433b20b7433377a0ae77f5989e30cf6c0f9fb081a0d6c8cdda5fb1a2bb35652b365759b8a035958bb3bed50e20bb708aeecf65e586d74bc252"
+  ]
+}


### PR DESCRIPTION
### `eliom.9.2.1`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications.
It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
Eliom allows implementing the whole application as a single program that includes both the client and the server code.
We use a syntax extension to distinguish between the two sides.
The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0