### PR TITLE
pardi is not compatible with zmq 5.1.4

### DIFF
--- a/packages/pardi/pardi.2.0.2/opam
+++ b/packages/pardi/pardi.2.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "minicli"
   "lz4"
   "cryptokit"
-  "zmq"
+  "zmq" {< "5.1.4"}
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "Parallel and distributed execution of command lines, pardi!"

--- a/packages/pardi/pardi.2.0.3/opam
+++ b/packages/pardi/pardi.2.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "minicli"
   "lz4"
   "cryptokit"
-  "zmq"
+  "zmq" {< "5.1.4"}
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "Parallel and distributed execution of command lines, pardi!"

--- a/packages/pardi/pardi.2.0.4/opam
+++ b/packages/pardi/pardi.2.0.4/opam
@@ -14,7 +14,7 @@ depends: [
   "minicli" {>= "5.0.0"}
   "lz4"
   "cryptokit"
-  "zmq" {>= "5.0.0"}
+  "zmq" {>= "5.0.0" & < "5.1.4"}
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "Parallel and distributed execution of command lines, pardi!"

--- a/packages/pardi/pardi.3.1.1/opam
+++ b/packages/pardi/pardi.3.1.1/opam
@@ -14,7 +14,7 @@ depends: [
   "minicli" {>= "5.0.0"}
   "lz4"
   "cryptokit"
-  "zmq" {>= "5.0.0"}
+  "zmq" {>= "5.0.0" & < "5.1.4"}
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "Parallel and distributed execution of command lines, pardi!"

--- a/packages/pardi/pardi.3.2.0/opam
+++ b/packages/pardi/pardi.3.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "minicli" {>= "5.0.0"}
   "lz4"
   "cryptokit"
-  "zmq" {>= "5.0.0"}
+  "zmq" {>= "5.0.0" & < "5.1.4"}
   "ocaml" {>= "4.05.0"}
 ]
 synopsis: "Parallel and distributed execution of command lines, pardi!"


### PR DESCRIPTION
Signatures became non-polymorphic. e.g. `[> Push] Zmq.Socket.t` -> `[Push] Zmq.Socket.t`
```
#=== ERROR while compiling pardi.3.2.0 ========================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/pardi.3.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pardi -j 31
# exit-code            1
# env-file             ~/.opam/log/pardi-5848-5b6d53.env
# output-file          ~/.opam/log/pardi-5848-5b6d53.out
### output ###
#       ocamlc src/.pardi.eobjs/byte/utls.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.pardi.eobjs/byte -I /home/opam/.opam/4.13/lib/batteries -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/cpu -I /home/opam/.opam/4.13/lib/cryptokit -I /home/opam/.opam/4.13/lib/ctypes -I /home/opam/.opam/4.13/lib/dolog -I /home/opam/.opam/4.13/lib/integers -I /home/opam/.opam/4.13/lib/lz4 -I /home/opam/.opam/4.13/lib/minicli -I /home/opam/.opam/4.13/lib/num -I /home/opam/.opam/4.13/lib/ocaml/threads -I /home/opam/.opam/4.13/lib/parany -I /home/opam/.opam/4.13/lib/stdint -I /home/opam/.opam/4.13/lib/zarith -I /home/opam/.opam/4.13/lib/zmq -I src/.sec_chan.objs/byte -no-alias-deps -o src/.pardi.eobjs/byte/utls.cmo -c -impl src/utls.ml)
# File "src/utls.ml", line 439, characters 4-8:
# 439 |     sock
#           ^^^^
# Error: This expression has type [ `Push ] Zmq.Socket.t
#        but an expression was expected of type [ `Pull ] Zmq.Socket.t
#        These two variant types have no intersection

-       ocamlc src/.pardi.eobjs/byte/utls.{cmi,cmo,cmt} (exit 2)
- (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.pardi.eobjs/byte -I /home/opam/.opam/4.13/lib/batteries -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/cpu -I /home/opam/.opam/4.13/lib/cryptokit -I /home/opam/.opam/4.13/lib/ctypes -I /home/opam/.opam/4.13/lib/dolog -I /home/opam/.opam/4.13/lib/integers -I /home/opam/.opam/4.13/lib/lz4 -I /home/opam/.opam/4.13/lib/minicli -I /home/opam/.opam/4.13/lib/num -I /home/opam/.opam/4.13/lib/ocaml/threads -I /home/opam/.opam/4.13/lib/parany -I /home/opam/.opam/4.13/lib/stdint -I /home/opam/.opam/4.13/lib/zarith -I /home/opam/.opam/4.13/lib/zmq -I src/.sec_chan.objs/byte -no-alias-deps -o src/.pardi.eobjs/byte/utls.cmo -c -impl src/utls.ml)
- File "src/utls.ml", line 439, characters 4-8:
- 439 |     sock
-           ^^^^
- Error: This expression has type [ `Push ] Zmq.Socket.t
-        but an expression was expected of type [ `Pull ] Zmq.Socket.t
-        These two variant types have no intersection
```
cc @UnixJunkie 