### PR TITLE
add upper bounds for tcpip 7.0.0:

### DIFF
--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {>= "6.0.0" & with-test}
+  "tcpip" {>= "6.0.0" & < "7.0.0" & with-test}
   "mirage-vnetif" {with-test}
   "mirage-crypto-rng" {>= "0.7.0" & with-test}
   "dune" {>= "2.0"}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.1/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {>= "6.0.0" & with-test}
+  "tcpip" {>= "6.0.0" & < "7.0.0" & with-test}
   "mirage-vnetif" {with-test}
   "mirage-crypto-rng" {>= "0.7.0" & with-test}
   "dune" {>= "2.0"}

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2/opam
@@ -23,7 +23,7 @@ depends: [
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "io-page-unix" {with-test}
-  "tcpip" {>= "6.0.0" & with-test}
+  "tcpip" {>= "6.0.0" & < "7.0.0" & with-test}
   "mirage-vnetif" {with-test}
   "mirage-crypto-rng" {>= "0.7.0" & with-test}
   "dune" {>= "2.0"}

--- a/packages/charrua/charrua.1.0.0/opam
+++ b/packages/charrua/charrua.1.0.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "dune"
+  "dune" {>= "1.2"}
   "ppx_sexp_conv" {>= "v0.10.0" & < "v0.15"}
   "ppx_cstruct"
   "ocaml"         {>= "4.04.2"}

--- a/packages/charrua/charrua.1.0.0/opam
+++ b/packages/charrua/charrua.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "sexplib"       {< "v0.15"}
   "ipaddr"        {>= "3.0.0" & < "4.0.0"}
   "macaddr"
-  "ethernet"      {>= "2.0.0"}
+  "ethernet"      {>= "2.0.0" & < "3.0.0"}
   "tcpip"         {>= "3.7.0" & < "5.0.0"}
   "rresult"
 ]

--- a/packages/charrua/charrua.1.1.0/opam
+++ b/packages/charrua/charrua.1.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.0.0"}
+  "ethernet"      {>= "2.0.0" & < "3.0.0"}
   "tcpip"         {>= "3.7.0" & < "5.0.0"}
   "rresult"
 ]

--- a/packages/charrua/charrua.1.2.0/opam
+++ b/packages/charrua/charrua.1.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.2.0"}
+  "ethernet"      {>= "2.2.0" & < "3.0.0"}
   "tcpip"         {>= "4.0.0" & < "5.0.0"}
   "rresult"
 ]

--- a/packages/charrua/charrua.1.2.1/opam
+++ b/packages/charrua/charrua.1.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.2.0"}
+  "ethernet"      {>= "2.2.0" & < "3.0.0"}
   "tcpip"         {>= "4.0.0" & < "5.0.0"}
   "rresult"
 ]

--- a/packages/charrua/charrua.1.2.2/opam
+++ b/packages/charrua/charrua.1.2.2/opam
@@ -23,8 +23,8 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.2.0"}
-  "tcpip"         {>= "5.0.0"}
+  "ethernet"      {>= "2.2.0" & < "3.0.0"}
+  "tcpip"         {>= "5.0.0" & < "7.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/charrua/charrua.1.3.0/opam
+++ b/packages/charrua/charrua.1.3.0/opam
@@ -23,8 +23,8 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.2.0"}
-  "tcpip"         {>= "5.0.0"}
+  "ethernet"      {>= "2.2.0" & < "3.0.0"}
+  "tcpip"         {>= "5.0.0" & < "7.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/charrua/charrua.1.4.0/opam
+++ b/packages/charrua/charrua.1.4.0/opam
@@ -23,8 +23,8 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.2.0"}
-  "tcpip"         {>= "5.0.0"}
+  "ethernet"      {>= "2.2.0" & < "3.0.0"}
+  "tcpip"         {>= "5.0.0" & < "7.0.0"}
   "rresult"
 ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/charrua/charrua.1.4.1/opam
+++ b/packages/charrua/charrua.1.4.1/opam
@@ -23,8 +23,8 @@ depends: [
   "macaddr"       {>= "4.0.0"}
   "ipaddr-sexp"
   "macaddr-sexp"
-  "ethernet"      {>= "2.2.0"}
-  "tcpip"         {>= "5.0.0"}
+  "ethernet"      {>= "2.2.0" & < "3.0.0"}
+  "tcpip"         {>= "5.0.0" & < "7.0.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 synopsis: "DHCP wire frame encoder and decoder"

--- a/packages/frenetic/frenetic.5.0.5/opam
+++ b/packages/frenetic/frenetic.5.0.5/opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "sedlex" {>= "2.4" }
   "sexplib" {>= "v0.14.0"}
-  "tcpip" {>= "6.3.0"}
+  "tcpip" {>= "6.3.0" & < "7.0.0"}
   "yojson" {>= "1.7.0"}
 ]
 url {

--- a/packages/mirage-nat/mirage-nat.1.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_deriving" {build & >= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "3.7.0" & < "4.0.0"}
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "arp"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.1.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock-unix" {with-test}
 ]
 synopsis:
-  "library for network address translation intended for use with mirage unikernels"
+  "Library for network address translation intended for use with mirage unikernels"
 url {
   src:
     "https://github.com/mirage/mirage-nat/releases/download/v1.1.0/mirage-nat-v1.1.0.tbz"

--- a/packages/mirage-nat/mirage-nat.1.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ppx_deriving" {build & >= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "3.7.2" & < "4.0.0" }
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "arp"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "3.7.9" & < "4.1.0" }
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "arp"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "4.1.0" & < "6.0.0" }
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.0/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "4.1.0" & < "6.0.0"}
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.1/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "4.1.0" & < "6.0.0"}
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.2/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.2/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "4.1.0" & < "6.0.0"}
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.3/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "4.1.0" & < "6.3.0"}
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "stdlib-shims"
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.2.2.4/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.4/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving" {>= "4.2" }
   "dune" {>= "1.0"}
   "tcpip" { >= "4.1.0" }
