### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-lwt and js_of_ocaml-compiler (4.0.0)

### DIFF
--- a/packages/async_js/async_js.v0.10.0/opam
+++ b/packages/async_js/async_js.v0.10.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_driver" {>= "v0.10" & < "v0.11"}
   "ppx_jane" {>= "v0.10" & < "v0.11"}
   "jbuilder" {>= "1.0+beta12"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {>= "3.0" & < "3.5"}
   "js_of_ocaml-ppx"
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
   "uri" {< "3.0.0"}

--- a/packages/incr_dom/incr_dom.v0.10.0/opam
+++ b/packages/incr_dom/incr_dom.v0.10.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_jane" {>= "v0.10" & < "v0.11"}
   "virtual_dom" {>= "v0.10" & < "v0.11"}
   "jbuilder" {>= "1.0+beta12"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {>= "3.0" & < "4.0.0"}
   "js_of_ocaml-ppx"
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
 ]

--- a/packages/incr_dom/incr_dom.v0.11.0/opam
+++ b/packages/incr_dom/incr_dom.v0.11.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_jane" {>= "v0.11" & < "v0.12"}
   "virtual_dom" {>= "v0.11" & < "v0.12"}
   "jbuilder" {>= "1.0+beta18.1"}
-  "js_of_ocaml" {>= "3.0"}
+  "js_of_ocaml" {>= "3.0"& < "4.0.0"}
   "js_of_ocaml-ppx"
   "ocaml-migrate-parsetree" {>= "1.0" & < "2.0.0"}
 ]

--- a/packages/incr_dom/incr_dom.v0.12.0/opam
+++ b/packages/incr_dom/incr_dom.v0.12.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_jane"        {>= "v0.12" & < "v0.13"}
   "virtual_dom"     {>= "v0.12" & < "v0.13"}
   "dune"            {>= "1.5.1"}
-  "js_of_ocaml"     {>= "3.2.1"}
+  "js_of_ocaml"     {>= "3.2.1" & < "4.0.0"}
   "js_of_ocaml-ppx"
 ]
 synopsis: "A library for building dynamic webapps, using Js_of_ocaml"

--- a/packages/incr_dom/incr_dom.v0.13.0/opam
+++ b/packages/incr_dom/incr_dom.v0.13.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_jane"        {>= "v0.13" & < "v0.14"}
   "virtual_dom"     {>= "v0.13" & < "v0.14"}
   "dune"            {>= "1.5.1"}
-  "js_of_ocaml"     {>= "3.4.1"}
+  "js_of_ocaml"     {>= "3.4.1" & < "4.0.0"}
   "js_of_ocaml-ppx"
 ]
 synopsis: "A library for building dynamic webapps, using Js_of_ocaml"

--- a/packages/incr_dom/incr_dom.v0.14.0/opam
+++ b/packages/incr_dom/incr_dom.v0.14.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_jane"        {>= "v0.14" & < "v0.15"}
   "virtual_dom"     {>= "v0.14" & < "v0.15"}
   "dune"            {>= "2.0.0"}
-  "js_of_ocaml"     {>= "3.4.1"}
+  "js_of_ocaml"     {>= "3.4.1" & < "4.0.0"}
   "js_of_ocaml-ppx"
 ]
 synopsis: "A library for building dynamic webapps, using Js_of_ocaml"

--- a/packages/incr_dom/incr_dom.v0.9.0/opam
+++ b/packages/incr_dom/incr_dom.v0.9.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_driver" {>= "v0.9" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "virtual_dom" {>= "v0.9" & < "v0.10"}
-  "js_of_ocaml"
+  "js_of_ocaml" {< "4.0.0" }
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}
 ]
 synopsis: "A library for building dynamic webapps, using Js_of_ocaml."

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_expect" {>= "v0.14.2" & with-test}
   "ppxlib" {>= "0.15.0"}
   "re" {with-test}
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "menhir"
   "menhirLib"
   "menhirSdk"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04" & < "4.14"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner"
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.4.0.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.4.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.4.0.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.4.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.4.0.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.4.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.4.0.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.4.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-compiler" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.4.0.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.4.0.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/js_of_ocaml/js_of_ocaml.4.0.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.4.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "uchar"
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.0.0/js_of_ocaml-4.0.0.tbz"
+  checksum: [
+    "sha256=df02f819e5b2f48234af2b3e3e7c9781afa8212f8bece7ebcfbd8358b394495e"
+    "sha512=92e822849c8be14ce0428f7f4be3991449f76e65d408073a5b8b9674ba2d099439027aa11618b603c7ee31a179cf6976d54a929917a69b269425f0367926c200"
+  ]
+}
+x-commit-hash: "6fb1d008061b6c028c375b240882bb735d54a5bc"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.13.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.13.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "eliom" {>= "6.12.1"}
   "calendar" {>= "2.0.0"}
