### PR TITLE
[new release] equinoxe, equinoxe-hlc and equinoxe-cohttp (0.2.0)

### DIFF
--- a/packages/equinoxe-cohttp/equinoxe-cohttp.0.2.0/opam
+++ b/packages/equinoxe-cohttp/equinoxe-cohttp.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Equinoxe with the cohttp-lwt-unix request handler"
+description:
+  "Equinoxe-cohttp is an implementation of the Equinoxe library using cohttp-lwt-unix."
+maintainer: ["Étienne Marais <etienne@maiste.fr>"]
+authors: ["Étienne Marais <etienne@maiste.fr>"]
+license: "MIT"
+homepage: "https://github.com/maiste/equinoxe"
+doc: "maiste.github.io/equinoxe"
+bug-reports: "https://github.com/maiste/equinoxe/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "equinoxe" {= version}
+  "cohttp-lwt-unix"
+  "httpaf-lwt-unix" {with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/maiste/equinoxe.git"
+url {
+  src:
+    "https://github.com/maiste/equinoxe/releases/download/0.2.0/equinoxe-0.2.0.tbz"
+  checksum: [
+    "sha256=ac2fcaaa08808908b6004e77c54dcd01ba0fe0561b3411908268ace292c22a8a"
+    "sha512=b6ea9372388f00404d726d9262ca7387d15794e0238856aa47c6e34e7d427bd9da787e97477487f2d124963d568df05b06abe0cef8ae06118a8e2c3f5fe1f2c7"
+  ]
+}
+x-commit-hash: "1aff288584c7c17929ce9d2e7d2ecd5c5a726ab9"

--- a/packages/equinoxe-hlc/equinoxe-hlc.0.2.0/opam
+++ b/packages/equinoxe-hlc/equinoxe-hlc.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Equinoxe with the http-lwt-client request handler"
+description:
+  "Equinoxe-hlc is an implementation of the Equinoxe library using http-lwt-client."
+maintainer: ["Étienne Marais <etienne@maiste.fr>"]
+authors: ["Étienne Marais <etienne@maiste.fr>"]
+license: "MIT"
+homepage: "https://github.com/maiste/equinoxe"
+doc: "maiste.github.io/equinoxe"
+bug-reports: "https://github.com/maiste/equinoxe/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "equinoxe" {= version}
+  "http-lwt-client"
+  "httpaf-lwt-unix" {with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/maiste/equinoxe.git"
+url {
+  src:
+    "https://github.com/maiste/equinoxe/releases/download/0.2.0/equinoxe-0.2.0.tbz"
+  checksum: [
+    "sha256=ac2fcaaa08808908b6004e77c54dcd01ba0fe0561b3411908268ace292c22a8a"
+    "sha512=b6ea9372388f00404d726d9262ca7387d15794e0238856aa47c6e34e7d427bd9da787e97477487f2d124963d568df05b06abe0cef8ae06118a8e2c3f5fe1f2c7"
+  ]
+}
+x-commit-hash: "1aff288584c7c17929ce9d2e7d2ecd5c5a726ab9"

--- a/packages/equinoxe/equinoxe.0.2.0/opam
+++ b/packages/equinoxe/equinoxe.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "An OCaml wrapper for the Equinix API"
+description: "Equinoxe is an OCaml wrapper for the Equinix API."
+maintainer: ["Étienne Marais <etienne@maiste.fr>"]
+authors: ["Étienne Marais <etienne@maiste.fr>"]
+license: "MIT"
+homepage: "https://github.com/maiste/equinoxe"
+doc: "maiste.github.io/equinoxe"
+bug-reports: "https://github.com/maiste/equinoxe/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "lwt" {>= "5.3.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/maiste/equinoxe.git"
+url {
+  src:
+    "https://github.com/maiste/equinoxe/releases/download/0.2.0/equinoxe-0.2.0.tbz"
+  checksum: [
+    "sha256=ac2fcaaa08808908b6004e77c54dcd01ba0fe0561b3411908268ace292c22a8a"
+    "sha512=b6ea9372388f00404d726d9262ca7387d15794e0238856aa47c6e34e7d427bd9da787e97477487f2d124963d568df05b06abe0cef8ae06118a8e2c3f5fe1f2c7"
+  ]
+}
+x-commit-hash: "1aff288584c7c17929ce9d2e7d2ecd5c5a726ab9"


### PR DESCRIPTION
An OCaml wrapper for the Equinix API

- Project page: <a href="https://github.com/maiste/equinoxe">https://github.com/maiste/equinoxe</a>
- Documentation: <a href="maiste.github.io/equinoxe">maiste.github.io/equinoxe</a>

##### CHANGES:

### Added

- Add a Cohttp client version, with a specific package (maiste/equinoxe#60, @maiste)

### Changed

- Rewrite the API using `io` monad (maiste/equinoxe#63, @art-w)

### Removed

- Remove `JSON` module and use `Ezjsonm` directly (maiste/equinoxe#63, @art-w)
