### PR TITLE
Package oraft.0.2.0

### DIFF
--- a/packages/oraft/oraft.0.2.0/opam
+++ b/packages/oraft/oraft.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "komamitsu@gmail.com"
+authors: ["Mitsunori Komatsu"]
+homepage: "https://github.com/komamitsu/oraft"
+bug-reports: "https://github.com/komamitsu/oraft/issues"
+dev-repo: "git+https://github.com/komamitsu/oraft.git"
+description: "Raft consensus algorithm implemented in OCaml"
+synopsis: "Raft consensus algorithm implemented in OCaml"
+license: "Apache-2.0"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+    "ocaml" {>= "4.05.0"}
+    "dune" {>= "2.0"}
+    "core" {>= "v0.9.0"}
+    "cohttp-lwt-unix"  {< "3.0.0"}
+    "yojson"
+    "ppx_deriving"
+    "ppx_deriving_yojson"
+    "ounit" {with-test}
+    "fileutils" {with-test}
+]
+url {
+  src: "https://github.com/komamitsu/oraft/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=01faf25fb31cd786385bdb7d013e8642"
+    "sha512=47f27e6afcc7619674e89d469a164009769c1be3e50ca35a69f741759df4bd16257ad36b75c28a5940c8221a4400f0c2ebb6c7f8d6c5b035841a9f3cb707f622"
+  ]
+}
+

--- a/packages/oraft/oraft.0.2.0/opam
+++ b/packages/oraft/oraft.0.2.0/opam
@@ -19,7 +19,7 @@ depends: [
     "cohttp-lwt-unix"  {< "3.0.0"}
     "yojson"
     "ppx_deriving"
-    "ppx_deriving_yojson"
+    "ppx_deriving_yojson" {>= "3.6.0"}
     "ounit" {with-test}
     "fileutils" {with-test}
 ]


### PR DESCRIPTION
### `oraft.0.2.0`
Raft consensus algorithm implemented in OCaml
Raft consensus algorithm implemented in OCaml



---
* Homepage: https://github.com/komamitsu/oraft
* Source repo: git+https://github.com/komamitsu/oraft.git
* Bug tracker: https://github.com/komamitsu/oraft/issues

---
:camel: Pull-request generated by opam-publish v2.1.0