### PR TITLE
conf-python-3: Add cygwinports depext installation

### DIFF
--- a/packages/conf-python-3/conf-python-3.1.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.1.0.0/opam
@@ -20,6 +20,7 @@ depexts: [
   ["lang/python36"] {os = "freebsd"}
   ["python36"] {os-distribution = "macports" & os = "macos"}
   ["python@3"] {os-distribution = "homebrew" & os = "macos"}
+  ["system:python3"] {os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on Python-3 installation"
 description: """


### PR DESCRIPTION
This adds a cygwinports depext for python3 in the `conf-python-3` package. It also uses the `system:` prefix (as mentioned in #20466).

I'm adding these depexts directly to my package to test them out before they are upstreamed into the mingw fork.