### PR TITLE
[new release] fftw3 (0.8.5)

### DIFF
--- a/packages/fftw3/fftw3.0.8.5/opam
+++ b/packages/fftw3/fftw3.0.8.5/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1"}
-  "dune-configurator"
+  "dune-configurator" {>= "1.11.4"}
   "cppo" {build}
   "conf-fftw3"
 ]

--- a/packages/fftw3/fftw3.0.8.5/opam
+++ b/packages/fftw3/fftw3.0.8.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+maintainer: "Christophe.Troestler@umons.ac.be"
+license: "LGPL-2.1"
+homepage: "https://github.com/Chris00/fftw-ocaml"
+dev-repo: "git+https://github.com/Chris00/fftw-ocaml.git"
+bug-reports: "https://github.com/Chris00/fftw-ocaml/issues"
+doc: "https://Chris00.github.io/fftw-ocaml/doc"
+tags: ["FFT"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "dune-configurator"
+  "cppo" {build}
+  "conf-fftw3"
+]
+synopsis: "Binding to the Fast Fourier Transform library FFTW"
+description: """
+Library binding the seminal library FFTW."""
+url {
+  src:
+    "https://github.com/Chris00/fftw-ocaml/releases/download/0.8.5/fftw3-0.8.5.tbz"
+  checksum: [
+    "sha256=6e3e5931eda0f66c2bf9cac2f40bf9d563fbf04adbaccb26278a7bf598537684"
+    "sha512=9e8684c9fb2327f7a18e04b7de770ada7cbac18eb03db37b3a974ff5968b6327f7b91aa489db5f70beac6757acea88d3e04c25e35380345ec3d33a0942b27450"
+  ]
+}
+x-commit-hash: "aa7b92af0e8b834facdbfd34aa3c7da4924c559b"


### PR DESCRIPTION
Binding to the Fast Fourier Transform library FFTW

- Project page: <a href="https://github.com/Chris00/fftw-ocaml">https://github.com/Chris00/fftw-ocaml</a>
- Documentation: <a href="https://Chris00.github.io/fftw-ocaml/doc">https://Chris00.github.io/fftw-ocaml/doc</a>

##### CHANGES:

- Update to `dune-configurator`.
- Remove the special OPAM rule for MacOS (@neynt).
- Fix deprecation warnings.
