### PR TITLE
Package core_unix.v0.14.0

### DIFF
--- a/packages/core_unix/core_unix.v0.14.0/opam
+++ b/packages/core_unix/core_unix.v0.14.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "v0.14.0"
 maintainer: "opensource@janestreet.com"
 authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
 homepage: "https://github.com/janestreet/core_unix"

--- a/packages/core_unix/core_unix.v0.14.0/opam
+++ b/packages/core_unix/core_unix.v0.14.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+version: "v0.14.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/core_unix"
+bug-reports: "https://github.com/janestreet/core_unix/issues"
+dev-repo: "git+https://github.com/janestreet/core_unix.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core_unix/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"                    {>= "4.08.0"}
+  "core"                     {>= "v0.14" & < "v0.15" }
+  "dune"                     {>= "2.0.0"}
+]
+synopsis: "Unix-specific portions of Core"
+description: "
+Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
+"
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+url {
+  src: "https://github.com/janestreet/core_unix/archive/v0.14.0.tar.gz"
+  checksum: [
+    "md5=b752da97c7c4c1f5ccb6885d17fed83b"
+    "sha512=d32fdb028262ee20f3e15ce2d3b8ecab4c3520010ee390adab73b1c6ef96e3505735b20d9c916534d508246f6cce4f0d5a900b47a5be4edbfee1d1d167d7cf5c"
+  ]
+}

--- a/packages/core_unix/core_unix.v0.14.0/opam
+++ b/packages/core_unix/core_unix.v0.14.0/opam
@@ -23,7 +23,7 @@ depexts: ["linux-headers"] {os-distribution = "alpine"}
 url {
   src: "https://github.com/janestreet/core_unix/archive/v0.14.0.tar.gz"
   checksum: [
-    "md5=b752da97c7c4c1f5ccb6885d17fed83b"
-    "sha512=d32fdb028262ee20f3e15ce2d3b8ecab4c3520010ee390adab73b1c6ef96e3505735b20d9c916534d508246f6cce4f0d5a900b47a5be4edbfee1d1d167d7cf5c"
+    "md5=f9a74834f239874286d84ec99d75e5fa"
+    "sha512=d020db759cde35c0e9d9919dee2c0ea5bb5b7a5ee75515be922d816f28eb9f74dba37e6e424a636e362eab5120b2c1e672f4e5ba798f2dac7974c0e135f80faf"
   ]
 }


### PR DESCRIPTION
In Jane Street v0.15 we're about to split up core library and move most of it into package `core_unix`.

This PR adds a compatibility package `core_unix.v0.14.0` which should be largely compatible with the upcoming `core_unix.v0.15.0`, while being implemented on top of `core.v0.14.*`.

cc @kit-ty-kate 

Signed-off-by: Arseniy Alekseyev <aalekseyev@janestreet.com>