### PR TITLE
[new release] solo5-elftool (0.3.0)

### DIFF
--- a/packages/solo5-elftool/solo5-elftool.0.3.0/opam
+++ b/packages/solo5-elftool/solo5-elftool.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage: "https://git.robur.io/robur/ocaml-solo5-elftool"
+dev-repo: "git+https://git.robur.io/robur/ocaml-solo5-elftool.git"
+bug-reports: "https://github.com/roburio/ocaml-solo5-elftool/issues"
+doc: "https://roburio.github.io/ocaml-solo5-elftool/doc"
+maintainer: [ "team@robur.coop" ]
+authors: [ "Reynir Björnsson <reynir@reynir.dk>" ]
+license: "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.8.0"}
+  "dune" {>= "2.9"}
+  "owee" {>= "0.4"}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.7"}
+  "cmdliner"
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+synopsis: "OCaml Solo5 elftool for querying solo5 manifests"
+description: """
+OCaml Solo5 elftool is a library and executable for reading solo5 device
+manifests from solo5 ELF executables.
+"""
+url {
+  src:
+    "https://github.com/roburio/ocaml-solo5-elftool/releases/download/v0.3.0/solo5-elftool-0.3.0.tbz"
+  checksum: [
+    "sha256=72eeec01675fef461bce4d49d860fdf893e281b142b9018504ccbec5c3552c7e"
+    "sha512=3fc15772be393ed24db98fa428e24377f6f38d50fa57e2de9bb6ec614ba2120b7cce8cf1c12bcb297c901f4645cc1a278c5487e49b5e64e2946a1982209b321e"
+  ]
+}
+x-commit-hash: "082680d4a9aa071a06674b4b393e7356cf065a3a"


### PR DESCRIPTION
OCaml Solo5 elftool for querying solo5 manifests

- Project page: <a href="https://git.robur.io/robur/ocaml-solo5-elftool">https://git.robur.io/robur/ocaml-solo5-elftool</a>
- Documentation: <a href="https://roburio.github.io/ocaml-solo5-elftool/doc">https://roburio.github.io/ocaml-solo5-elftool/doc</a>

##### CHANGES:

* Exceptions from Owee are caught in `query_abi` and `query_manifest`
