### PR TITLE
Package ocsigen-toolkit.3.1.1

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.1.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "3.6.0" & < "4.0.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/3.1.1.tar.gz"
+  checksum: [
+    "md5=7b02f3d930db29ad107a1bc3fd5e407d"
+    "sha512=96b3008450683262eed37f447e7f323493ce444b07efdd189df57a3ec3e0cc4e25a16e8790ea1f3635db0aca77f0bfc290d7c26d26199694154aae130a44d684"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.1.1`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0