### PR TITLE
[new release] rpclib, rpclib-lwt, rpclib-js, rpclib-html, rpclib-async, rpc and ppx_deriving_rpc (8.1.2)

### DIFF
--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.2/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.8.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for ocaml-rpc, a library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {= version}
+  "rresult" {>= "0.3.0"}
+  "ppxlib" {>= "0.18.0"}
+  "lwt" {with-test & >= "3.0.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"

--- a/packages/rpc/rpc.8.1.2/opam
+++ b/packages/rpc/rpc.8.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - meta-package"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project" "deprecated"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpc"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.04.1"}
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "rpclib-lwt" {=version}
+  "ppx_deriving_rpc" {=version}
+  "alcotest" {with-test}
+  "md2mld" {with-doc & >= "0.4.0"}
+  "conf-which" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+    ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+    ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+
+This is a dummy package installing the main library components.
+"""
+post-messages: ["DEPRECATED. This package is a virtual package and is outdated, you should consider using directly rpclib, rpclib-lwt, rpclib-async and ppx_deriving_rpc instead"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"

--- a/packages/rpclib-async/rpclib-async.8.1.2/opam
+++ b/packages/rpclib-async/rpclib-async.8.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Async interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "async" {>= "v0.9.0"}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"

--- a/packages/rpclib-html/rpclib-html.8.1.2/opam
+++ b/packages/rpclib-html/rpclib-html.8.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis:
+  "A library to deal with RPCs in OCaml - html documentation generator"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "cow" {>= "2.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"

--- a/packages/rpclib-js/rpclib-js.8.1.2/opam
+++ b/packages/rpclib-js/rpclib-js.8.1.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Bindings for js_of_ocaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "js_of_ocaml" {>= "3.5.0"}
+  "js_of_ocaml-ppx" {>= "3.5.0"}
+  "lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"

--- a/packages/rpclib-lwt/rpclib-lwt.8.1.2/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.8.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml - Lwt interface"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib-lwt"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "rpclib" {=version}
+  "lwt" {>= "3.0.0"}
+  "alcotest-lwt" {with-test}
+  "ppx_deriving_rpc" {with-test & =version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"

--- a/packages/rpclib/rpclib.8.1.2/opam
+++ b/packages/rpclib/rpclib.8.1.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A library to deal with RPCs in OCaml"
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire, Jon Ludlam"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-rpc"
+doc: "https://mirage.github.io/ocaml-rpc/rpclib"
+bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "alcotest" {with-test}
+  "dune" {>= "2.0.0"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "0.9.8"}
+  "rresult" {>= "0.3.0"}
+  "xmlm"
+  "yojson" {>= "1.7.0"}
+]
+conflicts: [
+   "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git://github.com/mirage/ocaml-rpc"
+description: """
+`ocaml-rpc` is a library that provides remote procedure calls (RPC)
+using XML or JSON as transport encodings, and multiple generators
+for documentations, clients, servers, javascript bindings, python
+bindings, ...
+
+The transport mechanism itself is outside the scope of this library
+as all conversions are from and to strings.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-rpc/releases/download/8.1.2/rpclib-8.1.2.tbz"
+  checksum: [
+    "sha256=b1f0e975f8522a91cccef03569b8f372eca4e666e9f3c20d2a9d82d0e096b235"
+    "sha512=ef75ec6032805b08bd49716d5e9a4ca888c1a581b50e4ad5cc1d003cd182a47cfc87c945e7564251c8e041fc3ffa1b11e0579597fc9806db88955b3e029ba4a3"
+  ]
+}
+x-commit-hash: "78c858a17a25af0ef245db86bc96202b81a0cd14"


### PR DESCRIPTION
A library to deal with RPCs in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-rpc">https://github.com/mirage/ocaml-rpc</a>
- Documentation: <a href="https://mirage.github.io/ocaml-rpc/rpclib">https://mirage.github.io/ocaml-rpc/rpclib</a>

##### CHANGES:

* Add the `noargs` constructor for declaring interfaces that do not take any
  parameters. (tbrk mirage/ocaml-rpc#170)
* Allow Xmlrpc callers to override the base64 decoding function. (tbrk mirage/ocaml-rpc#171)
