### PR TITLE
conf-cmake: Add cygwinports depext installation

### DIFF
--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["devel/cmake"] {os = "openbsd"}
   ["devel/cmake"] {os = "netbsd"}
   ["devel/cmake"] {os = "dragonfly"}
+  ["cmake"] {os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on cmake"
 description:


### PR DESCRIPTION
I'm not sure what the policy is for adding `cygwinports` depext. One of the problems with the libbinaryen package on Windows is that this isn't specified in the depext list and no cmake gets installed on Windows.

I noticed that `cygwinports` is at least specified in `conf-pkg-config`. Why doesn't it exist in more conf packages?

Ref discussion in #20463