### PR TITLE
functoria 3.x: require fmt 0.8.5 (Fmt.failwith with the right signatu…

### DIFF
--- a/packages/functoria/functoria.3.0.1/opam
+++ b/packages/functoria/functoria.3.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ocamlgraph"
   "logs"
   "bos"

--- a/packages/functoria/functoria.3.0.2/opam
+++ b/packages/functoria/functoria.3.0.2/opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ocamlgraph"
   "logs"
   "bos"

--- a/packages/functoria/functoria.3.0.3/opam
+++ b/packages/functoria/functoria.3.0.3/opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ocamlgraph"
   "logs"
   "bos"

--- a/packages/functoria/functoria.3.1.0/opam
+++ b/packages/functoria/functoria.3.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ocamlgraph"
   "logs"
   "bos"

--- a/packages/functoria/functoria.3.1.1/opam
+++ b/packages/functoria/functoria.3.1.1/opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {>= "0.9.8"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.5"}
   "ocamlgraph"
   "logs"
   "bos"


### PR DESCRIPTION
…re), fixes #20564

Extracted from #20558 