### PR TITLE
Package squirrel.0.1

### DIFF
--- a/packages/squirrel/squirrel.0.1/opam
+++ b/packages/squirrel/squirrel.0.1/opam
@@ -17,6 +17,7 @@ depends: [
   "alcotest"
   "menhir" {>= "20180523"}
   "pcre"
+  "conf-which" {build}
 ]
 
 install: [make "PREFIX=%{prefix}%" "install"]

--- a/packages/squirrel/squirrel.0.1/opam
+++ b/packages/squirrel/squirrel.0.1/opam
@@ -11,7 +11,8 @@ build: [
 ]
 
 depends: [
-  "fmt"
+  "ocaml" {>= "4.10"}
+  "fmt" {>= "0.8.7"}
   "ocamlgraph"
   "alcotest"
   "menhir"

--- a/packages/squirrel/squirrel.0.1/opam
+++ b/packages/squirrel/squirrel.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "The Squirrel Prover is a proof assistant for protocols, based on first-order logic and provides guarantees in the computational model"
+homepage: "https://squirrel-prover.github.io/"
+bug-reports: "https://github.com/squirrel-prover/squirrel-prover/issues"
+maintainer: "Charlie Jacomme <charlie.jacomme@cispa.de>"
+authors: "David Baelde, Stéphanie Delaune, Charlie Jacomme, Adrien Koutsos, Solène Moreau"
+build: [
+  [make]
+  [make "test"] {with-test}
+  [make "doc"] {with-doc}
+]
+
+depends: [
+  "fmt"
+  "ocamlgraph"
+  "alcotest"
+  "menhir"
+  "pcre"
+  "bisect_ppx" {dev & = "2.4.0"}
+]
+
+pin-depends: [
+  ["bisect_ppx.2.4.0" "git+https://github.com/aantron/bisect_ppx.git"]
+]
+
+install: [make "PREFIX=%{prefix}%" "install"]
+url {
+  src:
+    "https://github.com/squirrel-prover/squirrel-prover/archive/0.1.tar.gz"
+  checksum: [
+    "md5=656660bb1321baf5bba4542fd6804835"
+    "sha512=5fafc20c2021f92f83819a2b3fe697acbda57d9863c9a902f2094821fd705fa1426abceaa9be6c8c4d2b6187be57b30cf37d7cb77c6b8de01a6c6ece97d77c3c"
+  ]
+}

--- a/packages/squirrel/squirrel.0.1/opam
+++ b/packages/squirrel/squirrel.0.1/opam
@@ -15,13 +15,8 @@ depends: [
   "fmt" {>= "0.8.7"}
   "ocamlgraph"
   "alcotest"
-  "menhir"
+  "menhir" {>= "20180523"}
   "pcre"
-  "bisect_ppx" {dev & = "2.4.0"}
-]
-
-pin-depends: [
-  ["bisect_ppx.2.4.0" "git+https://github.com/aantron/bisect_ppx.git"]
 ]
 
 install: [make "PREFIX=%{prefix}%" "install"]


### PR DESCRIPTION
### `squirrel.0.1`
The Squirrel Prover is a proof assistant for protocols, based on first-order logic and provides guarantees in the computational model



---
* Homepage: https://squirrel-prover.github.io/
* Bug tracker: https://github.com/squirrel-prover/squirrel-prover/issues

---
:camel: Pull-request generated by opam-publish v2.1.0