### PR TITLE
[new release] dune-release (1.6.0)

### DIFF
--- a/packages/dune-release/dune-release.1.6.0/opam
+++ b/packages/dune-release/dune-release.1.6.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com)."""
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: [
+  "Daniel Bünzli"
+  "Thomas Gazagnaire"
+  "Nathan Rebours"
+  "Guillaume Petiot"
+  "Sonja Heinze"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/dune-release"
+bug-reports: "https://github.com/ocamllabs/dune-release/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.06.0"}
+  "curly"
+  "fmt" {>= "0.8.7"}
+  "fpath" {>= "0.7.3"}
+  "bos"
+  "cmdliner"
+  "re" {>= "1.7.2"}
+  "astring"
+  "opam-file-format" {>= "2.1.2"}
+  "opam-format" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-core" {>= "2.1.0"}
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+  "yojson" {>= "1.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamllabs/dune-release.git"
+url {
+  src:
+    "https://github.com/ocamllabs/dune-release/releases/download/1.6.0/dune-release-1.6.0.tbz"
+  checksum: [
+    "sha256=0e1b70588290015fd15f94f777ae6e48f32a0b9201fe1af71ae3d4c687ca591e"
+    "sha512=d8a2e1db19e50f0e8e6876c2006cca370de0d5f0b2e4566888e3eb52afab75087ab6f37762e9ebf783d3dcdcd9dfd7eae34fe5fd749402be84f330de20665db3"
+  ]
+}
+x-commit-hash: "497e0bdb8ae3802218b50e97b6abfc4ab5738257"

--- a/packages/dune-release/dune-release.1.6.0/opam
+++ b/packages/dune-release/dune-release.1.6.0/opam
@@ -23,7 +23,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "fpath" {>= "0.7.3"}
   "bos"
-  "cmdliner"
+  "cmdliner" {< "1.1.0"}
   "re" {>= "1.7.2"}
   "astring"
   "opam-file-format" {>= "2.1.2"}


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/ocamllabs/dune-release">https://github.com/ocamllabs/dune-release</a>

##### CHANGES:

### Added

- Add `--skip-lint`, `--skip-build`, `--skip-test` and
  `--keep-build-dir` to the main command (ocamllabs/dune-release#419, @NathanReb)
- Added support for parsing changelogs written in the style of
  [keepachangelog.com](https://keepachangelog.com/) (ocamllabs/dune-release#421, @ifazk)
