### PR TITLE
[new release] equinoxe, equinoxe-hlc and equinoxe-cohttp (0.2.0)

### DIFF
--- a/packages/equinoxe-cohttp/equinoxe-cohttp.0.2.0/opam
+++ b/packages/equinoxe-cohttp/equinoxe-cohttp.0.2.0/opam
@@ -31,7 +31,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/equinoxe-cohttp/equinoxe-cohttp.0.2.0/opam
+++ b/packages/equinoxe-cohttp/equinoxe-cohttp.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Equinoxe with the cohttp-lwt-unix request handler"
+description:
+  "Equinoxe-cohttp is an implementation of the Equinoxe library using cohttp-lwt-unix."
+maintainer: ["Étienne Marais <etienne@maiste.fr>"]
+authors: ["Étienne Marais <etienne@maiste.fr>"]
+license: "MIT"
+homepage: "https://github.com/maiste/equinoxe"
+doc: "maiste.github.io/equinoxe"
+bug-reports: "https://github.com/maiste/equinoxe/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "equinoxe" {= version}
+  "cohttp-lwt-unix"
+  "httpaf-lwt-unix" {with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/maiste/equinoxe.git"
+url {
+  src:
+    "https://github.com/maiste/equinoxe/releases/download/0.2.0/equinoxe-0.2.0.tbz"
+  checksum: [
+    "sha256=53a77e52522f4ddc271678c5a2b3639b59519bcc7d05dc55e751f854c9f25cdb"
+    "sha512=7169e110005c3bc9baa43632705f02fa75c9f04e6133b668b7a56870b69571eddfad9c649bc8d87672b8be560c9ed57c284c0fa659ce2eac4f8ff0c098c5a890"
+  ]
+}
+x-commit-hash: "1b8c29a35b1884c860900835f2bd478e19e58007"

--- a/packages/equinoxe-hlc/equinoxe-hlc.0.2.0/opam
+++ b/packages/equinoxe-hlc/equinoxe-hlc.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Equinoxe with the http-lwt-client request handler"
+description:
+  "Equinoxe-hlc is an implementation of the Equinoxe library using http-lwt-client."
+maintainer: ["Étienne Marais <etienne@maiste.fr>"]
+authors: ["Étienne Marais <etienne@maiste.fr>"]
+license: "MIT"
+homepage: "https://github.com/maiste/equinoxe"
+doc: "maiste.github.io/equinoxe"
+bug-reports: "https://github.com/maiste/equinoxe/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "equinoxe" {= version}
+  "http-lwt-client"
+  "httpaf-lwt-unix" {with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/maiste/equinoxe.git"
+url {
+  src:
+    "https://github.com/maiste/equinoxe/releases/download/0.2.0/equinoxe-0.2.0.tbz"
+  checksum: [
+    "sha256=53a77e52522f4ddc271678c5a2b3639b59519bcc7d05dc55e751f854c9f25cdb"
+    "sha512=7169e110005c3bc9baa43632705f02fa75c9f04e6133b668b7a56870b69571eddfad9c649bc8d87672b8be560c9ed57c284c0fa659ce2eac4f8ff0c098c5a890"
+  ]
+}
+x-commit-hash: "1b8c29a35b1884c860900835f2bd478e19e58007"

--- a/packages/equinoxe/equinoxe.0.2.0/opam
+++ b/packages/equinoxe/equinoxe.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "An OCaml wrapper for the Equinix API"
+description: "Equinoxe is an OCaml wrapper for the Equinix API."
+maintainer: ["Étienne Marais <etienne@maiste.fr>"]
+authors: ["Étienne Marais <etienne@maiste.fr>"]
+license: "MIT"
+homepage: "https://github.com/maiste/equinoxe"
+doc: "maiste.github.io/equinoxe"
+bug-reports: "https://github.com/maiste/equinoxe/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "ezjsonm" {>= "1.3.0"}
+  "lwt" {>= "5.3.0"}
+  "odate" {>= "0.6"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "ppx_deriving" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/maiste/equinoxe.git"
+url {
+  src:
+    "https://github.com/maiste/equinoxe/releases/download/0.2.0/equinoxe-0.2.0.tbz"
+  checksum: [
+    "sha256=53a77e52522f4ddc271678c5a2b3639b59519bcc7d05dc55e751f854c9f25cdb"
+    "sha512=7169e110005c3bc9baa43632705f02fa75c9f04e6133b668b7a56870b69571eddfad9c649bc8d87672b8be560c9ed57c284c0fa659ce2eac4f8ff0c098c5a890"
+  ]
+}
+x-commit-hash: "1b8c29a35b1884c860900835f2bd478e19e58007"


### PR DESCRIPTION
An OCaml wrapper for the Equinix API

- Project page: <a href="https://github.com/maiste/equinoxe">https://github.com/maiste/equinoxe</a>
- Documentation: <a href="maiste.github.io/equinoxe">maiste.github.io/equinoxe</a>

##### CHANGES:

### Added

- Add a Cohttp client version, with a specific package (maiste/equinoxe#60, @maiste)
- Add a statically-typed API (maiste/equinoxe#68, maiste/equinoxe#71, @maiste)
- Add unit tests to mock Equinix api (maiste/equinoxe#70, @art-w)

### Changed

- Rewrite the API using `io` monad (maiste/equinoxe#63, @art-w)
- Uniform error handling between Cohttp and HLC (maiste/equinoxe#69, @art-w)
- Update `Equinoxe-cohttp` and `Equinix-hlc` to support only new API (maiste/equinoxe#71, @maiste)

### Removed

- Remove `JSON` module and use `Ezjsonm` directly (maiste/equinoxe#63, @art-w)
- Remove timeout support from Cohttp (maiste/equinoxe#69, @art-w)
- Remove old API with JSON from `Equinoxe`, `Equinoxe-cohttp` and `Equinoxe-hlc` (maiste/equinoxe#68, maiste/equinoxe#71, @maiste)
- Remove `bin` directory (maiste/equinoxe#70, @maiste)
