### PR TITLE
Solo5 0.6.9

### DIFF
--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
@@ -36,6 +36,9 @@ available: [
   (arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+x-ci-accept-failures: [
+  "centos-7"
+]
 synopsis: "Solo5 sandboxed execution environment (hvt target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN="]
+]
+install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-hvt" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (hvt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the "hvt" target, including the
+"solo5-hvt" tender source code, and "solo5-hvt-configure" script
+used to specialize the tender at MirageOS unikernel build time.
+
+The "hvt" target is supported on 64-bit Linux, FreeBSD and
+OpenBSD systems with hardware virtualization."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.9/solo5-v0.6.9.tar.gz"
+  checksum: "sha512=e294bb2d02d2d629236615493302d0463c89388987723f3921f6a32c0d44fb843de332c9a148e0c6693f2c2ceee77d973b1cb06766da452c4288c8f6fad0183c"
+}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.9/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.9/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "CONFIG_XEN="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-muen" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-genode"
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-xen"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (muen target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "muen" target. The resulting
+unikernels can then be deployed directly on a host running the
+Muen Separation Kernel.
+
+Building the "muen" target is supported on 64-bit Linux, FreeBSD
+and OpenBSD systems."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.9/solo5-v0.6.9.tar.gz"
+  checksum: "sha512=e294bb2d02d2d629236615493302d0463c89388987723f3921f6a32c0d44fb843de332c9a148e0c6693f2c2ceee77d973b1cb06766da452c4288c8f6fad0183c"
+}

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.9/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.9/opam
@@ -30,6 +30,9 @@ available: [
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+x-ci-accept-failures: [
+  "centos-7"
+]
 synopsis: "Solo5 sandboxed execution environment (muen target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.9/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.9/opam
@@ -35,6 +35,9 @@ conflicts: [
 available: [
   (arch = "x86_64" | arch = "arm64") & os = "linux"
 ]
+x-ci-accept-failures: [
+  "centos-7"
+]
 synopsis: "Solo5 sandboxed execution environment (spt target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.9/opam
+++ b/packages/solo5-bindings-spt/solo5-bindings-spt.0.6.9/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-spt" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64") & os = "linux"
+]
+synopsis: "Solo5 sandboxed execution environment (spt target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels on the "spt" target and the "solo5-spt" tender
+binary used to run such unikernels.
+
+The "spt" target is supported on 64-bit Linux systems only."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.9/solo5-v0.6.9.tar.gz"
+  checksum: "sha512=e294bb2d02d2d629236615493302d0463c89388987723f3921f6a32c0d44fb843de332c9a148e0c6693f2c2ceee77d973b1cb06766da452c4288c8f6fad0183c"
+}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.9/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.9/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-virtio" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  arch = "x86_64" &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (virtio target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build
+MirageOS unikernels using the "virtio" target.
+
+The "virtio" target is supported on 64-bit Linux and FreeBSD
+systems with hardware virtualization, and produces unikernels
+suitable for running on any virtio-compliant hypervisor (e.g.
+QEMU/KVM).
+
+Note that the "virtio" target provides limited support for
+current and future Solo5 features and abstractions. We recommend
+that you use the "hvt" target instead."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.9/solo5-v0.6.9.tar.gz"
+  checksum: "sha512=e294bb2d02d2d629236615493302d0463c89388987723f3921f6a32c0d44fb843de332c9a148e0c6693f2c2ceee77d973b1cb06766da452c4288c8f6fad0183c"
+}

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.9/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.9/opam
@@ -30,6 +30,9 @@ available: [
   arch = "x86_64" &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+x-ci-accept-failures: [
+  "centos-7"
+]
 synopsis: "Solo5 sandboxed execution environment (virtio target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.9/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.9/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh"]
+  [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE="]
+]
+install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-xen" "PREFIX=%{prefix}%"]
+depends: [
+  "conf-pkg-config"
+  "conf-libseccomp" {build & os = "linux"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.6.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+]
+available: [
+  (arch = "x86_64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment (xen target)"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the "xen" target.
+
+The "xen" target is supported on 64-bit Linux, FreeBSD and
+OpenBSD systems with hardware virtualization."""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.6.9/solo5-v0.6.9.tar.gz"
+  checksum: "sha512=e294bb2d02d2d629236615493302d0463c89388987723f3921f6a32c0d44fb843de332c9a148e0c6693f2c2ceee77d973b1cb06766da452c4288c8f6fad0183c"
+}

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.9/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.9/opam
@@ -30,6 +30,9 @@ available: [
   (arch = "x86_64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")
 ]
+x-ci-accept-failures: [
+  "centos-7"
+]
 synopsis: "Solo5 sandboxed execution environment (xen target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended


### PR DESCRIPTION
* virtio: add missing reset for net and blk devices (Solo5/solo5#491)
* CI: disable genode (Solo5/solo5#493)
  Genode bindings are failing to build on Debian testing / GCC 10.x.
* Avoid "-" in section names (in the ld scripts) since some GNU ld versions
  reject that (alpine 3.15, Fefora 35) (Solo5/solo5#502)
* On OpenBSD, OpenBSD 6.7 is not supported anymore, all support releases use
  ld.lld (Solo5/solo5#495)