### PR TITLE
[new release] mirage-console, mirage-console-xen, mirage-console-xen-proto, mirage-console-xen-backend and mirage-console-unix (5.1.0)

### DIFF
--- a/packages/mirage-console-unix/mirage-console-unix.5.1.0/opam
+++ b/packages/mirage-console-unix/mirage-console-unix.5.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt" {>= "6.0.0"}
+  "mirage-console" {=version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage consoles for Unix"
+description: """
+This implements a MirageOS console device for use with
+Unix-based targets.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.1.0/mirage-console-5.1.0.tbz"
+  checksum: [
+    "sha256=9a36118ac6cd3896d8a12b96686a0fb9e5da926a80c265a1d004ef2cbb2fa4d3"
+    "sha512=2b27d4a34889e2152436dc650fa02d04d1b2690889f4c2d6e412381a76bf3417bc4a918663e565d9ccb02f67614ceb7242a989021237ca3a69198fc21a314ef1"
+  ]
+}
+x-commit-hash: "2918c0fcb5b19cad3d5a55ec0338ee4b49ceb97e"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.1.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "7.0.0"}
   "io-page" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
   "fmt" {>= "0.8.7"}

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.1.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "io-page" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
   "fmt" {>= "0.8.7"}
+  "cstruct" {>= "6.0.0"}
   "xenstore"
   "shared-memory-ring"
   "shared-memory-ring-lwt"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.1.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "6.0.0"}
+  "io-page" {>= "2.0.0"}
+  "lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.7"}
+  "xenstore"
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console backend for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.1.0/mirage-console-5.1.0.tbz"
+  checksum: [
+    "sha256=9a36118ac6cd3896d8a12b96686a0fb9e5da926a80c265a1d004ef2cbb2fa4d3"
+    "sha512=2b27d4a34889e2152436dc650fa02d04d1b2690889f4c2d6e412381a76bf3417bc4a918663e565d9ccb02f67614ceb7242a989021237ca3a69198fc21a314ef1"
+  ]
+}
+x-commit-hash: "2918c0fcb5b19cad3d5a55ec0338ee4b49ceb97e"

--- a/packages/mirage-console-xen-proto/mirage-console-xen-proto.5.1.0/opam
+++ b/packages/mirage-console-xen-proto/mirage-console-xen-proto.5.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-console" {= version}
+  "xenstore"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console protocol for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.1.0/mirage-console-5.1.0.tbz"
+  checksum: [
+    "sha256=9a36118ac6cd3896d8a12b96686a0fb9e5da926a80c265a1d004ef2cbb2fa4d3"
+    "sha512=2b27d4a34889e2152436dc650fa02d04d1b2690889f4c2d6e412381a76bf3417bc4a918663e565d9ccb02f67614ceb7242a989021237ca3a69198fc21a314ef1"
+  ]
+}
+x-commit-hash: "2918c0fcb5b19cad3d5a55ec0338ee4b49ceb97e"

--- a/packages/mirage-console-xen/mirage-console-xen.5.1.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.5.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "io-page" {>= "2.0.0"}
+  "xenstore"
+  "shared-memory-ring"
+  "lwt"
+  "mirage-flow"
+  "mirage-console" {=version}
+  "mirage-console-xen-proto" {=version}
+  "mirage-xen" {>= "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementation of Mirage console for Xen"
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.1.0/mirage-console-5.1.0.tbz"
+  checksum: [
+    "sha256=9a36118ac6cd3896d8a12b96686a0fb9e5da926a80c265a1d004ef2cbb2fa4d3"
+    "sha512=2b27d4a34889e2152436dc650fa02d04d1b2690889f4c2d6e412381a76bf3417bc4a918663e565d9ccb02f67614ceb7242a989021237ca3a69198fc21a314ef1"
+  ]
+}
+x-commit-hash: "2918c0fcb5b19cad3d5a55ec0338ee4b49ceb97e"

--- a/packages/mirage-console-xen/mirage-console-xen.5.1.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.5.1.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "io-page" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
   "xenstore"
   "shared-memory-ring"
   "lwt"

--- a/packages/mirage-console/mirage-console.5.1.0/opam
+++ b/packages/mirage-console/mirage-console.5.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-console"
+doc: "https://mirage.github.io/mirage-console/"
+bug-reports: "https://github.com/mirage/mirage-console/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-console.git"
+synopsis: "Implementations of Mirage console devices"
+description: """
+This is a general implementation of a console device, intended
+for use in MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-console/releases/download/v5.1.0/mirage-console-5.1.0.tbz"
+  checksum: [
+    "sha256=9a36118ac6cd3896d8a12b96686a0fb9e5da926a80c265a1d004ef2cbb2fa4d3"
+    "sha512=2b27d4a34889e2152436dc650fa02d04d1b2690889f4c2d6e412381a76bf3417bc4a918663e565d9ccb02f67614ceb7242a989021237ca3a69198fc21a314ef1"
+  ]
+}
+x-commit-hash: "2918c0fcb5b19cad3d5a55ec0338ee4b49ceb97e"


### PR DESCRIPTION
Implementations of Mirage console devices

- Project page: <a href="https://github.com/mirage/mirage-console">https://github.com/mirage/mirage-console</a>
- Documentation: <a href="https://mirage.github.io/mirage-console/">https://mirage.github.io/mirage-console/</a>

##### CHANGES:

* Replace `OS` by `Xen_os` (@dinosaure, mirage/mirage-console#87)
