### PR TITLE
lua_parser 1.0.1: make unavailable

### DIFF
--- a/packages/lua_parser/lua_parser.1.0.1/opam
+++ b/packages/lua_parser/lua_parser.1.0.1/opam
@@ -30,6 +30,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/drjdn/ocaml_lua_parser.git"
+available: false
 url {
   src: "https://github.com/drjdn/ocaml_lua_parser/archive/1.0.1.tar.gz"
   checksum: [


### PR DESCRIPTION
The tarball does no longer exist and is not in the cache