### PR TITLE
[new release] mirage-block-unix (2.13.0)

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.15.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.15.0/opam
@@ -13,7 +13,7 @@ depends: [
   "rresult"
   "lwt" {>= "2.4.3"}
   "mirage-block" {>= "2.0.0"}
-  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-unix" {>= "2.5.0" & < "2.13.0"}
   "mirage-kv"
   "mirage-block-combinators" {with-test}
   "io-page-unix" {>= "2.0.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.13.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.13.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+authors:      "Dave Scott <dave@recoil.org>"
+maintainer:   "dave@recoil.org"
+homepage:     "https://github.com/mirage/mirage-block-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-block-unix.git"
+doc:          "https://mirage.github.io/mirage-block-unix/"
+bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
+tags:         "org:mirage"
+license:      "ISC"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "uri" {>= "1.9.0"}
+  "logs"
+  "lwt" {>= "5.4.2"}
+  "io-page" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "diet" {with-test & >= "0.4"}
+  "fmt" {with-test}
+  "conf-linux-libc-dev" {os = "linux"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "MirageOS disk block driver for Unix"
+description: """
+Unix implementation of the Mirage `BLOCK_DEVICE` interface.
+
+This module provides raw I/O to files and block devices with as little
+caching as possible.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unix/releases/download/v2.13.0/mirage-block-unix-2.13.0.tbz"
+  checksum: [
+    "sha256=02850329301a41863c9055f832eb8968018944929f46b9501372ac599add800d"
+    "sha512=bc71cc512b57540e5bcb64de1215ff874ecec831c7372bbdeb99ef1cbd32579aa068cec2782528647d831358c05da5db6d0ae4880d1caedf239da6ab61a7bdb5"
+  ]
+}
+x-commit-hash: "59e1ece188a76e0fc3761d4a5bb4210a22fa3c64"

--- a/packages/qcow-tool/qcow-tool.0.11.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.11.0/opam
@@ -24,7 +24,7 @@ depends: [
   "mirage-types-lwt" {>= "2.6.0" & < "3.7.0"}
   "lwt"
   "mirage-block" {>= "2.0.0"}
-  "mirage-block-unix" {>= "2.9.0"}
+  "mirage-block-unix" {>= "2.9.0" & < "2.13.0"}
   "mirage-time"
   "sha" {>= "1.10"}
   "sexplib" {< "v0.15"}

--- a/packages/qcow/qcow.0.11.0/opam
+++ b/packages/qcow/qcow.0.11.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-types-lwt" {>= "2.6.0" & < "3.7.0"}
   "lwt" {>= "4.0.0"}
   "mirage-block" {>= "2.0.0"}
-  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-unix" {>= "2.5.0" & < "2.13.0"}
   "mirage-block-combinators"
   "mirage-time"
   "cmdliner"

--- a/packages/shared-block-ring/shared-block-ring.3.0.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.3.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt"
   "lwt_log"
   "mirage-block" {>= "2.0.1"}
-  "mirage-block-unix"
+  "mirage-block-unix" {< "2.13.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-clock-unix" {with-test}
   "mirage-time" {>= "2.0.1"}


### PR DESCRIPTION
MirageOS disk block driver for Unix

- Project page: <a href="https://github.com/mirage/mirage-block-unix">https://github.com/mirage/mirage-block-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-unix/">https://mirage.github.io/mirage-block-unix/</a>

##### CHANGES:

* Add a configuration field for the size of sectors (mirage/mirage-block-unix#106, @Julow, @hannesm, @dinosaure)
* Update to cstruct.6.0.0 (mirage/mirage-block-unix#108, @MisterDA, @dinosaure)
* Depends on `io-page.unix` instead of `io-page-unix` (@dinosaure)
