### PR TITLE
Package libbinaryen.102.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.102.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.102.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v102.0.1/libbinaryen-v102.0.1.tar.gz"
+  checksum: [
+    "md5=cabab2d7760fd221511dca2e2f2b6b25"
+    "sha512=9a196273b9359794953f421b8abe477abb443347e890c0467d989c959218da6350d4c15a306f026eaa026ed134c5dd3307e6599b08d57b290cd7dfece4503d51"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.102.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---


### Bug Fixes

* Copy wasm-delegations.def into the correct location ([#28](https://www.github.com/grain-lang/libbinaryen/issues/28)) ([c79bcc3](https://www.github.com/grain-lang/libbinaryen/commit/c79bcc39aa76d23d96086cd191a53b249bfedb6b))


---
:camel: Pull-request generated by opam-publish v2.0.3