### PR TITLE
[new release] ocamlformat, ocamlformat-rpc, ocamlformat-rpc-lib and ocamlformat-bench (0.20.0)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.20.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.20.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "csexp"
+  "sexplib0"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.0/ocamlformat-0.20.0.tbz"
+  checksum: [
+    "sha256=26d98d0a0c236c2c941386d6a9d1f935cd984a2b7eade9304b8dc372f8887e09"
+    "sha512=4e95ed41d059e5a1bac520731182ac493f0ce2c6a3bc95eea50c750258cad32963da76044c966942b3cb8b248d7de2466c97257f907ca3c267384422f26044dd"
+  ]
+}
+x-commit-hash: "00dda7f9f641643b1124d6944078cc2532e9a683"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.0/opam
@@ -20,7 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.2.0"}
+  "ocaml-version" {>= "3.3.0"}
   "ocp-indent"
   "odoc-parser" {>= "0.9.0"}
   "re" {>= "1.7.2"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "ocamlformat-rpc-lib"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "cmdliner"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.2.0"}
+  "ocp-indent"
+  "odoc-parser" {>= "0.9.0"}
+  "re" {>= "1.7.2"}
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.0/ocamlformat-0.20.0.tbz"
+  checksum: [
+    "sha256=26d98d0a0c236c2c941386d6a9d1f935cd984a2b7eade9304b8dc372f8887e09"
+    "sha512=4e95ed41d059e5a1bac520731182ac493f0ce2c6a3bc95eea50c750258cad32963da76044c966942b3cb8b248d7de2466c97257f907ca3c267384422f26044dd"
+  ]
+}
+x-commit-hash: "00dda7f9f641643b1124d6944078cc2532e9a683" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.20.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.20.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "cmdliner"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.2.0"}
+  "ocp-indent"
+  "odoc-parser" {>= "0.9.0"}
+  "re" {>= "1.7.2"}
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.0/ocamlformat-0.20.0.tbz"
+  checksum: [
+    "sha256=26d98d0a0c236c2c941386d6a9d1f935cd984a2b7eade9304b8dc372f8887e09"
+    "sha512=4e95ed41d059e5a1bac520731182ac493f0ce2c6a3bc95eea50c750258cad32963da76044c966942b3cb8b248d7de2466c97257f907ca3c267384422f26044dd"
+  ]
+}
+x-commit-hash: "00dda7f9f641643b1124d6944078cc2532e9a683" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.20.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.20.0/opam
@@ -19,7 +19,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.2.0"}
+  "ocaml-version" {>= "3.3.0"}
   "ocp-indent"
   "odoc-parser" {>= "0.9.0"}
   "re" {>= "1.7.2"}

--- a/packages/pyml_bindgen/pyml_bindgen.0.1.1/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "conf-python-3-dev" {>= "1" & with-test}
   "core_kernel" {>= "v0.12" & with-test}
