### PR TITLE
[new release] github, github-unix, github-jsoo and github-data (4.4.1)

### DIFF
--- a/packages/github-data/github-data.4.4.1/opam
+++ b/packages/github-data/github-data.4.4.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 data library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the data conversion library."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "yojson" {>= "1.7.0"}
+  "atdgen" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "github" {!= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.1/github-data-4.4.1.tbz"
+  checksum: [
+    "sha256=2e8ea3e84c3a72fbe80ea27f400228f8f3eb82be398b07f8a189a77f39648461"
+    "sha512=71e97efa2bb2ddad4f5fa5fb2234c017338dc19f34ba849bc8787fd7eb010560a219b85f6ac017539f31ca7d785d5936c84892ead929c7ac29202dd8d3791d0d"
+  ]
+}
+x-commit-hash: "d0d486a6ea03e502db28e122eabb7d34cb67e0fe"

--- a/packages/github-jsoo/github-jsoo.4.4.1/opam
+++ b/packages/github-jsoo/github-jsoo.4.4.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 JavaScript library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON). This library installs the JavaScript version, which uses [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "github" {= version}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "js_of_ocaml-lwt" {>= "3.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.1/github-data-4.4.1.tbz"
+  checksum: [
+    "sha256=2e8ea3e84c3a72fbe80ea27f400228f8f3eb82be398b07f8a189a77f39648461"
+    "sha512=71e97efa2bb2ddad4f5fa5fb2234c017338dc19f34ba849bc8787fd7eb010560a219b85f6ac017539f31ca7d785d5936c84892ead929c7ac29202dd8d3791d0d"
+  ]
+}
+x-commit-hash: "d0d486a6ea03e502db28e122eabb7d34cb67e0fe"

--- a/packages/github-unix/github-unix.4.4.1/opam
+++ b/packages/github-unix/github-unix.4.4.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 Unix library"
+description: """
+This library provides an OCaml interface to the [GitHub APIv3](https://docs.github.com/rest/)
+(JSON).  This package installs the Unix (Lwt) version."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "github" {= version}
+  "cohttp" {>= "4.0.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "stringext"
+  "cmdliner" {>= "0.9.8"}
+  "base-unix"
+  "lwt"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.1/github-data-4.4.1.tbz"
+  checksum: [
+    "sha256=2e8ea3e84c3a72fbe80ea27f400228f8f3eb82be398b07f8a189a77f39648461"
+    "sha512=71e97efa2bb2ddad4f5fa5fb2234c017338dc19f34ba849bc8787fd7eb010560a219b85f6ac017539f31ca7d785d5936c84892ead929c7ac29202dd8d3791d0d"
+  ]
+}
+x-commit-hash: "d0d486a6ea03e502db28e122eabb7d34cb67e0fe"

--- a/packages/github/github.4.4.1/opam
+++ b/packages/github/github.4.4.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "GitHub APIv3 OCaml library"
+description: """
+This library provides an OCaml interface to the
+[GitHub APIv3](https://docs.github.com/rest/) (JSON).
+
+It is compatible with [MirageOS](https://mirage.io) and also compiles to pure
+JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "David Sheets"
+  "Andy Ray"
+  "Jeff Hammerbacher"
+  "Thomas Gazagnaire"
+  "Rudi Grinberg"
+  "Qi Li"
+  "Jeremy Yallop"
+  "Dave Tucker"
+]
+license: "MIT"
+tags: ["org:mirage" "org:xapi-project" "git"]
+homepage: "https://github.com/mirage/ocaml-github"
+doc: "https://mirage.github.io/ocaml-github/"
+bug-reports: "https://github.com/mirage/ocaml-github/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "uri" {>= "1.9.0"}
+  "cohttp" {>= "4.0.0"}
+  "lwt" {>= "2.4.4"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "github-data" {= version}
+  "yojson" {>= "1.7.0"}
+  "stringext"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-github.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-github/releases/download/4.4.1/github-data-4.4.1.tbz"
+  checksum: [
+    "sha256=2e8ea3e84c3a72fbe80ea27f400228f8f3eb82be398b07f8a189a77f39648461"
+    "sha512=71e97efa2bb2ddad4f5fa5fb2234c017338dc19f34ba849bc8787fd7eb010560a219b85f6ac017539f31ca7d785d5936c84892ead929c7ac29202dd8d3791d0d"
+  ]
+}
+x-commit-hash: "d0d486a6ea03e502db28e122eabb7d34cb67e0fe"


### PR DESCRIPTION
GitHub APIv3 OCaml library

- Project page: <a href="https://github.com/mirage/ocaml-github">https://github.com/mirage/ocaml-github</a>
- Documentation: <a href="https://mirage.github.io/ocaml-github/">https://mirage.github.io/ocaml-github/</a>

##### CHANGES:

- Fix older versions of github can be co-installed with github-data (@dra27 mirage/ocaml-github#261)
- Fix github transitively depends on jsoo (@tmcgilchrist mirage/ocaml-github#262)
