### PR TITLE
Add: tgls.0.8.6

### DIFF
--- a/packages/tgls/tgls.0.8.6/opam
+++ b/packages/tgls/tgls.0.8.6/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml"
+description: """\
+Tgls is a set of independent OCaml libraries providing thin bindings
+to OpenGL libraries. It has support for core OpenGL 3.{2,3} and
+4.{0,1,2,3,4} and OpenGL ES 2 and 3.{0,1,2}.
+
+Tgls depends on [ocaml-ctypes][ctypes] and the C OpenGL library of your
+platform. It is distributed under the ISC license.
+          
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+
+Home page: <http://erratique.ch/software/tgls>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The tgls programmers"
+license: "ISC"
+tags: ["bindings" "opengl" "opengl-es" "graphics" "org:erratique"]
+homepage: "https://erratique.ch/software/tgls"
+doc: "https://erratique.ch/software/tgls/doc/"
+bug-reports: "https://github.com/dbuenzli/tgls/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "ctypes" {>= "0.4.0"}
+  "ctypes-foreign"
+  "xmlm" {dev}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/tgls.git"
+url {
+  src: "https://erratique.ch/software/tgls/releases/tgls-0.8.6.tbz"
+  checksum:
+    "sha512=837f030860a8c53d1dad5677240bb106fe4c44270a6615cdf90236fea50882420a303ac6df988b83ef92c1ae5fe6522e39dcb058ef4166422b7978dee4b5143b"
+}


### PR DESCRIPTION
* Add: `tgls.0.8.6` [home](https://erratique.ch/software/tgls), [doc](https://erratique.ch/software/tgls/doc/), [issues](https://github.com/dbuenzli/tgls/issues)  
  *Thin bindings to OpenGL {3,4} and OpenGL ES {2,3} for OCaml*


---

#### `tgls` v0.8.6 2022-02-10 La Forclaz (VS)

* Handle `Pervasives` deprecation (and thus support OCaml 5.00).

---

Use `b0 cmd -- .opam.publish tgls.0.8.6` to update the pull request.