### PR TITLE
[new release] solo5-elftool (0.2.0)

### DIFF
--- a/packages/solo5-elftool/solo5-elftool.0.2.0/opam
+++ b/packages/solo5-elftool/solo5-elftool.0.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage: "https://git.robur.io/robur/ocaml-solo5-elftool"
+dev-repo: "git+https://git.robur.io/robur/ocaml-solo5-elftool.git"
+bug-reports: "https://github.com/roburio/ocaml-solo5-elftool/issues"
+doc: "https://roburio.github.io/ocaml-solo5-elftool/doc"
+maintainer: [ "team@robur.coop" ]
+authors: [ "Reynir Björnsson <reynir@reynir.dk>" ]
+license: "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.8.0"}
+  "dune" {>= "2.9"}
+  "owee" {>= "0.4"}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.7"}
+  "cmdliner"
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+synopsis: "OCaml Solo5 elftool for querying solo5 manifests"
+description: """
+OCaml Solo5 elftool is a library and executable for reading solo5 device
+manifests from solo5 ELF executables.
+"""
+url {
+  src:
+    "https://github.com/roburio/ocaml-solo5-elftool/releases/download/v0.2.0/solo5-elftool-0.2.0.tbz"
+  checksum: [
+    "sha256=fb09e45777ed2aa49e0adb7e9ba974c8f15c6ff8fbee301bf0a16e2364906b83"
+    "sha512=3eb434f1bce11e5f14708cb64a8bcc97d17656df3dadf53f398821fa2fb7354996d6ae064cff0b9c98143c6e41393ba2f273083f771bfaa98c6e62ef0053d288"
+  ]
+}
+x-commit-hash: "0a82ca4734cf2a2831df86876ae9158bf5b7d56a"


### PR DESCRIPTION
OCaml Solo5 elftool for querying solo5 manifests

- Project page: <a href="https://git.robur.io/robur/ocaml-solo5-elftool">https://git.robur.io/robur/ocaml-solo5-elftool</a>
- Documentation: <a href="https://roburio.github.io/ocaml-solo5-elftool/doc">https://roburio.github.io/ocaml-solo5-elftool/doc</a>

##### CHANGES:

* Rename binary from solo5-elftool to osolo5-elftool so it can co-exist with
  the C binary
* Implement `query_abi` and `osolo5-elftool query-abi`
* Return a result error instead of an assertion exception on unknown manifest
  entry types
* Remove noop tests
