### PR TITLE
Add: gg.1.0.0

### DIFF
--- a/packages/gg/gg.1.0.0/opam
+++ b/packages/gg/gg.1.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Basic types for computer graphics in OCaml"
+description: """\
+Gg is an OCaml module providing basic types for computer graphics.
+
+It defines types and functions for floats, vectors, points, sizes,
+matrices, quaternions, axis-aligned boxes, colors, color spaces, and
+raster data.
+
+Gg is made of a single module, and is distributed under the ISC
+license.
+
+Home page: <http://erratique.ch/software/gg>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The gg programmers"
+license: "ISC"
+tags: ["matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
+homepage: "https://erratique.ch/software/gg"
+doc: "https://erratique.ch/software/gg/doc/"
+bug-reports: "https://github.com/dbuenzli/gg/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/gg.git"
+url {
+  src: "https://erratique.ch/software/gg/releases/gg-1.0.0.tbz"
+  checksum:
+    "sha512=86e3db9778103c6a9e3444585716c12dba0ba1af6b60e7b76f9cf282a23aa4cb075c764c470e9a878c3c90fe4a41e835be9180aaf0a4bc43ce3ad299b352e611"
+}


### PR DESCRIPTION
* Add: `gg.1.0.0` [home](https://erratique.ch/software/gg), [doc](https://erratique.ch/software/gg/doc/), [issues](https://github.com/dbuenzli/gg/issues)  
  *Basic types for computer graphics in OCaml*


---

#### `gg` v1.0.0 2022-02-15 La Forclaz (VS)

- Require OCaml 4.08.

- Handle `Pervasives`'s deprecation (and thus provide OCaml
  5.00 support).

- Drop dependency on `bigarray`'s ocamlfind package (and thus
  provide OCaml 5.00 support).
  
- Change the semantics of `Box{1,2,3}.inset`. Rather than return the
  empty box when the size in a dimension `i` become negative, clamp it
  to `0` and use the `i`th coordinate of the mid point of the box for
  the `i`th coordinate of the resulting box's origin. This means that
  insetting boxes with large values eventually degenerates to the mid
  point of a box instead of the empty box. This avoids losing a box's
  location when one grows and shrinks them arbitrarily, e.g. in
  reaction to user input. Thanks to Michel Schinz for suggesting this
  better semantics.

- Change `Gg.Float.pp` hexadecimal notation renderer to use the
  built-in `"%h"` string introduced in OCaml 4.03.0. Nans, zeros and
  infinities will render differently. Use the deprecated
  `Gg.Float.pp_legacy` if you need to recover the old hex rendering.

- The `Gg.Float` module now includes `Stdlib.Float` ([#19](https://github.com/dbuenzli/gg/issues/19)). Some values
  initially implemented in `Gg.Float` now use `Stdlib.Float`'s
  definition or are deprecated in favour of corresponding
  functionality named differently. Implementations may differ but this
  shouldn't matter most of the time except for the first three items
  in this list:

  * **WARNING** `Gg.Float.equal` is deleted in favour of `Stdlib.Float.equal`
    The implemention differs, it moves from `x = y`
    to `compare x y = 0` which differs on nan values. 
    `Stdlib.Float.equal` treats them as equal `Gg.Float.equal` does not.
  * **WARNING** `Gg.Float.round` is deleted and becomes `Stdlib.Float.round`.
    The implementation and behaviour on negative numbers differs. 
    `Gg.Float.round` always rounded towards positive infinity on ties (`-2.` 
    on `-2.5`). `Stdlib.Float.round`s away from zero on ties (`-3.` on `-2.5`).
  * **WARNING** `Gg.Float.round_to_int` is affected by the new `round`
    implementation (see previous point).
  * `Gg.Float.compare` is deleted and becomes `Stdlib.Float.compare`
    (same implementation).
  * `Gg.Float.pi` is deleted and becomes `Stdlib.Float.pi`, the bit pattern
    of the value is unchanged.
  * `Gg.Float.is_inf` is implemented by `Stdlib.Float.is_infinite` 
    and deprecated in favour of it (different implementation). 
  * `Gg.Float.is_int` is implemented by `Stdlib.Float.is_integer`
    and deprecated in favour of it (different implementation).
  * `Gg.Float.is_nan` is deleted and becomes `Stdlib.Float.is_nan` 
    (same implementation)
  * `Gg.Float.fmax` is implemented by `Stdlib.Float.max_num` and
    deprecated in favour of it. The result of `Gg.Float.fmax (-0.)
    (+0.)` is changed, it returns `+0.` instead of `-0.`.
  * `Gg.Float.fmin` is implemented by `Stdlib.Float.min_num` and
    deprecated in favour of it. The result of `Gg.Float.fmin (+0.)
    (-0.)` is changed, it returns `-0.` instead of `+0.`.
  * `Gg.Float.sign_bit` is deleted and becomes `Stdlib.Float.sign_bit`
    (different implementation).
  * `Gg.Float.succ` is deleted and becomes `Stdlib.Float.succ` 
    (different implementation). 
  * `Gg.Float.pred` is deleted and becomes `Stdlib.Float.pred` 
    (different implementation). 
  * `Gg.Float.nan` is renamed to `Gg.Float.nan_with_payload` 
    to leave room for `Stdlib.Float.nan`'s constant.

---

Use `b0 cmd -- .opam.publish gg.1.0.0` to update the pull request.