### PR TITLE
Package batteries.3.5.0

### DIFF
--- a/packages/batteries/batteries.3.5.0/opam
+++ b/packages/batteries/batteries.3.5.0/opam
@@ -31,9 +31,9 @@ install: [make "install"]
 dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
 url {
   src:
-    "https://github.com/ocaml-batteries-team/batteries-included/archive/86b7456d01accb880a2693739a444771721e5d7a.tar.gz"
+    "https://github.com/ocaml-batteries-team/batteries-included/archive/refs/tags/v3.5.0.tar.gz"
   checksum: [
-    "md5=7e9843f26a8a97cb2614870e13011b23"
-    "sha512=3a7f495e87df64e163e26d427b2dfb2c32bf4409d4d3952584378a209b9678a8ff5f2e7f115cc972d11ce43e9887207969d82ca8b03881c329604ba92d87ecd2"
+    "md5=e4b70d1a716f0aaba36f419f618d0a2e"
+    "sha512=a31f1f8cf2c7c3c6c757f3bfae98ff61bb32bab6a1f1e215937df42bcfa447aad41a37edb28d7bcecb88b3838ed8bd57142bcf8e2d28e09bb538055fd8a3b72d"
   ]
 }

--- a/packages/batteries/batteries.3.5.0/opam
+++ b/packages/batteries/batteries.3.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A community-maintained standard library extension"
+maintainer: [
+  "Cedric Cellier <rixed@happyleptic.org>"
+  "Francois Berenger <unixjunkie@sdf.org>"
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+  "Thibault Suzanne <thi.suzanne@gmail.com>"
+]
+authors: "OCaml batteries-included team"
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml-batteries-team/batteries-included"
+doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
+bug-reports:
+  "https://github.com/ocaml-batteries-team/batteries-included/issues"
+depends: [
+  "ocaml" {>= "4.00.0" & < "4.14.0"}
+  "ocamlfind" {build & >= "1.5.3"}
+  "ocamlbuild" {build}
+  "qtest" {with-test & >= "2.5"}
+  "qcheck" {with-test & >= "0.9" & < "0.14"}
+  "benchmark" {with-test & >= "1.6"}
+  "num"
+]
+conflicts: ["base-effects" "ocaml-option-no-flat-float-array"]
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  [make "all"]
+]
+run-test: [make "test"]
+install: [make "install"]
+dev-repo: "git://github.com/ocaml-batteries-team/batteries-included.git"
+url {
+  src:
+    "https://github.com/ocaml-batteries-team/batteries-included/archive/86b7456d01accb880a2693739a444771721e5d7a.tar.gz"
+  checksum: [
+    "md5=7e9843f26a8a97cb2614870e13011b23"
+    "sha512=3a7f495e87df64e163e26d427b2dfb2c32bf4409d4d3952584378a209b9678a8ff5f2e7f115cc972d11ce43e9887207969d82ca8b03881c329604ba92d87ecd2"
+  ]
+}

--- a/packages/batteries/batteries.3.5.0/opam
+++ b/packages/batteries/batteries.3.5.0/opam
@@ -13,7 +13,7 @@ doc: "http://ocaml-batteries-team.github.io/batteries-included/hdoc2/"
 bug-reports:
   "https://github.com/ocaml-batteries-team/batteries-included/issues"
 depends: [
-  "ocaml" {>= "4.00.0" & < "4.14.0"}
+  "ocaml" {>= "4.00.0" & < "4.15.0"}
   "ocamlfind" {build & >= "1.5.3"}
   "ocamlbuild" {build}
   "qtest" {with-test & >= "2.5"}


### PR DESCRIPTION
### `batteries.3.5.0`
A community-maintained standard library extension



---
* Homepage: https://github.com/ocaml-batteries-team/batteries-included
* Source repo: git://github.com/ocaml-batteries-team/batteries-included.git
* Bug tracker: https://github.com/ocaml-batteries-team/batteries-included/issues

---
:camel: Pull-request generated by opam-publish v2.1.0