### PR TITLE
goblint is not compatible with batteries 3.4.0

### DIFF
--- a/packages/goblint/goblint.1.0.0/opam
+++ b/packages/goblint/goblint.1.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "goblint-cil" {build}
-  "batteries" {build}
+  "batteries" {build & < "3.4.0"}
   "xml-light" {build}
   "ppx_distr_guards"
   "ppx_monadic"

--- a/packages/goblint/goblint.1.1.1/opam
+++ b/packages/goblint/goblint.1.1.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "4.09"}
   "dune" {>= "2.9.1"}
   "goblint-cil" {>= "1.8.2"}
-  "batteries" {>= "3.2.0"}
+  "batteries" {>= "3.2.0" & < "3.4.0"}
   "zarith" {>= "1.8"}
   "qcheck-core"
   "ppx_distr_guards" {>= "0.2"}


### PR DESCRIPTION
expects BatList.max to not have optional parameters `?cmp:('a -> 'a -> int)`
```
#=== ERROR while compiling goblint.1.1.1 ======================================#
# context              2.1.1 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/goblint.1.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p goblint -j 31 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/goblint-6525-ddb2a0.env
# output-file          ~/.opam/log/goblint-6525-ddb2a0.out
### output ###
#       ocamlc src/.goblint_lib.objs/byte/intDomain.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -ppx '.ppx/27f2167614ad3efeb6289ba343828ab9/ppx.exe --as-ppx --cookie '\''library-name="goblint_lib"'\''' -bin-annot -I src/.goblint_lib.objs/byte -I /home/opam/.opam/4.13/lib/batteries -I /home/opam/.opam/4.13/lib/biniou -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/easy-format -I /home/opam/.opam/4.13/lib/findlib -I /home/opam/.opam/4.13/lib/goblint-cil -I /home/opam/.opam/4.13/lib/goblint-cil/dataslicing -I /home/opam/.opam/4.13/lib/goblint-cil/liveness -I /home/opam/.opam/4.13/lib/goblint-cil/makecfg -I /home/opam/.opam/4.13/lib/goblint-cil/pta -I /home/opam/.opam/4.13/lib/goblint-cil/syntacticsearch -I /home/opam/.opam/4.13/lib/goblint-cil/zrapp -I /home/opam/.opam/4.13/lib/num -I /home/opam/.opam/4.13/lib/ppx_deriving/runtime -I /home/opam/.opam/4.13/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.13/lib/qcheck-core -I /home/opam/.opam/4.13/lib/qcheck-core/runner -I /home/opam/.opam/4.13/lib/result -I /home/opam/.opam/4.13/lib/sha -I /home/opam/.opam/4.13/lib/stdlib-shims -I /home/opam/.opam/4.13/lib/yojson -I /home/opam/.opam/4.13/lib/zarith -I src/sites/.goblint_sites.objs/byte -intf-suffix .ml -no-alias-deps -o src/.goblint_lib.objs/byte/intDomain.cmo -c -impl src/cdomains/intDomain.ml)
# File "src/cdomains/intDomain.ml", line 2804, characters 21-29:
# 2804 |   let minimal = flat List.max % mapp2 { fp2 = fun (type a) (module I:S with type t = a and type int_t = int_t) -> I.minimal }
#                             ^^^^^^^^
# Error: This expression has type ?cmp:('a -> 'a -> int) -> 'a list -> 'a
#        but an expression was expected of type 'b list -> 'c
#     ocamlopt src/.goblint_lib.objs/native/intDomain.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlopt.opt -w -40 -g -ppx '.ppx/27f2167614ad3efeb6289ba343828ab9/ppx.exe --as-ppx --cookie '\''library-name="goblint_lib"'\''' -I src/.goblint_lib.objs/byte -I src/.goblint_lib.objs/native -I /home/opam/.opam/4.13/lib/batteries -I /home/opam/.opam/4.13/lib/biniou -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/easy-format -I /home/opam/.opam/4.13/lib/findlib -I /home/opam/.opam/4.13/lib/goblint-cil -I /home/opam/.opam/4.13/lib/goblint-cil/dataslicing -I /home/opam/.opam/4.13/lib/goblint-cil/liveness -I /home/opam/.opam/4.13/lib/goblint-cil/makecfg -I /home/opam/.opam/4.13/lib/goblint-cil/pta -I /home/opam/.opam/4.13/lib/goblint-cil/syntacticsearch -I /home/opam/.opam/4.13/lib/goblint-cil/zrapp -I /home/opam/.opam/4.13/lib/num -I /home/opam/.opam/4.13/lib/ppx_deriving/runtime -I /home/opam/.opam/4.13/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.13/lib/qcheck-core -I /home/opam/.opam/4.13/lib/qcheck-core/runner -I /home/opam/.opam/4.13/lib/result -I /home/opam/.opam/4.13/lib/sha -I /home/opam/.opam/4.13/lib/stdlib-shims -I /home/opam/.opam/4.13/lib/yojson -I /home/opam/.opam/4.13/lib/zarith -I src/sites/.goblint_sites.objs/byte -I src/sites/.goblint_sites.objs/native -intf-suffix .ml -no-alias-deps -o src/.goblint_lib.objs/native/intDomain.cmx -c -impl src/cdomains/intDomain.ml)
# File "src/cdomains/intDomain.ml", line 2804, characters 21-29:
# 2804 |   let minimal = flat List.max % mapp2 { fp2 = fun (type a) (module I:S with type t = a and type int_t = int_t) -> I.minimal }
#                             ^^^^^^^^
# Error: This expression has type ?cmp:('a -> 'a -> int) -> 'a list -> 'a
#        but an expression was expected of type 'b list -> 'c
```
cc @sim642