### PR TITLE
[new release] mdx (2.0.0)

### DIFF
--- a/packages/http-cookie/http-cookie.4.1.0/opam
+++ b/packages/http-cookie/http-cookie.4.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "angstrom" {>= "0.15.0"}
   "ppx_expect" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/http-cookie/http-cookie.4.2.0/opam
+++ b/packages/http-cookie/http-cookie.4.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "angstrom" {>= "0.15.0"}
   "ppx_expect" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/iter/iter.1.2.1/opam
+++ b/packages/iter/iter.1.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune-configurator"
   "qcheck" {with-test}
   "qtest" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
   "odoc" {with-doc}
 ]
 depopts: ["base-bigarray"]

--- a/packages/lwt-pipe/lwt-pipe.0.1/opam
+++ b/packages/lwt-pipe/lwt-pipe.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "1.1"}
   "lwt"
   "ocaml" { >= "4.03.0" }
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
   "qcheck" {with-test & < "0.14"}
   "qtest" {with-test}
   "odoc" {with-doc}

--- a/packages/mdx/mdx.2.0.0/opam
+++ b/packages/mdx/mdx.2.0.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "result"
+  "ocaml-version" {>= "2.3.0"}
+  "odoc-parser" {>= "0.9.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/2.0.0/mdx-2.0.0.tbz"
+  checksum: [
+    "sha256=65b4cc7ff8891b8b1d183be13c26eb45ddbc5a8081ac6e200fd8ae043d592e45"
+    "sha512=676d73dd20586ad5457ad96c9f0b11d88a2caf5763935a317db88076fd611cedd27499bd574a140ed9f6c00d2b80e7e92e2cf66d5aece9e2bbc16ea9ad69fc67"
+  ]
+}
+x-commit-hash: "2adab029bde4141ecacde5ece71a7ca9e185e8cf"

--- a/packages/msat/msat.0.8.3/opam
+++ b/packages/msat/msat.0.8.3/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
   "containers" {with-test & >= "2.8.1" & < "4.0" }
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 tags: [ "sat" "smt" "cdcl" "functor" ]
 homepage: "https://github.com/Gbury/mSAT"

--- a/packages/msat/msat.0.9.1/opam
+++ b/packages/msat/msat.0.9.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
   "containers" {with-test & >= "2.8.1" & < "4.0" }
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 tags: [ "sat" "smt" "cdcl" "functor" ]
 homepage: "https://github.com/Gbury/mSAT"

--- a/packages/msat/msat.0.9/opam
+++ b/packages/msat/msat.0.9/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
   "containers" {with-test & >= "2.8.1" & < "4.0" }
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 tags: [ "sat" "smt" "cdcl" "functor" ]
 homepage: "https://github.com/Gbury/mSAT"

--- a/packages/preface/preface.0.1.0/opam
+++ b/packages/preface/preface.0.1.0/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest" {with-test}
   "qcheck-core" {with-test & < "0.18"}
   "qcheck-alcotest" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
   "odoc"{with-doc}
 ]
 

--- a/packages/routes/routes.0.4.0/opam
+++ b/packages/routes/routes.0.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "stdcompat" { >= "6" }
   "dune" { >= "1.8" }
   "alcotest" {with-test}
-  "mdx" { with-test }
+  "mdx" { with-test & < "2.0" }
 ]
 synopsis: "Typed routing for OCaml applications"
 description: """

--- a/packages/routes/routes.0.4.1/opam
+++ b/packages/routes/routes.0.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.05.0"}
   "dune" { >= "1.8" }
   "alcotest" {with-test}
-  "mdx" { with-test }
+  "mdx" { with-test & < "2.0" }
 ]
 synopsis: "Typed routing for OCaml applications"
 description: """

--- a/packages/routes/routes.0.5.0/opam
+++ b/packages/routes/routes.0.5.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" { >= "1.8" }
   "alcotest" {with-test}
-  "mdx" { with-test }
+  "mdx" { with-test & < "2.0" }
 ]
 synopsis: "Typed routing for OCaml applications"
 description: """

--- a/packages/routes/routes.0.5.1/opam
+++ b/packages/routes/routes.0.5.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" { >= "1.7" }
   "alcotest" {with-test}
-  "mdx" { with-test }
+  "mdx" { with-test & < "2.0" }
 ]
 synopsis: "Typed routing for OCaml applications"
 description: """

--- a/packages/routes/routes.0.6.0/opam
+++ b/packages/routes/routes.0.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.05"}
   "dune" { >= "1.7" }
   "alcotest" {with-test}
-  "mdx" { with-test }
+  "mdx" { with-test & < "2.0" }
 ]
 synopsis: "Typed routing for OCaml applications"
 description: """

--- a/packages/routes/routes.0.7.0/opam
+++ b/packages/routes/routes.0.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.06.1"}
   "dune" {>= "2.1"}
   "alcotest" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/routes/routes.0.7.3/opam
+++ b/packages/routes/routes.0.7.3/opam
@@ -12,7 +12,7 @@ depends: [
   "dune"
   "bisect_ppx" {dev & >= "2.0.0"}
   "alcotest" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/routes/routes.0.8.0/opam
+++ b/packages/routes/routes.0.8.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune"
   "bisect_ppx" {dev & >= "2.0.0"}
   "alcotest" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Added

- Add trailing `;;` to the output of toplevel phrases that were missing it.
  (realworldocaml/mdx#346, @Leonidas-from-XIV)
- Make MDX compatible with OCaml 4.14 (realworldocaml/mdx#356, @NathanReb)

#### Fixed

- Use the same output as the normal toplevel. Mdx used to carry an unsafe patch
  to work around a bug fixed in OCaml 4.06 and that patch would change the
  printed types in some corner cases. (realworldocaml/mdx#322, @emillon)

#### Removed

- Dropped compatibility with older OCaml versions. The minimal supported range
  is 4.08 to 4.13 now (realworldocaml/mdx#345, @Leonidas-from-XIV)
- Do not install deprecated `mdx` binary anymore (realworldocaml/mdx#274, @gpetiot)
- Remove deprecated `rule` command (realworldocaml/mdx#312, @gpetiot)
- Remove support for `require-package` label, use the `mdx` stanza in dune
  instead. This label was only used for the `rule` command and can now be
  safely removed. (realworldocaml/mdx#363, @Leonidas-from-XIV)
