### PR TITLE
[new release] mirage-stack (4.0.0)

### DIFF
--- a/packages/git-paf/git-paf.3.4.0/opam
+++ b/packages/git-paf/git-paf.3.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "mirage-time"
   "result"
   "rresult"

--- a/packages/git-paf/git-paf.3.5.0/opam
+++ b/packages/git-paf/git-paf.3.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "mirage-time"
   "result"
   "rresult"

--- a/packages/git-paf/git-paf.3.6.0/opam
+++ b/packages/git-paf/git-paf.3.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "mirage-time"
   "result"
   "rresult"

--- a/packages/mirage-stack/mirage-stack.4.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.4.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-stack"
+doc: "https://mirage.github.io/mirage-stack/"
+bug-reports: "https://github.com/mirage/mirage-stack/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tcpip" {>= "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-stack.git"
+synopsis: "MirageOS signatures for network stacks"
+description: """
+mirage-stack provides a set of module types which libraries intended to be used
+as MirageOS network stacks should implement.
+"""
+post-messages: [
+  "This package is deprecated. Please use the module types in Tcpip.Stack directly."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage-stack/releases/download/v4.0.0/mirage-stack-v4.0.0.tbz"
+  checksum: [
+    "sha256=abbd33190bd3e4a4eabcbdfb6d98d20fc4aed0fef628251eb327d625c23cccfc"
+    "sha512=83f121a22ce7a00aa2fc01d88603dafb6dd8d4cff0a2a9c6f73d8b1626aa43604ab797c793689190035289d2d00c77a60aa8d1b9f8fa66425dd19a08e7ccd518"
+  ]
+}
+x-commit-hash: "2d0fe8f5a198e04415eafd6496d5719f0a610e7e"

--- a/packages/mirage-stack/mirage-stack.4.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.4.0.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "Mindy Preston <meetup@yomimono.org>"
 authors: "Mindy Preston <meetup@yomimono.org>"
 license: "ISC"
-tags: "org:mirage"
+tags: ["org:mirage"]
 homepage: "https://github.com/mirage/mirage-stack"
 doc: "https://mirage.github.io/mirage-stack/"
 bug-reports: "https://github.com/mirage/mirage-stack/issues"


### PR DESCRIPTION
MirageOS signatures for network stacks

- Project page: <a href="https://github.com/mirage/mirage-stack">https://github.com/mirage/mirage-stack</a>
- Documentation: <a href="https://mirage.github.io/mirage-stack/">https://mirage.github.io/mirage-stack/</a>

##### CHANGES:

* Deprecate mirage-stack. The module types are now part of tcpip (>= 7.0.0)
  (mirage/mirage-stack#21 @hannesm)
