### PR TITLE
js_of_ocaml-compiler is not compatible with menhir 20211215

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppxlib" {>= "0.15.0"}
   "re" {with-test}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "menhirLib"
   "menhirSdk"
   "yojson"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ppxlib" {>= "0.15.0"}
   "re" {with-test}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "menhirLib"
   "menhirSdk"
   "yojson"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.5"}
   "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "yojson" # It's optional, but we want users to be able to use source-map without pain.
 ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.5"}
   "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "yojson" # It's optional, but we want users to be able to use source-map without pain.
 ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.5"}
   "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "ppxlib" {>= "0.15.0"}
   "yojson" # It's optional, but we want users to be able to use source-map without pain.
 ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.5"}
   "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "ppxlib" {>= "0.15.0"}
   "yojson" # It's optional, but we want users to be able to use source-map without pain.
 ]

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.5"}
   "ppx_expect" {with-test & >= "v0.12.0"}
   "cmdliner"
-  "menhir"
+  "menhir" {< "20211215"}
   "ppxlib" {>= "0.15.0"}
   "yojson" # It's optional, but we want users to be able to use source-map without pain.
 ]

--- a/packages/js_of_ocaml/js_of_ocaml.1.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.1.4.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {<= "4.01.0"}
   "ocamlfind"
   "lwt" {>= "2.3.0"}
-  "menhir"
+  "menhir" {< "20211215"}
   "camlp4"
 ]
 depopts: [


### PR DESCRIPTION
Fixed upstream in https://github.com/ocsigen/js_of_ocaml/pull/1186
```
#=== ERROR while compiling js_of_ocaml-compiler.3.11.0 ========================#
# context              2.0.10 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/js_of_ocaml-compiler.3.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p js_of_ocaml-compiler -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/js_of_ocaml-compiler-52-5f757a.env
# output-file          ~/.opam/log/js_of_ocaml-compiler-52-5f757a.out
### output ###
#        ocaml (internal)
# File "/home/opam/.opam/4.13/.opam-switch/build/js_of_ocaml-compiler.3.11.0/_build/.dune/default/tools/version/dune.ml", line 28, characters 14-37:
# 28 |   Hashtbl.add Toploop.directive_table "require"
#                    ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# File "/home/opam/.opam/4.13/.opam-switch/build/js_of_ocaml-compiler.3.11.0/_build/.dune/default/tools/version/dune.ml", line 30, characters 14-37:
# 30 |   Hashtbl.add Toploop.directive_table "use"
#                    ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# File "/home/opam/.opam/4.13/.opam-switch/build/js_of_ocaml-compiler.3.11.0/_build/.dune/default/tools/version/dune.ml", line 34, characters 14-37:
# 34 |   Hashtbl.add Toploop.directive_table "use_mod"
#                    ^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Toploop.directive_table
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
#       menhir compiler/lib/annot_parser.{ml,mli} (exit 1)
# (cd _build/default/compiler/lib && /home/opam/.opam/4.13/bin/menhir --stdlib . --explain annot_parser.mly)
# Error: the code back-end requires the type of every nonterminal symbol to be
# known. Please specify the type of every symbol via %type declarations, or
# enable type inference (look up --infer in the manual).
# Type inference is automatically enabled when Menhir is used via Dune.
# The types of the following nonterminal symbols are unknown:
# arg_annot
# endline
# loption(separated_nonempty_list(TComma,arg_annot))
# op
# option(delimited(LPARENT,separated_list(TComma,arg_annot),RPARENT))
# option(prim_annot)
# prim_annot
# separated_nonempty_list(TComma,TIdent)
# separated_nonempty_list(TComma,arg_annot)
# separated_nonempty_list(TComma,version)
# version
```