### PR TITLE
bls12-381-legacy 0.4.4

### DIFF
--- a/packages/bls12-381-gen/bls12-381-gen.0.4.4/opam
+++ b/packages/bls12-381-gen/bls12-381-gen.0.4.4/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Functors to generate BLS12-381 primitives based on stubs"
+description: "Functors to generate BLS12-381 primitives based on stubs"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.4-legacy/ocaml-bls12-381-0.4.4-legacy.tar.bz2"
+  checksum: [
+    "md5=a2051b5842a2deeb10ad99c57a7ea443"
+    "sha512=3e2669baf621304bbe14bcb53ab128d01577b98f13bec497953328c8605c9dc5667c873b680e087dd240362ee77b0f15d1d4bbe60dd67a2dc4b8b64838189d6a"
+  ]
+}

--- a/packages/bls12-381-legacy/bls12-381-legacy.0.4.4/opam
+++ b/packages/bls12-381-legacy/bls12-381-legacy.0.4.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "UNIX version of BLS12-381 primitives. Not implementating the virtual package bls12-381"
+description:
+  "This package should only be used if newer versions of bls12-381 conflict with this version. This package should be considered as legacy and should never be used."
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "conf-rust" {build}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.18.0" & < "0.19.0"}
+  "bls12-381-gen" {= version}
+  "tezos-rust-libs" {= "1.1"}
+  "alcotest" {with-test}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.4-legacy/ocaml-bls12-381-0.4.4-legacy.tar.bz2"
+  checksum: [
+    "md5=a2051b5842a2deeb10ad99c57a7ea443"
+    "sha512=3e2669baf621304bbe14bcb53ab128d01577b98f13bec497953328c8605c9dc5667c873b680e087dd240362ee77b0f15d1d4bbe60dd67a2dc4b8b64838189d6a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bls12-381-legacy.0.4.4`: UNIX version of BLS12-381 primitives. Not implementating the virtual package bls12-381

See branch [legacy](https://gitlab.com/dannywillems/ocaml-bls12-381/-/tree/legacy)
Simply removing ctypes-foreign dependency from 0.4.3.

---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.1.0