### PR TITLE
Add: note.0.0.2

### DIFF
--- a/packages/note/note.0.0.2/opam
+++ b/packages/note/note.0.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Declarative events and signals for OCaml"
+description: """\
+Note is an OCaml library for functional reactive programming (FRP). It
+provides support to program with time varying values: declarative
+events and signals.
+
+Note is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/note"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The note programmers"
+license: "ISC"
+tags: ["reactive" "declarative" "signal" "event" "frp" "org:erratique"]
+homepage: "https://erratique.ch/software/note"
+doc: "https://erratique.ch/software/note/doc/"
+bug-reports: "https://github.com/dbuenzli/note/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/note.git"
+url {
+  src: "https://erratique.ch/software/note/releases/note-0.0.2.tbz"
+  checksum:
+    "sha512=c697cbb0451d6f05e0397ef239810d270b8d98eabcab5e0c973f19f252ca10a851b14b0b7aa003d32ee7099d2cc2d2f6d5d4d6251f58c4341525d662494aac03"
+}


### PR DESCRIPTION
* Add: `note.0.0.2` [home](https://erratique.ch/software/note), [doc](https://erratique.ch/software/note/doc/), [issues](https://github.com/dbuenzli/note/issues)  
  *Declarative events and signals for OCaml*


---

#### `note` v0.0.2 2022-02-10

- Handle `Pervasives`'s deprecation (and thus support OCaml 5.00).

---

Use `b0 cmd -- .opam.publish note.0.0.2` to update the pull request.