### PR TITLE
Update archive links of old codes

### DIFF
--- a/packages/config-file/config-file.1.1/opam
+++ b/packages/config-file/config-file.1.1/opam
@@ -14,7 +14,6 @@ depends: ["ocaml" "ocamlfind" "camlp4"]
 install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 url {
-  src:
-    "https://download.ocamlcore.org/config-file/config_file/1.1/config-file-1.1.tar.gz"
-  checksum: "md5=7bc051234ceb29ffd5823ee6bcffe19c"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/config-file-1.1/old-codes-config-file-1.1.tar.gz"
+  checksum: "md5=77b0e72a15fe22868c6eceb8ba1f7325"
 }

--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -19,7 +19,6 @@ install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 flags: light-uninstall
 url {
-  src:
-    "https://download.ocamlcore.org/config-file/config_file/1.2/config-file-1.2.tar.gz"
-  checksum: "md5=fece1f143285fb5fddf17d5d36a577c5"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/config-file-1.2/old-codes-config-file-1.2.tar.gz"
+  checksum: "md5=2f3679799ae8e3bc67847a204aae71c9"
 }

--- a/packages/dbforge/dbforge.2.0.1/opam
+++ b/packages/dbforge/dbforge.2.0.1/opam
@@ -31,6 +31,6 @@ synopsis:
   "A tool to describe database schemas and generate OCaml code to access these databases."
 extra-files: ["dbforge.install" "md5=9f4defb2eb0a5be350e947226ac51657"]
 url {
-  src: "https://zoggy.github.io/dbforge/dbforge-2.0.1.tar.gz"
-  checksum: "md5=0eba41e65fb5f802db9618ca38202af2"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/dbforge-2.0.1/old-codes-dbforge-2.0.1.tar.gz"
+  checksum: "md5=11f39819ee4cf0adddeaf15072969815"
 }

--- a/packages/dbforge/dbforge.2.0/opam
+++ b/packages/dbforge/dbforge.2.0/opam
@@ -22,6 +22,6 @@ synopsis:
   "A tool to describe database schemas and generate OCaml code to access these databases."
 extra-files: ["dbforge.install" "md5=9f4defb2eb0a5be350e947226ac51657"]
 url {
-  src: "https://zoggy.github.io/dbforge/dbforge-2.0.tar.gz"
-  checksum: "md5=78660bfc79e6b2e374ca992ca6ad887f"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/dbforge-2.0/old-codes-dbforge-2.0.tar.gz"
+  checksum: "md5=6ab083277908d4961e1c28b5febb5a93"
 }

--- a/packages/genet/genet.0.1/opam
+++ b/packages/genet/genet.0.1/opam
@@ -27,6 +27,6 @@ install: [make "install"]
 license: "LGPL-3.0-only"
 synopsis: "Genet is tool to build a continuous integration platform."
 url {
-  src: "https://zoggy.github.io/genet/genet-0.1.tar.gz"
-  checksum: "md5=807a4a297ba32a3a177b6ddf04d1a141"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/genet-0.1/old-codes-genet-0.1.tar.gz"
+  checksum: "md5=1d9bb983b087e0519b2aa81b59303d16"
 }

--- a/packages/genet/genet.0.2/opam
+++ b/packages/genet/genet.0.2/opam
@@ -27,6 +27,6 @@ install: [make "install"]
 license: "LGPL-3.0-only"
 synopsis: "Genet is tool to build a continuous integration platform."
 url {
-  src: "https://zoggy.github.io/genet/genet-0.2.tar.gz"
-  checksum: "md5=8a839c8fe8e0ab99abfaea1d45d3fea0"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/genet-0.2/old-codes-genet-0.2.tar.gz"
+  checksum: "md5=095cb319f55be04c732af50c46b0489f"
 }

--- a/packages/genet/genet.0.3/opam
+++ b/packages/genet/genet.0.3/opam
@@ -45,6 +45,6 @@ and test cases.
 Genet computes all tool version combinations to execute the
 chains on the test cases. Results can be compared."""
 url {
-  src: "http://zoggy.github.io/genet/genet-0.3.tar.gz"
-  checksum: "md5=66e6d71b78d997e23e6a820e6e481396"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/genet-0.3/old-codes-genet-0.3.tar.gz"
+  checksum: "md5=2ccfd22c7d164e7f29a5ddc9729b7a9c"
 }

--- a/packages/genet/genet.0.4/opam
+++ b/packages/genet/genet.0.4/opam
@@ -45,6 +45,6 @@ and test cases.
 Genet computes all tool version combinations to execute the
 chains on the test cases. Results can be compared."""
 url {
-  src: "http://zoggy.github.io/genet/genet-0.4.tar.gz"
-  checksum: "md5=5dcba076865a9a020ecf44537dbfcffe"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/genet-0.4/old-codes-genet-0.4.tar.gz"
+  checksum: "md5=580d4fd4429ec4cfb0bd884144793ef1"
 }

