### PR TITLE
release ocamlfind.1.9.2

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.
+"""
+license: "MIT"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+depends: [
+  "ocaml" {>= "4.00.0"}
+]
+depopts: ["graphics"]
+build: [
+  [
+    "./configure"
+    "-bindir" bin
+    "-sitelib" lib
+    "-mandir" man
+    "-config" "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
+url {
+  src: "http://download.camlcity.org/download/findlib-1.9.2.tar.gz"
+  checksum: [
+    "md5=180b69dd4474614ad6044d879c467232"
+    "sha512=c43d43e502869d52e7eb0e5fcf900039fd4ce0c997a4c823f8d5d9ead0c62120447a787723b884bda0db210e9e60fb513d767c4ea6c18bb38effdc8e35a4b75e"
+  ]
+}


### PR DESCRIPTION
This is a new upstream release. Only change: support build with OCaml-5 trunk.