### PR TITLE
[new release] coin (0.1.4)

### DIFF
--- a/packages/coin/coin.0.1.4/opam
+++ b/packages/coin/coin.0.1.4/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/coin"
+bug-reports:  "https://github.com/mirage/coin/issues"
+dev-repo:     "git+https://github.com/mirage/coin.git"
+doc:          "https://mirage.github.io/coin/"
+license:      "MIT"
+synopsis:     "Mapper of KOI8-{U,R} to Unicode"
+description: """A simple mapper between KOI8-{U,R} to Unicode. Useful for
+a translation between KOI8-{U,R} and Unicode"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "dune"
+  "re"
+]
+url {
+  src:
+    "https://github.com/mirage/coin/releases/download/v0.1.4/coin-0.1.4.tbz"
+  checksum: [
+    "sha256=93a97199da5ca20fba02db6a47d70c8362f06fd8019736bc2a3386c635c6c900"
+    "sha512=08c0117d4bfb7921c6d8a841b39309dd63907e009b8ac18e7cc01912c392fc8accddd28cc5e02e5eb5cc0101ad2b33d5461379b92be44b9de2a667266d922d8b"
+  ]
+}
+x-commit-hash: "d6dae45f73b266be88938370f42111bbb4126e18"


### PR DESCRIPTION
Mapper of KOI8-{U,R} to Unicode

- Project page: <a href="https://github.com/mirage/coin">https://github.com/mirage/coin</a>
- Documentation: <a href="https://mirage.github.io/coin/">https://mirage.github.io/coin/</a>

##### CHANGES:

* Upgrade the code base and delete the `menhir` dependency (mirage/coin#5)
