### PR TITLE
Add: down.0.0.4

### DIFF
--- a/packages/down/down.0.0.4/opam
+++ b/packages/down/down.0.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: """An OCaml toplevel (REPL) upgrade"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The down programmers"]
+homepage: "https://erratique.ch/software/down"
+doc: "https://erratique.ch/software/down/doc/"
+dev-repo: "git+https://erratique.ch/repos/down.git"
+bug-reports: "https://github.com/dbuenzli/down/issues"
+license: ["ISC"]
+tags: ["dev" "toplevel" "repl" "org:erratique"]
+depends: ["ocaml" {>= "4.04.0" & < "4.14.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}
+          "uucp" {dev}]
+build: [["ocaml" "pkg/pkg.ml" "build"
+         "--dev-pkg" "%{dev}%"
+         "--lib-dir" "%{lib}%"]]
+install: 
+      # Following is only to deal with
+      # https://caml.inria.fr/mantis/view.php?id=7808
+      [["install" "-d" "%{lib}%/ocaml/"]
+       ["install" "src/down.top" "src/down.nattop" "%{lib}%/ocaml/"]]
+url {
+  src: "https://erratique.ch/software/down/releases/down-0.0.4.tbz"
+  checksum: "sha512=09cf03e04942de8469f04d1d2c2a5b91b92a3539b5c109d866555ad0ca0e848884371b4516b06c8c19aa030c279b487ecb788c354d2eec32f88343876e525eeb"}
+description: """
+Down is an unintrusive user experience upgrade for the `ocaml`
+toplevel (REPL). 
+
+Simply load the zero dependency `Down` library in the `ocaml` toplevel
+and you get line edition, history, session support and identifier
+completion and documentation (courtesy of [`ocp-index`][ocp-index]).
+
+Add this to your `~/.ocamlinit`:
+
+    #use "down.top"
+
+![tty](doc/tty.png)
+
+Down is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/down
+
+[ocp-index]: https://github.com/OCamlPro/ocp-index"""


### PR DESCRIPTION
* Add: `down.0.0.4` [home](https://erratique.ch/software/down), [doc](https://erratique.ch/software/down/doc/), [issues](https://github.com/dbuenzli/down/issues)  
  *An OCaml toplevel (REPL) upgrade*


---

#### `down` v0.0.4 2022-01-26 La Forclaz (VS)

- Upgrade Unicode TTY width data to 14.0.0.

---

Use `b0 cmd -- .opam.publish down.0.0.4` to update the pull request.