### PR TITLE
[new release] mimic (0.0.4)

### DIFF
--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "git" {= version}
-  "mimic" {>= "0.0.3"}
+  "mimic" {>= "0.0.3" & < "0.0.4"}
   "paf" {>= "0.0.2" & < "0.0.4"}
   "ca-certs-nss"
   "cohttp"

--- a/packages/git-paf/git-paf.3.5.0/opam
+++ b/packages/git-paf/git-paf.3.5.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "git" {= version}
-  "mimic" {>= "0.0.3"}
+  "mimic" {>= "0.0.3" & < "0.0.4"}
   "paf" {>= "0.0.2"}
   "ca-certs-nss"
   "fmt"

--- a/packages/git-paf/git-paf.3.6.0/opam
+++ b/packages/git-paf/git-paf.3.6.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "git" {= version}
-  "mimic" {>= "0.0.3"}
+  "mimic" {>= "0.0.3" & < "0.0.4"}
   "paf" {>= "0.0.2"}
   "ca-certs-nss"
   "fmt"

--- a/packages/mimic/mimic.0.0.4/opam
+++ b/packages/mimic/mimic.0.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A simple protocol dispatcher"
+description: "A middleware to dispatch protocols"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: "Romain Calascibetta"
+license: "ISC"
+homepage: "https://github.com/dinosaure/mimic"
+doc: "https://dinosaure.github.io/mimic/"
+bug-reports: "https://github.com/dinosaure/mimic/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/mimic.git"
+url {
+  src:
+    "https://github.com/dinosaure/mimic/releases/download/0.0.4/mimic-0.0.4.tbz"
+  checksum: [
+    "sha256=d566f6c6e7e018aa77149f856232b8e62f41e7e1e885d3d7fb0f52c34a61e496"
+    "sha512=649ed77c920216bb9cefc0e595b417f1677ce49be154fe3aae0b0da31fbc40d0ed1d80b9113257ab9515f2a623a44ba2ab1a1f47c62a144a370ad03409a45556"
+  ]
+}
+x-commit-hash: "7f2805b74f5e0db51f51b4e7764c8cbefed97f0c"

--- a/packages/mimic/mimic.0.0.4/opam
+++ b/packages/mimic/mimic.0.0.4/opam
@@ -20,6 +20,9 @@ depends: [
   "logs" {>= "0.7.0"}
   "ke" {>= "0.4" & with-test}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/paf/paf.0.0.2/opam
+++ b/packages/paf/paf.0.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "mirage-time"
   "httpaf"
   "tls-mirage"
-  "mimic"
+  "mimic" {< "0.0.4"}
   "cohttp-lwt"
   "letsencrypt" {< "0.3.0"}
   "emile" {>= "1.0"}

--- a/packages/paf/paf.0.0.3/opam
+++ b/packages/paf/paf.0.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "mirage-time"
   "httpaf"
   "tls-mirage" {>= "0.13.0"}
-  "mimic"
+  "mimic" {< "0.0.4"}
   "cohttp-lwt"
   "letsencrypt" {< "0.3.0"}
   "emile" {>= "1.0"}

--- a/packages/paf/paf.0.0.4/opam
+++ b/packages/paf/paf.0.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "mirage-stack" {>= "2.2.0"}
   "mirage-time"
   "tls-mirage" {>= "0.13.0"}
-  "mimic"
+  "mimic" {< "0.0.4"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.0.5/opam
+++ b/packages/paf/paf.0.0.5/opam
@@ -13,7 +13,7 @@ depends: [
   "mirage-stack" {>= "2.2.0"}
   "mirage-time"
   "tls-mirage" {>= "0.14.0" & < "0.15.0"}
-  "mimic"
+  "mimic" {< "0.0.4"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}

--- a/packages/paf/paf.0.0.6/opam
+++ b/packages/paf/paf.0.0.6/opam
@@ -13,7 +13,7 @@ depends: [
   "mirage-stack" {>= "2.2.0"}
   "mirage-time"
   "tls-mirage" {>= "0.15.0"}
-  "mimic"
+  "mimic" {< "0.0.4"}
   "ke" {>= "0.4"}
   "lwt" {with-test}
   "base-unix" {with-test}


### PR DESCRIPTION
A simple protocol dispatcher

- Project page: <a href="https://github.com/dinosaure/mimic">https://github.com/dinosaure/mimic</a>
- Documentation: <a href="https://dinosaure.github.io/mimic/">https://dinosaure.github.io/mimic/</a>

##### CHANGES:

- Use `Cstruct.length` instead of `Cstruct.len` (@dinosaure, dinosaure/mimic#2)
- Remove unnucessary `bigarray-compat` dependency (@hannesm, dinosaure/mimic#3)
- Remove `rresult` (@hannesm, dinosaure/mimic#4)
- Be able to introspect values produced by mimic (@dinosaure, dinosaure/mimic#5)
- Improve documentation (@dinosaure, dinosaure/mimic#6 & dinosaure/mimic#7)
