### PR TITLE
secp256k1-internal.0.3 - Fix archive

### DIFF
--- a/packages/secp256k1-internal/secp256k1-internal.0.3.1/opam
+++ b/packages/secp256k1-internal/secp256k1-internal.0.3.1/opam
@@ -8,8 +8,6 @@ license: "MIT"
 bug-reports: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
 
-flags: avoid-version
-
 build: [
   ["dune" "build" "-j" jobs "-p" name "@install"]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -30,9 +28,9 @@ depends: [
 available: arch != "s390x"
 
 url {
-  src: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/v0.2/ocaml-secp256k1-internal-0.3.tar.bz2"
+  src: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/0.3/ocaml-secp256k1-internal-0.3.tar.bz2"
   checksum: [
-    "sha256=a5e78b8210b000217b98771984d706dddbbb12983bd758a52c23a6746da9ddd8"
-    "sha512=3c40a5c19d697d153a14d9df3016d77041fea2eef0a831e6514f3b22e1cda3a0a1240631c94890fb8447eba64fe346bb59ab83ac108e22dbc89f7d547a3af83c"
+    "sha256=cc9c1f7ed70f30c17bddd45b2f95a83ab96d347432930856477709dc67643a63"
+    "sha512=66d4012a78ada07e85a8c3aedb367fbacd9b997347a8cdcdc3c7e39f302088a1d06a5741e5dd1f33456dd5676982d5d676612ae6511b90bc807d911472b9863e"
   ]
 }


### PR DESCRIPTION
Folllowing #20542
The archive was incorrect. I fixed it and bump the minor version.
Also "marked" secp256k1-internal.0.3.0 as broken