### PR TITLE
tezos-stdlib-unix < 8.0 will not be compatible with Lwt 5.6.0

### DIFF
--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.11" }
   "tezos-event-logging" { = version }
   "tezos-rpc" { = version }
-  "lwt" { >= "3.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
   "ptime" { >= "0.8.4" }
   "mtime" { >= "1.0.0" }
   "conf-libev"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.11" }
   "tezos-event-logging" { = version }
   "tezos-rpc" { = version }
-  "lwt" { >= "3.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
   "ptime" { >= "0.8.4" }
   "mtime" { >= "1.0.0" }
   "conf-libev"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.11" }
   "tezos-event-logging" { = version }
   "tezos-rpc" { = version }
-  "lwt" { >= "3.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
   "ptime" { >= "0.8.4" }
   "mtime" { >= "1.0.0" }
   "conf-libev"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.3/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.11" }
   "tezos-event-logging" { = version }
   "tezos-rpc" { = version }
-  "lwt" { >= "3.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
   "ptime" { >= "0.8.4" }
   "mtime" { >= "1.0.0" }
   "conf-libev"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.7.4/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.11" }
   "tezos-event-logging" { = version }
   "tezos-rpc" { = version }
-  "lwt" { >= "3.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
   "ptime" { >= "0.8.4" }
   "mtime" { >= "1.0.0" }
   "conf-libev"


### PR DESCRIPTION
Does not depend on result anymore :tada:
```
#=== ERROR while compiling tezos-stdlib-unix.7.2 ==============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/tezos-stdlib-unix.7.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tezos-stdlib-unix -j 127
# exit-code            1
# env-file             ~/.opam/log/tezos-stdlib-unix-11-8326ab.env
# output-file          ~/.opam/log/tezos-stdlib-unix-11-8326ab.out
### output ###
#       ocamlc src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte/tezos_stdlib_unix__Lwt_exit.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -open Tezos_error_monad -open Tezos_event_logging -open Tezos_rpc -open Tezos_stdlib -open Data_encoding -g -bin-annot -I src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte -I /home/opam/.opam/4.13/lib/astring -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/bytes -I /home/opam/.opam/4.13/lib/cstruct -I /home/opam/.opam/4.13/lib/data-encoding -I /home/opam/.opam/4.13/lib/domain-name -I /home/opam/.opam/4.13/lib/ezjsonm -I /home/opam/.opam/4.13/lib/fmt -I /home/opam/.opam/4.13/lib/hex -I /home/opam/.opam/4.13/lib/ipaddr -I /home/opam/.opam/4.13/lib/ipaddr/unix -I /home/opam/.opam/4.13/lib/json-data-encoding -I /home/opam/.opam/4.13/lib/json-data-encoding-bson -I /home/opam/.opam/4.13/lib/jsonm -I /home/opam/.opam/4.13/lib/lwt -I /home/opam/.opam/4.13/lib/lwt-canceler -I /home/opam/.opam/4.13/lib/lwt/unix -I /home/opam/.opam/4.13/lib/lwt_log -I /home/opam/.opam/4.13/lib/lwt_log/core -I /home/opam/.opam/4.13/lib/macaddr -I /home/opam/.opam/4.13/lib/mmap -I /home/opam/.opam/4.13/lib/mtime -I /home/opam/.opam/4.13/lib/mtime/os -I /home/opam/.opam/4.13/lib/ocaml/threads -I /home/opam/.opam/4.13/lib/ocplib-endian -I /home/opam/.opam/4.13/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.13/lib/ptime -I /home/opam/.opam/4.13/lib/ptime/clock/os -I /home/opam/.opam/4.13/lib/re -I /home/opam/.opam/4.13/lib/re/posix -I /home/opam/.opam/4.13/lib/resto -I /home/opam/.opam/4.13/lib/resto-directory -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/sexplib0 -I /home/opam/.opam/4.13/lib/stdlib-shims -I /home/opam/.opam/4.13/lib/stringext -I /home/opam/.opam/4.13/lib/tezos-error-monad -I /home/opam/.opam/4.13/lib/tezos-event-logging -I /home/opam/.opam/4.13/lib/tezos-rpc -I /home/opam/.opam/4.13/lib/tezos-stdlib -I /home/opam/.opam/4.13/lib/uchar -I /home/opam/.opam/4.13/lib/uri -I /home/opam/.opam/4.13/lib/uutf -I /home/opam/.opam/4.13/lib/zarith -no-alias-deps -open Tezos_stdlib_unix -o src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte/tezos_stdlib_unix__Lwt_exit.cmi -c -intf src/lib_stdlib_unix/lwt_exit.mli)
# File "src/lib_stdlib_unix/lwt_exit.mli", line 40, characters 44-57:
# 40 | val retcode_of_unit_result_lwt : (unit, 'a) Result.result Lwt.t -> int Lwt.t
#                                                  ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```
cc @raphael-proust could you confirm the next version is going to be 5.6.0 and not 5.5.1?