### PR TITLE
[new release] mirage, mirage-types, mirage-types-lwt and mirage-runtime (3.10.8)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.3.10.8/opam
+++ b/packages/mirage-runtime/mirage-runtime.3.10.8/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria-runtime"  {>= "3.0.2"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "lwt" {>= "4.0.0"}
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.8/mirage-v3.10.8.tbz"
+  checksum: [
+    "sha256=135d86ca74e68ddb61d4ef304d43fb951a10b7cbc488bf3d638fca4294016fb4"
+    "sha512=beaaa4e238bd5d785f073e62c3ebaa71a1f0e7f7287be73106ba5c20f3b3bc6cfe6825700521ce39dfed92f12857296a9137673e89e112d1461df02df070a6ca"
+  ]
+}
+x-commit-hash: "2f872b362bbdbd1cfe698d3a78d77b3823d119e5"

--- a/packages/mirage-types-lwt/mirage-types-lwt.3.10.8/opam
+++ b/packages/mirage-types-lwt/mirage-types-lwt.3.10.8/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends:   [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "mirage-types" {= version}
+]
+
+synopsis: "Lwt module type definitions for MirageOS applications"
+description: """
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`
+"""
+post-messages: [
+ "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.8/mirage-v3.10.8.tbz"
+  checksum: [
+    "sha256=135d86ca74e68ddb61d4ef304d43fb951a10b7cbc488bf3d638fca4294016fb4"
+    "sha512=beaaa4e238bd5d785f073e62c3ebaa71a1f0e7f7287be73106ba5c20f3b3bc6cfe6825700521ce39dfed92f12857296a9137673e89e112d1461df02df070a6ca"
+  ]
+}
+x-commit-hash: "2f872b362bbdbd1cfe698d3a78d77b3823d119e5"

--- a/packages/mirage-types/mirage-types.3.10.8/opam
+++ b/packages/mirage-types/mirage-types.3.10.8/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "mirage-device" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-protocols" {>= "5.0.0"}
+  "mirage-stack" {>= "2.2.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-fs" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+]
+synopsis: "Module type definitions for MirageOS applications"
+description: """
+Module type definitions for MirageOS applications
+"""
+post-messages: [
+  "This package will be retired in MirageOS 4.0. Please use individual signatures (mirage-net / mirage-clock / etc.) instead."
+]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.8/mirage-v3.10.8.tbz"
+  checksum: [
+    "sha256=135d86ca74e68ddb61d4ef304d43fb951a10b7cbc488bf3d638fca4294016fb4"
+    "sha512=beaaa4e238bd5d785f073e62c3ebaa71a1f0e7f7287be73106ba5c20f3b3bc6cfe6825700521ce39dfed92f12857296a9137673e89e112d1461df02df070a6ca"
+  ]
+}
+x-commit-hash: "2f872b362bbdbd1cfe698d3a78d77b3823d119e5"

--- a/packages/mirage/mirage.3.10.8/opam
+++ b/packages/mirage/mirage.3.10.8/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "ipaddr"             {>= "5.0.0"}
+  "functoria"          {>= "3.1.0"}
+  "bos"
+  "astring"
+  "logs"
+  "stdlib-shims"
+  "mirage-runtime"     {=version | (>= "3.10.0" & < "3.11.0")}
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+hypervisor.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v3.10.8/mirage-v3.10.8.tbz"
+  checksum: [
+    "sha256=135d86ca74e68ddb61d4ef304d43fb951a10b7cbc488bf3d638fca4294016fb4"
+    "sha512=beaaa4e238bd5d785f073e62c3ebaa71a1f0e7f7287be73106ba5c20f3b3bc6cfe6825700521ce39dfed92f12857296a9137673e89e112d1461df02df070a6ca"
+  ]
+}
+x-commit-hash: "2f872b362bbdbd1cfe698d3a78d77b3823d119e5"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- Allow tcpip 7.0.0, arp 3.0.0, ethernet 3.0.0 (mirage/mirage#1259 @hannesm)
