### PR TITLE
jbuilder is not compatible with OCaml 5.00

### DIFF
--- a/packages/jbuilder/jbuilder.1.0+beta20.1/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.1/opam
@@ -30,7 +30,7 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free."""
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.00"}
 ]
 url {
   src:

--- a/packages/jbuilder/jbuilder.1.0+beta20.2/opam
+++ b/packages/jbuilder/jbuilder.1.0+beta20.2/opam
@@ -30,7 +30,7 @@ several opam roots/switches simultaneously. This helps maintaining
 packages across several versions of OCaml and gives cross-compilation
 for free."""
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.00"}
 ]
 url {
   src:


### PR DESCRIPTION
The package is deprecated anyway.
Log:
```
#=== ERROR while compiling jbuilder.1.0+beta20.2 ==============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.00.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.00/.opam-switch/build/jbuilder.1.0+beta20.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml bootstrap.ml
# exit-code            2
# env-file             ~/.opam/log/jbuilder-19-58e986.env
# output-file          ~/.opam/log/jbuilder-19-58e986.out
### output ###
# File "./bootstrap.ml", line 21, characters 29-46:
# 21 |     let capitalize_ascii   = String.capitalize
#                                   ^^^^^^^^^^^^^^^^^
# Error: Unbound value String.capitalize

- File "./bootstrap.ml", line 21, characters 29-46:
- 21 |     let capitalize_ascii   = String.capitalize
-                                   ^^^^^^^^^^^^^^^^^
- Error: Unbound value String.capitalize
```