### PR TITLE
Package ocsigen-toolkit.3.2.0

### DIFF
--- a/packages/ocsigen-toolkit/ocsigen-toolkit.3.2.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.3.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+synopsis: "Reusable UI components for Eliom applications (client only, or client-server)"
+description: "The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications."
+authors: "dev@ocsigen.org"
+homepage: "http://www.ocsigen.org"
+bug-reports: "https://github.com/ocsigen/ocsigen-toolkit/issues/"
+dev-repo: "git+https://github.com/ocsigen/ocsigen-toolkit.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [ make "-j%{jobs}%" ]
+install: [ make "install" ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "js_of_ocaml" {>= "4.0.0" & < "4.1.0"}
+  "eliom" {>= "6.12.1"}
+  "calendar" {>= "2.0.0"}
+]
+url {
+  src: "https://github.com/ocsigen/ocsigen-toolkit/archive/3.2.0.tar.gz"
+  checksum: [
+    "md5=30e9d9771e497c0e8966b06e793cee3d"
+    "sha512=34808d92141528cb41e5e29d67655172f7486373a230183568845ca513a658d996354a2132b7028b92053940d907ba1e614d7ad276c129dbf1e3a466e99b91b0"
+  ]
+}


### PR DESCRIPTION
### `ocsigen-toolkit.3.2.0`
Reusable UI components for Eliom applications (client only, or client-server)
The Ocsigen Toolkit is a set of user interface widgets that facilitate the development of Eliom applications.



---
* Homepage: http://www.ocsigen.org
* Source repo: git+https://github.com/ocsigen/ocsigen-toolkit.git
* Bug tracker: https://github.com/ocsigen/ocsigen-toolkit/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0