### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.1.3)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.3/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.3/opam
@@ -36,8 +36,8 @@ url {
   src:
     "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.3/happy-eyeballs-0.1.3.tbz"
   checksum: [
-    "sha256=2498e21cb06d6b2ef7de09a2a4d019dcad7325b2680e5e6eee7c4a92010758e1"
-    "sha512=978336296343808feaeb1fadcca1b35fc55d2bd17fdf00b9e9ed530a3c73e3737f994cb7a5032c16ca240649ad7809afc3c648a68b096979aac51b82810f5904"
+    "sha256=2c303692dcfbbf86a07dd569a462866efef6b252826e5315c133835e595f415b"
+    "sha512=a8b67194634e908bfca4a8ab65d7c3ba1013d324b46f03af94293a6b724dc062f938afad6948d14b4badd87681bf030ed55ce15c6887d8b41c0558791441d22b"
   ]
 }
-x-commit-hash: "1c7d294223e09d7e7145f61dc3fdc20319c77aca"
+x-commit-hash: "3e216048e25cc6e8b29ddad3930b7250468c2100"

--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.3/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.1.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner"
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.3/happy-eyeballs-0.1.3.tbz"
+  checksum: [
+    "sha256=2498e21cb06d6b2ef7de09a2a4d019dcad7325b2680e5e6eee7c4a92010758e1"
+    "sha512=978336296343808feaeb1fadcca1b35fc55d2bd17fdf00b9e9ed530a3c73e3737f994cb7a5032c16ca240649ad7809afc3c648a68b096979aac51b82810f5904"
+  ]
+}
+x-commit-hash: "1c7d294223e09d7e7145f61dc3fdc20319c77aca"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.3/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.3/happy-eyeballs-0.1.3.tbz"
+  checksum: [
+    "sha256=2498e21cb06d6b2ef7de09a2a4d019dcad7325b2680e5e6eee7c4a92010758e1"
+    "sha512=978336296343808feaeb1fadcca1b35fc55d2bd17fdf00b9e9ed530a3c73e3737f994cb7a5032c16ca240649ad7809afc3c648a68b096979aac51b82810f5904"
+  ]
+}
+x-commit-hash: "1c7d294223e09d7e7145f61dc3fdc20319c77aca"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.3/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.1.3/opam
@@ -38,8 +38,8 @@ url {
   src:
     "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.3/happy-eyeballs-0.1.3.tbz"
   checksum: [
-    "sha256=2498e21cb06d6b2ef7de09a2a4d019dcad7325b2680e5e6eee7c4a92010758e1"
-    "sha512=978336296343808feaeb1fadcca1b35fc55d2bd17fdf00b9e9ed530a3c73e3737f994cb7a5032c16ca240649ad7809afc3c648a68b096979aac51b82810f5904"
+    "sha256=2c303692dcfbbf86a07dd569a462866efef6b252826e5315c133835e595f415b"
+    "sha512=a8b67194634e908bfca4a8ab65d7c3ba1013d324b46f03af94293a6b724dc062f938afad6948d14b4badd87681bf030ed55ce15c6887d8b41c0558791441d22b"
   ]
 }
-x-commit-hash: "1c7d294223e09d7e7145f61dc3fdc20319c77aca"
+x-commit-hash: "3e216048e25cc6e8b29ddad3930b7250468c2100"

--- a/packages/happy-eyeballs/happy-eyeballs.0.1.3/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.1.3/opam
@@ -33,8 +33,8 @@ url {
   src:
     "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.3/happy-eyeballs-0.1.3.tbz"
   checksum: [
-    "sha256=2498e21cb06d6b2ef7de09a2a4d019dcad7325b2680e5e6eee7c4a92010758e1"
-    "sha512=978336296343808feaeb1fadcca1b35fc55d2bd17fdf00b9e9ed530a3c73e3737f994cb7a5032c16ca240649ad7809afc3c648a68b096979aac51b82810f5904"
+    "sha256=2c303692dcfbbf86a07dd569a462866efef6b252826e5315c133835e595f415b"
+    "sha512=a8b67194634e908bfca4a8ab65d7c3ba1013d324b46f03af94293a6b724dc062f938afad6948d14b4badd87681bf030ed55ce15c6887d8b41c0558791441d22b"
   ]
 }
-x-commit-hash: "1c7d294223e09d7e7145f61dc3fdc20319c77aca"
+x-commit-hash: "3e216048e25cc6e8b29ddad3930b7250468c2100"

--- a/packages/happy-eyeballs/happy-eyeballs.0.1.3/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.1.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.1.3/happy-eyeballs-0.1.3.tbz"
+  checksum: [
+    "sha256=2498e21cb06d6b2ef7de09a2a4d019dcad7325b2680e5e6eee7c4a92010758e1"
+    "sha512=978336296343808feaeb1fadcca1b35fc55d2bd17fdf00b9e9ed530a3c73e3737f994cb7a5032c16ca240649ad7809afc3c648a68b096979aac51b82810f5904"
+  ]
+}
+x-commit-hash: "1c7d294223e09d7e7145f61dc3fdc20319c77aca"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Happy_eyeballs.create: add v6_connect_timeout parameter - the amount of
  nanoseconds (default: 200ms) after which to attempt IPv4 connection
  establishment. (roburio/happy-eyeballs#21 @hannesm, review by @reynir, issue reported at
  roburio/http-lwt-client#8 by @kit-ty-kate)
* Happy_eyeballs.create: add resolve_retries - the amount of resolve attempts
  when a (resolve) timeout occurs (default: 3). (roburio/happy-eyeballs#21 @hannesm, review by
  @reynir, issue reported at roburio/http-lwt-client#8 by @kit-ty-kate)
