### PR TITLE
camlp5: disable testing for macos/homebrew

### DIFF
--- a/packages/camlp5/camlp5.8.00.02/opam
+++ b/packages/camlp5/camlp5.8.00.02/opam
@@ -29,10 +29,10 @@ depends: [
   "ocaml" {>= "4.02" & < "4.14.0"}
   "conf-perl"
   "conf-perl-ipc-system-simple" {
-    os != "macos"
+    os-distribution != "homebrew"
   }
   "conf-perl-string-shellquote" {
-    os != "macos"
+    os-distribution != "homebrew"
   }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }
@@ -47,12 +47,12 @@ build: [
   [make "-C" "testsuite" "clean" "all-tests"] {
     with-test
   & ocaml:version >= "4.10.0"
-  & os != "macos"
+  & os-distribution != "homebrew"
   }
   [make "-C" "test" "clean" "all"] {
     with-test
   & ocaml:version >= "4.10.0"
-  & os != "macos"
+  & os-distribution != "homebrew"
   }
 ]
 install: [make "install"]

--- a/packages/camlp5/camlp5.8.00.02/opam
+++ b/packages/camlp5/camlp5.8.00.02/opam
@@ -29,12 +29,10 @@ depends: [
   "ocaml" {>= "4.02" & < "4.14.0"}
   "conf-perl"
   "conf-perl-ipc-system-simple" {
-    with-test
-  & os != "macos"
+    os != "macos"
   }
   "conf-perl-string-shellquote" {
-    with-test
-  & os != "macos"
+    os != "macos"
   }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }

--- a/packages/camlp5/camlp5.8.00.02/opam
+++ b/packages/camlp5/camlp5.8.00.02/opam
@@ -30,13 +30,11 @@ depends: [
   "conf-perl"
   "conf-perl-ipc-system-simple" {
     with-test
-  & os-distribution != "homebrew"
-  & os-distribution != "macports"
+  & os != "macos"
   }
   "conf-perl-string-shellquote" {
     with-test
-  & os-distribution != "homebrew"
-  & os-distribution != "macports"
+  & os != "macos"
   }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }
@@ -51,14 +49,12 @@ build: [
   [make "-C" "testsuite" "clean" "all-tests"] {
     with-test
   & ocaml:version >= "4.10.0"
-  & os-distribution != "homebrew"
-  & os-distribution != "macports"
+  & os != "macos"
   }
   [make "-C" "test" "clean" "all"] {
     with-test
   & ocaml:version >= "4.10.0"
-  & os-distribution != "homebrew"
-  & os-distribution != "macports"
+  & os != "macos"
   }
 ]
 install: [make "install"]

--- a/packages/camlp5/camlp5.8.00.02/opam
+++ b/packages/camlp5/camlp5.8.00.02/opam
@@ -28,12 +28,8 @@ bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
   "ocaml" {>= "4.02" & < "4.14.0"}
   "conf-perl"
-  "conf-perl-ipc-system-simple" {
-    os-distribution != "homebrew"
-  }
-  "conf-perl-string-shellquote" {
-    os-distribution != "homebrew"
-  }
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }
   "ounit" { with-test }

--- a/packages/camlp5/camlp5.8.00.02/opam
+++ b/packages/camlp5/camlp5.8.00.02/opam
@@ -28,8 +28,16 @@ bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
   "ocaml" {>= "4.02" & < "4.14.0"}
   "conf-perl"
-  "conf-perl-ipc-system-simple"
-  "conf-perl-string-shellquote"
+  "conf-perl-ipc-system-simple" {
+    with-test
+  & os-distribution != "homebrew"
+  & os-distribution != "macports"
+  }
+  "conf-perl-string-shellquote" {
+    with-test
+  & os-distribution != "homebrew"
+  & os-distribution != "macports"
+  }
   "conf-diffutils" { with-test & os-distribution = "alpine" }
   "pcre" { with-test }
   "ounit" { with-test }
@@ -40,8 +48,18 @@ build: [
   ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
   [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
   [make "-j%{jobs}%" "DEBUG=-g" "all"]
-  [make "-C" "testsuite" "clean" "all-tests"] { with-test & ocaml:version >= "4.10.0" }
-  [make "-C" "test" "clean" "all"] {with-test & ocaml:version >= "4.10.0" }
+  [make "-C" "testsuite" "clean" "all-tests"] {
+    with-test
+  & ocaml:version >= "4.10.0"
+  & os-distribution != "homebrew"
+  & os-distribution != "macports"
+  }
+  [make "-C" "test" "clean" "all"] {
+    with-test
+  & ocaml:version >= "4.10.0"
+  & os-distribution != "homebrew"
+  & os-distribution != "macports"
+  }
 ]
 install: [make "install"]
 


### PR DESCRIPTION
disable testing (and deps on conf-perl-* packages) on macos & homebrew, so camlp5 will install there.