### PR TITLE
3 packages from gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.11/json-data-encoding-0.11.tar.gz

### DIFF
--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.11/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.11/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.11/json-data-encoding-0.11.tar.gz"
+  checksum: [
+    "md5=80dd53c56b44d5696d8542ac7013a768"
+    "sha512=63894b9fa49b450445bbe125f81e0336dd0e59e23e6875cab4344c727ef454ee126b4344815d653332ccca7e8b9e80b0f272e5d407091d0b4f59426dc46a7994"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.11/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.11/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.11/json-data-encoding-0.11.tar.gz"
+  checksum: [
+    "md5=80dd53c56b44d5696d8542ac7013a768"
+    "sha512=63894b9fa49b450445bbe125f81e0336dd0e59e23e6875cab4344c727ef454ee126b4344815d653332ccca7e8b9e80b0f272e5d407091d0b4f59426dc46a7994"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.0.11/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.11/opam
@@ -18,8 +18,6 @@ depends: [
   "uri" {>= "1.9.0" }
   "crowbar" { with-test }
   "alcotest" { with-test }
-  "ocamlformat" { = "0.20.1" & dev }
-  "odoc" { dev }
 ]
 url {
   src:

--- a/packages/json-data-encoding/json-data-encoding.0.11/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.11/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "uri" {>= "1.9.0" }
+  "crowbar" { with-test }
+  "alcotest" { with-test }
+  "ocamlformat" { = "0.20.1" & dev }
+  "odoc" { dev }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.11/json-data-encoding-0.11.tar.gz"
+  checksum: [
+    "md5=80dd53c56b44d5696d8542ac7013a768"
+    "sha512=63894b9fa49b450445bbe125f81e0336dd0e59e23e6875cab4344c727ef454ee126b4344815d653332ccca7e8b9e80b0f272e5d407091d0b4f59426dc46a7994"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`json-data-encoding.0.11`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.0.11`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.0.11`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://gitlab.com/nomadic-labs/json-data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/json-data-encoding
* Bug tracker: https://gitlab.com/nomadic-labs/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0