### PR TITLE
Package camlix.0.1

### DIFF
--- a/packages/camlix/camlix.0.1/opam
+++ b/packages/camlix/camlix.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"             {>= "4.10.0"}
-  "dune"              {>= "2.0.0"}
+  "dune"              {>= "2.9.0"}
   "core"
   "ppx_compare"
   "ppx_jane"

--- a/packages/camlix/camlix.0.1/opam
+++ b/packages/camlix/camlix.0.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "reneweb"
+authors: ["reneweb"]
+homepage: "https://github.com/reneweb/camlix"
+bug-reports: "https://github.com/reneweb/camlix/issues"
+dev-repo: "git+https://github.com/reneweb/camlix.git"
+doc: "https://github.com/reneweb/camlix"
+license: "Apache-2.0"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.10.0"}
+  "dune"              {>= "2.0.0"}
+  "core"
+  "ppx_compare"
+  "ppx_jane"
+  "alcotest"
+]
+synopsis: "Simple circuit breaker"
+description: "
+Camlix is a simple circuit breaker library for ocaml
+"
+url {
+  src: "https://github.com/reneweb/camlix/archive/0.1.tar.gz"
+  checksum: [
+    "md5=0b306dd21a38f2d5c302d77bdbf2e4d2"
+    "sha512=812e9959b551c152f37ed17f0e2f010b13f91b561e07846136a699e3cefaa383013e4a30ded72c64dcac49f6136581330a126d57c4db1c60ff654081b5339d08"
+  ]
+}

--- a/packages/camlix/camlix.0.1/opam
+++ b/packages/camlix/camlix.0.1/opam
@@ -6,16 +6,15 @@ bug-reports: "https://github.com/reneweb/camlix/issues"
 dev-repo: "git+https://github.com/reneweb/camlix.git"
 doc: "https://github.com/reneweb/camlix"
 license: "Apache-2.0"
-build: [
-  ["dune" "build" "-p" name "-j" jobs]
-]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
 depends: [
   "ocaml"             {>= "4.10.0"}
   "dune"              {>= "2.9.0"}
   "core"
   "ppx_compare"
   "ppx_jane"
-  "alcotest"
+  "alcotest" {with-test}
 ]
 synopsis: "Simple circuit breaker"
 description: "


### PR DESCRIPTION
### `camlix.0.1`
Simple circuit breaker
Camlix is a simple circuit breaker library for ocaml



---
* Homepage: https://github.com/reneweb/camlix
* Source repo: git+https://github.com/reneweb/camlix.git
* Bug tracker: https://github.com/reneweb/camlix/issues

---
:camel: Pull-request generated by opam-publish v2.1.0