### PR TITLE
[new release] scad_ml (1.1.0)

### DIFF
--- a/packages/scad_ml/scad_ml.1.1.0/opam
+++ b/packages/scad_ml/scad_ml.1.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "OCaml DSL for 3D solid modelling in OpenSCAD"
+description:
+  "Scad_ml is an OCaml front-end to the OpenSCAD CAD programming language."
+maintainer: [
+  "Masaki Nakano<namachan10777@gmail.com>"
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+]
+authors: [
+  "Masaki Nakano<namachan10777@gmail.com>"
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+]
+license: "BSL-1.0"
+homepage: "https://github.com/namachan10777/scad-ml"
+doc: "https://namachan10777.github.io/scad-ml"
+bug-reports: "https://github.com/namachan10777/scad-ml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/namachan10777/scad-ml.git"
+url {
+  src:
+    "https://github.com/namachan10777/scad-ml/releases/download/v1.1.0/scad_ml-v1.1.0.tbz"
+  checksum: [
+    "sha256=2abd88cebe00d5b27266c303f8b913c26400a9796f29ccd51e4f2a7fbe83b114"
+    "sha512=303f837ae9790baff49f141b6915017985431855899f9963fb8bef168f497089077661e14b5431f77169cd1e98d5ecdb2e752ae1a9fac5a35b181ee685acf6f8"
+  ]
+}
+x-commit-hash: "b254d9c52ad406d4301b3faac5b566f9aa480273"


### PR DESCRIPTION
OCaml DSL for 3D solid modelling in OpenSCAD

- Project page: <a href="https://github.com/namachan10777/scad-ml">https://github.com/namachan10777/scad-ml</a>
- Documentation: <a href="https://namachan10777.github.io/scad-ml">https://namachan10777.github.io/scad-ml</a>

##### CHANGES:

- Added support for OpenSCAD `render`
