### PR TITLE
[new release] mula (0.1.2)

### DIFF
--- a/packages/mula/mula.0.1.2/opam
+++ b/packages/mula/mula.0.1.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "ML's Universal Levenshtein Automata library"
+description: "ML's radishal Universal Levenshtein Automata library."
+maintainer: ["Ifaz Kabir"]
+authors: ["Ifaz Kabir"]
+license: "CC0-1.0"
+homepage: "https://github.com/ifazk/mula"
+doc: "https://ifazk.github.io/mula/"
+bug-reports: "https://github.com/ifazk/mula/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08.1"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ifazk/mula.git"
+url {
+  src: "https://github.com/ifazk/mula/releases/download/0.1.2/mula-0.1.2.tbz"
+  checksum: [
+    "sha256=1f0ee42aca73e33459796baa26063bf82d290cb6f4c723d3e7c9a0e58f1e0d72"
+    "sha512=2158fb0cfd32b819141fca66ab29dbe480303191e744e617661aa39d772d03e2e158b4ca1ff4a8e18e9c1ea71cda10fe07b62df72beba04e29b289975f19f66e"
+  ]
+}
+x-commit-hash: "7aac9beed3e73f77b354c45d3ac006cc463fb503"


### PR DESCRIPTION
ML's Universal Levenshtein Automata library

- Project page: <a href="https://github.com/ifazk/mula">https://github.com/ifazk/mula</a>
- Documentation: <a href="https://ifazk.github.io/mula/">https://ifazk.github.io/mula/</a>

##### CHANGES:

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## 0.1.2 - 2021-12-10
### Added
- Main page for documentation now explain basic concepts and functionality and
  contains examples of using the library.

### Changed
- Optimizations
  - Now using an NFA that uses bitwise operations for transitions and requires less branching.

## 0.1.1 - 2021-06-23
### Added
- `ppx_inline_test` is now a test dependency, instead of a full dependency.
- Support OCaml > 4.08.1.
- Documentation and internal updates.

### Changed
- Optimizations
  - Improved subsumption for Demarau-Levenshtein
  - Early cutoff based on size difference for `Make.*.get_distance`.
  - Bit fiddling optimizations: `snoc_ones`, `snoc_zeros`.

## 0.1.0 - 2021-06-20

Initial release.
