### PR TITLE
[new release] mirage-console-solo5 (0.7.0)

### DIFF
--- a/packages/mirage-console-solo5/mirage-console-solo5.0.7.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-console-solo5.git"
+doc:           "https://mirage.github.io/mirage-console-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "cstruct"
+  "lwt"
+]
+synopsis: "Solo5 implementation of MirageOS console interface"
+description:
+  "This library implements the MirageOS console interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-console-solo5/releases/download/v0.7.0/mirage-console-solo5-0.7.0.tbz"
+  checksum: [
+    "sha256=f1e8f3c9f4f45a59f6aef544e8634176a2e40078a685bc08996659d3ece29972"
+    "sha512=3b5adcaf90b359481b5ca388f3506e7bd37c47bd3fbe6ab5e510e063ff4961013bfc0e1703c2a1b3043d335f3d9dbd8ce97a1ee04b1aea10999a4dd9c9c6ee5c"
+  ]
+}
+x-commit-hash: "e6d0626d38828983eafafb4c09af17df7008978b"

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.7.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.7.0/opam
@@ -16,7 +16,7 @@ tags: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.08.0"}

--- a/packages/mirage-console-solo5/mirage-console-solo5.0.7.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.7.0/opam
@@ -14,13 +14,13 @@ tags: [
   "org:mirage"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.0"}
+  "dune" {>= "2.0"}
   "mirage-console" {>= "3.0.0"}
   "mirage-solo5" {>= "0.7.0"}
   "cstruct"


### PR DESCRIPTION
Solo5 implementation of MirageOS console interface

- Project page: <a href="https://github.com/mirage/mirage-console-solo5">https://github.com/mirage/mirage-console-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-console-solo5/">https://mirage.github.io/mirage-console-solo5/</a>

##### CHANGES:

* `mirage-console-solo5` requires OCaml 4.08 (@hannesm, mirage/mirage-console-solo5#20)
* Be able to build and install `mirage-console-solo5` without the expected `dune`'s context (@TheLortex, @dinosaure, mirage/mirage-console-solo5#21)
