### PR TITLE
[new release] fromager (0.5.0)

### DIFF
--- a/packages/fromager/fromager.0.5.0/opam
+++ b/packages/fromager/fromager.0.5.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A CLI to format an ocaml codebase"
+maintainer: "davidwong.crypto@gmail.com"
+authors: "davidwong.crypto@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/mimoo/fromager"
+bug-reports: "davidwong.crypto@gmail.com"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8"}
+  "otoml" {>= "0.9.3"}
+  "core" {>= "v0.12.4"}
+  "ocamlformat"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/mimoo/fromager.git"
+url {
+  src:
+    "https://github.com/mimoo/fromager/releases/download/0.5.0/fromager-0.5.0.tbz"
+  checksum: [
+    "sha256=95a6fd40d040b6de00079f1f0f2080ef919e95f6008e63c1df2b3dcc65ded654"
+    "sha512=4f14ad769cec82c99bf724cdd8a0021c858df20c30b3303ca78b510f1620cf63313971f80a788fe445da0f65b5f61b2f113286ba8b0750f165108556caaae780"
+  ]
+}
+x-commit-hash: "30db1c516d0e4b673e6d5f3c408590558cbec053"


### PR DESCRIPTION
A CLI to format an ocaml codebase

- Project page: <a href="https://github.com/mimoo/fromager">https://github.com/mimoo/fromager</a>

##### CHANGES:

* Produce an informative error message if ocamlformat is not installed
* Switch from To.ml to OTOML
* Add support for passing options to ocamlformat through `[ocamlformat_options]` table
