### PR TITLE
[new release] hvsock (3.0.0)

### DIFF
--- a/packages/hvsock/hvsock.3.0.0/opam
+++ b/packages/hvsock/hvsock.3.0.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hvsock"
+dev-repo: "git+https://github.com/mirage/ocaml-hvsock.git"
+bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+doc: "https://mirage.github.io/ocaml-hvsock"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-threads"
+  "base-unix"
+  "lwt" {>= "3.2.0"}
+  "logs"
+  "fmt"
+  "cmdliner"
+  "sha"
+  "uri"
+  "base64" {>= "3.0.0"}
+  "uuidm"
+  "uutf"
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "dune" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+]
+synopsis: "Bindings for Hyper-V AF_VSOCK"
+description: """
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
+
+These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
+and Windows.
+
+*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
+definition of `AF_HYPERV` is not yet stable. If other address families are merged
+before this one then the value of `AF_HYPERV` will change!
+
+Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-hvsock/releases/download/3.0.0/hvsock-3.0.0.tbz"
+  checksum: [
+    "sha256=46d179976f153a7723890ba78fbcfee60e70b3cc9cc3574eb4bb8a682525e4e2"
+    "sha512=f38d53ba07ed77d39c1e92864506ebc7daab0321c8fc2709660c7a55bb43de82af56571d827cbc03443c1b5ccb3a898f6a2163d32d9c5c52b5f4e36507b56969"
+  ]
+}
+x-commit-hash: "6242f89010e79ae0e658880e4ce773587c815c9b"


### PR DESCRIPTION
Bindings for Hyper-V AF_VSOCK

- Project page: <a href="https://github.com/mirage/ocaml-hvsock">https://github.com/mirage/ocaml-hvsock</a>
- Documentation: <a href="https://mirage.github.io/ocaml-hvsock">https://mirage.github.io/ocaml-hvsock</a>

##### CHANGES:

- Use new Mirage signatures (mirage/ocaml-hvsock#66 from @talex5)
- Better dune lower bound from @mseri (mirage/ocaml-hvsock#65)
- Use new Cstruct.length (mirage/ocaml-hvsock#67 from @djs55)
