### PR TITLE
[new release] domain-name (0.4.0)

### DIFF
--- a/packages/domain-name/domain-name.0.4.0/opam
+++ b/packages/domain-name/domain-name.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/domain-name"
+doc: "https://hannesm.github.io/domain-name/doc"
+bug-reports: "https://github.com/hannesm/domain-name/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/domain-name.git"
+synopsis: "RFC 1035 Internet domain names"
+description: """
+A domain name is a sequence of labels separated by dots, such as `foo.example`.
+Each label may contain any bytes. The length of each label may not exceed 63
+charactes.  The total length of a domain name is limited to 253 (byte
+representation is 255), but other protocols (such as SMTP) may apply even
+smaller limits.  A domain name label is case preserving, comparison is done in a
+case insensitive manner.
+"""
+url {
+  src:
+    "https://github.com/hannesm/domain-name/releases/download/v0.4.0/domain-name-0.4.0.tbz"
+  checksum: [
+    "sha256=a5c06e22845895201973e812fe3019274d1db81c0a7873da6c8007c4ad2108c5"
+    "sha512=f25aedb1ddf6ab8c49b1545cf88f4990114a9e7954d91cabf260e6ce470abd42dd135e8a55084262a77d4c9ee4bff6dc00c71307b23a48d82d50593b910ee173"
+  ]
+}
+x-commit-hash: "e9833486ee40ef2c49c43dd72976022a627b4a34"


### PR DESCRIPTION
RFC 1035 Internet domain names

- Project page: <a href="https://github.com/hannesm/domain-name">https://github.com/hannesm/domain-name</a>
- Documentation: <a href="https://hannesm.github.io/domain-name/doc">https://hannesm.github.io/domain-name/doc</a>

##### CHANGES:

* compare: conform to canonical DNS name order (RFC 4034, Section 6.1)
