### PR TITLE
[new release] albatross (1.4.2)

### DIFF
--- a/packages/albatross/albatross.1.4.2/opam
+++ b/packages/albatross/albatross.1.4.2/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+available: os != "macos"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.4.2/albatross-1.4.2.tbz"
+  checksum: [
+    "sha256=9791ac76d5042b2037d94cc034d19124d1b3e70cd1affcba7802badeee8c056f"
+    "sha512=66c5e650cfef525cef7794bdb3a7c853908136cef23c739e5f5cf7a45dd22af722f26736e76794f0a153c347dc35dbce07be0303104dcf64ec55edc4483477b0"
+  ]
+}
+x-commit-hash: "4590b998bc86fea074ef51e20572c570c820018d"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- fix issues "use OCaml solo5-elftool instead of binary" where the compressed
  unikernel image was passed to the tool (if albatross-provision-request was
  used, and in albatross-daemon) (roburio/albatross#101 by @palainp, fixed in roburio/albatross#102 by @hannesm)
