### PR TITLE
Package ometrics.0.1.1

### DIFF
--- a/packages/ometrics/ometrics.0.1.1/opam
+++ b/packages/ometrics/ometrics.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+homepage: "https://gitlab.com/nomadic-labs/ometrics"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ometrics.git"
+bug-reports: "https://gitlab.com/nomadic-labs/ometrics/-/issues"
+synopsis: "OCaml analysis in a merge request changes"
+
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.1"}
+  "yojson" {>= "1.7.0"}
+  "menhirSdk"
+  "menhirLib"
+  "menhir"
+  "dot-merlin-reader" {>= "4.1"}
+  "csexp" {>= "1.5.1"}
+  "result" {>= "1.5"}
+  "cmdliner" {>= "1.0.4"}
+  "qcheck-alcotest" {with-test & >= "0.18"}
+  "bisect_ppx" {dev & >= "2.6.0"}
+]
+conflicts: [
+  "menhir" {!= "20211012"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+authors: [
+  "Thomas Letan <lthms@nomadic-labs.com>"
+  "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+]
+url {
+  src:
+    "https://github.com/vch9/ometrics/releases/download/0.1.1/ometrics-full.0.1.1.tar.gz"
+  checksum: [
+    "md5=2d31380b30aa90400e5faed1deeacd84"
+    "sha512=a7f74b97f04231c2454a2560e79ff102b507beed9f46d491a7b97ca8d063a934b05b5a66cb3b78a2aa2f88de82a9e223acc7cfd75acb3fffa1cf5836619e3455"
+  ]
+}


### PR DESCRIPTION
### `ometrics.0.1.1`
OCaml analysis in a merge request changes



---
* Homepage: https://gitlab.com/nomadic-labs/ometrics
* Source repo: git+https://gitlab.com/nomadic-labs/ometrics.git
* Bug tracker: https://gitlab.com/nomadic-labs/ometrics/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0