### PR TITLE
[new release] ppx_import (1.9.1)

### DIFF
--- a/packages/ppx_import/ppx_import.1.9.1/opam
+++ b/packages/ppx_import/ppx_import.1.9.1/opam
@@ -1,6 +1,5 @@
-description: "A syntax extension for importing declarations from interface files"
-synopsis: "A syntax extension for importing declarations from interface files"
 opam-version: "2.0"
+synopsis: "A syntax extension for importing declarations from interface files"
 maintainer: "whitequark <whitequark@whitequark.org>"
 authors: [ "whitequark <whitequark@whitequark.org>" ]
 homepage: "https://github.com/ocaml-ppx/ppx_import"

--- a/packages/ppx_import/ppx_import.1.9.1/opam
+++ b/packages/ppx_import/ppx_import.1.9.1/opam
@@ -1,0 +1,33 @@
+description: "A syntax extension for importing declarations from interface files"
+synopsis: "A syntax extension for importing declarations from interface files"
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  "ocaml"                   {              >= "4.05.0"  }
+  "dune"                    {              >= "1.11.0"  }
+  "ppxlib"                  {              >= "0.24.0"  }
+  "ounit"                   { with-test                 }
+  "ppx_deriving"            { with-test  & >= "4.2.1"   }
+  "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/1.9.1/ppx_import-1.9.1.tbz"
+  checksum: [
+    "sha256=d1b498e2ee380ecf385cf21b713e55b78006ff83e4cc528c97d08318567221d2"
+    "sha512=cb1b0a70a220d337c8663c2524f12a2bc9a473439d36ad79463230d0faee481f088fe60ceab7fe92078efbe28a68ad4388b46a6922108470481640ec59b1250a"
+  ]
+}
+x-commit-hash: "44c79bd97b7c8d901914baa7562174371ff5357d"


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

  * Support for OCaml 4.14 (ocaml-ppx/ppx_import#67 kit-ty-kate)
