### PR TITLE
Add: xmlm.1.4.0

### DIFF
--- a/packages/xmlm/xmlm.1.4.0/opam
+++ b/packages/xmlm/xmlm.1.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Streaming XML codec for OCaml"
+description: """\
+Xmlm is a streaming codec to decode and encode the XML data format. It
+can process XML documents without a complete in-memory representation of the
+data.
+
+Xmlm is made of a single independent module and distributed
+under the ISC license.
+
+Home page: http://erratique.ch/software/xmlm"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The xmlm programmers"
+license: "ISC"
+tags: ["xml" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/xmlm"
+doc: "https://erratique.ch/software/xmlm/doc/"
+bug-reports: "https://github.com/dbuenzli/xmlm/issues"
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/xmlm.git"
+url {
+  src: "https://erratique.ch/software/xmlm/releases/xmlm-1.4.0.tbz"
+  checksum:
+    "sha512=69f6112e6466952256d670fe1751fe4ae79e20d50f018ece1709eb2240cb1b00968ac7cee110771e0617a38ebc1cdb43e9d146471ce66ac1b176e4a1660531eb"
+}


### PR DESCRIPTION
* Add: `xmlm.1.4.0` [home](https://erratique.ch/software/xmlm), [doc](https://erratique.ch/software/xmlm/doc/), [issues](https://github.com/dbuenzli/xmlm/issues)  
  *Streaming XML codec for OCaml*


---

#### `xmlm` v1.4.0 2022-02-08 La Forclaz (VS)

- OCaml 5.00 support. Thanks to Antonio Nuno Monteiro for the patch.

---

Use `b0 cmd -- .opam.publish xmlm.1.4.0` to update the pull request.