### PR TITLE
Package pprint.20220102

### DIFF
--- a/packages/pprint/pprint.20220102/opam
+++ b/packages/pprint/pprint.20220102/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+  "Nicolas Pouillard <np@nicolaspouillard.fr>"
+]
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/fpottier/pprint"
+dev-repo: "git+ssh://git@github.com/fpottier/pprint.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "dune" {>= "1.3"}
+]
+synopsis: "A pretty-printing combinator library and rendering engine"
+description: "This library offers a set of combinators for building so-called documents as
+well as an efficient engine for converting documents to a textual, fixed-width
+format. The engine takes care of indentation and line breaks, while respecting
+the constraints imposed by the structure of the document and by the text width."
+url {
+  src: "https://github.com/fpottier/pprint/archive/20220102.tar.gz"
+  checksum: [
+    "md5=0cdcccc97103b9bc3dcc016ae1eef22e"
+    "sha512=b8d48f35554d52de4dc5b6e9cd278d007a54704a57a9e373b336de7a772a1af5d92b39cda8b6b89eb338d36a95b242cbeaea53e002a4d95c8d575393b95a744e"
+  ]
+}


### PR DESCRIPTION
### `pprint.20220102`
A pretty-printing combinator library and rendering engine
This library offers a set of combinators for building so-called documents as
well as an efficient engine for converting documents to a textual, fixed-width
format. The engine takes care of indentation and line breaks, while respecting
the constraints imposed by the structure of the document and by the text width.



---
* Homepage: https://github.com/fpottier/pprint
* Source repo: git+ssh://git@github.com/fpottier/pprint.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.1.0