### PR TITLE
Package ocolor.1.2.2

### DIFF
--- a/packages/ocolor/ocolor.1.2.2/opam
+++ b/packages/ocolor/ocolor.1.2.2/opam
@@ -4,7 +4,7 @@ maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
 authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "dune" {build & >= "1.6.3"}
+  "dune" {>= "1.6.3"}
   "cppo" {build & >= "1.6.5"}
 ]
 build: [

--- a/packages/ocolor/ocolor.1.2.2/opam
+++ b/packages/ocolor/ocolor.1.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Print with style in your terminal using Format's semantic tags"
+maintainer: "Marc Chevalier <ocolor@marc-chevalier.com>"
+authors: "Marc Chevalier <ocolor@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {build & >= "1.6.3"}
+  "cppo" {build & >= "1.6.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+homepage: "https://github.com/marc-chevalier/ocolor"
+bug-reports: "https://github.com/marc-chevalier/ocolor/issues"
+dev-repo: "git+https://github.com/marc-chevalier/ocolor.git"
+license: "MIT"
+description: """
+This package provides a nice way to use ANSI escape codes thanks to Format's
+semantic tags. This mode is compositional: ending a style restore the previous
+one, instead of destroying everything.
+This package also allows using directly ANSI escape codes (with Printf).
+
+Note that this library does not intend to handle anything else than ANSI escape
+codes (in particular, not the old Windows style of styling). Moreover, it aims
+to be as pure as possible, so insensitive to the environment. As a consequence,
+there is no mechanism to detect terminal's settings. However, some configuration
+is possible, but must be done manually.
+"""
+url {
+  src: "https://github.com/marc-chevalier/ocolor/archive/1.2.2.tar.gz"
+  checksum: [
+    "md5=15061f2d4a82e44fafea22f2b5a36eb1"
+    "sha512=44bc2cbfe29838c21b98e1a6d7e20f80c5f0affde7ceeb8229d4630460d240df59042e9c4b30b1f51d516acce6cb7d56b91a7791e7a2f9b8bf408c7f76ad2d96"
+  ]
+}


### PR DESCRIPTION
### `ocolor.1.2.2`
Print with style in your terminal using Format's semantic tags
This package provides a nice way to use ANSI escape codes thanks to Format's
semantic tags. This mode is compositional: ending a style restore the previous
one, instead of destroying everything.
This package also allows using directly ANSI escape codes (with Printf).

Note that this library does not intend to handle anything else than ANSI escape
codes (in particular, not the old Windows style of styling). Moreover, it aims
to be as pure as possible, so insensitive to the environment. As a consequence,
there is no mechanism to detect terminal's settings. However, some configuration
is possible, but must be done manually.



---
* Homepage: https://github.com/marc-chevalier/ocolor
* Source repo: git+https://github.com/marc-chevalier/ocolor.git
* Bug tracker: https://github.com/marc-chevalier/ocolor/issues

---
:camel: Pull-request generated by opam-publish v2.1.0