### PR TITLE
Add: omod.0.0.3

### DIFF
--- a/packages/omod/omod.0.0.3/opam
+++ b/packages/omod/omod.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Lookup and load installed OCaml modules"
+description: """\
+Omod is a library and command line tool to lookup and load installed OCaml
+modules. It provides a mechanism to load modules and their dependencies
+in the OCaml toplevel system (REPL).
+
+omod is distributed under the ISC license.
+
+Homepage: http://erratique.ch/software/omod"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The omod programmers"
+license: "ISC"
+tags: ["dev" "toplevel" "repl" "org:erratique"]
+homepage: "https://erratique.ch/software/omod"
+doc: "https://erratique.ch/software/omod/doc/"
+bug-reports: "https://github.com/dbuenzli/omod/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "cmdliner" {>= "1.1.0"}
+]
+build: [
+  "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%" "--lib-dir" "%{lib}%"
+]
+install: [
+  ["install" "-d" "%{lib}%/ocaml/"]
+  ["install" "src/omod.top" "src/omod.nattop" "%{lib}%/ocaml/"]
+]
+dev-repo: "git+https://erratique.ch/repos/omod.git"
+url {
+  src: "https://erratique.ch/software/omod/releases/omod-0.0.3.tbz"
+  checksum:
+    "sha512=4f53b8cdd054dc1a6813427452a91294e0bbcfefe948fc1caec47be136dbcecf13112bf2b620fa2f667592b04b28df74e3bf012ea0fb0038c1da4217155ca626"
+}


### PR DESCRIPTION
* Add: `omod.0.0.3` [home](https://erratique.ch/software/omod), [doc](https://erratique.ch/software/omod/doc/), [issues](https://github.com/dbuenzli/omod/issues)  
  *Lookup and load installed OCaml modules*


---

#### `omod` v0.0.3 2022-02-14 La Forclaz (VS)

- Allow to abort load sequence prompts cleanly with C-c ([#9](https://github.com/dbuenzli/omod/issues/9)).
- Fix variant specification in `Omod.load` ([#11](https://github.com/dbuenzli/omod/issues/11)).
- Move init sequences from `omod.[nat]top` to the loaded `omod.cma`
  and `omod_nattop.cmxs`. As a side effect removes
  the annoying warning on load visible since 4.13 ([#13](https://github.com/dbuenzli/omod/issues/13)) and allows
  to load `omod` via `ocamlafind` (i.e. via `#require`, not recommended
  but works).
- Require OCaml 4.08.
- Handle the deprecation of `Pervasives` (and thus support OCaml 5.00).
- `omod pkg`, order package info as found on the cli.

---

Use `b0 cmd -- .opam.publish omod.0.0.3` to update the pull request.