### PR TITLE
Update Camlp5 for compatibility with OCaml 4.14.0~alpha1.

### DIFF
--- a/packages/camlp5/camlp5.8.00.03/opam
+++ b/packages/camlp5/camlp5.8.00.03/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.05" & < "4.15.0"}
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "conf-diffutils" { with-test & os-distribution = "alpine" }
+  "pcre" { with-test }
+  "ounit" { with-test }
+  "rresult" { with-test }
+  "fmt" { with-test }
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] {
+    with-test
+  & ocaml:version >= "4.10.0"
+  & os-distribution != "homebrew"
+  }
+  [make "-C" "test" "clean" "all"] {
+    with-test
+  & ocaml:version >= "4.10.0"
+  & os-distribution != "homebrew"
+  }
+]
+install: [make "install"]
+
+post-messages:
+  "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion." { os = "macos" | os = "freebsd" | os = "openbsd" }
+
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/rel8.00.03.tar.gz"
+  checksum: [
+    "sha512=a6259d2d491ed1f967dd383f03d3da65a3f383d28340111f57883c6d56cee2d267c0f752ba98bcdb72c24cf724a606718de26b6c55b84ad9b5f8f6d620f3cba1"
+  ]
+}

--- a/packages/p5scm/p5scm.0.1.0/opam
+++ b/packages/p5scm/p5scm.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.12.0" & < "4.14.0"}
   "menhir" {>= "20201214"}
   "cppo" {>= "1.6.6"}
-  "camlp5" {>= "8.00~alpha05"}
+  "camlp5" {>= "8.00~alpha05" & < "8.00.03" }
   "sexp_pretty" {>= "v0.14.0"}
   "ppx_sexp_conv" {>= "v0.14.0"}
   "utop" {>= "2.7.0"}


### PR DESCRIPTION
There might need to be a further release if 4.14.0 changes
in significant ways, but this should cover all the changes
I'm aware of in the alpha.