### PR TITLE
Package pyml_bindgen.0.1.2

### DIFF
--- a/packages/pyml_bindgen/pyml_bindgen.0.1.2/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.1.2/opam
@@ -36,7 +36,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & arch != "x86_32"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/pyml_bindgen/pyml_bindgen.0.1.2/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.1.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Generate pyml bindings from OCaml value specifications"
+maintainer: "Ryan M. Moore"
+authors: "Ryan M. Moore"
+license: "MIT"
+homepage: "https://github.com/mooreryan/ocaml_python_bindgen"
+doc: "https://mooreryan.github.io/ocaml_python_bindgen/"
+bug-reports: "https://github.com/mooreryan/ocaml_python_bindgen/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "angstrom" {>= "0.15.0"}
+  "base" {>= "v0.12"}
+  "cmdliner" {>= "1.0"}
+  "ppx_let" {>= "v0.12"}
+  "ppx_sexp_conv" {>= "v0.12"}
+  "ppx_string" {>= "v0.12"}
+  "re2" {>= "v0.12"}
+  "stdio" {>= "v0.12"}
+  "ocaml" {>= "4.08.0"}
+  "conf-python-3-dev" {>= "1" & with-test}
+  "core_kernel" {>= "v0.12" & with-test}
+  "ocamlformat" {>= "0.19.0" & < "0.20.0" & with-test}
+  "ppx_inline_test" {>= "v0.12" & with-test}
+  "ppx_expect" {>= "v0.12" & with-test}
+  "pyml" {with-test}
+  "bisect_ppx" {dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mooreryan/ocaml_python_bindgen.git"
+url {
+  src:
+    "https://github.com/mooreryan/ocaml_python_bindgen/archive/0.1.2.tar.gz"
+  checksum: [
+    "md5=133b36ac67fba4e34aaffc68857a5a6f"
+    "sha512=05d6eef8b446513245333bd0a8555575802a7e2ba6d6d09fcf09258abd057657ecdddf28fc9cbd5ed83833ba4f169eca40d886f4d7e213460ec6146999c02c23"
+  ]
+}


### PR DESCRIPTION
### `pyml_bindgen.0.1.2`
Generate pyml bindings from OCaml value specifications



---
* Homepage: https://github.com/mooreryan/ocaml_python_bindgen
* Source repo: git+https://github.com/mooreryan/ocaml_python_bindgen.git
* Bug tracker: https://github.com/mooreryan/ocaml_python_bindgen/issues

---
:camel: Pull-request generated by opam-publish v2.1.0