### PR TITLE
Package binaryen.0.13.0

### DIFF
--- a/packages/binaryen/binaryen.0.13.0/opam
+++ b/packages/binaryen/binaryen.0.13.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "103.0.1" & < "104.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.13.0/binaryen-archive-v0.13.0.tar.gz"
+  checksum: [
+    "md5=e89520c5fab628abd0e4e34c1c0b76bd"
+    "sha512=43aff4f5f872d8144500949cf7767859d951c6c888dee65b8f286fcad49cfdc6af22413ba41888111bef0ddb0c3dacaaec0a5847b55a508753cd971bb242d6d5"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.13.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.13.0](https://github.com/grain-lang/binaryen.ml/compare/v0.12.1...v0.13.0) (2022-02-07)


### Features

* Add all `Module.Features` that were missing ([09c5d30](https://github.com/grain-lang/binaryen.ml/commit/09c5d3064e9fd80ea6adac8b2f40cf2b708ebb8c))
* Add functions for ref & table expressions ([09c5d30](https://github.com/grain-lang/binaryen.ml/commit/09c5d3064e9fd80ea6adac8b2f40cf2b708ebb8c))
* Upgrade to libbinaryen v103 ([#134](https://github.com/grain-lang/binaryen.ml/issues/134)) ([09c5d30](https://github.com/grain-lang/binaryen.ml/commit/09c5d3064e9fd80ea6adac8b2f40cf2b708ebb8c))


### Miscellaneous Chores

* Use a upload-release-action that works ([97dbcdc](https://github.com/grain-lang/binaryen.ml/commit/97dbcdc53e69ccdb6e88ef03ce0766443a024cf1))

---
:camel: Pull-request generated by opam-publish v2.0.3