### PR TITLE
uecc.0.2: conflict with dune 3

### DIFF
--- a/packages/uecc/uecc.0.2/opam
+++ b/packages/uecc/uecc.0.2/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "dune" {>= "2.0"}
+  "dune" {>= "2.0" & < "3.0"}
   "bigstring" {>= "0.1.1"}
   "alcotest" {with-test & >= "0.8.1"}
   "cstruct" {with-test & >= "3.2.1"}


### PR DESCRIPTION
This package does not have a `dune-project` file, so it will default to the latest one. Since there are changes to C flags in dune 3, this breaks uecc.0.2. This could be fixed upstream by adding a dune-project file with a dune-lang 2.0, but there is also a fixed version already.

See ocaml/dune#5268.
