### PR TITLE
5 packages from ocsigen/ocsipersist

### DIFF
--- a/packages/ocsipersist-lib/ocsipersist-lib.1.1.0/opam
+++ b/packages/ocsipersist-lib/ocsipersist-lib.1.1.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 authors:      "The Ocsigen team <dev@ocsigen.org>"
 maintainer:   "Jan Rochel <jan@besport.com>"
 license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
-synopsis:     "Persistent key/value storage (for Ocsigen) using DBM"
-description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+synopsis:     "Persistent key/value storage (for Ocsigen) - support library"
+description:  "This library defines signatures and auxiliary tools for defining backends for the Ocsipersist frontent. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM, PostgreSQL, SQLite."
 
 homepage: "https://github.com/ocsigen/ocsipersist"
 bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
@@ -13,11 +13,7 @@ build:   [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "dune" {>= "2.9"}
   "lwt" {>= "4.2.0"}
-  "lwt_log"
-  "xml-light"
-  "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
-  "dbm"
+  "lwt_ppx" {>= "2.0.0"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.1.0/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.1.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 authors:      "The Ocsigen team <dev@ocsigen.org>"
 maintainer:   "Jan Rochel <jan@besport.com>"
 license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
-synopsis:     "Persistent key/value storage (for Ocsigen) using DBM"
-description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
 
 homepage: "https://github.com/ocsigen/ocsipersist"
 bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
@@ -17,7 +17,7 @@ depends: [
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
   "ocsipersist-lib"
-  "dbm"
+  "pgocaml"
 ]
 url {
   src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"

--- a/packages/ocsipersist-sqlite/ocsipersist-sqlite.1.1.0/opam
+++ b/packages/ocsipersist-sqlite/ocsipersist-sqlite.1.1.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 authors:      "The Ocsigen team <dev@ocsigen.org>"
 maintainer:   "Jan Rochel <jan@besport.com>"
 license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
-synopsis:     "Persistent key/value storage (for Ocsigen) using DBM"
-description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+synopsis:     "Persistent key/value storage (for Ocsigen) using SQLite"
+description:  "This library provides a SQLite backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
 
 homepage: "https://github.com/ocsigen/ocsipersist"
 bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
@@ -17,7 +17,7 @@ depends: [
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
   "ocsipersist-lib"
-  "dbm"
+  "sqlite3"
 ]
 url {
   src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"

--- a/packages/ocsipersist/ocsipersist.1.1.0/opam
+++ b/packages/ocsipersist/ocsipersist.1.1.0/opam
@@ -2,8 +2,8 @@ opam-version: "2.0"
 authors:      "The Ocsigen team <dev@ocsigen.org>"
 maintainer:   "Jan Rochel <jan@besport.com>"
 license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
-synopsis:     "Persistent key/value storage (for Ocsigen) using DBM"
-description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+synopsis:     "Persistent key/value storage (for Ocsigen) using multiple backends"
+description:  "This is an virtual library defining a unified frontend for a number of key/value storage implementations. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM, PostgreSQL, SQLite."
 
 homepage: "https://github.com/ocsigen/ocsipersist"
 bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
@@ -13,11 +13,14 @@ build:   [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
   "dune" {>= "2.9"}
   "lwt" {>= "4.2.0"}
-  "lwt_log"
-  "xml-light"
   "ocsigenserver" {>= "3.0.0"}
   "ocsipersist-lib"
-  "dbm"
+]
+
+depopts: [
+	"ocsipersist-dbm"
+	"ocsipersist-pgsql"
+	"ocsipersist-sqlite"
 ]
 url {
   src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"


### PR DESCRIPTION
This pull-request concerns:
-`ocsipersist.1.1.0`: Persistent key/value storage (for Ocsigen) using multiple backends
-`ocsipersist-dbm.1.0.1`: Persistent key/value storage (for Ocsigen) using DBM
-`ocsipersist-lib.1.1.0`: Persistent key/value storage (for Ocsigen) - support library
-`ocsipersist-pgsql.1.1.0`: Persistent key/value storage (for Ocsigen) using PostgreSQL
-`ocsipersist-sqlite.1.1.0`: Persistent key/value storage (for Ocsigen) using SQLite



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0