### PR TITLE
paf, paf-cohttp, conduit-mirage: all require tcpip 6.0.0+

### DIFF
--- a/packages/conduit-mirage/conduit-mirage.2.3.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.2.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ca-certs-nss"
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
 ]
 conflicts: [
   "mirage-conduit"

--- a/packages/conduit-mirage/conduit-mirage.3.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.3.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml"       {>= "4.07.0"}
   "dune"        {>= "2.0.0"}
   "conduit"     {= version}
-  "tcpip"
+  "tcpip"       {>= "6.0.0"}
   "mirage-flow"
   "mirage-time"
   "dns-client"  {>= "4.6.0" & < "5.0.0"}

--- a/packages/conduit-mirage/conduit-mirage.4.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ca-certs-nss"
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
 ]
 conflicts: [
   "mirage-conduit"

--- a/packages/conduit-mirage/conduit-mirage.4.0.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "ca-certs-nss"
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
 ]
 conflicts: [
   "mirage-conduit"

--- a/packages/conduit-mirage/conduit-mirage.4.0.2/opam
+++ b/packages/conduit-mirage/conduit-mirage.4.0.2/opam
@@ -28,7 +28,7 @@ depends: [
   "ca-certs-nss"
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
 ]
 conflicts: [
   "mirage-conduit"

--- a/packages/conduit-mirage/conduit-mirage.5.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.5.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ca-certs-nss"
   "ipaddr" {>= "3.0.0"}
   "ipaddr-sexp"
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "fmt" {>= "0.8.7"}
 ]
 conflicts: [

--- a/packages/paf-cohttp/paf-cohttp.0.0.4/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"              {with-test}
   "mirage-crypto-rng" {with-test}
   "mirage-time-unix"  {with-test}
-  "tcpip"             {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}
   "lwt"               {with-test}
 ]

--- a/packages/paf-cohttp/paf-cohttp.0.0.5/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"              {with-test}
   "mirage-crypto-rng" {with-test}
   "mirage-time-unix"  {with-test}
-  "tcpip"             {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}
   "lwt"               {with-test}
 ]

--- a/packages/paf-cohttp/paf-cohttp.0.0.6/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"              {with-test}
   "mirage-crypto-rng" {with-test}
   "mirage-time-unix"  {with-test}
-  "tcpip"             {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}
   "lwt"               {with-test}
 ]

--- a/packages/paf/paf.0.0.1/opam
+++ b/packages/paf/paf.0.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "logs"              {with-test}
   "fmt"               {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip"             {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
   "mirage-time-unix"  {with-test}
   "ptime"             {with-test}
   "uri"               {with-test}

--- a/packages/paf/paf.0.0.2/opam
+++ b/packages/paf/paf.0.0.2/opam
@@ -24,7 +24,7 @@ depends: [
   "logs" {with-test}
   "fmt" {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "mirage-time-unix" {with-test}
   "ptime" {with-test}
   "uri" {with-test}

--- a/packages/paf/paf.0.0.3/opam
+++ b/packages/paf/paf.0.0.3/opam
@@ -24,7 +24,7 @@ depends: [
   "logs" {with-test}
   "fmt" {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "mirage-time-unix" {with-test}
   "ptime" {with-test}
   "uri" {with-test}

--- a/packages/paf/paf.0.0.4/opam
+++ b/packages/paf/paf.0.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {with-test}
   "fmt" {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "mirage-time-unix" {with-test}
   "ptime" {with-test}
   "uri" {with-test}

--- a/packages/paf/paf.0.0.5/opam
+++ b/packages/paf/paf.0.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {with-test}
   "fmt" {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "mirage-time-unix" {with-test}
   "ptime" {with-test}
   "uri" {with-test}

--- a/packages/paf/paf.0.0.6/opam
+++ b/packages/paf/paf.0.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "logs" {with-test}
   "fmt" {with-test}
   "mirage-crypto-rng" {with-test}
-  "tcpip" {with-test}
+  "tcpip" {with-test & >= "6.0.0"}
   "mirage-time-unix" {with-test}
   "ptime" {with-test}
   "uri" {with-test}


### PR DESCRIPTION
earlier releases do not contain the Tcpip_stack_socket.{V4,V6,V4V6} modules

see #20204 where the failures occured