### PR TITLE
batsat is not compatible with OCaml multicore

### DIFF
--- a/packages/batsat/batsat.0.4/opam
+++ b/packages/batsat/batsat.0.4/opam
@@ -13,6 +13,9 @@ depends: [
   "odoc" {with-doc}
   "conf-rust-2018" {build}
 ]
+conflicts: [
+  "base-domains"
+]
 tags: [ "minisat" "solver" "SAT" ]
 homepage: "https://github.com/c-cube/batsat-ocaml/"
 dev-repo: "git+https://github.com/c-cube/batsat-ocaml.git"

--- a/packages/batsat/batsat.0.5/opam
+++ b/packages/batsat/batsat.0.5/opam
@@ -13,6 +13,9 @@ depends: [
   "odoc" {with-doc}
   "conf-rust-2018" {build}
 ]
+conflicts: [
+  "base-domains"
+]
 tags: [ "minisat" "solver" "SAT" ]
 homepage: "https://github.com/c-cube/batsat-ocaml/"
 dev-repo: "git+https://github.com/c-cube/batsat-ocaml.git"

--- a/packages/batsat/batsat.0.6/opam
+++ b/packages/batsat/batsat.0.6/opam
@@ -14,6 +14,9 @@ depends: [
   "odoc" {with-doc}
   "conf-rust-2018" {build}
 ]
+conflicts: [
+  "base-domains"
+]
 tags: [ "minisat" "solver" "SAT" ]
 homepage: "https://github.com/c-cube/batsat-ocaml/"
 dev-repo: "git+https://github.com/c-cube/batsat-ocaml.git"


### PR DESCRIPTION
uses the rust binding of the OCaml runtime which has the wrong assumption about the new runtime.

cc @c-cube 

```
#=== ERROR while compiling batsat.0.4 =========================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.12.0+domains | file:///home/opam/opam-repository
# path                 ~/.opam/4.12+domains/.opam-switch/build/batsat.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p batsat -j 31
# exit-code            1
# env-file             ~/.opam/log/batsat-2892-2a45c7.env
# output-file          ~/.opam/log/batsat-2892-2a45c7.out
### output ###
#     ocamlopt tests/test1.exe (exit 2)
# (cd _build/default && /home/opam/.opam/4.12+domains/bin/ocamlopt.opt -w -40 -w @8 -safe-string -g -o tests/test1.exe /home/opam/.opam/4.12+domains/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.12+domains/lib/ocaml /home/opam/.opam/4.12+domains/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/4.12+domains/lib/ocaml src/batsat.cmxa -I src tests/.test1.eobjs/native/test1.cmx)
# /usr/bin/ld: Caml_state: TLS reference in /home/opam/.opam/4.12+domains/lib/ocaml/libthreadsnat.a(st_stubs.n.o) mismatches non-TLS reference in src/libbatsat_stubs.a(ocaml_sys-7b22bb2ee982a4c4.ocaml_sys.f8656534-cgu.3.rcgu.o)
# /usr/bin/ld: /home/opam/.opam/4.12+domains/lib/ocaml/libthreadsnat.a: error adding symbols: bad value
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)

-     ocamlopt tests/test1.exe (exit 2)
- (cd _build/default && /home/opam/.opam/4.12+domains/bin/ocamlopt.opt -w -40 -w @8 -safe-string -g -o tests/test1.exe /home/opam/.opam/4.12+domains/lib/ocaml/unix.cmxa -I /home/opam/.opam/4.12+domains/lib/ocaml /home/opam/.opam/4.12+domains/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/4.12+domains/lib/ocaml src/batsat.cmxa -I src tests/.test1.eobjs/native/test1.cmx)
- /usr/bin/ld: Caml_state: TLS reference in /home/opam/.opam/4.12+domains/lib/ocaml/libthreadsnat.a(st_stubs.n.o) mismatches non-TLS reference in src/libbatsat_stubs.a(ocaml_sys-7b22bb2ee982a4c4.ocaml_sys.f8656534-cgu.3.rcgu.o)
- /usr/bin/ld: /home/opam/.opam/4.12+domains/lib/ocaml/libthreadsnat.a: error adding symbols: bad value
- collect2: error: ld returned 1 exit status
- File "caml_startup", line 1:
- Error: Error during linking (exit code 1)
```