### PR TITLE
tezos-stdlib-unix < 10: Add missing conflicts

### DIFF
--- a/packages/tezos-error-monad/tezos-error-monad.8.0/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.8.0/opam
@@ -11,6 +11,7 @@ depends: [
   "data-encoding" { >= "0.2" & < "0.3" }
   "lwt-canceler" { >= "0.2" & < "0.3" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
+  "lwt" {>= "5.1.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-error-monad/tezos-error-monad.8.1/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.8.1/opam
@@ -11,6 +11,7 @@ depends: [
   "data-encoding" { >= "0.2" & < "0.3" }
   "lwt-canceler" { >= "0.2" & < "0.3" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
+  "lwt" {>= "5.1.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-error-monad/tezos-error-monad.8.2/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.8.2/opam
@@ -11,6 +11,7 @@ depends: [
   "data-encoding" { >= "0.2" & < "0.3" }
   "lwt-canceler" { >= "0.2" & < "0.3" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
+  "lwt" {>= "5.1.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-error-monad/tezos-error-monad.8.3/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.8.3/opam
@@ -11,6 +11,7 @@ depends: [
   "data-encoding" { >= "0.2" & < "0.3" }
   "lwt-canceler" { >= "0.2" & < "0.3" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
+  "lwt" {>= "5.1.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
@@ -16,6 +16,7 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
   "ezjsonm" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
@@ -16,6 +16,9 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
@@ -15,6 +15,7 @@ depends: [
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"
+  "ezjsonm" {>= "1.1.0"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
   "ezjsonm" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
@@ -16,6 +16,9 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
@@ -15,6 +15,7 @@ depends: [
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"
+  "ezjsonm" {>= "1.1.0"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
@@ -16,6 +16,7 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
   "ezjsonm" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
@@ -16,6 +16,9 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
@@ -15,6 +15,7 @@ depends: [
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"
+  "ezjsonm" {>= "1.1.0"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
@@ -16,6 +16,7 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
   "ezjsonm" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
@@ -16,6 +16,9 @@ depends: [
   "ipaddr" { >= "4.0.0" }
   "re"
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["mv" "src/lib_stdlib_unix/%{name}%.install" "./"]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
@@ -15,6 +15,7 @@ depends: [
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"
+  "ezjsonm" {>= "1.1.0"}
 ]
 conflicts: [
   "domain-name" {>= "0.3.1"}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.2/opam
@@ -17,6 +17,9 @@ depends: [
   "ezjsonm" { >= "1.1.0" }
   "fmt" { >= "0.8.7" }
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["rm" "-r" "vendors"]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.3/opam
@@ -17,6 +17,9 @@ depends: [
   "ezjsonm" { >= "1.1.0" }
   "fmt" { >= "0.8.7" }
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["rm" "-r" "vendors"]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.4/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.4/opam
@@ -17,6 +17,9 @@ depends: [
   "ezjsonm" { >= "1.1.0" }
   "fmt" { >= "0.8.7" }
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["rm" "-r" "vendors"]
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.7/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.7/opam
@@ -17,6 +17,9 @@ depends: [
   "ezjsonm" { >= "1.1.0" }
   "fmt" { >= "0.8.7" }
 ]
+conflicts: [
+  "domain-name" {>= "0.3.1"}
+]
 build: [
   ["rm" "-r" "vendors"]
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
uses Fmt implicitly through domain-name which removed its dependency to fmt in 0.3.1