### PR TITLE
[new release] irmin & all (2.10.1)

### DIFF
--- a/packages/irmin-bench/irmin-bench.2.10.1/opam
+++ b/packages/irmin-bench/irmin-bench.2.10.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-pack"   {= version}
+  "irmin-layers" {= version}
+  "irmin-test"   {= version}
+  "cmdliner"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "ppx_deriving_yojson"
+  "yojson"
+  "memtrace"     {>= "0.1.2"}
+  "repr"         {>= "0.3.0"}
+  "ppx_repr"
+  "re"           {>= "1.9.0"}
+  "fmt"
+  "uuidm"
+  "progress"     {>="0.2.1"}
+  "fpath"        {with-test}
+  "bentov"       {with-test}
+  "mtime"        {with-test}
+  "ppx_deriving" {with-test}
+  "alcotest"     {with-test}
+  "rusage"
+  "uutf"         {with-test}
+  "uucp"         {with-test}
+  "printbox"     {with-test}
+]
+
+synopsis: "Irmin benchmarking suite"
+description: """
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-chunk/irmin-chunk.2.10.1/opam
+++ b/packages/irmin-chunk/irmin-chunk.2.10.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-containers/irmin-containers.2.10.1/opam
+++ b/packages/irmin-containers/irmin-containers.2.10.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "irmin-unix" {= version}
+  "irmin-git"  {= version}
+  "ppx_irmin"  {= version}
+  "lwt"        {>= "5.3.0"}
+  "mtime"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Mergeable Irmin data structures"
+description: """
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-fs/irmin-fs.2.10.1/opam
+++ b/packages/irmin-fs/irmin-fs.2.10.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "astring"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-git/irmin-git.2.10.1/opam
+++ b/packages/irmin-git/irmin-git.2.10.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "git"        {>= "3.5.0"}
+  "digestif"   {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "fpath"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "uri"
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test}
+  "mtime"      {with-test & >= "1.0.0"}
+  "alcotest"   {with-test}
+]
+available: arch != "arm32" & arch != "x86_32"
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-graphql/irmin-graphql.2.10.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.7.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.13.0"}
+  "graphql-lwt"    {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "graphql_parser" {>= "0.13.0"}
+  "cohttp-lwt"
+  "cohttp"
+  "fmt"
+  "lwt"            {>= "5.3.0"}
+  "alcotest-lwt"    {with-test & >= "1.1.0"}
+  "yojson"          {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "alcotest"        {with-test & >= "1.2.3"}
+  "logs"            {with-test}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-http/irmin-http.2.10.1/opam
+++ b/packages/irmin-http/irmin-http.2.10.1/opam
@@ -30,7 +30,7 @@ depends: [
   "uri"
   "irmin-git"  {with-test & = version}
   "irmin-test" {with-test & = version}
-  "git-unix"   {with-test & >= "3.5.0"}
+  "git-unix"   {with-test & >= "3.7.0"}
   "digestif"   {with-test & >= "0.9.0"}
   "conduit-lwt-unix" {with-test}
   "cohttp-lwt-unix" {with-test}

--- a/packages/irmin-http/irmin-http.2.10.1/opam
+++ b/packages/irmin-http/irmin-http.2.10.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.7.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "uri"
+  "irmin-git"  {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test & >= "3.5.0"}
+  "digestif"   {with-test & >= "0.9.0"}
+  "conduit-lwt-unix" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "git-cohttp-unix" {with-test}
+]
+
+synopsis: "HTTP client and server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-layers/irmin-layers.2.10.1/opam
+++ b/packages/irmin-layers/irmin-layers.2.10.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.7.0"}
+  "mtime"      {>= "1.0.0"}
+  "irmin"      {= version}
+  "logs"
+  "lwt"        {>= "5.3.0"}
+]
+
+synopsis: "Combine different Irmin stores into a single, layered store"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.10.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.10.1/opam
@@ -17,9 +17,9 @@ depends: [
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
   "mirage-kv"    {>= "3.0.0"}
-  "git-paf"      {>= "3.5.0" & < "3.7.0"}
+  "git-paf"      {>= "3.7.0"}
   "fmt"
-  "git"          {>= "3.5.0" & < "3.7.0"}
+  "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}
   "mirage-clock"
   "uri"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.10.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.10.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.7.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"    {= version}
+  "mirage-kv"    {>= "3.0.0"}
+  "git-paf"      {>= "3.5.0" & < "3.7.0"}
+  "fmt"
+  "git"          {>= "3.5.0" & < "3.7.0"}
+  "lwt"          {>= "5.3.0"}
+  "mirage-clock"
+  "uri"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.10.1/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.2.10.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"          {>= "2.7.0"}
+  "irmin-mirage"  {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt"           {>= "5.3.0"}
+  "uri"
+  "git"           {>= "3.4.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-mirage/irmin-mirage.2.10.1/opam
+++ b/packages/irmin-mirage/irmin-mirage.2.10.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "2.7.0"}
+  "irmin"      {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-pack/irmin-pack.2.10.1/opam
+++ b/packages/irmin-pack/irmin-pack.2.10.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.08.0"}
+  "dune"         {>= "2.7.0"}
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "index"        {>= "1.5.0"}
+  "fmt"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "mtime"
+  "cmdliner"
+  "optint"       {>= "0.1.0"}
+  "irmin-test"   {with-test & = version}
+  "alcotest-lwt" {with-test}
+  "astring"      {with-test}
+  "fpath"        {with-test}
+  "alcotest"     {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-test/irmin-test.2.10.1/opam
+++ b/packages/irmin-test/irmin-test.2.10.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "irmin"        {= version}
+  "irmin-layers" {= version}
+  "ppx_irmin"    {= version}
+  "ocaml"        {>= "4.02.3"}
+  "dune"         {>= "2.7.0"}
+  "alcotest"     {>= "1.0.1"}
+  "mtime"        {>= "1.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "metrics-unix"
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "metrics" {>= "0.2.0"}
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-tezos/irmin-tezos.2.10.1/opam
+++ b/packages/irmin-tezos/irmin-tezos.2.10.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Irmin implementation of the Tezos context hash specification"
+description: "Irmin implementation of the Tezos context hash specification"
+maintainer: "Tarides <contact@tarides.com>"
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "MIT"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "irmin" {= version}
+  "irmin-pack" {= version}
+  "ppx_irmin" {= version}
+  "tezos-base58"
+  "digestif" {>= "0.7"}
+  "cmdliner"
+  "fmt"
+  "yojson"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test}]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin-unix/irmin-unix.2.10.1/opam
+++ b/packages/irmin-unix/irmin-unix.2.10.1/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+available: arch != "arm32" & arch != "x86_32"
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "2.7.0"}
+  "irmin"         {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-layers"  {= version}
+  "irmin-tezos"   {= version}
+  "git-unix"      {>= "3.7.0"}
+  "digestif"      {>= "0.9.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "0.1.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix"
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git"             {>= "3.7.0"}
+  "lwt"           {>= "5.3.0"}
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/irmin/irmin.2.10.1/opam
+++ b/packages/irmin/irmin.2.10.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "repr"    {>= "0.5.0" & < "0.6.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "uutf"
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "5.3.0"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "ppx_irmin" {= version}
+  "hex"      {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {with-test}
+]
+conflicts: [
+    "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+ ]
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"

--- a/packages/ppx_irmin/ppx_irmin.2.10.1/opam
+++ b/packages/ppx_irmin/ppx_irmin.2.10.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "dune" {>= "2.7.0"}
+  "ppx_repr" {>= "0.2.0"}
+]
+
+synopsis: "PPX deriver for Irmin type representations"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/2.10.1/irmin-2.10.1.tbz"
+  checksum: [
+    "sha256=fb753662f3a2046d7b17f5d67d4a33fc7fe5e1b07b4a581262267571ba76bed2"
+    "sha512=21fa1804cbc0d6e4c4ffc22010e1ce8de9e743e657034649a60b79501c4ce30edf7107d9f54da354196be3327dffae1e23154a0b565639185af0af1ff42fea4d"
+  ]
+}
+x-commit-hash: "19847d99551fa99df131388d42fb558957d9a33e"


### PR DESCRIPTION
PPX deriver for Irmin type representations

- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>

##### CHANGES:

### Fixed

- *irmin*
  - Fix bug introduced in mirage/irmin#1683 which causes `Tree.seq` and `Tree.list` to
    produce pruned children (mirage/irmin#1720, @Ngoguey42)
