### PR TITLE
Add: b0.0.0.4, odig.0.0.8

### DIFF
--- a/packages/b0/b0.0.0.4/opam
+++ b/packages/b0/b0.0.0.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Software construction and deployment kit"
+description: """\
+WARNING this package is unstable and work in progress, do not depend on it. 
+
+B0 describes software construction and deployments using modular and
+customizable definitions written in OCaml.
+
+B0 describes:
+
+* Build environments.
+* Software configuration, build and testing.
+* Source and binary deployments.
+* Software life-cycle procedures.
+
+B0 also provides the B00 build library which provides abitrary build
+abstraction with reliable and efficient incremental rebuilds. The B00
+library can be – and has been – used on its own to devise domain
+specific build systems.
+
+B0 is distributed under the ISC license. It depends on [cmdliner][cmdliner].
+
+[cmdliner]: https://erratique.ch/software/cmdliner"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The b0 programmers"
+license: ["ISC" "BSD-2-Clause"]
+tags: ["dev" "org:erratique" "org:b0-system" "build"]
+homepage: "https://erratique.ch/software/b0"
+doc: "https://erratique.ch/software/b0/doc"
+bug-reports: "https://github.com/b0-system/b0/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "cmdliner" {>= "1.1.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/b0.git"
+url {
+  src: "https://erratique.ch/software/b0/releases/b0-0.0.4.tbz"
+  checksum:
+    "sha512=665735c8b7a8674201be765bdd676a18d1e38eff35de9d44c3dc15e2bfed2247e8963c9a32ae62d9ca2d6cd1edebd849aac29fdd5a846c14a30feea3edfc0601"
+}

--- a/packages/odig/odig.0.0.8/opam
+++ b/packages/odig/odig.0.0.8/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Lookup documentation of installed OCaml packages"
+description: """\
+odig is a command line tool to lookup documentation of installed OCaml
+packages. It shows package metadata, readmes, change logs, licenses,
+cross-referenced `odoc` API documentation and manuals.
+
+odig is distributed under the ISC license. The theme fonts have their
+own [licenses](LICENSE.md).
+
+Homepage: https://erratique.ch/software/odig"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The odig programmers"
+license: [
+  "ISC" "LicenseRef-ParaType-Free-Font-License" "LicenseRef-DejaVu-fonts"
+]
+tags: [
+  "build" "dev" "doc" "meta" "packaging" "org:erratique" "org:b0-system"
+]
+homepage: "https://erratique.ch/software/odig"
+doc: "https://erratique.ch/software/odig/doc"
+bug-reports: "https://github.com/b0-system/odig/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "cmdliner" {>= "1.1.0"}
+  "odoc" {>= "2.0.0"}
+  "b0" {= "0.0.4"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/odig.git"
+url {
+  src: "https://erratique.ch/software/odig/releases/odig-0.0.8.tbz"
+  checksum:
+    "sha512=e8d8e902043e92d8a5fc5ef8b267dbd378fc491025a9e65756d31fa01589a7c8b4e8a8b6a63d51caeb27f4ab86df4759259be81e83e0386977d83ac190e9370b"
+}


### PR DESCRIPTION
* Add: `b0.0.0.4` [home](https://erratique.ch/software/b0), [doc](https://erratique.ch/software/b0/doc), [issues](https://github.com/b0-system/b0/issues)  
  *Software construction and deployment kit*
* Add: `odig.0.0.8` [home](https://erratique.ch/software/odig), [doc](https://erratique.ch/software/odig/doc), [issues](https://github.com/b0-system/odig/issues)  
  *Lookup documentation of installed OCaml packages*


---

#### `b0` v0.0.4 2022-02-09 La Forclaz (VS)

Support latest `cmdliner`.

---

#### `odig` v0.0.8 2022-02-09 La Forclaz (VS)

- Support Cmdliner 1.1.0.
- Exit code 3 is now reported as 123.

---

Use `b0 cmd -- .opam.publish b0.0.0.4 odig.0.0.8` to update the pull request.