-  "ocamlformat" {with-test}
+  "ocamlformat" {with-test & < "0.20.0"}
   "ppx_inline_test" {>= "v0.12" & with-test}
   "ppx_expect" {>= "v0.12" & with-test}
   "pyml" {with-test}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Deprecated

  + Profiles `compact` and `sparse` are now deprecated and will be removed by version 1.0 (ocaml-ppx/ocamlformat#1803, @gpetiot)

  + Options that are not set by the preset profiles are now deprecated and will be removed by version 1.0:
    - `align-cases`, `align-constructors-decl` and `align-variants-decl` (ocaml-ppx/ocamlformat#1793, @gpetiot)
    - `disambiguate-non-breaking-match` (ocaml-ppx/ocamlformat#1805, @gpetiot)
    - `break-before-in` (ocaml-ppx/ocamlformat#1888, @gpetiot)
    - `break-cases={toplevel,all}` (ocaml-ppx/ocamlformat#1890, @gpetiot)
    - `break-collection-expressions` (ocaml-ppx/ocamlformat#1891, @gpetiot)
    - `break-fun-decl=smart` (ocaml-ppx/ocamlformat#1892, @gpetiot)
    - `break-fun-sig=smart` (ocaml-ppx/ocamlformat#1893, @gpetiot)
    - `break-string-literals` (ocaml-ppx/ocamlformat#1894, @gpetiot)
    - `break-struct` (ocaml-ppx/ocamlformat#1895, @gpetiot)
    - `extension-indent` (ocaml-ppx/ocamlformat#1896, @gpetiot)
    - `function-indent` (ocaml-ppx/ocamlformat#1897, @gpetiot)
    - `function-indent-nested` (ocaml-ppx/ocamlformat#1898, @gpetiot)
    - `if-then-else={fit-or-vertical,k-r}` (ocaml-ppx/ocamlformat#1899, @gpetiot)
    - `indicate-multiline-delimiters=closing-on-separate-line` (ocaml-ppx/ocamlformat#1900, @gpetiot)
    - `indent-after-in` (ocaml-ppx/ocamlformat#1901, @gpetiot)
    - `let-binding-indent` (ocaml-ppx/ocamlformat#1902, @gpetiot)
    - `let-binding-spacing=sparse` (ocaml-ppx/ocamlformat#1903, @gpetiot)
    - `match-indent` (ocaml-ppx/ocamlformat#1904, @gpetiot)
    - `match-indent-nested` (ocaml-ppx/ocamlformat#1905, @gpetiot)
    - `module-item-spacing=preserve` (ocaml-ppx/ocamlformat#1906, @gpetiot)
    - `nested-match` (ocaml-ppx/ocamlformat#1907, @gpetiot)
    - `parens-tuple-patterns` (ocaml-ppx/ocamlformat#1908, @gpetiot)
    - `sequence-style=before` (ocaml-ppx/ocamlformat#1909, @gpetiot)
    - `stritem-extension-indent` (ocaml-ppx/ocamlformat#1910, @gpetiot)
    - `type-decl-indent` (ocaml-ppx/ocamlformat#1911, @gpetiot)

#### Bug fixes

  + Fix normalization of sequences of expressions (ocaml-ppx/ocamlformat#1731, @gpetiot)

  + Type constrained patterns are now always parenthesized, parentheses were missing in a class context (ocaml-ppx/ocamlformat#1734, @gpetiot)

  + Support sugared form of coercions in let bindings (ocaml-ppx/ocamlformat#1739, @gpetiot)

  + Add missing parentheses around constructor used as indexing op (ocaml-ppx/ocamlformat#1740, @gpetiot)

  + Honour .ocamlformat-ignore on Windows (ocaml-ppx/ocamlformat#1752, @nojb)

  + Avoid normalizing newlines inside quoted strings `{|...|}` (ocaml-ppx/ocamlformat#1754, @nojb, @hhugo)

  + Fix quadratic behavior when certain constructs are nested. This corresponds
    to the cases where a partial layout is triggered to determine if a construct
    fits on a single line for example. (ocaml-ppx/ocamlformat#1750, ocaml-ppx/ocamlformat#1766, @emillon)

  + Fix non stabilizing comments after infix operators (`*`, `%`, `#`-ops) (ocaml-ppx/ocamlformat#1776, @gpetiot)

  + Fix excessive break and wrong indentation after a short-open when `indicate-multiline-delimiters=closing-on-separate-line` (ocaml-ppx/ocamlformat#1786, @gpetiot)

  + Add parentheses around type alias used as type constraint (ocaml-ppx/ocamlformat#1801, @gpetiot)

  + Fix alignment of comments inside a tuple pattern and remove incorrect linebreak.
    Fix formatting of labelled arguments containing comments.
    (ocaml-ppx/ocamlformat#1797, @gpetiot)

  + Emacs: only hook ocamlformat mode on tuareg/caml modes when ocamlformat is not disabled (ocaml-ppx/ocamlformat#1814, @gpetiot)

  + Fix boxing of labelled arguments, avoid having a linebreak after a label when the argument has a comment attached (ocaml-ppx/ocamlformat#1830, ocaml-ppx/ocamlformat#1885, @gpetiot)

  + Add missing parentheses around application of prefix op when applied to other operands (ocaml-ppx/ocamlformat#1825, @gpetiot)

  + Fix application of a monadic binding when 'break-infix-before-func=false' (ocaml-ppx/ocamlformat#1849, @gpetiot)

  + Fix dropped comments attached to a sequence in a sugared extension node (ocaml-ppx/ocamlformat#1853, @gpetiot)

  + Fix formatting of exception types, and add missing parentheses (ocaml-ppx/ocamlformat#1873, @gpetiot)

  + Fix indentation of with-type constraints (ocaml-ppx/ocamlformat#1883, @gpetiot)

  + Preserve sugared syntax of extension points with attributes (ocaml-ppx/ocamlformat#1913, @gpetiot)

  + Improve comment attachment when followed but not preceded by a linebreak (ocaml-ppx/ocamlformat#1926, @gpetiot)

  + Fix position of comments preceding Pmod_ident (ocaml-ppx/ocamlformat#1939, @gpetiot)

  + Make the formatting of attributes and docstrings more consistent (ocaml-ppx/ocamlformat#1929, @gpetiot)

  + Fix stabilization of comments inside attributes (ocaml-ppx/ocamlformat#1942, @gpetiot)

#### Changes

  + Set 'module-item-spacing=compact' in the default/conventional profile (ocaml-ppx/ocamlformat#1848, @gpetiot)

  + Preserve bracketed lists in the Parsetree (ocaml-ppx/ocamlformat#1694, ocaml-ppx/ocamlformat#1876, ocaml-ppx/ocamlformat#1914, @gpetiot)

  + Line directives now cause OCamlFormat to emit an error, they were previously silently ignored (ocaml-ppx/ocamlformat#1845, @gpetiot)

  + Apply option 'module-item-spacing' on mutually recursive type declarations for more consistency (ocaml-ppx/ocamlformat#1854, @gpetiot)

#### New features

  + Handle merlin typed holes (ocaml-ppx/ocamlformat#1698, @gpetiot)

  + Handle punned labelled arguments with type constraint in function applications.
    For example, function application of the form `foo ~(x:int)` instead of the explicit `foo ~x:(x:int)`. (ocaml#10434) (ocaml-ppx/ocamlformat#1756, ocaml-ppx/ocamlformat#1759, @gpetiot)
    This syntax is only produced when the output syntax is at least OCaml 4.14.

  + Allow explicit binders for type variables (ocaml#10437) (ocaml-ppx/ocamlformat#1757, @gpetiot)

  + Add a new `ocaml-version` option to select the version of OCaml syntax of the output (ocaml-ppx/ocamlformat#1759, @gpetiot)

  + Allow disambiguated global identifiers (like t/2) so they can be formatted by tools like OCaml-LSP (ocaml-ppx/ocamlformat#1716, @let-def)

  + Handle let operator punning uniformly with other punning forms.
    Normalizes let operator to the punned form where possible, if output syntax version is at least OCaml 4.13.0. (ocaml-ppx/ocamlformat#1834, ocaml-ppx/ocamlformat#1846, @jberdine)

  + Remove unnecessary surrounding parentheses for immediate objects.
    This syntax is only produced when the output syntax is at least OCaml 4.14. (ocaml-ppx/ocamlformat#1934, @gpetiot)
