### PR TITLE
[new release] ctypes_stubs_js (0.1)

### DIFF
--- a/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
+++ b/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic-labs <contact@nomadic-labs.com>"]
+homepage: "https://gitlab.com/nomadic-labs/ctypes_stubs_js"
+synopsis: "Js_of_ocaml Javascript stubs for the OCaml ctypes library"
+
+license: "MIT"
+bug-reports: "https://gitlab.com/nomadic-labs/ctypes_stubs_js/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ctypes_stubs_js.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "integers_stubs_js"
+  "dune" {build & >= "2.9"}
+  "ctypes" {with-test}
+  "ppx_expect" {with-test}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ctypes_stubs_js/-/archive/0.1/ctypes_stubs_js-0.1.tar.gz"
+  checksum: [
+    "sha256=27498f868dc885ef2f4124b37a4ca4244547aa82406e7564722f31239a574269"
+    "sha512=ce238d8d2eaf48fe7536d644b5e981586fec88d60447e5fd79f82ede07dc99cef09c90d2e9c4d63f0b7fc469aecd93791c8ea2cb95893e1db5bda74b95dd3abe"
+  ]
+}
+x-commit-hash: "b704ba59a37f58759de847c811a8f94664e4026a"

--- a/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
+++ b/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "integers_stubs_js"
-  "dune" {build & >= "2.9"}
+  "dune" {>= "2.9"}
   "ctypes" {with-test}
   "ppx_expect" {with-test}
 ]

--- a/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
+++ b/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
@@ -21,8 +21,8 @@ url {
   src:
     "https://gitlab.com/nomadic-labs/ctypes_stubs_js/-/archive/0.1/ctypes_stubs_js-0.1.tar.gz"
   checksum: [
-    "sha256=27498f868dc885ef2f4124b37a4ca4244547aa82406e7564722f31239a574269"
-    "sha512=ce238d8d2eaf48fe7536d644b5e981586fec88d60447e5fd79f82ede07dc99cef09c90d2e9c4d63f0b7fc469aecd93791c8ea2cb95893e1db5bda74b95dd3abe"
+    "sha256=74ab170e064bff88eaa592efc992d24fa1665c67047fc822276eae52c0f3384d"
+    "sha512=935e7f89e2cea9022f1d10aadb7d992ed207c010f872f360a251c290e21678e86a686ebd102ca688b6a2c2b49ee575a4b30ede96897b830c0b9072ebe2717f89"
   ]
 }
 x-commit-hash: "b704ba59a37f58759de847c811a8f94664e4026a"


### PR DESCRIPTION
Js_of_ocaml Javascript stubs for the OCaml ctypes library

- Project page: <a href="https://gitlab.com/nomadic-labs/ctypes_stubs_js">https://gitlab.com/nomadic-labs/ctypes_stubs_js</a>

##### CHANGES:

## Features/Changes
* Initial release
