### PR TITLE
Package ocsigen-toolkit.3.1.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.1.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.1.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/3.1.0.tar.gz"
+  checksum: [
+    "md5=393b04099b25a3faec73e194188df3c5"
+    "sha512=6f8d9ab7a678032e574bcb56b2e7f4e38d559eff1236065048e4270174f296a416c02e942ca358fd5d539ec0bd7814207e104fa10e8b4ef1532f4e7cb23d9aca"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.1.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0