### PR TITLE
[new release] mirage-block-solo5 (0.7.0)

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.7.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.7.0/opam
@@ -11,14 +11,14 @@ tags: [
 ]
 
 build: [
- ["dune" "subst"] {pinned}
+ ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
  ["dune" "runtest" "-p" name] {with-test}
 ]
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"  {>= "1.0"}
+  "dune"  {>= "2.0"}
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "6.0.0"}
   "mirage-block" {>= "2.0.0"}

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.7.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.7.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+doc:           "https://mirage.github.io/mirage-block-solo5/"
+license:       "ISC"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {pinned}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-block-solo5/releases/download/v0.7.0/mirage-block-solo5-0.7.0.tbz"
+  checksum: [
+    "sha256=521bf32fefae88a83d28ca9d157760799f1bb88f3e3bb3872be7f3d6e1a5de00"
+    "sha512=4c37cb8e26bc66056e034bebbfd43b7891fbf794637c444148f6c75c9264a61a697310156864c2bf8385406d8eb96fbdf77c75865087b68ebb2359b2a73b12a0"
+  ]
+}
+x-commit-hash: "169ecc177bd8bb41197a3abac943bbfe5b9f9001"


### PR DESCRIPTION
Solo5 implementation of MirageOS block interface

- Project page: <a href="https://github.com/mirage/mirage-block-solo5">https://github.com/mirage/mirage-block-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-solo5/">https://mirage.github.io/mirage-block-solo5/</a>

##### CHANGES:

* Adapt to the new `mirage-block.2.0.0` API (@hannesm, mirage/mirage-block-solo5#20)
* Be able to install & build `mirage-block-solo5` without the expected `dune`'s context
  (@TheLortex, @dinosaure, mirage/mirage-block-solo5#21)
* Use `Solo5_os` instead of `OS` (@dinosaure, mirage/mirage-block-solo5#22)
