### PR TITLE
Package binaryen.0.12.1

### DIFF
--- a/packages/binaryen/binaryen.0.12.1/opam
+++ b/packages/binaryen/binaryen.0.12.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "102.0.4" & < "103.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.12.1/binaryen-archive-v0.12.1.tar.gz"
+  checksum: [
+    "md5=ffed26e73a1a38edab292888d38b8773"
+    "sha512=05a14a58c0798ca98288bb44083f812455a931dc4dd9112db5071af278528d6ae42eeef7d8dc038be9baef4256427857f41c9634477ee659254ae814ab231410"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.12.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.0.3