### PR TITLE
[new release] bigarray-compat (1.1.0)

### DIFF
--- a/packages/bigarray-compat/bigarray-compat.1.1.0/opam
+++ b/packages/bigarray-compat/bigarray-compat.1.1.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Lucas Pluvinage <lucas.pluvinage@gmail.com>"
+authors: [ "Lucas Pluvinage <lucas.pluvinage@gmail.com>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/bigarray-compat"
+bug-reports: "https://github.com/mirage/bigarray-compat/issues"
+dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.0"}
+]
+synopsis:
+  "Compatibility library to use Stdlib.Bigarray when possible"
+url {
+  src:
+    "https://github.com/mirage/bigarray-compat/releases/download/v1.1.0/bigarray-compat-1.1.0.tbz"
+  checksum: [
+    "sha256=434469a48d5c84e80d621b13d95eb067f8138c1650a1fd5ae6009a19b93718d5"
+    "sha512=7be283fd957ee168ce1e62835d22114da405e4b7da9619b4f2030a832d45ca210a0c8f1d1c57c92e224f3512308a8a0f0923b94f44b6f582acbe0e7728d179d4"
+  ]
+}
+x-commit-hash: "2ea842ba4ab2cfee7b711f7ad927917f3179a6f9"

--- a/packages/bigarray-compat/bigarray-compat.1.1.0/opam
+++ b/packages/bigarray-compat/bigarray-compat.1.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/bigarray-compat"
 bug-reports: "https://github.com/mirage/bigarray-compat/issues"
 dev-repo: "git+https://github.com/mirage/bigarray-compat.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [


### PR DESCRIPTION
Compatibility library to use Stdlib.Bigarray when possible

- Project page: <a href="https://github.com/mirage/bigarray-compat">https://github.com/mirage/bigarray-compat</a>

##### CHANGES:

- add support for OCaml 4.02.3 (@dinosaure, mirage/bigarray-compat#3)
- opam: remove the 'build' directive on dune dependency (@CraigFe, mirage/bigarray-compat#2)
- Make version check compatible with new major versions (@emillon, mirage/bigarray-compat#1)
