### PR TITLE
[new release] tcalc (1.0.1)

### DIFF
--- a/packages/tcalc/tcalc.1.0.1/opam
+++ b/packages/tcalc/tcalc.1.0.1/opam
@@ -10,7 +10,7 @@ license: "Unlicense"
 homepage: "https://github.com/lindig/tcalc"
 bug-reports: "https://github.com/lindig/tcalc/issues"
 depends: [
-  "dune" {build}
+  "dune" {>= "2.0"}
   "ocaml" {>= "4.08.0"}
   "linenoise" {>= "1.3.1"}
 ]

--- a/packages/tcalc/tcalc.1.0.1/opam
+++ b/packages/tcalc/tcalc.1.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Minimal desktop calculator for timestamps"
+description: """
+TCalc implements a minimal desktop calculator that in addition to
+floating point numbers recognises durations in hh:min:sec format and
+converts them to seconds. This can simplify time-based calculations."""
+maintainer: "Christian Lindig <lindig@gmail.com>"
+authors: "Christian Lindig <lindig@gmail.com>"
+license: "Unlicense"
+homepage: "https://github.com/lindig/tcalc"
+bug-reports: "https://github.com/lindig/tcalc/issues"
+depends: [
+  "dune" {build}
+  "ocaml" {>= "4.08.0"}
+  "linenoise" {>= "1.3.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/lindig/tcalc.git"
+url {
+  src:
+    "https://github.com/lindig/tcalc/releases/download/1.0.1/tcalc-1.0.1.tbz"
+  checksum: [
+    "sha256=ca4ad22224da943592779fbba8d29792a5ef0b9474bdfd5cbf36cb1e0de092ef"
+    "sha512=a8d9f197eb2fa85ac9b1c5c46fb6c8719f4c85108a0be1071f4f7b1a4b73f0b890937e1f7516efa7058e30f360cecfb6d348448048eb23d14b8f425217009538"
+  ]
+}
+x-commit-hash: "27a4ac80dfa73f930f9febc50831116ceae678b6"


### PR DESCRIPTION
Minimal desktop calculator for timestamps

- Project page: <a href="https://github.com/lindig/tcalc">https://github.com/lindig/tcalc</a>

##### CHANGES:

First release on Opam
