### PR TITLE
16 packages from framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz

### DIFF
--- a/packages/stog/stog.0.20.0/opam
+++ b/packages/stog/stog.0.20.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis:
+  "Static web site compiler, able to handle blog posts as well as regular pages or any XML document in general"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0" & < "4.13"}
+  "dune-build-info" {>= "2.9.1"}
+  "dune-site" {>= "2.9.1"}
+  "fmt" {>= "0.9.0"}
+  "higlo" {>= "0.8"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "menhir" {>= "20211128"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "ptime" {>= "0.8.2"}
+  "uri" {>= "4.2.0"}
+  "uutf" {>= "1.0.0"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_all/stog_all.0.20.0/opam
+++ b/packages/stog_all/stog_all.0.20.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all Stog libraries, tools and plugins"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "stog_server" {= version}
+  "stog_server_multi" {= version}
+  "stog_plugins" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_asy/stog_asy.0.20.0/opam
+++ b/packages/stog_asy/stog_asy.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to include Asymptote results in documents"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_dot/stog_dot.0.20.0/opam
+++ b/packages/stog_dot/stog_dot.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate and include graphviz graphs in documents"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_extern/stog_extern.0.20.0/opam
+++ b/packages/stog_extern/stog_extern.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to pipe documents in external commands"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_markdown/stog_markdown.0.20.0/opam
+++ b/packages/stog_markdown/stog_markdown.0.20.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to use markdown syntax"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "omd" {>= "1.9.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_multi_doc/stog_multi_doc.0.20.0/opam
+++ b/packages/stog_multi_doc/stog_multi_doc.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to define various documents in one file"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_nocaml/stog_nocaml.0.20.0/opam
+++ b/packages/stog_nocaml/stog_nocaml.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to block commands executing ocaml code"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_noexec/stog_noexec.0.20.0/opam
+++ b/packages/stog_noexec/stog_noexec.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to prevent running command with <exec>"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_plugins/stog_plugins.0.20.0/opam
+++ b/packages/stog_plugins/stog_plugins.0.20.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install all Stog plugins"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog_asy" {= version}
+  "stog_dot" {= version}
+  "stog_extern" {= version}
+  "stog_markdown" {= version}
+  "stog_multi_doc" {= version}
+  "stog_nocaml" {= version}
+  "stog_noexec" {= version}
+  "stog_rel_href" {= version}
+  "stog_sitemap" {= version}
+  "stog_writing" {= version}
+  "odoc" {with-doc}
+]
+depopts: [
+  "stog_rdf" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_rdf/stog_rdf.0.20.0/opam
+++ b/packages/stog_rdf/stog_rdf.0.20.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate rdf triples and execute sparql queries"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "rdf" {>= "0.13.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_rel_href/stog_rel_href.0.20.0/opam
+++ b/packages/stog_rel_href/stog_rel_href.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate relative urls"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_server/stog_server.0.20.0/opam
+++ b/packages/stog_server/stog_server.0.20.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Stog server library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "cryptokit" {>= "1.16.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "ojs_base_all" {>= "0.7.0"}
+  "websocket" {>= "2.14"}
+  "xmldiff" {>= "0.7.0"}
+  "xmldiff_js" {>= "0.7.0"}
+  "xtmpl_js" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_server_multi/stog_server_multi.0.20.0/opam
+++ b/packages/stog_server_multi/stog_server_multi.0.20.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Stog multi server library"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "stog_server" {= version}
+  "ojs_base_ppx" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_sitemap/stog_sitemap.0.20.0/opam
+++ b/packages/stog_sitemap/stog_sitemap.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate a sitemap file"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}

--- a/packages/stog_writing/stog_writing.0.20.0/opam
+++ b/packages/stog_writing/stog_writing.0.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Stog plugin to generate table of contents and bibliographies"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://www.good-eris.net/stog/"
+doc: "https://www.good-eris.net/stog/doc.html"
+bug-reports: "https://framagit.org/zoggy/stog/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "stog" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/stog.git"
+url {
+  src: "https://framagit.org/zoggy/stog/-/archive/0.20.0/stog-0.20.0.tar.gz"
+  checksum: [
+    "md5=2b0da8498e2e425cdbc44ff7ecb2a097"
+    "sha512=ae11b868e2a6d5e92ffffdde04f25ae1595e4bd7c9a6447327764327f17d2641713f01374f14ec9fd52e0ca7e0feb9d85c4fc5913aa49b4d1d73c52427d4263e"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`stog.0.20.0`: Static web site compiler, able to handle blog posts as well as
 regular pages or any XML document in general
-`stog_all.0.20.0`: Virtual package to install all Stog libraries, tools and
 plugins
-`stog_asy.0.20.0`: Stog plugin to include Asymptote results in documents
-`stog_dot.0.20.0`: Stog plugin to generate and include graphviz graphs in
 documents
-`stog_extern.0.20.0`: Stog plugin to pipe documents in external commands
-`stog_markdown.0.20.0`: Stog plugin to use markdown syntax
-`stog_multi_doc.0.20.0`: Stog plugin to define various documents in one file
-`stog_nocaml.0.20.0`: Stog plugin to block commands executing ocaml code
-`stog_noexec.0.20.0`: Stog plugin to prevent running command with <exec>
-`stog_plugins.0.20.0`: Virtual package to install all Stog plugins
-`stog_rdf.0.20.0`: Stog plugin to generate rdf triples and execute sparql
 queries
-`stog_rel_href.0.20.0`: Stog plugin to generate relative urls
-`stog_server.0.20.0`: Stog server library
-`stog_server_multi.0.20.0`: Stog multi server library
-`stog_sitemap.0.20.0`: Stog plugin to generate a sitemap file
-`stog_writing.0.20.0`: Stog plugin to generate table of contents and
 bibliographies



---
* Homepage: https://www.good-eris.net/stog/
* Source repo: git+https://framagit.org/zoggy/stog.git
* Bug tracker: https://framagit.org/zoggy/stog/issues

---
:camel: Pull-request generated by opam-publish v2.1.0