### PR TITLE
[new release] mirage-unix (5.0.0)

### DIFF
--- a/packages/mirage-unix/mirage-unix.5.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.5.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-unix"
+bug-reports:  "https://github.com/mirage/mirage-unix/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-unix.git"
+doc:          "https://mirage.github.io/mirage-unix/doc"
+license:      "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.11"}
+  "lwt" {>= "2.4.3"}
+  "duration"
+  "mirage-runtime" {>= "4.0"}
+  "io-page" {>= "2.4.0"}
+]
+tags: "org:mirage"
+synopsis: "Unix core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Unix targets, which handles the main loop and timers.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-unix/releases/download/v5.0.0/mirage-unix-5.0.0.tbz"
+  checksum: [
+    "sha256=810d7a69fef779bb20d77d5df83a94cbb88acdd956af1a7669ccd02784fc1e9b"
+    "sha512=5100244a75ab02b680758c371f3b099e76617f74059a0e6c813df67f6bbe43e096a37f0bc5ab02f983ade9eb6c4090a97e9c6bd4b1be2634a1b6fd070bd9375c"
+  ]
+}
+x-commit-hash: "1aa24bb27ddda927036eccdc4346e56d2be122e6"


### PR DESCRIPTION
Unix core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-unix">https://github.com/mirage/mirage-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-unix/doc">https://mirage.github.io/mirage-unix/doc</a>

##### CHANGES:

* **breaking changes** mirage-unix provides its own module `Unix_os` (instead of `OS`) (@dinosaure, mirage/mirage-unix#19)
