### PR TITLE
[new release] colombe, sendmail and sendmail-lwt (0.6.0)

### DIFF
--- a/packages/colombe/colombe.0.6.0/opam
+++ b/packages/colombe/colombe.0.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+x-commit-hash: "7ad4a6b62be0dd325191effa3f34c14354f2a5b7"
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.6.0/colombe-v0.6.0.tbz"
+  checksum: [
+    "sha256=914e25db190507f800fd17e34b5c73e34b581a151b7d0df9fc13f0577796cd88"
+    "sha512=e203add8b22a91f8bb5a967c3fe6e88ec27d124d3c36aef6751ba2ec2dcee3f5036469a866febaa944410e41dd48c899ac460cdba014568d8bd55ba2d41fecef"
+  ]
+}

--- a/packages/sendmail-lwt/sendmail-lwt.0.6.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.6.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.8"}
+  "dune" {>= "2.0"}
   "sendmail" {= version}
   "domain-name"
   "lwt"

--- a/packages/sendmail-lwt/sendmail-lwt.0.6.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+x-commit-hash: "7ad4a6b62be0dd325191effa3f34c14354f2a5b7"
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.6.0/colombe-v0.6.0.tbz"
+  checksum: [
+    "sha256=914e25db190507f800fd17e34b5c73e34b581a151b7d0df9fc13f0577796cd88"
+    "sha512=e203add8b22a91f8bb5a967c3fe6e88ec27d124d3c36aef6751ba2ec2dcee3f5036469a866febaa944410e41dd48c899ac460cdba014568d8bd55ba2d41fecef"
+  ]
+}

--- a/packages/sendmail/sendmail.0.6.0/opam
+++ b/packages/sendmail/sendmail.0.6.0/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.8"}
+  "dune" {>= "2.0"}
   "colombe" {= version}
   "tls" {>= "0.13.0"}
   "base64" {>= "3.0.0"}

--- a/packages/sendmail/sendmail.0.6.0/opam
+++ b/packages/sendmail/sendmail.0.6.0/opam
@@ -26,6 +26,7 @@ depends: [
   "emile" {>= "0.8" & with-test}
   "mrmime" {>= "0.3.2" & with-test}
   "cstruct" {>= "6.0.0"}
+  "bigstringaf" {>= "0.2.0"}
   "alcotest" {with-test}
 ]
 x-commit-hash: "7ad4a6b62be0dd325191effa3f34c14354f2a5b7"

--- a/packages/sendmail/sendmail.0.6.0/opam
+++ b/packages/sendmail/sendmail.0.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.8"}
+  "colombe" {= version}
+  "tls" {>= "0.13.0"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+x-commit-hash: "7ad4a6b62be0dd325191effa3f34c14354f2a5b7"
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.6.0/colombe-v0.6.0.tbz"
+  checksum: [
+    "sha256=914e25db190507f800fd17e34b5c73e34b581a151b7d0df9fc13f0577796cd88"
+    "sha512=e203add8b22a91f8bb5a967c3fe6e88ec27d124d3c36aef6751ba2ec2dcee3f5036469a866febaa944410e41dd48c899ac460cdba014568d8bd55ba2d41fecef"
+  ]
+}


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Better implementation of `STARTTLS` (@dinosaure, mirage/colombe#50)
- Properly quit if the server does not implement `STARTTLS` (@dinosaure, mirage/colombe#51)
- Add `let+` operator which manipulate `result` type (@dinosaure, mirage/colombe#52)
- Upgrade `fmt.0.8.9` (@dinosaure, mirage/colombe#53)
- Be able to pre-allocate resources when we want to send an email (@dinosaure, mirage/colombe#54)
