### PR TITLE
Package ppx_test.1.8.0

### DIFF
--- a/packages/levenshtein/levenshtein.1.1.3/opam
+++ b/packages/levenshtein/levenshtein.1.1.3/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "4.02.1"}
   "jbuilder"
   "ppx_test" {>= "1.6.0"}
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Levenshtein distance algorithm for general array"
 description: """

--- a/packages/ppx_test/ppx_test.1.8.0/opam
+++ b/packages/ppx_test/ppx_test.1.8.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "A ppx replacement of pa_ounit"
+description: """\
+ppx_test tries to replace pa_ounit. It provides the following syntax sugars:
+
+* _with_location_ e, returns e and its source code location
+* _module_path_, returns the current module path name
+* let %TEST name = e, a replacement of TEST name = e
+* let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e"""
+maintainer: "jun.furuse@gmail.com"
+authors: "Jun Furuse"
+license: "MIT"
+homepage: "https://gitlab.com/camlspotter/ppx_test"
+bug-reports: "https://gitlab.com/camlspotter/ppx_test/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "re" {>= "1.8.0"}
+  "ppxx" {>= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/camlspotter/ppx_test"
+url {
+  src:
+    "https://gitlab.com/camlspotter/ppx_test/-/archive/1.8.0/ppx_test-1.8.0.tar.gz"
+  checksum: [
+    "md5=11571478e9dd5b3c04681e89a0106044"
+    "sha512=12e67fa5eff5bc7df6575d01ca7aa53d28a1ff044a007dd3791af13388311e8a6c2e1130cc2bd338415b229c6f101355a4205a9c905382248a1d7857773047ec"
+  ]
+}


### PR DESCRIPTION
### `ppx_test.1.8.0`
A ppx replacement of pa_ounit
ppx_test tries to replace pa_ounit. It provides the following syntax sugars:

* _with_location_ e, returns e and its source code location
* _module_path_, returns the current module path name
* let %TEST name = e, a replacement of TEST name = e
* let %TEST_UNIT name = e, a replacement of TEST_UNIT name = e



---
* Homepage: https://gitlab.com/camlspotter/ppx_test
* Source repo: git+https://gitlab.com/camlspotter/ppx_test
* Bug tracker: https://gitlab.com/camlspotter/ppx_test/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0