### PR TITLE
conjury is not compatible with OCaml 4.13

### DIFF
--- a/packages/conjury/conjury.2.0.1/opam
+++ b/packages/conjury/conjury.2.0.1/opam
@@ -7,6 +7,7 @@ bug-reports: "https://bitbucket.org/jhw/conjury/issues"
 dev-repo: "git+https://bitbucket.org/jhw/conjury"
 tags: [ "org:conjury.org" ]
 depends: [
+    "ocaml" {< "4.13"}
     "ocaml" { with-test & >= "4.04" }
     "ocamlfind" { with-test & >= "1.7.3" }
     "omake" { >= "0.10.3" }

--- a/packages/conjury/conjury.2.0/opam
+++ b/packages/conjury/conjury.2.0/opam
@@ -7,6 +7,7 @@ bug-reports: "https://bitbucket.org/jhw/conjury/issues"
 dev-repo: "git+https://bitbucket.org/jhw/conjury"
 tags: [ "org:conjury.org" ]
 depends: [
+    "ocaml" {< "4.13"}
     "ocaml" { with-test & >= "4.04" }
     "ocamlfind" { with-test & >= "1.7.3" }
     "omake" { >= "0.10.3" }


### PR DESCRIPTION
uses -warn-error, missing-mli

cc @jhwoodyatt 

```
#=== ERROR while compiling conjury.2.0.1 ======================================#
# context              2.1.0 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/conjury.2.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build omake test
# exit-code            2
# env-file             ~/.opam/log/conjury-5475-c8e2fa.env
# output-file          ~/.opam/log/conjury-5475-c8e2fa.out
### output ###
# *** omake: reading OMakefiles
# OMake warning: could not create and/or lock a cache file for
#    /home/opam/.opam/4.13/lib/omake/Pervasives.om
# --- Selecting C/C++ tool cc -> cc
# --- Selecting C/C++ tool c++ -> c++
# --- Selecting C/C++ tool ar -> ar
# --- Checking C/C++ header availability <stddef.h> -> yes
# --- Checking C/C++ header availability <stdlib.h> -> yes
# --- Checking C/C++ header availability <assert.h> -> yes
# --- Selecting OCaml tool ocamlc -> ocamlc.opt
# --- Querying OCaml compiler configuration (ocamlc.opt)...
# --- Checking command availability 'ocamlfind' -> /home/opam/.opam/4.13/bin/ocamlfind
# *** omake: finished reading OMakefiles (0.25 sec)
# - build tests/ocaml ../../stage/develop/lib/main.cmo
# + ocamlfind ocamlc -g -principal -strict-formats -strict-sequence -w +A -warn-error A -bin-annot -I ../../stage/develop/lib -package unix,ounit2 -compat-32 -c -o ../../stage/develop/lib/main.cmo main.ml
# File "main.ml", line 1:
# Error (warning 70 [missing-mli]): Cannot find interface file.
# - build tests/ocaml ../../stage/develop/lib/main.cmx
# + ocamlfind ocamlopt -g -principal -strict-formats -strict-sequence -w +A -warn-error A -I ../../stage/develop/lib -package unix,ounit2 -c -o ../../stage/develop/lib/main.cmx main.ml
# File "main.ml", line 1:
# Error (warning 70 [missing-mli]): Cannot find interface file.
# *** omake: 50/59 targets are up to date
# *** omake: failed (0.37 sec, 6/6 scans, 22/22 rules, 27/74 digests)
# *** omake: targets were not rebuilt because of errors:
#    stage/develop/lib/main.cmo
#       depends on: tests/ocaml/main.ml
#    stage/develop/lib/main.cmx
#       depends on: tests/ocaml/main.ml
```