### PR TITLE
[new release] dns, dns-tsig, dns-stub, dns-server, dns-resolver, dns-mirage, dns-client, dns-cli and dns-certify (6.1.3)

### DIFF
--- a/packages/dns-certify/dns-certify.6.1.3/opam
+++ b/packages/dns-certify/dns-certify.6.1.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.13.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-cli/dns-cli.6.1.3/opam
+++ b/packages/dns-cli/dns-cli.6.1.3/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.13.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-client/dns-client.6.1.3/opam
+++ b/packages/dns-client/dns-client.6.1.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "happy-eyeballs" {>= "0.1.0"}
+  "alcotest" {with-test}
+  "tls" {>= "0.15.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "ca-certs"
+  "ca-certs-nss"
+]
+synopsis: "DNS resolver API"
+description: """
+A resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-mirage/dns-mirage.6.1.3/opam
+++ b/packages/dns-mirage/dns-mirage.6.1.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-resolver/dns-resolver.6.1.3/opam
+++ b/packages/dns-resolver/dns-resolver.6.1.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {with-test}
+  "tls" "tls-mirage"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-server/dns-server.6.1.3/opam
+++ b/packages/dns-server/dns-server.6.1.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-stub/dns-stub.6.1.3/opam
+++ b/packages/dns-stub/dns-stub.6.1.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns-tsig/dns-tsig.6.1.3/opam
+++ b/packages/dns-tsig/dns-tsig.6.1.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/dns/dns.6.1.3/opam
+++ b/packages/dns/dns.6.1.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.3.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.1.3/dns-v6.1.3.tbz"
+  checksum: [
+    "sha256=984c488f05af72f52625df67a5f53bd0aa7bb139e0f92556437d341d3e4d8647"
+    "sha512=330f28465a980ab8a2ce99bc0672ad61488767ef866aa7752e842478866bef085eaead75f49add325e3895b9f498f9aad21ef4e067c72ec5d7a442a1410e62e6"
+  ]
+}
+x-commit-hash: "26ec8f85517e3193816bf69e9e300fc4882e1b1e"

--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -32,7 +32,7 @@ depends: [
   "tls"              {with-test}
   "io-page"          {with-test & >= "1.6.1" & <  "2.0.0"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
-  "mirage-stack-lwt" {with-test & >= "1.3.0"}
+  "mirage-stack-lwt" {with-test & >= "1.3.0" & < "4.0.0"}
   "mirage-time-unix"
 ]
 url {

--- a/packages/git-mirage/git-mirage.2.0.0/opam
+++ b/packages/git-mirage/git-mirage.2.0.0/opam
@@ -32,7 +32,7 @@ depends: [
   "tls"              {with-test}
   "io-page"          {with-test & >= "1.6.1" & <  "2.0.0"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
-  "mirage-stack-lwt" {with-test & >= "1.3.0" & < "4.0.0"}
+  "mirage-stack-lwt" {with-test & >= "1.3.0"}
   "mirage-time-unix"
 ]
 url {

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "io-page"          {with-test & >= "1.6.1"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
-  "mirage-stack-lwt" {with-test & >= "1.3.0" & < "4.0.0"}
+  "mirage-stack-lwt" {with-test & >= "1.3.0"}
   "mirage-time-unix"
 ]
 url {

--- a/packages/git-mirage/git-mirage.2.1.0/opam
+++ b/packages/git-mirage/git-mirage.2.1.0/opam
@@ -33,7 +33,7 @@ depends: [
   "io-page"          {with-test & >= "1.6.1"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
-  "mirage-stack-lwt" {with-test & >= "1.3.0"}
+  "mirage-stack-lwt" {with-test & >= "1.3.0" & < "4.0.0"}
   "mirage-time-unix"
 ]
 url {

--- a/packages/git-mirage/git-mirage.2.1.1/opam
+++ b/packages/git-mirage/git-mirage.2.1.1/opam
@@ -32,7 +32,7 @@ depends: [
   "io-page"          {with-test & >= "1.6.1"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
-  "mirage-stack-lwt" {with-test & >= "1.3.0"}
+  "mirage-stack-lwt" {with-test & >= "1.3.0" & < "4.0.0"}
   "mirage-random-test" {with-test}
   "mirage-time-unix"
 ]

--- a/packages/git-mirage/git-mirage.2.1.1/opam
+++ b/packages/git-mirage/git-mirage.2.1.1/opam
@@ -32,7 +32,7 @@ depends: [
   "io-page"          {with-test & >= "1.6.1"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
-  "mirage-stack-lwt" {with-test & >= "1.3.0" & < "4.0.0"}
+  "mirage-stack-lwt" {with-test & >= "1.3.0"}
   "mirage-random-test" {with-test}
   "mirage-time-unix"
 ]

--- a/packages/git-mirage/git-mirage.2.1.2/opam
+++ b/packages/git-mirage/git-mirage.2.1.2/opam
@@ -32,7 +32,7 @@ depends: [
   "io-page"          {with-test & >= "1.6.1"}
   "tcpip"            {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"     {with-test}
-  "mirage-stack" {with-test & >= "2.0.0"}
+  "mirage-stack" {with-test & >= "2.0.0" & < "4.0.0"}
   "mirage-random-test" {with-test}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/git-mirage/git-mirage.2.1.2/opam
+++ b/packages/git-mirage/git-mirage.2.1.2/opam
@@ -10,7 +10,7 @@ doc:          "https://mirage.github.io/ocaml-git/"
 synopsis:     "MirageOS backend for the Git protocol(s)"
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]

--- a/packages/git-mirage/git-mirage.2.1.3/opam
+++ b/packages/git-mirage/git-mirage.2.1.3/opam
@@ -10,14 +10,14 @@ doc:          "https://mirage.github.io/ocaml-git/"
 synopsis:     "MirageOS backend for the Git protocol(s)"
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
 
 depends: [
   "ocaml"             {>= "4.07.0"}
-  "dune"
+  "dune"              {>= "1.1"}
   "cohttp-mirage"     {>= "1.0.0"}
   "mirage-flow"       {>= "2.0.0"}
   "mirage-channel"    {>= "4.0.0"}

--- a/packages/git-mirage/git-mirage.2.1.3/opam
+++ b/packages/git-mirage/git-mirage.2.1.3/opam
@@ -32,7 +32,7 @@ depends: [
   "io-page"           {with-test & >= "1.6.1"}
   "tcpip"             {with-test & >= "3.3.0" & < "6.0.0"}
   "io-page-unix"      {with-test}
-  "mirage-stack"      {with-test & >= "2.0.0"}
+  "mirage-stack"      {with-test & >= "2.0.0" & < "4.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
   "mirage-time-unix"  {with-test & >= "2.0.1"}
 ]

--- a/packages/git-mirage/git-mirage.3.0.0/opam
+++ b/packages/git-mirage/git-mirage.3.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.0.0/opam
+++ b/packages/git-mirage/git-mirage.3.0.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ke" {>= "0.4" & with-test}
 ]
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
 ]

--- a/packages/git-mirage/git-mirage.3.1.0/opam
+++ b/packages/git-mirage/git-mirage.3.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.1.0/opam
+++ b/packages/git-mirage/git-mirage.3.1.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ke" {>= "0.4" & with-test}
 ]
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
 ]

--- a/packages/git-mirage/git-mirage.3.1.1/opam
+++ b/packages/git-mirage/git-mirage.3.1.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "2.6.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.2.0/opam
+++ b/packages/git-mirage/git-mirage.3.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.3.0/opam
+++ b/packages/git-mirage/git-mirage.3.3.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.3.1/opam
+++ b/packages/git-mirage/git-mirage.3.3.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.3.2/opam
+++ b/packages/git-mirage/git-mirage.3.3.2/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.3.3/opam
+++ b/packages/git-mirage/git-mirage.3.3.3/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.4.0/opam
+++ b/packages/git-mirage/git-mirage.3.4.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.5.0/opam
+++ b/packages/git-mirage/git-mirage.3.5.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/git-mirage/git-mirage.3.6.0/opam
+++ b/packages/git-mirage/git-mirage.3.6.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
   "mimic"
-  "mirage-stack"
+  "mirage-stack" {< "4.0.0"}
   "git" {= version}
   "awa"
   "awa-mirage"

--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.2/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.2/happy-eyeballs-0.1.2.tbz"
+  checksum: [
+    "sha256=8bb198a62fd5346649fb5fc3c6812cd5b4197d10d36f8309228bed5e7e63d442"
+    "sha512=c83d890305a742d16ace76c6bed285e7a5b21e521a29d7360f7f8fe5217bcb28e1a79ee8f54319cf5aafdc3be1cfcfb932098808613e4dd1d55a6aac8e19d0b4"
+  ]
+}
+x-commit-hash: "823b87d4b1f50c67ae96402caa6d61c80d4cf457"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.1/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.2/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.3/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.3/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.4/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.4/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.5/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.5/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.6/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.7/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.7/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "rresult"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.8/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.0.8/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
 ]

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
 ]

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.1/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "lwt"
   "mirage-clock" {>= "3.0.0"}
-  "mirage-stack" {>= "2.2.0"}
+  "mirage-stack" {>= "2.2.0" & < "4.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
 ]

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.2/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.2/happy-eyeballs-0.1.2.tbz"
+  checksum: [
+    "sha256=8bb198a62fd5346649fb5fc3c6812cd5b4197d10d36f8309228bed5e7e63d442"
+    "sha512=c83d890305a742d16ace76c6bed285e7a5b21e521a29d7360f7f8fe5217bcb28e1a79ee8f54319cf5aafdc3be1cfcfb932098808613e4dd1d55a6aac8e19d0b4"
+  ]
+}
+x-commit-hash: "823b87d4b1f50c67ae96402caa6d61c80d4cf457"

--- a/packages/happy-eyeballs/happy-eyeballs.0.1.2/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.2/happy-eyeballs-0.1.2.tbz"
+  checksum: [
+    "sha256=8bb198a62fd5346649fb5fc3c6812cd5b4197d10d36f8309228bed5e7e63d442"
+    "sha512=c83d890305a742d16ace76c6bed285e7a5b21e521a29d7360f7f8fe5217bcb28e1a79ee8f54319cf5aafdc3be1cfcfb932098808613e4dd1d55a6aac8e19d0b4"
+  ]
+}
+x-commit-hash: "823b87d4b1f50c67ae96402caa6d61c80d4cf457"


### PR DESCRIPTION
An opinionated Domain Name System (DNS) library

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* dns-mirage: use tcpip >= 7.0.0 instead of deprecated mirage-stack and
  mirage-protocols (mirage/ocaml-dns#283 @dinosaure)
