### PR TITLE
Add new package for the 'E Theorem Prover'

### DIFF
--- a/packages/eprover/eprover.2.6/opam
+++ b/packages/eprover/eprover.2.6/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: [ "Stephan Schulz" "Simon Cruanes" "Petar Vukmirovic" "Mohamed Bassem" "Martin Moehrmann" ]
+homepage: "https://wwwlehre.dhbw-stuttgart.de/~sschulz/E/E.html"
+license: ["LGPL-2.1-or-later" "GPL-2.0-or-later"]
+dev-repo: "git+https://github.com/eprover/eprover.git"
+bug-reports: "Stephan Schulz (see homepage for email)"
+build: [
+  [ "./configure" "--bindir=%{bin}%" ]
+  [ make "-j" "%{jobs}%" ]
+]
+install: [
+  [ make "install" ]
+]
+depends: [
+  "conf-gcc"
+]
+synopsis: "E Theorem Prover"
+description: "E is a theorem prover for full first-order logic with equality. It accepts a problem specification, typically consisting of a number of first-order clauses or formulas, and a conjecture, again either in clausal or full first-order form. The system will then try to find a formal proof for the conjecture, assuming the axioms."
+url {
+  # Note: the main author prefers this download link over the also available github tag tarball download and expects that the link is stable over time
+  src: "http://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_2.6/E.tgz"
+  checksum: "sha512=20ba97779b81b215296215e6fb10db742c16684c6a38a4612ee2c28a72917aaea8f87daea4cd49557f5b47720c62cffd38445cf779e6690dd0f0924d26b37683"
+}


### PR DESCRIPTION
This is yet another of my "why not use opam for useful C++ software" packages.

It adds an opam package for the E Theorem prover, an automated theorem prover. This compiles and installs an executable, which communicates via a standard text file format for theorem provers.

Addition of this package as well as the meta information has been agreed on with the authors via email.

This is used in the Coq ecosystem. In case you believe this is not useful for the OCaml ecosystem, I can also add it to Coq's opam repo.