### PR TITLE
[new release] elpi (1.14.0)

### DIFF
--- a/packages/elpi/elpi.1.14.0/opam
+++ b/packages/elpi/elpi.1.14.0/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "TIMEOUT=240"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "stdlib-shims"
+  "camlp5" {< "7.99"}
+  "ppxlib" {>= "0.12.0" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.2.0"}
+  "conf-time" {with-test}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer needs
+  not to care about De Bruijn indexes.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.14.0/elpi-1.14.0.tbz"
+  checksum: [
+    "sha256=acc61ab4f9d9b80cc2b1d848bf3ed1c121634e8b42e0dfe086005a76b79ec2ec"
+    "sha512=de851b0cb1bd65e18fdc2b4a992a52eceb4c8e68a059e3652d7cfe525f0d31303ce323c2c20f01c55a633a6481adba05d16cc4c7f44707e189c073e759a1accd"
+  ]
+}
+x-commit-hash: "d607597c71515554ed9b9a3e430ccecdc50400f4"


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

- Runtime/FFI:
  - Fix handling of eta expanded unification variables. Many thanks to
    Nathan Guermond for testing this tricky case.
  - Change `Rawdata.Constants.eqc` to a builtin
  - Fix `Rawdata.Constants.cutc` has always been a builtin
  - Fix compatibility with OCaml multicore, no more `PtrMap`
- API:
  - New `FlexibleData.WeakMap` to link unification variables with host
    data based on OCaml's `Ephemeron`
  - Change `Conversion.extra_goals` is now an extensible data type with one
    standard constructor `Conversion.Unify` taking two terms
  - New `RawData.set_extra_goals_postprocessing` can be used to
    post process the extra goals generated by an FFI call.
    One has to translate extensions to the `extra_goals` datatype to
    `RawData.RawGoal` (or `Conversion.Unify`), but can also take global
    actions like cancelling out useless or duplicate goals
  - Change `Setup.init` to take in input a `~file_resolver` rather than a list
    of `~paths` and a `~basedir`. A custom file resolver can use some logic
    from the host application to find files, rather than an hardcoded one
  - New `Parse.std_resolver` building a standard resolver (based on paths)
  - Change signature of `Parse.resolve_file` making `?cwd` explicit
- Library:
  - Better error messages in `std.nth`
  - `declare_constraint` is now `variadic any prop`, so that one can pass
    variables of different types as keys for the constraint. A list of variables
    (of the same type) is still supported.
