### PR TITLE
Bisect_ppx 2.8.0: OCaml coverage tool

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.8.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.02.0"}
+  "ppxlib" {>= "0.21.0"}
+
+  "ocamlformat" {with-test & = "0.16.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@compatible"] {with-test}
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.8.0.tar.gz"
+  checksum: "md5=ba8c80cd2bf6b86537296736a4c6ba89"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.8.0):

> Additions
>
> - HTML: collapsible tree index for large projects, activated by `--tree` option (aantron/bisect_ppx#396, Arvid Jakobsson).
>
> Bugs fixed
>
> - Don't instrument lazy values which are compiled as already forced (aantron/bisect_ppx#398, reported by @Ngoguey42).
> - Use `Sys.backend_type` to detect js_of_ocaml (aantron/bisect_ppx#397, Pat Rondon).
> - Text summary report: show files with 0 points as having 100% coverage (aantron/bisect_ppx@f3b9108).

cc @arvidj @pat-rondon