### PR TITLE
js_of_ocaml-compiler.4.0.0: Unlock OCaml 4.14

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
@@ -11,7 +11,7 @@ doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.04" & < "4.14"}
+  "ocaml" {>= "4.04" & < "4.15"}
   "num" {with-test}
   "ppx_expect" {>= "v0.14.2" & with-test}
   "ppxlib" {>= "0.15.0"}


### PR DESCRIPTION
Seems to have been overlooked in #20533 