### PR TITLE
daft is not compatible with zmq 5.1.4

### DIFF
--- a/packages/daft/daft.0.0.2/opam
+++ b/packages/daft/daft.0.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "dolog" {< "4.0.0"}
   "batteries"
   "fileutils" {< "0.5.0"}
-  "zmq"
+  "zmq" {< "5.1.4"}
   "cryptokit"
   "base-unix"
 ]

--- a/packages/daft/daft.0.0.3/opam
+++ b/packages/daft/daft.0.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "batteries"
   "fileutils"
-  "zmq" {>= "5.0.0"}
+  "zmq" {>= "5.0.0" & < "5.1.4"}
   "cryptokit"
   "base-unix"
 ]


### PR DESCRIPTION
Signatures became non-polymorphic. e.g. `[> Push] Zmq.Socket.t` -> `[Push] Zmq.Socket.t`
```
#=== ERROR while compiling daft.0.0.3 =========================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/daft.0.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/daft-3580-9cb2a2.env
# output-file          ~/.opam/log/daft-3580-9cb2a2.out
### output ###
# obuild configure
# Configuring DAFT-0.1...
# obuild build
# [ 1 of 13] Compiling Colors                        
# [ 2 of 13] Compiling Types                         
# [ 3 of 13] Compiling Utils                         
# 
# File "src/utils.ml", line 163, characters 4-8:
# 163 |     sock
#           ^^^^
# Error: This expression has type [ `Push ] Zmq.Socket.t
#        but an expression was expected of type [ `Pull ] Zmq.Socket.t
#        These two variant types have no intersection
# 
# make: *** [Makefile:9: build] Error 6
```
cc @UnixJunkie 