### PR TITLE
Adjust lower version boundary for camlp-streams

### DIFF
--- a/packages/camlp-streams/camlp-streams.5.0/opam
+++ b/packages/camlp-streams/camlp-streams.5.0/opam
@@ -32,7 +32,7 @@ bug-reports: "https://github.com/ocaml/camlp-streams/issues"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.5"}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.02.3"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
https://github.com/ocaml/camlp-streams/pull/3 was merged but the change *technically* only required adjusting the version constraints since the code builds on 4.02.3 fine so as @gasche suggests it should be possible to just adjust them on the existing release.

Given it is merged upstream, any future releases will have this lower constraint from the get-go.