### PR TITLE
Add a post-message for num's known install failure

### DIFF
--- a/packages/num/num.0/opam
+++ b/packages/num/num.0/opam
@@ -17,14 +17,3 @@ depends: [
 ]
 synopsis:
   "The Num library for arbitrary-precision integer and rational arithmetic"
-post-messages: [
-  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
-is due to a known packaging bug with the num package. As a workaround run the following two commands,
-then try to reinstall the target package again:
-
-  ocamlfind remove num
-  ocamlfind remove num-top
-
-See https://github.com/ocaml/opam-repository/issues/14646 for details."
-  {failure}
-]

--- a/packages/num/num.0/opam
+++ b/packages/num/num.0/opam
@@ -17,3 +17,14 @@ depends: [
 ]
 synopsis:
   "The Num library for arbitrary-precision integer and rational arithmetic"
+post-messages: [
+  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
+is due to a known packaging bug with the num package. As a workaround run the following two commands,
+then try to reinstall the target package again:
+
+  ocamlfind remove num
+  ocamlfind remove num-top
+
+See https://github.com/ocaml/opam-repository/issues/14646 for details."
+  {failure}
+]

--- a/packages/num/num.1.0/opam
+++ b/packages/num/num.1.0/opam
@@ -39,3 +39,14 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.0.tar.gz"
   checksum: "md5=a4c359108d0b885bf43909e705b21291"
 }
+post-messages: [
+  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
+is due to a known packaging bug with the num package. As a workaround run the following two commands,
+then try to reinstall the target package again:
+
+  ocamlfind remove num
+  ocamlfind remove num-top
+
+See https://github.com/ocaml/opam-repository/issues/14646 for details."
+  {failure}
+]

--- a/packages/num/num.1.0/opam
+++ b/packages/num/num.1.0/opam
@@ -14,9 +14,13 @@ build: [
   [make]
 ]
 install: [
-  make
-  "install" {!ocaml:preinstalled}
-  "findlib-install" {ocaml:preinstalled}
+  ["ocamlfind" "remove" "num"]
+  ["ocamlfind" "remove" "num-top"]
+  [
+    make
+    "install" {!ocaml:preinstalled}
+    "findlib-install" {ocaml:preinstalled}
+  ]
 ]
 remove: [
   make
@@ -39,14 +43,3 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.0.tar.gz"
   checksum: "md5=a4c359108d0b885bf43909e705b21291"
 }
-post-messages: [
-  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
-is due to a known packaging bug with the num package. As a workaround run the following two commands,
-then try to reinstall the target package again:
-
-  ocamlfind remove num
-  ocamlfind remove num-top
-
-See https://github.com/ocaml/opam-repository/issues/14646 for details."
-  {failure}
-]

--- a/packages/num/num.1.1/opam
+++ b/packages/num/num.1.1/opam
@@ -39,3 +39,14 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.1.tar.gz"
   checksum: "md5=710cbe18b144955687a03ebab439ff2b"
 }
+post-messages: [
+  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
+is due to a known packaging bug with the num package. As a workaround run the following two commands,
+then try to reinstall the target package again:
+
+  ocamlfind remove num
+  ocamlfind remove num-top
+
+See https://github.com/ocaml/opam-repository/issues/14646 for details."
+  {failure}
+]

--- a/packages/num/num.1.1/opam
+++ b/packages/num/num.1.1/opam
@@ -14,9 +14,13 @@ build: [
   [make]
 ]
 install: [
-  make
-  "install" {!ocaml:preinstalled}
-  "findlib-install" {ocaml:preinstalled}
+  ["ocamlfind" "remove" "num"]
+  ["ocamlfind" "remove" "num-top"]
+  [
+    make
+    "install" {!ocaml:preinstalled}
+    "findlib-install" {ocaml:preinstalled}
+  ]
 ]
 remove: [
   make
@@ -39,14 +43,3 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.1.tar.gz"
   checksum: "md5=710cbe18b144955687a03ebab439ff2b"
 }
-post-messages: [
-  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
-is due to a known packaging bug with the num package. As a workaround run the following two commands,
-then try to reinstall the target package again:
-
-  ocamlfind remove num
-  ocamlfind remove num-top
-
-See https://github.com/ocaml/opam-repository/issues/14646 for details."
-  {failure}
-]

--- a/packages/num/num.1.2/opam
+++ b/packages/num/num.1.2/opam
@@ -14,9 +14,13 @@ build: [
   [make]
 ]
 install: [
-  make
-  "install" {!ocaml:preinstalled}
-  "findlib-install" {ocaml:preinstalled}
+  ["ocamlfind" "remove" "num"]
+  ["ocamlfind" "remove" "num-top"]
+  [
+    make
+    "install" {!ocaml:preinstalled}
+    "findlib-install" {ocaml:preinstalled}
+  ]
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
@@ -33,14 +37,3 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.2.tar.gz"
   checksum: "md5=4f43ce8e44db68692bee50f2f8ef911c"
 }
