### PR TITLE
Add support for Github actions-based CI

### DIFF
--- a/.github/check-installable/action.yml
+++ b/.github/check-installable/action.yml
@@ -1,0 +1,35 @@
+name: Check if package is installable
+inputs:
+  opam:
+    required: true
+  package:
+    required: true
+outputs:
+  installable:
+    description: "Is the package installable?"
+    value: ${{ steps.installable.outputs.installable }}
+runs:
+  using: composite
+  steps:
+    - name: Get opam cli option
+      id: cli
+      shell: sh
+      run: |
+        if [ "${{ inputs.opam }}" = "opam-2.1" ]; then
+          echo '##[set-output name=cli]--cli=2.1'
+        fi
+    - name: Check if package is installable
+      id: installable
+      shell: sh
+      run: |
+        if opam ${{ steps.cli.outputs.cli }} list --readonly --external --resolve=${{ inputs.package }} >/dev/null 2>&1; then
+          echo '##[set-output name=installable]true';
+        else
+          echo "Package is not installable";
+        fi
+    - name: Annotate result
+      if: ${{ !steps.installable.outputs.installable }}
+      uses: actions/github-script@v5
+      with:
+        script: |
+          core.notice('${{ inputs.package }} is not installable');

--- a/.github/install-ocaml/action.yml
+++ b/.github/install-ocaml/action.yml
@@ -1,0 +1,14 @@
+name: Install OCaml
+inputs:
+  compiler:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup OCaml
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: ${{ inputs.compiler }}
+        opam-disable-sandboxing: true
+        opam-repositories: |
+          default: file://.

--- a/.github/install-package/action.yml
+++ b/.github/install-package/action.yml
@@ -1,0 +1,30 @@
+name: Install Package
+inputs:
+  opam:
+    required: true
+  package:
+    required: true
+  env:
+    default: '{}'
+runs:
+  using: composite
+  steps:
+    - name: Get opam cli option
+      id: cli
+      shell: sh
+      run: |
+        if [ "${{ inputs.opam }}" = "opam-2.1" ]; then
+          echo '##[set-output name=cli]--cli=2.1 --confirm-level=unsafe-yes'
+        fi
+    - name: Install ${{ inputs.package }} depopts
+      if: inputs.opam == 'opam-2.0'
+      shell: sh
+      run: |
+        opam depext ${{ inputs.package }}
+    - name: Install ${{ inputs.package }}
+      shell: sh
+      env: ${{ fromJson(inputs.env) }}
+      run: |
+        opam install --deps-only ${{ steps.cli.outputs.cli }} ${{ inputs.package }}
+        opam install ${{ steps.cli.outputs.cli }} ${{ inputs.package }}
+        opam remove ${{ steps.cli.outputs.cli }} ${{ inputs.package }}

--- a/.github/install-system-packages/action.yml
+++ b/.github/install-system-packages/action.yml
@@ -1,0 +1,35 @@
+name: Install System Packages
+inputs:
+  distribution:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install debian system packages
+      if: startsWith(inputs.distribution, 'debian') || startsWith(inputs.distribution, 'ubuntu')
+      shell: sh
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get update
+        apt-get install -qq -yy curl darcs gcc git m4 make mercurial patch rsync sudo unzip bzip2
+    - name: Install alpine system packages
+      if: startsWith(inputs.distribution, 'alpine')
+      shell: sh
+      run: |
+        apk add build-base coreutils curl libgcc libstdc++ musl patch unzip bzip2 mercurial git rsync tar
+    - name: Install yum-based system packages
+      if: startsWith(inputs.distribution, 'centos') || startsWith(inputs.distribution, 'fedora') || startsWith(inputs.distribution, 'oraclelinux')
+      shell: sh
+      run: |
+        yum install -y curl diffutils gcc gcc-c++ tar git m4 make mercurial patch rsync sudo unzip gzip bzip2
+    - name: Install opensuse system packages
+      if: startsWith(inputs.distribution, 'opensuse')
+      shell: sh
+      run: |
+        zypper install -y curl diffutils gcc gcc-c++ tar git m4 make mercurial patch rsync sudo unzip gzip bzip2 which
+    - name: Install archlinux system packages
+      if: startsWith(inputs.distribution, 'archlinux')
+      shell: sh
+      run: |
+        pacman -Sy --noconfirm base-devel unzip git rsync

