### PR TITLE
[new release] mirage-solo5 (0.7.0)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.7.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.7.0/opam
@@ -17,7 +17,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.7.0"}
   "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.0.1"}

--- a/packages/mirage-solo5/mirage-solo5.0.7.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.7.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.6.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.7.0/mirage-solo5-0.7.0.tbz"
+  checksum: [
+    "sha256=ef2fbc0f51b8c8567f78c2e412a7c29a9457c4d0477abc1e239b3cbe2c9d2130"
+    "sha512=7997bacd9d6737d6747e258e04ff4785ca1232bbaad18bd95ed79f654d56b964f01e127598b17b0eb3f930e918a16a8b844f011401f5bf21b555cc3ce209b705"
+  ]
+}
+x-commit-hash: "225b807f19f02f8288195c2a2e11d065da81d009"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Support Mirage OS 4. Stop manually building and installing
  `libmirage-solo5_bindings.a`. This change is not compatible
  with MirageOS 3 (mirage/mirage-solo5#82, @dinosaure, @TheLortex)
* Rename the OS module into Solo5_os (mirage/mirage-solo5#83, @dinosaure)
