### PR TITLE
Mark js-build-tools as deprecated and mark it incompatible with OCaml 5.00

### DIFF
--- a/packages/js-build-tools/js-build-tools.113.33.03/opam
+++ b/packages/js-build-tools/js-build-tools.113.33.03/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind" {build & >= "1.3.2"}
   "ocamlbuild"
 ]
+flags: deprecated
 synopsis: "Collection of tools to help building Jane Street Packages"
 description: """
 This packages contains tools to help building Jane Street

--- a/packages/js-build-tools/js-build-tools.113.33.04/opam
+++ b/packages/js-build-tools/js-build-tools.113.33.04/opam
@@ -10,11 +10,12 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.00"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
   "ocamlbuild"
 ]
+flags: deprecated
 synopsis: "Collection of tools to help building Jane Street Packages"
 description: """
 This packages contains tools to help building Jane Street


### PR DESCRIPTION
Build fail with
```
#=== ERROR while compiling js-build-tools.113.33.04 ===========================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.00.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.00/.opam-switch/build/js-build-tools.113.33.04
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.00
# exit-code            2
# env-file             ~/.opam/log/js-build-tools-10-2bc6c1.env
# output-file          ~/.opam/log/js-build-tools-10-2bc6c1.out
### output ###
# File "./setup.ml", line 1402, characters 23-41:
# 1402 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```
and the package itself is deprecated. See https://github.com/janestreet-deprecated/js-build-tools