### PR TITLE
Package opam-custom-install.0.2

### DIFF
--- a/packages/opam-custom-install/opam-custom-install.0.2/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+synopsis: "An opam plugin to install a package using a custom command"
+description: """
+Provides the `opam custom-install` command, which allows to wrap a custom install command, and make opam register it as the installation of a given package. This is a prototype provided for the moment as a plugin, but might get integrated into opam if useful.
+"""
+tags: ["org:ocamlpro" "org:opam"]
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+depends: [
+  "dune" {>= "1.5"}
+  "opam-client" {>= "2.1.2"}
+]
+homepage: "https://gitlab.ocamlpro.com/louis/opam-custom-install"
+bug-reports: "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/issues"
+dev-repo: "git+https://gitlab.ocamlpro.com/louis/opam-custom-install.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+flags: plugin
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+url {
+  src:
+    "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/archive/0.2/opam-custom-install-0.2.tar.gz"
+  checksum: [
+    "md5=82f4b7100bfee1744a3982cccbab5d20"
+    "sha512=76a09a4a12905016f28661c1e2ada8407c9e2f21aee423ea46fb1ba90171c411831496e4126606486be61a042167c4067bca13e0ad4a7dbe850f8a71721aa874"
+  ]
+}


### PR DESCRIPTION
### `opam-custom-install.0.2`
An opam plugin to install a package using a custom command
Provides the `opam custom-install` command, which allows to wrap a custom install command, and make opam register it as the installation of a given package. This is a prototype provided for the moment as a plugin, but might get integrated into opam if useful.



---
* Homepage: https://gitlab.ocamlpro.com/louis/opam-custom-install
* Source repo: git+https://gitlab.ocamlpro.com/louis/opam-custom-install.git
* Bug tracker: https://gitlab.ocamlpro.com/louis/opam-custom-install/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0