### PR TITLE
Dune3: add implicit "result" dependencies

### DIFF
--- a/packages/dispatch/dispatch.0.5.0/opam
+++ b/packages/dispatch/dispatch.0.5.0/opam
@@ -9,6 +9,7 @@ depends: [
   "ocaml" {>="4.03.0"}
   "alcotest" {with-test & > "0.5.0"}
   "dune" {>= "1.0"}
+  "result"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/lsp/lsp.1.9.1/opam
+++ b/packages/lsp/lsp.1.9.1/opam
@@ -30,6 +30,7 @@ depends: [
   "uutf"
   "odoc" {with-doc}
   "ocaml" {>= "4.12"}
+  "result"
 ]
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [

--- a/packages/rpclib/rpclib.8.1.1/opam
+++ b/packages/rpclib/rpclib.8.1.1/opam
@@ -14,11 +14,9 @@ depends: [
   "base64" {>= "3.4.0"}
   "cmdliner" {>= "0.9.8"}
   "rresult" {>= "0.3.0"}
+  "result" {>= "1.5"}
   "xmlm"
   "yojson" {>= "1.7.0"}
-]
-conflicts: [
-  "result" {< "1.5"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Dune < 3.0 ships with META files that implicitly define a "result" library. However, it is not the same as the one from opam (see https://github.com/ocaml/dune/pull/4946#issuecomment-928031670).

So an explicit dependency is still necessary for packages that refer to the result library.

See ocaml/dune#5263.
