### PR TITLE
rpclib < 6.1.0 implicitly used the result package

### DIFF
--- a/packages/rpclib/rpclib.5.9.0/opam
+++ b/packages/rpclib/rpclib.5.9.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest" {with-test & < "1.0.0"}
   "jbuilder"
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson"
 ]

--- a/packages/rpclib/rpclib.5.9.0/opam
+++ b/packages/rpclib/rpclib.5.9.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest" {with-test & < "1.0.0"}
   "jbuilder" {>= "1.0+beta9"}
   "cmdliner" {>= "0.9.8"}
-  "rresult" {< "0.7.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "xmlm"
   "yojson"
 ]

--- a/packages/rpclib/rpclib.5.9.0/opam
+++ b/packages/rpclib/rpclib.5.9.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "alcotest" {with-test & < "1.0.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta9"}
   "cmdliner" {>= "0.9.8"}
   "rresult" {< "0.7.0"}
   "xmlm"

--- a/packages/rpclib/rpclib.5.9.0/opam
+++ b/packages/rpclib/rpclib.5.9.0/opam
@@ -16,8 +16,8 @@ build: [
 depends: [
   "ocaml" {>= "4.04.0"}
   "alcotest" {with-test & < "1.0.0"}
-  "jbuilder"
-  "cmdliner"
+  "jbuilder" {>= "1.0+beta7"}
+  "cmdliner" {>= "0.9.8"}
   "rresult" {< "0.7.0"}
   "xmlm"
   "yojson"

--- a/packages/rpclib/rpclib.6.0.0/opam
+++ b/packages/rpclib/rpclib.6.0.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" < "4.10.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "jbuilder" {>= "1.0+beta9"}
   "alcotest" {with-test & < "1.0.0"}
   "cmdliner" {>= "0.9.8"}
   "rresult" {< "0.7.0"}

--- a/packages/rpclib/rpclib.6.0.0/opam
+++ b/packages/rpclib/rpclib.6.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder" {>= "1.0+beta9"}
   "alcotest" {with-test & < "1.0.0"}
   "cmdliner" {>= "0.9.8"}
-  "rresult" {< "0.7.0"}
+  "rresult" {>= "0.3.0" & < "0.7.0"}
   "xmlm"
   "yojson"
 ]

--- a/packages/rpclib/rpclib.6.0.0/opam
+++ b/packages/rpclib/rpclib.6.0.0/opam
@@ -15,9 +15,9 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" < "4.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "alcotest" {with-test & < "1.0.0"}
-  "cmdliner"
+  "cmdliner" {>= "0.9.8"}
   "rresult" {< "0.7.0"}
   "xmlm"
   "yojson"

--- a/packages/rpclib/rpclib.6.0.0/opam
+++ b/packages/rpclib/rpclib.6.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "jbuilder"
   "alcotest" {with-test & < "1.0.0"}
   "cmdliner"
-  "rresult"
+  "rresult" {< "0.7.0"}
   "xmlm"
   "yojson"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling rpclib.5.9.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/rpclib.5.9.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p rpclib -j 71
# exit-code            1
# env-file             ~/.opam/log/rpclib-10-12ef4d.env
# output-file          ~/.opam/log/rpclib-10-12ef4d.out
### output ###
# File "src/lib/jbuild", line 12, characters 14-20:
# Error: Library "result" not found.
# Hint: try: jbuilder external-lib-deps --missing -p rpclib @install
```
as well as
```
#=== ERROR while compiling rpclib.6.0.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.09/.opam-switch/build/rpclib.6.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p rpclib -j 31
# exit-code            1
# env-file             ~/.opam/log/rpclib-10-e2a601.env
# output-file          ~/.opam/log/rpclib-10-e2a601.out
### output ###
#       ocamlc src/lib/.rpclib_core.objs/byte/rpc.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.09/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/.rpclib_core.objs/byte -I /home/opam/.opam/4.09/lib/rresult -no-alias-deps -o src/lib/.rpclib_core.objs/byte/rpc.cmi -c -intf src/lib/rpc.mli)
# File "src/lib/rpc.mli", line 81, characters 60-73:
# 81 |     {field_get: 'a. string -> 'a typ -> ('a, Rresult.R.msg) Result.result}
#                                                                  ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```