### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.10.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.10.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.10.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.10.0/jsonrpc-1.10.0.tbz"
+  checksum: [
+    "sha256=9640f418cbacedb41d888908e99d3ad349d473c35876271acc9185d5c6ca1104"
+    "sha512=7353542380fcd419569fd729017ba592d817c284209033016c6921bd6bf0568fc51c8f47f88a82713bebbfacc9bdd841f512d984dd49c014632d27910089c935"
+  ]
+}
+x-commit-hash: "ed15093b0de1997720c90cc257c507952014dded"

--- a/packages/lsp/lsp.1.10.0/opam
+++ b/packages/lsp/lsp.1.10.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "pp"
+  "csexp" {>= "1.5"}
+  "uutf"
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.10.0/jsonrpc-1.10.0.tbz"
+  checksum: [
+    "sha256=9640f418cbacedb41d888908e99d3ad349d473c35876271acc9185d5c6ca1104"
+    "sha512=7353542380fcd419569fd729017ba592d817c284209033016c6921bd6bf0568fc51c8f47f88a82713bebbfacc9bdd841f512d984dd49c014632d27910089c935"
+  ]
+}
+x-commit-hash: "ed15093b0de1997720c90cc257c507952014dded"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.10.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.10.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-build-info"
+  "spawn"
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "result" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.18.0" & < "0.20.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.13" & < "4.14"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.10.0/jsonrpc-1.10.0.tbz"
+  checksum: [
+    "sha256=9640f418cbacedb41d888908e99d3ad349d473c35876271acc9185d5c6ca1104"
+    "sha512=7353542380fcd419569fd729017ba592d817c284209033016c6921bd6bf0568fc51c8f47f88a82713bebbfacc9bdd841f512d984dd49c014632d27910089c935"
+  ]
+}
+x-commit-hash: "ed15093b0de1997720c90cc257c507952014dded"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add better support for code folding: more folds and more precise folds

## Fixes

- Fix infer interface code action crash when implementation source does not
  exist (ocaml/ocaml-lsp#597)

- Improve error message when the reason plugin for merlin is absent (ocaml/ocaml-lsp#608)

- Fix `chdir` races when running ppx (ocaml/ocaml-lsp#550)

- More accurate completion kinds.
  New completion kinds for variants and fields. Removed inaccurate completion
  kinds for constructors and types. (ocaml/ocaml-lsp#510)

- Fix handling request cancellation (ocaml/ocaml-lsp#616)
