### PR TITLE
Solo5 0.7.0

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.0/opam
@@ -28,6 +28,9 @@ depexts: [
 ]
 available: [
   (arch != "arm64") &
+  (arch != "arm32") &
+  (arch != "ppc64") &
+  (arch != "s390x") &
   (os = "linux" & os-family = "debian")
 ]
 synopsis: "Solo5 sandboxed execution environment"

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.0/solo5-v0.7.0.tar.gz"
+  checksum: "sha512=7d89539d4964c4c2133bddf82fab865db523b069845b2f6367f3f2bf68e743cfe97e5ffff6fa90a217cc9392078b52de63ecd8e540e9a50c39f435fded0717d0"
+}

--- a/packages/solo5/solo5.0.7.0/opam
+++ b/packages/solo5/solo5.0.7.0/opam
@@ -34,9 +34,11 @@ conflicts: [
   "solo5-bindings-xen"
 ]
 available: [
-  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
+  (arch = "x86_64" | arch = "arm64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd") &
+  (arch != "ppc64")
 ]
+x-ci-accept-failures: [ "centos-7" ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """
 Solo5 is a sandboxed execution environment primarily intended

--- a/packages/solo5/solo5.0.7.0/opam
+++ b/packages/solo5/solo5.0.7.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.0/solo5-v0.7.0.tar.gz"
+  checksum: "sha512=7d89539d4964c4c2133bddf82fab865db523b069845b2f6367f3f2bf68e743cfe97e5ffff6fa90a217cc9392078b52de63ecd8e540e9a50c39f435fded0717d0"
+}


### PR DESCRIPTION
## v0.7.0 (2021-12-31)

* Remove Genode bindings (#494, #506)
  The Genode bindings becomes incompatible with the upcoming LLVM/Clang based
  toolchain. It can be reinstated in the future if there is interest.

  `GENODE_ABI_TARGET` is not removed to disallow to re-use it for another
  purpose than the Genode binding.
* New packaging, toolchains, cross-compilation (#494, #506)
  + Make Solo5 installable system-wide and be able to packaging Solo5 for the
    BSDs and Linux distributions
  + Replace Solo5-internal use of `pkg-config` by generated toolchain wrappers
    installed as "PREFIX/bin/ARCH-solo5-none-static-{cc,ld,objcopy}"
  + Solo5 bindings (ABIs) are co-installable under the same PREFIX
  + OPAM packaging is simplified (only one package `solo5` remains)
  + Experimental: support for the cross-compilation (specially `aarch64`)
* virtio: FreeBSD requires the grub-bhyve command (#506)
* virtio: FreeBSD: wait a bit for `cat` to create the nmdm device (#506)
* OpenBSD: all supported releases of OpenBSD use `ld.ldd` (#495, #506)
* Be able to release our cross toolchain via our opam-release.sh script (#504)

**NOTE**: `pkg-config` still is required by Solo5 to get flags from
`libseccomp`.