### PR TITLE
Add: uuidm.0.9.8

### DIFF
--- a/packages/uuidm/uuidm.0.9.8/opam
+++ b/packages/uuidm/uuidm.0.9.8/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Universally unique identifiers (UUIDs) for OCaml"
+description: """\
+Uuidm is an OCaml module implementing 128 bits universally unique
+identifiers version 3, 5 (named based with MD5, SHA-1 hashing) and 4
+(random based) according to [RFC 4122][rfc4122].
+
+Uuidm has no dependency and is distributed under the ISC license.
+
+[rfc4122]: http://tools.ietf.org/html/rfc4122
+
+Homepage: <http://erratique.ch/software/uuidm>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuidm programmers"
+license: "ISC"
+tags: ["uuid" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/uuidm"
+doc: "https://erratique.ch/software/uuidm/doc/"
+bug-reports: "https://github.com/dbuenzli/uuidm/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuidm.git"
+url {
+  src: "https://erratique.ch/software/uuidm/releases/uuidm-0.9.8.tbz"
+  checksum:
+    "sha512=d5073ae49c402ab3ea6dc8f86bc5b8cc14129437e23e47da4d91431648fcb31c4dce6308f9c936c58df9a2c6afda61d77105a3022e369cca4e4c140320e803b5"
+}


### PR DESCRIPTION
* Add: `uuidm.0.9.8` [home](https://erratique.ch/software/uuidm), [doc](https://erratique.ch/software/uuidm/doc/), [issues](https://github.com/dbuenzli/uuidm/issues)  
  *Universally unique identifiers (UUIDs) for OCaml*


---

#### `uuidm` v0.9.8 2022-02-09 La Forclaz (VS)

- Add deprecation warnings on what is already deprecated.
- Require OCaml 4.08 and support 5.00 (Thanks to Kate @ki-ty-kate
  for the patch).

---

Use `b0 cmd -- .opam.publish uuidm.0.9.8` to update the pull request.