### PR TITLE
2 packages from gitlab.com/nomadic-labs/ringo/-/archive/v0.7/ringo-v0.7.tar.gz

### DIFF
--- a/packages/ringo-lwt/ringo-lwt.0.7/opam
+++ b/packages/ringo-lwt/ringo-lwt.0.7/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+  "ringo" {= version }
+  "lwt"
+  "base-unix" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt-wrappers for Ringo caches"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.7/ringo-v0.7.tar.gz"
+  checksum: [
+    "md5=e32bbf680f33158cac632d5bcef478cb"
+    "sha512=1e5daa9c5741ebce5a0265227674daed9f1bf7a2acd9be8ea655ae26220f85e003fb4ac3783253391ea6780d8bef9cd057df62c3872a9f6e6871852b4df3dc74"
+  ]
+}

--- a/packages/ringo/ringo.0.7/opam
+++ b/packages/ringo/ringo.0.7/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.7/ringo-v0.7.tar.gz"
+  checksum: [
+    "md5=e32bbf680f33158cac632d5bcef478cb"
+    "sha512=1e5daa9c5741ebce5a0265227674daed9f1bf7a2acd9be8ea655ae26220f85e003fb4ac3783253391ea6780d8bef9cd057df62c3872a9f6e6871852b4df3dc74"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ringo.0.7`: Caches (bounded-size key-value stores) and other bounded-size stores
-`ringo-lwt.0.7`: Lwt-wrappers for Ringo caches



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0