### PR TITLE
Add: topkg.1.0.5, topkg-care.1.0.5

### DIFF
--- a/packages/topkg-care/topkg-care.1.0.5/opam
+++ b/packages/topkg-care/topkg-care.1.0.5/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: """The transitory OCaml software packager"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The topkg programmers"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+license: ["ISC"]
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: ["ocaml" {>= "4.05.0"}
+          "ocamlfind" {build & >= "1.6.1"}
+          "ocamlbuild"
+          "topkg" {= version}
+          "fmt"
+          "logs"
+          "bos" {>= "0.1.5"}
+          "cmdliner" {>= "1.0.0"}
+          "webbrowser"
+          "opam-format" {>= "2.0.0"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
+                                      "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.0.5.tbz"
+  checksum: "sha512=9450e9139209aacd8ddb4ba18e4225770837e526a52a56d94fd5c9c4c9941e83e0e7102e2292b440104f4c338fabab47cdd6bb51d69b41cc92cc7a551e6fefab"}
+description: """
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: http://erratique.ch/software/topkg"""

--- a/packages/topkg/topkg.1.0.5/opam
+++ b/packages/topkg/topkg.1.0.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: """The transitory OCaml software packager"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The topkg programmers"]
+homepage: "https://erratique.ch/software/topkg"
+doc: "https://erratique.ch/software/topkg/doc"
+dev-repo: "git+https://erratique.ch/repos/topkg.git"
+bug-reports: "https://github.com/dbuenzli/topkg/issues"
+license: ["ISC"]
+tags: ["packaging" "ocamlbuild" "org:erratique"]
+depends: ["ocaml" {>= "4.05.0"}
+          "ocamlfind" {build & >= "1.6.1"}
+          "ocamlbuild"]
+build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
+                                      "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/topkg/releases/topkg-1.0.5.tbz"
+  checksum: "sha512=9450e9139209aacd8ddb4ba18e4225770837e526a52a56d94fd5c9c4c9941e83e0e7102e2292b440104f4c338fabab47cdd6bb51d69b41cc92cc7a551e6fefab"}
+description: """
+Topkg is a packager for distributing OCaml software. It provides an
+API to describe the files a package installs in a given build
+configuration and to specify information about the package's
+distribution, creation and publication procedures.
+
+The optional topkg-care package provides the `topkg` command line tool
+which helps with various aspects of a package's life cycle: creating
+and linting a distribution, releasing it on the WWW, publish its
+documentation, add it to the OCaml opam repository, etc.
+
+Topkg is distributed under the ISC license and has **no**
+dependencies. This is what your packages will need as a *build*
+dependency.
+
+Topkg-care is distributed under the ISC license it depends on
+[fmt][fmt], [logs][logs], [bos][bos], [cmdliner][cmdliner],
+[webbrowser][webbrowser] and `opam-format`.
+
+[fmt]: http://erratique.ch/software/fmt
+[logs]: http://erratique.ch/software/logs
+[bos]: http://erratique.ch/software/bos
+[cmdliner]: http://erratique.ch/software/cmdliner
+[webbrowser]: http://erratique.ch/software/webbrowser
+
+Home page: http://erratique.ch/software/topkg"""


### PR DESCRIPTION
* Add: `topkg.1.0.5` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*
* Add: `topkg-care.1.0.5` [home](https://erratique.ch/software/topkg), [doc](https://erratique.ch/software/topkg/doc), [issues](https://github.com/dbuenzli/topkg/issues)  
  *The transitory OCaml software packager*


---

#### `topkg-care`, `topkg` v1.0.5 2022-01-28 La Forclaz (VS)

- `Topkg.String.parse_version`. Support for the new OCaml 
  version string format (https://github.com/ocaml/ocaml/pull/9712)
- Switch from `opam config var` to `opam var`.
- Fix compilation for next version of `cmdliner`.

---

Use `b0 cmd -- .opam.publish topkg.1.0.5 topkg-care.1.0.5` to update the pull request.