### PR TITLE
ppx_factory.0.2.0: Remove upper bound on OCaml version

### DIFF
--- a/packages/ppx_factory/ppx_factory.0.2.0/opam
+++ b/packages/ppx_factory/ppx_factory.0.2.0/opam
@@ -17,7 +17,7 @@ run-test: [
 ]
 depends: [
   "dune" {>= "1.1"}
-  "ocaml" {>= "4.07.0" & < "4.12.0"}
+  "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
   "ppxlib" {>= "0.14.0"}
   "ppx_deriving" {with-test}


### PR DESCRIPTION
I don't think there was a good reason to put an upper bound in the first place and tests pass with OCaml 4.12 and 4.13 (https://github.com/cryptosense/ppx_factory).