### PR TITLE
[new release] ppx_deriving_hash (0.1.1)

### DIFF
--- a/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.1/opam
+++ b/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "[@@deriving hash]"
+description:
+  "Deriver for standard hash functions without extra dependencies."
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ppx_deriving_hash"
+bug-reports: "https://github.com/sim642/ppx_deriving_hash/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ppxlib"
+  "ppx_deriving" {>= "5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ppx_deriving_hash.git"
+url {
+  src:
+    "https://github.com/sim642/ppx_deriving_hash/releases/download/0.1.1/ppx_deriving_hash-0.1.1.tbz"
+  checksum: [
+    "sha256=bdaaac5ab278eee6ded154e405eb7fa8a2dd2b7483032628ce56ef21ae062f24"
+    "sha512=2f19db33fe08c7deb196c7040d649713e5a45389b4cc4074f49b25c9744cd9c70fcd6cdb4814981418d4a7120eecddbeabb7f63688080517c777000dba857655"
+  ]
+}
+x-commit-hash: "221737ebcfed3dfe8d6af981739c7c335c4822e6"


### PR DESCRIPTION
[@@deriving hash]

- Project page: <a href="https://github.com/sim642/ppx_deriving_hash">https://github.com/sim642/ppx_deriving_hash</a>

##### CHANGES:

* Fix compatibility with OCaml 4.05, 4.06 and 4.07.
