### PR TITLE
[new release] awa, awa-mirage and awa-lwt (0.1.0)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.1.0/opam
+++ b/packages/awa-lwt/awa-lwt.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.0/awa-0.1.0.tbz"
+  checksum: [
+    "sha256=68f9c50e9e76a18547affe7a945c3482d549d0abc76b0c8ce451ada473ce558f"
+    "sha512=6e9408d324e766092c7c512c6f39de5b50ce1003d723be3119d936d7de390577738010b38240048cb032e4dc56cac2130e7658c005c00a899a3034e6389c1b84"
+  ]
+}
+x-commit-hash: "de7effb995998d2ded83501ab046d9dcb66f5f02"

--- a/packages/awa-mirage/awa-mirage.0.1.0/opam
+++ b/packages/awa-mirage/awa-mirage.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "mirage-time"
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.0/awa-0.1.0.tbz"
+  checksum: [
+    "sha256=68f9c50e9e76a18547affe7a945c3482d549d0abc76b0c8ce451ada473ce558f"
+    "sha512=6e9408d324e766092c7c512c6f39de5b50ce1003d723be3119d936d7de390577738010b38240048cb032e4dc56cac2130e7658c005c00a899a3034e6389c1b84"
+  ]
+}
+x-commit-hash: "de7effb995998d2ded83501ab046d9dcb66f5f02"

--- a/packages/awa/awa.0.1.0/opam
+++ b/packages/awa/awa.0.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.15.2"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "cstruct-sexp"
+  "sexplib"
+  "mtime"
+  "logs"
+  "fmt"
+  "cmdliner"
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.0/awa-0.1.0.tbz"
+  checksum: [
+    "sha256=68f9c50e9e76a18547affe7a945c3482d549d0abc76b0c8ce451ada473ce558f"
+    "sha512=6e9408d324e766092c7c512c6f39de5b50ce1003d723be3119d936d7de390577738010b38240048cb032e4dc56cac2130e7658c005c00a899a3034e6389c1b84"
+  ]
+}
+x-commit-hash: "de7effb995998d2ded83501ab046d9dcb66f5f02"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* mirage: add server implementation, and ssh subsystem (mirage/awa-ssh#35, @palainp)
* client: accept channel extended data (stderr) (@art-w, mirage/awa-ssh#43)
* cram test for awa_gen_key and what a user provides (@dinosaure, mirage/awa-ssh#44)
