### PR TITLE
Package sexp_decode.0.2

### DIFF
--- a/packages/sexp_decode/sexp_decode.0.2/opam
+++ b/packages/sexp_decode/sexp_decode.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A library to decode S-expression into structured data"
+description:
+  "A library of monadic combinators that help translating S-expressions (as provided by the Csexp library) into structured data"
+maintainer: "Benoît Montagu <benoit.montagu@inria.fr>"
+authors: "Benoît Montagu <benoit.montagu@inria.fr>"
+license: "LGPL-3.0-or-later"
+homepage: "https://gitlab.inria.fr/bmontagu/sexp_decode"
+bug-reports: "Benoît Montagu <benoit.montagu@inria.fr>"
+depends: [
+  "csexp" {>= "1.5.1"}
+  "dune" {>= "2.9" & build >= "2.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://gitlab.inria.fr/bmontagu/sexp_decode"
+url {
+  src:
+    "https://gitlab.inria.fr/bmontagu/sexp_decode/-/archive/0.2/sexp_decode-0.2.tar.gz"
+  checksum: [
+    "md5=4d3c4855d568c33dfe631c7a19fbf516"
+    "sha512=8abc7ddabb378816efe9e0829bd3c812b2b083a1a6aee66fb28c62e7225a5d245e8a8ab07f9284ad3335d3f092c89d8ac657eeee0f635494a0b2bf7a7839828e"
+  ]
+}

--- a/packages/sexp_decode/sexp_decode.0.2/opam
+++ b/packages/sexp_decode/sexp_decode.0.2/opam
@@ -8,8 +8,9 @@ license: "LGPL-3.0-or-later"
 homepage: "https://gitlab.inria.fr/bmontagu/sexp_decode"
 bug-reports: "Benoît Montagu <benoit.montagu@inria.fr>"
 depends: [
+  "ocaml" {>= "4.08"}
   "csexp" {>= "1.5.1"}
-  "dune" {>= "2.9" & build >= "2.9.0"}
+  "dune" {>= "2.9"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
### `sexp_decode.0.2`
A library to decode S-expression into structured data
A library of monadic combinators that help translating S-expressions (as provided by the Csexp library) into structured data



---
* Homepage: https://gitlab.inria.fr/bmontagu/sexp_decode
* Source repo: git+https://gitlab.inria.fr/bmontagu/sexp_decode
* Bug tracker: Benoît Montagu <benoit.montagu@inria.fr>

---
:camel: Pull-request generated by opam-publish v2.1.0