### PR TITLE
added packages/oranger/oranger.4.3.3/opam

### DIFF
--- a/packages/oranger/oranger.4.3.3/opam
+++ b/packages/oranger/oranger.4.3.3/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "https://github.com/UnixJunkie/oranger"
+bug-reports: "https://github.com/UnixJunkie/oranger/issues"
+dev-repo: "git+https://github.com/UnixJunkie/oranger.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["tar" "xzf" "0.9.11.tar.gz"]
+  ["mkdir" "ranger-0.9.11/cpp_version/build"]
+  ["sh" "-c" "cd ranger-0.9.11/cpp_version/build && %{conf-cmake:cmd}% ../"]
+  [make "-C" "ranger-0.9.11/cpp_version/build"]
+]
+install: [
+  ["cp" "ranger-0.9.11/cpp_version/build/ranger" "%{bin}%/ml_rf_ranger"]
+]
+depends: [
+  "dune" {>= "1.0.0"}
+  "conf-cmake" {build}
+  "re" {>= "1.9.0"}
+  "dolog" {>= "6.0.0"}
+  "batteries" {>= "3.3.0"}
+  "minicli" {>= "5.0.2"}
+  "cpm" {>= "12.0.0"}
+  "line_oriented" {>= "1.0.0"}
+  "molenc" {>= "16.0.0"}
+  "parany" {>= "12.0.3"}
+]
+depopts: [
+  "conf-gnuplot"
+]
+synopsis: "OCaml wrapper for the ranger (C++) random forests implementation"
+description: """
+Ranger is run from the command line and data are exchanged via text files.
+This is quick and dirty, not a clean OCaml interface to ranger.
+The oranger_rfr program allows to train/test a random-forests regressor model.
+
+$ oranger_rfr
+usage:
+oranger_rfr  [-p <float>]: proportion of the (randomized) dataset
+  used to train (default=0.80)
+  [-np <int>]: max number of processes (default=1)
+  [-n <int>]: |RF|; default=100
+  [--mtry <float>]: proportion of randomly selected features
+  to use at each split (default=(sqrt(|features|))/|features|)
+  [--scan-mtry]: scan for best mtry in [0.001,0.002,0.005,...,1.0]
+  (incompatible with --mtry)
+  [--mtry-range <string>]: mtrys to test e.g. "0.001,0.002,0.005"
+  [-o <filename>]: output scores to file
+  [--train <train.txt>]: training set (overrides -p)
+  [--valid <valid.txt>]: validation set (overrides -p)
+  [--test <test.txt>]: test set (overrides -p)
+  [--NxCV <int>]: number of folds of cross validation
+  [--seed <int>: fix random seed]
+  [--no-regr-plot]: turn OFF regression plot
+  [--rec-plot]: turn ON REC curve
+  [--y-rand]: turn ON Y-randomization
+  [-s <filename>]: save model to file
+  [-l <filename>]: load model from file
+  [--max-feat <int>]: max feature id.  (cf. end of encoding dict)
+  [-v]: verbose/debug mode
+  [-h|--help]: show this help message
+"""
+extra-source "0.9.11.tar.gz" {
+  src: "https://github.com/imbs-hl/ranger/archive/0.9.11.tar.gz"
+  checksum: "md5=cf770dfdde5ef250bfd561ef2b0758ee"
+}
+url {
+  src: "https://github.com/UnixJunkie/oranger/archive/v4.3.3.tar.gz"
+  checksum: "md5=0c6b40873ca79cd656f323a009050fa2"
+}


### PR DESCRIPTION
small bug correction: there was no default mtry value
while earlier versions or oranger had this feature
(you don't need to choose an mtry value in order to train
a model; however, for a production model it is
advized to try optimizing the mtry fraction).