### PR TITLE
Add coq-of-ocaml.2.5.2

### DIFF
--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.12/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.12/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/foobar-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/foobar-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/foobar-land/coq-of-ocaml/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["sh" "-c" "cd proofs && ./configure.sh"] {coq:installed}
+  [make "-C" "proofs" "-j%{jobs}%"] {coq:installed}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  [make "-C" "proofs" "install"] {coq:installed}
+]
+depends: [
+  "csexp"
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12" & < "4.13"}
+  "ocamlfind" {>= "1.5.2"}
+  "result"
+  "smart-print"
+  "yojson" {>= "1.6.0"}
+]
+depopts: [
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.11"}
+]
+tags: [
+  "keyword:compilation"
+  "keyword:OCaml"
+  "logpath:CoqOfOCaml"
+]
+synopsis: "Compile a subset of OCaml to Coq"
+
+url {
+  src: "https://github.com/foobar-land/coq-of-ocaml/releases/download/2.5.2/coq-of-ocaml-full.2.5.2.tar.gz"
+  checksum: [
+    "sha256=55564be48ccbdb5b7bcaced6480365e099b8bd7193454b613a4398fd033247ac"
+    "sha512=712c9d594f6f045c127dd9883315286ad83268f7e627771b17437e167d5bbfd221fa79d071b1e77e04e80d219b820dfef14eb0494433e778c9ecfd52d131e665"
+  ]
+}

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.13/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.13/opam
@@ -15,7 +15,7 @@ install: [
 ]
 depends: [
   "csexp"
-  "dune" {>= "2.8"}
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.13" & < "4.14"}
   "ocamlfind" {>= "1.5.2"}
   "result"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.13/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.13/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@clarus.me"
+homepage: "https://github.com/foobar-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/foobar-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/foobar-land/coq-of-ocaml/issues"
+authors: ["Guillaume Claret"]
+license: "MIT"
+build: [
+  ["sh" "-c" "cd proofs && ./configure.sh"] {coq:installed}
+  [make "-C" "proofs" "-j%{jobs}%"] {coq:installed}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install: [
+  [make "-C" "proofs" "install"] {coq:installed}
+]
+depends: [
+  "csexp"
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.13" & < "4.14"}
+  "ocamlfind" {>= "1.5.2"}
+  "result"
+  "smart-print"
+  "yojson" {>= "1.6.0"}
+]
+depopts: [
+  "coq"
+]
+conflicts: [
+  "coq" {< "8.11"}
+]
+tags: [
+  "keyword:compilation"
+  "keyword:OCaml"
+  "logpath:CoqOfOCaml"
+]
+synopsis: "Compile a subset of OCaml to Coq"
+
+url {
+  src: "https://github.com/foobar-land/coq-of-ocaml/releases/download/2.5.2/coq-of-ocaml-full.2.5.2+4.13.tar.gz"
+  checksum: [
+    "sha256=9dfde155240061a70b803715609246d360605d887035070b160190e21f672dbd"
+    "sha512=259a034fdff6cc0ca4af935eb07ec4dac7916a199452bec2bccbf5b6e26f6dfbcbd33ba53dfe63d0fc64a9c04763129e76ff6d04ebd53bb24e378b96457651ec"
+  ]
+}


### PR DESCRIPTION
Add `coq-of-ocaml.2.5.2` with support for both OCaml 4.12 and OCaml 4.13.