### PR TITLE
Add: uutf.1.0.3

### DIFF
--- a/packages/uutf/uutf.1.0.3/opam
+++ b/packages/uutf/uutf.1.0.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: """Non-blocking streaming Unicode codec for OCaml"""
+maintainer: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+authors: ["The uutf programmers"]
+homepage: "https://erratique.ch/software/uutf"
+doc: "https://erratique.ch/software/uutf/doc/"
+dev-repo: "git+https://erratique.ch/repos/uutf.git"
+bug-reports: "https://github.com/dbuenzli/uutf/issues"
+license: ["ISC"]
+tags: ["unicode" "text" "utf-8" "utf-16" "codec" "org:erratique"]
+depends: ["ocaml" {>= "4.03.0"}
+          "ocamlfind" {build}
+          "ocamlbuild" {build}
+          "topkg" {build & >= "1.0.3"}]
+depopts: ["cmdliner"]
+conflicts: ["cmdliner" {< "0.9.8"}]
+build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"
+          "--with-cmdliner" "%{cmdliner:installed}%"]]
+url {
+  src: "https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz"
+  checksum: "sha512=50cc4486021da46fb08156e9daec0d57b4ca469b07309c508d5a9a41e9dbcf1f32dec2ed7be027326544453dcaf9c2534919395fd826dc7768efc6cc4bfcc9f8"}
+description: """
+Uutf is a non-blocking streaming codec to decode and encode the UTF-8,
+UTF-16, UTF-16LE and UTF-16BE encoding schemes. It can efficiently
+work character by character without blocking on IO. Decoders perform
+character position tracking and support newline normalization.
+
+Functions are also provided to fold over the characters of UTF encoded
+OCaml string values and to directly encode characters in OCaml
+Buffer.t values. **Note** that since OCaml 4.14, that functionality
+can be found in the Stdlib and you are encouraged to migrate to it.
+
+Uutf has no dependency and is distributed under the ISC license.
+
+Home page: http://erratique.ch/software/uutf  
+Contact: Daniel Bünzli `<daniel.buenzl i@erratique.ch>`"""


### PR DESCRIPTION
* Add: `uutf.1.0.3` [home](https://erratique.ch/software/uutf), [doc](https://erratique.ch/software/uutf/doc/), [issues](https://github.com/dbuenzli/uutf/issues)  
  *Non-blocking streaming Unicode codec for OCaml*


---

#### `uutf` v1.0.3 2022-02-03

- Support for OCaml 5.00, thanks to Kate (@kit-ty-kate) for
  the patch.

---

Use `b0 cmd -- .opam.publish uutf.1.0.3` to update the pull request.