### PR TITLE
posix-base: add lower bound on ctypes

### DIFF
--- a/packages/posix-base/posix-base.2.0.0/opam
+++ b/packages/posix-base/posix-base.2.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/savonet/ocaml-posix/issues"
 depends: [
   "dune" {> "2.5"}
   "integers"
-  "ctypes" {>= "0.6.0"}
+  "ctypes" {>= "0.12.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/posix-base/posix-base.2.0.0/opam
+++ b/packages/posix-base/posix-base.2.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/savonet/ocaml-posix/issues"
 depends: [
   "dune" {> "2.5"}
   "integers"
-  "ctypes"
+  "ctypes" {>= "0.6.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Uses Cstubs.concurrency_policy

Seen on https://github.com/ocaml/opam-repository/pull/20354

Logs at: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/ac4413a44a70b1cc7e0d9a8cd30fb780b1c471b4/variant/opam-2.1,compilers,4.03,srt.0.2.1,lower-bounds

```
#=== ERROR while compiling posix-base.2.0.0 ===================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/posix-base.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p posix-base -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/posix-base-24-442382.env
# output-file          ~/.opam/log/posix-base-24-442382.out
### output ###
#       ocamlc posix-base/src/.posix_base.objs/byte/posix_base.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlc.opt -w -40 -g -bin-annot -I posix-base/src/.posix_base.objs/byte -I /home/opam/.opam/4.03/lib/bytes -I /home/opam/.opam/4.03/lib/ctypes -I /home/opam/.opam/4.03/lib/integers -no-alias-deps -o posix-base/src/.posix_base.objs/byte/posix_base.cmi -c -intf posix-base/src/posix_base.mli)
# File "posix-base/src/posix_base.mli", line 23, characters 22-47:
# Error: Unbound type constructor Cstubs.concurrency_policy
```


Signed-off-by: Marcello Seri <marcello.seri@gmail.com>