### PR TITLE
Package libbinaryen.102.0.3

### DIFF
--- a/packages/libbinaryen/libbinaryen.102.0.3/opam
+++ b/packages/libbinaryen/libbinaryen.102.0.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v102.0.3/libbinaryen-v102.0.3.tar.gz"
+  checksum: [
+    "md5=f687b2b32b8b8c02e9544c24de5cb77e"
+    "sha512=0784f36e00122ae41c7394e7ca4d2e146180b4ee23cd00c946361ff54d4abbc4f46dc831ff3925d8b5ffa7bfb1a4149734e738f75ae2ced7d40d1b0fed57f661"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.102.0.3`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---


### Bug Fixes

* Remove library_flags & only specify c_library_flags where needed ([#37](https://www.github.com/grain-lang/libbinaryen/issues/37)) ([cd8c41a](https://www.github.com/grain-lang/libbinaryen/commit/cd8c41a9ffae5949063f0ace49d0ecdcc74b4c31))
* Run cmake build with -j4 for faster builds ([cd8c41a](https://www.github.com/grain-lang/libbinaryen/commit/cd8c41a9ffae5949063f0ace49d0ecdcc74b4c31))


---
:camel: Pull-request generated by opam-publish v2.0.3