### PR TITLE
Lock binaryen bindings to 4.12

### DIFF
--- a/packages/binaryen/binaryen.0.11.0/opam
+++ b/packages/binaryen/binaryen.0.11.0/opam
@@ -6,7 +6,7 @@ license: " Apache-2.0"
 homepage: "https://github.com/grain-lang/binaryen.ml"
 bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
 depends: [
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.12" < "4.13"}
   "dune" {>= "2.9.1"}
   "dune-configurator" {>= "2.9.1"}
   "js_of_ocaml" {>= "3.10.0"}


### PR DESCRIPTION
In #20447, @kit-ty-kate "unlocked" ocaml 4.13; however, I had thought I locked this down for a specific reason.

When trying to apply this [same patch upstream](https://github.com/grain-lang/binaryen.ml/pull/121), it was apparent that the reason for this is that ocaml 4.13 + windows explodes in CI: https://github.com/grain-lang/binaryen.ml/runs/4829181505?check_suite_focus=true

Attached is the log if you aren't allowed to see it in the GitHub Actions UI.
[error.log](https://github.com/ocaml/opam-repository/files/7876105/error.log)

If I'm doing something wrong, please let me know, but I think we should lock ocaml to 4.12 for the time being.