-post-messages: [
-  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
-is due to a known packaging bug with the num package. As a workaround run the following two commands,
-then try to reinstall the target package again:
-
-  ocamlfind remove num
-  ocamlfind remove num-top
-
-See https://github.com/ocaml/opam-repository/issues/14646 for details."
-  {failure}
-]

--- a/packages/num/num.1.2/opam
+++ b/packages/num/num.1.2/opam
@@ -33,3 +33,14 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.2.tar.gz"
   checksum: "md5=4f43ce8e44db68692bee50f2f8ef911c"
 }
+post-messages: [
+  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
+is due to a known packaging bug with the num package. As a workaround run the following two commands,
+then try to reinstall the target package again:
+
+  ocamlfind remove num
+  ocamlfind remove num-top
+
+See https://github.com/ocaml/opam-repository/issues/14646 for details."
+  {failure}
+]

--- a/packages/num/num.1.3/opam
+++ b/packages/num/num.1.3/opam
@@ -13,9 +13,13 @@ build: [
   [make]
 ]
 install: [
-  make
-  "install" {!ocaml:preinstalled}
-  "findlib-install" {ocaml:preinstalled}
+  ["ocamlfind" "remove" "num"]
+  ["ocamlfind" "remove" "num-top"]
+  [
+    make
+    "install" {!ocaml:preinstalled}
+    "findlib-install" {ocaml:preinstalled}
+  ]
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
@@ -32,14 +36,3 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.3.tar.gz"
   checksum: "md5=f074e12325e84ebc883b37e5db10403d"
 }
-post-messages: [
-  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
-is due to a known packaging bug with the num package. As a workaround run the following two commands,
-then try to reinstall the target package again:
-
-  ocamlfind remove num
-  ocamlfind remove num-top
-
-See https://github.com/ocaml/opam-repository/issues/14646 for details."
-  {failure}
-]

--- a/packages/num/num.1.3/opam
+++ b/packages/num/num.1.3/opam
@@ -32,3 +32,14 @@ url {
   src: "https://github.com/ocaml/num/archive/v1.3.tar.gz"
   checksum: "md5=f074e12325e84ebc883b37e5db10403d"
 }
+post-messages: [
+  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
+is due to a known packaging bug with the num package. As a workaround run the following two commands,
+then try to reinstall the target package again:
+
+  ocamlfind remove num
+  ocamlfind remove num-top
+
+See https://github.com/ocaml/opam-repository/issues/14646 for details."
+  {failure}
+]

--- a/packages/num/num.1.4/opam
+++ b/packages/num/num.1.4/opam
@@ -13,9 +13,13 @@ depends: [
 conflicts: ["base-num"]
 build: make
 install: [
-  make
-  "install" {!ocaml:preinstalled}
-  "findlib-install" {ocaml:preinstalled}
+  ["ocamlfind" "remove" "num"]
+  ["ocamlfind" "remove" "num-top"]
+  [
+    make
+    "install" {!ocaml:preinstalled}
+    "findlib-install" {ocaml:preinstalled}
+  ]
 ]
 dev-repo: "git+https://github.com/ocaml/num.git"
 url {
@@ -25,14 +29,3 @@ url {
     "sha512=0cc9be8ad95704bb683b4bf6698bada1ee9a40dc05924b72adc7b969685c33eeb68ccf174cc09f6a228c48c18fe94af06f28bebc086a24973a066da620db8e6f"
   ]
 }
-post-messages: [
-  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
-is due to a known packaging bug with the num package. As a workaround run the following two commands,
-then try to reinstall the target package again:
-
-  ocamlfind remove num
-  ocamlfind remove num-top
-
-See https://github.com/ocaml/opam-repository/issues/14646 for details."
-  {failure}
-]

--- a/packages/num/num.1.4/opam
+++ b/packages/num/num.1.4/opam
@@ -25,3 +25,14 @@ url {
     "sha512=0cc9be8ad95704bb683b4bf6698bada1ee9a40dc05924b72adc7b969685c33eeb68ccf174cc09f6a228c48c18fe94af06f28bebc086a24973a066da620db8e6f"
   ]
 }
+post-messages: [
+  "Installation failure with the message 'The installation of num failed at \"make findlib-install\"'
+is due to a known packaging bug with the num package. As a workaround run the following two commands,
+then try to reinstall the target package again:
+
+  ocamlfind remove num
+  ocamlfind remove num-top
+
+See https://github.com/ocaml/opam-repository/issues/14646 for details."
+  {failure}
+]


### PR DESCRIPTION
This is meant to help users workaround the known installation failure with num reported in #14646 (and the various linked issues). 

The failure message was first suggested at https://github.com/ocaml/opam-repository/issues/14646#issuecomment-933022088, and pointers to the configuration change needed was provided by @dbuenzli in a reply.

This PR is to propose the workaround, but I honestly don't know which versions it should be applied to or what the optimal messaging is here. All corrections and suggestions for improvement welcome.