### PR TITLE
[new release] awa, awa-mirage and awa-lwt (0.0.5)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.0.5/opam
+++ b/packages/awa-lwt/awa-lwt.0.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.5/awa-0.0.5.tbz"
+  checksum: [
+    "sha256=44d7b3802a4190d9e8a19aeb81828b0684908890dc72a0a1f5148e3b63fd1892"
+    "sha512=25259ceda105fadcea7a549f4b51fe09e47de0c09de87c7c893c0fb840fc11e73552bfdadcaf0a42dfd0620d012605973ac8f988f801150540e249d911289ba8"
+  ]
+}
+x-commit-hash: "cdbc37730b78622958150ffeb40dab3afcaa5ea4"

--- a/packages/awa-mirage/awa-mirage.0.0.5/opam
+++ b/packages/awa-mirage/awa-mirage.0.0.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.5/awa-0.0.5.tbz"
+  checksum: [
+    "sha256=44d7b3802a4190d9e8a19aeb81828b0684908890dc72a0a1f5148e3b63fd1892"
+    "sha512=25259ceda105fadcea7a549f4b51fe09e47de0c09de87c7c893c0fb840fc11e73552bfdadcaf0a42dfd0620d012605973ac8f988f801150540e249d911289ba8"
+  ]
+}
+x-commit-hash: "cdbc37730b78622958150ffeb40dab3afcaa5ea4"

--- a/packages/awa/awa.0.0.5/opam
+++ b/packages/awa/awa.0.0.5/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.15.2"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "cstruct-sexp"
+  "sexplib"
+  "mtime"
+  "logs"
+  "fmt"
+  "cmdliner"
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.0.5/awa-0.0.5.tbz"
+  checksum: [
+    "sha256=44d7b3802a4190d9e8a19aeb81828b0684908890dc72a0a1f5148e3b63fd1892"
+    "sha512=25259ceda105fadcea7a549f4b51fe09e47de0c09de87c7c893c0fb840fc11e73552bfdadcaf0a42dfd0620d012605973ac8f988f801150540e249d911289ba8"
+  ]
+}
+x-commit-hash: "cdbc37730b78622958150ffeb40dab3afcaa5ea4"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* use `eqaf` and hash to test the password (@dinosaure, @hannesm, mirage/awa-ssh#41)
* fix isomorphism between `of_seed`/`of_string` and `awa_gen_key` tool (@dinosaure, @hannesm, mirage/awa-ssh#40)
* provide `Keys.of_string` (@dinosaure, @hannesm, mirage/awa-ssh#37)
* conflict `awa` with `result < 1.5` (@hannesm, 1c3d2eb)
