### PR TITLE
Package higlo.0.8

### DIFF
--- a/packages/higlo/higlo.0.8/opam
+++ b/packages/higlo/higlo.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Syntax highlighting library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/higlo/"
+doc: "https://zoggy.frama.io/higlo/doc.html"
+bug-reports: "https://framagit.org/zoggy/higlo/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "1.2"}
+  "xtmpl" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/higlo.git"
+url {
+  src: "https://framagit.org/zoggy/higlo/-/archive/0.8/higlo-0.8.tar.bz2"
+  checksum: [
+    "md5=8a92052d66ad8afe241d66274d58a0b9"
+    "sha512=5f82c286eb9a4f5e18ea2df23f943907403c593f8dbfecb10c12aa2c40aa0264ac63030e0ee5e133240e36178e1bfc2eb3e9fba64ebc885bb2c2eaf964ee389c"
+  ]
+}


### PR DESCRIPTION
### `higlo.0.8`
Syntax highlighting library



---
* Homepage: https://zoggy.frama.io/higlo/
* Source repo: git+https://framagit.org/zoggy/higlo.git
* Bug tracker: https://framagit.org/zoggy/higlo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0