### PR TITLE
[new release] paf, paf-cohttp and paf-le (0.0.8)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.0.8/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.8/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"           {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
 dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
 url {
   src:

--- a/packages/paf-cohttp/paf-cohttp.0.0.8/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.8/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.8/paf-0.0.8.tbz"
+  checksum: [
+    "sha256=0b2208575d46ee850f3c7ba1a2fe762cfe08878a58e9b7140290f6dfff6adfd9"
+    "sha512=895901787ea41edfeb711050c3cdc09458c7e5cc96769951a5add3c07c79449daf6736a3170eafffcb5e237204a37e512aba546ac5ed64080cba9651a44e7e59"
+  ]
+}
+x-commit-hash: "062b7d8ab89868428442c8fb0e538cf7e568d180"

--- a/packages/paf-le/paf-le.0.0.8/opam
+++ b/packages/paf-le/paf-le.0.0.8/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.8/paf-0.0.8.tbz"
+  checksum: [
+    "sha256=0b2208575d46ee850f3c7ba1a2fe762cfe08878a58e9b7140290f6dfff6adfd9"
+    "sha512=895901787ea41edfeb711050c3cdc09458c7e5cc96769951a5add3c07c79449daf6736a3170eafffcb5e237204a37e512aba546ac5ed64080cba9651a44e7e59"
+  ]
+}
+x-commit-hash: "062b7d8ab89868428442c8fb0e538cf7e568d180"

--- a/packages/paf/paf.0.0.8/opam
+++ b/packages/paf/paf.0.0.8/opam
@@ -32,7 +32,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { os != "macos" }
 dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
 url {
   src:

--- a/packages/paf/paf.0.0.8/opam
+++ b/packages/paf/paf.0.0.8/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.8/paf-0.0.8.tbz"
+  checksum: [
+    "sha256=0b2208575d46ee850f3c7ba1a2fe762cfe08878a58e9b7140290f6dfff6adfd9"
+    "sha512=895901787ea41edfeb711050c3cdc09458c7e5cc96769951a5add3c07c79449daf6736a3170eafffcb5e237204a37e512aba546ac5ed64080cba9651a44e7e59"
+  ]
+}
+x-commit-hash: "062b7d8ab89868428442c8fb0e538cf7e568d180"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

* Upgrade to `tcpip.7.0.0` (@dinosaure, dinosaure/paf-le-chien#54)
* Let the user to manipulate the incoming flow (@dinosaure, dinosaure/paf-le-chien#55)
