### PR TITLE
[new release] mdx (1.11.1)

### DIFF
--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date.
+
+`ocaml-mdx` is released as two binaries called `ocaml-mdx` and `mdx` which are
+the same, mdx being the deprecated name, kept for now for compatibility."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.02.3"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-version" {>= "2.3.0"}
+  "odoc-parser" {>= "0.9.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/1.11.1/mdx-1.11.1.tbz"
+  checksum: [
+    "sha256=603990812efa7184d88a4896d7f9369b43d32e3dbdd26fe9cecb5a5f5f32c1e0"
+    "sha512=461bb3f2e25f8a2f869577ec8f95f731e0765a534043088fdc88ee9fabaa52926eb957124529ff889f1d698df594b235219c677521eebe01a5959c7db75131ea"
+  ]
+}
+x-commit-hash: "9292da3b88a1db17bf4f096b1d5010b30f1e20ac"

--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "csexp" {>= "1.3.2"}
   "astring"
   "logs" {>= "0.7.0"}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Added

- Make MDX compatible with OCaml 4.14 (realworldocaml/mdx#356, @NathanReb)
