### PR TITLE
5 packages from ocsigen/ocsipersist at 1.1.0

### DIFF
--- a/packages/ocsipersist-dbm/ocsipersist-dbm.1.0.1/opam
+++ b/packages/ocsipersist-dbm/ocsipersist-dbm.1.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "dbm"
 ]
 url {

--- a/packages/ocsipersist-dbm/ocsipersist-dbm.1.0/opam
+++ b/packages/ocsipersist-dbm/ocsipersist-dbm.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "dbm"
 ]
 url {

--- a/packages/ocsipersist-dbm/ocsipersist-dbm.1.1.0/opam
+++ b/packages/ocsipersist-dbm/ocsipersist-dbm.1.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using DBM"
+description:  "This library provides a DBM backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib" {>= "1.1.0" & < "1.2.0"}
+  "dbm"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=9d878dd68c0618b87268ebbd1472fa8c"
+    "sha512=82d82f854af3d6708c571d0c586a5abbba35a9c9e7482b81fdce5207e1f3f98dde3823550d3661714e7faa586888a0b6e4d5ae64f36983575079a9820d5d11ee"
+  ]
+}

--- a/packages/ocsipersist-lib/ocsipersist-lib.1.1.0/opam
+++ b/packages/ocsipersist-lib/ocsipersist-lib.1.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) - support library"
+description:  "This library defines signatures and auxiliary tools for defining backends for the Ocsipersist frontent. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_ppx" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=9d878dd68c0618b87268ebbd1472fa8c"
+    "sha512=82d82f854af3d6708c571d0c586a5abbba35a9c9e7482b81fdce5207e1f3f98dde3823550d3661714e7faa586888a0b6e4d5ae64f36983575079a9820d5d11ee"
+  ]
+}

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.1/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.2/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.3/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.4/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.5/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0.5/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.1.0/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.1.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using PostgreSQL"
+description:  "This library provides a PostgreSQL backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib" {>= "1.1.0" & < "1.2.0"}
+  "pgocaml"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=9d878dd68c0618b87268ebbd1472fa8c"
+    "sha512=82d82f854af3d6708c571d0c586a5abbba35a9c9e7482b81fdce5207e1f3f98dde3823550d3661714e7faa586888a0b6e4d5ae64f36983575079a9820d5d11ee"
+  ]
+}

--- a/packages/ocsipersist-sqlite/ocsipersist-sqlite.1.0/opam
+++ b/packages/ocsipersist-sqlite/ocsipersist-sqlite.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log"
   "xml-light"
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
   "sqlite3"
 ]
 url {

--- a/packages/ocsipersist-sqlite/ocsipersist-sqlite.1.1.0/opam
+++ b/packages/ocsipersist-sqlite/ocsipersist-sqlite.1.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using SQLite"
+description:  "This library provides a SQLite backend for the unified key/value storage frontend as defined in the ocsipersist package. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "lwt_log"
+  "xml-light"
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib" {>= "1.1.0" & < "1.2.0"}
+  "sqlite3"
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=9d878dd68c0618b87268ebbd1472fa8c"
+    "sha512=82d82f854af3d6708c571d0c586a5abbba35a9c9e7482b81fdce5207e1f3f98dde3823550d3661714e7faa586888a0b6e4d5ae64f36983575079a9820d5d11ee"
+  ]
+}

