### PR TITLE
Add: brr.0.0.3

### DIFF
--- a/packages/brr/brr.0.0.3/opam
+++ b/packages/brr/brr.0.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: """Browser programming toolkit for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The brr programmers"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+depends: ["ocaml" {>= "4.08.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "js_of_ocaml-compiler" {>= "4.0.0"}
+          "js_of_ocaml-toplevel" {>= "4.0.0"}
+          "note"]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.3.tbz"
+  checksum: "sha512=5fa5498c57f86799a3bd9743c41991bb7bc347f424258b474ac92d6b7cf645300c9b618ebe78ac3973d6940b38d2d7c415be20c2b68cb89452288bd3f9122add"}
+description: """
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* Note based reactive support (optional and experimental).
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on [Note][note]
+and on the `js_of_ocaml` compiler and runtime – but not on its
+libraries or syntax extension.
+
+[note]: https://erratique.ch/software/note
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: https://erratique.ch/software/brr"""


### PR DESCRIPTION
* Add: `brr.0.0.3` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.3 2022-01-30 La Forclaz (VS)

- Require `js_of_ocaml` 4.0.0:

  * Allows `brr`, `js_of_ocaml`, and `gen_js_api` bindings to be used in the 
    same program.
  * Adding `-no-check-prims` during bytecode linking is no longer required.

  Thanks to Hugo Heuzard for making the ground work in `js_of_ocaml` and 
  providing a patch ([#2](https://github.com/dbuenzli/brr/issues/2), [#33](https://github.com/dbuenzli/brr/issues/33)).
  
- Add `Brr.Ev.beforeunload`.
- Add `Brr.Ev.Pointer.as_mouse`.
- Tweak `Brr.Ev.{Drag,Wheel}.as_mouse_event` into 
  `Brr.Ev.{Drag,Wheel}.as_mouse` to avoid coercion madness.
- Add `Brr.El.{previous,next}_sibling`.
- Add `Brr.El.remove_inline_style`.
- Add `Brr.El.Style.{top,left,right,bottom,position,z_index}`.
- Fix `Blob.of_jstr`. It was not working. Thanks to Kiran Gopinathan for
  the report ([#31](https://github.com/dbuenzli/brr/issues/31)).
- `Ev.target_{of,to}_jv` take and return a `Jv.t` value instead of an `'a`.
  Thanks to Joseph Price for the report ([#28](https://github.com/dbuenzli/brr/issues/28)).

---

Use `b0 cmd -- .opam.publish brr.0.0.3` to update the pull request.