### PR TITLE
conf-libcurl: add macos targets

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -15,6 +15,8 @@ depexts: [
   ["libcurl-devel"] {os-family = "suse"}
   ["libcurl-devel"] {os-distribution = "fedora"}
   ["libcurl-devel"] {os-distribution = "ol"}
+  ["curl"] {os-distribution = "homebrew" & os = "macos"}
+  ["curl"] {os-distribution = "macports" & os = "macos"}
 ]
 synopsis: "Virtual package relying on a libcurl system installation"
 description:


### PR DESCRIPTION
Ocurl is starting failing on macos due to outdated curl shipped by the system.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>