### PR TITLE
bls12-381.2.0.0 and bls12-381-unix.2.0.0

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
@@ -1,0 +1,34 @@
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381 with blst backend"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bls12-381" {= version}
+  "hex"
+  "alcotest" {with-test}
+  "integers"
+  "bisect_ppx" {with-test & >= "2.5"}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+available: arch != "ppc64"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/6b0262fa33e768540fd4d104a8d7e6a2cbe686f8/ocaml-bls12-381-6b0262fa33e768540fd4d104a8d7e6a2cbe686f8.tar.bz2"
+  checksum: [
+    "md5=6043fb56a200c993a65bf97d4ae27c4e"
+    "sha512=fd025ad83d197e9fa6fde7d87a5bf5358830e1a2431fe24c969b72da919dc24a5aba6650d74daf63d345921d55494e3c54e6591d305790307b2fa414e8476569"
+  ]
+}

--- a/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
   "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
 ]
-available: arch != "ppc64"
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"

--- a/packages/bls12-381/bls12-381.2.0.0/opam
+++ b/packages/bls12-381/bls12-381.2.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/6b0262fa33e768540fd4d104a8d7e6a2cbe686f8/ocaml-bls12-381-6b0262fa33e768540fd4d104a8d7e6a2cbe686f8.tar.bz2"
+  checksum: [
+    "md5=6043fb56a200c993a65bf97d4ae27c4e"
+    "sha512=fd025ad83d197e9fa6fde7d87a5bf5358830e1a2431fe24c969b72da919dc24a5aba6650d74daf63d345921d55494e3c54e6591d305790307b2fa414e8476569"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bls12-381.2.0.0`: Virtual package for BLS12-381 primitives
-`bls12-381-unix.2.0.0`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381 with blst backend



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.0.3