--- a/.github/package-revdeps/action.yml
+++ b/.github/package-revdeps/action.yml
@@ -1,0 +1,26 @@
+name: Get package revdeps
+inputs:
+  package:
+    required: true
+  cache_key:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Store package revdeps
+      uses: actions/cache@v2
+      id: cache_revdeps
+      with:
+        path: ${{ inputs.package }}.revdeps
+        key: ${{ inputs.cache_key }}-${{ inputs.package }}
+
+    - name: Get package revdeps
+      id: revdeps
+      shell: sh
+      if: ${{ !steps.cache_revdeps.outputs.cache-hit }}
+      env:
+        OCAMLCLI: ''
+      run: |
+        REVDEPS=`(opam list -s --color=never --depends-on ${{ inputs.package }} --coinstallable-with ${{ inputs.package }} --installable --all-versions --recursive --depopts && opam list -s --color=never --depends-on ${{ inputs.package }} --coinstallable-with ${{ inputs.package }} --installable --all-versions --with-test --depopts) | sort -u | grep -v ${{ inputs.package }} | while read i; do echo "\"$i\""; done | paste -sd ',' -`
+        echo "${{ inputs.package }} revdeps: [$REVDEPS]"
+        echo "[$REVDEPS]" > ${{ inputs.package }}.revdeps

--- a/.github/revdeps-config/action.yml
+++ b/.github/revdeps-config/action.yml
@@ -1,0 +1,38 @@
+name: Get revdeps configl
+inputs:
+  packages:
+    required: true
+  cache_key:
+    required: true
+outputs:
+  revdeps_config:
+    description: "Revdeps config"
+    value: ${{ steps.revdeps_config.outputs.result }}
+runs:
+  using: composite
+  steps:
+    - name: Setup node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+    - name: Install @action/cache
+      shell: sh
+      run: npm install @actions/cache
+    - name: Collect revdeps
+      id: revdeps_config
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const cache = require('@actions/cache');
+          const fs = require('fs');
+
+          let config = [];
+          const packages = JSON.parse('${{ inputs.packages }}');
+          await Promise.all(packages.map(async (package) => {
+            await cache.restoreCache([`${package}.revdeps`], `${{ inputs.cache_key }}-${package}`);
+            const revdeps = JSON.parse(fs.readFileSync(`${package}.revdeps`));
+            revdeps.forEach((revdep) => config.push({package, revdep}));
+          }));
+
+          console.log(`Revdeps config: ${JSON.stringify(config, null, 2)}`);
+          return config;

