### PR TITLE
Cohttp 5.0.0 upper bounds

### DIFF
--- a/packages/h1_parser/h1_parser.0.0.2/opam
+++ b/packages/h1_parser/h1_parser.0.0.2/opam
@@ -20,6 +20,9 @@ depends: [
   "ppx_assert" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "cohttp-lwt-unix" {with-test & >= "5.0.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/ocsigenserver/ocsigenserver.3.0.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.3.0.0/opam
@@ -52,7 +52,7 @@ depends: [
   "cryptokit"
   "dbm" | "sqlite3" | "pgocaml"
   "ipaddr" {>= "2.1"}
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" {< "5.0.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "hmap"
   "xml-light"

--- a/packages/ocsigenserver/ocsigenserver.4.0.1/opam
+++ b/packages/ocsigenserver/ocsigenserver.4.0.1/opam
@@ -56,7 +56,7 @@ depends: [
   "cryptokit"
   "dbm" | "sqlite3" | "pgocaml"
   "ipaddr" {>= "2.1"}
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" {< "5.0.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "hmap"
   "xml-light"

--- a/packages/ocsigenserver/ocsigenserver.4.0.2/opam
+++ b/packages/ocsigenserver/ocsigenserver.4.0.2/opam
@@ -56,7 +56,7 @@ depends: [
   "cryptokit"
   "dbm" | "sqlite3" | "pgocaml"
   "ipaddr" {>= "2.1"}
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" {< "5.0.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "hmap"
   "xml-light"

--- a/packages/ocsigenserver/ocsigenserver.5.0.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.5.0.0/opam
@@ -56,7 +56,7 @@ depends: [
   "cryptokit"
   "dbm" | "sqlite3" | "pgocaml"
   "ipaddr" {>= "2.1"}
-  "cohttp-lwt-unix"
+  "cohttp-lwt-unix" {< "5.0.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "hmap"
   "xml-light"

--- a/packages/podge/podge.0.2/opam
+++ b/packages/podge/podge.0.2/opam
@@ -19,7 +19,7 @@ remove: ["ocamlfind" "remove" "podge"]
 depends: [
   "ocaml" {>= "4.02.2"}
   "base-unix"
-  "cohttp" {>= "0.9.7"}
+  "cohttp" {>= "0.9.7" & < "5.0.0"}
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "tyxml" {< "4.0.0"}

--- a/packages/podge/podge.0.3/opam
+++ b/packages/podge/podge.0.3/opam
@@ -18,7 +18,7 @@ remove: ["ocamlfind" "remove" "podge"]
 depends: [
   "ocaml" {>= "4.02.1"}
   "base-unix"
-  "cohttp" {>= "0.9.7"}
+  "cohttp" {>= "0.9.7" & < "5.0.0"}
   "oasis" {build & >= "0.4"}
   "ocamlfind" {build}
   "re" {>= "1.3.0"}

--- a/packages/reddit_api_async/reddit_api_async.0.1.0/opam
+++ b/packages/reddit_api_async/reddit_api_async.0.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "2.5"}
   "async" {>= "v0.14.0"}
   "async_ssl" {>= "v0.14.0"}
-  "cohttp-async" {>= "2.5.4"}
+  "cohttp-async" {>= "2.5.4" & < "5.0.0"}
   "core" {>= "v0.14.0"}
   "ezjsonm" {>= "1.0"}
   "reddit_api_kernel" {= version}

--- a/packages/reddit_api_async/reddit_api_async.0.1.1/opam
+++ b/packages/reddit_api_async/reddit_api_async.0.1.1/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "2.5"}
   "async" {>= "v0.14.0"}
   "async_ssl" {>= "v0.14.0"}
-  "cohttp-async" {>= "2.5.4"}
+  "cohttp-async" {>= "2.5.4" & < "5.0.0"}
   "core" {>= "v0.14.0"}
   "ezjsonm" {>= "1.0"}
   "reddit_api_kernel" {= version}

--- a/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
+++ b/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.3.0"}
   "websocket" {= version}
   "lwt_log" {>= "1.1.1"}
-  "cohttp-lwt-unix" {>= "2.5.1"}
+  "cohttp-lwt-unix" {>= "2.5.1" & < "5.0.0"}
 ]
 synopsis: "Websocket library (Lwt)"
 description: """

--- a/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
+++ b/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/vbmithr/ocaml-websocket"
 bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
 dev-repo: "git+https://github.com/vbmithr/ocaml-websocket"
 doc: "https://vbmithr.github.io/ocaml-websocket/doc"
+license: "ISC"
 tags: [
   "org:mirage"
   "org:xapi-project"

--- a/packages/zeit/zeit.0.1.0/opam
+++ b/packages/zeit/zeit.0.1.0/opam
@@ -16,6 +16,9 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_let" {< "v0.15"}
 ]
+conflicts: [
+  "cohttp-lwt-unix" {with-test & >= "5.0.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Related to https://github.com/ocaml/opam-repository/pull/20246

- ocsigenserver: ping @jrochel 
- websocket-lwt-unix: ping @vbmithr 
- Reddit_api_async: ping @leviroth 

The extra `zeit` failure is due to tests relying on incorrect headers ordering (ping @emillon)
```
#=== ERROR while compiling zeit.0.1.0 =========================================#
# context              2.0.10 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/zeit.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p zeit -j 31
# exit-code            1
# env-file             ~/.opam/log/zeit-778-6d07ae.env
# output-file          ~/.opam/log/zeit-778-6d07ae.out
### output ###
#     test_all alias test/runtest (exit 1)
# (cd _build/default/test && ./test_all.exe)
# ...FF...
# ==============================================================================
# Error: zeit:1:client:1:post_file:1:HTTP error.
# 
# File "/home/opam/.opam/4.13/.opam-switch/build/zeit.0.1.0/_build/default/test/oUnit-zeit-builder#07.log", line 23, characters 1-1:
# Error: zeit:1:client:1:post_file:1:HTTP error (in the log).
# 
# File "test/test_client.ml", line 60, characters 1-1:
# Error: zeit:1:client:1:post_file:1:HTTP error (in the code).
# 
# when comparing cohttp_call calls
# expected: (POST,
#  Authorization: Bearer TOKEN
# Content-Type: application/octet-stream
# Content-Length: 5
# x-now-digest: aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
# x-now-size: 5
# 
# ,
#  https://api.zeit.co/v2/now/files, "hello")
# but got: (POST,
#  Authorization: Bearer TOKEN
# Content-Length: 5
# Content-Type: application/octet-stream
# x-now-digest: aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
# x-now-size: 5
# 
# ,
#  https://api.zeit.co/v2/now/files, "hello")
# ------------------------------------------------------------------------------
# ==============================================================================
# Error: zeit:1:client:1:post_file:0:OK.
# 
# File "/home/opam/.opam/4.13/.opam-switch/build/zeit.0.1.0/_build/default/test/oUnit-zeit-builder#06.log", line 23, characters 1-1:
# Error: zeit:1:client:1:post_file:0:OK (in the log).
# 
# File "test/test_client.ml", line 60, characters 1-1:
# Error: zeit:1:client:1:post_file:0:OK (in the code).
# 
# when comparing cohttp_call calls
# expected: (POST,
#  Authorization: Bearer TOKEN
# Content-Type: application/octet-stream
# Content-Length: 5
# x-now-digest: aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
# x-now-size: 5
# 
# ,
#  https://api.zeit.co/v2/now/files, "hello")
# but got: (POST,
#  Authorization: Bearer TOKEN
# Content-Length: 5
# Content-Type: application/octet-stream
# x-now-digest: aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
# x-now-size: 5
# 
# ,
#  https://api.zeit.co/v2/now/files, "hello")
# ------------------------------------------------------------------------------
# Ran: 8 tests in: 0.12 seconds.
# FAILED: Cases: 8 Tried: 8 Errors: 0 Failures: 2 Skip:  0 Todo: 0 Timeouts: 0.
```
But not really an incompatibility, so I did not touch it.

