### PR TITLE
Package libbinaryen.103.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.103.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.103.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v103.0.0/libbinaryen-v103.0.0.tar.gz"
+  checksum: [
+    "md5=2e90c6e2095881ce17adc001c31cf1a5"
+    "sha512=8303affe6de40a8fc41188f0323a49be8b77b1e3f670ffc8b8ca9fe1e4a91f84ec80d639b9bf6d7bae4087d4fa112adce9be3d6be6f17cd47df2a4883becadf3"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.103.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
### ⚠ BREAKING CHANGES

- Bump binaryen to version_103 (#24)

### Features

- Bump binaryen to version_103 ([#24](https://www.github.com/grain-lang/libbinaryen/issues/24)) ([aa8a42d](https://www.github.com/grain-lang/libbinaryen/commit/aa8a42dd4c55065d5f7b27b813573d137c1dde08))


---
:camel: Pull-request generated by opam-publish v2.0.3