### PR TITLE
Switch bls12-381 tarball sources to tags/releases instead of commits

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.1.1.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.1.1.1/opam
@@ -25,10 +25,10 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/22247018c0651ea62ae898c8ffcc388cc73f758f/ocaml-bls12-381-22247018c0651ea62ae898c8ffcc388cc73f758f.tar.bz2"
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.1.1/ocaml-bls12-381-1.1.1.tar.bz2"
   checksum: [
-    "md5=964b8d53cdbf5358465c4eb610c03da2"
-    "sha512=c6252a2cf543ab689dbe3be35a0a63d8cbbc1f4a5252ad9afa2ccb22d13d202d64a5b9f6ce5eb8c409eb594645d9490842f48b664e091f2a20f36f2d5ea1cd97"
+    "md5=32a535b7e01cc49580bbb951e753d771"
+    "sha512=0fcb37697b98709306123bbf2db8658caf914c5cc34af40c336061582e4662f682827bffbfe1fa47fba84365498e422c4f2cdfb8676504a40ea24683335d96e0"
   ]
 }
 x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
@@ -26,9 +26,9 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/6b0262fa33e768540fd4d104a8d7e6a2cbe686f8/ocaml-bls12-381-6b0262fa33e768540fd4d104a8d7e6a2cbe686f8.tar.bz2"
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.0/ocaml-bls12-381-2.0.0.tar.bz2"
   checksum: [
-    "md5=6043fb56a200c993a65bf97d4ae27c4e"
-    "sha512=fd025ad83d197e9fa6fde7d87a5bf5358830e1a2431fe24c969b72da919dc24a5aba6650d74daf63d345921d55494e3c54e6591d305790307b2fa414e8476569"
+    "md5=d1517198f5fd0d02fe0bf0f620880320"
+    "sha512=1408455cf390aa7c52a2ddc52d0c33ea04cc17096ec8f6a679595e17646b0e7f4a29f2ce720aedeaba0e545f6ea391d438d56a7f66417f94044db87afefa9dc2"
   ]
 }

--- a/packages/bls12-381/bls12-381.1.1.1/opam
+++ b/packages/bls12-381/bls12-381.1.1.1/opam
@@ -15,9 +15,9 @@ build: ["dune" "build" "-j" jobs "-p" name "@install"]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/22247018c0651ea62ae898c8ffcc388cc73f758f/ocaml-bls12-381-22247018c0651ea62ae898c8ffcc388cc73f758f.tar.bz2"
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.1.1/ocaml-bls12-381-1.1.1.tar.bz2"
   checksum: [
-    "md5=964b8d53cdbf5358465c4eb610c03da2"
-    "sha512=c6252a2cf543ab689dbe3be35a0a63d8cbbc1f4a5252ad9afa2ccb22d13d202d64a5b9f6ce5eb8c409eb594645d9490842f48b664e091f2a20f36f2d5ea1cd97"
+    "md5=32a535b7e01cc49580bbb951e753d771"
+    "sha512=0fcb37697b98709306123bbf2db8658caf914c5cc34af40c336061582e4662f682827bffbfe1fa47fba84365498e422c4f2cdfb8676504a40ea24683335d96e0"
   ]
 }

--- a/packages/bls12-381/bls12-381.2.0.0/opam
+++ b/packages/bls12-381/bls12-381.2.0.0/opam
@@ -15,9 +15,9 @@ build: ["dune" "build" "-j" jobs "-p" name "@install"]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/6b0262fa33e768540fd4d104a8d7e6a2cbe686f8/ocaml-bls12-381-6b0262fa33e768540fd4d104a8d7e6a2cbe686f8.tar.bz2"
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.0/ocaml-bls12-381-2.0.0.tar.bz2"
   checksum: [
-    "md5=6043fb56a200c993a65bf97d4ae27c4e"
-    "sha512=fd025ad83d197e9fa6fde7d87a5bf5358830e1a2431fe24c969b72da919dc24a5aba6650d74daf63d345921d55494e3c54e6591d305790307b2fa414e8476569"
+    "md5=d1517198f5fd0d02fe0bf0f620880320"
+    "sha512=1408455cf390aa7c52a2ddc52d0c33ea04cc17096ec8f6a679595e17646b0e7f4a29f2ce720aedeaba0e545f6ea391d438d56a7f66417f94044db87afefa9dc2"
   ]
 }


### PR DESCRIPTION
The date the archives are built is used when computing the hashes (downloading the archive and checking the files attributes show the date of the files is the date of the built). GitLab does not guarentee the tarballs are not going to be regenerated when commit hashes are used, at least, less than for the releases.
This commit changes that for bls12-381 packages.
It can be verified the commits are the same, see:
- [bls12-381.1.1.1](https://gitlab.com/dannywillems/ocaml-bls12-381/-/tags/1.1.1)
- [bls12-381.2.0.0](https://gitlab.com/dannywillems/ocaml-bls12-381/-/tags/2.0.0)