### PR TITLE
[new release] doi2bib (0.5.2)

### DIFF
--- a/packages/doi2bib/doi2bib.0.5.2/opam
+++ b/packages/doi2bib/doi2bib.0.5.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "cmdliner" {>= "1.0.0"}
+  "clz" {>= "0.1.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "lwt" {>= "5.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "tls" {>= "0.12.0"}
+  "re" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.5.2/doi2bib-0.5.2.tbz"
+  checksum: [
+    "sha256=b0b6f01e5b2fa7b4d9ec234f6bce4aae11549042f5aa713e014b3b903a4795c0"
+    "sha512=e93f6c607d1e31ace1f56905ceaf9feb85e0c195490ba4468fee87a4d221de0d00b9d9d5afebf0e93ec49ca0db6511923e6d19bcb7ea41cc73f6417cbd35eda7"
+  ]
+}
+x-commit-hash: "38eea26321b787d8942d8387377ff74c5ac316c3"

--- a/packages/doi2bib/doi2bib.0.5.2/opam
+++ b/packages/doi2bib/doi2bib.0.5.2/opam
@@ -30,7 +30,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+#    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID

- Project page: <a href="https://github.com/mseri/doi2bib">https://github.com/mseri/doi2bib</a>

##### CHANGES:

- Move from cuz to the published clz
- Move from dx.doi.org to crossref rest api service,
  the latter gives better and more consistent results and
  does not seem to require a fallback service any longer
- Update arxiv generated bibtex accordingly
- Update ocamlformat
