### PR TITLE
new release ocaml-freestanding.0.7.0

### DIFF
--- a/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.1.2-2/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "conf-m4" {build}
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"

--- a/packages/gmp-freestanding/gmp-freestanding.6.2.0/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.2.0/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "conf-m4" {build}
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"

--- a/packages/gmp-freestanding/gmp-freestanding.6.2.1/opam
+++ b/packages/gmp-freestanding/gmp-freestanding.6.2.1/opam
@@ -14,7 +14,7 @@ remove: [
 ]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "conf-m4" {build}
 ]
 synopsis: "The GNU Multiple Precision Arithmetic Library"

--- a/packages/ocaml-freestanding-cross-aarch64/ocaml-freestanding-cross-aarch64.0.7.0/opam
+++ b/packages/ocaml-freestanding-cross-aarch64/ocaml-freestanding-cross-aarch64.0.7.0/opam
@@ -10,12 +10,9 @@ build: [
   ["./configure.sh"
    "--prefix=%{prefix}%"
    "--target=aarch64-solo5-none-static"
-   "--ocaml-configure-option=--with-afl" {ocaml-option-afl:installed}
    "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
    "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
-   "--ocaml-configure-option=--enable-frame-pointers" {ocaml-option-fp:installed}
    "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
-   "--ocaml-configure-option=--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
   ]
   [make "-j%{jobs}%"]
 ]

--- a/packages/ocaml-freestanding-cross-aarch64/ocaml-freestanding-cross-aarch64.0.7.0/opam
+++ b/packages/ocaml-freestanding-cross-aarch64/ocaml-freestanding-cross-aarch64.0.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=aarch64-solo5-none-static"
+   "--ocaml-configure-option=--with-afl" {ocaml-option-afl:installed}
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+   "--ocaml-configure-option=--enable-frame-pointers" {ocaml-option-fp:installed}
+   "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
+   "--ocaml-configure-option=--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install" ]
+depends: [
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.14.0"}
+  "solo5" {>= "0.7.0"}
+  "solo5-cross-aarch64" {>= "0.7.0" }
+]
+conflicts: [
+  "ocaml-freestanding"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a freestanding OCaml cross-compiler for ARM64, suitable for linking with a unikernel base layer."
+url {
+  src: "https://github.com/mirage/ocaml-freestanding/archive/v0.7.0.tar.gz"
+  checksum: "sha512=eadbeae13d3eaac2de64aa10c0c98e705047c161a079019442be92ed1ff7cad495ca858a46ccf262c1f57a605fbd5779da1a33ab1dd75fc5b9360dd4b9df0984"
+}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.7.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.7.0/opam
@@ -11,12 +11,9 @@ build: [
    "--prefix=%{prefix}%"
    "--target=x86_64-solo5-none-static" { arch = "x86_64" }
    "--target=aarch64-solo5-none-static" { arch = "arm64" }
-   "--ocaml-configure-option=--with-afl" {ocaml-option-afl:installed}
    "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
    "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
-   "--ocaml-configure-option=--enable-frame-pointers" {ocaml-option-fp:installed}
    "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
-   "--ocaml-configure-option=--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
   ]
   [make "-j%{jobs}%"]
 ]

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.7.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.7.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-freestanding"
+bug-reports: "https://github.com/mirage/ocaml-freestanding/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-freestanding.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=x86_64-solo5-none-static" { arch = "x86_64" }
+   "--target=aarch64-solo5-none-static" { arch = "arm64" }
+   "--ocaml-configure-option=--with-afl" {ocaml-option-afl:installed}
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+   "--ocaml-configure-option=--enable-frame-pointers" {ocaml-option-fp:installed}
+   "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
+   "--ocaml-configure-option=--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install" ]
+depends: [
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.14.0"}
+  "solo5" {>= "0.7.0"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a freestanding OCaml cross-compiler, suitable for linking with a unikernel base layer."
+url {
+  src: "https://github.com/mirage/ocaml-freestanding/archive/v0.7.0.tar.gz"
+  checksum: "sha512=eadbeae13d3eaac2de64aa10c0c98e705047c161a079019442be92ed1ff7cad495ca858a46ccf262c1f57a605fbd5779da1a33ab1dd75fc5b9360dd4b9df0984"
+}

--- a/packages/zarith-freestanding/zarith-freestanding.1.10/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.10/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh" prefix]
 remove: ["sh" "-eux" "./mirage-uninstall.sh" prefix]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.10"}
   "ocamlfind" {build}

--- a/packages/zarith-freestanding/zarith-freestanding.1.11/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.11/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh" prefix]
 remove: ["sh" "-eux" "./mirage-uninstall.sh" prefix]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.11"}
   "ocamlfind" {build}

--- a/packages/zarith-freestanding/zarith-freestanding.1.12/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.12/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh" prefix]
 remove: ["sh" "-eux" "./mirage-uninstall.sh" prefix]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.12"}
   "ocamlfind" {build}

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-1/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.7"}
   "ocamlfind" {build}

--- a/packages/zarith-freestanding/zarith-freestanding.1.7-2/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.7-2/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.7"}
   "ocamlfind" {build}

--- a/packages/zarith-freestanding/zarith-freestanding.1.9.1/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.9.1/opam
@@ -8,7 +8,7 @@ install: ["sh" "-eux" "./mirage-install.sh"]
 remove: ["sh" "-eux" "./mirage-uninstall.sh"]
 depends: [
   "ocaml"
-  "ocaml-freestanding" {>= "0.4.1"}
+  "ocaml-freestanding" {>= "0.4.1" & < "0.7.0"}
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.9.1"}
   "ocamlfind" {build}


### PR DESCRIPTION
## v0.7.0 (2022-01-03)

* **NOTE**: This release is a part of the MirageOS 4.0 release and, at this stage, `ocaml-freestanding.0.7.0` will **not** continue to support MirageOS 3 unikernels. `ocaml-freestanding` becomes a real cross-compiler used then by `dune` (with the cross-compilation option) to compile libraries including C stubs. For the MirageOS 4.0 perspective, libraries which include C stubs does not need anymore to compile multiple times C artifacts depending on what `ocaml-freestanding` provides. The `dune` context will help the compilation of these C stubs according the target chosen by the end-user (with the `mirage` tool).

* Add compatibility with the solo5 0.7.0 package split. (mirage/ocaml-freestanding#104)
* Build a freestanding cross-compiler to use with the ocamlfind toolchain feature. This cross-compiler is able to build partial executables to link with a solo5 bindings library. (mirage/ocaml-freestanding#104)
* Fix the OpenBSD 7 support (mirage/ocaml-freestanding#104)
* Remove `pkg-config` (mirage/ocaml-freestanding#104)