### PR TITLE
Package erssical.1.1.0

### DIFF
--- a/packages/erssical/erssical.1.1.0/opam
+++ b/packages/erssical/erssical.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Converting RSS event feeds to ical"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rss" "xml" "ical" "http"]
+homepage: "https://zoggy.frama.io/erssical/"
+doc: "https://zoggy.frama.io/erssical/doc.html"
+bug-reports: "https://framagit.org/zoggy/erssical/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "icalendar" {>= "0.1.5"}
+  "lru-cache" {>= "0.3"}
+  "ocaml" {>= "4.12.0"}
+  "rss" {>= "3.0"}
+  "xtmpl" {>= "0.19.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://framagit.org/zoggy/erssical.git"
+url {
+  src:
+    "https://framagit.org/zoggy/erssical/-/archive/1.1.0/erssical-1.1.0.tar.bz2"
+  checksum: [
+    "md5=2fde0c7c62d55988919e0000f5fd8ea0"
+    "sha512=484ebb1827aad3c86c87552b0b8d83c80a5bffa58674724aca23ea1677a646bdf598cfeced58783746aa4c44a61fd33d2a2252b965a3de830dacf599fea5988e"
+  ]
+}

--- a/packages/erssical/erssical.1.1.0/opam
+++ b/packages/erssical/erssical.1.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt_ppx"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/erssical/erssical.1.1.0/opam
+++ b/packages/erssical/erssical.1.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "rss" {>= "3.0"}
   "xtmpl" {>= "0.19.0"}
+  "lwt_ppx"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
### `erssical.1.1.0`
Converting RSS event feeds to ical



---
* Homepage: https://zoggy.frama.io/erssical/
* Source repo: git+https://framagit.org/zoggy/erssical.git
* Bug tracker: https://framagit.org/zoggy/erssical/issues

---
:camel: Pull-request generated by opam-publish v2.1.0