### PR TITLE
linenoise >= 1.1.0 < 1.3.1 is not compatible with OCaml 4.09

### DIFF
--- a/packages/linenoise/linenoise.1.1.0/opam
+++ b/packages/linenoise/linenoise.1.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.09"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "result"
 ]
 synopsis: "Simple readline like functionality with nice hints feature."

--- a/packages/linenoise/linenoise.1.1.0/opam
+++ b/packages/linenoise/linenoise.1.1.0/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "4.09"}
   "jbuilder"
   "result"
 ]

--- a/packages/linenoise/linenoise.1.2.0/opam
+++ b/packages/linenoise/linenoise.1.2.0/opam
@@ -6,6 +6,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/fxfactorial/ocaml-linenoise"
 bug-reports: "https://github.com/fxfactorial/ocaml-linenoise/issues"
 depends: [
+  "ocaml" {< "4.09"}
   "dune"
   "result"
 ]

--- a/packages/linenoise/linenoise.1.2.0/opam
+++ b/packages/linenoise/linenoise.1.2.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/fxfactorial/ocaml-linenoise"
 bug-reports: "https://github.com/fxfactorial/ocaml-linenoise/issues"
 depends: [
   "ocaml" {< "4.09"}
-  "dune"
+  "dune" {>= "1.1"}
   "result"
 ]
 build: [

--- a/packages/linenoise/linenoise.1.3.0/opam
+++ b/packages/linenoise/linenoise.1.3.0/opam
@@ -6,6 +6,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/ocaml-community/ocaml-linenoise"
 bug-reports: "https://github.com/ocaml-community/ocaml-linenoise/issues"
 depends: [
+  "ocaml" {< "4.09"}
   "dune"
   "result"
 ]

--- a/packages/linenoise/linenoise.1.3.0/opam
+++ b/packages/linenoise/linenoise.1.3.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/ocaml-community/ocaml-linenoise"
 bug-reports: "https://github.com/ocaml-community/ocaml-linenoise/issues"
 depends: [
   "ocaml" {< "4.09"}
-  "dune"
+  "dune" {>= "1.1"}
   "result"
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling linenoise.1.3.0 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.09/.opam-switch/build/linenoise.1.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p linenoise
# exit-code            1
# env-file             ~/.opam/log/linenoise-11-265fe9.env
# output-file          ~/.opam/log/linenoise-11-265fe9.out
### output ###
#   ocamlmklib src/dlllinenoise_stubs.so,src/liblinenoise_stubs.a (exit 2)
# (cd _build/default && /home/opam/.opam/4.09/bin/ocamlmklib.opt -g -o src/linenoise_stubs src/linenoise_src.o src/linenoise_stubs.o)
# /usr/bin/ld: src/linenoise_stubs.o:/home/opam/.opam/4.09/.opam-switch/build/linenoise.1.3.0/_build/default/src/linenoise_src.h:46: multiple definition of `linenoiseWasInterrupted'; src/linenoise_src.o:/home/opam/.opam/4.09/.opam-switch/build/linenoise.1.3.0/_build/default/src/linenoise_src.h:46: first defined here
# collect2: error: ld returned 1 exit status
```
Was fixed in 1.3.1