### PR TITLE
[new release] owee (0.4)

### DIFF
--- a/packages/owee/owee.0.4/opam
+++ b/packages/owee/owee.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Frédéric Bour <frederic.bour@lakaban.net>"
+authors: "Frédéric Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/owee"
+bug-reports: "https://github.com/let-def/owee"
+license: "MIT"
+dev-repo: "git+https://github.com/let-def/owee.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.0"}
+]
+available: arch != "x86_32" & arch != "arm32"
+synopsis: "OCaml library to work with DWARF format"
+description: """
+Owee is an experimental library to work with DWARF format.
+It can parse ELF binaries and interpret DWARF debugline programs.
+
+It can also be used to find locations of functions from the current process."""
+url {
+  src: "https://github.com/let-def/owee/releases/download/v0.4/owee-0.4.tbz"
+  checksum: [
+    "sha256=6b7f3c4241ba41732ffc04705cf5935cf917b7ab3cc3f514be21cee63c88ab14"
+    "sha512=8625045c55abd99568c9720aebd4b2ef1705287cb9c60047e25d291db169ca6b956e6308001afa3e8bd4507dc56e9bd108d5aea27742384e7d6513817d205ebd"
+  ]
+}
+x-commit-hash: "81328cd73c1145c27ff1eb98818642c742b13ced"


### PR DESCRIPTION
OCaml library to work with DWARF format

- Project page: <a href="https://github.com/let-def/owee">https://github.com/let-def/owee</a>

##### CHANGES:

Tue Dec 14 10:30:09 CET 2021

- Support OCaml up to 4.13.
- Parse Linux memory map files
- Support elf notes (contributed by Greta Yorsh, @gretayjs)
- Bug fixes (with contributions from Nandor Licker)
