### PR TITLE
lablgtk3 < 3.1.1 is not compatible with OCaml 4.09

### DIFF
--- a/packages/lablgtk3/lablgtk3.0.beta1/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta1/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk3"]]
 depends: [
-  "ocaml" {>= "4.05" & < "4.10"}
+  "ocaml" {>= "4.05" & < "4.09"}
   "ocamlfind" {build & >= "1.2.1"}
   "conf-gtk3" {>= "18"}
 ]

--- a/packages/lablgtk3/lablgtk3.0.beta2/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta2/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk3"]]
 depends: [
-  "ocaml" {>= "4.05" & < "4.10"}
+  "ocaml" {>= "4.05" & < "4.09"}
   "ocamlfind" {build & >= "1.2.1"}
   "conf-gtk3" {>= "18"}
 ]

--- a/packages/lablgtk3/lablgtk3.0.beta3/opam
+++ b/packages/lablgtk3/lablgtk3.0.beta3/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lablgtk3"]]
 depends: [
-  "ocaml" {>= "4.05" & < "4.10"}
+  "ocaml" {>= "4.05" & < "4.09"}
   "ocamlfind" {build & >= "1.2.1"}
   "conf-gtk3" {>= "18"}
 ]

--- a/packages/lablgtk3/lablgtk3.3.0.beta4/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta4/opam
@@ -12,7 +12,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" & < "4.10" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      { >= "1.4.0"  }
   "dune-configurator"
   "conf-gtk3" { build & >= "18"     }

--- a/packages/lablgtk3/lablgtk3.3.0.beta5-1/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5-1/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" & < "4.10" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      {         >= "1.8.0"  }
   "dune-configurator"
   "conf-gtk3" { build & >= "18"     }

--- a/packages/lablgtk3/lablgtk3.3.0.beta5/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta5/opam
@@ -15,7 +15,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" & < "4.10" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      {         >= "1.4.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833

--- a/packages/lablgtk3/lablgtk3.3.0.beta6/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta6/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" & < "4.10" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      {         >= "1.4.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833

--- a/packages/lablgtk3/lablgtk3.3.0.beta7/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta7/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" & < "4.10" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      {         >= "1.6.0"
                       & != "1.7.0"
                       & != "1.7.1"  } # Due to dune/dune#1833

--- a/packages/lablgtk3/lablgtk3.3.0.beta8/opam
+++ b/packages/lablgtk3/lablgtk3.3.0.beta8/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" & < "4.10" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      {         >= "1.8.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }

--- a/packages/lablgtk3/lablgtk3.3.1.0/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.0/opam
@@ -16,7 +16,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
-  "ocaml"     {         >= "4.05.0" }
+  "ocaml"     {         >= "4.05.0" & < "4.09" }
   "dune"      {         >= "1.8.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }


### PR DESCRIPTION
```
#=== ERROR while compiling lablgtk3.3.1.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lablgtk3 -j 47
# exit-code            1
# env-file             ~/.opam/log/lablgtk3-10-101270.env
# output-file          ~/.opam/log/lablgtk3-10-101270.out
### output ###            
#   ocamlmklib src/dlllablgtk3_stubs.so,src/liblablgtk3_stubs.a (exit 2)
# (cd _build/default && /home/opam/.opam/4.09/bin/ocamlmklib.opt -g -o src/lablgtk3_stubs src/cairo_pango_stubs.o src/ml_gdk.o src/ml_gdkpixbuf.o src/ml_glib.o src/ml_gobject.o src/ml_gpointer.o src/ml_gtk.o src/ml_gtkaction.o src/ml_gtkassistant.o src/ml_gtkbin.o src/ml_gtkbuilder.o src/ml_gtkbutton.o src/ml_gtkedit.o src/ml_gtkfile.o src/ml_gtkmenu.o src/ml_gtkmisc.o src/ml_gtkpack.o src/ml_gtkrange.o src/ml_gtkstock.o src/ml_gtktext.o src/ml_gtktree.o src/ml_gvaluecaml.o src/ml_pango.o src/wrappers.o -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0)
# /usr/bin/ld: src/ml_gdkpixbuf.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkassistant.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkbin.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkbuilder.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkbutton.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkedit.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkmenu.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkmisc.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkpack.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkrange.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtkstock.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtktext.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# /usr/bin/ld: src/ml_gtktree.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: multiple definition of `ml_table_extension_events'; src/ml_gdk.o:/home/opam/.opam/4.09/.opam-switch/build/lablgtk3.3.1.0/_build/default/src/ml_gdk.h:89: first defined here
# collect2: error: ld returned 1 exit status
```
Was fixed in 3.1.1 by https://github.com/garrigue/lablgtk/commit/a665ac7ce0ed71bdd47750e25bfb3eba608616b8