### PR TITLE
eigen < 0.0.6: Make CI accept failures

### DIFF
--- a/packages/eigen/eigen.0.0.1/opam
+++ b/packages/eigen/eigen.0.0.1/opam
@@ -27,6 +27,11 @@ depends: [
   "ocamlfind" {build}
 ]
 available: arch = "x86_32" | arch = "x86_64"
+x-ci-accept-failures: [
+  "debian-11" # /usr/bin/ld: cannot find -leigen
+  "debian-testing" # /usr/bin/ld: cannot find -leigen
+  "debian-unstable" # /usr/bin/ld: cannot find -leigen
+]
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.1/opam
+++ b/packages/eigen/eigen.0.0.1/opam
@@ -26,12 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: arch = "x86_32" | arch = "x86_64"
-x-ci-accept-failures: [
-  "debian-11" # /usr/bin/ld: cannot find -leigen
-  "debian-testing" # /usr/bin/ld: cannot find -leigen
-  "debian-unstable" # /usr/bin/ld: cannot find -leigen
-]
+available: false # writes outside the sandbox https://github.com/owlbarn/eigen/blob/0.0.1/_oasis#L24
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.2/opam
+++ b/packages/eigen/eigen.0.0.2/opam
@@ -27,6 +27,11 @@ depends: [
   "ocamlfind" {build}
 ]
 available: arch = "x86_32" | arch = "x86_64"
+x-ci-accept-failures: [
+  "debian-11" # /usr/bin/ld: cannot find -leigen
+  "debian-testing" # /usr/bin/ld: cannot find -leigen
+  "debian-unstable" # /usr/bin/ld: cannot find -leigen
+]
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.2/opam
+++ b/packages/eigen/eigen.0.0.2/opam
@@ -26,12 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: arch = "x86_32" | arch = "x86_64"
-x-ci-accept-failures: [
-  "debian-11" # /usr/bin/ld: cannot find -leigen
-  "debian-testing" # /usr/bin/ld: cannot find -leigen
-  "debian-unstable" # /usr/bin/ld: cannot find -leigen
-]
+available: false # writes outside the sandbox https://github.com/owlbarn/eigen/blob/0.0.2/_oasis#L24
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.3/opam
+++ b/packages/eigen/eigen.0.0.3/opam
@@ -27,6 +27,11 @@ depends: [
   "ocamlfind" {build}
 ]
 available: arch = "x86_32" | arch = "x86_64"
+x-ci-accept-failures: [
+  "debian-11" # /usr/bin/ld: cannot find -leigen
+  "debian-testing" # /usr/bin/ld: cannot find -leigen
+  "debian-unstable" # /usr/bin/ld: cannot find -leigen
+]
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.3/opam
+++ b/packages/eigen/eigen.0.0.3/opam
@@ -26,12 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: arch = "x86_32" | arch = "x86_64"
-x-ci-accept-failures: [
-  "debian-11" # /usr/bin/ld: cannot find -leigen
-  "debian-testing" # /usr/bin/ld: cannot find -leigen
-  "debian-unstable" # /usr/bin/ld: cannot find -leigen
-]
+available: false # writes outside the sandbox https://github.com/owlbarn/eigen/blob/0.0.3/_oasis#L24
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.4/opam
+++ b/packages/eigen/eigen.0.0.4/opam
@@ -26,12 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: arch = "x86_32" | arch = "x86_64"
-x-ci-accept-failures: [
-  "debian-11" # /usr/bin/ld: cannot find -leigen
-  "debian-testing" # /usr/bin/ld: cannot find -leigen
-  "debian-unstable" # /usr/bin/ld: cannot find -leigen
-]
+available: false # writes outside the sandbox https://github.com/owlbarn/eigen/blob/0.0.4/_oasis#L24
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.4/opam
+++ b/packages/eigen/eigen.0.0.4/opam
@@ -27,6 +27,11 @@ depends: [
   "ocamlfind" {build}
 ]
 available: arch = "x86_32" | arch = "x86_64"
+x-ci-accept-failures: [
+  "debian-11" # /usr/bin/ld: cannot find -leigen
+  "debian-testing" # /usr/bin/ld: cannot find -leigen
+  "debian-unstable" # /usr/bin/ld: cannot find -leigen
+]
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.5/opam
+++ b/packages/eigen/eigen.0.0.5/opam
@@ -27,6 +27,11 @@ depends: [
   "ocamlfind" {build}
 ]
 available: arch = "x86_32" | arch = "x86_64"
