### PR TITLE
lablgtk3.3.1.2 isn’t compatible with OCaml < 4.09

### DIFF
--- a/packages/lablgtk3/lablgtk3.3.1.2/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.2/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" }
+  "ocaml"     {         >= "4.09.0" }
   "dune"      {         >= "1.8.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }

--- a/packages/lablgtk3/lablgtk3.3.1.2/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.2/opam
@@ -28,6 +28,9 @@ conflicts: [
 build: [
   [ "dune" "build" "-p" name "-j"  jobs ]
 ]
+run-test: [
+  ["dune" "build" "-p" name "-j" jobs "examples/buttons.exe"]
+]
 url {
   src:
     "https://github.com/garrigue/lablgtk/archive/3.1.2.tar.gz"


### PR DESCRIPTION
Uses caml_sys_modify_argv as pointed out in https://github.com/ocaml/opam-repository/pull/20310#discussion_r775039077

cc @garrigue could you add some tests to at least build some example binaries to detect this kind of issues early? (one of the binaries in `examples/` would do I guess)