### PR TITLE
[new release] pyre-ast (0.1.7)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.7/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.7/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.7/pyre-ast-0.1.7.tbz"
+  checksum: [
+    "sha256=bd49bf6cdcd74e8171b6afd5e569eb96d26f6654e752da54ffa808d9eb224b82"
+    "sha512=024df614e24054587378efa8dd57a43cd47be537a088c42357df29ebcb718785d9c840da2695d20c1840ae2e4159ddf44794d826a0c320c484a5b4d91c55bf02"
+  ]
+}
+x-commit-hash: "fd89c208cf689ae2135fce03395d14489e2d6da5"


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- `IndentationError` now gets correctly recognized as syntax error. This provides us with more precise locations info for the error.
