### PR TITLE
git-{mirage, unix}: lower bound on mirage-clock

### DIFF
--- a/packages/git-mirage/git-mirage.3.3.0/opam
+++ b/packages/git-mirage/git-mirage.3.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-mirage/git-mirage.3.3.1/opam
+++ b/packages/git-mirage/git-mirage.3.3.1/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-mirage/git-mirage.3.3.2/opam
+++ b/packages/git-mirage/git-mirage.3.3.2/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-mirage/git-mirage.3.3.3/opam
+++ b/packages/git-mirage/git-mirage.3.3.3/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-mirage/git-mirage.3.4.0/opam
+++ b/packages/git-mirage/git-mirage.3.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-mirage/git-mirage.3.5.0/opam
+++ b/packages/git-mirage/git-mirage.3.5.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-mirage/git-mirage.3.6.0/opam
+++ b/packages/git-mirage/git-mirage.3.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "ipaddr" {>= "5.0.1"}
   "lwt" {>= "5.3.0"}
-  "mirage-clock" {>= "3.1.0"}
+  "mirage-clock" {>= "4.0.0"}
   "mirage-flow" {>= "2.0.1"}
   "mirage-protocols" {>= "5.0.0"}
   "mirage-random" {>= "2.0.0"}

--- a/packages/git-unix/git-unix.3.3.0/opam
+++ b/packages/git-unix/git-unix.3.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.3.1/opam
+++ b/packages/git-unix/git-unix.3.3.1/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix"
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.3.1/opam
+++ b/packages/git-unix/git-unix.3.3.1/opam
@@ -28,7 +28,7 @@ depends: [
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-clock-unix"
+  "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"
   "cmdliner" {>= "1.0.4"}

--- a/packages/git-unix/git-unix.3.3.2/opam
+++ b/packages/git-unix/git-unix.3.3.2/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix"
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.3.2/opam
+++ b/packages/git-unix/git-unix.3.3.2/opam
@@ -28,7 +28,7 @@ depends: [
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-clock-unix"
+  "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"
   "cmdliner" {>= "1.0.4"}

--- a/packages/git-unix/git-unix.3.3.3/opam
+++ b/packages/git-unix/git-unix.3.3.3/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix"
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.3.3/opam
+++ b/packages/git-unix/git-unix.3.3.3/opam
@@ -28,7 +28,7 @@ depends: [
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-clock-unix"
+  "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"
   "cmdliner" {>= "1.0.4"}

--- a/packages/git-unix/git-unix.3.4.0/opam
+++ b/packages/git-unix/git-unix.3.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix"
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.4.0/opam
+++ b/packages/git-unix/git-unix.3.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-clock-unix"
+  "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"
   "cmdliner" {>= "1.0.4"}

--- a/packages/git-unix/git-unix.3.5.0/opam
+++ b/packages/git-unix/git-unix.3.5.0/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix"
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.5.0/opam
+++ b/packages/git-unix/git-unix.3.5.0/opam
@@ -28,7 +28,7 @@ depends: [
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-clock-unix"
+  "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"
   "cmdliner" {>= "1.0.4"}

--- a/packages/git-unix/git-unix.3.6.0/opam
+++ b/packages/git-unix/git-unix.3.6.0/opam
@@ -27,7 +27,7 @@ depends: [
   "alcotest-lwt" {with-test & >= "1.1.0"}
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
-  "mirage-clock"
+  "mirage-clock" {>= "4.0.0"}
   "mirage-clock-unix"
   "astring" {>= "0.8.5"}
   "awa"

--- a/packages/git-unix/git-unix.3.6.0/opam
+++ b/packages/git-unix/git-unix.3.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "base64" {with-test & >= "3.0.0"}
   "git-cohttp-unix" {= version}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-clock-unix"
+  "mirage-clock-unix" {>= "4.0.0"}
   "astring" {>= "0.8.5"}
   "awa"
   "cmdliner" {>= "1.0.4"}


### PR DESCRIPTION
From the lower bound checks in https://github.com/ocaml/opam-repository/pull/20304