### PR TITLE
Package libbinaryen.102.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.102.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.102.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v102.0.0/libbinaryen-v102.0.0.tar.gz"
+  checksum: [
+    "md5=92a1da6f1dd5546c15b804de7d5e5f76"
+    "sha512=4b3face3d686b671f8993d3818b4a299c7beeb726ff91cfcd2dfe7ee64568a1300e505d8422b3c09579cdf9bdf5b2284c94c6d16d60d5cdccee0d6d354e852f9"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.102.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---


### ⚠ BREAKING CHANGES

* Bump binaryen to version_102 (#20)

### Features

* Bump binaryen to version_102 ([#20](https://www.github.com/grain-lang/libbinaryen/issues/20)) ([5e147d7](https://www.github.com/grain-lang/libbinaryen/commit/5e147d7ff767b21cacdacd786eb1e6860394925c))


---
:camel: Pull-request generated by opam-publish v2.0.3