### PR TITLE
Package binaryen.0.11.2

### DIFF
--- a/packages/binaryen/binaryen.0.11.2/opam
+++ b/packages/binaryen/binaryen.0.11.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml" {>= "3.10.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "101.0.1" & < "102.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.11.2/binaryen-archive-v0.11.2.tar.gz"
+  checksum: [
+    "md5=d34659e0e0389cb1b6e16ea4c3c7b2ad"
+    "sha512=e1b10c38cb9df11c9d09fd2dfd70c60be2a5f8b26d8f4bf6940c16a3a7f876b880c19ea80a96361db3c82934bbd1ded441d254dac0739995523923a98a344dff"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.11.2`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
### Bug Fixes

- Handle JS global in non-node environments ([#125](https://www.github.com/grain-lang/binaryen.ml/issues/125)) ([74e94fe](https://www.github.com/grain-lang/binaryen.ml/commit/74e94fe8ac7b2c2a66b8118b5eaa3a81e5f9296a))


---
:camel: Pull-request generated by opam-publish v2.0.3