--- a/packages/ocsipersist/ocsipersist.1.0.1/opam
+++ b/packages/ocsipersist/ocsipersist.1.0.1/opam
@@ -14,13 +14,19 @@ depends: [
   "dune" {>= "2.9"}
   "lwt" {>= "4.2.0"}
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
 ]
 
 depopts: [
 	"ocsipersist-dbm"
 	"ocsipersist-pgsql"
 	"ocsipersist-sqlite"
+]
+
+conflicts: [
+	"ocsipersist-dbm" {< "1.0.0" | >= "1.1.0"}
+	"ocsipersist-pgsql" {< "1.0.0" | >= "1.1.0"}
+	"ocsipersist-sqlite" {< "1.0.0" | >= "1.1.0"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsipersist/archive/1.0.1.tar.gz"

--- a/packages/ocsipersist/ocsipersist.1.0/opam
+++ b/packages/ocsipersist/ocsipersist.1.0/opam
@@ -14,7 +14,19 @@ depends: [
   "dune" {>= "2.9"}
   "lwt" {>= "4.2.0"}
   "ocsigenserver" {>= "3.0.0"}
-  "ocsipersist-lib"
+  "ocsipersist-lib" {>= "1.0.0" & < "1.1.0"}
+]
+
+depopts: [
+	"ocsipersist-dbm"
+	"ocsipersist-pgsql"
+	"ocsipersist-sqlite"
+]
+
+conflicts: [
+	"ocsipersist-dbm" {< "1.0.0" | >= "1.1.0"}
+	"ocsipersist-pgsql" {< "1.0.0" | >= "1.1.0"}
+	"ocsipersist-sqlite" {< "1.0.0" | >= "1.1.0"}
 ]
 url {
   src: "https://github.com/jrochel/ocsipersist/archive/1.0.tar.gz"

--- a/packages/ocsipersist/ocsipersist.1.1.0/opam
+++ b/packages/ocsipersist/ocsipersist.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+authors:      "The Ocsigen team <dev@ocsigen.org>"
+maintainer:   "Jan Rochel <jan@besport.com>"
+license:      "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:     "Persistent key/value storage (for Ocsigen) using multiple backends"
+description:  "This is an virtual library defining a unified frontend for a number of key/value storage implementations. Ocsipersist is used pervasively in Eliom/Ocsigen to handle sessions and references. It can be used as an extension for ocsigenserver or as a library. Implementations of the following backends currently exist: DBM, PostgreSQL, SQLite."
+
+homepage: "https://github.com/ocsigen/ocsipersist"
+bug-reports: "https://github.com/ocsigen/ocsipersist/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsipersist.git"
+build:   [ "dune" "build" "-p" name "-j" jobs ]
+
+depends: [
+  "dune" {>= "2.9"}
+  "lwt" {>= "4.2.0"}
+  "ocsigenserver" {>= "3.0.0"}
+  "ocsipersist-lib" {>= "1.1.0" & < "1.2.0"}
+]
+
+depopts: [
+	"ocsipersist-dbm"
+	"ocsipersist-pgsql"
+	"ocsipersist-sqlite"
+]
+
+conflicts: [
+	"ocsipersist-dbm" {< "1.1.0" | >= "1.2.0"}
+	"ocsipersist-pgsql" {< "1.1.0" | >= "1.2.0"}
+	"ocsipersist-sqlite" {< "1.1.0" | >= "1.2.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsipersist/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=9d878dd68c0618b87268ebbd1472fa8c"
+    "sha512=82d82f854af3d6708c571d0c586a5abbba35a9c9e7482b81fdce5207e1f3f98dde3823550d3661714e7faa586888a0b6e4d5ae64f36983575079a9820d5d11ee"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocsipersist.1.1.0`: Persistent key/value storage (for Ocsigen) using multiple backends
-`ocsipersist-dbm.1.1.0`: Persistent key/value storage (for Ocsigen) using DBM
-`ocsipersist-lib.1.1.0`: Persistent key/value storage (for Ocsigen) - support library
-`ocsipersist-pgsql.1.1.0`: Persistent key/value storage (for Ocsigen) using PostgreSQL
-`ocsipersist-sqlite.1.1.0`: Persistent key/value storage (for Ocsigen) using SQLite



---
* Homepage: https://github.com/ocsigen/ocsipersist
* Source repo: git+https://github.com/ocsigen/ocsipersist.git
* Bug tracker: https://github.com/ocsigen/ocsipersist/issues

---
:camel: Pull-request generated by opam-publish v2.1.0