### PR TITLE
add proper perl depext for macos/macports

### DIFF
--- a/packages/conf-perl/conf-perl.2/opam
+++ b/packages/conf-perl/conf-perl.2/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "tim@gfxmonk.net"
+homepage: "https://www.perl.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall"
+build: [["perl" "--version"]]
+depexts: [
+  ["perl"] {os-family = "debian"}
+  ["perl"] {os-distribution = "alpine"}
+  ["perl"] {os-distribution = "nixos"}
+  ["perl"] {os-distribution = "arch"}
+  ["perl-Pod-Html"] {os-distribution = "fedora"}
+  ["perl-Pod-Html"] {os-distribution = "centos" & os-version >= "8"}
+  ["perl5"] {os-distribution = "macports" & os = "macos"}
+]
+synopsis: "Virtual package relying on perl"
+description:
+  "This package can only install if the perl program is installed on the system."
+flags: conf


### PR DESCRIPTION
Let's see if we can get "conf-perl" working correctly on macos.

I tried this as part of another PR, and somehow it broke tons of other things.  So trying this in isolation, maybe I can figure out what's wrong.  Or maybe it'll just work, b/c geez, it's so simple.