### PR TITLE
release ocamlfind-1.9.3

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "A library manager for OCaml"
+description: """
+Findlib is a library manager for OCaml. It provides a convention how
+to store libraries, and a file format ("META") to describe the
+properties of libraries. There is also a tool (ocamlfind) for
+interpreting the META files, so that it is very easy to use libraries
+in programs and scripts.
+"""
+license: "MIT"
+maintainer: "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
+homepage: "http://projects.camlcity.org/projects/findlib.html"
+bug-reports: "https://github.com/ocaml/ocamlfind/issues"
+depends: [
+  "ocaml" {>= "4.00.0"}
+]
+depopts: ["graphics"]
+build: [
+  [
+    "./configure"
+    "-bindir" bin
+    "-sitelib" lib
+    "-mandir" man
+    "-config" "%{lib}%/findlib.conf"
+    "-no-custom"
+    "-no-camlp4" {!ocaml:preinstalled & ocaml:version >= "4.02.0"}
+    "-no-topfind" {ocaml:preinstalled}
+  ]
+  [make "all"]
+  [make "opt"] {ocaml:native}
+]
+install: [
+  [make "install"]
+  ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
+]
+dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
+url {
+  src: "http://download.camlcity.org/download/findlib-1.9.2.tar.gz"
+  checksum: [
+    "md5=24047dd8a0da5322253de9b7aa254e42"
+    "sha512=27cc4ce141576bf477fb9d61a82ad65f55478740eed59fb43f43edb794140829fd2ff89ad27d8a890cfc336b54c073a06de05b31100fc7c01cacbd7d88e928ea"
+  ]
+}

--- a/packages/ocamlfind/ocamlfind.1.9.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.3/opam
@@ -36,7 +36,7 @@ install: [
 ]
 dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
 url {
-  src: "http://download.camlcity.org/download/findlib-1.9.2.tar.gz"
+  src: "http://download.camlcity.org/download/findlib-1.9.3.tar.gz"
   checksum: [
     "md5=24047dd8a0da5322253de9b7aa254e42"
     "sha512=27cc4ce141576bf477fb9d61a82ad65f55478740eed59fb43f43edb794140829fd2ff89ad27d8a890cfc336b54c073a06de05b31100fc7c01cacbd7d88e928ea"


### PR DESCRIPTION
Includes the second part of the support for OCaml-5 trunk from https://github.com/ocaml/ocamlfind/pull/32.
