### PR TITLE
Fix constraint in OCanren-ppx (repair  #20720)

### DIFF
--- a/packages/OCanren-ppx/OCanren-ppx.0.3.0~alpha1/opam
+++ b/packages/OCanren-ppx/OCanren-ppx.0.3.0~alpha1/opam
@@ -37,7 +37,7 @@ depends: [
   "base"
   "ppx_inline_test"
   "ppx_expect"
-  "OCanren" { >= "0.3.0"}
+  "OCanren" { >= "0.3.0~" }
   "ocamlformat" { with-test }
   "GT"
   "odoc" {with-doc}

--- a/packages/noCanren/noCanren.0.3.0~alpha1/opam
+++ b/packages/noCanren/noCanren.0.3.0~alpha1/opam
@@ -15,8 +15,8 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.13" & < "4.14"}
   "GT"
-  "OCanren" {>= "0.3.0" } #{with-test}
-  "OCanren-ppx" {>= "0.3.0" } #{with-test}
+  "OCanren" {>= "0.3.0~" }
+  "OCanren-ppx" {>= "0.3.0~" }
   "odoc" {with-doc}
   "ocamlformat" {with-test}
   "ppxlib"


### PR DESCRIPTION
I wanted `OCanren-ppx.0.3.0~alpha1` to be installed along with
`OCanren.0.3.0~alpha1`. So, I need to change constraint from

    "OCanren" { >= "0.3.0" }

to

    "OCanren" { >= "0.3.0~" }

because

0.3.0~ < 0.3.0~alpha1 < 0.3.0

Signed-off-by: Kakadu <Kakadu@pm.me>