### PR TITLE
ez_api.1.0.0: fix cohttp upper bound and cleanup depopts

### DIFF
--- a/packages/ez_api/ez_api.1.0.0/opam
+++ b/packages/ez_api/ez_api.1.0.0/opam
@@ -23,24 +23,24 @@ depends: [
 depopts: [
   "geoip"
   "js_of_ocaml-lwt"
-  "calendar" {>= "2.03"}
+  "calendar"
   "cohttp-lwt-unix"
-  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "cohttp-lwt-jsoo"
   "lwt_log"
   "tls"
-  "httpaf-lwt-unix" {>= "0.6.0"}
-  "ocurl" {>= "0.8.0"}
-  "ezjs_fetch" {>= "0.2"}
+  "httpaf-lwt-unix"
+  "ocurl"
+  "ezjs_fetch"
   "websocket-lwt-unix"
   "websocket-httpaf-lwt"
   "ppxlib"
   "ppx_deriving_encoding"
-  "digestif" {>= "1.0.0"}
+  "digestif"
 ]
 conflicts: [
   "calendar" {< "2.03"}
   "cohttp-lwt-jsoo" {< "4.0.0"}
-  "cohttp" {< "5.0.0"}
+  "cohttp" {>= "5.0.0"}
   "httpaf-lwt-unix" {< "0.6.0"}
   "ezjs_fetch" {< "0.2"}
   "ocurl" {< "0.8.0"}


### PR DESCRIPTION
The first was a mistake on my side, the second was some overdue polishing (All removed versions are correctly present in the conflicts)
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>