-  "ethernet" { >= "2.0.0" }
+  "ethernet" { >= "2.0.0" & < "3.0.0" }
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}
   "fmt" {with-test & >= "0.8.7"}

--- a/packages/mirage-protocols/mirage-protocols.1.3.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.3.0/opam
@@ -21,6 +21,7 @@ depends: [
   "fmt"
   "duration"
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to be used as MirageOS network implementations should implement.

--- a/packages/mirage-protocols/mirage-protocols.1.4.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.4.0/opam
@@ -21,6 +21,7 @@ depends: [
   "fmt"
   "duration"
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to be used as MirageOS network implementations should implement.

--- a/packages/mirage-protocols/mirage-protocols.1.4.1/opam
+++ b/packages/mirage-protocols/mirage-protocols.1.4.1/opam
@@ -21,6 +21,7 @@ depends: [
   "fmt"
   "duration"
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """\
 

--- a/packages/mirage-protocols/mirage-protocols.2.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.2.0.0/opam
@@ -22,6 +22,7 @@ depends: [
   "fmt"
   "duration"
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.3.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.3.0.0/opam
@@ -22,6 +22,7 @@ depends: [
   "fmt"
   "duration"
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.3.1.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.3.1.0/opam
@@ -22,6 +22,7 @@ depends: [
   "fmt"
   "duration"
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.4.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.4.0.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ipaddr" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.4.0.1/opam
+++ b/packages/mirage-protocols/mirage-protocols.4.0.1/opam
@@ -24,6 +24,7 @@ depends: [
   "ipaddr" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.5.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.5.0.0/opam
@@ -24,6 +24,7 @@ depends: [
   "ipaddr" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.6.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.6.0.0/opam
@@ -25,6 +25,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "cstruct" {>= "6.0.0"}
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/mirage-protocols/mirage-protocols.7.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.7.0.0/opam
@@ -24,6 +24,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "cstruct" {>= "6.0.0"}
 ]
+conflicts: [ "tcpip" {>= "7.0.0"} ]
 synopsis: "MirageOS signatures for network protocols"
 description: """
 mirage-protocols provides a set of module types which libraries intended to

--- a/packages/tcpip/tcpip.3.4.2/opam
+++ b/packages/tcpip/tcpip.3.4.2/opam
@@ -45,7 +45,7 @@ depends: [
   "randomconv"
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/tcpip/tcpip.3.4.2/opam
+++ b/packages/tcpip/tcpip.3.4.2/opam
@@ -37,7 +37,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "logs" {>= "0.6.0"}
   "duration"

--- a/packages/tcpip/tcpip.3.5.0/opam
+++ b/packages/tcpip/tcpip.3.5.0/opam
@@ -46,7 +46,7 @@ depends: [
   "randomconv"
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/tcpip/tcpip.3.5.0/opam
+++ b/packages/tcpip/tcpip.3.5.0/opam
@@ -38,7 +38,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "logs" {>= "0.6.0"}
   "duration"

--- a/packages/tcpip/tcpip.3.5.1/opam
+++ b/packages/tcpip/tcpip.3.5.1/opam
@@ -38,7 +38,7 @@ depends: [
   "mirage-time-lwt" {>= "1.0.0"}
   "ipaddr" {>= "2.2.0" & < "3.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "logs" {>= "0.6.0"}
   "duration"

--- a/packages/tcpip/tcpip.3.5.1/opam
+++ b/packages/tcpip/tcpip.3.5.1/opam
@@ -46,7 +46,7 @@ depends: [
   "randomconv"
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.6.0/opam
+++ b/packages/tcpip/tcpip.3.6.0/opam
@@ -39,7 +39,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "logs" {>= "0.6.0"}
   "duration"

--- a/packages/tcpip/tcpip.3.6.0/opam
+++ b/packages/tcpip/tcpip.3.6.0/opam
@@ -47,7 +47,7 @@ depends: [
   "randomconv"
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -49,7 +49,7 @@ depends: [
   "ethernet" {< "2.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.0/opam
+++ b/packages/tcpip/tcpip.3.7.0/opam
@@ -39,7 +39,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.1/opam
+++ b/packages/tcpip/tcpip.3.7.1/opam
@@ -38,7 +38,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.2/opam
+++ b/packages/tcpip/tcpip.3.7.2/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.2/opam
+++ b/packages/tcpip/tcpip.3.7.2/opam
@@ -38,7 +38,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.3/opam
+++ b/packages/tcpip/tcpip.3.7.3/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.3/opam
+++ b/packages/tcpip/tcpip.3.7.3/opam
@@ -38,7 +38,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.4/opam
+++ b/packages/tcpip/tcpip.3.7.4/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.4/opam
+++ b/packages/tcpip/tcpip.3.7.4/opam
@@ -38,7 +38,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.5/opam
+++ b/packages/tcpip/tcpip.3.7.5/opam
@@ -37,7 +37,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.5/opam
+++ b/packages/tcpip/tcpip.3.7.5/opam
@@ -46,7 +46,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.6/opam
+++ b/packages/tcpip/tcpip.3.7.6/opam
@@ -37,7 +37,7 @@ depends: [
   "ipaddr" {>= "3.0.0"}
   "macaddr" {< "4.0.0"}
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.6/opam
+++ b/packages/tcpip/tcpip.3.7.6/opam
@@ -46,7 +46,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.7/opam
+++ b/packages/tcpip/tcpip.3.7.7/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.7/opam
+++ b/packages/tcpip/tcpip.3.7.7/opam
@@ -38,7 +38,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.8/opam
+++ b/packages/tcpip/tcpip.3.7.8/opam
@@ -38,7 +38,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -47,7 +47,7 @@ depends: [
   "ethernet" {>= "2.0.0" & < "3.0.0"}
   "mirage-flow" {with-test & >= "1.2.0" & < "2.0.0"}
   "mirage-vnetif" {with-test & >= "0.4.0"}
-  "alcotest" {with-test & >= "0.7.0"}
+  "alcotest" {with-test & >= "0.7.0" & < "1.4.0"}
   "pcap-format" {with-test}
   "mirage-clock-unix" {with-test & >= "1.2.0"}
   "mirage-random-test" {with-test}

--- a/packages/tcpip/tcpip.3.7.9/opam
+++ b/packages/tcpip/tcpip.3.7.9/opam
@@ -38,7 +38,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "3.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0" & < "4.0.0"}
   "mirage-protocols" {>= "4.0.0" & < "5.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "4.0.0"}

--- a/packages/tcpip/tcpip.4.0.0/opam
+++ b/packages/tcpip/tcpip.4.0.0/opam
@@ -37,7 +37,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0" & < "5.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0" & < "4.0.0"}
   "mirage-protocols" {>= "4.0.0" & < "5.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "4.0.0"}

--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -37,7 +37,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.0.0" & < "4.0.0"}
   "mirage-protocols" {>= "4.0.0" & < "5.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -36,7 +36,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.5.0.1/opam
+++ b/packages/tcpip/tcpip.5.0.1/opam
@@ -36,7 +36,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.5.0.1/opam
+++ b/packages/tcpip/tcpip.5.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.1.0"}
+  "mirage-stack" {>= "2.1.0" & < "4.0.0"}
   "mirage-protocols" {>= "4.0.0" & < "5.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/tcpip/tcpip.6.0.0/opam
+++ b/packages/tcpip/tcpip.6.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/tcpip/tcpip.6.1.0/opam
+++ b/packages/tcpip/tcpip.6.1.0/opam
@@ -40,7 +40,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -33,7 +33,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/tcpip/tcpip.6.2.0/opam
+++ b/packages/tcpip/tcpip.6.2.0/opam
@@ -40,7 +40,7 @@ depends: [
   "macaddr" {>="4.0.0"}
   "macaddr-cstruct"
   "mirage-profile" {>= "0.5"}
-  "fmt"
+  "fmt" {>= "0.8.0"}
   "lwt" {>= "4.0.0"}
   "lwt-dllist"
   "logs" {>= "0.6.0"}

--- a/packages/tcpip/tcpip.6.3.0/opam
+++ b/packages/tcpip/tcpip.6.3.0/opam
@@ -33,7 +33,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-protocols" {>= "5.0.0" & < "6.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}

--- a/packages/tcpip/tcpip.6.4.0/opam
+++ b/packages/tcpip/tcpip.6.4.0/opam
@@ -33,8 +33,8 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-random" {>= "2.0.0"}
-  "mirage-stack" {>= "2.2.0"}
-  "mirage-protocols" {>= "6.0.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
+  "mirage-protocols" {>= "6.0.0" & < "8.0.0"}
   "mirage-time" {>= "2.0.0"}
   "ipaddr" {>= "5.0.0"}
   "macaddr" {>="4.0.0"}


### PR DESCRIPTION
- frenetic (tcpip.unix no longer exists)
- capnpn-rpc-mirage (tcpip.unix no longer exists)
- charrua (ethernet 3.0.0 no longer provides Ethernet_wire.sizeof_ethernet)
- mirage-nat (ethernet 3.0.0 no longer provides Ethernet_wire.sizeof_ethernet)
- ~~paf, paf-cohttp: ill-typed functor application
  (since Mirage_protocols.Keepalive is now Tcpip.Tcp.Keepalive)~~

this is reverse dependency fixes for #20201 