### PR TITLE
[new release] domainslib (0.4.0)

### DIFF
--- a/packages/domainslib/domainslib.0.4.0/opam
+++ b/packages/domainslib/domainslib.0.4.0/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "dune" {>= "1.8"}
+  "base-domains"
+  "mirage-clock-unix" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.4.0.tar.gz"
+  checksum: "md5=8ae1c816334f7c374bfb955a7bad1759"
+}


### PR DESCRIPTION
This release includes:

* Usage of effect handlers for task creation. This introduces a breaking change; all computations need to be enclosed in a Task.run function. See https://github.com/ocaml-multicore/domainslib/pull/51.
* Multi_channel uses a per-channel domain-local key, removing the global key. https://github.com/ocaml-multicore/domainslib/pull/50
* Bug fixes in parallel_scan. https://github.com/ocaml-multicore/domainslib/pull/60