--- a/packages/genet/genet.0.5/opam
+++ b/packages/genet/genet.0.5/opam
@@ -45,6 +45,6 @@ Genet computes all tool version combinations to execute the
 chains on the test cases. Results can be compared."""
 flags: light-uninstall
 url {
-  src: "http://zoggy.github.io/genet/genet-0.5.tar.gz"
-  checksum: "md5=42dc4a3150dc730b5b4b10bf7038672d"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/genet-0.5/old-codes-genet-0.5.tar.gz"
+  checksum: "md5=db26ab76407f8bff7d818378082fedee"
 }

--- a/packages/gtktop/gtktop.2.0/opam
+++ b/packages/gtktop/gtktop.2.0/opam
@@ -16,6 +16,6 @@ install: [make "install"]
 synopsis: "A small library to ease the creation of graphical toplevels."
 dev-repo: "git+https://github.com/zoggy/gtktop.git"
 url {
-  src: "https://zoggy.github.io/gtktop/gtktop-2.0.tar.gz"
-  checksum: "md5=c77091dcddc63711c370370a6860dbb3"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/gtktop-2.0/old-codes-gtktop-2.0.tar.gz"
+  checksum: "md5=750293eb817e18279eb2a97469db8862"
 }

--- a/packages/socket-daemon/socket-daemon.0.1.0/opam
+++ b/packages/socket-daemon/socket-daemon.0.1.0/opam
@@ -24,6 +24,6 @@ client which send commands (stop, restart, ...) to the server through
 the socket."""
 flags: light-uninstall
 url {
-  src: "https://github.com/zoggy/ocaml-socket-daemon/archive/0.1.0.tar.gz"
-  checksum: "md5=f6b01fb8fe450a61676c4ac745c484a5"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/ocaml-socket-daemon-0.1.0/old-codes-ocaml-socket-daemon-0.1.0.tar.gz"
+  checksum: "md5=79e3168cf61119611ad0255d9d3cd946"
 }

--- a/packages/socket-daemon/socket-daemon.0.2.0/opam
+++ b/packages/socket-daemon/socket-daemon.0.2.0/opam
@@ -34,6 +34,6 @@ client which send commands (stop, restart, ...) to the server through
 the socket."""
 flags: light-uninstall
 url {
-  src: "https://github.com/zoggy/ocaml-socket-daemon/archive/0.2.0.tar.gz"
-  checksum: "md5=5274441dd15c5abdca6b370cb5af15b9"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/ocaml-socket-daemon-0.2.0/old-codes-ocaml-socket-daemon-0.2.0.tar.gz"
+  checksum: "md5=39e2ffb5b69cbff132705fe864cbfaa5"
 }

--- a/packages/socket-daemon/socket-daemon.0.3.0/opam
+++ b/packages/socket-daemon/socket-daemon.0.3.0/opam
@@ -34,7 +34,6 @@ client which send commands (stop, restart, ...) to the server through
 the socket."""
 flags: light-uninstall
 url {
-  src:
-    "https://github.com/zoggy/ocaml-socket-daemon/archive/release-0.3.0.tar.gz"
-  checksum: "md5=b8b982c83dd18f4f2ac89bce00caab89"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/ocaml-socket-daemon-0.3.0/old-codes-ocaml-socket-daemon-0.3.0.tar.gz"
+  checksum: "md5=66db35438bdf0dda3eead4d83c71246c"
 }

--- a/packages/stog-rdf/stog-rdf.0.10.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.10.0/opam
@@ -22,6 +22,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-rdf/-/archive/0.10.0/stog-rdf-0.10.0.tar.gz"
-  checksum: "md5=b73074ff4b0b25c5d1cf8447d6b290ca"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-rdf-0.10.0/old-codes-stog-rdf-0.10.0.tar.gz"
+  checksum: "md5=43660c0d8dd59d8122d1e7204ac25abe"
 }

--- a/packages/stog-rdf/stog-rdf.0.11.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.11.0/opam
@@ -23,6 +23,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-rdf/-/archive/0.11.0/stog-rdf-0.11.0.tar.gz"
-  checksum: "md5=b561f0b91611f70016ca1054f45bc6fb"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-rdf-0.11.0/old-codes-stog-rdf-0.11.0.tar.gz"
+  checksum: "md5=6580e6b136962d843b111de2a2ac3672"
 }

