### PR TITLE
[new release] xdg, stdune, ordering, fiber, dyn, dune, dune-site, dune-rpc, dune-rpc-lwt, dune-private-libs, dune-glob, dune-configurator, dune-build-info and dune-action-plugin (3.0.0)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.3.0.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.0.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "dune-glob"
-  "csexp" {>= "1.4.0"}
+  "csexp" {>= "1.5.0"}
   "ppx_expect" {with-test}
   "stdune" {= version}
   "dune-private-libs" {= version}

--- a/packages/dune-action-plugin/dune-action-plugin.3.0.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-glob"
+  "csexp" {>= "1.4.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-build-info/dune-build-info.3.0.0/opam
+++ b/packages/dune-build-info/dune-build-info.3.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-build-info/dune-build-info.3.0.0/opam
+++ b/packages/dune-build-info/dune-build-info.3.0.0/opam
@@ -15,6 +15,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
+  "ocaml" {>= "4.08"}
   "dune" {>= "3.0"}
   "odoc" {with-doc}
 ]

--- a/packages/dune-configurator/dune-configurator.3.0.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.0.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.04.0"}
-  "csexp" {>= "1.3.0"}
+  "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-configurator/dune-configurator.3.0.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.04.0"}
+  "csexp" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-glob/dune-glob.3.0.0/opam
+++ b/packages/dune-glob/dune-glob.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-private-libs/dune-private-libs.3.0.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "csexp" {>= "1.4.0"}
+  "pp"
+  "dyn"
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.0/opam
@@ -9,10 +9,10 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
-  "result"
+  "result" {>= "1.5"}
   "dune-rpc" {= version}