+  "js_of_ocaml" {< "4.0.0"}
 ]
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/2.13.0.tar.gz"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.0.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.0.1/opam
@@ -13,7 +13,9 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "eliom" {>= "6.12.1"}
   "calendar" {>= "2.0.0"}
+  "js_of_ocaml" {< "4.0.0"}
 ]
+
 url {
   src: "https://github.com/ocsigen/ocsigen-toolkit/archive/3.0.1.tar.gz"
   checksum: [


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Compiler: add --target-env flag, for JS runtime specific compilation targets (ocsigen/js_of_ocaml#1160).
* Compiler: static evaluation of backend_type (ocsigen/js_of_ocaml#1166)
* Compiler: speedup emitting js files (ocsigen/js_of_ocaml#1174)
* Compiler: simplify (a | 0) >>> 0 into (a >>> 0) (ocsigen/js_of_ocaml#1177)
* Compiler: improve static evaluation of cond (ocsigen/js_of_ocaml#1178)
* Compiler: be more consistent dealing with js vs ocaml strings (ocsigen/js_of_ocaml#984)
* Compiler: Compiler: add BigInt to provided symbols (fix ocsigen/js_of_ocaml#1168) (ocsigen/js_of_ocaml#1191)
* Compiler: use globalThis, drop joo_global_object ocsigen/js_of_ocaml#1193
* Compiler: new -Werror flag to turn wanrings into errors (ocsigen/js_of_ocaml#1222)
* Compiler: make the inlining less agressive, reduce size, improve pref (ocsigen/js_of_ocaml#1220)
* Compiler: rename internal library js_of_ocaml-compiler.runtime to js_of_ocaml-compiler.runtime-files
* Lib: new runtime library to improve compatibility with Brr and gen_js_api
* Lib: add messageEvent to Dom_html (ocsigen/js_of_ocaml#1164)
* Lib: add PerformanceObserver API (ocsigen/js_of_ocaml#1164)
* Lib: add CSSStyleDeclaration.{setProperty, getPropertyValue, getPropertyPriority, removeProperty} (ocsigen/js_of_ocaml#1170)
* Lib: make window.{inner,outer}{Width,Height} non-optional
* Lib: introduce Js_of_ocaml.Js_error module, deprecate Js_of_ocaml.Js.Error exception.
* Lib: add deprecation warning for deprecated code
* PPX: json can now be derived for mutable records (ocsigen/js_of_ocaml#1184)
* Runtime: use crypto.getRandomValues when available (ocsigen/js_of_ocaml#1209)
* Misc: move js_of_ocaml-ocamlbuild out to its own repo
* Misc: add support for OCaml 4.14 (ocsigen/js_of_ocaml#1173)

## Bug fixes
* Compiler: fix sourcemap warning for empty cma (ocsigen/js_of_ocaml#1169)
* Compiler: Strengthen bound checks. (ocsigen/js_of_ocaml#1172)
* Compiler: fix `--wrap-with-fun` under node (ocsigen/js_of_ocaml#653, ocsigen/js_of_ocaml#1171)
* Compiler: fix parsing of annotaions in js stubs (ocsigen/js_of_ocaml#1212, fix ocsigen/js_of_ocaml#1213)
* Ppx: allow apostrophe in lident (fix ocsigen/js_of_ocaml#1183) (ocsigen/js_of_ocaml#1192)
* Runtime: fix float parsing in hexadecimal form
* Runtime: fix implementation of caml_js_instanceof
* Graphics: fix mouse_{x,y} (ocsigen/js_of_ocaml#1206)
