### PR TITLE
dune.2.9.2 produces output that is not compatible with OCaml 4.02

### DIFF
--- a/packages/dune/dune.2.9.2/opam
+++ b/packages/dune/dune.2.9.2/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.03" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
uses Toploop.add_directive
```
#=== ERROR while compiling lwt_react.1.1.5 ====================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.02.3 | file:///home/opam/opam-repository
# path                 ~/.opam/4.02/.opam-switch/build/lwt_react.1.1.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lwt_react -j 31
# exit-code            1
# env-file             ~/.opam/log/lwt_react-19-79c9de.env
# output-file          ~/.opam/log/lwt_react-19-79c9de.out
### output ###
#        ocaml (internal) (exit 2)
# (cd src/react && /home/opam/.opam/4.02/bin/ocaml -I +compiler-libs /home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/react/dune.ml)
# File "/home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/react/dune.ml", line 30, characters 4-17:
# Error: Unbound value add_directive
#        ocaml (internal) (exit 2)
# (cd src/unix && /home/opam/.opam/4.02/bin/ocaml -I +compiler-libs /home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/unix/dune.ml)
# File "/home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/unix/dune.ml", line 30, characters 4-17:
# Error: Unbound value add_directive
#        ocaml (internal) (exit 2)
# (cd src/unix/luv && /home/opam/.opam/4.02/bin/ocaml -I +compiler-libs /home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/unix/luv/dune.ml)
# File "/home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/unix/luv/dune.ml", line 30, characters 4-17:
# Error: Unbound value add_directive
#        ocaml (internal) (exit 2)
# (cd src/ppx && /home/opam/.opam/4.02/bin/ocaml -I +compiler-libs /home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/ppx/dune.ml)
# File "/home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/ppx/dune.ml", line 30, characters 4-17:
# Error: Unbound value add_directive
#        ocaml (internal) (exit 2)
# (cd src/core && /home/opam/.opam/4.02/bin/ocaml -I +compiler-libs /home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/core/dune.ml)
# File "/home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/core/dune.ml", line 30, characters 4-17:
# Error: Unbound value add_directive
#        ocaml (internal) (exit 2)
# (cd src/domain && /home/opam/.opam/4.02/bin/ocaml -I +compiler-libs /home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/domain/dune.ml)
# File "/home/opam/.opam/4.02/.opam-switch/build/lwt_react.1.1.5/_build/.dune/default/src/domain/dune.ml", line 30, characters 4-17:
# Error: Unbound value add_directive
```
Observed in #20529 