### PR TITLE
Release Caqti 1.7.0.

### DIFF
--- a/packages/caqti-async/caqti-async.1.7.0/opam
+++ b/packages/caqti-async/caqti-async.1.7.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {>= "1.5.0"}
+  "alcotest-async" {>= "1.5.0"}
+  "async_kernel" {>= "v0.11.0"}
+  "async_unix" {>= "v0.11.0"}
+  "caqti" {>= "1.7.0" & < "1.8.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "cmdliner" {with-test & < "1.1.0"}
+  "core_kernel"
+  "dune" {>= "2.0"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.7.0/caqti-v1.7.0.tbz"
+  checksum: [
+    "sha256=a363cfcc15f2a3ab9721d08789a65aaa1108d27f974a9b68425a889596e27fb8"
+    "sha512=982b9c65fde0405b5d33822ff2743d1c8a8c0611dcd6615dd0af5b32048262f7ddbcae8434193cfd2b7ee845f29c2821d869862b34086099fcffc912b51d61a2"
+  ]
+}
+x-commit-hash: "2448138a9102f54d2d971cf1f6923420477ee14b"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.7.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.7.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.7.0" & < "1.8.0~"}
+  "dune" {>= "2.0"}
+  "mariadb" {>= "1.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.7.0/caqti-v1.7.0.tbz"
+  checksum: [
+    "sha256=a363cfcc15f2a3ab9721d08789a65aaa1108d27f974a9b68425a889596e27fb8"
+    "sha512=982b9c65fde0405b5d33822ff2743d1c8a8c0611dcd6615dd0af5b32048262f7ddbcae8434193cfd2b7ee845f29c2821d869862b34086099fcffc912b51d61a2"
+  ]
+}
+x-commit-hash: "2448138a9102f54d2d971cf1f6923420477ee14b"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.7.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.7.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml"
+  "caqti" {>= "1.7.0" & < "1.8.0~"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.7.0/caqti-v1.7.0.tbz"
+  checksum: [
+    "sha256=a363cfcc15f2a3ab9721d08789a65aaa1108d27f974a9b68425a889596e27fb8"
+    "sha512=982b9c65fde0405b5d33822ff2743d1c8a8c0611dcd6615dd0af5b32048262f7ddbcae8434193cfd2b7ee845f29c2821d869862b34086099fcffc912b51d61a2"
+  ]
+}
+x-commit-hash: "2448138a9102f54d2d971cf1f6923420477ee14b"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.7.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.1.7.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "caqti" {>= "1.7.0" & < "1.8.0~"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "sqlite3"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.7.0/caqti-v1.7.0.tbz"
+  checksum: [
+    "sha256=a363cfcc15f2a3ab9721d08789a65aaa1108d27f974a9b68425a889596e27fb8"
+    "sha512=982b9c65fde0405b5d33822ff2743d1c8a8c0611dcd6615dd0af5b32048262f7ddbcae8434193cfd2b7ee845f29c2821d869862b34086099fcffc912b51d61a2"
+  ]
+}
+x-commit-hash: "2448138a9102f54d2d971cf1f6923420477ee14b"

--- a/packages/caqti-dynload/caqti-dynload.1.3.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.1.3.0/opam
@@ -7,7 +7,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "caqti" {>= "1.3.0" & < "1.7.0~"}
+  "caqti" {>= "1.3.0" & < "1.8.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
   "dune" {>= "1.11"}
   "ocamlfind"

--- a/packages/caqti-lwt/caqti-lwt.1.7.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.1.7.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {>= "1.5.0"}
+  "alcotest-lwt" {>= "1.5.0"}
+  "caqti" {>= "1.7.0" & < "1.8.0~"}
+  "caqti-dynload" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "caqti-driver-sqlite3" {with-test & >= "1.0.0" & < "2.0.0~"}
+  "cmdliner" {with-test & < "1.1.0"}
+  "dune" {>= "2.0"}
+  "logs"
+  "lwt" {>= "3.2.0"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.7.0/caqti-v1.7.0.tbz"
+  checksum: [
+    "sha256=a363cfcc15f2a3ab9721d08789a65aaa1108d27f974a9b68425a889596e27fb8"
+    "sha512=982b9c65fde0405b5d33822ff2743d1c8a8c0611dcd6615dd0af5b32048262f7ddbcae8434193cfd2b7ee845f29c2821d869862b34086099fcffc912b51d61a2"
+  ]
+}
+x-commit-hash: "2448138a9102f54d2d971cf1f6923420477ee14b"

--- a/packages/caqti/caqti.1.7.0/opam
+++ b/packages/caqti/caqti.1.7.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {>= "1.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "bigstringaf"
+  "cmdliner" {with-test & < "1.1.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "2.0"}
+  "logs"
+  "ocaml" {>= "4.04.0"}
+  "odoc" {with-doc}
+  "ptime"
+  "re" {with-test}
+  "uri" {>= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.7.0/caqti-v1.7.0.tbz"
+  checksum: [
+    "sha256=a363cfcc15f2a3ab9721d08789a65aaa1108d27f974a9b68425a889596e27fb8"
+    "sha512=982b9c65fde0405b5d33822ff2743d1c8a8c0611dcd6615dd0af5b32048262f7ddbcae8434193cfd2b7ee845f29c2821d869862b34086099fcffc912b51d61a2"
+  ]
+}
+x-commit-hash: "2448138a9102f54d2d971cf1f6923420477ee14b"


### PR DESCRIPTION
It's time for a [new release of Caqti](https://github.com/paurkedal/ocaml-caqti/releases/tag/v1.7.0).
