### PR TITLE
[new release] sha (1.15.2)

### DIFF
--- a/packages/sha/sha.1.15.2/opam
+++ b/packages/sha/sha.1.15.2/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Binding to the SHA cryptographic functions"
+description: """
+This is the binding for SHA interface code in OCaml. Offering the same
+interface than the MD5 digest included in the OCaml standard library.
+It's currently providing SHA1, SHA256 and SHA512 hash functions."""
+maintainer: ["dave@recoil.org"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Goswin von Brederlow"
+  "Eric Cooper"
+  "Florent Monnier"
+  "Forrest L Norvell"
+  "Vincent Bernadoff"
+  "David Scott"
+  "Olaf Hering"
+  "Arthur Teisseire"
+  "Nicolás Ojeda Bär"
+  "Christopher Zimmermann"
+  "Thomas Leonard"
+  "Antonin Décimo"
+]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-sha"
+bug-reports: "https://github.com/djs55/ocaml-sha/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.02"}
+  "stdlib-shims" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/djs55/ocaml-sha.git"
+url {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/1.15.2/sha-1.15.2.tbz"
+  checksum: [
+    "sha256=3fbd57b39a7c40068eb41ae1eccba140938beb5e3806a4cbbd79593b2183ffb7"
+    "sha512=25b01596c49427af484ae903508359261bd2cef355d43b5f29a2a87fb45b2a8a3e913e1324592c3efa02b5fef75b1aea76989d96268356d7a946b6d42c3be1ad"
+  ]
+}
+x-commit-hash: "a3e1e7e2f661e2f33c04c630623a73a94bb0679b"


### PR DESCRIPTION
Binding to the SHA cryptographic functions

- Project page: <a href="https://github.com/djs55/ocaml-sha">https://github.com/djs55/ocaml-sha</a>

##### CHANGES:

- Use modern Bigarray functions by @MisterDA (djs55/ocaml-sha#55)
