### PR TITLE
conf-cmake: Specify system prefix for cygwinports

### DIFF
--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -20,7 +20,7 @@ depexts: [
   ["devel/cmake"] {os = "openbsd"}
   ["devel/cmake"] {os = "netbsd"}
   ["devel/cmake"] {os = "dragonfly"}
-  ["cmake"] {os-distribution = "cygwinports"}
+  ["system:cmake"] {os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on cmake"
 description:


### PR DESCRIPTION
I was getting depext failures with just "cmake" in my manifest, so I [dove into the depext-cygwinports wrapper](https://github.com/fdopen/depext-cygwinports/blob/master/cygwin.ml#L169-L174) and found that unless you specify `system:` prefix on your depext names, it'll try to prefix `mingw64-x86_64-` [to your package name](https://github.com/fdopen/depext-cygwinports/blob/master/cygwin.ml#L189-L195).

This should make the cmake package install without the prefix hack.