### PR TITLE
[new release] mirage-qubes and mirage-qubes-ipv4 (0.9.2)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.2/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.2/opam
@@ -8,7 +8,7 @@ dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
 doc:          "https://mirage.github.io/mirage-qubes"
 
 build: [
-  [ "dune" "subst"] {pinned}
+  [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.2/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "cstruct" { >= "1.9.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.2/mirage-qubes-0.9.2.tbz"
+  checksum: [
+    "sha256=7f57d7c1858e65b8400dcbc97f699220cccd12ff170f439428dd752a954c72e7"
+    "sha512=61a97e009bc7f2bc8f2f04d463fb20727e02e5033ce1e9961da77d7deb1e8b07ebb4c13522f5c4b84f0326b19f09830aacb0295a56a45279c357916253e593ea"
+  ]
+}
+x-commit-hash: "eccbc57f8baf6145de5ca1c49a5e97777a1570a3"

--- a/packages/mirage-qubes/mirage-qubes.0.9.2/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.2/opam
@@ -8,7 +8,7 @@ doc:          "https://mirage.github.io/mirage-qubes"
 license:      "BSD-2-Clause"
 
 build: [
-  [ "dune" "subst"] {pinned}
+  [ "dune" "subst"] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 

--- a/packages/mirage-qubes/mirage-qubes.0.9.2/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.2/opam
@@ -21,6 +21,7 @@ depends: [
   "lwt"
   "logs" { >= "0.5.0" }
   "ocaml" { >= "4.08.0" }
+  "fmt" { >= "0.8.5" }
 ]
 synopsis: "Implementations of various Qubes protocols for MirageOS"
 description: """

--- a/packages/mirage-qubes/mirage-qubes.0.9.2/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.2/mirage-qubes-0.9.2.tbz"
+  checksum: [
+    "sha256=7f57d7c1858e65b8400dcbc97f699220cccd12ff170f439428dd752a954c72e7"
+    "sha512=61a97e009bc7f2bc8f2f04d463fb20727e02e5033ce1e9961da77d7deb1e8b07ebb4c13522f5c4b84f0326b19f09830aacb0295a56a45279c357916253e593ea"
+  ]
+}
+x-commit-hash: "eccbc57f8baf6145de5ca1c49a5e97777a1570a3"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- avoid deprecated Cstruct.len, use Cstruct.length instead (mirage/mirage-qubes#64 @hannesm)
- adapt to tcpip 7.0.0 changes (mirage/mirage-qubes#64 @hannesm)
