### PR TITLE
svmwrap is not compatible with batteries 3.4.0

### DIFF
--- a/packages/svmwrap/svmwrap.3.1.0/opam
+++ b/packages/svmwrap/svmwrap.3.1.0/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "base-unix"
-  "batteries"
+  "batteries" {< "3.4.0"}
   "conf-libsvm-tools"
   "cpm" {>= "11.0.0"}
   "dolog" {>= "6.0.0"}

--- a/packages/svmwrap/svmwrap.4.0.0/opam
+++ b/packages/svmwrap/svmwrap.4.0.0/opam
@@ -8,7 +8,7 @@ license: "BSD-3-Clause"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "base-unix"
-  "batteries"
+  "batteries" {< "3.4.0"}
   "conf-libsvm-tools"
   "cpm" {>= "11.0.0"}
   "dolog" {>= "6.0.0"}


### PR DESCRIPTION
expects BatList.min to not have optional parameters `?cmp:('a -> 'a -> int)`
```
#=== ERROR while compiling molenc.16.2.0 ======================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/molenc.16.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p molenc -j 31
# exit-code            1
# env-file             ~/.opam/log/molenc-19-9cc836.env
# output-file          ~/.opam/log/molenc-19-9cc836.out
### output ###
#       ocamlc src/.encoder.eobjs/byte/merge.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.encoder.eobjs/byte -I /home/opam/.opam/4.13/lib/batteries -I /home/opam/.opam/4.13/lib/bst -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/camltc -I /home/opam/.opam/4.13/lib/camltc/tc -I /home/opam/.opam/4.13/lib/cpm -I /home/opam/.opam/4.13/lib/cpu -I /home/opam/.opam/4.13/lib/dokeysto -I /home/opam/.opam/4.13/lib/dokeysto_camltc -I /home/opam/.opam/4.13/lib/dolog -I /home/opam/.opam/4.13/lib/extunix -I /home/opam/.opam/4.13/lib/line_oriented -I /home/opam/.opam/4.13/lib/logs -I /home/opam/.opam/4.13/lib/lwt -I /home/opam/.opam/4.13/lib/lwt/unix -I /home/opam/.opam/4.13/lib/minicli -I /home/opam/.opam/4.13/lib/mmap -I /home/opam/.opam/4.13/lib/num -I /home/opam/.opam/4.13/lib/ocaml/threads -I /home/opam/.opam/4.13/lib/ocamlgraph -I /home/opam/.opam/4.13/lib/ocplib-endian -I /home/opam/.opam/4.13/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.13/lib/parany -I /home/opam/.opam/4.13/lib/result -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/stdlib-shims -I /home/opam/.opam/4.13/lib/vector3 -I src/.molenc.objs/byte -no-alias-deps -o src/.encoder.eobjs/byte/merge.cmo -c -impl src/merge.ml)
# File "src/merge.ml", line 88, characters 13-24:
# 88 |     | Min -> BatList.min
#                   ^^^^^^^^^^^
# Error: This expression has type ?cmp:('a -> 'a -> int) -> 'a list -> 'a
#        but an expression was expected of type float list -> float
```
cc @UnixJunkie 