### PR TITLE
Package iri.0.6.0

### DIFF
--- a/packages/iri/iri.0.6.0/opam
+++ b/packages/iri/iri.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["iri" "web" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri/"
+doc: "https://framagit.org/zoggy/ocaml-iri/"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "2.3"}
+  "uunf" {>= "0.9.7"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-iri/-/archive/0.6.0/ocaml-iri-0.6.0.tar.bz2"
+  checksum: [
+    "md5=40574cd88a7fc984adae1839fedb2b10"
+    "sha512=91cccd28a7e051ab4b8842f8dba6db2b7784e15d3f15c9d97ff64aefc40fce5d51b90b7ad996341da8b1f027ddff06e7c13e8d663c93fda864b2992447bf7454"
+  ]
+}


### PR DESCRIPTION
### `iri.0.6.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri/
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/issues

---
:camel: Pull-request generated by opam-publish v2.1.0