### PR TITLE
dune 1.11: add conflict with num =1.0

### DIFF
--- a/packages/dune/dune.1.11.0/opam
+++ b/packages/dune/dune.1.11.0/opam
@@ -34,6 +34,7 @@ conflicts: [
   "jbuilder" {!= "transition"}
   "odoc" {< "1.3.0"}
   "dune-release" {< "1.3.0"}
+  "num" {= "1.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [

--- a/packages/dune/dune.1.11.0/opam
+++ b/packages/dune/dune.1.11.0/opam
@@ -33,6 +33,7 @@ conflicts: [
   "jbuilder" {!= "transition"}
   "odoc" {< "1.3.0"}
   "dune-release" {< "1.3.0"}
+  "num"
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [

--- a/packages/dune/dune.1.11.0/opam
+++ b/packages/dune/dune.1.11.0/opam
@@ -33,7 +33,6 @@ conflicts: [
   "jbuilder" {!= "transition"}
   "odoc" {< "1.3.0"}
   "dune-release" {< "1.3.0"}
-  "num" {= "1.0"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [

--- a/packages/dune/dune.1.11.0/opam
+++ b/packages/dune/dune.1.11.0/opam
@@ -1,7 +1,6 @@
 opam-version: "2.0"
 synopsis: "Fast, portable and opinionated build system"
 description: """
-
 dune is a build system that was designed to simplify the release of
 Jane Street packages. It reads metadata from "dune" files following a
 very simple s-expression syntax.


### PR DESCRIPTION
This is a test to check if the error
```

#=== ERROR while compiling dune.1.11.0 ========================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.10.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.10/.opam-switch/build/dune.1.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./boot.exe --release -j 31
# exit-code            1
# env-file             ~/.opam/log/dune-99-bf8fcb.env
# output-file          ~/.opam/log/dune-99-bf8fcb.out
### output ###
# Error: stat: /home/opam/.opam/4.10/lib/ocaml/arith_flags.cmx: No such file or directory
# -> required by src/stdune/.stdune.objs/native/stdune__Appendable_list.cmx
# -> required by src/catapult/.catapult.objs/native/catapult.cmx
# -> required by src/.dune.objs/native/dune__Action.cmx
# -> required by bin/.main.objs/native/main.cmx
# -> required by bin/main.a
# -> required by bin/main/main_dune.exe
# -> required by install bin/dune
# -> required by dune.install
```
seen on Frama-C PR is due to a problem in num =1.0

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>