### PR TITLE
lablgtk.2.18.10 is not compatible with OCaml 4.09

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.10/opam
+++ b/packages/lablgtk/lablgtk.2.18.10/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "4.09"}
   "ocamlfind" {>= "1.2.1"}
   "conf-gtk2" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling lablgtk.2.18.10 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.09/.opam-switch/build/lablgtk.2.18.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build make world
# exit-code            2
# env-file             ~/.opam/log/lablgtk-10-909272.env
# output-file          ~/.opam/log/lablgtk-10-909272.out
### output ###
# ocamlmklib -verbose -ocamlc "ocamlc.opt" -ocamlopt "ocamlopt.opt" -o lablgtk -oc lablgtk2 ml_gdkpixbuf.o ml_gdk.o ml_glib.o ml_gobject.o ml_gpointer.o ml_gvaluecaml.o wrappers.o ml_gtk.o ml_pango.o ml_gtkaction.o ml_gtkbin.o ml_gtkbroken.o ml_gtkbutton.o ml_gtkassistant.o ml_gtkedit.o ml_gtkfile.o ml_gtklist.o ml_gtkmenu.o ml_gtkmisc.o ml_gtkpack.o ml_gtkrange.o ml_gtkstock.o ml_gtktext.o ml_gtktree.o gaux.cmo gpointer.cmo gutf8.cmo glib.cmo gobject.cmo gdkEnums.cmo pangoEnums.cmo gtkEnums.cmo pango.cmo gdk.cmo gdkEvent.cmo gdkKeysyms.cmo gdkPixbuf.cmo gtk.cmo gtkSignal.cmo gtkStock.cmo gtkObject.cmo gtkBaseProps.cmo gtkBinProps.cmo gtkButtonProps.cmo gtkEditProps.cmo gtkListProps.cmo gtkMenuProps.cmo gtkMiscProps.cmo gtkPackProps.cmo gtkRangeProps.cmo gtkTextProps.cmo gtkTreeProps.cmo gtkFileProps.cmo gtkActionProps.cmo gtkBrokenProps.cmo gtkAssistantProps.cmo gtkData.cmo gtkBase.cmo gtkPack.cmo gtkButton.cmo gtkAssistant.cmo gtkMenu.cmo gtkMisc.cmo gtkWindow.cmo gtkList.cmo gtkBin.cmo gtkEdit.cmo gtkRange.cmo gtkText.cmo gtkTree.cmo gtkFile.cmo gtkMain.cmo gtkBroken.cmo gPango.cmo gDraw.cmo gObj.cmo ogtkBaseProps.cmo gData.cmo ogtkBinProps.cmo ogtkButtonProps.cmo ogtkEditProps.cmo ogtkListProps.cmo ogtkMenuProps.cmo ogtkMiscProps.cmo ogtkPackProps.cmo ogtkRangeProps.cmo ogtkTextProps.cmo ogtkTreeProps.cmo ogtkFileProps.cmo ogtkActionProps.cmo ogtkBrokenProps.cmo ogtkAssistantProps.cmo gMain.cmo gContainer.cmo gPack.cmo gButton.cmo gText.cmo gMenu.cmo gMisc.cmo gTree.cmo gList.cmo gFile.cmo gWindow.cmo gAssistant.cmo gBin.cmo gEdit.cmo gRange.cmo gAction.cmo gBroken.cmo gUtil.cmo gToolbox.cmo -lgtk-x11-2.0 -lgdk-x11-2.0 -lpangocairo-1.0 -latk-1.0 -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lpangoft2-1.0 -lpango-1.0 -lgobject-2.0 -lglib-2.0 -lharfbuzz -lfontconfig -lfreetype
# + gcc -shared  -o ./dlllablgtk2.so ml_gdkpixbuf.o ml_gdk.o ml_glib.o ml_gobject.o ml_gpointer.o ml_gvaluecaml.o wrappers.o ml_gtk.o ml_pango.o ml_gtkaction.o ml_gtkbin.o ml_gtkbroken.o ml_gtkbutton.o ml_gtkassistant.o ml_gtkedit.o ml_gtkfile.o ml_gtklist.o ml_gtkmenu.o ml_gtkmisc.o ml_gtkpack.o ml_gtkrange.o ml_gtkstock.o ml_gtktext.o ml_gtktree.o    -lgtk-x11-2.0 -lgdk-x11-2.0 -lpangocairo-1.0 -latk-1.0 -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lpangoft2-1.0 -lpango-1.0 -lgobject-2.0 -lglib-2.0 -lharfbuzz -lfontconfig -lfreetype 
# /usr/bin/ld: ml_gdk.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtk.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkbin.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkbroken.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkbutton.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkassistant.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkedit.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtklist.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkmenu.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkmisc.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkpack.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkrange.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtkstock.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtktext.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# /usr/bin/ld: ml_gtktree.o:(.bss+0x0): multiple definition of `ml_table_extension_events'; ml_gdkpixbuf.o:(.bss+0x0): first defined here
# collect2: error: ld returned 1 exit status
# make[1]: *** [Makefile:467: lablgtk.cma] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.09/.opam-switch/build/lablgtk.2.18.10/src'
# make: *** [Makefile:5: world] Error 2
```
Fixed in 2.18.11 in https://github.com/garrigue/lablgtk/commit/156973670a9c00b10f7f97201bbca054e6f3b66b