### PR TITLE
extunix.0.1.4: only enable test if with-test

### DIFF
--- a/packages/extunix/extunix.0.1.4/opam
+++ b/packages/extunix/extunix.0.1.4/opam
@@ -49,7 +49,6 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "base-unsafe-string"
   "ocamlbuild" {build}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"

--- a/packages/extunix/extunix.0.1.4/opam
+++ b/packages/extunix/extunix.0.1.4/opam
@@ -25,7 +25,7 @@ build: [
     "ocaml"
     "setup.ml"
     "-configure"
-    "--%{ounit:enable}%-tests"
+    "--%{ounit:enable}%-tests" {with-test}
     "--prefix"
     prefix
   ] {ocaml:version >= "4.02.0"}
@@ -49,6 +49,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
+  "base-unsafe-string"
   "ocamlbuild" {build}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"


### PR DESCRIPTION
Otherwise this enables tests even for more recent compilers,
making it fail due to the use of unsafe-string. Seen on #20685

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>