### PR TITLE
fstar.2021.06.06: update constraints

### DIFF
--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -27,6 +27,7 @@ depends: [
   "process"
   "z3" {= "4.8.5"}
 ]
+available: arch = "x86_64" | arch = "x86_32"
 build: [make "PREFIX=%{prefix}%" "-j" jobs]
 install: [make "PREFIX=%{prefix}%" "install"]
 depexts: [

--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "fileutils"
   "menhir" {build & >= "20161115"}
-  "pprint" {build & >= "20130324" & < "20211129"}
+  "pprint" {build & >= "20130324" & <= "20211129"}
   "sedlex" {build & >= "2.0" & < "2.4"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving"

--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlbuild" {build}
   "fileutils"
   "menhir" {build & >= "20161115"}
-  "pprint" {build & >= "20130324"}
+  "pprint" {build & >= "20130324" & < "20211129"}
   "sedlex" {build & >= "2.0" & < "2.4"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving"

--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -27,7 +27,7 @@ depends: [
   "process"
   "z3" {= "4.8.5"}
 ]
-available: arch = "x86_64" | arch = "x86_32"
+available: arch = "x86_64" | arch = "x86_32" | (arch = "arm64" & os = "macos")
 build: [make "PREFIX=%{prefix}%" "-j" jobs]
 install: [make "PREFIX=%{prefix}%" "install"]
 depexts: [

--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -27,7 +27,6 @@ depends: [
   "process"
   "z3" {= "4.8.5"}
 ]
-available: arch = "x86_64" | arch = "x86_32"
 build: [make "PREFIX=%{prefix}%" "-j" jobs]
 install: [make "PREFIX=%{prefix}%" "install"]
 depexts: [


### PR DESCRIPTION
Suggested by @R1kM:
* `arch` constraints currently do not allow building on macos + M1, maybe they are not necessary at all.
* This release of F* is not compatible with recent releases of pprint.
