### PR TITLE
Package libbinaryen.102.0.2

### DIFF
--- a/packages/libbinaryen/libbinaryen.102.0.2/opam
+++ b/packages/libbinaryen/libbinaryen.102.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v102.0.2/libbinaryen-v102.0.2.tar.gz"
+  checksum: [
+    "md5=a9dced5be38c23cdea189dc18bce14f6"
+    "sha512=47eb5c6247d57f4238bca3cdd13dfe95e2cd0b29d9235004d0b2aa492e67b6bcfdb18df7dc7f558e9c889acadbf6dc4e162ba2595ac6a8cc19006afb76de94fc"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.102.0.2`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---


### Bug Fixes

* Ensure project can build with Opam on Windows ([#33](https://www.github.com/grain-lang/libbinaryen/issues/33)) ([e6070de](https://www.github.com/grain-lang/libbinaryen/commit/e6070de21672242df02247f84c11f156d435787e))


---
:camel: Pull-request generated by opam-publish v2.0.3