### PR TITLE
Luv 0.5.11: binding to libuv, the async I/O library

### DIFF
--- a/packages/luv/luv.0.5.11/opam
+++ b/packages/luv/luv.0.5.11/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.02.0"}
+  "result"
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "1.5.2"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.11/luv-0.5.11.tar.gz"
+  checksum: "md5=efe61a4b4725d59901984022c02ef698"
+}

--- a/packages/luv_unix/luv_unix.0.5.0/opam
+++ b/packages/luv_unix/luv_unix.0.5.0/opam
@@ -15,6 +15,7 @@ depends: [
   "base-unix"
   "dune" {>= "2.0.0"}
   "luv" {>= "0.5.7"}  # uv.h.
+  "ctypes" {>= "0.14.0"}
   "ocaml" {>= "4.02.0"}
   "result"
 ]

--- a/packages/luv_unix/luv_unix.0.5.0/opam
+++ b/packages/luv_unix/luv_unix.0.5.0/opam
@@ -14,7 +14,7 @@ dev-repo: "git+https://github.com/aantron/luv.git"
 depends: [
   "base-unix"
   "dune" {>= "2.0.0"}
-  "luv" {>= "0.5.7"}  # uv.h.
+  "luv" {>= "0.5.8"}  # uv.h.
   "ctypes" {>= "0.14.0"}
   "ocaml" {>= "4.02.0"}
   "result"

--- a/packages/luv_unix/luv_unix.0.5.0/opam
+++ b/packages/luv_unix/luv_unix.0.5.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for interfacing Luv and Unix"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix"
+  "dune" {>= "2.0.0"}
+  "luv" {>= "0.5.7"}  # uv.h.
+  "ocaml" {>= "4.02.0"}
+  "result"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.11/luv-0.5.11.tar.gz"
+  checksum: "md5=efe61a4b4725d59901984022c02ef698"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/luv/releases/tag/0.5.11):

> Additions
>
> - Upgrade libuv to [1.43.0](https://github.com/libuv/libuv/releases/tag/v1.43.0) (aantron/luv#128).
> - Support building on MSVC (aantron/luv#126, Jonah Beckford).
>
> Bugs fixed
>
> - Invalid pointer-integer comparison warning on Windows (aantron/luv#127, Antonin Décimo).

Besides Luv 0.5.11, this PR adds package `luv_unix` to the opam repository for the first time. `luv_unix` is a [tiny adapter](https://github.com/aantron/luv/blob/2dc38710097a598beab942e0cb0ffe41d20ec94d/src/unix/luv_unix.mli) between Luv and the standard library's `Unix` (Luv is, otherwise, a completely standalone I/O library that could be used without `Unix`, in principle).

cc @talex5, @jonahbeckford 