### PR TITLE
[new release] ethernet (3.0.0)

### DIFF
--- a/packages/ethernet/ethernet.3.0.0/opam
+++ b/packages/ethernet/ethernet.3.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_cstruct"
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-profile" {>= "0.5"}
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v3.0.0/ethernet-v3.0.0.tbz"
+  checksum: [
+    "sha256=e95974f6363bd21e995a1c72ca03d09674c32ed2fbffada5aa82f096ee460929"
+    "sha512=171d061b16f2e00b9caa3dfc1cd9b5b358d380e892281ac5c137dc2a3119c3fa288ea927dcb4e9efbcf4850f6857ed0d4b754f56dbb248c1c6150779e57d24e4"
+  ]
+}
+x-commit-hash: "6c93d92d0363165729a4d1f51c63b43bc4987c3c"


### PR DESCRIPTION
OCaml Ethernet (IEEE 802.3) layer, used in MirageOS

- Project page: <a href="https://github.com/mirage/ethernet">https://github.com/mirage/ethernet</a>
- Documentation: <a href="https://mirage.github.io/ethernet/">https://mirage.github.io/ethernet/</a>

##### CHANGES:

* Include Mirage_protocols.ETHERNET module type in ethernet directly, remove
  dependency on mirage-protocols (mirage/ethernet#8 @hannesm)
* The ethernet library is now wrapped, this means a lot of API breakage.
  The most used binding, Ethernet_wire.sizeof_ethernet is now known as
  Ethernet.Packet.sizeof_ethernet. (mirage/ethernet#8 @hannesm)
