### PR TITLE
[new release] links, links-postgresql, links-sqlite3 and links-mysql (0.9.5)

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.5/opam
+++ b/packages/links-mysql/links-mysql.0.9.5/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "conf-mysql"
   "mysql"
   "links" {= version}

--- a/packages/links-mysql/links-mysql.0.9.5/opam
+++ b/packages/links-mysql/links-mysql.0.9.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "MySQL database driver for the Links Programming Language"
+description: "MySQL database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "conf-mysql"
+  "mysql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.5/links-0.9.5.tbz"
+  checksum: [
+    "sha256=0345666bac0976875b2e6ddcca5d097e5ec993e294b74c1344aef5e8c0500394"
+    "sha512=449be4a5554fa2bf0d35337f342dfc59c3293bd34d3da448b7a94ce97000f1b98b23c458aa1f8666b8396154ab7f5cd12fe486c1de4c12c142c3e0ae3ddce2a4"
+  ]
+}
+x-commit-hash: "c29ce89e044566ab8d2edbb922a71891b82adecb"

--- a/packages/links-postgresql/links-postgresql.0.9.5/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.5/opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "postgresql"
   "links" {= version}
 ]

--- a/packages/links-postgresql/links-postgresql.0.9.5/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "Postgresql database driver for the Links Programming Language"
+description: "Postgresql database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "postgresql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.5/links-0.9.5.tbz"
+  checksum: [
+    "sha256=0345666bac0976875b2e6ddcca5d097e5ec993e294b74c1344aef5e8c0500394"
+    "sha512=449be4a5554fa2bf0d35337f342dfc59c3293bd34d3da448b7a94ce97000f1b98b23c458aa1f8666b8396154ab7f5cd12fe486c1de4c12c142c3e0ae3ddce2a4"
+  ]
+}
+x-commit-hash: "c29ce89e044566ab8d2edbb922a71891b82adecb"

--- a/packages/links-sqlite3/links-sqlite3.0.9.5/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.5/opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "sqlite3"
   "links" {= version}
 ]

--- a/packages/links-sqlite3/links-sqlite3.0.9.5/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jan Stolarek <jan.stolarek@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "SQLite database driver for the Links Programming Language"
+description: "SQLite database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "sqlite3"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.5/links-0.9.5.tbz"
+  checksum: [
+    "sha256=0345666bac0976875b2e6ddcca5d097e5ec993e294b74c1344aef5e8c0500394"
+    "sha512=449be4a5554fa2bf0d35337f342dfc59c3293bd34d3da448b7a94ce97000f1b98b23c458aa1f8666b8396154ab7f5cd12fe486c1de4c12c142c3e0ae3ddce2a4"
+  ]
+}
+x-commit-hash: "c29ce89e044566ab8d2edbb922a71891b82adecb"

--- a/packages/links/links.0.9.5/opam
+++ b/packages/links/links.0.9.5/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Simon Fowler <simon.fowler@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.10.0"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "5.0.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir" {>= "20210419"}
+  "ppx_sexp_conv"
+  "calendar" {>= "2.0.4"}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.5/links-0.9.5.tbz"
+  checksum: [
+    "sha256=0345666bac0976875b2e6ddcca5d097e5ec993e294b74c1344aef5e8c0500394"
+    "sha512=449be4a5554fa2bf0d35337f342dfc59c3293bd34d3da448b7a94ce97000f1b98b23c458aa1f8666b8396154ab7f5cd12fe486c1de4c12c142c3e0ae3ddce2a4"
+  ]
+}
+x-commit-hash: "c29ce89e044566ab8d2edbb922a71891b82adecb"

--- a/packages/links/links.0.9.5/opam
+++ b/packages/links/links.0.9.5/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.10.0"}
+  "dune" {>= "2.7"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}
   "base64"


### PR DESCRIPTION
The Links Programming Language

- Project page: <a href="https://github.com/links-lang/links">https://github.com/links-lang/links</a>

##### CHANGES:

This is a minor hotfix release.

* The database query deduplication now correctly handles subexpressions recursively.
* Fixed a bug whereby messages received on the client-side would not
  be deserialised correctly.
* The Links runtime, now internally, uses `Lwt.pause` rather than the
  deprecated `Lwt_main.yield`. As a side effect we have updated the
  Lwt version constraint to be greater or equal to `5.0.0`.
