### PR TITLE
Fix ethernet.3.0.0’s revdeps

### DIFF
--- a/packages/arp/arp.2.3.1/opam
+++ b/packages/arp/arp.2.3.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random-test" {with-test & >= "0.1.0"}
   "bisect_ppx" {dev & >= "2.5.0"}
   "alcotest" {with-test & < "1.4.0"}
-  "ethernet" {with-test & >= "2.0.0"}
+  "ethernet" {with-test & >= "2.0.0" & < "3.0.0"}
   "fmt" {with-test}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/arp/arp.2.3.2/opam
+++ b/packages/arp/arp.2.3.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random-test" {with-test & >= "0.1.0"}
   "bisect_ppx" {dev & >= "2.5.0"}
   "alcotest" {with-test}
-  "ethernet" {with-test & >= "2.0.0"}
+  "ethernet" {with-test & >= "2.0.0" & < "3.0.0"}
   "fmt" {with-test}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.2/opam
+++ b/packages/tcpip/tcpip.3.7.2/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.3/opam
+++ b/packages/tcpip/tcpip.3.7.3/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.4/opam
+++ b/packages/tcpip/tcpip.3.7.4/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.5/opam
+++ b/packages/tcpip/tcpip.3.7.5/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.6/opam
+++ b/packages/tcpip/tcpip.3.7.6/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.7/opam
+++ b/packages/tcpip/tcpip.3.7.7/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -44,7 +44,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
   "alcotest" {with-test & >= "0.7.0"}

--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
 #  "mirage-flow" {with-test & >= "2.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}
 #  "alcotest" {with-test & >="0.7.0"}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -43,7 +43,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
 #  "mirage-flow" {with-test & >= "2.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}
 #  "alcotest" {with-test & >="0.7.0"}

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -42,7 +42,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
 #  "mirage-flow" {with-test & >= "2.0.0"}
 #  "mirage-vnetif" {with-test & >= "0.5.0"}
 #  "alcotest" {with-test & >="0.7.0"}

--- a/packages/tcpip/tcpip.5.0.1/opam
+++ b/packages/tcpip/tcpip.5.0.1/opam
@@ -42,7 +42,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -41,7 +41,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -46,7 +46,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0" & < "1.4.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -46,7 +46,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -46,7 +46,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}

--- a/packages/tcpip/tcpip.6.4.0/opam
+++ b/packages/tcpip/tcpip.6.4.0/opam
@@ -46,7 +46,7 @@ depends: [
   "logs" {>= "0.6.0"}
   "duration"
   "randomconv"
-  "ethernet" {>= "2.0.0"}
+  "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.5.0"}
   "alcotest" {with-test & >="0.7.0"}


### PR DESCRIPTION
Splitting the revdeps fixes from https://github.com/ocaml/opam-repository/pull/20190 to speed up the process