### PR TITLE
updates conf-bap-llvm to reflect versions supported by modern bap

### DIFF
--- a/packages/conf-bap-llvm/conf-bap-llvm.1.7/files/find-llvm.ml.in
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.7/files/find-llvm.ml.in
@@ -1,0 +1,183 @@
+open Printf
+open StdLabels
+
+let versions = ["12.0"; "11.0"; "10.0"; "9.0"; "8.0"; "7.0"; "6.0"]
+
+let (/) = Filename.concat
+
+let input_all ch =
+  let buf = Buffer.create 4096 in
+  let rec read () = Buffer.add_channel buf ch 4096; read () in
+  try read ()
+  with End_of_file -> String.trim @@ Buffer.contents buf
+
+exception Command_failed of Unix.process_status
+
+let process_status_to_string s =
+  let open Unix in
+  match s with
+  | WEXITED i -> sprintf "exit status %d" 1
+  | WSTOPPED i -> sprintf "proccess was stopped by signal %d" i
+  | WSIGNALED i -> sprintf "proccess was killed by signal %d" i
+
+let exn_to_string = function
+  | Command_failed s -> sprintf "%s" (process_status_to_string s)
+  | e -> Printexc.to_string e
+
+let cmd fmt =
+  let run c =
+    try
+      let inp = Unix.open_process_in c in
+      let res = input_all inp in
+      match Unix.close_process_in inp with
+      | Unix.WEXITED 0 -> Some res
+      | s -> raise (Command_failed s)
+    with e -> None in
+  ksprintf run fmt
+
+let which c = cmd "which %s" c
+
+let index_opt str c =
+  try Some (String.index str '.')
+  with Not_found -> None
+
+let major_version ver = match index_opt ver '.' with
+  | None -> ver
+  | Some i -> String.sub ver 0 i
+
+let versions_equal v v' =
+  String.equal (major_version v) (major_version v')
+
+let is_supported_version cfg =
+  match cmd "%s --version" cfg with
+  | None -> false
+  | Some ver' -> List.exists (versions_equal ver') versions
+
+let of_opam_config () =
+  match "%{llvm-config}%" with
+  | "" -> None
+  | cfg -> which cfg
+
+let of_env () =
+  try which (Sys.getenv "LLVM_CONFIG")
+  with Not_found -> None
+
+let write path version =
+  let digest = Digest.to_hex (Digest.file path) in
+  let oc = open_out "%{_:name}%.config" in
+  fprintf oc {|
+opam-version: "2.0"
+file-depends: [ [ %S %S ] ]
+variables {
+  config: %S
+  package-version: "%s"
+}
+|} path digest path version;
+  close_out oc
+
+let has_prefix str pref =
+  let len = String.length pref in
+  len <= String.length str &&
+  String.sub str 0 len = pref
+
+let is_llvm_config file =
+  has_prefix (Filename.basename file) "llvm-config" &&
+  is_supported_version file
+
+let opendir path =
+  try Some (Unix.opendir path)
+  with Unix.Unix_error _ -> None
+
+let next dir =
+  try Some (Unix.readdir dir)
+  with End_of_file -> None
+
+let is_dir path =
+  Sys.file_exists path && Sys.is_directory path
+
+let search path =
+  let is_parent p = p = Filename.parent_dir_name in
+  let is_hidden p = String.length p > 0 && p.[0] = '.' in
+  let leave dir result =
+    Unix.closedir dir;
+    result in
+  let rec read current dir =
+    match next dir with
+    | None -> leave dir None
+    | Some entry when is_parent entry || is_hidden entry ->
+      read current dir
+    | Some entry when is_dir (current / entry) ->
+      begin
+        let path = current / entry in
+        match opendir path with
+        | None -> read current dir
+        | Some subdir -> match read path subdir with
+          | None -> read current dir
+          | found -> leave dir found
+      end
+    | Some entry ->
+      let path = current / entry in
+      if is_llvm_config path
+      then leave dir (Some path)
+      else read current dir in
+  match opendir path with
+  | None -> None
+  | Some dir -> read path dir
+
+let find_in_cellar () = match cmd "brew --cellar" with
+  | None -> None
+  | Some cellar -> search cellar
+
+let macports_config ver = sprintf "llvm-config-mp-%s" ver
+
+let configs_of_version ver =
+  let ver' = match index_opt ver '.' with
+    | None -> ver
+    | Some i -> String.sub ver 0 i ^ String.sub ver (i + 1) 1 in
+  let configs = [
+    sprintf "llvm-config-%s" ver;
+    sprintf "llvm-config-%s" ver';
+    sprintf "llvm-config-%s" (major_version ver)] in
+  match "%{os}%" with
+  | "macos" -> macports_config ver :: configs
+  | _ -> configs
+
+let locate_by_version () =
+  let rec find = function
+    | [] -> None
+    | cfg :: cfgs -> match which cfg with
+      | Some _ as path -> path
+      | None -> find cfgs in
+  find @@
+  List.fold_left versions ~init:[] ~f:(fun acc ver ->
+      acc @ configs_of_version ver)
+
+let which_llvm_config () = match which "llvm-config" with
+  | None -> None
+  | Some cfg ->
+    if is_supported_version cfg then Some cfg
+    else None
+
+let rec first_success fs =
+  match fs with
+  | [] -> None
+  | f :: fs -> match f () with
+    | None -> first_success fs
+    | x -> x
+
+let () =
+  try
+    let base = [ of_opam_config; of_env; locate_by_version;
+                 which_llvm_config;] in
+    let os_specific = match "%{os}%" with
+      | "macos" -> [find_in_cellar]
+      | _ -> [] in
+    match first_success (base @ os_specific) with
+    | None -> eprintf "LLVM not found"; exit 1
+    | Some path ->
+      match cmd "%s --version" path with
+      | None -> eprintf "'%s --version' failed\n" path; exit 1
+      | Some version -> write path version
+  with e ->
+    eprintf "build failed: %s\n" (Printexc.to_string e);
+    exit 1