--- a/packages/stog-rdf/stog-rdf.0.15.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.15.0/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-rdf/-/archive/0.15.0/stog-rdf-0.15.0.tar.gz"
-  checksum: "md5=d91dead5619459d3861eab4310858aba"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-rdf-0.15.0/old-codes-stog-rdf-0.15.0.tar.gz"
+  checksum: "md5=cfc8779b79371d66b6dc60040bba982e"
 }

--- a/packages/stog-rdf/stog-rdf.0.16.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.16.0/opam
@@ -24,6 +24,6 @@ depends: [
 synopsis: "Plugin for Stog. Define and query RDF graphs in rewrite rules."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-rdf/-/archive/0.16.0/stog-rdf-0.16.0.tar.gz"
-  checksum: "md5=b1547a91e4f0512b454f0b49a55e68a7"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-rdf-0.16.0/old-codes-stog-rdf-0.16.0.tar.gz"
+  checksum: "md5=73dbb2f1b33d9c71f2e5dd626dc29b90"
 }

--- a/packages/stog-rdf/stog-rdf.0.16.1/opam
+++ b/packages/stog-rdf/stog-rdf.0.16.1/opam
@@ -28,6 +28,6 @@ documents and to generate RDF graphs from elements in
 documents."""
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-rdf/-/archive/0.16.1/stog-rdf-0.16.1.tar.gz"
-  checksum: "md5=c5ceda5190eb8c0333e795cc7d1b7d31"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-rdf-0.16.1/old-codes-stog-rdf-0.16.1.tar.gz"
+  checksum: "md5=9b5650b064f146d5d635ee828448f83a"
 }

--- a/packages/stog-rdf/stog-rdf.0.7.0/opam
+++ b/packages/stog-rdf/stog-rdf.0.7.0/opam
@@ -11,6 +11,6 @@ install: [make "install"]
 synopsis:
   "Plugin for Stog. Allow defining RDF triples to generate a RDF graph for the site."
 url {
-  src: "https://framagit.org/zoggy/stog-rdf/-/archive/0.7.0/stog-rdf-0.7.0.tar.gz"
-  checksum: "md5=4b7d30a49147cd1765b5efcfd5394cfd"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-rdf-0.7.0/old-codes-stog-rdf-0.7.0.tar.gz"
+  checksum: "md5=1076711b7d8458cdc88d93ff6a618d04"
 }

--- a/packages/stog-writing/stog-writing.0.10.0/opam
+++ b/packages/stog-writing/stog-writing.0.10.0/opam
@@ -18,6 +18,6 @@ synopsis:
 description: "web sites."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.10.0/stog-writing-0.10.0.tar.gz"
-  checksum: "md5=a9f3ac0c7390279a04053e9ff37ea8bd"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.10.0/old-codes-stog-writing-0.10.0.tar.gz"
+  checksum: "md5=f5e51cba705cb1f3ff682ce1cbd536ae"
 }

--- a/packages/stog-writing/stog-writing.0.11.0/opam
+++ b/packages/stog-writing/stog-writing.0.11.0/opam
@@ -18,6 +18,6 @@ synopsis:
 description: "web sites."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.11.0/stog-writing-0.11.0.tar.gz"
-  checksum: "md5=7a2aa022923727b67edc316179d00d38"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.11.0/old-codes-stog-writing-0.11.0.tar.gz"
+  checksum: "md5=fc5f15779e308a4a0643d9ff4fcddcaa"
 }

--- a/packages/stog-writing/stog-writing.0.12.0/opam
+++ b/packages/stog-writing/stog-writing.0.12.0/opam
@@ -17,6 +17,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.12.0/stog-writing-0.12.0.tar.gz"
-  checksum: "md5=5d0e3cc73e4b8b1bf91c4e83ed2698e1"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.12.0/old-codes-stog-writing-0.12.0.tar.gz"
+  checksum: "md5=0dddd2b91952de682402cd271487b9ee"
 }

--- a/packages/stog-writing/stog-writing.0.13.0/opam
+++ b/packages/stog-writing/stog-writing.0.13.0/opam
@@ -17,6 +17,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.13.0/stog-writing-0.13.0.tar.gz"
-  checksum: "md5=8f0a2aaf3696148327926a8cc00b1def"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.13.0/old-codes-stog-writing-0.13.0.tar.gz"
+  checksum: "md5=db0951d9f706442c103b5f2469de6089"
 }

--- a/packages/stog-writing/stog-writing.0.15.0/opam
+++ b/packages/stog-writing/stog-writing.0.15.0/opam
@@ -23,6 +23,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.15.0/stog-writing-0.15.0.tar.gz"
-  checksum: "md5=d91c9100fa1908ad61f361afb83674c8"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.15.0/old-codes-stog-writing-0.15.0.tar.gz"
+  checksum: "md5=37646fc84d8d0704bc3a692b27a635c3"
 }

--- a/packages/stog-writing/stog-writing.0.16.0/opam
+++ b/packages/stog-writing/stog-writing.0.16.0/opam
@@ -23,6 +23,6 @@ synopsis:
   "Plugin for Stog to use footnotes and bibliographies in stog-generated web sites."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.16.0/stog-writing-0.16.0.tar.gz"
-  checksum: "md5=556bf42a8faddc22e29605775dac545a"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.16.0/old-codes-stog-writing-0.16.0.tar.gz"
+  checksum: "md5=62dd89710979c02cf5c689e1ee625973"
 }

--- a/packages/stog-writing/stog-writing.0.17.0/opam
+++ b/packages/stog-writing/stog-writing.0.17.0/opam
@@ -20,6 +20,6 @@ synopsis:
 description: "No longer description :)"
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.17.0/stog-writing-0.17.0.tar.gz"
-  checksum: "md5=f8851fd6b5c839580018c8654ff3b16c"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.17.0/old-codes-stog-writing-0.17.0.tar.gz"
+  checksum: "md5=761ddc0756dfaabf2810398a3f7878b4"
 }

--- a/packages/stog-writing/stog-writing.0.19.0/opam
+++ b/packages/stog-writing/stog-writing.0.19.0/opam
@@ -17,9 +17,9 @@ build: [make "all"]
 install: [make "install"]
 dev-repo: "git+https://framagit.org/zoggy/stog-writing.git"
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.19.0/stog-writing-0.19.0.tar.gz"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.19.0/old-codes-stog-writing-0.19.0.tar.gz"
   checksum: [
-    "md5=71669e2dcf3d643e2fbd71237136b27f"
-    "sha512=97b63fd61b102a717bb13e73d5388843902e84bed4ed78b6b37d059ea9a8cc195406451819e7faed8fcd63f15f8182c251d61f53f40be29bb7a0a9c8f88f9bf2"
+    "md5=55b90122e1d836adee9b9333a5aa026d"
+    "sha512=901969057af5df11c2d2f3764fa07b87dc28631941b6b5d21091371e0d501559891b60346571a39c4702eef67fd9e4cb02e860b681b552ef6ab2e376f5c4db9d"
   ]
 }

--- a/packages/stog-writing/stog-writing.0.6/opam
+++ b/packages/stog-writing/stog-writing.0.6/opam
@@ -12,6 +12,6 @@ synopsis:
   "Plugin for Stog. Allow adding footnotes and bibliographies in stog-generated"
 description: "web sites."
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.6/stog-writing-0.6.tar.gz"
-  checksum: "md5=faaf7153e81a921d06ac0ab89f4fe44c"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.6.0/old-codes-stog-writing-0.6.0.tar.gz"
+  checksum: "md5=2b3166056567219b57f968b604015e62"
 }

--- a/packages/stog-writing/stog-writing.0.7.0/opam
+++ b/packages/stog-writing/stog-writing.0.7.0/opam
@@ -12,6 +12,6 @@ synopsis:
   "Plugin for Stog. Allow adding footnotes and bibliographies in stog-generated"
 description: "web sites."
 url {
-  src: "https://framagit.org/zoggy/stog-writing/-/archive/0.7.0/stog-writing-0.7.0.tar.gz"
-  checksum: "md5=0e1c4d4eae3319cde00b4ded319cfb48"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/stog-writing-0.7.0/old-codes-stog-writing-0.7.0.tar.gz"
+  checksum: "md5=475bac9d14929be224492913a26246ec"
 }

--- a/packages/testrunner/testrunner.0.1.0/opam
+++ b/packages/testrunner/testrunner.0.1.0/opam
@@ -29,6 +29,6 @@ Tests are described in JSON files, with nested JSON values.
 Generates report in text and XML formats."""
 flags: light-uninstall
 url {
-  src: "https://github.com/zoggy/ocaml-testrunner/archive/v0.1.0.tar.gz"
-  checksum: "md5=31424f1282db7412d3f6669749c758a0"
+  src: "https://framagit.org/zoggy/old-codes/-/archive/ocaml-testrunner-0.1.0/old-codes-ocaml-testrunner-0.1.0.tar.gz"
+  checksum: "md5=afbbd356737cff011d0faa249bc258e1"
 }


### PR DESCRIPTION
On my way to remove old repositories, I archived git histories of these codes to a single git repo and added tags so that old archives can now be retrieved from this new repo. For example, dbforge 2.0.1 archive can now be retrieved from https://framagit.org/zoggy/old-codes/-/archive/dbforge-2.0.1/old-codes-dbforge-2.0.1.tar.gz 

I did not updated any other information (except checksums of course). I doubt all these codes will be missing to someone.