### PR TITLE
[new release] protocol-9p, protocol-9p-unix and protocol-9p-tool (2.0.2)

### DIFF
--- a/packages/protocol-9p-tool/protocol-9p-tool.2.0.2/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.2.0.2/opam
@@ -17,6 +17,7 @@ depends: [
   "lambda-term"
   "win-error"
   "cmdliner"
+  "cstruct" {>= "6.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/protocol-9p-tool/protocol-9p-tool.2.0.2/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.2.0.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard" "Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+doc: "https://mirage.github.io/ocaml-9p/"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "protocol-9p"
+  "protocol-9p-unix"
+  "base-bytes"
+  "rresult"
+  "logs" {>= "0.5.0"}
+  "fmt"
+  "lambda-term"
+  "win-error"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
+synopsis: "An implementation of the 9p protocol in pure OCaml"
+description: """
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style. This opam package contains the Unix
+client.
+
+Example of the CLI program is:
+```
+o9p ls --username vagrant   /var
+drwxr-xr-x ? root root 4096 Feb 2  2015 lib
+drwxr-xr-x ? root root 4096 Mar 15 2015 cache
+-rwxrwxrwx ? root root 9    May 10 2014 lock
+drwxrwxrwx ? root root 4096 Jul 6  2015 tmp
+drwxr-xr-x ? root root 4096 May 11 2014 spool
+drwxrwxr-x ? root sshd 4096 Sep 28 2015 log
+drwxr-xr-x ? root root 4096 Sep 21 2015 backups
+drwxrwxr-x ? root mail 4096 Apr 16 2014 mail
+drwxr-xr-x ? root root 4096 Apr 16 2014 opt
+drwxrwxr-x ? root 50   4096 Apr 10 2014 local
+-rwxrwxrwx ? root root 4    May 10 2014 run
+```
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-9p/releases/download/2.0.2/protocol-9p-2.0.2.tbz"
+  checksum: [
+    "sha256=a4c0585e81f5c57c879560318016aeb022163044f2c7ae086af3dfcbbe1b8164"
+    "sha512=253bafb9a41d7e641d8f8c117de4a561f7b0a81dd7e54ab9ea322375818fe1e4d952bc7b4fdabc88cab30b2df082f0cf5c0764e5d63474c1ee43a8e3f591694e"
+  ]
+}
+x-commit-hash: "5fcd2ff1904cb044c36e4e9b0131714d11e34127"

--- a/packages/protocol-9p-tool/protocol-9p-tool.2.0.2/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.2.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "rresult"
   "logs" {>= "0.5.0"}
   "fmt"
-  "lambda-term"
+  "lambda-term" {>= "2.0.0"}
   "win-error"
   "cmdliner"
   "cstruct" {>= "6.0.0"}

--- a/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
@@ -30,7 +30,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
 synopsis: "A Unix implementation of the 9p protocol in pure OCaml"

--- a/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard" "Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+doc: "https://mirage.github.io/ocaml-9p/"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "protocol-9p" {>="1.0.1"}
+  "base-bytes"
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt" {>= "6.0.0"}
+  "sexplib" {> "113.00.00" & < "v0.15"}
+  "prometheus"
+  "rresult"
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-channel" {with-test & >= "4.0.0"}
+  "lwt" {>= "3.0.0"}
+  "base-unix"
+  "astring"
+  "fmt"
+  "logs" {with-test & >= "0.5.0"}
+  "win-error"
+  "io-page-unix" {>= "2.0.0"}
+  "ppx_sexp_conv" {< "v0.15"}
+  "alcotest" {with-test & >= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
+synopsis: "A Unix implementation of the 9p protocol in pure OCaml"
+description: """
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style.  This package supports the Unix socket
+library.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-9p/releases/download/2.0.2/protocol-9p-2.0.2.tbz"
+  checksum: [
+    "sha256=a4c0585e81f5c57c879560318016aeb022163044f2c7ae086af3dfcbbe1b8164"
+    "sha512=253bafb9a41d7e641d8f8c117de4a561f7b0a81dd7e54ab9ea322375818fe1e4d952bc7b4fdabc88cab30b2df082f0cf5c0764e5d63474c1ee43a8e3f591694e"
+  ]
+}
+x-commit-hash: "5fcd2ff1904cb044c36e4e9b0131714d11e34127"
+

--- a/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.2.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "base-bytes"
   "cstruct" {>= "6.0.0"}
   "cstruct-lwt" {>= "6.0.0"}
-  "sexplib" {> "113.00.00" & < "v0.15"}
+  "sexplib" {> "113.00.00"}
   "prometheus"
   "rresult"
   "mirage-flow" {>= "3.0.0"}

--- a/packages/protocol-9p/protocol-9p.2.0.2/opam
+++ b/packages/protocol-9p/protocol-9p.2.0.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "David Sheets" "Thomas Leonard" "Anil Madhavapeddy"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-9p"
+doc: "https://mirage.github.io/ocaml-9p/"
+bug-reports: "https://github.com/mirage/ocaml-9p/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "base-bytes"
+  "cstruct" {>= "6.0.0"}
+  "cstruct-sexp"
+  "sexplib" {> "113.00.00" & < "v0.15"}
+  "rresult"
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "lwt" {>= "3.0.0"}
+  "astring"
+  "fmt"
+  "logs" {>= "0.5.0"}
+  "win-error"
+  "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}
+  "alcotest" {with-test & >= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-9p.git"
+synopsis: "An implementation of the 9p protocol in pure OCaml"
+description: """
+ocaml-9p is an implementation of the 9P protocol, written in
+a Mirage-friendly style.  This library supports the
+[9P2000.u extension](http://ericvh.github.io/9p-rfc/rfc9p2000.u.html).
+Please also refer to the `protocol-9p-unix` package for a
+Unix/Windows implementation, and to `protocol-9p-tool` for a
+CLI interface.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-9p/releases/download/2.0.2/protocol-9p-2.0.2.tbz"
+  checksum: [
+    "sha256=a4c0585e81f5c57c879560318016aeb022163044f2c7ae086af3dfcbbe1b8164"
+    "sha512=253bafb9a41d7e641d8f8c117de4a561f7b0a81dd7e54ab9ea322375818fe1e4d952bc7b4fdabc88cab30b2df082f0cf5c0764e5d63474c1ee43a8e3f591694e"
+  ]
+}
+x-commit-hash: "5fcd2ff1904cb044c36e4e9b0131714d11e34127"

--- a/packages/protocol-9p/protocol-9p.2.0.2/opam
+++ b/packages/protocol-9p/protocol-9p.2.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-channel" {>= "4.0.0"}
   "lwt" {>= "3.0.0"}
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "logs" {>= "0.5.0"}
   "win-error"
   "ppx_sexp_conv" {>= "v0.9.0" & < "v0.15"}


### PR DESCRIPTION
An implementation of the 9p protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-9p">https://github.com/mirage/ocaml-9p</a>
- Documentation: <a href="https://mirage.github.io/ocaml-9p/">https://mirage.github.io/ocaml-9p/</a>

##### CHANGES:

* Update to Cstruct.length in cstruct.6.0.0 and use Fmt.str
  rather than Fmt.strf (@djs55)
