### PR TITLE
lablgtk is not compatible with ocaml-multicore

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.10/opam
+++ b/packages/lablgtk/lablgtk.2.18.10/opam
@@ -24,6 +24,9 @@ depopts: [
   "conf-glade"
   "lablgl"
 ]
+conflicts: [
+  "base-domains"
+]
 patches: ["lablgldir.patch"]
 post-messages: [
   "This package requires gtk+ 2.0 development packages installed on your system"

--- a/packages/lablgtk/lablgtk.2.18.11/opam
+++ b/packages/lablgtk/lablgtk.2.18.11/opam
@@ -23,6 +23,9 @@ depopts: [
   "conf-glade"
   "lablgl"
 ]
+conflicts: [
+  "base-domains"
+]
 patches: ["lablgldir.patch"]
 post-messages: [
   "This package requires gtk+ 2.0 development packages installed on your system"

--- a/packages/lablgtk3/lablgtk3.3.1.0/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.0/opam
@@ -21,6 +21,9 @@ depends: [
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
 ]
+conflicts: [
+  "base-domains"
+]
 
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]

--- a/packages/lablgtk3/lablgtk3.3.1.1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.1/opam
@@ -21,6 +21,9 @@ depends: [
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
 ]
+conflicts: [
+  "base-domains"
+]
 
 build: [
   [ "dune" "build" "-p" name "-j"  jobs ]


### PR DESCRIPTION
Segfaults on any use.
At the very least it uses `Obj.truncate` which is not compatible with ocaml-multicore:
```
#=== ERROR while compiling lablgtk3.3.1.1 =====================================#
# context              2.1.0 | linux/x86_64 | ocaml-variants.4.12.0+domains | file:///home/opam/opam-repository
# path                 ~/.opam/4.12+domains/.opam-switch/build/lablgtk3.3.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lablgtk3 -j 127
# exit-code            1
# env-file             ~/.opam/log/lablgtk3-19-cc69a1.env
# output-file          ~/.opam/log/lablgtk3-19-cc69a1.out
### output ###
# File "src/gtkMain.ml", line 49, characters 4-16:
# 49 |     Obj.truncate (Obj.repr Sys.argv) (Array.length argv) [@warnerror "-3"];
#          ^^^^^^^^^^^^
# Alert deprecated: Stdlib.Obj.truncate
```