### PR TITLE
[new release] lambdapi (2.1.0)

### DIFF
--- a/packages/lambdapi/lambdapi.2.1.0/opam
+++ b/packages/lambdapi/lambdapi.2.1.0/opam
@@ -73,10 +73,10 @@ build: [
 dev-repo: "git+https://github.com/Deducteam/lambdapi.git"
 url {
   src:
-    "https://github.com/Deducteam/lambdapi/archive/refs/tags/2.1.0.tar.gz"
+    "https://github.com/Deducteam/lambdapi/releases/download/2.1.0/lambdapi-2.1.0.tbz"
   checksum: [
-    "sha256=41d14f4df32f9ddc6c7895fcbd4abfb895ef8fa2d09da4fefa2288e696801e16"
-    "sha512=8d8e0dd34a4daf33c508c73fb2bbb97a65cc7072cbd6df9836b1922c7eda7a1e8bc2a69d1e8afce7f78e6dd5238ec0f886565f4fd3164ca78932deccdf2139be"
+    "sha256=04fac3b56d1855795d7d2d2442bc650183bcd71f676c3ea77f37240e33769ce9"
+    "sha512=37f7bec3bc48632379ca9fb3eb562a0c0387e54afbdd10fb842b8da70c6dad529bb98c14b9d7cddf44a1d5aa61bba86338d310e6a7b420e95b2996b4fbafc95c"
   ]
 }
-x-commit-hash: "089f239ad951c8848e6b1394fa38dfe2eacd3a1c"
+x-commit-hash: "215a0e2434811f026c357f92ca15652e31a945a5"


### PR DESCRIPTION
Proof assistant for the λΠ-calculus modulo rewriting

- Project page: <a href="https://github.com/Deducteam/lambdapi">https://github.com/Deducteam/lambdapi</a>

##### CHANGES:

### Added

- In Logic/, a library of logics.

- The command export to translate signatures to the lp or dk files formats.

- New release of the VSCode extension.

- A small tutorial in tests/OK/tutorial.lp.

- The why3 tactic handles universal and existential quantifiers through
  two new builtins ("ex" and "all"). Codewise, it requires a new
  translation from encoded types to Why3 types.

- Tems may be _placeholders_. Placeholders are holes in the
  concrete syntax. They are refined into metavariables. *Placeholders
  cannot appear nonlinearly in terms*. From [A Bidirectional Refinement
  Algorithm...](https://arxiv.org/abs/1202.4905), p. 31,
  > Non linear placeholders are not allowed since two occurrences could be
  in contexts that bind different set of variables and instantiation with
  terms that live in one context would make no sense in the other one.

### Changed

- Moved the files tool/hrs.ml and tool/xtc.ml into the new export/ directory.

- Because placeholders are simple holes, the term `_ → _` is scoped
  into a full dependent product `Π x: M, N` where `N` is a metavariable
  that depend on `x` (see file `tests/OK/767.lp`)

- Type checking is slower following Deducteam/lambdapi#696 because of refinement (not only
  the type but also the term must be destructured and rebuilt),
  |         | master | refiner |
  |---------|--------|---------|
  | holide  | 7:0    | 11:33   |
  | iprover | 5:58   | 6:50    |

### Removed

- The command beautify superseded by the new command export.

- Unused variable warning: whether a variable is used or not cannot be
  decided while scoping (following Deducteam/lambdapi#696) since placeholders that do not
  depend on variables may be refined later into metavariables that may
  depend on them.

- Metavariables cannot be referenced by their name anymore, hence the
  syntax `?M.[x;y]` is obsolete, but `?0.[x;y]` isn't.
