### PR TITLE
macos homebrew package is called python@3

### DIFF
--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["lang/python36"] {os = "netbsd"}
   ["lang/python36"] {os = "freebsd"}
   ["python36"] {os-distribution = "macports" & os = "macos"}
-  ["python3"] {os-distribution = "homebrew" & os = "macos"}
+  ["python@3"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on Python-3 installation"
 description: """


### PR DESCRIPTION
With current name, `depext` doesn't identify the already installed package and offers to install it, then fails:
```
The following system packages will first need to be installed:
    python3

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><>  🐫
Let opam run your package manager to install the required system packages?
(answer 'n' for other options) [Y/n] y
+ /opt/homebrew/bin/brew "install" "python3"
- Warning: python@3.9 3.9.9 is already installed and up-to-date.
- To reinstall 3.9.9, run:
-   brew reinstall python@3.9
```

Here's a way to confirm:
```
❯ brew list | grep python3
❯ brew list | grep python@3
python@3.9
❯ brew install python@3
...
Warning: python@3.9 3.9.9 is already installed and up-to-date.
To reinstall 3.9.9, run:
  brew reinstall python@3.9
```