### PR TITLE
[new release] mirage-net-solo5 (0.7.0)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.7.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.7.0/opam
@@ -20,7 +20,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"
+  "dune" {>= "2.0"}
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.7.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.7.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.7.0/mirage-net-solo5-0.7.0.tbz"
+  checksum: [
+    "sha256=af3b2b5076040bf286970fb13c31a753cad865de0de787a082631000540265e8"
+    "sha512=e16f768e9c07234842867e7b4dc60d6835f0b7415a6e8553a01825af646e565535318b1aa5650832f66d585303c9fa992598071ead9c0a0a1f86bec8e534c1bc"
+  ]
+}
+x-commit-hash: "57b20fba68ae893e8cf18d61f0bb8ade733c4f28"


### PR DESCRIPTION
Solo5 implementation of MirageOS network interface

- Project page: <a href="https://github.com/mirage/mirage-net-solo5">https://github.com/mirage/mirage-net-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-solo5/">https://mirage.github.io/mirage-net-solo5/</a>

##### CHANGES:

* Upgrade and fix the package with newer version of dependencies (@hannesm, mirage/mirage-net-solo5#37)
* Be able to compile & install `mirage-net-solo5` without the expected `dune`'s context (@TheLortex, @dinosaure, mirage/mirage-net-solo5#38)
* Use `Solo5_os` instead of `OS` (@dinosaure, mirage/mirage-net-solo5#39)
