### PR TITLE
[new release] charrua, charrua-unix, charrua-server and charrua-client (1.5.0)

### DIFF
--- a/packages/charrua-client/charrua-client.1.5.0/opam
+++ b/packages/charrua-client/charrua-client.1.5.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "DHCP client implementation"
+description: """\
+charrua-client is a DHCP client powered by [charrua](https://github.com/mirage/charrua).
+
+The base library exposes a simple state machine in `Dhcp_client`
+for use in acquiring a DHCP lease."""
+maintainer: "Mindy Preston"
+authors: "Mindy Preston"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://docs.mirage.io"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "charrua-server" {= version & with-test}
+  "charrua" {= version}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "duration"
+  "logs"
+  "fmt"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz"
+  checksum: [
+    "sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1"
+    "sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87"
+  ]
+}
+x-commit-hash: "fb614f77b8f4cbd5f6409453a8f030b21d7e1a93"

--- a/packages/charrua-server/charrua-server.1.5.0/opam
+++ b/packages/charrua-server/charrua-server.1.5.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "DHCP server"
+description: """\
+Charrua-server consists of a single `Dhcp_server` module used for constructing DHCP
+servers.
+
+[dhcp](https://github.com/mirage/mirage-skeleton/tree/master/applications/dhcp)
+is a Mirage DHCP unikernel server based on charrua, included as a part of the MirageOS unikernel example and starting-point repository.
+
+#### Features
+
+* `Dhcp_server` supports a stripped down ISC dhcpd.conf, so you can probably just
+  use your old `dhcpd.conf`. It also supports manual configuration building in
+  OCaml.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+doc: "https://mirage.github.io/charrua/"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "menhir" {build & >= "20180523"}
+  "charrua" {= version}
+  "cstruct" {>= "6.0.0"}
+  "sexplib"
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "macaddr-sexp"
+  "cstruct-unix" {with-test}
+  "ppx_cstruct" {>= "6.0.0" & with-test}
+  "tcpip" {>= "7.0.0" & with-test}
+  "alcotest" {with-test & >= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz"
+  checksum: [
+    "sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1"
+    "sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87"
+  ]
+}
+x-commit-hash: "fb614f77b8f4cbd5f6409453a8f030b21d7e1a93"

--- a/packages/charrua-unix/charrua-unix.1.5.0/opam
+++ b/packages/charrua-unix/charrua-unix.1.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Unix DHCP daemon"
+description: """\
+charrua-unix is an _ISC-licensed_ Unix DHCP daemon based on
+[charrua](http://www.github.com/mirage/charrua)."""
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+depends: [
+  "dune" {>= "1.4.0"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "3.0.0"}
+  "lwt_log"
+  "charrua" {= version}
+  "charrua-server" {= version}
+  "cstruct-unix"
+  "cmdliner"
+  "rawlink" {>= "1.0"}
+  "tuntap" {>= "2.0.0"}
+  "mtime" {>= "1.0.0"}
+  "cstruct-lwt" {>= "6.0.0"}
+  "ipaddr" {>= "5.1.0"}
+  "tcpip" {>= "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/charrua.git"
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz"
+  checksum: [
+    "sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1"
+    "sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87"
+  ]
+}
+x-commit-hash: "fb614f77b8f4cbd5f6409453a8f030b21d7e1a93"

--- a/packages/charrua/charrua.1.5.0/opam
+++ b/packages/charrua/charrua.1.5.0/opam
@@ -6,12 +6,10 @@ homepage: "https://github.com/mirage/charrua"
 bug-reports: "https://github.com/mirage/charrua/issues"
 dev-repo: "git+https://github.com/mirage/charrua.git"
 doc: "https://mirage.github.io/charrua/"
-
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
-
 depends: [
   "ocaml"         {>= "4.08.0"}
   "dune"          {>= "1.4.0"}

--- a/packages/charrua/charrua.1.5.0/opam
+++ b/packages/charrua/charrua.1.5.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/charrua"
+bug-reports: "https://github.com/mirage/charrua/issues"
+dev-repo: "git+https://github.com/mirage/charrua.git"
+doc: "https://mirage.github.io/charrua/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml"         {>= "4.08.0"}
+  "dune"          {>= "1.4.0"}
+  "ppx_sexp_conv" {>="v0.10.0"}
+  "ppx_cstruct"
+  "cstruct"       {>= "6.0.0"}
+  "sexplib"
+  "ipaddr"        {>= "5.0.0"}
+  "macaddr"       {>= "4.0.0"}
+  "ipaddr-sexp"
+  "macaddr-sexp"
+  "ethernet"      {>= "3.0.0"}
+  "tcpip"         {>= "7.0.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "DHCP wire frame encoder and decoder"
+description: """
+Charrua consists a single modules, `Dhcp_wire` responsible for parsing and
+constructing DHCP messages
+
+You can browse the API for [charrua](http://www.github.com/mirage/charrua) at
+https://mirage.github.io/charrua/
+
+#### Features
+
+* `Dhcp_wire` provides marshalling and unmarshalling utilities for DHCP.
+* Logic/sequencing is agnostic of IO and platform, so it can run on Unix as a
+  process, as a Mirage unikernel or anything else.
+* All DHCP options are supported at the time of this writing.
+* Code is purely applicative.
+* It's in OCaml, so it's pretty cool.
+
+The name `charrua` is a reference to the, now extinct, semi-nomadic people of
+southern South America.
+"""
+url {
+  src:
+    "https://github.com/mirage/charrua/releases/download/v1.5.0/charrua-v1.5.0.tbz"
+  checksum: [
+    "sha256=4ce74a5e78402f3d645ddcb344aaa1348349a8d5a35b8b55112aff0cb84db8e1"
+    "sha512=ac6960de516642793b928224c95da997042d2907829496843481894b38804e3b465b5f9703bd8c02e5202059847ee5c16db6975c630b462448db511b39f34f87"
+  ]
+}
+x-commit-hash: "fb614f77b8f4cbd5f6409453a8f030b21d7e1a93"


### PR DESCRIPTION
DHCP wire frame encoder and decoder

- Project page: <a href="https://github.com/mirage/charrua">https://github.com/mirage/charrua</a>
- Documentation: <a href="https://mirage.github.io/charrua/">https://mirage.github.io/charrua/</a>

##### CHANGES:

* Adapt to mirage-protocols 8.0.0, ethernet 3.0.0, arp 3.0.0, and tcpip 7.0.0
  changes (mirage/charrua#116 @hannesm)
* Avoid deprecated Lwt_main.yield, use Lwt.pause instead (mirage/charrua#115 @hannesm)
