### PR TITLE
[new release] mirage-net-xen and netchannel (2.1.0)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "7.0.0"}
   "netchannel" {= version}
   "lwt-dllist"
   "logs" {>= "0.5.0"}

--- a/packages/mirage-net-xen/mirage-net-xen.2.1.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer:    "anil@recoil.org"
 authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
 homepage:      "https://github.com/mirage/mirage-net-xen"
 bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"

--- a/packages/mirage-net-xen/mirage-net-xen.2.1.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.0/mirage-net-xen-2.1.0.tbz"
+  checksum: [
+    "sha256=5c60078cd4debbaaabdfb6f379315e545a65af218b4c5b80af6128cfe9a539de"
+    "sha512=fc51d8198ef9d3be3a093e1a149a2b946b11e830f549a961cde4fa5fcb86e498a1f07700933ba7da152ac6f36b00002e22b5388cc3cad5bc444cdbff81464bca"
+  ]
+}
+x-commit-hash: "bd9d31cc1bf0939d8ef6ba3d16ba0170636e7cb4"

--- a/packages/netchannel/netchannel.2.1.0/opam
+++ b/packages/netchannel/netchannel.2.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "7.0.0"}
   "ipaddr" {>= "3.0.0"}
   "mirage-profile" {>="0.3"}
   "shared-memory-ring" {>="3.0.0"}

--- a/packages/netchannel/netchannel.2.1.0/opam
+++ b/packages/netchannel/netchannel.2.1.0/opam
@@ -26,6 +26,7 @@ depends: [
   "sexplib" {>= "113.01.00"}
   "logs" {>= "0.5.0"}
   "lwt-dllist"
+  "result" {>= "1.5"}
   "macaddr" {>= "5.2.0"}
 ]
 tags: "org:mirage"

--- a/packages/netchannel/netchannel.2.1.0/opam
+++ b/packages/netchannel/netchannel.2.1.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer:    "anil@recoil.org"
 authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
 homepage:      "https://github.com/mirage/mirage-net-xen"
 bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
 dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"

--- a/packages/netchannel/netchannel.2.1.0/opam
+++ b/packages/netchannel/netchannel.2.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "6.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "lwt-dllist"
+  "macaddr" {>= "5.2.0"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.0/mirage-net-xen-2.1.0.tbz"
+  checksum: [
+    "sha256=5c60078cd4debbaaabdfb6f379315e545a65af218b4c5b80af6128cfe9a539de"
+    "sha512=fc51d8198ef9d3be3a093e1a149a2b946b11e830f549a961cde4fa5fcb86e498a1f07700933ba7da152ac6f36b00002e22b5388cc3cad5bc444cdbff81464bca"
+  ]
+}
+x-commit-hash: "bd9d31cc1bf0939d8ef6ba3d16ba0170636e7cb4"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Lint OPAM file (@hannesm, mirage/mirage-net-xen#100)
* Update the project with `cstruct.6.0.0` (@hannesm, mirage/mirage-net-xen#100)
* Rename `OS` by `Xen_os` (@dinosaure, mirage/mirage-net-xen#101)
