### PR TITLE
arp, arp-mirage, ethernet: add upper bounds for mirage-protocols 8.0.0

### DIFF
--- a/packages/arp-mirage/arp-mirage.2.2.0/opam
+++ b/packages/arp-mirage/arp-mirage.2.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-time" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "lwt"
   "lwt" {with-test & < "5.0.0"}
   "duration"

--- a/packages/arp-mirage/arp-mirage.2.2.1/opam
+++ b/packages/arp-mirage/arp-mirage.2.2.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-time" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "lwt"
   "duration"
   "arp" {= version}

--- a/packages/arp/arp.2.3.1/opam
+++ b/packages/arp/arp.2.3.1/opam
@@ -15,7 +15,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "logs"
   "mirage-time" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "lwt"
   "duration"
   "mirage-profile" {>= "0.9"}

--- a/packages/arp/arp.2.3.2/opam
+++ b/packages/arp/arp.2.3.2/opam
@@ -15,7 +15,7 @@ depends: [
   "macaddr" {>= "4.0.0"}
   "logs"
   "mirage-time" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "lwt"
   "duration"
   "mirage-profile" {>= "0.9"}

--- a/packages/ethernet/ethernet.2.2.0/opam
+++ b/packages/ethernet/ethernet.2.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "cstruct" {>= "3.0.2"}
   "ppx_cstruct"
   "mirage-net" {>= "3.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "macaddr" {>= "4.0.0"}
   "mirage-profile" {>= "0.5"}
   "fmt"

--- a/packages/ethernet/ethernet.2.2.1/opam
+++ b/packages/ethernet/ethernet.2.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "ppx_cstruct"
   "mirage-net" {>= "3.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "macaddr" {>= "4.0.0"}
   "mirage-profile" {>= "0.5"}
   "lwt" {>= "3.0.0"}


### PR DESCRIPTION
to avoid failures (dependency inversion in the upcoming release)