### PR TITLE
[new release] logs-syslog (0.3.1)

### DIFF
--- a/packages/logs-syslog/logs-syslog.0.3.1/opam
+++ b/packages/logs-syslog/logs-syslog.0.3.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/hannesm/logs-syslog"
+doc: "https://hannesm.github.io/logs-syslog/doc"
+dev-repo: "git+https://github.com/hannesm/logs-syslog.git"
+bug-reports: "https://github.com/hannesm/logs-syslog/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1.0"}
+  "logs"
+  "ptime"
+  "syslog-message" {>= "1.0.0"}
+]
+
+depopts: [
+  "lwt"
+  "x509" "tls" "tls-mirage" "cstruct"
+  "mirage-kv"
+  "mirage-console" "mirage-clock" "ipaddr" "tcpip"
+]
+
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+  "mirage-console" {< "3.0.0"}
+  "mirage-clock" {< "3.0.0"}
+  "tcpip" {< "7.0.0"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+
+synopsis: "Logs reporter to syslog (UDP/TCP/TLS)"
+description: """
+This library provides log reporters using syslog over various transports (UDP,
+TCP, TLS) with various effectful layers: Unix, Lwt, MirageOS.  It integrates the
+[Logs](http://erratique.ch/software/logs) library, which provides logging
+infrastructure for OCaml, with the
+[syslog-message](http://verbosemo.de/syslog-message/) library, which provides
+encoding and decoding of syslog messages ([RFC
+3164](https://tools.ietf.org/html/rfc3164)).
+"""
+url {
+  src:
+    "https://github.com/hannesm/logs-syslog/releases/download/v0.3.1/logs-syslog-v0.3.1.tbz"
+  checksum: [
+    "sha256=348c54b71e4e89b30342644736e9b4cc79b749cc9f45186a2f7aebced9142ad4"
+    "sha512=efe92e684b006c711bda6e129de159090f1db16a0868ccc5d6953164cecf6fcab29237fb13eae68a69db91a0f5203d21d03550383b4fccf1b3de953db961d771"
+  ]
+}
+x-commit-hash: "d67d478078a4c5bbf285d9386ece8d3340583dff"


### PR DESCRIPTION
Logs reporter to syslog (UDP/TCP/TLS)

- Project page: <a href="https://github.com/hannesm/logs-syslog">https://github.com/hannesm/logs-syslog</a>
- Documentation: <a href="https://hannesm.github.io/logs-syslog/doc">https://hannesm.github.io/logs-syslog/doc</a>

##### CHANGES:

- upgrade to tcpip 7.0.0 and deprecation of mirage-stack
