### PR TITLE
[new release] coq-serapi (8.15.0+0.15.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.15" & < "8.16"     }
+  "cmdliner"            {           >= "1.0.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.15.0%2B0.15.0/coq-serapi-8.15.0.0.15.0.tbz"
+  checksum: [
+    "sha256=5cd48e23a8893f71f7b599dc919ce52d19eb4a6feeaa49f954e0a7123496a306"
+    "sha512=cc09f481c5dfdf181711aa13ef1d93176b4143a14ef863375f98e25db15da8ed4335526a27ba33479594a0bd745733eaaf02437ce7e0f972d97673b04d25773c"
+  ]
+}
+x-commit-hash: "9204d486b50ed3c6ec5952cdcc895f762378d11c"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serapi] (!) support for Coq 8.15, see upstream changes; nothing
            too remarkable so far, except for `NewTip` -> `NewAddTip`
            in the answer response, we may want to add a compat layer
            for this if problematic. (ejgallego/coq-serapi#265, @ejgallego)
