### PR TITLE
Package binaryen.0.11.1

### DIFF
--- a/packages/binaryen/binaryen.0.11.1/opam
+++ b/packages/binaryen/binaryen.0.11.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml" {>= "3.10.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "101.0.1" & < "102.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.11.1/binaryen-archive-v0.11.1.tar.gz"
+  checksum: [
+    "md5=82ccde70241bfe49a5dd60f9e0804a16"
+    "sha512=7357ca4f44302ab9b0713855b4939ca0c77761ea945fff6039d5e58294a65876f24cf2ee0ccbad886d8ce2879243454d96987d3860342989b55e9197a569c0ca"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.11.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---


### Bug Fixes

* Make features work in 32-bit mode ([#123](https://www.github.com/grain-lang/binaryen.ml/issues/123)) ([e435c8b](https://www.github.com/grain-lang/binaryen.ml/commit/e435c8bd9f6619c42b82e53e5d1caa929b5d4ebf))


---
:camel: Pull-request generated by opam-publish v2.0.3