### PR TITLE
config-file: revert to old tarball

### DIFF
--- a/packages/config-file/config-file.1.1/opam
+++ b/packages/config-file/config-file.1.1/opam
@@ -14,6 +14,6 @@ depends: ["ocaml" "ocamlfind" "camlp4"]
 install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 url {
-  src: "https://framagit.org/zoggy/old-codes/-/archive/config-file-1.1/old-codes-config-file-1.1.tar.gz"
-  checksum: "md5=77b0e72a15fe22868c6eceb8ba1f7325"
+  src:"https://github.com/ocaml/opam-source-archives/raw/main/config-file-1.1.tar.gz"
+  checksum: "md5=7bc051234ceb29ffd5823ee6bcffe19c"
 }

--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -19,6 +19,6 @@ install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 flags: light-uninstall
 url {
-  src: "https://framagit.org/zoggy/old-codes/-/archive/config-file-1.2/old-codes-config-file-1.2.tar.gz"
-  checksum: "md5=2f3679799ae8e3bc67847a204aae71c9"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/config-file-1.2.tar.gz"
+  checksum: "md5=fece1f143285fb5fddf17d5d36a577c5"
 }


### PR DESCRIPTION
The new one has a small change which, in particular, creates issue to a patch needed for the cygwin repo.
See https://github.com/ocaml/opam-repository/pull/20216#discussion_r774975042 and https://github.com/ocaml/opam-repository/issues/20302

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>