### PR TITLE
Package binaryen.0.12.0

### DIFF
--- a/packages/binaryen/binaryen.0.12.0/opam
+++ b/packages/binaryen/binaryen.0.12.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml" {>= "3.10.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "102.0.4" & < "103.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.12.0/binaryen-archive-v0.12.0.tar.gz"
+  checksum: [
+    "md5=d7dc5e6710699da6680a622b068deef6"
+    "sha512=72cfe10eb0ad4964e59c64a1dfa0be5fcf52a4872bd2e2b5d7955bf259f8e8e24965558c94a5d78261914d65af45a51fd443aa7a3d615e19be23fd2cd3d502b6"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.12.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
### ⚠ BREAKING CHANGES

- Add table type to add_table signature
- Rename Event to Tag to match Binaryen

### Features

- Add table type to add_table signature ([5c50272](https://www.github.com/grain-lang/binaryen.ml/commit/5c502720943a8bf6e649891051db00336eec9451))
- Add update_maps function that Binaryen added ([5c50272](https://www.github.com/grain-lang/binaryen.ml/commit/5c502720943a8bf6e649891051db00336eec9451))
- Rename Event to Tag to match Binaryen ([5c50272](https://www.github.com/grain-lang/binaryen.ml/commit/5c502720943a8bf6e649891051db00336eec9451))
- Upgrade to libbinaryen v102 ([#120](https://www.github.com/grain-lang/binaryen.ml/issues/120)) ([5c50272](https://www.github.com/grain-lang/binaryen.ml/commit/5c502720943a8bf6e649891051db00336eec9451))


---
:camel: Pull-request generated by opam-publish v2.0.3