### PR TITLE
[new release] pp-binary-ints (0.1.1)

### DIFF
--- a/packages/pp-binary-ints/pp-binary-ints.0.1.1/opam
+++ b/packages/pp-binary-ints/pp-binary-ints.0.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pretty Printing Binary Integers"
+description: """
+Pretty Printing Binary Integers
+This library contains functions for pretty printing integers as
+unsigned binary integers.
+"""
+maintainer: ["Ifaz Kabir"]
+authors: ["Ifaz Kabir"]
+license: "CC0-1.0"
+tags: ["printf" "format" "boolean" "binary"]
+homepage: "https://github.com/ifazk/pp-binary-ints"
+doc: "https://ifazk.github.io/pp-binary-ints/"
+bug-reports: "https://github.com/ifazk/pp-binary-ints/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.10"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ifazk/pp-binary-ints.git"
+url {
+  src:
+    "https://github.com/ifazk/pp-binary-ints/releases/download/0.1.1/pp-binary-ints-0.1.1.tbz"
+  checksum: [
+    "sha256=199c232eab930f0c69bd5ed9d48236bee2dfb91184d173bfbace060b2adc81a1"
+    "sha512=2750927e7bd783f104147c6c877dc1eb2e0fa6a05de481bc42585536a8b71a42a496038dc5bd10dcc715c64c70d0573facfa0cbb49c4693db6ecb21c39fc73d9"
+  ]
+}
+x-commit-hash: "2fc82e815cf178c161f2f1b3b536787ec02e790e"


### PR DESCRIPTION
Pretty Printing Binary Integers

- Project page: <a href="https://github.com/ifazk/pp-binary-ints">https://github.com/ifazk/pp-binary-ints</a>
- Documentation: <a href="https://ifazk.github.io/pp-binary-ints/">https://ifazk.github.io/pp-binary-ints/</a>

##### CHANGES:

### Added
- Support for `int32`, `int64`, and `nativeint`.
- `*.{make_pp_int,make_to_string}` with optional arguments.
