### PR TITLE
LablGtk3 3.1.2 extra packages

### DIFF
--- a/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.2/opam
+++ b/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.2/opam
@@ -12,7 +12,7 @@ authors: ["Jacques Garrigue et al., Nagoya University"]
 homepage: "https://github.com/garrigue/lablgtk"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 dev-repo: "git+https://github.com/garrigue/lablgtk.git"
-doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-goocanvas2"
 license: "LGPL with linking exception"
 
 depends: [

--- a/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.2/opam
+++ b/packages/lablgtk3-goocanvas2/lablgtk3-goocanvas2.3.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ GooCanvas library"
+description: """
+OCaml interface to GTK+3, goocanvas library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.09.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-goocanvas2"      { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "subst" ] {pinned}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/archive/3.1.2.tar.gz"
+  checksum: [
+    "md5=e991d9419a722fc513f4b4878e8c2cbe"
+  ]
+}

--- a/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.2/opam
+++ b/packages/lablgtk3-gtkspell3/lablgtk3-gtkspell3.3.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+3"
+description: """
+OCaml interface to GTK+3, gtkspell library
+
+See https://garrigue.github.io/lablgtk/ for more information.
+
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-gtkspell3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                { >= "4.09.0" }
+  "dune"                 { >= "1.8.0"  }
+  "lablgtk3"             {  = version  }
+]
+depexts: [
+  ["gtkspell3-dev"] {os-distribution = "alpine"}
+  ["gtkspell3"] {os-distribution = "archlinux"}
+  ["epel-release" "gtkspell3-devel"] {os-distribution = "centos"}
+  ["libgtkspell3-3-dev"] {os-distribution = "debian"}
+  ["gtkspell3-devel"] {os-distribution = "fedora"}
+  ["gtkspell3"] {os = "freebsd"}
+  ["gtkspell3"] {os = "openbsd"}
+  ["gtkspell3-devel"] {os-family = "suse"}
+  ["libgtkspell3-3-dev"] {os-distribution = "ubuntu"}
+  ["gtkspell3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/archive/3.1.2.tar.gz"
+  checksum: [
+    "md5=e991d9419a722fc513f4b4878e8c2cbe"
+  ]
+}

--- a/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.2/opam
+++ b/packages/lablgtk3-sourceview3/lablgtk3-sourceview3.3.1.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "OCaml interface to GTK+ gtksourceview library"
+description: """
+OCaml interface to GTK+3, gtksourceview3 library.
+
+See https://garrigue.github.io/lablgtk/ for more information.
+"""
+
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://github.com/garrigue/lablgtk"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+doc: "https://garrigue.github.io/lablgtk/lablgtk3-sourceview3"
+license: "LGPL with linking exception"
+
+depends: [
+  "ocaml"                {         >= "4.09.0" }
+  "dune"                 {         >= "1.8.0"  }
+  "lablgtk3"             {          = version  }
+  "conf-gtksourceview3"  { build & >= "0"      }
+]
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/archive/3.1.2.tar.gz"
+  checksum: [
+    "md5=e991d9419a722fc513f4b4878e8c2cbe"
+  ]
+}

--- a/packages/lablgtk3/lablgtk3.3.1.2/files/dune-project.patch
+++ b/packages/lablgtk3/lablgtk3.3.1.2/files/dune-project.patch
@@ -1,0 +1,8 @@
+diff --git a/dune-project b/dune-project
+index 389cd199..da00e4e1 100644
+--- a/dune-project
++++ b/dune-project
+@@ -1,2 +1,3 @@
+ (lang dune 1.8)
+ (name lablgtk3)
++(version 3.1.2)

--- a/packages/lablgtk3/lablgtk3.3.1.2/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.2/opam
@@ -31,6 +31,10 @@ build: [
 run-test: [
   ["dune" "build" "-p" name "-j" jobs "examples/buttons.exe"]
 ]
+patches: ["dune-project.patch"]
+extra-files: [
+  ["dune-project.patch" "md5=6caf83a63a129f5376c4c85bdf0edd56"]
+]
 url {
   src:
     "https://github.com/garrigue/lablgtk/archive/3.1.2.tar.gz"


### PR DESCRIPTION
These are packages associated with LablGtk3 (using the same tarball).
They were not included in #20311 