### PR TITLE
conf-libopus: update suse library name

### DIFF
--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -12,7 +12,8 @@ depexts: [
   ["libopus-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["opus-dev"] {os-family = "alpine"}
   ["opus"] {os-family = "arch"}
-  ["libopus"] {os = "freebsd" | os-distribution = "nixos" | os-family = "suse"}
+  ["libopus"] {os = "freebsd" | os-distribution = "nixos"}
+  ["libopus0"] {os-family = "suse"}
   ["libopusenc"] {os = "macos" & os-distribution = "homebrew"}
   ["opus-devel"] {os-distribution="centos" | os-family = "fedora"}
 ]


### PR DESCRIPTION
Should fix one of the failures in https://github.com/ocaml/opam-repository/pull/20356/files

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>