### PR TITLE
[new release] ocaml-migrate-parsetree (2.3.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
@@ -4,7 +4,7 @@ authors: [
   "Frédéric Bour <frederic.bour@lakaban.net>"
   "Jérémie Dimino <jeremie@dimino.org>"
 ]
-license: "LGPL-2.1 with OCaml linking exception"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
 bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
 dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
@@ -16,6 +16,9 @@ depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "4.02.3" & < "4.15"}
   "cinaps" {with-test & >= "v0.13.0"}
+]
+conflicts: [
+  "base-effects"
 ]
 synopsis: "Convert OCaml parsetrees between different versions"
 description: """

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.02.3" & < "4.15"}
+  "cinaps" {with-test & >= "v0.13.0"}
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/v2.3.0/ocaml-migrate-parsetree-2.3.0.tbz"
+  checksum: [
+    "sha256=108126b247f190e04c8afd3d72ced0b63ffdf73c3f801f09be5db0cd7280bf0a"
+    "sha512=cccd766d33e2c70015735e050c2b7cdacf9f046e2874b563ef64b77706f56d004aa9b9df7d5cc201e5f3ba6e3267f95f654e1e3de58891b91f9c28a61988a9ee"
+  ]
+}
+x-commit-hash: "7ef6ff49bfd7d6d816be61d3acea460af25d7d99"


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Add support for 4.14 (ocaml-ppx/ocaml-migrate-parsetree#119, @kit-ty-kate)
