### PR TITLE
mirage-crypto-pk: use mirage-runtime >= "4.0" (instead of "4.0.0") to support mirage 4.0.0~beta1 release

### DIFF
--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.3/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.3/opam
@@ -26,7 +26,7 @@ depends: [
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.7"}
   "rresult" {>= "0.6.0"}
-  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0.0"})
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0"})
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.4/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.4/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib0"
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.8"}
-  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0.0"})
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0"})
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.5/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.10.5/opam
@@ -24,7 +24,7 @@ depends: [
   "sexplib0"
   "zarith" {>= "1.4"}
   "eqaf" {>= "0.8"}
-  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0.0"})
+  (("mirage-no-solo5" & "mirage-no-xen") | "zarith-freestanding" | "mirage-runtime" {>= "4.0"})
 ]
 conflicts: [
   "mirage-xen" {< "6.0.0"}


### PR DESCRIPTION
extracted from #20558 /cc @samoht @dinosaure 