### PR TITLE
[new release] ocamlformat, ocamlformat-rpc and ocamlformat-rpc-lib (0.20.1)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.20.1/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.20.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "csexp"
+  "sexplib0"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-rpc-lib-0.20.1.tbz"
+  checksum: [
+    "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
+    "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"
+  ]
+}
+x-commit-hash: "74668925ca977e252acb084bd139b3077cf95b58"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.20.1/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.20.1/opam
@@ -31,7 +31,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-rpc-lib-0.20.1.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-0.20.1.tbz"
   checksum: [
     "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
     "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.1/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.1/opam
@@ -47,7 +47,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-rpc-lib-0.20.1.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-0.20.1.tbz"
   checksum: [
     "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
     "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.1/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "ocamlformat-rpc-lib"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "cmdliner"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocp-indent"
+  "odoc-parser" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-rpc-lib-0.20.1.tbz"
+  checksum: [
+    "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
+    "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"
+  ]
+}
+x-commit-hash: "74668925ca977e252acb084bd139b3077cf95b58" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.20.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.20.1/opam
@@ -46,7 +46,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-rpc-lib-0.20.1.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-0.20.1.tbz"
   checksum: [
     "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
     "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"

--- a/packages/ocamlformat/ocamlformat.0.20.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.20.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "cmdliner"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocp-indent"
+  "odoc-parser" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.20.1/ocamlformat-rpc-lib-0.20.1.tbz"
+  checksum: [
+    "sha256=7d3a51645416fa78287344fa03af6b78450067a1a61e4790bf1b29779cd10235"
+    "sha512=8cc8bc9ebf822b18cf54f2f5b0b61c7bf775a1de9b984f57448dcee391627a08d43e7b15a2cfbd287f5ae16b3b9dd18c42086b59ccfbe3174184418652c4f668"
+  ]
+}
+x-commit-hash: "74668925ca977e252acb084bd139b3077cf95b58" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### New features

  + Update to odoc-parser 1.0.0 (ocaml-ppx/ocamlformat#1843, @Julow).
    New syntax: code blocks can carry metadata, e.g.:
      `{@ocaml kind=toplevel env=e1[ code ]}`
