### PR TITLE
Package docker_hub.0.1.0

### DIFF
--- a/packages/docker_hub/docker_hub.0.1.0/opam
+++ b/packages/docker_hub/docker_hub.0.1.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Library aiming to provide data from hub.docker.com"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/ocaml-docker-hub"
+doc: "https://kit-ty-kate.github.io/ocaml-docker-hub/"
+bug-reports: "https://github.com/kit-ty-kate/ocaml-docker-hub/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "lwt"
+  "lwt_ppx"
+  "yojson"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-docker-hub.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocaml-docker-hub/releases/download/v0.1.0/docker_hub-0.1.0.tar.gz"
+  checksum: [
+    "md5=6b18910fdc25d446e4bd07d4af071f1d"
+    "sha512=37c70f5c15c5f4d77796b743bebc6b64a680822fe27e0197f5794495b0aabd42f801d6826ae439aa934bdee682225d75b18e89d6f497f2ea8ae54da33b013650"
+  ]
+}


### PR DESCRIPTION
### `docker_hub.0.1.0`
Library aiming to provide data from hub.docker.com



---
* Homepage: https://github.com/kit-ty-kate/ocaml-docker-hub
* Source repo: git+https://github.com/kit-ty-kate/opam-docker-hub.git
* Bug tracker: https://github.com/kit-ty-kate/ocaml-docker-hub/issues

---
:camel: Pull-request generated by opam-publish v2.1.0