### PR TITLE
hacl-star and hacl-star-raw (0.4.4)

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.4.4/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency.
+"""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "ocamlfind" {build}
+  "ctypes" { >= "0.18.0" }
+  "conf-which" {build}
+]
+available: [
+  os = "freebsd" | os-family != "bsd"
+]
+x-ci-accept-failures: [
+  "centos-7" "oraclelinux-7" # Default C compiler is too old
+]
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [
+  make "-C" "raw" "install-hacl-star-raw"
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.4/hacl-star.0.4.4.tar.gz"
+  checksum: [
+    "md5=cab04a1971aeab8531e58398fba589f6"
+    "sha256=621aa0955c009f7e642e1a5f2ffd949ffe6651073afc90833e2a28e67eaf3bc6"
+    "sha512=f25d7e160c8596bf21b686071b973a467c5bafed125aef41b4432fedfa8037e274c923999211e47f2f93840058d92ace805c8970111efde4cb31c7cdac77cf5f"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.4.4/opam
+++ b/packages/hacl-star/hacl-star.0.4.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+description: """
+Documentation for this library can be found
+[here](https://hacl-star.github.io/ocaml_doc/hacl-star/index.html).
+"""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+doc: "https://hacl-star.github.io/ocaml_doc"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+  "odoc" {with-doc}
+]
+available: [
+  os = "freebsd" | os-family != "bsd"
+]
+build: [
+  [
+    "dune" "build" "-p" name "-j" jobs
+    "@doc" {with-doc}
+  ]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.4/hacl-star.0.4.4.tar.gz"
+  checksum: [
+    "md5=cab04a1971aeab8531e58398fba589f6"
+    "sha256=621aa0955c009f7e642e1a5f2ffd949ffe6651073afc90833e2a28e67eaf3bc6"
+    "sha512=f25d7e160c8596bf21b686071b973a467c5bafed125aef41b4432fedfa8037e274c923999211e47f2f93840058d92ace805c8970111efde4cb31c7cdac77cf5f"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-hacl-star.0.4.4: OCaml API for EverCrypt/HACL*
-hacl-star-raw.0.4.4: Auto-generated low-level OCaml bindings for EverCrypt/HACL*