### PR TITLE
2 packages from gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.1/ocaml-bls12-381-2.0.1.tar.bz2

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.2.0.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: """\
+UNIX version of BLS12-381 primitives implementing the virtual package
+bls12-381 with blst backend"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "dune-configurator" {build}
+  "zarith" {>= "1.10" & < "2.0"}
+  "bls12-381" {= version}
+  "hex"
+  "alcotest" {with-test}
+  "integers"
+  "bisect_ppx" {with-test & >= "2.5"}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+available: arch != "ppc64"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.1/ocaml-bls12-381-2.0.1.tar.bz2"
+  checksum: [
+    "md5=493da0d50891299fb9577e6855653dca"
+    "sha512=994ac11cb76b0d83592cfb6b7a6d6f488a5d9c525d9bc1ccd81e797ee56c0e0b9a00d889118b4e5a01282d332d63d94d32ccbb6e063a28c1c53fecbea23dbef6"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/bls12-381-unix/bls12-381-unix.2.0.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
   "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
 ]
-available: arch != "ppc64"
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"

--- a/packages/bls12-381/bls12-381.2.0.1/opam
+++ b/packages/bls12-381/bls12-381.2.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Virtual package for BLS12-381 primitives"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.1/ocaml-bls12-381-2.0.1.tar.bz2"
+  checksum: [
+    "md5=493da0d50891299fb9577e6855653dca"
+    "sha512=994ac11cb76b0d83592cfb6b7a6d6f488a5d9c525d9bc1ccd81e797ee56c0e0b9a00d889118b4e5a01282d332d63d94d32ccbb6e063a28c1c53fecbea23dbef6"
+  ]
+}


### PR DESCRIPTION
Critical bugfix on top of 2.0.1, see release.

This pull-request concerns:
-`bls12-381.2.0.1`: Virtual package for BLS12-381 primitives
-`bls12-381-unix.2.0.1`: UNIX version of BLS12-381 primitives implementing the virtual package
 bls12-381 with blst backend



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.1.0