### PR TITLE
Package res_tailwindcss.0.1.2

### DIFF
--- a/packages/res_tailwindcss/res_tailwindcss.0.1.2/opam
+++ b/packages/res_tailwindcss/res_tailwindcss.0.1.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "PPX validates the tailwindcss class names"
+description: """
+ppx_tailwindcss validates the tailwindcss class names in compile time.
+"""
+maintainer: "Greenlabs Dev <developer@greenlabs.co.kr>"
+authors: "Greenlabs Dev <developer@greenlabs.co.kr>"
+license: "MIT"
+homepage: "https://github.com/green-labs/res_tailwindcss"
+bug-reports: "https://github.com/green-labs/res_tailwindcss/issues"
+dev-repo: "git+https://github.com/green-labs/res_tailwindcss.git"
+depends: [
+  "ocaml" {>= "4.12.1"}
+  "dune" { >= "2.8"}
+  "ppxlib"
+  "core"
+  "ppx_inline_test"
+  "ppx_expect"
+  "ppx_deriving"
+  "menhir" { >= "20211230"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/green-labs/ppx_tailwindcss/archive/opam-0.1.2.tar.gz"
+  checksum: [
+    "md5=41ee181d9324e451341f5f99ba843ad1"
+    "sha512=c74b38da98efa381e0c950de0daa96f5c2702c770062733c6cbf2852b6737e5195aa6c7d56ab7775dbc4740a632e83814e0f987c5d747316752023b08484cfd7"
+  ]
+}


### PR DESCRIPTION
### `res_tailwindcss.0.1.2`
PPX validates the tailwindcss class names
ppx_tailwindcss validates the tailwindcss class names in compile time.



---
* Homepage: https://github.com/green-labs/res_tailwindcss
* Source repo: git+https://github.com/green-labs/res_tailwindcss.git
* Bug tracker: https://github.com/green-labs/res_tailwindcss/issues

---
:camel: Pull-request generated by opam-publish v2.1.0