### PR TITLE
Add: ptime.1.0.0

### DIFF
--- a/packages/ptime/ptime.1.0.0/opam
+++ b/packages/ptime/ptime.1.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "POSIX time for OCaml"
+description: """\
+Ptime has platform independent POSIX time support in pure OCaml. It
+provides a type to represent a well-defined range of POSIX timestamps
+with picosecond precision, conversion with date-time values,
+conversion with [RFC 3339 timestamps][rfc3339] and pretty printing to
+a human-readable, locale-independent representation.
+
+The additional Ptime_clock library provides access to a system POSIX
+clock and to the system's current time zone offset.
+
+Ptime is not a calendar library.
+
+Ptime has no dependency. Ptime_clock depends on your system library or
+JavaScript runtime system. Ptime and its libraries are distributed
+under the ISC license.
+
+[rfc3339]: http://tools.ietf.org/html/rfc3339
+
+Home page: http://erratique.ch/software/ptime"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The ptime programmers"
+license: "ISC"
+tags: ["time" "posix" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/ptime"
+doc: "https://erratique.ch/software/ptime/doc/"
+bug-reports: "https://github.com/dbuenzli/ptime/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build & != "0.9.0"}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/ptime.git"
+url {
+  src: "https://erratique.ch/software/ptime/releases/ptime-1.0.0.tbz"
+  checksum:
+    "sha512=df2410d9cc25a33083fe968a584b8fb4d68ad5c077f3356da0a20427e6cd8756a5b946b921e5cf8ed4097f2c506e93345d9dca63b113be644d5a7cc0753d1534"
+}


### PR DESCRIPTION
* Add: `ptime.1.0.0` [home](https://erratique.ch/software/ptime), [doc](https://erratique.ch/software/ptime/doc/), [issues](https://github.com/dbuenzli/ptime/issues)  
  *POSIX time for OCaml*


---

#### `ptime` v1.0.0 2022-02-16 La Forclaz

* Change the `js_of_ocaml` strategy for `Ptime_clock`'s JavaScript
  implementation. Primitives of `ptime.clock.os` are now implemented
  in pure JavaScript and linked by `js_of_ocaml`. This means that the
  `ptime.clock.jsoo` library no longer exists, simply link against
  `ptime.clock.os` instead. Thanks to Hugo Heuzard for suggesting and
  implementing this.

* Require OCaml >= 4.08
* Correct a potential overflow in Ptime.Span.of_float_s ([#26](https://github.com/dbuenzli/ptime/issues/26)).

---

Use `b0 cmd -- .opam.publish ptime.1.0.0` to update the pull request.