### PR TITLE
dune < 2.9.2 is not compatible with OCaml 5.00

### DIFF
--- a/packages/dune/dune.2.8.5/opam
+++ b/packages/dune/dune.2.8.5/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.00"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.9.0/opam
+++ b/packages/dune/dune.2.9.0/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.00"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.9.1/opam
+++ b/packages/dune/dune.2.9.1/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.00"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling dune.2.9.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.00.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.00/.opam-switch/build/dune.2.9.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml bootstrap.ml -j 47
# exit-code            2
# env-file             ~/.opam/log/dune-19-000d8e.env
# output-file          ~/.opam/log/dune-19-000d8e.out
### output ###
# File "./bootstrap.ml", line 46, characters 17-27:
# 46 |               && String.sub fn 0 (String.length duneboot) = duneboot
#                       ^^^^^^^^^^
# Warning 6 [labels-omitted]: labels pos, len were omitted in the application of this function.
# File "./bootstrap.ml", line 103, characters 28-37:
# 103 |   let args = Array.to_list (Array.sub Sys.argv 1 (Array.length Sys.argv - 1)) in
#                                   ^^^^^^^^^
# Warning 6 [labels-omitted]: labels pos, len were omitted in the application of this function.
# ocamlc -output-complete-exe -w -24 -g -o .duneboot.exe -I boot unix.cma boot/libs.ml boot/duneboot.ml
# ./.duneboot.exe -j 47
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads build_path_prefix_map.ml
# File "vendor/build_path_prefix_map/src/build_path_prefix_map.ml", line 5, characters 17-31:
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads cmdliner_base.ml
# File "vendor/cmdliner/src/cmdliner_base.ml", line 158, characters 14-27:
# Warning 6 [labels-omitted]: labels kind, ambs were omitted in the application of this function.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads opamLexer.ml
# File "vendor/opam-file-format/src/opamLexer.mll", line 21, characters 2-16:
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads cmdliner_docgen.ml
# File "vendor/cmdliner/src/cmdliner_docgen.ml", line 278, characters 23-39:
# Warning 6 [labels-omitted]: label sec was omitted in the application of this function.
# File "vendor/cmdliner/src/cmdliner_docgen.ml", line 293, characters 22-56:
# Warning 6 [labels-omitted]: label sec was omitted in the application of this function.
# File "vendor/cmdliner/src/cmdliner_docgen.ml", line 294, characters 35-51:
# Warning 6 [labels-omitted]: label sec was omitted in the application of this function.
# File "vendor/cmdliner/src/cmdliner_docgen.ml", line 295, characters 36-52:
# Warning 6 [labels-omitted]: label sec was omitted in the application of this function.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads cmdliner_cline.ml
# File "vendor/cmdliner/src/cmdliner_cline.ml", line 128, characters 20-47:
# Warning 6 [labels-omitted]: labels kind, ambs were omitted in the application of this function.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads cmdliner_arg.ml
# File "vendor/cmdliner/src/cmdliner_arg.ml", line 193, characters 24-50:
# Warning 6 [labels-omitted]: label err was omitted in the application of this function.
# File "vendor/cmdliner/src/cmdliner_arg.ml", line 243, characters 24-50:
# Warning 6 [labels-omitted]: label err was omitted in the application of this function.
# File "vendor/cmdliner/src/cmdliner_arg.ml", line 260, characters 10-36:
# Warning 6 [labels-omitted]: label pos was omitted in the application of this function.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads cmdliner.ml
# File "vendor/cmdliner/src/cmdliner.ml", line 195, characters 25-47:
# Warning 6 [labels-omitted]: label errs was omitted in the application of this function.
# cd _boot && /home/opam/.opam/5.00/bin/ocamlopt.opt -c -g -no-alias-deps -w -49 -I +threads dune_lang__t.ml
# File "src/dune_lang/t.ml", line 81, characters 7-44:
# Error: Unbound value Format.pp_get_formatter_tag_functions
# Hint: Did you mean pp_get_formatter_stag_functions?
```