### PR TITLE
Package libbinaryen.104.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.104.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.104.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v104.0.0/libbinaryen-v104.0.0.tar.gz"
+  checksum: [
+    "md5=a15f4777fa283b4900f509c99e028ce6"
+    "sha512=26fbdc7c6d3a743bdf701f1ce4eb84e4c8db025a615e9e7eae4655bc7143f6aa6276c7b7e411256a38569c2a02111b32e906f43cc613aff56261041b3f1cc7dd"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.104.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [104.0.0](https://github.com/grain-lang/libbinaryen/compare/v103.0.1...v104.0.0) (2022-02-07)


### ⚠ BREAKING CHANGES

* Update binaryen to version_104

### Features

* Update binaryen to version_104 ([#42](https://github.com/grain-lang/libbinaryen/issues/42)) ([2000604](https://github.com/grain-lang/libbinaryen/commit/20006049db29f5256c69524821af2424484e0448))

---
:camel: Pull-request generated by opam-publish v2.0.3