+x-ci-accept-failures: [
+  "debian-11" # /usr/bin/ld: cannot find -leigen
+  "debian-testing" # /usr/bin/ld: cannot find -leigen
+  "debian-unstable" # /usr/bin/ld: cannot find -leigen
+]
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."

--- a/packages/eigen/eigen.0.0.5/opam
+++ b/packages/eigen/eigen.0.0.5/opam
@@ -26,12 +26,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]
-available: arch = "x86_32" | arch = "x86_64"
-x-ci-accept-failures: [
-  "debian-11" # /usr/bin/ld: cannot find -leigen
-  "debian-testing" # /usr/bin/ld: cannot find -leigen
-  "debian-unstable" # /usr/bin/ld: cannot find -leigen
-]
+available: false # writes outside the sandbox https://github.com/owlbarn/eigen/blob/0.0.5/_oasis#L24
 synopsis: "Owl's OCaml interface to Eigen3 C++ library"
 description:
   "Eigen is a thin OCaml interface to Eigen3 C++ template library used in Owl to provide basic numerical support for both sparse and dense matrix operations."


### PR DESCRIPTION
```
#=== ERROR while compiling eigen.0.0.3 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/eigen.0.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -build
# exit-code            1
# env-file             ~/.opam/log/eigen-10-5a80e3.env
# output-file          ~/.opam/log/eigen-10-5a80e3.out
### output ###
# File "./setup.ml", line 1775, characters 22-40:
# 1775 |         let compare = Pervasives.compare
#                              ^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
# File "setup.ml", line 3467, characters 16-34:
# Alert deprecated: module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
# g++ -c -fPIC -ansi -Wno-extern-c-compat -Wno-c++11-long-long -I. eigen_dsmat.cpp -o eigen_dsmat.o
# g++ -c -fPIC -ansi -Wno-extern-c-compat -Wno-c++11-long-long -I. eigen_spmat.cpp -o eigen_spmat.o
# ar rvs libeigen.a eigen_dsmat.o eigen_spmat.o
# ar: creating libeigen.a
# a - eigen_dsmat.o
# a - eigen_spmat.o
# cp: cannot create regular file '/home/opam/.opam/4.13/lib/libeigen.a': Read-only file system
# rm -rf _build *.byte *.a *.o *.so *.cmo *.cmi
# /home/opam/.opam/4.13/.opam-switch/build/eigen.0.0.3
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/4.13/lib/ocamlbuild /home/opam/.opam/4.13/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/4.13/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# /home/opam/.opam/4.13/bin/ocamlfind ocamlc -g -ccopt -I/home/opam/.opam/4.13/lib/ctypes -package ctypes.stubs -package ctypes -c lib/eigen_utils_stubs.c
# mv eigen_utils_stubs.o lib/eigen_utils_stubs.o
# /home/opam/.opam/4.13/bin/ocamlfind ocamlc -g -ccopt -I/home/opam/.opam/4.13/lib/ctypes -package ctypes.stubs -package ctypes -c lib/ffi_eigen_generated_stub.c
# mv ffi_eigen_generated_stub.o lib/ffi_eigen_generated_stub.o
# /home/opam/.opam/4.13/bin/ocamlfind ocamlmklib -o lib/eigen_stubs -g -L/home/opam/.opam/4.13/lib -leigen -lstdc++ lib/eigen_utils_stubs.o lib/ffi_eigen_generated_stub.o
# + /home/opam/.opam/4.13/bin/ocamlfind ocamlmklib -o lib/eigen_stubs -g -L/home/opam/.opam/4.13/lib -leigen -lstdc++ lib/eigen_utils_stubs.o lib/ffi_eigen_generated_stub.o
# /usr/bin/ld: cannot find -leigen: No such file or directory
# collect2: error: ld returned 1 exit status
# Command exited with code 2.
# E: Failure("Command ''/home/opam/.opam/4.13/bin/ocamlbuild' lib/libeigen_stubs.a lib/dlleigen_stubs.so lib/eigen.cma lib/eigen.cmxa lib/eigen.a lib/eigen.cmxs -use-ocamlfind -tag debug' terminated with error code 10")
```
Doesn’t happen with eigen >= 0.0.6