### PR TITLE
ocamlformat < 0.19 requires odoc < 2.0 (uses odoc.parser)

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.11.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.11.0/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.1.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
-  "odoc" {>= "1.4.1"}
+  "odoc" {>= "1.4.1" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.12/opam
+++ b/packages/ocamlformat/ocamlformat.0.12/opam
@@ -25,7 +25,7 @@ depends: [
   "dune" {>= "1.11.1"}
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.13.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.13.0/opam
@@ -29,7 +29,7 @@ depends: [
   "fpath"
   "ocaml-migrate-parsetree" {>= "1.3.1" & < "2.0.0"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.14.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.0/opam
@@ -30,7 +30,7 @@ depends: [
   "menhir" {>= "20181006"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.14.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.1/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {>= "20181006"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.14.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.2/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {>= "20181006"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.14"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.14.3/opam
+++ b/packages/ocamlformat/ocamlformat.0.14.3/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir" {>= "20181006"}
   "ocaml-migrate-parsetree" {>= "1.5.0" & < "2.0.0"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}
   "uuseg" {>= "10.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.15.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.15.1/opam
@@ -21,7 +21,7 @@ depends: [
   "fpath"
   "menhir" {>= "20181006"}
   "ocp-indent" {with-test}
-  "odoc" {>= "1.4.2"}
+  "odoc" {>= "1.4.2" & < "2.0"}
   "ppxlib" {>= "0.18.0" & < "0.22.0"}
   "re" {>= "1.7.2"}
   "stdio" {< "v0.15"}


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlformat.0.15.1 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.10.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.10/.opam-switch/build/ocamlformat.0.15.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocamlformat -j 71
# exit-code            1
# env-file             ~/.opam/log/ocamlformat-19-635cd8.env
# output-file          ~/.opam/log/ocamlformat-19-635cd8.out
### output ###
# File "lib/dune", line 26, characters 62-73:
# 26 |  (libraries format_ import ocaml-migrate-parsetree odoc.model odoc.parser
#                                                                    ^^^^^^^^^^^
# Error: Library "odoc.parser" not found.
# Hint: try:
#   dune external-lib-deps --missing --no-config --root . --ignore-promoted-rules --default-target @install --always-show-command-line --promote-install-files --release --only-packages ocamlformat -p ocamlformat --profile release -j 71 @install
```