### PR TITLE
[new release] ppx_import (1.9.0)

### DIFF
--- a/packages/ppx_import/ppx_import.1.9.0/opam
+++ b/packages/ppx_import/ppx_import.1.9.0/opam
@@ -12,7 +12,7 @@ tags: [ "syntax" ]
 
 depends: [
   "ocaml"                   {              >= "4.05.0" }
-  "dune"                    {              >= "1.2.0"  }
+  "dune"                    {              >= "1.11"  }
   "ppxlib"                  {              >= "0.24.0"  }
   "ounit"                   { with-test                }
   "ppx_deriving"            { with-test  & >= "4.2.1"  }

--- a/packages/ppx_import/ppx_import.1.9.0/opam
+++ b/packages/ppx_import/ppx_import.1.9.0/opam
@@ -1,0 +1,33 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.05.0" }
+  "dune"                    {              >= "1.2.0"  }
+  "ppxlib"                  {              >= "0.24.0"  }
+  "ounit"                   { with-test                }
+  "ppx_deriving"            { with-test  & >= "4.2.1"  }
+  "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/v1.9.0/ppx_import-1.9.0.tbz"
+  checksum: [
+    "sha256=ed09f06d52d53cb30997f600bac534fc4f7e5fe3996bae6a4ff8d63a6d2688dc"
+    "sha512=f312b4589ec06d4db94665352ea7d8f1d5afeab76aa5cbea26f53dcfebb8405451e586a14a28f5856cd32f138773eb4c1d5521f44f15d8fab7db1211c2b68bd3"
+  ]
+}
+x-commit-hash: "8307bbc163153998ffb61bc6d3d861e3bfe0db76"


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

  * Migrate to ppxlib ocaml-ppx/ppx_import#54 , closes ocaml-ppx/ppx_import#44 (tatchi)

  * Drop support for OCaml `4.04.2`. Minimal supported version is now `4.05.0` ocaml-ppx/ppx_import#54 (tatchi)

  * Bump minimum dune version to 1.11 ocaml-ppx/ppx_import#56 (tatchi)

  * Update CI to test OCaml 4.12.0, no changes required
    (ocaml-ppx/ppx_import#53, Emilio J. Gallego Arias)

  * Remove the OCaml upper bound in the opam file
    (ocaml-ppx/ppx_import#53, Emilio J. Gallego Arias, kit-ty-kate)
