### PR TITLE
Update ppx_seq.0.2.0

### DIFF
--- a/packages/ppx_seq/ppx_seq.0.2.0/opam
+++ b/packages/ppx_seq/ppx_seq.0.2.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "2.9" & build}
   "ppxlib" {>= "0.23" & build}
-  "seq"
+  "seq" {with-test}
   "odoc" {with-doc}
 ]
 build: [
@@ -38,9 +38,9 @@ dev-repo: "git+https://git.sr.ht/~hyphens/ppx_seq"
 url {
   src: "https://github.com/hyphenrf/ppx_seq/archive/refs/tags/0.2.tar.gz"
   checksum: [
-    "md5=d3e1bd461b6dac32af5bf65f15c5d8f4"
-    "sha256=2f350243541f1a54a34112462fcdf7ae8e33a7ceb3336ffc070c961c92059def"
-    "sha512=4b14eb5a5d25930e7e6978774ce95de8cddf8f93adbfd51e057488c4aaebe13ecb976ac7163b826c28b02811e63b2f81fa8d81ff16fe0d5b3497e9fa7c4510d8"
+    "md5=6de710e3be3c6ff4c69e3cb932f05467"
+    "sha256=6f83c627e9ee91d0f7d85675fbb85f169c0489d1221227a6b23fd97b9ccd0b0f"
+    "sha512=62897fe5249880b811f1bbef0c42eaa148d1060d9046312a9cd5979eeeea9a13e19efc6701cdcb1c436b4d6554f31a16a057bbc1bbad6a4e432daecc930171e8"
   ]
   mirrors: "https://git.sr.ht/~hyphens/ppx_seq/archive/0.2.tar.gz"
 }

--- a/packages/ppx_seq/ppx_seq.0.2.0/opam
+++ b/packages/ppx_seq/ppx_seq.0.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Seq literals ppx for OCaml"
+description: """
+Simple unintrusive ppx rewriter that offers Seq literals.
+It offers List-like syntax in the form of [%seq a; b; c...]
+"""
+maintainer: "hyphens@pm.me"
+authors: "Hazem Elmasry"
+license: "ISC"
+tags: "syntax"
+homepage: "https://sr.ht/~hyphens/ppx_seq"
+doc: "https://git.sr.ht/~hyphens/ppx_seq/tree/master/item/README"
+bug-reports: "https://lists.sr.ht/~hyphens/ppx_seq"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "2.9" & build}
+  "ppxlib" {>= "0.23" & build}
+  "seq"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.sr.ht/~hyphens/ppx_seq"
+url {
+  src: "https://github.com/hyphenrf/ppx_seq/archive/refs/tags/0.2.tar.gz"
+  checksum: [
+    "md5=d3e1bd461b6dac32af5bf65f15c5d8f4"
+    "sha256=2f350243541f1a54a34112462fcdf7ae8e33a7ceb3336ffc070c961c92059def"
+    "sha512=4b14eb5a5d25930e7e6978774ce95de8cddf8f93adbfd51e057488c4aaebe13ecb976ac7163b826c28b02811e63b2f81fa8d81ff16fe0d5b3497e9fa7c4510d8"
+  ]
+  mirrors: "https://git.sr.ht/~hyphens/ppx_seq/archive/0.2.tar.gz"
+}

--- a/packages/ppx_seq/ppx_seq.0.2.0/opam
+++ b/packages/ppx_seq/ppx_seq.0.2.0/opam
@@ -13,8 +13,8 @@ doc: "https://git.sr.ht/~hyphens/ppx_seq/tree/master/item/README"
 bug-reports: "https://lists.sr.ht/~hyphens/ppx_seq"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {>= "2.9" & build}
-  "ppxlib" {>= "0.23" & build}
+  "dune" {>= "2.9"}
+  "ppxlib" {>= "0.23"}
   "seq" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Update features lower OCaml version bounds and perf annotations for compilers that support it.