### PR TITLE
Dream 1.0.0~alpha3: OCaml Web framework

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha1/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+
+synopsis: "Internal: shared http/af stack for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream-pure"
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+
+  # Currently vendored.
+  # "gluten"
+  # "gluten-lwt-unix"
+  # "httpaf"
+  # "httpaf-lwt-unix"
+  # "h2"
+  # "h2-lwt-unix"
+  # "hpack"
+  # "websocketaf"
+
+  # Dependencies of vendored packages.
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "bigstringaf" {>= "0.5.0"}  # h2.
+  "digestif" {>= "0.7.2"}  # websocket/af, sha1, default implementation.
+  "faraday" {>= "0.6.1"}
+  "faraday-lwt-unix"
+  "psq"  # h2.
+  "result"  # http/af, websocket/af.
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha3/dream-1.0.0-alpha3.tar.gz"
+  checksum: "md5=148588e6f584cd9f2438e56da7df2f56"
+}

--- a/packages/dream-pure/dream-pure.1.0.0~alpha1/opam
+++ b/packages/dream-pure/dream-pure.1.0.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+
+synopsis: "Internal: shared HTTP types for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base64" {>= "3.1.0"}  # Base64.encode_string.
+  "bigstringaf" {>= "0.5.0"}  # Bigstringaf.to_string.
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "hmap"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.weekday.
+  "uri" {>= "4.2.0"}
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "ppx_expect" {with-test}
+  "ppx_yojson_conv" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha3/dream-1.0.0-alpha3.tar.gz"
+  checksum: "md5=148588e6f584cd9f2438e56da7df2f56"
+}

--- a/packages/dream/dream.1.0.0~alpha3/opam
+++ b/packages/dream/dream.1.0.0~alpha3/opam
@@ -1,0 +1,100 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "caqti" {>= "1.6.0"}  # https://github.com/aantron/dream/issues/44.
+  "caqti-lwt"
+  "conf-libev" {os != "win32"}
+  "cstruct" {>= "6.0.0"}
+  "dream-pure"
+  "dream-httpaf"
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "mirage-clock"
+  "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
+  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.v.
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "lambdasoup" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+  "tyxml-jsx" {with-test & >= "4.5.0"}
+  "tyxml-ppx" {with-test & >= "4.5.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha3/dream-1.0.0-alpha3.tar.gz"
+  checksum: "md5=148588e6f584cd9f2438e56da7df2f56"
+}


### PR DESCRIPTION
[Project homepage](https://github.com/aantron/dream)

As a brief summary of the [changelog](https://github.com/aantron/dream/releases/tag/1.0.0-alpha3):

This release includes a complete rework of Dream's internal I/O model, in part to make Dream compose very naturally with its counterpart Web client (which will be released shortly). The rework also addresses or makes it possible to readily address all the I/O issues found since the initial announcement of Dream.

Another major change is a swtich from immutable HTTP requests and responses to mutable.

The release also includes a large number of contributions from many contributors, which were held up by this rework. With the I/O rework and client compatibility removed as risks, I hope to get Dream onto a more regular release schedule from this release on.

Two packages are being factored out of package `dream`: `dream-pure`, containing the core type definitions and basic functions on the types, and `dream-httpaf`, containing the vendored http/af stack and helpers directly related to it. These packages are being factored out because they will also be used by the client.