### PR TITLE
Sundials/ML 6.0.0p0

### DIFF
--- a/packages/sundialsml/sundialsml.6.0.0p0/opam
+++ b/packages/sundialsml/sundialsml.6.0.0p0/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer: "tim@tbrk.org"
+authors: [
+    "Timothy Bourke <tim@tbrk.org>"
+    "Jun Inoue <Jun.Lambda@gmail.com>"
+    "Marc Pouzet <Marc.Pouzet@ens.fr>"
+]
+homepage: "http://inria-parkas.github.io/sundialsml/"
+bug-reports: "https://github.com/inria-parkas/sundialsml/issues"
+dev-repo: "git+https://github.com/inria-parkas/sundialsml"
+doc: "http://inria-parkas.github.io/sundialsml/"
+tags: [
+    "numerical"
+    "simulation"
+    "mathematics"
+    "science"
+]
+license: "BSD-3-Clause"
+build: [
+    ["./configure" "--stubdir=%{stublibs}%/"
+		   "--libdir=%{lib}%/"
+		   "--docdir=%{doc}%/sundialsml/"
+		   "--os-distribution=%{os-distribution}%"]
+    [make "-j%{jobs}%"]
+    [make "doc"] {with-doc}
+]
+install: [
+  [make "install-findlib"]
+  [make "install-doc"] {with-doc}
+]
+remove: [
+    ["ocamlfind" "remove" "sundialsml"]
+    ["rm" "-rf" "%{doc}%/sundialsml"]
+]
+depends: [
+    "ocaml" {>= "4.03.0"}
+    "base-bigarray"
+    "ocamlfind" {build}
+    "conf-sundials" {>= "2" & build}
+]
+depopts: [
+    "mpi"
+]
+synopsis: "Interface to the Sundials suite of numerical solvers"
+conflicts: ["base-domains"]
+description: """
+Sundials is a collection of six numerical solvers: CVODE, CVODES, IDA, IDAS,
+ARKODE, and KINSOL. This interface provides access to all features of the
+underlying library except the Hypre and PETSC nvectors.
+
+The structure of the OCaml interface mostly follows that of the original
+library, both for ease of reading the existing documentation and for
+converting existing source code, but several changes have been made for
+programming convenience and to increase safety, namely:
+
+- solver sessions are mostly configured via algebraic data types rather than
+  multiple function calls;
+
+- errors are signalled by exceptions not return codes (also from
+  user-supplied callback routines);
+
+- user data is shared between callback routines via closures (partial
+  applications of functions);
+
+- vectors are checked for compatibility with a session (using a combination
+  of static and dynamic checks), and;
+
+- explicit free commands are not necessary since OCaml is a
+  garbage-collected language.
+
+The detailed OCaml documentation contains cross-links to the original
+documentation. OCaml versions of the standard examples usually have an
+overhead of about 30% compared to the original C versions, and only rarely
+more than 50%."""
+url {
+  src: "https://github.com/inria-parkas/sundialsml/archive/refs/tags/v6.0.0p0.tar.gz"
+  checksum: "md5=9c2ab20c507df76a0ebd86d8b85bb08e"
+}

--- a/packages/zelus/zelus.2.1/opam
+++ b/packages/zelus/zelus.2.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/INRIA/zelus/issues"
 depends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "2.6"}
-  "menhir"
+  "menhir" {>= "20180523"}
 ]
 depopts: ["sundialsml"]
 conflicts: ["sundialsml" {>= "5.8.0p0"}]

--- a/packages/zelus/zelus.2.1/opam
+++ b/packages/zelus/zelus.2.1/opam
@@ -14,6 +14,7 @@ depends: [
   "menhir"
 ]
 depopts: ["sundialsml"]
+conflicts: ["sundialsml" {>= "5.8.0p0"}]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/zelus/zelus.2.2/opam
+++ b/packages/zelus/zelus.2.2/opam
@@ -15,6 +15,7 @@ depends: [
   "menhir" {>= "20180523"}
 ]
 depopts: ["sundialsml"]
+conflicts: ["sundialsml" {>= "5.8.0p0"}]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Update package for latest release of Sundials/ML. User code that works with the the 5.8.0p0 release should continue working without modification on this new release.