### PR TITLE
[new release] metrics, metrics-unix, metrics-rusage, metrics-lwt and metrics-influx (0.4.0)

### DIFF
--- a/packages/metrics-influx/metrics-influx.0.4.0/opam
+++ b/packages/metrics-influx/metrics-influx.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "fmt" {>= "0.8.7"}
+  "duration"
+  "lwt" {>= "2.4.7"}
+]
+synopsis: "Influx reporter for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.0/metrics-0.4.0.tbz"
+  checksum: [
+    "sha256=91b8755a4b5090371713c3b55919bebed6a055f4aa97c4b982bd1b5e7fe389af"
+    "sha512=00b271b74b7081b2fe202f402c9be6fef70da7241ee82a82b7a52329aad7c1d73c0eb7ee579a20a08c0e54f546351104dd822052624654ecbfc1c33d067656fa"
+  ]
+}
+x-commit-hash: "1976c64867bbf30de16fc86d29563bb3d4127a3f"

--- a/packages/metrics-lwt/metrics-lwt.0.4.0/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "lwt" {>= "2.4.7"}
+  "logs"
+]
+synopsis: "Lwt backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.0/metrics-0.4.0.tbz"
+  checksum: [
+    "sha256=91b8755a4b5090371713c3b55919bebed6a055f4aa97c4b982bd1b5e7fe389af"
+    "sha512=00b271b74b7081b2fe202f402c9be6fef70da7241ee82a82b7a52329aad7c1d73c0eb7ee579a20a08c0e54f546351104dd822052624654ecbfc1c33d067656fa"
+  ]
+}
+x-commit-hash: "1976c64867bbf30de16fc86d29563bb3d4127a3f"

--- a/packages/metrics-rusage/metrics-rusage.0.4.0/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "team@robur.coop"
+authors:      ["Reynir Bjoernsson" "Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Resource usage (getrusage) sources for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.0/metrics-0.4.0.tbz"
+  checksum: [
+    "sha256=91b8755a4b5090371713c3b55919bebed6a055f4aa97c4b982bd1b5e7fe389af"
+    "sha512=00b271b74b7081b2fe202f402c9be6fef70da7241ee82a82b7a52329aad7c1d73c0eb7ee579a20a08c0e54f546351104dd822052624654ecbfc1c33d067656fa"
+  ]
+}
+x-commit-hash: "1976c64867bbf30de16fc86d29563bb3d4127a3f"

--- a/packages/metrics-rusage/metrics-rusage.0.4.0/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.4.0/opam
@@ -20,6 +20,7 @@ depends: [
   "logs"
   "fmt" {>= "0.8.7"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 synopsis: "Resource usage (getrusage) sources for the Metrics library"
 url {
   src:

--- a/packages/metrics-unix/metrics-unix.0.4.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "uuidm" {>= "0.9.6"}
+  "metrics" {= version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "2.4.7"}
+  "metrics-lwt" {= version & with-test}
+  "conf-gnuplot"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Unix backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.0/metrics-0.4.0.tbz"
+  checksum: [
+    "sha256=91b8755a4b5090371713c3b55919bebed6a055f4aa97c4b982bd1b5e7fe389af"
+    "sha512=00b271b74b7081b2fe202f402c9be6fef70da7241ee82a82b7a52329aad7c1d73c0eb7ee579a20a08c0e54f546351104dd822052624654ecbfc1c33d067656fa"
+  ]
+}
+x-commit-hash: "1976c64867bbf30de16fc86d29563bb3d4127a3f"

--- a/packages/metrics/metrics.0.4.0/opam
+++ b/packages/metrics/metrics.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.4"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+]
+synopsis: "Metrics infrastructure for OCaml"
+description: """
+Metrics provides a basic infrastructure to monitor and gather runtime
+metrics for OCaml program. Monitoring is performed on sources, indexed
+by tags, allowing users to enable or disable at runtime the gathering
+of data-points. As disabled metric sources have a low runtime cost
+(only a closure allocation), the library is designed to instrument
+production systems.
+
+Metric reporting is decoupled from monitoring and is handled by a
+custom reporter. A few reporters are (will be) provided by default.
+
+Metrics is heavily inspired by
+[Logs](http://erratique.ch/software/logs).
+"""
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.0/metrics-0.4.0.tbz"
+  checksum: [
+    "sha256=91b8755a4b5090371713c3b55919bebed6a055f4aa97c4b982bd1b5e7fe389af"
+    "sha512=00b271b74b7081b2fe202f402c9be6fef70da7241ee82a82b7a52329aad7c1d73c0eb7ee579a20a08c0e54f546351104dd822052624654ecbfc1c33d067656fa"
+  ]
+}
+x-commit-hash: "1976c64867bbf30de16fc86d29563bb3d4127a3f"


### PR DESCRIPTION
Metrics infrastructure for OCaml

- Project page: <a href="https://github.com/mirage/metrics">https://github.com/mirage/metrics</a>
- Documentation: <a href="https://mirage.github.io/metrics/">https://mirage.github.io/metrics/</a>

##### CHANGES:

- metrics-influx: remove astring dependency (mirage/metrics#52 @hannesm)
- metrics-rusage: remove rresult dependency (mirage/metrics#52 @hannesm)
- metrics-mirage: remove this package (unused, mirage/metrics#53 @hannesm)
- metrics: provide tags_enabled and all_enabled to allow introspection what
  sources are enabled (mirage/metrics#55 @hannesm, requested by @reynir in mirage/metrics#54)
