### PR TITLE
ocamlnet is not compatible with ocaml-multicore

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.9-1/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9-1/opam
@@ -52,6 +52,7 @@ conflicts: [
   "ocaml-variants"
     {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
   "shell"
+  "base-domains"
 ]
 extra-files: [
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]

--- a/packages/ocamlnet/ocamlnet.4.1.9/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9/opam
@@ -51,6 +51,7 @@ conflicts: [
   "ocaml-variants"
     {= "4.04.0+flambda" | = "4.04.1+flambda" | = "4.04.2+flambda"}
   "shell"
+  "base-domains"
 ]
 extra-files: ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
 url {


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlnet.4.1.9-1 ===================================#
# context              2.1.1 | linux/x86_64 | ocaml-variants.4.12.0+domains | file:///home/opam/opam-repository
# path                 ~/.opam/4.12+domains/.opam-switch/build/ocamlnet.4.1.9-1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/ocamlnet-19-f7fa1c.env
# output-file          ~/.opam/log/ocamlnet-19-f7fa1c.out
### output ###
# In file included from netsys_c.h:63,
#                  from netsys_c_mem.c:3:
# netsys_c_mem.c: In function 'netsys_color':
# netsys_c_mem.c:352:20: warning: implicit declaration of function 'Color_hd' [-Wimplicit-function-declaration]
#   352 |     return Val_int(Color_hd(Hd_val(objv)) >> 8);
#       |                    ^~~~~~~~
# /home/opam/.opam/4.12+domains/lib/ocaml/caml/mlvalues.h:82:47: note: in definition of macro 'Val_long'
#    82 | #define Val_long(x)     ((intnat) (((uintnat)(x) << 1)) + 1)
#       |                                               ^
# netsys_c_mem.c:352:12: note: in expansion of macro 'Val_int'
#   352 |     return Val_int(Color_hd(Hd_val(objv)) >> 8);
#       |            ^~~~~~~
# netsys_c_mem.c: In function 'netsys_set_color':
# netsys_c_mem.c:359:18: error: lvalue required as left operand of assignment
#   359 |     Hd_val(objv) = Whitehd_hd(Hd_val(objv)) | (col << 8);
#       |                  ^
# netsys_c_mem.c: In function 'netsys_init_value_1':
# netsys_c_mem.c:839:34: error: lvalue required as left operand of assignment
#   839 |                     Hd_val(copy) = Whitehd_hd(Hd_val(copy)) | color;
#       |                                  ^
# netsys_c_mem.c:906:36: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   906 |                         custom_ops = Custom_ops_val(work);
#       |                                    ^
# netsys_c_mem.c:979:38: error: lvalue required as left operand of assignment
#   979 |                         Hd_val(copy) = Whitehd_hd(Hd_val(copy)) | color;
#       |                                      ^
# netsys_c_mem.c: In function 'netsys_copy_value':
# netsys_c_mem.c:1391:22: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#  1391 |     bigarray_ops.ops =
#       |                      ^
# netsys_c_mem.c:1397:19: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#  1397 |     int32_ops.ops = Custom_ops_val(caml_copy_int32(0));
#       |                   ^
# netsys_c_mem.c:1401:19: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#  1401 |     int64_ops.ops = Custom_ops_val(caml_copy_int64(0));
#       |                   ^
# netsys_c_mem.c:1405:23: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#  1405 |     nativeint_ops.ops = Custom_ops_val(caml_copy_nativeint(0));
#       |                       ^
# netsys_c_mem.c:1422:17: warning: implicit declaration of function 'caml_allocation_color' [-Wimplicit-function-declaration]
#  1422 |         color = caml_allocation_color(extra_block);
#       |                 ^~~~~~~~~~~~~~~~~~~~~
# netsys_c_mem.c: In function 'netsys_get_custom_ops':
# netsys_c_mem.c:1511:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#  1511 |         custom_ops = Custom_ops_val(v);
#       |                    ^
# netsys_c_mem.c: In function 'netsys_is_bigarray':
# netsys_c_mem.c:1529:20: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#  1529 |         custom_ops = Custom_ops_val(v);
#       |                    ^
# make[1]: *** [../../Makefile.rules:143: netsys_c_mem.o] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.12+domains/.opam-switch/build/ocamlnet.4.1.9-1/src/netsys'
# make: *** [Makefile:23: all] Error 2
```