### PR TITLE
bls12-381.1.0.2 and bls12-381-unix.1.0.2 - Support s390x for 1.0.x

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.1.0.2/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.1.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381 with blst backend"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "zarith" {>= "1.10" & < "2.0"}
+  "ctypes" {>= "0.18.0" & < "0.19.0"}
+  "bls12-381" {= version}
+  "hex"
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+available: arch != "ppc64"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/f1727556f0fb6589b5e01a9eae8ba8fda8ccd476/ocaml-bls12-381-f1727556f0fb6589b5e01a9eae8ba8fda8ccd476.tar.bz2"
+  checksum: [
+    "md5=03d11cf2499950d764c47a0630782c40"
+    "sha512=95ea54c9b2c4c7d19f87a3b89090d336aff9ecca54ec8250b0842ab3809224ade1ba66ff987cf3060054475cd92267c3251acf268d57432473349aff56442215"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/bls12-381/bls12-381.1.0.2/opam
+++ b/packages/bls12-381/bls12-381.1.0.2/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/f1727556f0fb6589b5e01a9eae8ba8fda8ccd476/ocaml-bls12-381-f1727556f0fb6589b5e01a9eae8ba8fda8ccd476.tar.bz2"
+  checksum: [
+    "md5=03d11cf2499950d764c47a0630782c40"
+    "sha512=95ea54c9b2c4c7d19f87a3b89090d336aff9ecca54ec8250b0842ab3809224ade1ba66ff987cf3060054475cd92267c3251acf268d57432473349aff56442215"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bls12-381.1.0.2`: Virtual package for BLS12-381 primitives
-`bls12-381-unix.1.0.2`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381 with blst backend



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.1.0