### PR TITLE
Fixes #19243: There should be a conf package that installs adwaita-icon-theme-full

### DIFF
--- a/packages/conf-adwaita-icon-theme/conf-adwaita-icon-theme.2/opam
+++ b/packages/conf-adwaita-icon-theme/conf-adwaita-icon-theme.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://github.com/GNOME/adwaita-icon-theme"
+bug-reports: "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/issues"
+authors: "GNOME devs"
+license: ["LGPL-3.0-only" "CC-BY-SA-3.0"]
+# E.g. on Centos8 there is no system package that does contain the .pc file.
+build: [
+  [ "sh" "-c" "pkg-config --short-errors --print-errors adwaita-icon-theme || test -d /usr/share/icons/Adwaita" ] {os-distribution != "ubuntu"}
+  [ "sh" "-c" "apt list "adwaita-icon-theme-full" | grep installed" ] {os-distribution = "ubuntu"}
+] 
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  [ "adwaita-icon-theme" ] {os-family = "debian" }
+  [ "adwaita-icon-theme-full" ] {os-distribution = "ubuntu"}
+  [ "adwaita-icon-theme" ] {os-family = "amzn"}
+  [ "adwaita-icon-theme" ] {os-family = "ol"}
+  [ "adwaita-icon-theme" ] {os-family = "rhel"}
+  [ "adwaita-icon-theme" ] {os-family = "centos"}
+  [ "adwaita-icon-theme" ] {os-family = "fedora"}
+  [ "adwaita-icon-theme" ] {os-family = "mageia"}
+  [ "adwaita-icon-theme" ] {os-family = "suse" | os-family = "opensuse"}
+  [ "adwaita-icon-theme" ] {os-family = "homebrew"}
+  [ "adwaita-icon-theme" ] {os-family = "macports"}
+  [ "adwaita-icon-theme" ] {os-family = "alpine"}
+  [ "adwaita-icon-theme" ] {os-family = "arch" | os-family = "archlinux"}
+  [ "x11-themes/adwaita-icon-theme" ] {os-family = "gentoo"}
+  [ "adwaita-icon-theme" ] {os = "freebsd"}
+  [ "x11/gnome/adwaita-icon-theme" ] {os = "openbsd"}
+  [ "graphics/adwaita-icon-theme" ] {os = "netbsd"}
+]
+synopsis: "Virtual package relying on adwaita-icon-theme"
+description:
+  "This package can only install if the adwaita-icon-theme package is installed on the system."
+flags: conf

--- a/packages/conf-adwaita-icon-theme/conf-adwaita-icon-theme.2/opam
+++ b/packages/conf-adwaita-icon-theme/conf-adwaita-icon-theme.2/opam
@@ -13,8 +13,8 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  [ "adwaita-icon-theme" ] {os-family = "debian" }
-  [ "adwaita-icon-theme-full" ] {os-distribution = "ubuntu"}
+  [ "adwaita-icon-theme" ] {os-family = "debian" & os-distribution != "ubuntu"}
+  [ "adwaita-icon-theme-full" ] {os-family = "ubuntu" | os-distribution = "ubuntu"}
   [ "adwaita-icon-theme" ] {os-family = "amzn"}
   [ "adwaita-icon-theme" ] {os-family = "ol"}
   [ "adwaita-icon-theme" ] {os-family = "rhel"}


### PR DESCRIPTION
This PR fixes #19243 following the discussion in the issue.

Please note that the original package has a bug - there is no "os-family ubuntu". The os-family of ubuntu is debian.