### PR TITLE
Package binaryen.0.11.0

### DIFF
--- a/packages/binaryen/binaryen.0.11.0/opam
+++ b/packages/binaryen/binaryen.0.11.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml" {>= "3.10.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "101.0.1" & < "102.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.11.0/binaryen-archive-v0.11.0.tar.gz"
+  checksum: [
+    "md5=ff1863f8cf93b9e0c11554c3395f798f"
+    "sha512=6a832906cd5209435652f5be0786a24ddebe902707cfb5d883bc96aadc2106a5705b00334b8ccabc8e70102389ecf72c173f9e5b515bf83dca30e8be414f05f8"
+  ]
+}

--- a/packages/binaryen/binaryen.0.11.0/opam
+++ b/packages/binaryen/binaryen.0.11.0/opam
@@ -18,6 +18,7 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
+available: arch != "arm32" & arch != "x86_32"
 dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
 url {
   src:

--- a/packages/binaryen/binaryen.0.11.0/opam
+++ b/packages/binaryen/binaryen.0.11.0/opam
@@ -6,7 +6,7 @@ license: " Apache-2.0"
 homepage: "https://github.com/grain-lang/binaryen.ml"
 bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
 depends: [
-  "ocaml" {>= "4.12" & < "4.13"}
+  "ocaml" {>= "4.12"}
   "dune" {>= "2.9.1"}
   "dune-configurator" {>= "2.9.1"}
   "js_of_ocaml" {>= "3.10.0"}


### PR DESCRIPTION
### `binaryen.0.11.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
### ⚠ BREAKING CHANGES

- Switch to libbinaryen dependency (#113)
- Remove MacOS-specific library flags (#111)
- Require OCaml 4.12 (#108)

### Features

- Depend on libbinaryen ([59874ce](https://www.github.com/grain-lang/binaryen.ml/commit/59874ce785288d4a33ed5408ac4a0a33e16ff4c1))
- Remove MacOS-specific library flags ([#111](https://www.github.com/grain-lang/binaryen.ml/issues/111)) ([5a67f9f](https://www.github.com/grain-lang/binaryen.ml/commit/5a67f9f330332f8957976841819707d09124dc94))
- Require OCaml 4.12 ([#108](https://www.github.com/grain-lang/binaryen.ml/issues/108)) ([36eedea](https://www.github.com/grain-lang/binaryen.ml/commit/36eedea279fb19ee6131b72b21c24ba0a9d7f993))
- Switch to libbinaryen dependency ([#113](https://www.github.com/grain-lang/binaryen.ml/issues/113)) ([59874ce](https://www.github.com/grain-lang/binaryen.ml/commit/59874ce785288d4a33ed5408ac4a0a33e16ff4c1))


---
:camel: Pull-request generated by opam-publish v2.0.3