### PR TITLE
[new release] albatross (1.4.0)

### DIFF
--- a/packages/albatross/albatross.1.4.0/opam
+++ b/packages/albatross/albatross.1.4.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+available: os != "macos"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.4.0/albatross-1.4.0.tbz"
+  checksum: [
+    "sha256=84c1e078f766c4defc2790c545548360bd053bfe16f7b9b393a13d9a43e791ad"
+    "sha512=db62fee7a5d4ad3a89aa23b4532faced116fbf86638dc9a12ed01ec3ec797fafb30e1a95e1c643db005eef4fb52b78a57388f7947def736670eac216bcb1a314"
+  ]
+}
+x-commit-hash: "772d4f67fc040dc1f35bd9e7022590b5d361dd1c"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- albatross-provision-ca: support signing of server certificates
- use solo5-elftool (developed in OCaml) instead of binary, avoids solo5
  dependency for albatross-client-* (roburio/albatross#94 @reynir, fixes roburio/albatross#93), removes jsonm
  dependency
- albatross-influx: reconnect TCP to influx (telegraf) host (roburio/albatross#97 @hannesm,
  fixes roburio/albatross#69)
- by default, do not print argv in unikernel_info (and pp_wire). only if the
  logging level is verbose (roburio/albatross#96 @hannesm, fixes @92)
- avoid file descriptor leak on Linux in albatross-stats when reading
  /proc/<pid>/status (roburio/albatross#99 @hannesm)
- remove astring dependency (roburio/albatross#99 @hannesm)
- Debian packaging
  - install metadata and service scripts with 0644 permissions (@reynir)
  - postinst: do not use sudo (@reynir)
  - postinst: set ownerhip of /var/lib/albatross and /var/lib/albatross/block
    to $ALBATROSS_USER (@reynir)
  - postinst: create group and user only if they do not exist yet (@reynir)
  - install daemons into /usr/libexec/albatross to avoid accidental invocation
    (@hannesm roburio/albatross#95, fixes roburio/albatross#91)
  - add network.target and NetworkManager-wait-online.service to dependencies
    of albatross_daemon to ensure bridges already exists (roburio/albatross#98 @reynir,
    fixes roburio/albatross#90)
