### PR TITLE
cppffigen: an FFI generator for C++ libraries based on STL

### DIFF
--- a/packages/cppffigen/cppffigen.0.002/opam
+++ b/packages/cppffigen/cppffigen.0.002/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+version: "0.002"
+synopsis: "A C++ foreign-function-interface generator for Ocaml based on C++ STL Containers"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/ocaml-cppffigen"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ppx_sexp_conv"
+  "pcre"
+  "sexplib"
+  "cmdliner"
+]
+build: [
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/ocaml-cppffigen"
+url {
+  src: "https://github.com/chetmurthy/ocaml-cppffigen/archive/refs/tags/0.002.tar.gz"
+  checksum: [
+    "sha512=65cd953733c063b692bebfc47c36ed9fdc90a248bd1bca496e1ad35e653ab430cd7040ef7216abd5056d3f5bac90e7de44d31f981fdab05f736a352de266f3a3"
+  ]
+}

--- a/packages/cppffigen/cppffigen.0.002/opam
+++ b/packages/cppffigen/cppffigen.0.002/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-version: "0.002"
 synopsis: "A C++ foreign-function-interface generator for Ocaml based on C++ STL Containers"
+license: "Apache-2.0"
 maintainer: "Chet Murthy <chetsky@gmail.com>"
 authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/ocaml-cppffigen"

--- a/packages/cppffigen/cppffigen.0.002/opam
+++ b/packages/cppffigen/cppffigen.0.002/opam
@@ -6,11 +6,11 @@ authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/ocaml-cppffigen"
 bug-reports: "Chet Murthy <chetsky@gmail.com>"
 depends: [
-  "ppx_deriving"
-  "ppx_sexp_conv"
-  "pcre"
-  "sexplib"
-  "cmdliner"
+  "ppx_deriving" { >= "5.2.1" }
+  "ppx_sexp_conv" { >= "v0.14.3" }
+  "pcre" { >= "7.5.0" }
+  "sexplib" { >= "v0.14.0" }
+  "cmdliner" { >= "1.0.4" }
 ]
 build: [
   [make "all"]

--- a/packages/cppffigen/cppffigen.0.002/opam
+++ b/packages/cppffigen/cppffigen.0.002/opam
@@ -6,6 +6,7 @@ authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/ocaml-cppffigen"
 bug-reports: "Chet Murthy <chetsky@gmail.com>"
 depends: [
+  "ppx_deriving"
   "ppx_sexp_conv"
   "pcre"
   "sexplib"


### PR DESCRIPTION
This is the first release of cppffigen, a C++ FFI generator for C++ libraries that expose their APIs using STL collection classes and following the Google C++ API style guide.