### PR TITLE
Sundials/ML v5.8.0p0

### DIFF
--- a/packages/conf-sundials/conf-sundials.2/files/test.c
+++ b/packages/conf-sundials/conf-sundials.2/files/test.c
@@ -1,0 +1,1 @@
+#include <sundials/sundials_config.h>

--- a/packages/conf-sundials/conf-sundials.2/opam
+++ b/packages/conf-sundials/conf-sundials.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://computing.llnl.gov/projects/sundials"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "Sundials dev team"
+license: "BSD-3-Clause"
+build: ["cc" "-E" "test.c"]
+depexts: [
+  ["libsundials-dev"] {(os-family = "debian" | os-family = "ubuntu") & os-distribution != "debian" & os-distribution != "ubuntu"}
+  ["libsundials-dev"] {os-distribution = "debian" & os-version >= "10"}
+  ["libsundials-dev"] {os-distribution = "ubuntu" & os-version >= "18.04"}
+  ["libsundials-serial-dev"] {os-distribution = "debian" & os-version < "10"}
+  ["libsundials-serial-dev"] {os-distribution = "ubuntu" & os-version < "18.04"}
+  ["suitesparse-devel" "sundials-devel"] {os-distribution = "fedora"}
+  ["epel-release" "lapack-devel" "suitesparse-devel" "sundials-devel"] {os-distribution = "centos"}
+  ["sundials-devel"] {os-distribution = "rhel"}
+  ["sundials-devel"] {os-distribution = "ol"}
+  ["lapack-devel" "suitesparse-devel" "sundials-devel"] {os-family = "suse"}
+  ["sundials"] {os-family = "arch"}
+  ["sci-libs/sundials"] {os-family = "gentoo"}
+  ["sundials"] {os = "macos" & os-distribution = "homebrew"}
+  ["sundials" "SuiteSparse_config"] {os = "macos" & os-distribution = "macports"}
+  ["sundials"] {os = "freebsd"}
+  ["sundials"] {os = "openbsd"}
+  ["sundials"] {os = "netbsd"}
+]
+x-ci-accept-failures: [
+  "alpine-3.12" # package not available by default
+  "alpine-3.13" # package not available by default
+  "alpine-3.14" # package not available by default
+  "oraclelinux-7" # requires addition of epel-release repos
+  "oraclelinux-8" # requires addition of epel-release repos
+]
+extra-files: [
+  ["test.c" "md5=00a7c58d130f4aabfec5fe37aff9907e"]
+]
+synopsis: "Virtual package relying on sundials"
+description:
+  "This package can only install if the sundials library is installed on the system."
+flags: conf

--- a/packages/sundialsml/sundialsml.5.8.0p0/opam
+++ b/packages/sundialsml/sundialsml.5.8.0p0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer: "tim@tbrk.org"
+authors: [
+    "Timothy Bourke <tim@tbrk.org>"
+    "Jun Inoue <Jun.Lambda@gmail.com>"
+    "Marc Pouzet <Marc.Pouzet@ens.fr>"
+]
+homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
+dev-repo: "git+https://github.com/inria-parkas/sundialsml"
+doc: "http://inria-parkas.github.io/sundialsml/"
+tags: [
+    "numerical"
+    "simulation"
+    "mathematics"
+    "science"
+]
+license: "BSD-3-Clause"
+build: [
+    ["./configure" "--stubdir=%{stublibs}%/"
+		   "--libdir=%{lib}%/"
+		   "--docdir=%{doc}%/sundialsml/"
+		   "--os-distribution=%{os-distribution}%"]
+    [make "-j%{jobs}%"]
+    [make "doc"] {with-doc}
+]
+install: [
+  [make "install-findlib"]
+  [make "install-doc"] {with-doc}
+]
+remove: [
+    ["ocamlfind" "remove" "sundialsml"]
+    ["rm" "-rf" "%{doc}%/sundialsml"]
+]
+depends: [
+    "ocaml" {>= "4.03.0"}
+    "base-bigarray"
+    "ocamlfind" {build}
+    "conf-sundials" {build}
+]
+depopts: [
+    "mpi"
+]
+synopsis: "Interface to the Sundials suite of numerical solvers"
+description: """
+Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
+ARKODE, and KINSOL. This interface provides access to all features of the
+underlying library except the Hypre and PETSC nvectors.
+
+The structure of the OCaml interface mostly follows that of the original
+library, both for ease of reading the existing documentation and for
+converting existing source code, but several changes have been made for
+programming convenience and to increase safety, namely:
+
+- solver sessions are mostly configured via algebraic data types rather than
+  multiple function calls;
+
+- errors are signalled by exceptions not return codes (also from
+  user-supplied callback routines);
+
+- user data is shared between callback routines via closures (partial
+  applications of functions);
+
+- vectors are checked for compatibility with a session (using a combination
+  of static and dynamic checks), and;
+
+- explicit free commands are not necessary since OCaml is a
+  garbage-collected language.
+
+The detailed OCaml documentation contains cross-links to the original
+documentation. OCaml versions of the standard examples usually have an
+overhead of about 30% compared to the original C versions, and only rarely
+more than 50%."""
+url {
+  src: "https://github.com/inria-parkas/sundialsml/archive/refs/tags/v5.8.0p0.zip"
+  checksum: "md5=46bce6084b7cc70b368add49aa1dd68b"
+}

--- a/packages/sundialsml/sundialsml.5.8.0p0/opam
+++ b/packages/sundialsml/sundialsml.5.8.0p0/opam
@@ -36,12 +36,13 @@ depends: [
     "ocaml" {>= "4.03.0"}
     "base-bigarray"
     "ocamlfind" {build}
-    "conf-sundials" {build}
+    "conf-sundials" {>= "2" & build}
 ]
 depopts: [
     "mpi"
 ]
 synopsis: "Interface to the Sundials suite of numerical solvers"
+conflicts: ["base-domains"]
 description: """
 Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
 ARKODE, and KINSOL. This interface provides access to all features of the
@@ -72,6 +73,6 @@ documentation. OCaml versions of the standard examples usually have an
 overhead of about 30% compared to the original C versions, and only rarely
 more than 50%."""
 url {
-  src: "https://github.com/inria-parkas/sundialsml/archive/refs/tags/v5.8.0p0.zip"
-  checksum: "md5=46bce6084b7cc70b368add49aa1dd68b"
+  src: "https://github.com/inria-parkas/sundialsml/archive/refs/tags/v5.8.0p0.tar.gz"
+  checksum: "md5=86b07c66f5190188725ad8ed3d78f181"
 }


### PR DESCRIPTION
Upgrade to the latest release of Sundials/ML which supports versions 2.7.0 to 5.8.0 inclusive of the Sundials suite of numerical solvers from LLNL.