### PR TITLE
Release conjury-2.1.

### DIFF
--- a/packages/conjury/conjury.2.1/opam
+++ b/packages/conjury/conjury.2.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Conjury library for OMake"
+maintainer: "james woodyatt <jhw@conjury.org>"
+authors: "james woodyatt <jhw@conjury.org>"
+license: "BSD-2-Clause"
+tags: "org:conjury.org"
+homepage: "https://bitbucket.org/jhw/conjury/"
+bug-reports: "https://bitbucket.org/jhw/conjury/issues"
+depends: [
+  "base-unix"
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {>= "1.7.3"}
+  "omake" {>= "0.10.3"}
+  "ounit2" {with-test >= "2.2"}
+]
+build: [
+  ["omake" "--dotomake.omake" "--force-dotomake" "--configure" "build"]
+  ["omake" "--dotomake.omake" "--force-dotomake" "test"] {with-test}
+]
+install: ["omake" "--dotomake.omake" "--force-dotomake" "install"]
+dev-repo: "git+https://bitbucket.org/jhw/conjury"
+url {
+  src: "https://bitbucket.org/jhw/conjury/get/r2.1.tar.gz"
+  checksum: "md5=916fb05b6ad9c0fa29be9e0aa49f3dc4"
+}


### PR DESCRIPTION
The Conjury package is currently used only by Orsetto, whose forthcoming next release depends on features in this new minor version.