### PR TITLE
Package libbinaryen.102.0.4

### DIFF
--- a/packages/libbinaryen/libbinaryen.102.0.4/opam
+++ b/packages/libbinaryen/libbinaryen.102.0.4/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v102.0.4/libbinaryen-v102.0.4.tar.gz"
+  checksum: [
+    "md5=b3f7b816623f771bc6c68801af0c4d7b"
+    "sha512=e7c37ebcc601f8a9dd9382e34e9a846350688f4346f35a1ee1f970e29da244cb335ab4e7f1551b2766099df293d9bd298464349638e61838c445561a65412bdc"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.102.0.4`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---


### Bug Fixes

* Use double dash before -j4 to always pass through ([#39](https://www.github.com/grain-lang/libbinaryen/issues/39)) ([002eb47](https://www.github.com/grain-lang/libbinaryen/commit/002eb470eb3a7c751ca7071b8840df73433ab430))


---
:camel: Pull-request generated by opam-publish v2.0.3