### PR TITLE
[new release] mirage-clock, mirage-clock-unix and mirage-clock-freestanding (4.1.0)

### DIFF
--- a/packages/mirage-clock-freestanding/mirage-clock-freestanding.4.1.0/opam
+++ b/packages/mirage-clock-freestanding/mirage-clock-freestanding.4.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mirage-clock" {= version}
+]
+conflicts: [
+  "mirage-solo5" {< "0.7.0"}
+  "mirage-xen" {< "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.1.0/mirage-clock-4.1.0.tbz"
+  checksum: [
+    "sha256=b08d4e949336d3a678ade1807e83e74ca8a3f6ee68db00770277e19b3ee183b6"
+    "sha512=27f0e3527e1bd34dc93327e69a30ef8b92e158b03065a8bffa8d59fa45853ed4145c761f448be3c16246c0e1adb582e584ca8d73dca6b66b1f20657955b5a148"
+  ]
+}
+x-commit-hash: "dd8fd33bb4e73ebe3710af4262192908db0ff7c3"

--- a/packages/mirage-clock-unix/mirage-clock-unix.4.1.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.4.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.1.0/mirage-clock-4.1.0.tbz"
+  checksum: [
+    "sha256=b08d4e949336d3a678ade1807e83e74ca8a3f6ee68db00770277e19b3ee183b6"
+    "sha512=27f0e3527e1bd34dc93327e69a30ef8b92e158b03065a8bffa8d59fa45853ed4145c761f448be3c16246c0e1adb582e584ca8d73dca6b66b1f20657955b5a148"
+  ]
+}
+x-commit-hash: "dd8fd33bb4e73ebe3710af4262192908db0ff7c3"

--- a/packages/mirage-clock/mirage-clock.4.1.0/opam
+++ b/packages/mirage-clock/mirage-clock.4.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.1.0/mirage-clock-4.1.0.tbz"
+  checksum: [
+    "sha256=b08d4e949336d3a678ade1807e83e74ca8a3f6ee68db00770277e19b3ee183b6"
+    "sha512=27f0e3527e1bd34dc93327e69a30ef8b92e158b03065a8bffa8d59fa45853ed4145c761f448be3c16246c0e1adb582e584ca8d73dca6b66b1f20657955b5a148"
+  ]
+}
+x-commit-hash: "dd8fd33bb4e73ebe3710af4262192908db0ff7c3"


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-clock">https://github.com/mirage/mirage-clock</a>
- Documentation: <a href="https://mirage.github.io/mirage-clock/">https://mirage.github.io/mirage-clock/</a>

##### CHANGES:

* Be able to build & instal the distribution via `opam` without the expected `dune`'s context (@TheLortex, @dinosaure, mirage/mirage-clock#49)
