### PR TITLE
Fix constraints about the new release of MirageOS 4.0.0

### DIFF
--- a/packages/git-unix/git-unix.3.7.0/opam
+++ b/packages/git-unix/git-unix.3.7.0/opam
@@ -33,7 +33,7 @@ depends: [
   "astring" {>= "0.8.5"}
   "awa" {>= "0.0.5"}
   "mirage-time"
-  "mirage-unix" {>= "4.0.0"}
+  "mirage-unix" {>= "4.0.0" & < "5.0.0"}
   "cmdliner" {>= "1.0.4"}
   "decompress" {>= "1.4.0"}
   "domain-name" {>= "0.3.0"}

--- a/packages/mirage-block-solo5/mirage-block-solo5.0.6.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.6.1/opam
@@ -22,7 +22,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "mirage-block" {>= "2.0.0"}
-  "mirage-solo5" {>= "0.6.0" & < "0.8.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
   "fmt"
 ]
 synopsis: "Solo5 implementation of MirageOS block interface"

--- a/packages/mirage-block-xen/mirage-block-xen.2.0.0/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "shared-memory-ring-lwt"
   "mirage-block" {>= "2.0.0"}
   "io-page" {>= "2.0.0"}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
   "xenstore"
 ]
 build: [

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.4.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.4.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
   "io-page" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
   "xenstore"

--- a/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.0.0/opam
+++ b/packages/mirage-console-xen-backend/mirage-console-xen-backend.5.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
   "io-page" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
   "fmt" {>= "0.8.7"}

--- a/packages/mirage-console-xen/mirage-console-xen.4.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.4.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "mirage-flow"
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mirage-console-xen/mirage-console-xen.5.0.0/opam
+++ b/packages/mirage-console-xen/mirage-console-xen.5.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "mirage-flow"
   "mirage-console" {=version}
   "mirage-console-xen-proto" {=version}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
   "cstruct" {>= "6.0.0"}
 ]
 build: [

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.2/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.3/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.3/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.4/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.4/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.5/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.10.5/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.0/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.10/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.10/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.5/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.5/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.6/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.6/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.7/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.7/opam
@@ -21,7 +21,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.8/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.8.8/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.1/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.2/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.9.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-runtime" {>= "3.8.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
   "mirage-time-unix" {with-test & >= "2.0.0"}
   "mirage-clock-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-entropy/mirage-entropy.0.5.1/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.5.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.7.0"}
   "ocaml" {>= "4.07.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-runtime" {>= "3.7.0"}
+  "mirage-runtime" {>= "3.7.0" & < "4.0"}
   "lwt" {>= "4.0.0"}
   "mirage-unix" {with-test & >= "3.0.0"}
 ]

--- a/packages/mirage-net-solo5/mirage-net-solo5.0.6.2/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.6.2/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "macaddr" { >= "4.0.0"}
-  "mirage-solo5" {>= "0.6.0" & < "0.8.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
   "logs" {>= "0.6.0"}
   "metrics"
   "fmt"

--- a/packages/mirage-net-xen/mirage-net-xen.2.0.0/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-net" {>= "3.0.0"}
   "io-page" {>= "1.5.0"}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
   "netchannel" {= version}
   "lwt-dllist"
   "logs" {>= "0.5.0"}

--- a/packages/vchan-xen/vchan-xen.6.0.0/opam
+++ b/packages/vchan-xen/vchan-xen.6.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "io-page"
   "mirage-flow" {>= "2.0.0"}
   "xenstore" {>= "1.2.2"}
-  "mirage-xen" {>= "6.0.0"}
+  "mirage-xen" {>= "6.0.0" & < "7.0.0"}
   "xenstore_transport" {>= "1.0.0"}
   "sexplib"
   "cmdliner"


### PR DESCRIPTION
Related to #20621 which fixes few constraints. Only `git`, `vchan-xen` and `mirage-entropy` probably needs a release.