### PR TITLE
Update macOS conf-openblas to use pkg-config

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -10,7 +10,7 @@ build: [
   [
     "sh"
     "-exc"
-    "cc $CFLAGS -I/usr/local/opt/openblas/include test.c -L/usr/local/opt/openblas/lib -lopenblas"
+    "cc $CFLAGS $(pkg-config --cflags openblas) test.c $(pkg-config --libs openblas)"
   ] {os = "macos" & os-distribution = "homebrew"}
   ["sh" "-exc" "cc $CFLAGS test.c -lcblas"]
     {os-family = "arch"}


### PR DESCRIPTION
homebrew updates pkg-config. If we use those paths we can become resilient to version and brew install prefix changes in path.

xref links:
https://inbox.vuxu.org/caml-list/CAPFanBHtO4gEnUPw2N6g=4rJz6ZcmVj0PUDfbzxpD6kboxoVNA@mail.gmail.com/
From: Gabriel Scherer <gabriel.scherer@gmail.com>
To: nicolas.ratier@femto-st.fr
Cc: caml users <caml-list@inria.fr>, Liang Wang <liang.wang@cl.cam.ac.uk>
Subject: Re: [Caml-list] Problem with: opam install conf-openblas (openSUSE 13.2, OCaml 4.06.1, opam 1.2.2)

https://github.com/owlbarn/owl/issues/212
https://github.com/ocaml/opam-repository/pull/11804