### PR TITLE
[new release] timere-parse.0.0.6

### DIFF
--- a/packages/timere-parse/timere-parse.0.0.6/opam
+++ b/packages/timere-parse/timere-parse.0.0.6/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OCaml date time and duration natural language parsing library"
+description: """
+(WIP) Facilities for parsing natural language expressions into
+
+- Timere objects
+
+- Date time
+
+- Hour minute second
+
+- Duration
+"""
+maintainer: "Darren Ldl <darrenldldev@gmail.com>"
+authors: "Daypack developers"
+license: "MIT"
+homepage: "https://github.com/daypack-dev/timere"
+bug-reports: "https://github.com/daypack-dev/timere/issues"
+dev-repo: "git+https://github.com/daypack-dev/timere"
+depends: [
+  "ocaml" {>= "4.06.1"}
+  "dune" {>= "2.7.0"}
+  "oseq" {>= "0.3"}
+  "re" {>= "1.9.0"}
+  "timedesc" {>= "0.6.0"}
+  "timere" {>= "0.7.0"}
+  "mparser" {>= "1.2.3"}
+  "containers" {>= "3.6"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/daypack-dev/timere/releases/download/parse-v0.0.6/parse-v0.0.6.tar.gz"
+  checksum:
+    "sha256=a767ff83514b540e6805f93293e8a50db3e9343184ee834f475308db12ef0629"
+}


### PR DESCRIPTION
OCaml date time and duration natural language parsing library

Homepage: https://github.com/daypack-dev/timere