### PR TITLE
functoria-runtime: add upper bounds to prepare for the MirageOS 4

### DIFF
--- a/packages/functoria-runtime/functoria-runtime.3.0.1/opam
+++ b/packages/functoria-runtime/functoria-runtime.3.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "1.1"}
   "cmdliner" {>= "0.9.8"}
   "fmt"
-  "alcotest"  {with-test}
+  "alcotest"  {with-test & < "1.4.0"}
 ]
 
 synopsis: "Runtime support library for functoria-generated code"

--- a/packages/functoria-runtime/functoria-runtime.3.0.1/opam
+++ b/packages/functoria-runtime/functoria-runtime.3.0.1/opam
@@ -22,7 +22,6 @@ depends: [
   "dune" {>= "1.1"}
   "cmdliner" {>= "0.9.8"}
   "fmt"
-  "alcotest"  {with-test & < "1.4.0"}
 ]
 
 synopsis: "Runtime support library for functoria-generated code"

--- a/packages/functoria-runtime/functoria-runtime.3.0.2/opam
+++ b/packages/functoria-runtime/functoria-runtime.3.0.2/opam
@@ -25,8 +25,9 @@ depends: [
   "dune" {with-test & < "2.8.0"}
   "cmdliner" {>= "0.9.8"}
   "fmt"
-  "functoria" {with-test & >= "2.2.0"}
-  "alcotest"  {with-test}
+  "fmt" {with-test & < "0.8.10"}
+  "functoria" {with-test & >= "2.2.0" & < "4.0"}
+  "alcotest"  {with-test & < "1.4.0"}
 ]
 
 synopsis: "Runtime support library for functoria-generated code"

--- a/packages/functoria-runtime/functoria-runtime.3.0.3/opam
+++ b/packages/functoria-runtime/functoria-runtime.3.0.3/opam
@@ -25,8 +25,9 @@ depends: [
   "dune" {with-test & < "2.8.0"}
   "cmdliner" {>= "0.9.8"}
   "fmt"
-  "functoria" {with-test & >= "2.2.0"}
-  "alcotest"  {with-test}
+  "fmt" {with-test & < "0.8.10"}
+  "functoria" {with-test & >= "2.2.0" & < "4.0"}
+  "alcotest"  {with-test & < "1.4.0"}
 ]
 
 synopsis: "Runtime support library for functoria-generated code"


### PR DESCRIPTION
Extracted from #20558 