### PR TITLE
[new release] mirage-protocols (8.0.0)

### DIFF
--- a/packages/mirage-protocols/mirage-protocols.8.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.8.0.0/opam
@@ -7,12 +7,10 @@ license:      "ISC"
 dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
 bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
 tags:         ["org:mirage"]
-
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
-
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}

--- a/packages/mirage-protocols/mirage-protocols.8.0.0/opam
+++ b/packages/mirage-protocols/mirage-protocols.8.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Mindy Preston <meetup@yomimono.org>"
+authors:      ["Mindy Preston <meetup@yomimono.org>"]
+homepage:     "https://github.com/mirage/mirage-protocols"
+doc:          "https://mirage.github.io/mirage-protocols/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-protocols.git"
+bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ipaddr" {>= "4.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+]
+synopsis: "MirageOS signatures for network protocols"
+description: """
+mirage-protocols provides a set of module types which libraries intended to
+be used as MirageOS network implementations should implement.
+
+The current signatures are: ETHERNET, ARP, IP, ICMP, UDP, TCP.
+"""
+post-messages: [
+  "This package is deprecated. Please use Ethernet.S, Arp.S, or the Tcpip module types directly"
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-protocols/releases/download/v8.0.0/mirage-protocols-v8.0.0.tbz"
+  checksum: [
+    "sha256=503091e09ab7b70f4ffc8970ed3e3edfeca2f50ed516a9c78577920af83d772c"
+    "sha512=c7cd35f5467265d46ecb50424c166431a25a24597196d409d877261f63ad3b7ec738e9f33ce728556b4babb1e7a031744c4f2eec3d70109296dc746933a4c4c3"
+  ]
+}
+x-commit-hash: "37aa4a86f9f423bb7fe1d70c8a71331060a45048"

--- a/packages/mirage-stack/mirage-stack.2.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "fmt"
   "lwt" {>= "4.0.0"}
 ]

--- a/packages/mirage-stack/mirage-stack.2.0.1/opam
+++ b/packages/mirage-stack/mirage-stack.2.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "fmt"
   "lwt" {>= "4.0.0"}
 ]

--- a/packages/mirage-stack/mirage-stack.2.1.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "fmt"
   "lwt" {>= "4.0.0"}
 ]

--- a/packages/mirage-stack/mirage-stack.2.2.0/opam
+++ b/packages/mirage-stack/mirage-stack.2.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "mirage-device" {>= "2.0.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "fmt"
   "lwt" {>= "4.0.0"}
 ]

--- a/packages/mirage-stack/mirage-stack.3.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.3.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-stack/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
-  "mirage-protocols" {>= "4.0.0"}
+  "mirage-protocols" {>= "4.0.0" & < "8.0.0"}
   "fmt"
   "lwt" {>= "4.0.0"}
 ]


### PR DESCRIPTION
MirageOS signatures for network protocols

- Project page: <a href="https://github.com/mirage/mirage-protocols">https://github.com/mirage/mirage-protocols</a>
- Documentation: <a href="https://mirage.github.io/mirage-protocols/">https://mirage.github.io/mirage-protocols/</a>

##### CHANGES:

* Deprecate this package, the module types are now defined by arp (>= 3.0.0),
  ethernet (>= 3.0.0) and tcpip (>= 7.0.0) (mirage/mirage-protocols#30 @hannesm)
