### PR TITLE
fix: add ocaml < 5.00.

### DIFF
--- a/packages/fix/fix.20181206/opam
+++ b/packages/fix/fix.20181206/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.00" }
   "dune"
 ]
 synopsis: "Facilities for memoization and fixed points"

--- a/packages/fix/fix.20200131/opam
+++ b/packages/fix/fix.20200131/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.00" }
   "dune" { >= "1.3" }
 ]
 synopsis: "Facilities for memoization and fixed points"

--- a/packages/fix/fix.20201120/opam
+++ b/packages/fix/fix.20201120/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.00" }
   "dune" {>=  "1.3" }
 ]
 synopsis: "Facilities for memoization and fixed points"

--- a/packages/fix/fix.20211125/opam
+++ b/packages/fix/fix.20211125/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.00" }
   "dune" { >= "1.3" }
 ]
 synopsis: "Facilities for memoization and fixed points"

--- a/packages/fix/fix.20211231/opam
+++ b/packages/fix/fix.20211231/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.00" }
   "dune" { >= "1.3" }
 ]
 synopsis: "Algorithmic building blocks for memoization, recursion, and more"

--- a/packages/menhir/menhir.20211125/opam
+++ b/packages/menhir/menhir.20211125/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.00"}
   "dune" {>= "2.8.0"}
   "menhirLib" {= version}
   "menhirSdk" {= version}

--- a/packages/menhir/menhir.20211128/opam
+++ b/packages/menhir/menhir.20211128/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.00"}
   "dune" {>= "2.8.0"}
   "menhirLib" {= version}
   "menhirSdk" {= version}

--- a/packages/menhir/menhir.20211230/opam
+++ b/packages/menhir/menhir.20211230/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.00"}
   "dune" {>= "2.8.0"}
   "menhirLib" {= version}
   "menhirSdk" {= version}


### PR DESCRIPTION
These releases of fix use the old ephemeron API.