### PR TITLE
[new release] capnp-rpc, capnp-rpc-unix, capnp-rpc-net, capnp-rpc-mirage and capnp-rpc-lwt (1.2.2)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2.2/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "lwt"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.2/capnp-rpc-1.2.2.tbz"
+  checksum: [
+    "sha256=cb771a4bae4b26e2fe225eb0a7ee3ee4a3e9bc3802d3b7094e32f4d7c55a2054"
+    "sha512=bb499492ac404008effc17bea06444055ff2b42de2a41eab9c27383f64b3e2f9da713b4b887ec4ccb22cb9fd0d2a05a969b80781497a1853e5ec5f1ec728a963"
+  ]
+}
+x-commit-hash: "8bca1b5ba48e1a6cb81b0a739f985f3081c1a11b"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.2/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "dns-client" {>= "6.0.0"}
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "arp" {>= "3.0.0" & with-test}
+  "asetmap" {with-test}
+  "astring" {with-test}
+  "ethernet" {>= "3.0.0" & with-test}
+  "io-page-unix" {with-test}
+  "mirage-vnetif" {with-test}
+  "mirage-crypto-rng" {>= "0.7.0" & with-test}
+  "dune" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.2/capnp-rpc-1.2.2.tbz"
+  checksum: [
+    "sha256=cb771a4bae4b26e2fe225eb0a7ee3ee4a3e9bc3802d3b7094e32f4d7c55a2054"
+    "sha512=bb499492ac404008effc17bea06444055ff2b42de2a41eab9c27383f64b3e2f9da713b4b887ec4ccb22cb9fd0d2a05a969b80781497a1853e5ec5f1ec728a963"
+  ]
+}
+x-commit-hash: "8bca1b5ba48e1a6cb81b0a739f985f3081c1a11b"

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2.2/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "cstruct" {>= "6.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "tls" {>= "0.13.1"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.15.0"}
+  "tls-mirage"
+  "dune" {>= "2.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.2/capnp-rpc-1.2.2.tbz"
+  checksum: [
+    "sha256=cb771a4bae4b26e2fe225eb0a7ee3ee4a3e9bc3802d3b7094e32f4d7c55a2054"
+    "sha512=bb499492ac404008effc17bea06444055ff2b42de2a41eab9c27383f64b3e2f9da713b4b887ec4ccb22cb9fd0d2a05a969b80781497a1853e5ec5f1ec728a963"
+  ]
+}
+x-commit-hash: "8bca1b5ba48e1a6cb81b0a739f985f3081c1a11b"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner"
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" { >= "1.0.1" & with-test}
+  "mirage-crypto-rng" {>= "0.7.0"}
+  "lwt"
+  "asetmap" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.2/capnp-rpc-1.2.2.tbz"
+  checksum: [
+    "sha256=cb771a4bae4b26e2fe225eb0a7ee3ee4a3e9bc3802d3b7094e32f4d7c55a2054"
+    "sha512=bb499492ac404008effc17bea06444055ff2b42de2a41eab9c27383f64b3e2f9da713b4b887ec4ccb22cb9fd0d2a05a969b80781497a1853e5ec5f1ec728a963"
+  ]
+}
+x-commit-hash: "8bca1b5ba48e1a6cb81b0a739f985f3081c1a11b"

--- a/packages/capnp-rpc/capnp-rpc.1.2.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "stdint"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "dune" {>= "2.0"}
+  "alcotest" {with-test & >= "1.0.1"}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.2/capnp-rpc-1.2.2.tbz"
+  checksum: [
+    "sha256=cb771a4bae4b26e2fe225eb0a7ee3ee4a3e9bc3802d3b7094e32f4d7c55a2054"
+    "sha512=bb499492ac404008effc17bea06444055ff2b42de2a41eab9c27383f64b3e2f9da713b4b887ec4ccb22cb9fd0d2a05a969b80781497a1853e5ec5f1ec728a963"
+  ]
+}
+x-commit-hash: "8bca1b5ba48e1a6cb81b0a739f985f3081c1a11b"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Switch from mirage-{stack,protocols} to tcpip (@MisterDA mirage/capnp-rpc#246).

- Remove deprecated tcpip.unix dependency (@hannesm mirage/capnp-rpc#245).

- Add OCaml 4.14 support (@kit-ty-kate mirage/capnp-rpc#244).
