### PR TITLE
coq.8.13 is not compatible with nnpchecker

### DIFF
--- a/packages/coq/coq.8.13.0/opam
+++ b/packages/coq/coq.8.13.0/opam
@@ -29,6 +29,7 @@ depends: [
 ]
 conflicts: [
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 build: [
   [

--- a/packages/coq/coq.8.13.1/opam
+++ b/packages/coq/coq.8.13.1/opam
@@ -29,6 +29,7 @@ depends: [
 ]
 conflicts: [
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 build: [
   [

--- a/packages/coq/coq.8.13.2/opam
+++ b/packages/coq/coq.8.13.2/opam
@@ -29,6 +29,7 @@ depends: [
 ]
 conflicts: [
   "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
 ]
 build: [
   [


### PR DESCRIPTION
```
#=== ERROR while compiling coq.8.13.0 =========================================#
# context              2.1.1 | linux/x86_64 | ocaml-variants.4.12.0+nnpchecker | file:///home/opam/opam-repository
# path                 ~/.opam/4.12+nnpchecker/.opam-switch/build/coq.8.13.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make COQ_USE_DUNE= -j31
# exit-code            2
# env-file             ~/.opam/log/coq-19-55e863.env
# output-file          ~/.opam/log/coq-19-55e863.out
### output ###
[...]
# Out-of-heap pointer at 0x7fba583f4990 of value 0x56239f9fe740 has non-black head (tag=132)
# Out-of-heap pointer at 0x7fba583f49b8 of value 0x56239f9fe740 has non-black head (tag=132)
# Out-of-heap pointer at 0x7fba583f49e0 of value 0x56239f9fe740 has non-black head (tag=132)
# Out-of-heap pointer at 0x7fba583f4a08 of value 0x56239f9fe740 has non-black head (tag=132)
# Out-of-heap pointer at 0x7fba583f4a30 of value 0x56239f9fe740 has non-black head (tag=132)
# 
# Out-of-heap pointers were detected by the runtime.
# The process would otherwise have terminated normally.
# make[1]: *** [Makefile.build:863: theories/Init/Notations.vo] Error 70
# make[1]: *** Waiting for unfinished jobs....
# make[1]: Leaving directory '/home/opam/.opam/4.12+nnpchecker/.opam-switch/build/coq.8.13.0'
# make: *** [Makefile.make:178: submake] Error 2
```