### PR TITLE
ez_api 1.0: incompatible with new cohttp5 header module

### DIFF
--- a/packages/ez_api/ez_api.1.0.0/opam
+++ b/packages/ez_api/ez_api.1.0.0/opam
@@ -40,6 +40,7 @@ depopts: [
 conflicts: [
   "calendar" {< "2.03"}
   "cohttp-lwt-jsoo" {< "4.0.0"}
+  "cohttp" {< "5.0.0"}
   "httpaf-lwt-unix" {< "0.6.0"}
   "ezjs_fetch" {< "0.2"}
   "ocurl" {< "0.8.0"}


### PR DESCRIPTION
Seen on: https://github.com/ocaml/opam-repository/pull/20246

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>