### PR TITLE
2 packages from OCamlPro/drom at 0.6.0

### DIFF
--- a/packages/drom/drom.0.6.0/opam
+++ b/packages/drom/drom.0.6.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:
+  "The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like user experience"
+description: """\
+The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like
+user experience. It can be used to create full OCaml projects with
+sphinx and odoc documentation. It has specific knowledge of Github and
+will generate files for Github Actions CI and Github pages.
+"""
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+maintainer: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+homepage: "https://ocamlpro.github.io/drom"
+doc: "https://ocamlpro.github.io/drom/sphinx"
+bug-reports: "https://github.com/ocamlpro/drom/issues"
+dev-repo: "git+https://github.com/ocamlpro/drom.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh build '%{name}%'"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["sh" "-c" "./scripts/after.sh build '%{name}%'"]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.7.0"}
+  "drom_lib" {= version}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+url {
+  src: "https://github.com/OCamlPro/drom/archive/v0.6.0.tar.gz"
+  checksum: [
+    "md5=abd11ae9727899dbae6ad79639c66204"
+    "sha512=3e8e7ad76608e8025ff129b9f2ad1377585da64ee599a28e4a29419d99529e82bb90fbb6d71088ad5393b696e3df8c62b57792da32834c3158f0976c6d1c7883"
+  ]
+}

--- a/packages/drom_lib/drom_lib.0.6.0/opam
+++ b/packages/drom_lib/drom_lib.0.6.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:
+  "The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like user experience"
+description: """\
+The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like
+user experience. It can be used to create full OCaml projects with
+sphinx and odoc documentation. It has specific knowledge of Github and
+will generate files for Github Actions CI and Github pages.
+"""
+authors: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+maintainer: [
+  "Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"
+  "Léo Andrès <leo.andres@ocamlpro.com>"
+]
+homepage: "https://ocamlpro.github.io/drom"
+doc: "https://ocamlpro.github.io/drom/sphinx"
+bug-reports: "https://github.com/ocamlpro/drom/issues"
+dev-repo: "git+https://github.com/ocamlpro/drom.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh build '%{name}%'"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["sh" "-c" "./scripts/after.sh build '%{name}%'"]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.7.0"}
+  "toml" {>= "7.0.0" & < "8.0.0"}
+  "ez_subst" {>= "0.1"}
+  "ez_opam_file" {>= "0.1.0" & < "1.0.0"}
+  "ez_file" {>= "0.2.0" & < "1.0.0"}
+  "ez_config" {>= "0.1.0" & < "1.0.0"}
+  "ez_cmdliner" {>= "0.2.0" & < "1.0.0"}
+  "directories" {>= "0.2"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+url {
+  src: "https://github.com/OCamlPro/drom/archive/v0.6.0.tar.gz"
+  checksum: [
+    "md5=abd11ae9727899dbae6ad79639c66204"
+    "sha512=3e8e7ad76608e8025ff129b9f2ad1377585da64ee599a28e4a29419d99529e82bb90fbb6d71088ad5393b696e3df8c62b57792da32834c3158f0976c6d1c7883"
+  ]
+}


### PR DESCRIPTION
The drom tool is a wrapper over opam/dune in an attempt to provide a cargo-like user experience

This pull-request concerns:
-`drom.0.6.0`
-`drom_lib.0.6.0`



---
* Homepage: https://ocamlpro.github.io/drom
* Source repo: git+https://github.com/ocamlpro/drom.git
* Bug tracker: https://github.com/ocamlpro/drom/issues

---
:camel: Pull-request generated by opam-publish v2.0.3