### PR TITLE
hacl-star and hacl-star-raw (0.4.5)

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency.
+"""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "ocamlfind" {build}
+  "ctypes" { >= "0.18.0" }
+  "conf-which" {build}
+]
+available: [
+  os = "freebsd" | os-family != "bsd"
+]
+x-ci-accept-failures: [
+  "centos-7" "oraclelinux-7" # Default C compiler is too old
+]
+build: [
+  ["sh" "-exc" "cd raw && ./configure"]
+  [make "-C" "raw"]
+]
+install: [
+  make "-C" "raw" "install-hacl-star-raw"
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
+  checksum: [
+    "md5=1e492dba6eb5cd5ea55cce69dfad81dd"
+    "sha256=8e72630116224308ce32061d65ef6a11b49a5b97d0b7ff20097961b7d0452ec7"
+    "sha512=395d6e3807cd0f1e9f470d418057c01d93492df1dbfe06a77b0ab8534bc3007a50f09380b6a8667c33e1188881d923715e00a6d106c67bed57ab8e82a710f471"
+  ]
+}

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
@@ -18,25 +18,29 @@ depends: [
   "conf-which" {build}
 ]
 available: [
-  os = "freebsd" | os-family != "bsd"
+  arch != "ppc64" & arch != "ppc32" &
+  (os = "freebsd" | os-family != "bsd")
 ]
 x-ci-accept-failures: [
   "centos-7" "oraclelinux-7" # Default C compiler is too old
 ]
 build: [
-  ["sh" "-exc" "cd raw && ./configure"]
-  [make "-C" "raw"]
+  ["sh" "-exc" "cd raw && ./configure"] {!dev}
+  [make "-C" "raw"] {!dev}
+  ["sh" "-exc" "cd dist/gcc-compatible && ./configure"] {dev}
+  [make "-C" "dist/gcc-compatible"] {dev}
 ]
 install: [
-  make "-C" "raw" "install-hacl-star-raw"
+  [make "-C" "raw" "install-hacl-star-raw"] {!dev}
+  [make "-C" "dist/gcc-compatible" "install-hacl-star-raw"] {dev}
 ]
 dev-repo: "git+https://github.com/project-everest/hacl-star.git"
 url {
   src:
     "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
   checksum: [
-    "md5=1e492dba6eb5cd5ea55cce69dfad81dd"
-    "sha256=8e72630116224308ce32061d65ef6a11b49a5b97d0b7ff20097961b7d0452ec7"
-    "sha512=395d6e3807cd0f1e9f470d418057c01d93492df1dbfe06a77b0ab8534bc3007a50f09380b6a8667c33e1188881d923715e00a6d106c67bed57ab8e82a710f471"
+    "md5=fdcd7a590913428d5d3142872d7089a0"
+    "sha256=47bf253f804ec369b2fbc76c892ba89275fde17d7444d291d5eb5c179a05e174"
+    "sha512=1f2c144852566464ef72caeb21567b125fa9eb395d9e25b64bb110f116e75b7befdb3e3e190dd8a3f59c74b36d70bb4eb6dcd7ba62061fd91b4c263de0f29c4f"
   ]
 }

--- a/packages/hacl-star/hacl-star.0.4.5/opam
+++ b/packages/hacl-star/hacl-star.0.4.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+description: """
+Documentation for this library can be found
+[here](https://hacl-star.github.io/ocaml_doc/hacl-star/index.html).
+"""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: [ "Project Everest" ]
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+doc: "https://hacl-star.github.io/ocaml_doc"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+  "odoc" {with-doc}
+]
+available: [
+  os = "freebsd" | os-family != "bsd"
+]
+build: [
+  [
+    "dune" "build" "-p" name "-j" jobs
+    "@doc" {with-doc}
+  ]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
+  checksum: [
+    "md5=1e492dba6eb5cd5ea55cce69dfad81dd"
+    "sha256=8e72630116224308ce32061d65ef6a11b49a5b97d0b7ff20097961b7d0452ec7"
+    "sha512=395d6e3807cd0f1e9f470d418057c01d93492df1dbfe06a77b0ab8534bc3007a50f09380b6a8667c33e1188881d923715e00a6d106c67bed57ab8e82a710f471"
+  ]
+}

--- a/packages/hacl-star/hacl-star.0.4.5/opam
+++ b/packages/hacl-star/hacl-star.0.4.5/opam
@@ -19,7 +19,8 @@ depends: [
   "odoc" {with-doc}
 ]
 available: [
-  os = "freebsd" | os-family != "bsd"
+  arch != "ppc64" & arch != "ppc32" &
+  (os = "freebsd" | os-family != "bsd")
 ]
 build: [
   [
@@ -35,8 +36,8 @@ url {
   src:
     "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
   checksum: [
-    "md5=1e492dba6eb5cd5ea55cce69dfad81dd"
-    "sha256=8e72630116224308ce32061d65ef6a11b49a5b97d0b7ff20097961b7d0452ec7"
-    "sha512=395d6e3807cd0f1e9f470d418057c01d93492df1dbfe06a77b0ab8534bc3007a50f09380b6a8667c33e1188881d923715e00a6d106c67bed57ab8e82a710f471"
+    "md5=fdcd7a590913428d5d3142872d7089a0"
+    "sha256=47bf253f804ec369b2fbc76c892ba89275fde17d7444d291d5eb5c179a05e174"
+    "sha512=1f2c144852566464ef72caeb21567b125fa9eb395d9e25b64bb110f116e75b7befdb3e3e190dd8a3f59c74b36d70bb4eb6dcd7ba62061fd91b4c263de0f29c4f"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-hacl-star.0.4.4: OCaml API for EverCrypt/HACL*
-hacl-star-raw.0.4.4: Auto-generated low-level OCaml bindings for EverCrypt/HACL*