### PR TITLE
6 packages from framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2

### DIFF
--- a/packages/ojs_base/ojs_base.0.7.0/opam
+++ b/packages/ojs_base/ojs_base.0.7.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Base library for developing OCaml web apps based on websockets and js_of_ocaml"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+tags: ["javascript" "web" "components"]
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "websocket" {>= "2.14"}
+  "websocket-lwt-unix" {>= "2.14"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "yojson" {>= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2"
+  checksum: [
+    "md5=85b8a0746e9be8c20cf082f2573b5895"
+    "sha512=ec707820ff69ddbf9c631cf6a1c8748e82346daded1a4f73c5702128d07858f915e62d529e5fec01e99263f33eefb1586067341c058535806e0092b9d040644a"
+  ]
+}

--- a/packages/ojs_base_all/ojs_base_all.0.7.0/opam
+++ b/packages/ojs_base_all/ojs_base_all.0.7.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all ojs_base packages"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "ojs_filetree" {= version}
+  "ojs_list" {= version}
+  "ojs_ed" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2"
+  checksum: [
+    "md5=85b8a0746e9be8c20cf082f2573b5895"
+    "sha512=ec707820ff69ddbf9c631cf6a1c8748e82346daded1a4f73c5702128d07858f915e62d529e5fec01e99263f33eefb1586067341c058535806e0092b9d040644a"
+  ]
+}

--- a/packages/ojs_base_ppx/ojs_base_ppx.0.7.0/opam
+++ b/packages/ojs_base_ppx/ojs_base_ppx.0.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PPx extension for the Ojs_base library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "ojs_base" {= version}
+  "ppx_tools" {>= "6.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2"
+  checksum: [
+    "md5=85b8a0746e9be8c20cf082f2573b5895"
+    "sha512=ec707820ff69ddbf9c631cf6a1c8748e82346daded1a4f73c5702128d07858f915e62d529e5fec01e99263f33eefb1586067341c058535806e0092b9d040644a"
+  ]
+}

--- a/packages/ojs_ed/ojs_ed.0.7.0/opam
+++ b/packages/ojs_ed/ojs_ed.0.7.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Using file editor in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2"
+  checksum: [
+    "md5=85b8a0746e9be8c20cf082f2573b5895"
+    "sha512=ec707820ff69ddbf9c631cf6a1c8748e82346daded1a4f73c5702128d07858f915e62d529e5fec01e99263f33eefb1586067341c058535806e0092b9d040644a"
+  ]
+}

--- a/packages/ojs_filetree/ojs_filetree.0.7.0/opam
+++ b/packages/ojs_filetree/ojs_filetree.0.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Using filetrees in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "magic-mime" {>= "1.2.0"}
+  "base64" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2"
+  checksum: [
+    "md5=85b8a0746e9be8c20cf082f2573b5895"
+    "sha512=ec707820ff69ddbf9c631cf6a1c8748e82346daded1a4f73c5702128d07858f915e62d529e5fec01e99263f33eefb1586067341c058535806e0092b9d040644a"
+  ]
+}

--- a/packages/ojs_list/ojs_list.0.7.0/opam
+++ b/packages/ojs_list/ojs_list.0.7.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Using lists in ojs_base applications, common part"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "http://zoggy.frama.io/ojs-base/"
+doc: "http://zoggy.frama.io/ojs-base/refdoc/"
+bug-reports: "https://framagit.org/zoggy/ojs-base/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ojs_base" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ojs-base.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ojs-base/-/archive/0.7.0/ojs-base-0.7.0.tar.bz2"
+  checksum: [
+    "md5=85b8a0746e9be8c20cf082f2573b5895"
+    "sha512=ec707820ff69ddbf9c631cf6a1c8748e82346daded1a4f73c5702128d07858f915e62d529e5fec01e99263f33eefb1586067341c058535806e0092b9d040644a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ojs_base.0.7.0`: Base library for developing OCaml web apps based on
 websockets and js_of_ocaml
-`ojs_base_all.0.7.0`: Virtual package to install all ojs_base packages
-`ojs_base_ppx.0.7.0`: PPx extension for the Ojs_base library
-`ojs_ed.0.7.0`: Using file editor in ojs_base applications, common part
-`ojs_filetree.0.7.0`: Using filetrees in ojs_base applications, common part
-`ojs_list.0.7.0`: Using lists in ojs_base applications, common part



---
* Homepage: http://zoggy.frama.io/ojs-base/
* Source repo: git+https://framagit.org/zoggy/ojs-base.git
* Bug tracker: https://framagit.org/zoggy/ojs-base/issues

---
:camel: Pull-request generated by opam-publish v2.1.0