### PR TITLE
Package libbinaryen.101.0.2

### DIFF
--- a/packages/libbinaryen/libbinaryen.101.0.2/opam
+++ b/packages/libbinaryen/libbinaryen.101.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v101.0.2/libbinaryen.tar.gz"
+  checksum: [
+    "md5=5b45c146dd6d62a19fb0089f11795a17"
+    "sha512=d2fdf834ee48fdc5ffa0f8d3574f400afdcf7002ee3cfc6485a0f89f20b8b1cdd7d7ae4c56ef4e5e396bad6a579733da9d94bd07f881cc962974b53f2a297e67"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.101.0.2`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
### Bug Fixes

- Always have a target non-Windows/non-MacOS ([#17](https://www.github.com/grain-lang/libbinaryen/issues/17)) ([fac9d36](https://www.github.com/grain-lang/libbinaryen/commit/fac9d36e5ddbfa7aaa7cc86344e53d716ae98c60))


---
:camel: Pull-request generated by opam-publish v2.0.3