### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.0.7)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.0.7/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.7/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"              {with-test}
   "mirage-crypto-rng" {with-test}
   "mirage-time-unix"  {with-test}
-  "tcpip"             {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}
   "lwt"               {with-test}
   "astring"           {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.0.7/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.7/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.7/paf-0.0.7.tbz"
+  checksum: [
+    "sha256=ad2f045877bc2908083da0ccb0e7baaf2f120eb1f14f3945f6f309b803a65ce8"
+    "sha512=8fa8a6b9f0728e6bda58a03921cad1427ecf3ecb0b3863d3c9724f02ff40a344b89c6892b6a692faeb398d067d6aeb7c62bb54a6da42f918d55b9d4eb272bffd"
+  ]
+}
+x-commit-hash: "b9acef214351015668ef1d54c1ec4f52a41adab6"

--- a/packages/paf-le/paf-le.0.0.7/opam
+++ b/packages/paf-le/paf-le.0.0.7/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-stack"
+  "mirage-time"
+  "tls-mirage"
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.7/paf-0.0.7.tbz"
+  checksum: [
+    "sha256=ad2f045877bc2908083da0ccb0e7baaf2f120eb1f14f3945f6f309b803a65ce8"
+    "sha512=8fa8a6b9f0728e6bda58a03921cad1427ecf3ecb0b3863d3c9724f02ff40a344b89c6892b6a692faeb398d067d6aeb7c62bb54a6da42f918d55b9d4eb272bffd"
+  ]
+}
+x-commit-hash: "b9acef214351015668ef1d54c1ec4f52a41adab6"

--- a/packages/paf/paf.0.0.7/opam
+++ b/packages/paf/paf.0.0.7/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {with-test}
   "fmt" {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "mirage-time-unix" {with-test}
   "ptime" {with-test}
   "uri" {with-test}

--- a/packages/paf/paf.0.0.7/opam
+++ b/packages/paf/paf.0.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "mirage-stack" {>= "3.0.0"}
+  "mirage-time"
+  "tls-mirage" {>= "0.15.0"}
+  "mimic"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "tcpip" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.7/paf-0.0.7.tbz"
+  checksum: [
+    "sha256=ad2f045877bc2908083da0ccb0e7baaf2f120eb1f14f3945f6f309b803a65ce8"
+    "sha512=8fa8a6b9f0728e6bda58a03921cad1427ecf3ecb0b3863d3c9724f02ff40a344b89c6892b6a692faeb398d067d6aeb7c62bb54a6da42f918d55b9d4eb272bffd"
+  ]
+}
+x-commit-hash: "b9acef214351015668ef1d54c1ec4f52a41adab6"

--- a/packages/paf/paf.0.0.7/opam
+++ b/packages/paf/paf.0.0.7/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "mirage-stack" {>= "3.0.0"}
-  "mirage-time"
+  "mirage-time" {>= "2.0.0"} 
   "tls-mirage" {>= "0.15.0"}
   "mimic"
   "ke" {>= "0.4"}

--- a/packages/paf/paf.0.0.7/opam
+++ b/packages/paf/paf.0.0.7/opam
@@ -31,6 +31,7 @@ depends: [
   "faraday" {>= "0.7.2"}
   "tls" {>= "0.15.0"}
   "cstruct" {>= "6.0.0"}
+  "mirage-protocols" {>= "7.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Avoid `astring` dependency (@dinosaure, dinosaure/paf-le-chien#45)
- Remove `rresult` dependency (@hannesm, @dinosaure, dinosaure/paf-le-chien#47)
- Upgrade the code-base with `mirage-stack.3.0.0` (@dinosaure, dinosaure/paf-le-chien#49)
- Update ALPN module without GADT (@dinosaure, dinosaure/paf-le-chien#50)
