### PR TITLE
ocaml-xdg-basedir < transition should conflict with xdg-basedir

### DIFF
--- a/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.2/opam
+++ b/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.2/opam
@@ -12,6 +12,9 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "xdg-basedir"
+]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "xdg-basedir specification implementation"
 description: """

--- a/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.3/opam
+++ b/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.3/opam
@@ -16,6 +16,9 @@ depends: [
   "ounit"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "xdg-basedir"
+]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "xdg-basedir specification implementation"
 description: """


### PR DESCRIPTION
Creates race condition when upgrading otherwise as both install the same library.

Introduced in #20418 