### PR TITLE
comby*.1.7.0: point to the original tarball

### DIFF
--- a/packages/comby-kernel/comby-kernel.1.7.0/opam
+++ b/packages/comby-kernel/comby-kernel.1.7.0/opam
@@ -36,7 +36,7 @@ description: """
 Comby-kernel is the library that exposes the core matching engine for the comby application tool.
 """
 url {
-  src: "https://github.com/comby-tools/comby/archive/1.7.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/comby-kernel.1.7.0.tar.gz"
   checksum: [
     "md5=ee6556d8bd9b25ed0445ebe23862e48a"
     "sha512=e6386c8ce5ef14bbcab2b0ead5b1edc39375438f56330d5f02e81e467afe6623a7e299f97f26008d77bbc62850c6dc63a7cbe5b81671b5183ff3adeee5946bb3"

--- a/packages/comby-semantic/comby-semantic.1.7.0/opam
+++ b/packages/comby-semantic/comby-semantic.1.7.0/opam
@@ -33,7 +33,7 @@ description: """
 An early-stage library that interfaces with external services to provide semantic information of programs for the comby application tool."
 """
 url {
-  src: "https://github.com/comby-tools/comby/archive/1.7.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/comby-kernel.1.7.0.tar.gz"
   checksum: [
     "md5=ee6556d8bd9b25ed0445ebe23862e48a"
     "sha512=e6386c8ce5ef14bbcab2b0ead5b1edc39375438f56330d5f02e81e467afe6623a7e299f97f26008d77bbc62850c6dc63a7cbe5b81671b5183ff3adeee5946bb3"

--- a/packages/comby/comby.1.7.0/opam
+++ b/packages/comby/comby.1.7.0/opam
@@ -54,7 +54,7 @@ recognize code structures like blocks and expressions (e.g., delimited by
 braces or parentheses), strings (e.g., delimited by quotes), and so on.
 """
 url {
-  src: "https://github.com/comby-tools/comby/archive/1.7.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/comby-kernel.1.7.0.tar.gz"
   checksum: [
     "md5=ee6556d8bd9b25ed0445ebe23862e48a"
     "sha512=e6386c8ce5ef14bbcab2b0ead5b1edc39375438f56330d5f02e81e467afe6623a7e299f97f26008d77bbc62850c6dc63a7cbe5b81671b5183ff3adeee5946bb3"


### PR DESCRIPTION
Seen in many CI runs:
```
#=== ERROR while fetching sources for comby-semantic.1.7.0 ====================#
OpamSolution.Fetch_fail("https://github.com/comby-tools/comby/archive/1.7.0.tar.gz (Bad checksum, expected md5=ee6556d8bd9b25ed0445ebe23862e48a)")

#=== ERROR while fetching sources for comby-kernel.1.7.0 ======================#
OpamSolution.Fetch_fail("https://github.com/comby-tools/comby/archive/1.7.0.tar.gz (Bad checksum, expected md5=ee6556d8bd9b25ed0445ebe23862e48a)")
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>
