### PR TITLE
3 packages from c-cube/printbox at 0.6

### DIFF
--- a/packages/printbox-html/printbox-html.0.6/opam
+++ b/packages/printbox-html/printbox-html.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Printbox unicode handling"
+description: """
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats
+"""
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "odoc" {with-doc}
+  "printbox" {= version}
+  "tyxml"
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src: "https://github.com/c-cube/printbox/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=052766382422020d9e92641d788c1b50"
+    "sha512=95739aa35afae261912a192faff55a6f2293cf82f6e814a7329a88a03c8aaf6d26eab124687b81f98b92d96f7bbe5eaf8a376dcacca12c74f769eadede26da20"
+  ]
+}

--- a/packages/printbox-html/printbox-html.0.6/opam
+++ b/packages/printbox-html/printbox-html.0.6/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" { >= "2.0" }
   "odoc" {with-doc}
   "printbox" {= version}
-  "tyxml"
+  "tyxml" {>="4.3"}
 ]
 license: "BSD-2-Clause"
 tags: [ "print" "box" "table" "tree" ]

--- a/packages/printbox-text/printbox-text.0.6/opam
+++ b/packages/printbox-text/printbox-text.0.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Text renderer for printbox, using unicode edges"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+  "printbox" { = version }
+  "uutf" { >= "1.0" }
+  "uucp" { >= "1.0" }
+  "mdx" {with-test & >= "1.4" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src: "https://github.com/c-cube/printbox/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=052766382422020d9e92641d788c1b50"
+    "sha512=95739aa35afae261912a192faff55a6f2293cf82f6e814a7329a88a03c8aaf6d26eab124687b81f98b92d96f7bbe5eaf8a376dcacca12c74f769eadede26da20"
+  ]
+}

--- a/packages/printbox-text/printbox-text.0.6/opam
+++ b/packages/printbox-text/printbox-text.0.6/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" { >= "4.03" }
   "printbox" { = version }
   "uutf" { >= "1.0" }
-  "uucp" { >= "1.0" }
+  "uucp" { >= "1.1.0" }
   "mdx" {with-test & >= "1.4" }
 ]
 license: "BSD-2-Clause"

--- a/packages/printbox-text/printbox-text.0.6/opam
+++ b/packages/printbox-text/printbox-text.0.6/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" { >= "4.03" }
   "printbox" { = version }
   "uutf" { >= "1.0" }
-  "uucp" { >= "1.1.0" }
+  "uucp" { >= "2.0" }
   "mdx" {with-test & >= "1.4" }
 ]
 license: "BSD-2-Clause"

--- a/packages/printbox/printbox.0.6/opam
+++ b/packages/printbox/printbox.0.6/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src: "https://github.com/c-cube/printbox/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=052766382422020d9e92641d788c1b50"
+    "sha512=95739aa35afae261912a192faff55a6f2293cf82f6e814a7329a88a03c8aaf6d26eab124687b81f98b92d96f7bbe5eaf8a376dcacca12c74f769eadede26da20"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`printbox.0.6`: Allows to print nested boxes, lists, arrays, tables in several formats
-`printbox-html.0.6`: Printbox unicode handling
-`printbox-text.0.6`: Text renderer for printbox, using unicode edges



---
* Homepage: https://github.com/c-cube/printbox/
* Source repo: git+https://github.com/c-cube/printbox.git
* Bug tracker: https://github.com/c-cube/printbox/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0