### PR TITLE
ez_cmdliner 0.2: add lower bound on ocplib_stuff

### DIFF
--- a/packages/ez_cmdliner/ez_cmdliner.0.2.0/opam
+++ b/packages/ez_cmdliner/ez_cmdliner.0.2.0/opam
@@ -29,7 +29,7 @@ build: [
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
-  "ocplib_stuff" {}
+  "ocplib_stuff" {>= "0.3.0"}
   "ez_subst" {>= "0.1"}
   "cmdliner" {>= "1.0.0" & < "2.0.0"}
   "ppx_inline_test" {with-test}


### PR DESCRIPTION
Uses EzString.chop_prefix
Seen on https://github.com/ocaml/opam-repository/pull/20173

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>