### PR TITLE
Bump satyrographos.0.0.2.11's version constraints on opam

### DIFF
--- a/packages/satyrographos/satyrographos.0.0.2.11/opam
+++ b/packages/satyrographos/satyrographos.0.0.2.11/opam
@@ -27,8 +27,13 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "ocamlgraph"
-  "opam-format" {>= "2.0" & < "2.1"}
-  "opam-state" {>= "2.0" & < "2.1"}
+  ( "opam-format" {>= "2.0.4" & < "2.2"}
+    & "opam-state" {>= "2.0.4" & < "2.2"}
+    & "ocaml" {< "4.12.0"}
+  | "opam-format" {>= "2.1.0" & < "2.2"}
+    & "opam-state" {>= "2.1.0" & < "2.2"}
+    & "ocaml" {>= "4.12.0"}
+  )
   "re" { >= "1.9.0" }
   "stringext" {with-test}
   "uri" {>= "3.0.0"}


### PR DESCRIPTION
satyrographos.0.0.2.11 (added with https://github.com/ocaml/opam-repository/pull/20220) actually works on OPAM 2.1.  This commit updates the version constraint.

Question: This commit workarounds a problem where OPAM 2.0 cannot be compiled in OCaml 4.12.  Should I submit another MR to update dependencies of `opam-core` instead of a workaround here?