### PR TITLE
ocamlnet: request more paths from pkg-config

### DIFF
--- a/packages/ocamlnet/ocamlnet.4.1.9-1/files/pkg-config.patch
+++ b/packages/ocamlnet/ocamlnet.4.1.9-1/files/pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git code/src/nettls-gnutls/configure code/src/nettls-gnutls/configure
+index 247ee47..341231a 100755
+--- code/src/nettls-gnutls/configure
++++ code/src/nettls-gnutls/configure
+@@ -9,7 +9,7 @@
+ have_gnutls=0
+ 
+ if [ -z "$PKG_CONFIG" ]; then
+-    PKG_CONFIG="pkg-config"
++    PKG_CONFIG="pkg-config --keep-system-cflags --keep-system-libs"
+ fi
+ 
+ if [ -z "$GNUTLS_LIBS" ]; then

--- a/packages/ocamlnet/ocamlnet.4.1.9-1/opam
+++ b/packages/ocamlnet/ocamlnet.4.1.9-1/opam
@@ -6,7 +6,7 @@ license: ["zlib-acknowledgement" "BSD-3-Clause" "GPL-2.0-only"]
 doc: "http://projects.camlcity.org/projects/dl/ocamlnet-4.1.9/doc/html-main/index.html"
 bug-reports: "https://gitlab.com/gerdstolpmann/lib-ocamlnet3/-/issues"
 dev-repo: "git+https://gitlab.com/gerdstolpmann/lib-ocamlnet3.git"
-patches: ["fix-version-number.patch"]
+patches: ["fix-version-number.patch" "pkg-config.patch"]
 build: [
   [
     "env" "MAKE=%{make}%"
@@ -57,6 +57,7 @@ conflicts: [
 extra-files: [
   ["ocamlnet.install" "md5=ed54a9f3d6382ccc01ea1cf1af8f2c38"]
   ["fix-version-number.patch" "md5=23c41def93bfc8bdbd9805a36849fe74"]
+  ["pkg-config.patch" "md5=c8a13068b0edc9947e18b57510cff953"]
 ]
 url {
   src: "http://download.camlcity.org/download/ocamlnet-4.1.9.tar.gz"


### PR DESCRIPTION
this is a work-around for the "broken" ports pkgconf, which is forced
inte the PATH by conf-pkg-config.

OpenBSD has a custom-tailored /usr/bin/pkg-config.

The full-featured ports /usr/local/bin/pkgconf is installed via ports. But this thing is too smart. It strips -L/usr/local/lib from its recommended options.

Adding the --keep-system option will make it less smart and more helpful.

This whole problem occurs only because conf-pkg-config adds a symlink to the opam path to enforce use of the smart and full-featured ports pkgconf. The full featured pkgconf seems to be required by mirage.