--- a/.github/scripts/packages.sh
+++ b/.github/scripts/packages.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+PACKAGES=`git diff --name-only origin/master..HEAD | grep '^packages' | cut -d'/' -f 3 | while read i; do echo "\"$i\""; done`
+
+echo "Packages to test: [$PACKAGES]"
+echo "##[set-output name=packages][${PACKAGES}]"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,250 @@
+name: CI
+on:
+  pull_request:
+
+jobs:
+  cancel_previous_run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      default_compiler: '4.13.1'
+      default_opam: 'opam-2.1'
+      compilers: |
+        ["4.02","4.03","4.04","4.05","4.06","4.07",
+         "4.08","4.09","4.10","4.11","4.12","4.13"]
+      distributions: |
+        ["alpine:3.13","alpine:3.14",
+         "archlinux",
+         "centos:7","centos:8",
+         "debian:testing","debian:unstable",
+         "fedora:34",
+         "oraclelinux:7","oraclelinux:8",
+         "ubuntu:18.04","ubuntu:20.04","ubuntu:21.04"]
+      extras: |
+        ["afl", "flambda", "flambda+fp", "fp", "nnp",
+         "nnpchecker", "no-flat-float-array"] 
+      opam_versions: |
+        ["opam-2.0", "opam-2.1"]
+      packages: ${{ steps.packages.outputs.packages }}
+      cache_key: v1-opam-${{ github.run_id }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: List packages to be tested
+        id: packages
+        run: |
+          ./.github/scripts/packages.sh
+
+  compilers:
+    runs-on: ubuntu-latest
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        opam:  ${{ fromJson(needs.config.outputs.opam_versions) }}
+        compiler: ${{ fromJson(needs.config.outputs.compilers) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ matrix.compiler }}
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}
+      - name: Get ${{ matrix.package }} revdeps
+        id: revdeps
+        if: startsWith(needs.config.outputs.default_compiler, matrix.compiler) && matrix.opam == needs.config.outputs.default_opam
+        uses: ./.github/package-revdeps
+        with:
+          package: ${{ matrix.package }}
+          cache_key: ${{ needs.config.outputs.cache_key }}
+
+  revdeps_config:
+    runs-on: ubuntu-latest
+    needs: [config, compilers]
+    outputs:
+      revdeps_config: ${{ steps.revdeps_config.outputs.revdeps_config }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Export revdeps config
+        id: revdeps_config
+        uses: ./.github/revdeps-config
+        with:
+          packages: ${{ needs.config.outputs.packages }}
+          cache_key: ${{ needs.config.outputs.cache_key }}
+
+  revdeps:
+    runs-on: ubuntu-latest
+    needs: [config, revdeps_config]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.revdeps_config.outputs.revdeps_config) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ needs.config.outputs.default_compiler }}
+      - name: Check if ${{ matrix.revdep }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.revdep }}
+      - name: Install ${{ matrix.revdep }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.revdep }}
+
+  distributions:
+    runs-on: ubuntu-latest
+    needs: config
+    container:
+      image: ${{ matrix.distribution }}
+    strategy:
+      fail-fast: false
+      matrix:
+        opam:  ${{ fromJson(needs.config.outputs.opam_versions) }}
+        distribution: ${{ fromJson(needs.config.outputs.distributions) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install system packages
+        uses: ./.github/install-system-packages
+        with:
+          distribution: ${{ matrix.distribution }}
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ matrix.compiler }}
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}
+
+  macos:
+    runs-on: macos-latest
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        opam:  ${{ fromJson(needs.config.outputs.opam_versions) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ matrix.compiler }}
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}
+
+  extras:
+    runs-on: ubuntu-latest
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        extra: ${{ fromJson(needs.config.outputs.extras) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Compute OCaml options
+        id: ocaml_options
+        run: |
+          OCAML_OPTIONS=`echo "${{ matrix.extra }}" | tr '+' '\n' | while read i; do echo "ocaml-option-$i"; done | paste -sd ',' -`
+          echo "OCaml options: $OCAML_OPTIONS"
+          echo "##[set-output name=ocaml_options]$OCAML_OPTIONS" 
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: 'ocaml-variants.${{ needs.config.outputs.default_compiler }}+options,${{ steps.ocaml_options.outputs.ocaml_options }}'
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}

--- a/packages/liquidsoap/liquidsoap.2.0.1/opam
+++ b/packages/liquidsoap/liquidsoap.2.0.1/opam
@@ -9,9 +9,9 @@ use, in the Unix tradition of simple strong components working
 together."""
 maintainer: "romain.beauxis@gmail.com"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+bug-reports: "https://github.com/savonet/liquidsoap/issues"
 license: "GPL-2.0-or-later"
 homepage: "https://github.com/savonet/liquidsoap"
-bug-reports: "https://github.com/savonet/liquidsoap/issues"
 depends: [
   "conf-autoconf" {dev}
   "conf-automake" {dev}


### PR DESCRIPTION
This PR adds support for CI using github actions, following a discussion in https://github.com/ocaml/opam-repository/pull/20271#issuecomment-999170463

Example of a full run: https://github.com/toots/opam-repository/actions/runs/1620485627

### Implementation details
* The builds are made from scratch, using official docker images for distributions or github runners and the standard `ocaml/setup-ocaml@v2` and etc. No need to maintain a matrix of docker images
* OCaml builds are cached and take about `1m40s`
* Most features from the current CI are supported except:
  * The `opensus` image was buggy and had to be dropped
  * lowerbound tests aren't implemented as it seems that the required solver is not (yet) available with the `opam` build shipped by `ocaml/setup-ocaml@v2`
  * Architectures other than the one provided by the runners (`linux`/`mac`, `amd64`) are not supported. Windows could be but the dance between official `opam` packages and `windows` packages does seem to make this painful.
  * `extra` are supported based on available `ocaml-option-*` packages.
 
 Overall, this seems to be an interesting option as this is free and scales well. It could be nice to have it along the official CI to see how it behaves and, perhaps, use it to alleviate some of the pressure on the current CI.