### PR TITLE
New OSDP version 1.1.0

### DIFF
--- a/packages/conf-csdp/conf-csdp.1/opam
+++ b/packages/conf-csdp/conf-csdp.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Pierre Roux"
 authors: "CSDP"
-license: "CPL"
+license: "CPL-1.0"
 homepage: "https://github.com/coin-or/Csdp/wiki"
 build: ["sh" "-exc" "command -v csdp"]
 depexts: [

--- a/packages/conf-csdp/conf-csdp.1/opam
+++ b/packages/conf-csdp/conf-csdp.1/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/coin-or/Csdp/wiki"
 build: ["sh" "-exc" "command -v csdp"]
 depexts: [
   ["coinor-csdp"] {os-family = "debian"}
-  ["csdp"] {os-distribution = "centos"}
 ]
 synopsis: "Virtual package relying on a CSDP binary system installation"
 description:

--- a/packages/conf-csdp/conf-csdp.1/opam
+++ b/packages/conf-csdp/conf-csdp.1/opam
@@ -1,10 +1,12 @@
 opam-version: "2.0"
 maintainer: "Pierre Roux"
 authors: "CSDP"
+license: "CPL"
 homepage: "https://github.com/coin-or/Csdp/wiki"
 build: ["sh" "-exc" "command -v csdp"]
 depexts: [
   ["coinor-csdp"] {os-family = "debian"}
+  ["csdp-tools"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
 ]
 synopsis: "Virtual package relying on a CSDP binary system installation"
 description:

--- a/packages/conf-csdp/conf-csdp.1/opam
+++ b/packages/conf-csdp/conf-csdp.1/opam
@@ -7,6 +7,7 @@ build: ["sh" "-exc" "command -v csdp"]
 depexts: [
   ["coinor-csdp"] {os-family = "debian"}
   ["csdp-tools"] {os-distribution = "centos" | os-distribution = "fedora" | os-distribution = "ol"}
+  ["coin-or-csdp"] {os-distribution = "archlinux"}
 ]
 synopsis: "Virtual package relying on a CSDP binary system installation"
 description:

--- a/packages/osdp/osdp.1.1.0/opam
+++ b/packages/osdp/osdp.1.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Pierre Roux"
+author: "Pierre Roux <pierre.roux@onera.fr>"
+homepage: "https://github.com/Embedded-SW-VnV/osdp"
+dev-repo: "git+https://github.com/Embedded-SW-VnV/osdp"
+bug-reports: "author"
+license: "LGPL-3.0-or-later"
+build: [
+  ["autoconf"]
+  ["./configure"]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "conf-autoconf" {build}
+  "zarith" {>= "1.4"}
+  "ocplib-simplex" {= "0.4"}
+  "conf-csdp"
+]
+depopts: ["conf-sdpa"]
+synopsis: "OCaml Interface to SDP solvers"
+description: """
+OSDP is an OCaml frontend library to semi-definite programming (SDP)
+numerical optimization solvers. This package will be installed with
+the solver CSDP. It will also be compiled with SDPA and Mosek support
+if they can be found in the PATH."""
+url {
+  src:
+    "https://github.com/Embedded-SW-VnV/osdp/archive/refs/tags/v1.1.0.tar.gz"
+  checksum: "sha512=4def6516b6af9f9af8e988a7bbe9af14ac25cea22ef93fd05a485b50e1ac7198498f34100880fbef41819ccdbda231aeff475dfa7fade81885da9a3fe94837d9"
+}


### PR DESCRIPTION
The CI will fail with all but Debian based systems because of the absence of depext for conf-csdp, c.f., previous version: https://github.com/ocaml/opam-repository/pull/13179