### PR TITLE
Introduce base-nnp

### DIFF
--- a/packages/base-nnp/base-nnp.base/opam
+++ b/packages/base-nnp/base-nnp.base/opam
@@ -1,0 +1,10 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+synopsis: "Naked pointers prohibited in the OCaml heap"
+description: """
+Installed when the compiler does not permit naked pointers in
+the heap. Prior to OCaml 5.00.0, this mode was expressly selected
+by configuring with --disable-naked-pointers. The shared memory
+parallelism added in OCaml 5.00.0 requires this mode.
+"""
+depends: "ocaml" {>= "5.00"} | "ocaml-option-nnp" | "ocaml-variants" {= "4.06.1+no-naked-pointers+flambda"}

--- a/packages/base-nnp/base-nnp.base/opam
+++ b/packages/base-nnp/base-nnp.base/opam
@@ -7,4 +7,4 @@ the heap. Prior to OCaml 5.00.0, this mode was expressly selected
 by configuring with --disable-naked-pointers. The shared memory
 parallelism added in OCaml 5.00.0 requires this mode.
 """
-depends: "ocaml" {>= "5.00"} | "ocaml-option-nnp" | "ocaml-variants" {= "4.06.1+no-naked-pointers+flambda"}
+depends: "base-domains" | "ocaml-option-nnp" | "ocaml-variants" {= "4.06.1+no-naked-pointers+flambda"}

--- a/packages/coq/coq.8.13.0/opam
+++ b/packages/coq/coq.8.13.0/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 build: [

--- a/packages/coq/coq.8.13.1/opam
+++ b/packages/coq/coq.8.13.1/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 build: [

--- a/packages/coq/coq.8.13.2/opam
+++ b/packages/coq/coq.8.13.2/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 build: [

--- a/packages/coq/coq.8.14.0/opam
+++ b/packages/coq/coq.8.14.0/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 build: [

--- a/packages/coq/coq.8.14.1/opam
+++ b/packages/coq/coq.8.14.1/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 build: [

--- a/packages/coq/coq.8.15.0/opam
+++ b/packages/coq/coq.8.15.0/opam
@@ -28,7 +28,7 @@ depends: [
   "zarith" {>= "1.10"}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 build: [

--- a/packages/ctypes/ctypes.0.10.0/opam
+++ b/packages/ctypes/ctypes.0.10.0/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.10.1/opam
+++ b/packages/ctypes/ctypes.0.10.1/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.10.2/opam
+++ b/packages/ctypes/ctypes.0.10.2/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.10.3/opam
+++ b/packages/ctypes/ctypes.0.10.3/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.10.4/opam
+++ b/packages/ctypes/ctypes.0.10.4/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.10.5/opam
+++ b/packages/ctypes/ctypes.0.10.5/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.11.0/opam
+++ b/packages/ctypes/ctypes.0.11.0/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.11.1/opam
+++ b/packages/ctypes/ctypes.0.11.1/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.11.2/opam
+++ b/packages/ctypes/ctypes.0.11.2/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.11.3/opam
+++ b/packages/ctypes/ctypes.0.11.3/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.11.4/opam
+++ b/packages/ctypes/ctypes.0.11.4/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.11.5/opam
+++ b/packages/ctypes/ctypes.0.11.5/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.12.0/opam
+++ b/packages/ctypes/ctypes.0.12.0/opam
@@ -62,6 +62,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.12.1/opam
+++ b/packages/ctypes/ctypes.0.12.1/opam
@@ -62,6 +62,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.13.0/opam
+++ b/packages/ctypes/ctypes.0.13.0/opam
@@ -62,6 +62,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.13.1/opam
+++ b/packages/ctypes/ctypes.0.13.1/opam
@@ -62,6 +62,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.14.0/opam
+++ b/packages/ctypes/ctypes.0.14.0/opam
@@ -62,6 +62,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.15.0/opam
+++ b/packages/ctypes/ctypes.0.15.0/opam
@@ -62,6 +62,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.15.1/opam
+++ b/packages/ctypes/ctypes.0.15.1/opam
@@ -58,6 +58,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.16.0/opam
+++ b/packages/ctypes/ctypes.0.16.0/opam
@@ -58,6 +58,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.17.0/opam
+++ b/packages/ctypes/ctypes.0.17.0/opam
@@ -58,6 +58,6 @@ url {
 available: false
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.17.1/opam
+++ b/packages/ctypes/ctypes.0.17.1/opam
@@ -57,6 +57,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.18.0/opam
+++ b/packages/ctypes/ctypes.0.18.0/opam
@@ -57,6 +57,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.19.1/opam
+++ b/packages/ctypes/ctypes.0.19.1/opam
@@ -57,6 +57,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.8.0/opam
+++ b/packages/ctypes/ctypes.0.8.0/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.8.1/opam
+++ b/packages/ctypes/ctypes.0.8.1/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.8.2/opam
+++ b/packages/ctypes/ctypes.0.8.2/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.9.0/opam
+++ b/packages/ctypes/ctypes.0.9.0/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.9.1/opam
+++ b/packages/ctypes/ctypes.0.9.1/opam
@@ -61,6 +61,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.9.2/opam
+++ b/packages/ctypes/ctypes.0.9.2/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.9.3/opam
+++ b/packages/ctypes/ctypes.0.9.3/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.9.4/opam
+++ b/packages/ctypes/ctypes.0.9.4/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ctypes/ctypes.0.9.5/opam
+++ b/packages/ctypes/ctypes.0.9.5/opam
@@ -60,6 +60,6 @@ url {
 }
 conflicts: [
   "mirage-xen" {>= "6.0.0"}
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/llvm/llvm.10.0.0/opam
+++ b/packages/llvm/llvm.10.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-cmake" {build}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 patches: [

--- a/packages/llvm/llvm.11.0.0/opam
+++ b/packages/llvm/llvm.11.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-cmake" {build}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 patches: [

--- a/packages/llvm/llvm.12.0.1/opam
+++ b/packages/llvm/llvm.12.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-cmake" {build}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 patches: [

--- a/packages/llvm/llvm.13.0.0/opam
+++ b/packages/llvm/llvm.13.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-cmake" {build}
 ]
 conflicts: [
-  "ocaml-option-nnp"
+  "base-nnp"
   "ocaml-option-nnpchecker"
 ]
 patches: [

--- a/packages/ocaml-option-nnp/ocaml-option-nnp.1/opam
+++ b/packages/ocaml-option-nnp/ocaml-option-nnp.1/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 synopsis: "Set OCaml to be compiled with --disable-naked-pointers"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~" & < "5.00.0~~"}
+  "base-nnp" {post}
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
@@ -7,6 +7,7 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
+  "base-nnp" {post}
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.5.00.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.00.0+trunk/opam
@@ -12,6 +12,7 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-domains" {post}
+  "base-nnp" {post}
   "ocaml-beta" {opam-version < "2.1"}
 ]
 conflict-class: "ocaml-core-compiler"


### PR DESCRIPTION
OCaml 5.00.0 makes `--disable-naked-pointers` mode the default. #20420 prevents the `ocaml-option-nnp` package from being specified for > 5.00.0. In some ways (as was done in the ocaml-multicore project's repo), the `ocaml-option-nnp` should be forced, but this isn't consistent with how the other `ocaml-option-` packages are used, or the base packages.

However, in changing this, packages which didn't support no-naked-pointers mode, and so which _conflicted_ `ocaml-option-nnp` are now installable on OCaml 5.00.0 (e.g. `llvm`) even though they presumably don't work.

This PR introduces `base-nnp.base` which is installed automatically by `ocaml-variants.5.00.0+trunk` (along with `base-unix.base`, etc.) and which is also pulled in if `ocaml-option-nnp` is selected for 4.12-4.14. Packages which conflicted `ocaml-option-nnp` are updated to conflict `base-nnp` instead.