### PR TITLE
Package monorobot.0.1

### DIFF
--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -13,7 +13,7 @@ depends: [
  "atd" {>= "2.2.1"}
  "atdgen" {>= "2.2.1"}
  "atdgen-runtime" {>= "2.2.1"}
- "base" {>= "v0.12.0"}
+ "base" {>= "v0.13.0"}
  "base64" {>= "3.0.0"}
  "biniou"
  "cmdliner"

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Notification bot for monorepos"
+description: "Notification bot to handle webhook events and post notifications to Slack."
+maintainer: "Ahrefs <github@ahrefs.com>"
+authors: "Ahrefs <github@ahrefs.com>"
+homepage: "https://github.com/ahrefs/monorobot"
+bug-reports: "https://github.com/ahrefs/monorobot/issues"
+dev-repo: "git+https://github.com/ahrefs/monorobot.git"
+depends: [
+ "ocaml" {>= "4.03.0"}
+ "dune" {>= "2.5.0"}
+ "atdgen"
+ "base"
+ "base64"
+ "biniou"
+ "cmdliner"
+ "cstruct"
+ "devkit"
+ "hex"
+ "lwt"
+ "lwt_ppx"
+ "nocrypto"
+ "re2"
+ "stdio"
+ "uri"
+ "ocamlformat" {dev}
+ "omd" {<= "1.3.1"}
+ "yojson"
+]
+build: ["dune" "build" "-p" name]
+url {
+  src: "https://github.com/ahrefs/monorobot/archive/0.1.tar.gz"
+  checksum: [
+    "md5=db7f01d60ca034702787efd0b760a8ad"
+    "sha512=9e33bea9aaadff777552d92971c725bf41280102832c29f5501b18f80fa33fa29ed9c0224796b10cc13bcea253b21cc121f76e66bcb349993acf7819b915634b"
+  ]
+}

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/ahrefs/monorobot.git"
 depends: [
  "ocaml" {>= "4.08.0"}
  "dune" {>= "2.5.0"}
- "atdgen"
+ "atdgen" {>= "2.2.1"}
  "atdgen-runtime"
  "base" {>= "v0.12.0"}
  "base64"
@@ -18,7 +18,7 @@ depends: [
  "cmdliner"
  "cstruct"
  "devkit" {>= "1.20210120"}
- "extlib" {>= "1.7.1"}
+ "extlib" {>= "1.7.8"}
  "hex"
  "lwt"
  "lwt_ppx" {>= "2.0.0"}

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -1,21 +1,23 @@
 opam-version: "2.0"
+license: "MIT"
 synopsis: "Notification bot for monorepos"
-description: "Notification bot to handle webhook events and post notifications to Slack."
+description: "Notification bot to handle webhook events from monorepos and post notifications to Slack."
 maintainer: "Ahrefs <github@ahrefs.com>"
 authors: "Ahrefs <github@ahrefs.com>"
 homepage: "https://github.com/ahrefs/monorobot"
 bug-reports: "https://github.com/ahrefs/monorobot/issues"
 dev-repo: "git+https://github.com/ahrefs/monorobot.git"
 depends: [
- "ocaml" {>= "4.03.0"}
+ "ocaml" {>= "4.08.0"}
  "dune" {>= "2.5.0"}
  "atdgen"
- "base"
+ "atdgen-runtime"
+ "base" {>= "0.12.0"}
  "base64"
  "biniou"
  "cmdliner"
  "cstruct"
- "devkit"
+ "devkit" {>= "1.20210120"}
  "hex"
  "lwt"
  "lwt_ppx"
@@ -23,11 +25,10 @@ depends: [
  "re2"
  "stdio"
  "uri"
- "ocamlformat" {dev}
  "omd" {<= "1.3.1"}
  "yojson"
 ]
-build: ["dune" "build" "-p" name]
+build: ["dune" "build" "-p" name "-j" jobs]
 url {
   src: "https://github.com/ahrefs/monorobot/archive/0.1.tar.gz"
   checksum: [

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -12,7 +12,7 @@ depends: [
  "dune" {>= "2.5.0"}
  "atdgen"
  "atdgen-runtime"
- "base" {>= "0.12.0"}
+ "base" {>= "v0.12.0"}
  "base64"
  "biniou"
  "cmdliner"

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -14,7 +14,7 @@ depends: [
  "atdgen" {>= "2.2.1"}
  "atdgen-runtime" {>= "2.2.1"}
  "base" {>= "v0.12.0"}
- "base64"
+ "base64" {>= "3.0.0"}
  "biniou"
  "cmdliner"
  "cstruct"

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -21,7 +21,7 @@ depends: [
  "devkit" {>= "1.20210120"}
  "extlib" {>= "1.7.8"}
  "hex"
- "lwt"
+ "lwt" {>= "5.1.0"}
  "lwt_ppx" {>= "2.0.0"}
  "nocrypto"
  "re2"

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -18,9 +18,10 @@ depends: [
  "cmdliner"
  "cstruct"
  "devkit" {>= "1.20210120"}
+ "extlib" {>= "1.7.1"}
  "hex"
  "lwt"
- "lwt_ppx"
+ "lwt_ppx" {>= "2.0.0"}
  "nocrypto"
  "re2"
  "stdio"

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -10,8 +10,9 @@ dev-repo: "git+https://github.com/ahrefs/monorobot.git"
 depends: [
  "ocaml" {>= "4.08.0"}
  "dune" {>= "2.5.0"}
+ "atd" {>= "2.2.1"}
  "atdgen" {>= "2.2.1"}
- "atdgen-runtime"
+ "atdgen-runtime" {>= "2.2.1"}
  "base" {>= "v0.12.0"}
  "base64"
  "biniou"

--- a/packages/monorobot/monorobot.0.1/opam
+++ b/packages/monorobot/monorobot.0.1/opam
@@ -16,7 +16,7 @@ depends: [
  "base" {>= "v0.13.0"}
  "base64" {>= "3.0.0"}
  "biniou"
- "cmdliner"
+ "cmdliner" {>= "0.9.8"}
  "cstruct"
  "devkit" {>= "1.20210120"}
  "extlib" {>= "1.7.8"}


### PR DESCRIPTION
### `monorobot.0.1`
Notification bot for monorepos
Notification bot to handle webhook events and post notifications to Slack.



---
* Homepage: https://github.com/ahrefs/monorobot
* Source repo: git+https://github.com/ahrefs/monorobot.git
* Bug tracker: https://github.com/ahrefs/monorobot/issues

---
:camel: Pull-request generated by opam-publish v2.1.0