### PR TITLE
irmin-http: cohttp-lwt-unix needed for tests

### DIFF
--- a/packages/irmin-http/irmin-http.2.6.0/opam
+++ b/packages/irmin-http/irmin-http.2.6.0/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.6.0/opam
+++ b/packages/irmin-http/irmin-http.2.6.0/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.6.1/opam
+++ b/packages/irmin-http/irmin-http.2.6.1/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.6.1/opam
+++ b/packages/irmin-http/irmin-http.2.6.1/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.7.0/opam
+++ b/packages/irmin-http/irmin-http.2.7.0/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.7.0/opam
+++ b/packages/irmin-http/irmin-http.2.7.0/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.7.1/opam
+++ b/packages/irmin-http/irmin-http.2.7.1/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.7.1/opam
+++ b/packages/irmin-http/irmin-http.2.7.1/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.7.2/opam
+++ b/packages/irmin-http/irmin-http.2.7.2/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.7.2/opam
+++ b/packages/irmin-http/irmin-http.2.7.2/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.4.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.8.0/opam
+++ b/packages/irmin-http/irmin-http.2.8.0/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.5.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.8.0/opam
+++ b/packages/irmin-http/irmin-http.2.8.0/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.5.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.9.0/opam
+++ b/packages/irmin-http/irmin-http.2.9.0/opam
@@ -32,6 +32,7 @@ depends: [
   "irmin-test" {with-test & = version}
   "git-unix"   {with-test & >= "3.5.0"}
   "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"

--- a/packages/irmin-http/irmin-http.2.9.0/opam
+++ b/packages/irmin-http/irmin-http.2.9.0/opam
@@ -33,6 +33,7 @@ depends: [
   "git-unix"   {with-test & >= "3.5.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
 ]
 
 synopsis: "HTTP client and server for Irmin"


### PR DESCRIPTION
as well as conduit-lwt-unix but that is required by cohttp-lwt-unix.

Seen on: https://github.com/ocaml/opam-repository/pull/20343 
```
Processing  1/2: [irmin-http: dune runtest]
+ /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "dune" "runtest" "-p" "irmin-http" "-j" "31" (CWD=/home/opam/.opam/4.13/.opam-switch/build/irmin-http.2.6.0)
- File "test/irmin-http/dune", line 4, characters 56-72:
- 4 |  (libraries alcotest cohttp-lwt cohttp-lwt-unix conduit conduit-lwt-unix fmt
-                                                             ^^^^^^^^^^^^^^^^
- Error: Library "conduit-lwt-unix" not found.
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>