### PR TITLE
Patch world breaking gitlab-unix.0.1.0 installation

### DIFF
--- a/packages/gitlab-unix/gitlab-unix.0.1.0/files/no-diff-installed.patch
+++ b/packages/gitlab-unix/gitlab-unix.0.1.0/files/no-diff-installed.patch
@@ -1,0 +1,12 @@
+--- a/test/dune	2022-02-02 10:44:47.000000000 +0000
++++ b/test/dune	2022-02-02 10:45:06.000000000 +0000
+@@ -7,9 +7,7 @@
+ ;   (source_tree cases)))
+
+ (executable
+- (package gitlab-unix)
+  (libraries gitlab-unix cmdliner)
+- (public_name diff)
+  (modules diff)
+  (name diff))
+

--- a/packages/gitlab-unix/gitlab-unix.0.1.0/opam
+++ b/packages/gitlab-unix/gitlab-unix.0.1.0/opam
@@ -25,6 +25,9 @@ depends: [
   "mdx" {with-test}
   "odoc" {with-doc}
 ]
+patches: [
+  "no-diff-installed.patch"
+]
 build: [
   ["dune" "subst"] {dev}
   [
@@ -41,6 +44,9 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/tmcgilchrist/ocaml-gitlab.git"
+extra-files: [
+  ["no-diff-installed.patch" "md5=6a44152813a8357668b081c331c0aec9"]
+]
 url {
   src:
     "https://github.com/tmcgilchrist/ocaml-gitlab/releases/download/0.1.0/lab-0.1.0.tbz"


### PR DESCRIPTION
Installing `diff` will break anyone (including opam itself) trying to do anything after installing `gitlab-unix.0.1.0`

Reported by @dinosaure 
cc @tmcgilchrist