### PR TITLE
Package libbinaryen.103.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.103.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.103.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v103.0.1/libbinaryen-v103.0.1.tar.gz"
+  checksum: [
+    "md5=3ca1ae0165bc8657431b317b5f0d5ee5"
+    "sha512=9b37fcde749afefd60fedd83a7835a7465ae388e907db3af52166b47b8b061d2a961055483c8ee0bfb1a992638279a51025662b06a0bbef5dbbdf28a1d287b86"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.103.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---


### Bug Fixes

* Copy wasm-delegations.def into the correct location ([#28](https://www.github.com/grain-lang/libbinaryen/issues/28)) ([#31](https://www.github.com/grain-lang/libbinaryen/issues/31)) ([bc0c7ee](https://www.github.com/grain-lang/libbinaryen/commit/bc0c7ee35de32c90b52cd73a28e5e5eccfd28a3f))
* Ensure project can build with Opam on Windows ([#33](https://www.github.com/grain-lang/libbinaryen/issues/33)) ([#35](https://www.github.com/grain-lang/libbinaryen/issues/35)) ([cf3a72e](https://www.github.com/grain-lang/libbinaryen/commit/cf3a72e931dc5323eb901955f4121a9266bdf7a5))
* Remove library_flags & only specify c_library_flags where needed ([#41](https://www.github.com/grain-lang/libbinaryen/issues/41)) ([a89fad6](https://www.github.com/grain-lang/libbinaryen/commit/a89fad610435b327df333cb0ef687087be0fd536))
* Run cmake build with -j4 for faster builds ([a89fad6](https://www.github.com/grain-lang/libbinaryen/commit/a89fad610435b327df333cb0ef687087be0fd536))
* Use double dash before -j4 to always pass through ([#39](https://www.github.com/grain-lang/libbinaryen/issues/39)) ([a89fad6](https://www.github.com/grain-lang/libbinaryen/commit/a89fad610435b327df333cb0ef687087be0fd536))


---
:camel: Pull-request generated by opam-publish v2.0.3