-  "csexp" {>= "1.4.0"}
-  "lwt"
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.3.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "result"
+  "dune-rpc" {= version}
+  "csexp" {>= "1.4.0"}
+  "lwt"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-rpc/dune-rpc.3.0.0/opam
+++ b/packages/dune-rpc/dune-rpc.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune-site/dune-site.3.0.0/opam
+++ b/packages/dune-site/dune-site.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations informations inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune/dune.3.0.0/opam
+++ b/packages/dune/dune.3.0.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/dune/dune.3.0.0/opam
+++ b/packages/dune/dune.3.0.0/opam
@@ -33,6 +33,7 @@ conflicts: [
   "dune-release" {< "1.3.0"}
   "js_of_ocaml-compiler" {< "3.6.0"}
   "jbuilder" {= "transition"}
+  "base-effects"
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [

--- a/packages/dyn/dyn.3.0.0/opam
+++ b/packages/dyn/dyn.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "ordering"
+  "pp"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/fiber/fiber.3.0.0/opam
+++ b/packages/fiber/fiber.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Structured concurrency library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "stdune"
+  "dyn"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/ordering/ordering.3.0.0/opam
+++ b/packages/ordering/ordering.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/stdune/stdune.3.0.0/opam
+++ b/packages/stdune/stdune.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "dyn"
+  "ordering"
+  "pp"
+  "csexp"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/stdune/stdune.3.0.0/opam
+++ b/packages/stdune/stdune.3.0.0/opam
@@ -11,10 +11,10 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.08.0"}
-  "dyn"
-  "ordering"
-  "pp"
-  "csexp"
+  "dyn" {>= version}
+  "ordering" {>= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"

--- a/packages/xdg/xdg.3.0.0/opam
+++ b/packages/xdg/xdg.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.0/fiber-3.0.0.tbz"
+  checksum: [
+    "sha256=86be7e12ab9501eb47cd749bd00010b90bc4d8e5bdd6c8a200c5a4661ea52a35"
+    "sha512=a04b13eedda52dcc2f7d7644aa86e4225afc1635a7eff1827a0b87698b5c339c916f1c458ad3c573cba079cd6002e25e2e46792153c59a8870c3bbae1e37ceb2"
+  ]
+}
+x-commit-hash: "efad78e826e6af26e140ed9f9e3a00b17f89d617"

--- a/packages/xdg/xdg.3.0.0/opam
+++ b/packages/xdg/xdg.3.0.0/opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
+  "ocaml" {>= "4.08"}
   "dune" {>= "3.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
XDG Base Directory Specification

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Remove `uchar` and `seq` dummy ocamlfind libraries from dune's builtin
  library database (ocaml/dune#5260, @kit-ty-kate)

- Add a `DUNE_DIFF_COMMAND` environment variable to match `--diff-command`
  command-line parameter (@raphael-proust, fix ocaml/dune#5369, ocaml/dune#5375)

- Add support for odoc-link rules (ocaml/dune#5045, @lubegasimon)

- Dune will no longer generate documentation for hidden modules (ocaml/dune#5045,
  @lubegasimon)

- Parse the `native_pack_linker` field of `ocamlc -config` (ocaml/dune#5281, @TheLortex)

- Fix plugins with dot in the name (ocaml/dune#5182, @bobot, review @rgrinberg)

- Don't generate the dune-site build part when not needed (ocaml/dune#4861, @bobot,
  review @kit-ty-kate)

- Fix installation of implementations of virtual libraries (ocaml/dune#5150, fix ocaml/dune#3636,
  @rgrinberg)

- Run tests in all modes defined. Previously, jsoo was excluded. (@hhugo,
  ocaml/dune#5049, fix ocaml/dune#4951)

- Allow to configure the alias to run the jsoo tests (@hhugo, ocaml/dune#5049, ocaml/dune#4999)

- Set jsoo compilation flags in the `env` stanza (@hhugo, ocaml/dune#5049, ocaml/dune#1613)

- Allow to configure jsoo separate compilation in the `env` stanza. Previously,
  it was hard coded to always be enabled in the `dev` profile. (@hhugo, ocaml/dune#5049,
  fix ocaml/dune#970)

- Fix build-info version in jsoo executables (@hhugo, ocaml/dune#5049, fix ocaml/dune#4444)

- Pass `-no-check-prims` when building bytecode for jsoo (@hhugo, ocaml/dune#5049, ocaml/dune#4027)

- Fix jsoo builds when dynamically linked foreign archives are disabled
  (@hhugo, ocaml/dune#5049)

- Disallow empty packages starting from 3.0.  Empty packages may be
  re-enabled by adding the `(allow_empty)` to the package stanza in
  the dune-project file. (ocaml/dune#4867, fix ocaml/dune#2882, @kit-ty-kate, @rgrinberg)

- Add `link_flags` field to the `executable` field of `inline_tests` (ocaml/dune#5088,
  fix ocaml/dune#1530, @jvillard)

- In watch mode, use fsevents instead of fswatch on OSX (ocaml/dune#4937, ocaml/dune#4990, fixes
  ocaml/dune#4896 @rgrinberg)

- Remove `inotifywait` watch mode backend on Linux. We now use the inotify API
  exclusively (ocaml/dune#4941, @rgrinberg)

- Report cycles between virtual libraries and their implementation (ocaml/dune#5050,
  fixes ocaml/dune#2896, @rgrinberg)

- Warn when lang versions have an ignored suffix. `(lang dune 2.3.4)` or `(lang
  dune 2.3suffix)` were silently parsed as `2.3` and we know suggest to remove
  the prefix. (ocaml/dune#5040, @emillon)

- Allow users to specify dynamic dependencies in rules. For example `(deps
  %{read:foo.gen})` (ocaml/dune#4662, fixes ocaml/dune#4089, @jeremiedimino)

- Sandbox infer rules for menhir. Fixes possible "inconsistent assumptions"
  errors (ocaml/dune#5015, @rgrinberg)

- Experimental support for ctypes stubs (ocaml/dune#3905, fixes ocaml/dune#135, @mbacarella)

- Fix interpretation of `binaries` defined in the `env stanza`. Binaries
  defined in `x/dune` wouldn't be visible in `x/*/**/dune. (ocaml/dune#4975, fixes ocaml/dune#4976,
  @Leonidas-from-XIV, @rgrinberg)

- Do not list private libraries in package listings (ocaml/dune#4945, fixes ocaml/dune#4799,
  @rgrinberg)

- Allow spaces in cram test paths (ocaml/dune#4980, fixes ocaml/dune#4162, @rgrinberg)

- Improve error handling of misbehaving cram scripts. (ocaml/dune#4981, fix ocaml/dune#4230,
  @rgrinberg)

- Fix `foreign_stubs` inside a `tests` stanza. Previously, dune would crash
  when this field was present (ocaml/dune#4942, fix ocaml/dune#4946, @rgrinberg)

- Add the `enabled_if` field to `inline_tests` within the `library` stanza.
  This allows us to disable executing the inline tests while still allowing for
  compilation (ocaml/dune#4939, @rgrinberg)

- Generate a `dune-project` when initializing projects with `dune init proj ...`
  (ocaml/dune#4881, closes ocaml/dune#4367, @shonfeder)

- Allow spaces in the directory argument of the `subdir` stanza (ocaml/dune#4943, fixes
  ocaml/dune#4907, @rgrinberg)

- Add a `%{toolchain}` expansion variable (ocaml/dune#4899, fixes ocaml/dune#3949, @rgrinberg)

- Include dependencies of executables when creating toplevels (either `dune
  top` or `dune utop`) (ocaml/dune#4882, fixes ocaml/dune#4872, @Gopiancode)

- Fixes `opam` META file requires entry for private libs (ocaml/dune#4841, fixes ocaml/dune#4839, @toots)

- Fixes `dune exec` not adding .exe on Windows (ocaml/dune#4371, fixes ocaml/dune#3322, @MisterDA)

- Allow multiple cinaps stanzas in the same directory (ocaml/dune#4460, @rgrinberg)

- Fix `$ dune subst` in empty git repositories (ocaml/dune#4441, fixes ocaml/dune#3619, @rgrinberg)

- Improve interpretation of ansi escape sequence when spawning processes (ocaml/dune#4408,
  fixes ocaml/dune#2665, @rgrinberg)

- Allow `(package pkg)` in dependencies even if `pkg` is an installed package
  (ocaml/dune#4170, @bobot)

- Allow `%{version:pkg}` to work for external packages (ocaml/dune#4104, @kit-ty-kate)

- Add `(glob_files_rec <dir>/<glob>)` for globbing files recursively (ocaml/dune#4176,
  @jeremiedimino)

- Automatically generate empty `.mli` files for executables and tests (ocaml/dune#3768,
  fixes ocaml/dune#3745, @CraigFe)

- Add `ocaml` command subgroup for OCaml related commands such as `utop`, `top`,
  and `merlin` (ocaml/dune#3936, @rgrinberg).

- Detect unknown variables more eagerly (ocaml/dune#4184, @jeremiedimino)

- Improve location of variables and macros in error messages (ocaml/dune#4205,
  @jeremiedimino)

- Auto-detect `dune-project` files as `dune` files in Emacs (ocaml/dune#4222, @shonfeder)

- Dune no longer automatically create or edit `dune-project` files
  (ocaml/dune#4239, fixes ocaml/dune#4108, @jeremiedimino)

- Warn if `dune-project` is not found (fatal in release mode) (ocaml/dune#5343, @emillon)

- Cleanup temporary files after running `$ dune exec`. (ocaml/dune#4260, fixes ocaml/dune#4243,
  @rgrinberg)

- Add a new subcommand `dune ocaml dump-dot-merlin` that prints a mix of all the
  merlin configuration of a directory (defaulting to the current directory) in
  the Merlin configuration syntax. (ocaml/dune#4250, @voodoos)

- Enable cram tests by default (ocaml/dune#4262, @rgrinberg)

- Drop support for opam 1.x (ocaml/dune#4280, @jeremiedimino)

- Stop calling `ocamlfind` to determine the library search path or
  library installation directory. This makes the behavior of Dune
  simpler and more reproducible (ocaml/dune#4281, @jeremiedimino)

- Remove the `external-lib-deps` command. This command was only
  approximative and the cost of maintainance was getting too high. We
  removed it to make room for new more important features (ocaml/dune#4298,
  @jeremiedimino)

- It is now possible to define action dependencies through a chain
  of aliases. (ocaml/dune#4303, @aalekseyev)

- If an .ml file is not used by an executable, Dune no longer report
  parsing error in this file (ocaml/dune#4330, @jeremiedimino)

- Add support for sandboxing using hard links (ocaml/dune#4360, Andrey Mokhov)

- Fix dune crash when `subdir` is an absolute path (ocaml/dune#4366, @anmonteiro)

- Changed the implementation of actions attached to aliases, as in
  `(rule (alias runtest) (action (run ./test)))`. A visible result for
  users is that such actions are now memoized for longer. For
  instance:
  ```
  $ echo '(rule (alias runtest) (action (echo "X=%{env:X=0}\n")))` > dune
  $ X=1 dune runtest
  X=1
  $ X=2 dune runtest
  X=2
  $ X=1 dune runtest
  ```
  Previously, Dune would have re-executed the action again at the last
  line. Now it remembers the result of the first execution.

- Fix a bug where dune would always re-run all actions that produce symlinks,
  even if their dependencies did not change. (ocaml/dune#4405, @aalekseyev)

- Fix a bug that was causing Dune to re-hash generated files more
  often than necessary (ocaml/dune#4419, @jeremiedimino)

- Fields allowed in the config file are now also allowed in the
  workspace file (ocaml/dune#4426, @jeremiedimino)

- Add options to control how Dune should handle stdout and stderr of
  actions when then succeed. It is now possible to ask Dune to ignore
  the stdout of actions when they succeed or to request that the
  stderr of actions must be empty. This allows to reduce the noise of
  large builds (ocaml/dune#4422, ocaml/dune#4515, @jeremiedimino)

- The `@all` alias no longer depends directly on copies of files from the source
  directory (ocaml/dune#4461, @nojb)

- Allow dune-file as an alternative file name for dune files (needs to be
  enabled in the dune-project file) (ocaml/dune#4428, @nojb)

- Drop support for upgrading jbuilder projects (ocaml/dune#4473, @jeremiedimino)

- Extend the environment variable `BUILD_PATH_PREFIX_MAP` to rewrite
  the root of the build dir (or sandbox) to `/workspace_root` (ocaml/dune#4466,
  @jeremiedimino)

- Simplify the implementation of build cache. We stop using the cache daemon to
  access the cache and instead write to and read from it directly. The new cache
  implementation is based on Jenga's cache library, which was thoroughly tested
  on large-scale builds. Using Jenga's cache library will also make it easier
  for us to port Jenga's cloud cache to Dune. (ocaml/dune#4443, ocaml/dune#4465, Andrey Mokhov)

- More informative error message when Dune can't read a target that's supposed
  to be produced by the action. Old message is still produced on ENOENT, but other
  errors deserve a more detailed report. (ocaml/dune#4501, @aalekseyev)

- Fixed a bug where a sandboxed action would fail if it declares no dependencies in
  its initial working directory or any directory it `chdir`s into. (ocaml/dune#4509, @aalekseyev)

- Fix a crash when clearing temporary directories (ocaml/dune#4489, ocaml/dune#4529, Andrey Mokhov)

- Dune now memoizes all errors when running in the file-watching mode. This
  speeds up incremental rebuilds but may be inconvenient in rare cases, e.g. if
  a build action fails due to a spurious error, such as running out of memory.
  Right now, the only way to force such actions to be rebuilt is to restart
  Dune, which clears all memoized errors. In future, we would like to provide a
  way to rerun all actions failed due to errors without restarting the build,
  e.g. via a Dune RPC call. (ocaml/dune#4522, Andrey Mokhov)

- Remove `dune compute`. It was broken and unused (ocaml/dune#4540,
  @jeremiedimino)

- No longer generate an approximate merlin files when computing the
  ocaml flags fails, for instance because they include the contents of
  a file that failed to build. This was a niche feature and it was
  getting in the way of making Dune's core better. (ocaml/dune#4607, @jeremiedimino)

- Make Dune display the progress indicator in all output modes except quiet
  (ocaml/dune#4618, @aalekseyev)

- Report accurate process timing information in trace mode (enabled with
  `--trace-file`) (ocaml/dune#4517, @rgrinberg)

- Do not log `live_words` and `free_words` in trace file. This allows using
  `Gc.quick_stat` which does not scan the heap. (ocaml/dune#4643, @emillon)

- Don't let command run by Dune observe the environment variable
  `INSIDE_EMACS` in order to improve reproducibility (ocaml/dune#4680,
  @jeremiedimino)

- Fix `root_module` when used in public libraries (ocaml/dune#4685, fixes ocaml/dune#4684,
  @rgrinberg, @CraigFe)

- Fix `root_module` when used with preprocessing (ocaml/dune#4683, fixes ocaml/dune#4682,
  @rgrinberg, @CraigFe)

- Display Coq profile flags in `dune printenv` (ocaml/dune#4767, @ejgallego)

- Introduce mdx stanza 0.2, requiring mdx >= 1.9.0, with a new generic `deps`
  field and the possibility to statically link `libraries` in the test
  executable. (ocaml/dune#3956, ocaml/dune#5391, fixes ocaml/dune#3955)

- Improve lookup of optional or disabled binaries. Previously, we'd treat every
  executable with missing libraries as optional. Now, we treat make sure to
  look at the library's optional or enabled_if status (ocaml/dune#4786).

- Always use 7 char hash prefix in build info version (ocaml/dune#4857, @jberdine, fixes
  ocaml/dune#4855)

- Allow to explicitly disable/enable the use of `dune subst` by adding a
  new `(subst <disable|enable>)` stanza to the `dune-project` file.
  (ocaml/dune#4864, @kit-ty-kate)

- Simplify the way `dune` discovers the root of the workspace. It now
  stops at the first `dune-workspace` file it encounters, and fails if
  it finds neither a `dune-workspace` nor a `dune-project` file
  (ocaml/dune#4921, fixes ocaml/dune#4459, @jeremiedimino)

- Dune no longer reads installed META files for libraries distributed with the
  compiler, instead using its own internal database. (ocaml/dune#4946, @nojb)

- Add support for `(empty_module_interface_if_absent)` in executable and library
  stanzas. (ocaml/dune#4955, @nojb)

- Add support for `%{bin-available:...}` (ocaml/dune#4995, @jeremiedimino)

- Make sure running `git` or `hg` in a sandboxed action, such as a
  cram test cannot escape the sandbox and pick up some random git or
  mercurial repository on the file system (ocaml/dune#4996, @jeremiedimino)

- Allow `%{read:...}` in more places such as `(enabled_if ...)`
  (ocaml/dune#4994, @jeremiedimino)

- Run each action in its own process group so that we don't leave
  stray processes behind when killing actions (ocaml/dune#4998, @jeremiedimino)

- Add an option `expand_aliases_in_sandbox` (ocaml/dune#5003, @jeremiedimino)

- Allow to cancel the initial scan via Control+C (ocaml/dune#4460, fixes ocaml/dune#4364
  @jeremiedimino)

- Add experimental support for directory targets (ocaml/dune#3316, ocaml/dune#5025, Andrey Mokhov),
  enabled via `(using directory-targets 0.1)` in `dune-project`.

- Delete old `promote-into`, `promote-until-clean` and `promote-until-clean-into`
  syntax (ocaml/dune#5091, Andrey Mokhov).

- Add link_flags in the env stanza (ocaml/dune#5215)

- Bootstrap: ignore errors when trying to remove generated files. (ocaml/dune#5407,
  @damiendoligez)
