### PR TITLE
[new release] bimage, bimage-unix, bimage-io and bimage-display (0.5.0)

### DIFF
--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -13,7 +13,7 @@ depends:
     "ocaml" {>= "4.08.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
-    "glfw-ocaml"
+    "glfw-ocaml" {>= "3.3"}
     "conf-glew"
 ]
 

--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml"
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=8ee23867215305089235568c1e2eb8722d068ffe86df2c86b546e54abe869080"
+    "sha512=b3b7e5d0ef78170447680982e0eab8cf61ac42401d68b296b990cc79f314669e6c1b590659e16d43d146b1e388c9e58d2a82c52736fa34670f25e92b486dc068"
+  ]
+}
+x-commit-hash: "47f6825f3c6a6ad8df0085258624b08870b10ba1"

--- a/packages/bimage-io/bimage-io.0.5.0/opam
+++ b/packages/bimage-io/bimage-io.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=8ee23867215305089235568c1e2eb8722d068ffe86df2c86b546e54abe869080"
+    "sha512=b3b7e5d0ef78170447680982e0eab8cf61ac42401d68b296b990cc79f314669e6c1b590659e16d43d146b1e388c9e58d2a82c52736fa34670f25e92b486dc068"
+  ]
+}
+x-commit-hash: "47f6825f3c6a6ad8df0085258624b08870b10ba1"

--- a/packages/bimage-unix/bimage-unix.0.5.0/opam
+++ b/packages/bimage-unix/bimage-unix.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=8ee23867215305089235568c1e2eb8722d068ffe86df2c86b546e54abe869080"
+    "sha512=b3b7e5d0ef78170447680982e0eab8cf61ac42401d68b296b990cc79f314669e6c1b590659e16d43d146b1e388c9e58d2a82c52736fa34670f25e92b486dc068"
+  ]
+}
+x-commit-hash: "47f6825f3c6a6ad8df0085258624b08870b10ba1"

--- a/packages/bimage/bimage.0.5.0/opam
+++ b/packages/bimage/bimage.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=8ee23867215305089235568c1e2eb8722d068ffe86df2c86b546e54abe869080"
+    "sha512=b3b7e5d0ef78170447680982e0eab8cf61ac42401d68b296b990cc79f314669e6c1b590659e16d43d146b1e388c9e58d2a82c52736fa34670f25e92b486dc068"
+  ]
+}
+x-commit-hash: "47f6825f3c6a6ad8df0085258624b08870b10ba1"


### PR DESCRIPTION
A simple, efficient image-processing library

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- Removed `Bimage_unix.Thread.Filter`
- Renamed `Bimage_unix.{Data_unix,Image_unix}.create_mmap` to `mmap`
- Removed `Filter.Make`, `FILTER` and `bimage-lwt`
