### PR TITLE
[new release] uuuu (0.3.0)

### DIFF
--- a/packages/uuuu/uuuu.0.3.0/opam
+++ b/packages/uuuu/uuuu.0.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uuuu"
+bug-reports:  "https://github.com/mirage/uuuu/issues"
+dev-repo:     "git+https://github.com/mirage/uuuu.git"
+doc:          "https://mirage.github.io/uuuu/"
+license:      "MIT"
+synopsis:     "Mapper of ISO-8859-* to Unicode"
+description: """A simple mapper between ISO-8859-* to Unicode. Useful for
+a translation between ISO-8859-* and Unicode"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind"
+  "dune"
+  "re" {>= "1.7.2"}
+]
+url {
+  src:
+    "https://github.com/mirage/uuuu/releases/download/v0.3.0/uuuu-0.3.0.tbz"
+  checksum: [
+    "sha256=6b7ee8f3e343813b0c6ac8ddb7f6720b2ccd27b4208313d3bcff5d7d984fc3a6"
+    "sha512=4b26676fe809d2aba74614ab739315aa7b0f08469ff97400e05efba05e6e3fed4edf3ce5ed3b920e438f46f6b344f81c30a90534b27a8b09f4f0c69c29f68cc3"
+  ]
+}
+x-commit-hash: "2ec13393e02137f2d2566ccb29853d045d5e1a60"


### PR DESCRIPTION
Mapper of ISO-8859-* to Unicode

- Project page: <a href="https://github.com/mirage/uuuu">https://github.com/mirage/uuuu</a>
- Documentation: <a href="https://mirage.github.io/uuuu/">https://mirage.github.io/uuuu/</a>

##### CHANGES:

* Add `ocamlfind` as a dependency for `generate/generate.ml` which
  uses `topfind`
* Upgrade the code and delete the `menhir` dependency
