### PR TITLE
Add conflict for `github-data` mis-matched `github`

### DIFF
--- a/packages/github-data/github-data.4.4.0/opam
+++ b/packages/github-data/github-data.4.4.0/opam
@@ -27,6 +27,9 @@ depends: [
   "atdgen" {>= "2.0.0"}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "github" {!= version}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
`github-data` contains modules which were packaged in _older_ versions of `github`. The new `github` package contains a precise dependency on `github-data`, but that allows old releases to be co-installed with `github-data` even though they are not co-linkable.

Highly related to https://github.com/ocaml/opam-repository/issues/19880#issuecomment-954121920