### PR TITLE
bls12-381.1.1.1 and bls12-381-unix.1.1.1 - s390x support for 1.1.x

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.1.1.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.1.1.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381 with blst backend"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bls12-381" {= version}
+  "hex"
+  "alcotest" {with-test}
+  "integers"
+  "bisect_ppx" {with-test & >= "2.5"}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+available: arch != "ppc64"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/22247018c0651ea62ae898c8ffcc388cc73f758f/ocaml-bls12-381-22247018c0651ea62ae898c8ffcc388cc73f758f.tar.bz2"
+  checksum: [
+    "md5=964b8d53cdbf5358465c4eb610c03da2"
+    "sha512=c6252a2cf543ab689dbe3be35a0a63d8cbbc1f4a5252ad9afa2ccb22d13d202d64a5b9f6ce5eb8c409eb594645d9490842f48b664e091f2a20f36f2d5ea1cd97"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/bls12-381/bls12-381.1.1.1/opam
+++ b/packages/bls12-381/bls12-381.1.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/22247018c0651ea62ae898c8ffcc388cc73f758f/ocaml-bls12-381-22247018c0651ea62ae898c8ffcc388cc73f758f.tar.bz2"
+  checksum: [
+    "md5=964b8d53cdbf5358465c4eb610c03da2"
+    "sha512=c6252a2cf543ab689dbe3be35a0a63d8cbbc1f4a5252ad9afa2ccb22d13d202d64a5b9f6ce5eb8c409eb594645d9490842f48b664e091f2a20f36f2d5ea1cd97"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bls12-381.1.1.1`: Virtual package for BLS12-381 primitives
-`bls12-381-unix.1.1.1`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381 with blst backend



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.1.0