### PR TITLE
Package eliom.9.4.0

### DIFF
--- a/packages/eliom/eliom.9.4.0/opam
+++ b/packages/eliom/eliom.9.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: """
+Eliom is a framework for implementing client/server Web applications.
+It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
+Eliom allows implementing the whole application as a single program that includes both the client and the server code.
+We use a syntax extension to distinguish between the two sides.
+The client-side code is compiled to JS using Ocsigen Js_of_ocaml.
+"""
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "base-bytes"
+  "ocsipersist" {>= "1.0" & < "2.0"}
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/9.4.0.tar.gz"
+  checksum: [
+    "md5=3343b24ca20faba7cc74a7376f6a839e"
+    "sha512=89fc135908303271cefa8a3f3805f31ca9a1a980ddc153f15bf0cc2ce89b5f6f080a2b9a85c83f1846888a8bf00fa5edfe7cac197b72c5d61e19160b91061d75"
+  ]
+}


### PR DESCRIPTION
### `eliom.9.4.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications.
It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
Eliom allows implementing the whole application as a single program that includes both the client and the server code.
We use a syntax extension to distinguish between the two sides.
The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0