### PR TITLE
[new release] stdcompat.18

### DIFF
--- a/packages/stdcompat/stdcompat.18/opam
+++ b/packages/stdcompat/stdcompat.18/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.08"}
+]
+depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+build: [
+  ["./configure" "--prefix=%{prefix}%"]
+  [make "all" "test" {with-test}]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/v18/stdcompat-18.tar.gz"
+  checksum: [
+    "sha512=4323a43d906121951f62ee8da4dec2c3be30540bbdca114096fa3ca655ba05342b429343d0b51df6e8173541e255e3bfe57a047147b27bca1f6bb22a15ce0013"
+  ]
+}


### PR DESCRIPTION
This PR adds the new release of `stdcompat.18`.

* Support for OCaml 4.14 with
  - Lot of new functions in `Seq`
  - `Uchar.utf_decode` and co
  - `In_channel` and `Out_channel` modules
  - `Sys.{development_version, ocaml_release}`

* Add `Stdlib.{acosh,asinh,atanh}` missing from 4.13 and `Stdlib.__FUNCTION__` missing from 4.12

* Add module `Unit` missing from 4.08

* Add module `Random`, with new functions introduced from 4.13

* `Filename.chop_suffix` checks that suffixes match and fails otherwise
  (behavior introduced in 4.14)

* `Buffer.add_channel` adds data read from the channel even if `End_of_file` has been reached
  (behavior introduced in 4.03)

* Add dependency for generating `.cmt` files
  (reported by Sabyrzhan Tasbolatov)