### PR TITLE
ppx_deriving.4.5 is not compatible with dune 3.0

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.5/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.5/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "dune"     {>= "1.6.3"}
+  "dune"     {>= "1.6.3" & < "3.0"}
   "cppo"     {build & >= "1.2.2"}
   "ppxfind"  {build}
   "ocaml-migrate-parsetree" {< "2.0.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling ppx_deriving.4.5 ===================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.12.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.12+dune3/.opam-switch/build/ppx_deriving.4.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_deriving -j 31
# exit-code            1
# env-file             ~/.opam/log/ppx_deriving-19-fa2e7c.env
# output-file          ~/.opam/log/ppx_deriving-19-fa2e7c.out
### output ###
# File "src_plugins/map/dune", line 1, characters 0-146:
# 1 | (rule
# 2 |  (deps ppx_deriving_map.cppo.ml)
# 3 |  (targets ppx_deriving_map.ml)
# 4 |  (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
# (cd _build/default/src_plugins/map && /home/opam/.opam/4.12+dune3/bin/cppo -V OCAML:4.12.1 ppx_deriving_map.cppo.ml -o ppx_deriving_map.ml)
# Error: File "ppx_deriving_map.cppo.ml", line 1, characters 0-33
# Error: Cannot find included file "../compat_macros.cppo"
```