### PR TITLE
[new release] pp-binary-ints (1.0.0)

### DIFF
--- a/packages/pp-binary-ints/pp-binary-ints.1.0.0/opam
+++ b/packages/pp-binary-ints/pp-binary-ints.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pretty Printing Binary Integers"
+description: """
+Pretty Printing Binary Integers
+This library contains functions for pretty printing integers as
+unsigned binary integers.
+"""
+maintainer: ["Ifaz Kabir"]
+authors: ["Ifaz Kabir"]
+license: "CC0-1.0"
+tags: ["printf" "format" "boolean" "binary"]
+homepage: "https://github.com/ifazk/pp-binary-ints"
+doc: "https://ifazk.github.io/pp-binary-ints/"
+bug-reports: "https://github.com/ifazk/pp-binary-ints/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.10"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ifazk/pp-binary-ints.git"
+url {
+  src:
+    "https://github.com/ifazk/pp-binary-ints/releases/download/1.0.0/pp-binary-ints-1.0.0.tbz"
+  checksum: [
+    "sha256=4840fc294cf861bddecdbb3218f0ef26d37d2207d45a45d19d01f14e5528cd1b"
+    "sha512=123ec3a792e5148d324ac1406d62fcee798af8ec7a75d23986ac18018ea816d954a71e01d8edbb734fb9f5855686f63e22765da49c72802e67acb9749e6d6616"
+  ]
+}
+x-commit-hash: "ddabbb925df3f8c4a1c911c4b884ce76e2550f7e"


### PR DESCRIPTION
Pretty Printing Binary Integers

- Project page: <a href="https://github.com/ifazk/pp-binary-ints">https://github.com/ifazk/pp-binary-ints</a>
- Documentation: <a href="https://ifazk.github.io/pp-binary-ints/">https://ifazk.github.io/pp-binary-ints/</a>

##### CHANGES:

### Changed
- Default flags have changed to padding with zeros, with separators and
  prefixes, and zero printing behaves just like non-zero printing. Since the
  primary purpose of this library is debugging, this should help.
- `*.{make_pp_int,make_to_string}` no longer take an optional `flags` parameter,
  and instead takes optional boolean parameters `zero_padding`, `left_padding`,
  `separators`, `prefix`, `suffix`, `zero_special`.
- Renamed `*.{pp_binary_int}` to `*.{pp_int_with}` for consistency.

### Fixed
- Padding with zeros no longer assumes prefixes are always 2 characters long.
