### PR TITLE
Package lua_parser.1.0.1

### DIFF
--- a/packages/lua_parser/lua_parser.1.0.1/opam
+++ b/packages/lua_parser/lua_parser.1.0.1/opam
@@ -8,12 +8,13 @@ license: "MIT"
 homepage: "https://github.com/drjdn/ocaml_lua_parser"
 bug-reports: "https://github.com/drjdn/ocaml_lua_parser/issues"
 depends: [
-  "dune" {>= "2.5"}
+  "dune" {>= "2.8"}
   "menhir" {>= "20200624"}
   "sexp_pretty" {>= "v0.14.0"}
   "sexplib" {>= "v0.14.0"}
   "ppx_sexp_conv" {>= "v0.14.1"}
   "ppx_deriving" {>= "4.5"}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -31,9 +32,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/drjdn/ocaml_lua_parser.git"
 url {
-  src: "https://github.com/drjdn/ocaml_lua_parser/archive/1.0.1.tar.gz"
+  src: "https://github.com/drjdn/ocaml_lua_parser/archive/1.0.2.tar.gz"
   checksum: [
-    "md5=4db40248809ddaac3e0dfcd2a5078f2f"
-    "sha512=4f7c76e82d25119b9e5a1881cf32d7b359eb77eb09a790ec5556373b7ff92ade3bce2a3986ffff27c76043af0915dc45c917e32ebaae7c4be6f830bad67fabd1"
+    "md5=c42700c716816a1e47313a0e98355674"
+    "sha512=8576be83413edf3b45968f10b9c2fcf31be5ef3a0a6218ba70556a92756fcc1e2f670c7acb76e3897a24d0b47fd226b0db3492ab12100f1a951b6dedea5eccfd"
   ]
 }


### PR DESCRIPTION
### `lua_parser.1.0.1`
A Lua 5.2 Parser
This is a parser and pretty-printer for lua 5.2



---
* Homepage: https://github.com/drjdn/ocaml_lua_parser
* Source repo: git+https://github.com/drjdn/ocaml_lua_parser.git
* Bug tracker: https://github.com/drjdn/ocaml_lua_parser/issues

---
:camel: Pull-request generated by opam-publish v2.1.0