### PR TITLE
SZXX.2.1.0 - support for weird inline formatting, other edge cases

### DIFF
--- a/packages/SZXX/SZXX.2.1.0/opam
+++ b/packages/SZXX/SZXX.2.1.0/opam
@@ -27,8 +27,6 @@ depends: [
   "ppx_jane" { with-test }
   "yojson" { with-test }
   "ppx_deriving_yojson" { >= "3.5.2" & with-test }
-  "ocaml-lsp-server" { with-test }
-  "ocamlformat" { = "0.15.0" & with-test }
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 url {

--- a/packages/SZXX/SZXX.2.1.0/opam
+++ b/packages/SZXX/SZXX.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
+SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
+"""
+license: "MIT"
+tags: ["Stream" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "4.08.1" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core_kernel" { >= "v0.13.0" }
+  "decompress" { >= "1.4.1" }
+  "lwt" { >= "5.3.0" }
+
+  "alcotest-lwt" { with-test }
+  "ppx_jane" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  "ocaml-lsp-server" { with-test }
+  "ocamlformat" { = "0.15.0" & with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=fa2003308327051d39f3b5ce169b8cc8"
+    "sha512=b359ca7ebb45f3d44e320e75be7c9ce2f0131551e32c6c14fb0b96a75704040729227673586f4d219671c157d95156b4f441c171e5c52fb85177099ea0773033"
+  ]
+}


### PR DESCRIPTION
### `SZXX.2.1.0`
Streaming ZIP XML XLSX parser
SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.1.0