### PR TITLE
[new release] bimage, bimage-unix, bimage-io and bimage-display (0.5.0)

### DIFF
--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0" & os = "linux"}
+    "ocaml" {>= "4.08.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "glfw-ocaml" {>= "3.3.0"}

--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -28,6 +28,9 @@ Window system for Bimage
 description: """
 Allows for Bimage Images to be displayed using OpenGL
 """
+
+available: os = "linux"
+
 url {
   src:
     "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"

--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0"}
+    "ocaml" {>= "4.08.0" & os = "linux"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "glfw-ocaml" {>= "3.3.0"}

--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml" {>= "3.3.0"}
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=3875b65b243ea7055af6aeb70099fcfbde7973ad02e5b1613c16ffb702c77cd8"
+    "sha512=7ff3fd5d71c93b11a487d7be3fdfca4b0e98973551f44d2fd49b8b4ce866f7ad380a4a784ba16ea01173c52e24b2d93b9a635c471b690b35792c12c4ee69a886"
+  ]
+}
+x-commit-hash: "40b4b115ccebb1819a70b4a69cb48297971e30ae"

--- a/packages/bimage-io/bimage-io.0.5.0/opam
+++ b/packages/bimage-io/bimage-io.0.5.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0" & os = "linux"}
+    "ocaml" {>= "4.08.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "conf-openimageio"

--- a/packages/bimage-io/bimage-io.0.5.0/opam
+++ b/packages/bimage-io/bimage-io.0.5.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0"}
+    "ocaml" {>= "4.08.0" & os = "linux"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "conf-openimageio"

--- a/packages/bimage-io/bimage-io.0.5.0/opam
+++ b/packages/bimage-io/bimage-io.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=3875b65b243ea7055af6aeb70099fcfbde7973ad02e5b1613c16ffb702c77cd8"
+    "sha512=7ff3fd5d71c93b11a487d7be3fdfca4b0e98973551f44d2fd49b8b4ce866f7ad380a4a784ba16ea01173c52e24b2d93b9a635c471b690b35792c12c4ee69a886"
+  ]
+}
+x-commit-hash: "40b4b115ccebb1819a70b4a69cb48297971e30ae"

--- a/packages/bimage-io/bimage-io.0.5.0/opam
+++ b/packages/bimage-io/bimage-io.0.5.0/opam
@@ -27,6 +27,9 @@ Input/output for Bimage using OpenImageIO
 description: """
 Input/output for Bimage using OpenImageIO
 """
+
+available: os = "linux"
+
 url {
   src:
     "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"

--- a/packages/bimage-unix/bimage-unix.0.5.0/opam
+++ b/packages/bimage-unix/bimage-unix.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=3875b65b243ea7055af6aeb70099fcfbde7973ad02e5b1613c16ffb702c77cd8"
+    "sha512=7ff3fd5d71c93b11a487d7be3fdfca4b0e98973551f44d2fd49b8b4ce866f7ad380a4a784ba16ea01173c52e24b2d93b9a635c471b690b35792c12c4ee69a886"
+  ]
+}
+x-commit-hash: "40b4b115ccebb1819a70b4a69cb48297971e30ae"

--- a/packages/bimage/bimage.0.5.0/opam
+++ b/packages/bimage/bimage.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.5.0/bimage-0.5.0.tbz"
+  checksum: [
+    "sha256=3875b65b243ea7055af6aeb70099fcfbde7973ad02e5b1613c16ffb702c77cd8"
+    "sha512=7ff3fd5d71c93b11a487d7be3fdfca4b0e98973551f44d2fd49b8b4ce866f7ad380a4a784ba16ea01173c52e24b2d93b9a635c471b690b35792c12c4ee69a886"
+  ]
+}
+x-commit-hash: "40b4b115ccebb1819a70b4a69cb48297971e30ae"


### PR DESCRIPTION
A simple, efficient image-processing library

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- Removed `Bimage_unix.Thread.Filter`
- Renamed `Bimage_unix.{Data_unix,Image_unix}.create_mmap` to `mmap`
- Removed `Filter.Make`, `FILTER` and `bimage-lwt`
