### PR TITLE
add upper bounds for printbox 0.6

### DIFF
--- a/packages/electrod/electrod.0.1.4/opam
+++ b/packages/electrod/electrod.0.1.4/opam
@@ -20,7 +20,7 @@ depends: [
   "gen"
   "hashcons"
   "logs"
-  "menhir"
+  "menhir" {< "20211128"}
   "mtime"
   "ppx_blob"
   "ppx_deriving"

--- a/packages/electrod/electrod.0.1.4/opam
+++ b/packages/electrod/electrod.0.1.4/opam
@@ -24,7 +24,7 @@ depends: [
   "mtime"
   "ppx_blob"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "sequence" {>= "0.5"}
   "visitors"
 ]

--- a/packages/electrod/electrod.0.1.6/opam
+++ b/packages/electrod/electrod.0.1.6/opam
@@ -19,7 +19,7 @@ depends: [
   "gen"
   "hashcons"
   "logs"
-  "menhir"
+  "menhir" {< "20211128"}
   "mtime"
   "ppx_expect" {< "v0.15"}
   "ppx_inline_test" {< "v0.15"}

--- a/packages/electrod/electrod.0.1.6/opam
+++ b/packages/electrod/electrod.0.1.6/opam
@@ -23,7 +23,7 @@ depends: [
   "mtime"
   "ppx_expect" {< "v0.15"}
   "ppx_inline_test" {< "v0.15"}
-  "printbox"
+  "printbox" {< "0.6"}
   "sequence" {>= "0.5"}
   "visitors"
 ]

--- a/packages/electrod/electrod.0.1.7/opam
+++ b/packages/electrod/electrod.0.1.7/opam
@@ -23,7 +23,7 @@ depends: [
   "mtime"
   "ppx_expect" {< "v0.15"}
   "ppx_inline_test" {< "v0.15"}
-  "printbox"
+  "printbox" {< "0.6"}
   "sequence" {>= "0.5"}
   "visitors" {>= "20180513"}
 ]

--- a/packages/electrod/electrod.0.1.7/opam
+++ b/packages/electrod/electrod.0.1.7/opam
@@ -19,7 +19,7 @@ depends: [
   "gen"
   "hashcons"
   "logs"
-  "menhir"
+  "menhir" {< "20211128"}
   "mtime"
   "ppx_expect" {< "v0.15"}
   "ppx_inline_test" {< "v0.15"}

--- a/packages/electrod/electrod.0.2.1/opam
+++ b/packages/electrod/electrod.0.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "gen"
   "hashcons"
   "logs"
-  "menhir"
+  "menhir" {< "20211128"}
   "mtime"
   "ppx_inline_test" {< "v0.14"}
   "printbox" {< "0.6"}

--- a/packages/electrod/electrod.0.2.1/opam
+++ b/packages/electrod/electrod.0.2.1/opam
@@ -22,7 +22,7 @@ depends: [
   "menhir"
   "mtime"
   "ppx_inline_test" {< "v0.14"}
-  "printbox"
+  "printbox" {< "0.6"}
   "sequence" {>= "0.5"}
   "stdcompat"
   "visitors" {>= "20180513"}

--- a/packages/electrod/electrod.0.2.3/opam
+++ b/packages/electrod/electrod.0.2.3/opam
@@ -23,7 +23,7 @@ depends: [
   "menhir" {< "20211215"}
   "mtime"
   "ppx_inline_test" {< "v0.15"}
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.3.2/opam
+++ b/packages/electrod/electrod.0.3.2/opam
@@ -33,7 +33,7 @@ depends: [
   "menhir" {< "20211215"}
   "mtime"
   "ppx_inline_test" {< "v0.15"}
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.4.1/opam
+++ b/packages/electrod/electrod.0.4.1/opam
@@ -33,7 +33,7 @@ depends: [
   "menhir" {< "20200525"}
   "mtime"
   "ppx_inline_test" {< "v0.15"}
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.5/opam
+++ b/packages/electrod/electrod.0.5/opam
@@ -27,7 +27,7 @@ depends: [
   "menhir" {< "20200525"}
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.6.2/opam
+++ b/packages/electrod/electrod.0.6.2/opam
@@ -27,7 +27,7 @@ depends: [
   "menhir"
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.6/opam
+++ b/packages/electrod/electrod.0.6/opam
@@ -27,7 +27,7 @@ depends: [
   "menhir" {< "20200525"}
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.7.1/opam
+++ b/packages/electrod/electrod.0.7.1/opam
@@ -27,7 +27,7 @@ depends: [
   "menhir"
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.8.0/opam
+++ b/packages/electrod/electrod.0.8.0/opam
@@ -28,7 +28,7 @@ depends: [
   "menhir"
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.0.9.0/opam
+++ b/packages/electrod/electrod.0.9.0/opam
@@ -28,7 +28,7 @@ depends: [
   "menhir"
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/electrod/electrod.1.0.0/opam
+++ b/packages/electrod/electrod.1.0.0/opam
@@ -28,7 +28,7 @@ depends: [
   "menhir"
   "mtime"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
   "iter"
   "stdcompat"
   "stdlib-shims"

--- a/packages/phylogenetics/phylogenetics.0.0.0/opam
+++ b/packages/phylogenetics/phylogenetics.0.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "lacaml" {>= "10.0.2"}
   "menhir"
   "ppx_deriving"
-  "printbox"
+  "printbox" {< "0.6"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/20480
In all cases the error is
```
# Error: Unbound module PrintBox_text
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>