### PR TITLE
2 packages from gitlab.com/nomadic-labs/ringo/-/archive/v0.6/ringo-v0.6.tar.gz

### DIFF
--- a/packages/ringo-lwt/ringo-lwt.0.6/opam
+++ b/packages/ringo-lwt/ringo-lwt.0.6/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+  "ringo" {= version }
+  "lwt"
+  "base-unix" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt-wrappers for Ringo caches"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.6/ringo-v0.6.tar.gz"
+  checksum: [
+    "md5=9e542555814d906bc8da0236e1adf815"
+    "sha512=db25e84ed67b6e55d630c372b33e61037bf197407e05ad5bf1b2b5ccf2719fab4437cbd2040d48fd15db590b52f0f1d4598105ca029749702e69e80f2ae15f51"
+  ]
+}

--- a/packages/ringo/ringo.0.6/opam
+++ b/packages/ringo/ringo.0.6/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.6/ringo-v0.6.tar.gz"
+  checksum: [
+    "md5=9e542555814d906bc8da0236e1adf815"
+    "sha512=db25e84ed67b6e55d630c372b33e61037bf197407e05ad5bf1b2b5ccf2719fab4437cbd2040d48fd15db590b52f0f1d4598105ca029749702e69e80f2ae15f51"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ringo.0.6`: Caches (bounded-size key-value stores) and other bounded-size stores
-`ringo-lwt.0.6`: Lwt-wrappers for Ringo caches



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0