### PR TITLE
Package core_compat.0.14.0

### DIFF
--- a/packages/core_compat/core_compat.0.14.0/opam
+++ b/packages/core_compat/core_compat.0.14.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_compat"
+bug-reports: "https://github.com/janestreet/core_compat/issues"
+dev-repo: "git+https://github.com/janestreet/core_compat.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_compat/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "core" {>= "v0.14" & < "v0.15"}
+  "core_kernel" {>= "v0.14" & < "v0.15"}
+  "dune"        {>= "2.0.0"}
+]
+synopsis: "Compatibility for core 0.14"
+description: "
+Compatibility wrapper to make it possible to have code compatible with both Core 0.14 and 0.15.
+"
+url {
+  src: "https://github.com/janestreet/core_compat/archive/v0.14.0.tar.gz"
+  checksum: [
+    "md5=1e40d5e4c881e56d8ebe72249fce8af2"
+    "sha512=280689280597a12df1e507b19b6f108baebe742dd1266522a56dcb622dc698afad28a494988b230e2b3543eecdbbdca002b7a52febff91a3f93f187890a79925"
+  ]
+}

--- a/packages/core_compat/core_compat.v0.14.0/opam
+++ b/packages/core_compat/core_compat.v0.14.0/opam
@@ -15,9 +15,9 @@ depends: [
   "core_kernel" {>= "v0.14" & < "v0.15"}
   "dune"        {>= "2.0.0"}
 ]
-synopsis: "Compatibility for core 0.14"
+synopsis: "Compatibility for core v0.14"
 description: "
-Compatibility wrapper to make it possible to have code compatible with both Core 0.14 and 0.15.
+Compatibility wrapper to make it possible to have code compatible with both Core v0.14 and v0.15.
 "
 url {
   src: "https://github.com/janestreet/core_compat/archive/v0.14.0.tar.gz"


### PR DESCRIPTION
### `core_compat.v0.14.0`
Compatibility for core v0.14
Compatibility wrapper to make it possible to have code compatible with both Core v0.14 and v0.15.



---
* Homepage: https://github.com/janestreet/core_compat
* Source repo: git+https://github.com/janestreet/core_compat.git
* Bug tracker: https://github.com/janestreet/core_compat/issues

---
:camel: Pull-request generated by opam-publish v2.1.0