### PR TITLE
Specify `--docdir` for the +trunk packages for 4.14 and 5.00

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.14.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+trunk/opam
@@ -20,6 +20,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}

--- a/packages/ocaml-variants/ocaml-variants.5.00.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.00.0+trunk/opam
@@ -21,6 +21,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}


### PR DESCRIPTION
Enables #10669 for the 4.14 and 5.00 trunk packages (already the specified for the 4.14.0 alpha)