### PR TITLE
[new release] tcpip (7.0.0)

### DIFF
--- a/packages/tcpip/tcpip.7.0.0/opam
+++ b/packages/tcpip/tcpip.7.0.0/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "result" {< "1.5"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "ppx_cstruct"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "ipaddr-cstruct" {with-test}
+  "lru" {>= "0.3.0"}
+  "metrics"
+]
+depopts: [
+  "ocaml-freestanding"
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v7.0.0/tcpip-v7.0.0.tbz"
+  checksum: [
+    "sha256=42242a10e9d4f34cb5df739c96eb8124041485a65893ec37b01b8fd4aa360026"
+    "sha512=8d1ca9053b2addb8880264bee122f2c0d37404903e044c86f73e3707654a25d744ae398231562f59b3375031db7997e5111c4b7fbb3a5e11758b3d3261c89a49"
+  ]
+}
+x-commit-hash: "3ab30ab7b43dede75abf7b37838e051e0ddbb23a"


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Fix memory leak in processing RST packets (mirage/mirage-tcpip#460 @balrajsingh, reported in
  mirage/mirage-tcpip#456 by @dinosaure)
* Move module types (IP, UDP, TCP, STACK, ICMP) into tcpip core library
  (mirage/mirage-tcpip#463 @hannesm)
* API breakage: Tcpip_checksum is now part of tcpip.checksum (used to be
  part of tcpip mirage/mirage-tcpip#463 @hannesm)
* API breakage: tcpip.unix has been removed (mirage/mirage-tcpip#463 @hannesm)
* Use Lwt.pause instead of deprecated Lwt_{unix,main}.yield (mirage/mirage-tcpip#461 @dinosaure)
