### PR TITLE
[new release] ca-certs-nss (3.74)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.74/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.74/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "mirage-crypto"
+  "mirage-clock" {>= "3.0.0"}
+  "x509" {>= "0.15.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" {build}
+  "fmt" {build & >= "0.8.7"}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.74/ca-certs-nss-3.74.tbz"
+  checksum: [
+    "sha256=c95f5b2e36a0564e6f65421e0e197d7cfe600d19eb492f8f27c4841cbe68b231"
+    "sha512=42ae429ae32047959adc6d107e37e5608b4bca7484efc2b71ee9e319e639639f3f663f1d8528538aecf10584b1839f002e0e6c7602900b600a129ff56cf30fa5"
+  ]
+}
+x-commit-hash: "c8a06689d7fc4b382fbd3ba2cdab36f8378c9bf0"


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.74 (Jan 6th 2022)
* Update to NSS 3.73.1, 3.73, 3.72 (no changes in certdata.txt)
