### PR TITLE
[new release] mirage-xen (7.0.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.7.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.7.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v7.0.0/mirage-xen-7.0.0.tbz"
+  checksum: [
+    "sha256=ccd11949533b7bbcbe5f35e8cdd189071e9a462d4cfc4ee46cc7891b32f6888f"
+    "sha512=fec022ee38694e9be497e793633c4358190addf39fb6288160d82927eb6426ab0f682ca70f6cc2e0244055d0b046a97aee1dcd80b668ba30f8039e467efafcb9"
+  ]
+}
+x-commit-hash: "0fc00bbddf2a37fd8695d8d68ffb02879a4ed792"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Disable formatting to allow CI to succeed (@hannesm, mirage/mirage-xen#34)
* Be able to compile & generate documentation even if
  the package does not exists into the expected `dune`'s workspace
  (@TheLortex, @dinosaure, mirage/mirage-xen#37)
* **breaking change** `mirage-xen` defines its own `OS` module: `Xen_os`
  (@dinosaure, mirage/mirage-xen#38)
