### PR TITLE
Package ocsigen-ppx-rpc.1.0

### DIFF
--- a/packages/ocsigen-ppx-rpc/ocsigen-ppx-rpc.1.0/opam
+++ b/packages/ocsigen-ppx-rpc/ocsigen-ppx-rpc.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "dev@ocsigen.org"
+maintainer: "dev@ocsigen.org"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocsigen/ocsigen-ppx-rpc/"
+bug-reports: "https://github.com/ocsigen/ocsigen-ppx-rpc/issues"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-ppx-rpc.git"
+synopsis: "This PPX adds a syntax for RPCs for Eliom and Ocsigen Start"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.8"}
+  "ppxlib" {>= "0.15.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-ppx-rpc/archive/1.0.tar.gz"
+  checksum: [
+    "md5=5d77314a867eeed90a716df837da5ac9"
+    "sha512=a4399b48b7ff0fc62a9ec69b0b982350b39cfb5b18d4a13f9aee3e68b78b4a61d65d02d5d8cd08745455a417a44f964c69b6b8709494cf4de57dbf2700cdef68"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-ppx-rpc.1.0`
This PPX adds a syntax for RPCs for Eliom and Ocsigen Start



---
* Homepage: https://github.com/ocsigen/ocsigen-ppx-rpc/
* Source repo: git+https://github.com/ocsigen/ocsigen-ppx-rpc.git
* Bug tracker: https://github.com/ocsigen/ocsigen-ppx-rpc/issues

---
:camel: Pull-request generated by opam-publish v2.1.0