### PR TITLE
[new release] received (v0.5.1)

### DIFF
--- a/packages/received/received.v0.5.1/opam
+++ b/packages/received/received.v0.5.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "Received field according RFC5321"
+doc:          "https://mirage.github.io/colombe/"
+description: """A little library to parse or emit a Received field according
+RFC5321. It is able to notify which SMTP server serves the email (and track, by this way,
+on which way - TLS or not - the email was transmitted)."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.03.0"}
+  "dune"     {>= "1.8.0"}
+  "mrmime"   {>= "0.5.0"}
+  "emile"    {>= "0.8"}
+  "angstrom" {>= "0.14.0"}
+  "colombe"  {>= "0.4.0"}
+]
+x-commit-hash: "add3b2c3fec18277bfba34b5ba8da256b4f6bf4c"
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/received-v0.5.1/received-received-v0.5.1.tbz"
+  checksum: [
+    "sha256=28d0f5a62d4b40c00f91d729a8c93bb64c998c3e6de5612a549ee56bf857aae3"
+    "sha512=14d4fab9dc176a12aec9b6279cebef64cf9209c55b1731b3bd2d7f89886c28578aebcd80ce892f2fc49ea13e0d2b0491316eb887ec839929c4d38393ab4822a7"
+  ]
+}


### PR DESCRIPTION
Received field according RFC5321

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Upgrade `received` with the new version of `mrmime` (mirage/colombe#38, @dinosaure)
