### PR TITLE
Package opam-grep.0.3.0

### DIFF
--- a/packages/opam-grep/opam-grep.0.3.0/opam
+++ b/packages/opam-grep/opam-grep.0.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin that greps anything in the sources of every opam packages"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-grep"
+bug-reports: "https://github.com/kit-ty-kate/opam-grep/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "progress" {>= "0.2.1"}
+  "cmdliner" {>= "1.0.4"}
+  "fpath" {>= "0.7.3"}
+  "bos" {>= "0.2.0"}
+]
+available: os != "win32"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/kit-ty-kate/opam-grep.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-grep/releases/download/v0.3.0/opam-grep-0.3.0.tar.gz"
+  checksum: [
+    "md5=89612e37a1a226febb54b9c3a0762575"
+    "sha512=ce3834ddd9ed907f220f8f74eb136ae3b034eb0b853d39ea10b7ba1f0b1c83c2c405a3596ba863efb2fdde97d19939515e30be3422dd3865c98a3d191e6d5f46"
+  ]
+}


### PR DESCRIPTION
### `opam-grep.0.3.0`
An opam plugin that greps anything in the sources of every opam packages



---
* Homepage: https://github.com/kit-ty-kate/opam-grep
* Source repo: git://github.com/kit-ty-kate/opam-grep.git
* Bug tracker: https://github.com/kit-ty-kate/opam-grep/issues

---
:camel: Pull-request generated by opam-publish v2.1.0