### PR TITLE
[new release] mirage-nat (2.2.5)

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.2.5/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ipaddr"
+  "cstruct" {>= "6.0.0"}
+  "lru" {>= "0.3.0"}
+  "ppx_deriving" {>= "4.2" }
+  "dune" {>= "1.0"}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" { >= "3.0.0" }
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+  "lwt" {with-test}
+  "logs" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v2.2.5/mirage-nat-v2.2.5.tbz"
+  checksum: [
+    "sha256=048456aa671f438af47e1816e53cc7b80a32e04df1c79ecfe70a725fc907b707"
+    "sha512=6de96fadd624a8054cbca09d4b13f40f4ff78fa8fb0e18170d5514a291bde2c3e56dfed1472a9420dab5e8aff4ab4e7cd25907df299f2554e4e3d419a2f0ab16"
+  ]
+}
+x-commit-hash: "81d91428e0fe1e61f6302a9f5cc9e4877a2aa5fd"

--- a/packages/mirage-nat/mirage-nat.2.2.5/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.5/opam
@@ -16,17 +16,19 @@ depends: [
   "ipaddr"
   "cstruct" {>= "6.0.0"}
   "lru" {>= "0.3.0"}
-  "ppx_deriving" {>= "4.2" }
+  "ppx_deriving" {>= "4.2"}
   "dune" {>= "1.0"}
-  "tcpip" { >= "7.0.0" }
-  "ethernet" { >= "3.0.0" }
+  "tcpip" {>= "7.0.0"}
+  "ethernet" {>= "3.0.0"}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}
   "fmt" {with-test & >= "0.8.7"}
   "lwt" {with-test}
   "logs" {with-test}
 ]
-conflicts: [ "result" {< "1.5"} ]
+conflicts: [
+  "result" {< "1.5"}
+]
 synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
 description: """
 Mirage-nat is a library for [network address


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- adapt to ethernet 3.0.0 and tcpip 7.0.0 changes (mirage/mirage-nat#46 @hannesm)
