### PR TITLE
Remove use of the outdated hidden-version flag

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha2/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~alpha3/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~beta2/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0~rc1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version avoid-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~alpha2/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~beta1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0~rc2/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~alpha1/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-src/ocaml-src.4.13.dev/opam
+++ b/packages/ocaml-src/ocaml-src.4.13.dev/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml#4.13"
 depends: [
   "ocaml" {= "4.13.2"}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
-flags: [ hidden-version avoid-version ]
+flags: [ avoid-version ]
 extra-files: ["META" "md5=b8fd299f14ac907cd4916c811726f93b"]
 url {
   src: "git+https://github.com/ocaml/ocaml.git#4.13"

--- a/packages/ocaml-variants/ocaml-variants.4.02.4+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.4+trunk/opam
@@ -12,10 +12,10 @@ depends: [
   "base-bigarray" {post}
   "base-threads" {post}
   "base-ocamlbuild" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.03.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.1+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.04.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.3+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk+safe-string/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.05.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.1+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+force-safe-string/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.06.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.2+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+default-unsafe-string/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.07.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.2+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+default-unsafe-string/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+force-safe-string/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.08.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.2+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+default-unsafe-string/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.2+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.3+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+afl/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+flambda/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk+fp/opam
@@ -10,10 +10,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.11.3+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.3+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   ["sed" "-ib" "-e" "s/ -Werror//" "configure"]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version avoid-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.2+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version avoid-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+trunk/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version avoid-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
@@ -11,10 +11,10 @@ depends: [
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler avoid-version hidden-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.5.00.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.00.0+trunk/opam
@@ -13,10 +13,10 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-beta" {opam-version < "2.1"}
+  "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: [ compiler hidden-version avoid-version ]
+flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [


### PR DESCRIPTION
`hidden-verison` was only available in some beta versions of opam 2.1.0.
It has been renamed into `avoid-version` in the actual release.

The trick here is to make those packages go through ocaml-beta instead if some users still use beta versions of opam 2.1 as `2.1 < 2.1.0~beta1 < 2.1.0`