### PR TITLE
[new release] pyre-ast (0.1.8)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.8/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.8/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.8/pyre-ast-0.1.8.tbz"
+  checksum: [
+    "sha256=b5a77edb62222661f3b1209ffc194ddfe7c6c5b7dc082a2495f6f4dbf8f62db4"
+    "sha512=813faed918d12fa01f556da57eb2307d29634dbe810241669d20031c3aba9f8cc70c3f35504d60032b8e76c20629bbe7cf3dcc668e41a3567c9a8f1cffe42b83"
+  ]
+}
+x-commit-hash: "ae943492e22ec101a795e89cf97e78b9ba50a91e"


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- Bump the bundled CPython version to 3.10.1
- Fixed a potential segfault issue when parsing sources with non-utf8 encoding
- [API Breaking] The default line/column numbers for parsing errors are now set to -1, to be consistent with CPython runtime behaviors
