### PR TITLE
logs: add conflict with cmdliner < 0.9.8

### DIFF
--- a/packages/logs/logs.0.7.0/opam
+++ b/packages/logs/logs.0.7.0/opam
@@ -21,7 +21,9 @@ depopts: [
   "base-threads"
 ]
 conflicts: [
-  "js_of_ocaml" { < "3.3.0" } ]
+   "cmdliner" {< "0.9.8"}
+   "js_of_ocaml" { < "3.3.0" }
+]
 
 build: [[
   "ocaml" "pkg/pkg.ml" "build"


### PR DESCRIPTION
It is the last remaining constraint to fix https://github.com/ocaml/opam-repository/issues/19701

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>