### PR TITLE
Package unionFind.20220122

### DIFF
--- a/packages/unionFind/unionFind.20220122/opam
+++ b/packages/unionFind/unionFind.20220122/opam
@@ -1,0 +1,26 @@
+
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/unionFind"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/unionFind.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune"  { >= "1.4"  }
+]
+synopsis: "Implementations of the union-find data structure"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/unionFind/-/archive/20220122/archive.tar.gz"
+  checksum: [
+    "md5=7238ac49fba7c730e90cf1a577207347"
+    "sha512=c49dd3f9a6689f6a5efe39c26efe2c137f8812b4be6ee76c2cc20068cf86ad73c0ac97ec9a543245dddb63792ce8c1904576b3435bf419cc7837bc5e368eee6d"
+  ]
+}


### PR DESCRIPTION
### `unionFind.20220122`
Implementations of the union-find data structure



---
* Homepage: https://gitlab.inria.fr/fpottier/unionFind
* Source repo: git+https://gitlab.inria.fr/fpottier/unionFind.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.1.0