### PR TITLE
[new release] odoc (2.0.2)

### DIFF
--- a/packages/odoc/odoc.2.0.2/opam
+++ b/packages/odoc/odoc.2.0.2/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "odoc-parser" {>= "0.9.0"}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "2.9.1"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+  "logs"
+  "re" {>= "1.7.2"}
+
+  "ocaml-migrate-parsetree" {>= "1.0.6"}
+
+  "ocaml-version" {with-test & >= "2.3.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test & >= "0.8.3"}
+  "markup" {with-test & >= "1.0.0"}
+  "ocamlfind" {with-test}
+  "yojson" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "bisect_ppx" {dev & = "2.5.0"}
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
+  "bos" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.0.2/odoc-2.0.2.tbz"
+  checksum: [
+    "sha256=41fb15e43f49a3b1f436115d1358a0c7a61d38fea9a2b56861af859863629ff0"
+    "sha512=4762ee06d0a58fe22b44f6a0c0dda4890f919e6eaa0bd07706a425c00bd39f4a74e0222f2bd5810e3ea9347596ac6a7e835932a440362c82a22c0e1eb61f2a58"
+  ]
+}
+x-commit-hash: "b266aabde8a1bd8094bd1bca9401748a7195076a"


### PR DESCRIPTION
OCaml documentation generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

Additions
- Compatibility with OCaml 4.14 (@patricoferris, @kit-ty-kate, ocaml/odoc#788)