--- a/packages/conf-bap-llvm/conf-bap-llvm.1.7/opam
+++ b/packages/conf-bap-llvm/conf-bap-llvm.1.7/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "http://llvm.org"
+authors: "The LLVM Team"
+bug-reports: "https://llvm.org/bugs/"
+license: "BSD"
+build: [
+  ["ocaml" "unix.cma" "find-llvm.ml"]
+]
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "base-unix"
+  "conf-which" {build}
+]
+depexts: [
+
+  # debian
+  ["llvm-7-dev"] {os-distribution = "debian" & os-version < "11"}
+  ["llvm-9-dev"] {os-distribution = "debian" & os-version >= "11"}
+
+  # ubuntu
+  ["llvm-3.8-dev"] {os-distribution = "ubuntu" & os-version = "14.04"} #trusty
+  ["llvm-8-dev"]   {os-distribution = "ubuntu" & os-version = "16.04"} #xenial
+  ["llvm-9-dev"]   {os-distribution = "ubuntu" & os-version = "18.04"} #bionic
+  ["llvm-10-dev"]  {os-distribution = "ubuntu" & os-version = "20.04"} #focal
+
+  # fedora
+  ["llvm-devel" "llvm-static"] {os-distribution = "fedora"}
+
+  # macos
+  ["llvm-6.0"] {os = "macos" & os-distribution = "macports"}
+  ["llvm@9"]   {os = "macos" & os-distribution = "homebrew"}
+
+  #alpine
+  ["llvm-dev" "llvm-static"] {os-distribution = "alpine"}
+]
+
+substs: [ "find-llvm.ml" ]
+flags: [ conf ]
+
+synopsis: "Checks if a supported version of LLVM is installed"
+description: """
+The supported LLVM versions range from 6.0 to 12.0, bounds including.
+
+A preferred `llvm-config` can be choosen by setting opam config variable:
+```
+opam config set llvm-config your-llvm-config
+```
+OR by setting the `LLVM_CONFIG` environment variable before installation.
+"""


### PR DESCRIPTION
It looks like we didn't update this package for a long time. BAP supports llvm versions from 6 to 12 (and up to 14 in the 2.5.0-alpha). 