### PR TITLE
[new release] index and index-bench (1.6.0)

### DIFF
--- a/packages/index-bench/index-bench.1.6.0/opam
+++ b/packages/index-bench/index-bench.1.6.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Index benchmarking suite"
+maintainer: "Clement Pascutto"
+authors: ["Clement Pascutto" "Thomas Gazagnaire" "Ioana Cristescu"]
+license: "MIT"
+homepage: "https://github.com/mirage/index"
+bug-reports: "https://github.com/mirage/index/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cmdliner"
+  "dune" {>= "2.7.0"}
+  "fmt"
+  "index" {= version}
+  "metrics"
+  "metrics-unix"
+  "ppx_deriving_yojson"
+  "re" {>= "1.9.0"}
+  "stdlib-shims"
+  "yojson"
+  "ppx_repr"
+  "mtime"
+  "logs" {>= "0.7.0"}
+  "progress" {>= "0.2.1"}
+  "tezos-base58" {>= "1.0.0" & with-test}
+  "digestif" {>= "0.7" & with-test}
+  "optint" {>= "0.1.0" & with-test}
+  "repr" {>= "0.2.1" & with-test}
+  "rusage" {>= "1.0.0" & with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/index.git"
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.6.0/index-1.6.0.tbz"
+  checksum: [
+    "sha256=5e0c1f6cbd6e485cbbf2344c8f76de8a7869155355ae6edd5550c88da0661594"
+    "sha512=613fa206d1124b34259421f4ea978ce4e9404d78af3a687c1e406d88a5d481bd51465fafae58da9eb3e6a0b5408118b8a7dfe1fbb05ce8fed4b8b0a572beb99b"
+  ]
+}
+x-commit-hash: "c05846f784a3f4db11f1d113fc5a2c1fa8b743c6"

--- a/packages/index/index.1.6.0/opam
+++ b/packages/index/index.1.6.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   "Clement Pascutto"
+authors:      [
+   "Craig Ferguson <craig@tarides.com>"
+   "Thomas Gazagnaire <thomas@tarides.com>"
+   "Ioana Cristescu <ioana@tarides.com>"
+   "Clément Pascutto <clement@tarides.com>"
+]
+license:      "MIT"
+homepage:     "https://github.com/mirage/index"
+bug-reports:  "https://github.com/mirage/index/issues"
+dev-repo:     "git+https://github.com/mirage/index.git"
+doc:          "https://mirage.github.io/index/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.7.0"}
+  "optint"  {>= "0.1.0"}
+  "repr"    {>= "0.6.0"}
+  "ppx_repr"
+  "fmt"     {>= "0.8.5"}
+  "logs"    {>= "0.7.0"}
+  "mtime"   {>= "1.1.0"}
+  "cmdliner" {< "1.1.0"}
+  "progress" {>= "0.2.1"}
+  "semaphore-compat" {>= "1.0.1"}
+  "jsonm"
+  "stdlib-shims"
+  "alcotest" {with-test}
+  "crowbar"  {with-test & >= "0.2"}
+  "re"       {with-test}
+  "lru"      {>= "0.3.0"}
+]
+synopsis: "A platform-agnostic multi-level index for OCaml"
+description:"""
+Index is a scalable implementation of persistent indices in OCaml.
+
+It takes an arbitrary IO implementation and user-supplied content
+types and supplies a standard key-value interface for persistent
+storage. Index provides instance sharing: each OCaml
+run-time can share a common singleton instance.
+
+Index supports multiple-reader/single-writer access. Concurrent access
+is safely managed using lock files."""
+url {
+  src:
+    "https://github.com/mirage/index/releases/download/1.6.0/index-1.6.0.tbz"
+  checksum: [
+    "sha256=5e0c1f6cbd6e485cbbf2344c8f76de8a7869155355ae6edd5550c88da0661594"
+    "sha512=613fa206d1124b34259421f4ea978ce4e9404d78af3a687c1e406d88a5d481bd51465fafae58da9eb3e6a0b5408118b8a7dfe1fbb05ce8fed4b8b0a572beb99b"
+  ]
+}
+x-commit-hash: "c05846f784a3f4db11f1d113fc5a2c1fa8b743c6"


### PR DESCRIPTION
A platform-agnostic multi-level index for OCaml

- Project page: <a href="https://github.com/mirage/index">https://github.com/mirage/index</a>
- Documentation: <a href="https://mirage.github.io/index/">https://mirage.github.io/index/</a>

##### CHANGES:

## Added

- Added a `Raw.Header_prefix` function, for use by libraries that share the
  file format used by `index.unix`. (mirage/index#378)
