### PR TITLE
[new release] git-cohttp, git-cohttp-unix, git-mirage, git, git-paf and git-unix (3.7.0)

### DIFF
--- a/packages/git-cohttp-unix/git-cohttp-unix.3.7.0/opam
+++ b/packages/git-cohttp-unix/git-cohttp-unix.3.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "git-cohttp" {= version}
+  "cohttp-lwt-unix"
+  "cohttp" {>= "2.5.4"}
+  "cohttp-lwt" {>= "2.5.4"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=277f6c6f684522aee60c007cd2637b6a9e8557835970bcb14721ccb13ea7b015"
+    "sha512=2045f39e101aebeb3b24a6732e4fff3aea8e6613eb5e65ba327cd7f2396a6c271bd24dd195619732a9f837c41fd81871ca99b63022faba7440224359a7e50126"
+  ]
+}

--- a/packages/git-cohttp/git-cohttp.3.7.0/opam
+++ b/packages/git-cohttp/git-cohttp.3.7.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "cohttp"
+  "cohttp-lwt"
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=277f6c6f684522aee60c007cd2637b6a9e8557835970bcb14721ccb13ea7b015"
+    "sha512=2045f39e101aebeb3b24a6732e4fff3aea8e6613eb5e65ba327cd7f2396a6c271bd24dd195619732a9f837c41fd81871ca99b63022faba7440224359a7e50126"
+  ]
+}

--- a/packages/git-mirage/git-mirage.3.7.0/opam
+++ b/packages/git-mirage/git-mirage.3.7.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mirage-stack"
+  "git" {= version}
+  "git-paf" {= version}
+  "awa" {>= "0.0.5"}
+  "awa-mirage" {>= "0.0.5"}
+  "dns" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0"}
+  "tls"
+  "tls-mirage"
+  "mirage-protocols" {>= "7.0.0"}
+  "uri"
+  "hex"
+  "happy-eyeballs-mirage" {>= "0.1.1"}
+  "happy-eyeballs" {>= "0.1.1"}
+  "ca-certs-nss"
+  "mirage-crypto"
+  "ptime"
+  "x509"
+  "cstruct"
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=277f6c6f684522aee60c007cd2637b6a9e8557835970bcb14721ccb13ea7b015"
+    "sha512=2045f39e101aebeb3b24a6732e4fff3aea8e6613eb5e65ba327cd7f2396a6c271bd24dd195619732a9f837c41fd81871ca99b63022faba7440224359a7e50126"
+  ]
+}

--- a/packages/git-paf/git-paf.3.7.0/opam
+++ b/packages/git-paf/git-paf.3.7.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "mimic" {>= "0.0.4"}
+  "paf" {>= "0.0.7"}
+  "ca-certs-nss"
+  "fmt"
+  "ipaddr"
+  "logs"
+  "lwt"
+  "mirage-clock"
+  "mirage-stack"
+  "mirage-time"
+  "result"
+  "rresult"
+  "tls" {>= "0.14.0"}
+  "uri"
+  "bigarray-compat"
+  "bigstringaf"
+  "domain-name"
+  "httpaf"
+  "mirage-flow"
+  "tls-mirage"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=277f6c6f684522aee60c007cd2637b6a9e8557835970bcb14721ccb13ea7b015"
+    "sha512=2045f39e101aebeb3b24a6732e4fff3aea8e6613eb5e65ba327cd7f2396a6c271bd24dd195619732a9f837c41fd81871ca99b63022faba7440224359a7e50126"
+  ]
+}

--- a/packages/git-unix/git-unix.3.7.0/opam
+++ b/packages/git-unix/git-unix.3.7.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "git-mirage" {= version}
+  "happy-eyeballs-lwt" {>= "0.1.1"}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "git-cohttp-unix" {= version}
+  "mirage-clock"
+  "mirage-clock-unix"
+  "astring" {>= "0.8.5"}
+  "awa" {>= "0.0.5"}
+  "mirage-protocols" {>= "7.0.0"}
+  "mirage-time"
+  "mirage-unix" {>= "4.0.0"}
+  "cmdliner" {>= "1.0.4"}
+  "decompress" {>= "1.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "awa-mirage" {>= "0.0.5"}
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ptime"
+  "mimic"
+  "ca-certs-nss" {>= "3.60"}
+  "tls" {>= "0.14.0"}
+  "tls-mirage" {>= "0.14.0"}
+  "cohttp-lwt-unix" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=277f6c6f684522aee60c007cd2637b6a9e8557835970bcb14721ccb13ea7b015"
+    "sha512=2045f39e101aebeb3b24a6732e4fff3aea8e6613eb5e65ba327cd7f2396a6c271bd24dd195619732a9f837c41fd81871ca99b63022faba7440224359a7e50126"
+  ]
+}

--- a/packages/git/git.3.7.0/opam
+++ b/packages/git/git.3.7.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic" {>= "0.0.4"}
+  "cstruct" {>= "6.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.0"}
+  "carton-lwt" {>= "0.4.0"}
+  "carton-git" {>= "0.4.0"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "hxd" {>= "0.3.1"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=277f6c6f684522aee60c007cd2637b6a9e8557835970bcb14721ccb13ea7b015"
+    "sha512=2045f39e101aebeb3b24a6732e4fff3aea8e6613eb5e65ba327cd7f2396a6c271bd24dd195619732a9f837c41fd81871ca99b63022faba7440224359a7e50126"
+  ]
+}

--- a/packages/git/git.3.7.0/opam
+++ b/packages/git/git.3.7.0/opam
@@ -57,7 +57,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-git.git"
 x-commit-hash: "c2d1d6e8e710279b87560b46c9bbbb51f99a1d95"


### PR DESCRIPTION
A package to use HTTP-based ocaml-git with Unix backend

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Drop unneeded `mirage-protocols` dependency (@hannesm, mirage/ocaml-git#537)
- Delete HTTP functor and use happy-eyeballs (@dinosaure, mirage/ocaml-git#539)
- Be compatible with `mirage-protocols.7.0.0` (@dinosaure, mirage/ocaml-git#541)
- Use `Lwt.pause` instead of `Lwt_unix.yield` (@dinosaure, mirage/ocaml-git#542)
- Link with logs and `logs.fmt` (@MisterDA, mirage/ocaml-git#544)
