### PR TITLE
[new release] multipart_form and multipart_form-lwt (0.4.0)

### DIFF
--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -66,7 +66,7 @@ depends: [
   "magic-mime"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
-  "multipart-form-data" {>= "0.3.0"}
+  "multipart-form-data" {>= "0.3.0" & < "0.4.0"}
   "ocaml" {>= "4.08.0"}
   "opam-installer" {build}
   "uri" {>= "4.0.0"}

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -67,7 +67,7 @@ depends: [
   "magic-mime"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
-  "multipart_form" {>= "0.3.0"}
+  "multipart_form" {>= "0.3.0" & < "0.4.0"}
   "ocaml" {>= "4.08.0"}
   "uri" {>= "4.2.0"}
   "yojson"  # ...

--- a/packages/multipart_form-lwt/multipart_form-lwt.0.4.0/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.4.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom"
+  "bigarray-compat"
+  "bigstringaf"
+  "ke"
+  "lwt" 
+  "result"
+  "multipart_form" {= version}
+  "alcotest-lwt" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "unstrctrd" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.4.0/multipart_form-0.4.0.tbz"
+  checksum: [
+    "sha256=79f81d9a197e5771552175086fb36d59fc91420f84859c095987b18c167f39e0"
+    "sha512=92f5cf2ae412237f9e036bbd31b47ca379aadc427eaeaac06d6d1d0a50fad59112dfa644766751a2bf3967445a76f6e9c27fb1352265017f61bcefc864bf133a"
+  ]
+}
+x-commit-hash: "cdcb0b3ccabb878f9e605b7c2506c9500bf9d034"

--- a/packages/multipart_form/multipart_form.0.4.0/opam
+++ b/packages/multipart_form/multipart_form.0.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "unstrctrd" {>= "0.2"}
+  "rresult"
+  "uutf"
+  "stdlib-shims"
+  "pecu" {>= "0.4"}
+  "prettym"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ke" {>= "0.4"}
+  "alcotest" {with-test}
+  "rosetta" {with-test}
+  "bigarray-compat" {>= "1.0.0"}
+  "bigstringaf" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.4.0/multipart_form-0.4.0.tbz"
+  checksum: [
+    "sha256=79f81d9a197e5771552175086fb36d59fc91420f84859c095987b18c167f39e0"
+    "sha512=92f5cf2ae412237f9e036bbd31b47ca379aadc427eaeaac06d6d1d0a50fad59112dfa644766751a2bf3967445a76f6e9c27fb1352265017f61bcefc864bf133a"
+  ]
+}
+x-commit-hash: "cdcb0b3ccabb878f9e605b7c2506c9500bf9d034"


### PR DESCRIPTION
Multipart-form: RFC2183, RFC2388 & RFC7578

- Project page: <a href="https://github.com/dinosaure/multipart_form">https://github.com/dinosaure/multipart_form</a>
- Documentation: <a href="https://dinosaure.github.io/multipart_form/">https://dinosaure.github.io/multipart_form/</a>

##### CHANGES:

- Split the distribution into two packages: `multipart_form{,-lwt}` (@dinosaure, @leviroth, dinosaure/multipart_form#23)
- Documentation about `Content-Type` (@dinosaure, dinosaure/multipart_form#24)
- Upgrade the distribution with few new releases (@dinosaure, dinosaure/multipart_form#24)
- Add a test about the lwt support (@dinosaure, @taiseiKMC, dinosaure/multipart_form#25, dinosaure/multipart_form#27)
- Allow filenames with space (@dinosaure, @aantron, @cemerick, dinosaure/multipart_form#28)
