### PR TITLE
2 packages from OCamlPro/ocp-index at 1.3.3

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.3.3/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis:
+  "Console browser for the documentation of installed OCaml libraries"
+description: """\
+ocp-browser is a ncurses-like interface that allows to easily browse the
+interfaces and documentation of all installed OCaml modules."""
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne"]
+license: "GPL-3.0-only"
+tags: ["org:ocamlpro" "org:typerex"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-index" {= version}
+  "cmdliner"
+  "lambda-term"
+  "zed" {>= "2.0.0"}
+  "odoc" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.3.3.tar.gz"
+  checksum: [
+    "md5=738dd32765ce0b6b6423620cc62b7db9"
+    "sha512=6360240c951ac64baf9b3736c9a37c41a5ac8c5ddf52e723019fb5ef294e786e245712fd88f408bd8f6881d8741ab152872181062acd81443eec07d1d703e85a"
+  ]
+}

--- a/packages/ocp-index/ocp-index.1.3.3/opam
+++ b/packages/ocp-index/ocp-index.1.3.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Lightweight completion and documentation browsing for OCaml libraries"
+description: """\
+This package includes
+* The `ocp-index` library and command-line tool
+* `ocp-grep`, a tool that finds uses of a given (qualified) identifier in a source tree
+* bindings for emacs and vim (sublime text also [available](https://github.com/whitequark/sublime-ocp-index/))
+
+To automatically configure your editors, install this with package `user-setup`."""
+maintainer: "louis.gesbert@ocamlpro.com"
+authors: ["Louis Gesbert" "Gabriel Radanne"]
+license: ["LGPL-2.1-only with OCaml-LGPL-linking-exception" "GPL-3.0-only"]
+tags: ["org:ocamlpro" "org:typerex"]
+homepage: "http://www.typerex.org/ocp-index.html"
+bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.0"}
+  "ocp-indent" {>= "1.4.2"}
+  "re" {>= "1.9.0"}
+  "cmdliner"
+  "odoc" {with-doc}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  """\
+This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path "%{prefix}%/share/emacs/site-lisp")
+  (require 'ocp-index)
+
+* for Vim, add the following line to ~/.vimrc:
+  set rtp+=%{share}%/ocp-index/vim"""
+    {success & !user-setup:installed}
+dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
+url {
+  src: "https://github.com/OCamlPro/ocp-index/archive/refs/tags/1.3.3.tar.gz"
+  checksum: [
+    "md5=738dd32765ce0b6b6423620cc62b7db9"
+    "sha512=6360240c951ac64baf9b3736c9a37c41a5ac8c5ddf52e723019fb5ef294e786e245712fd88f408bd8f6881d8741ab152872181062acd81443eec07d1d703e85a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocp-browser.1.3.3`: Console browser for the documentation of installed OCaml
 libraries
-`ocp-index.1.3.3`: Lightweight completion and documentation browsing for OCaml
 libraries



---
* Homepage: http://www.typerex.org/ocp-index.html
* Source repo: git+https://github.com/OCamlPro/ocp-index.git
* Bug tracker: https://github.com/OCamlPro/ocp-index/issues

---
:camel: Pull-request generated by opam-publish v2.1.0