### PR TITLE
h1_parser 0.0.2: fix conflict

### DIFF
--- a/packages/h1_parser/h1_parser.0.0.2/opam
+++ b/packages/h1_parser/h1_parser.0.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "odoc" {with-doc}
 ]
 conflicts: [
-  "cohttp-lwt-unix" {with-test & >= "5.0.0"}
+  "cohttp" {with-test & >= "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
It was incorrectly conflicting with cohttp-lwt-unix.
Seen on https://github.com/ocaml/opam-repository/pull/20246

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>