### PR TITLE
[new release] mirage-block-xen (2.1.0)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.2.1.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "logs"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
-  "ppx_cstruct" {build & >= "3.6.0"}
+  "ppx_cstruct" {>= "3.6.0"}
   "shared-memory-ring"
   "shared-memory-ring-lwt"
   "mirage-block" {>= "2.0.0"}

--- a/packages/mirage-block-xen/mirage-block-xen.2.1.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "shared-memory-ring-lwt"
   "mirage-block" {>= "2.0.0"}
   "io-page" {>= "2.0.0"}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "7.0.0"}
   "xenstore"
 ]
 build: [

--- a/packages/mirage-block-xen/mirage-block-xen.2.1.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.1.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "io-page" {>= "2.0.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v2.1.0/mirage-block-xen-2.1.0.tbz"
+  checksum: [
+    "sha256=42ee97e0604535baa4a7a1393b43cf06370bcefdb952b362c15da05835bbd851"
+    "sha512=8b19c175c5dd82f94b97a89446324ff54f2e6f5007d7a671c2ba6c474b1c66142ae26b08d4b74f062eb6bcb271338c5ee0b6ace5b3bfc27305098c138d512119"
+  ]
+}
+x-commit-hash: "8a2ae2c4cdb2c4cc297c1d85554b01e6d8c78345"


### PR DESCRIPTION
MirageOS block driver for Xen that implements the blkfront/back protocol

- Project page: <a href="https://github.com/mirage/mirage-block-xen">https://github.com/mirage/mirage-block-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-xen/">https://mirage.github.io/mirage-block-xen/</a>

##### CHANGES:

* Lint the OPAM file (@hannesm, mirage/mirage-block-xen#88)
* Replace `OS` by `Xen_os` (@dinosaure, mirage/mirage-block-xen#89)
