### PR TITLE
raw_spacetime: add upper bound on ocaml 4.12

### DIFF
--- a/packages/raw_spacetime/raw_spacetime.base/opam
+++ b/packages/raw_spacetime/raw_spacetime.base/opam
@@ -3,7 +3,7 @@ maintainer: " "
 authors: " "
 homepage: " "
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.12"}
   "ocamlfind" {>= "1.7.1"}
 ]
 synopsis: "Raw_spacetime_lib library distributed with the OCaml compiler"


### PR DESCRIPTION
Spacetime was removed in that release.
Seen on https://github.com/ocaml/opam-repository/pull/20228

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>