### PR TITLE
[new release] albatross (1.4.1)

### DIFF
--- a/packages/albatross/albatross.1.4.1/opam
+++ b/packages/albatross/albatross.1.4.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+available: os != "macos"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.4.1/albatross-1.4.1.tbz"
+  checksum: [
+    "sha256=c9ad2de7169806ffa2d9879e1365c797f96753147dfdfaa92310bde8e0aba785"
+    "sha512=0622c66c7e2a601057af07e463a6fa1f30fdb38ae614ba0c8d527cf0dcf61f52802ea8fcd2ca1a696496a141f6630082fe386c6248d15038981f56cf14853917"
+  ]
+}
+x-commit-hash: "15f89e1469b3016989fa5c5e95816fb952fcdf9b"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- Debian packaging fix typo in lib_exec_dir (create_package.sh, roburio/albatross#100 @dinosaure)
