### PR TITLE
[new release] poll (0.1.0)

### DIFF
--- a/packages/poll/poll.0.1.0/opam
+++ b/packages/poll/poll.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "Portable OCaml interface to macOS/Linux/Windows native IO event notification mechanisms"
+description:
+  "poll provides a portable OCaml interface to IO event notification mechanisms on macOS, Linux and Windows. It uses kqueue on macOS, epoll on Linux, and uses a vendored copy of wepoll on Windows."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["epoll" "kqueue" "wepoll"]
+homepage: "https://github.com/anuragsoni/poll"
+doc: "https://anuragsoni.github.io/poll"
+bug-reports: "https://github.com/anuragsoni/poll/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "base-unix"
+  "ppx_optcomp"
+  "kqueue" {>= "0.2.0"}
+  "dune-configurator"
+  "ppx_expect" {with-test}
+  "ocaml" {>= "4.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/anuragsoni/poll.git"
+conflicts: [
+  "ppxlib" {< "0.14.0"}
+]
+url {
+  src:
+    "https://github.com/anuragsoni/poll/releases/download/0.1.0/poll-0.1.0.tbz"
+  checksum: [
+    "sha256=96af2adb195aea4dcd6554e6b3f6043852edef7866882f2c0864d3cee811408a"
+    "sha512=0c54f40adec2fe26cb4f0bb9ed4fb8f644ab59a6246be5e7dc75b53f1b6cdddc2aec159400d063c3c92a33ff0c9c063e47016ced1bd5c6715faee13750792c38"
+  ]
+}
+x-commit-hash: "1d506aa9175385ea405617c87c0fa48694b3729f"

--- a/packages/poll/poll.0.1.0/opam
+++ b/packages/poll/poll.0.1.0/opam
@@ -49,3 +49,4 @@ url {
   ]
 }
 x-commit-hash: "1d506aa9175385ea405617c87c0fa48694b3729f"
+available: [ arch != "s390x" ]


### PR DESCRIPTION
Portable OCaml interface to macOS/Linux/Windows native IO event notification mechanisms

- Project page: <a href="https://github.com/anuragsoni/poll">https://github.com/anuragsoni/poll</a>
- Documentation: <a href="https://anuragsoni.github.io/poll">https://anuragsoni.github.io/poll</a>

##### CHANGES:

* Initial release
  - Supports a polling api using the platform event notification mechanisms on macOS (Kqueue), Linux (Epoll) and windows (wepoll - an epoll emulation using IOCP).
