### PR TITLE
Add: mtime.1.4.0

### DIFF
--- a/packages/archsat/archsat.1.1/opam
+++ b/packages/archsat/archsat.1.1/opam
@@ -31,7 +31,7 @@ depends: [
   "zarith"
   "ocamlgraph"
   "gen"
-  "mtime"
+  "mtime"       { <  "1.4.0" }
   "iter"        { >= "0.5" }
   "spelll"      { >= "0.3" }
   "uucp"

--- a/packages/metrics-unix/metrics-unix.0.1.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "fmt" {>= "0.8.5"}
   "uuidm" {>= "0.9.6"}
   "metrics" {< "0.5"} # should have been "= version" but to avoid breaking lock files and stuff..
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & < "1.4.0"}
   "lwt" {>= "2.4.7"}
   "conf-gnuplot"
   "metrics-lwt" {with-test}

--- a/packages/metrics-unix/metrics-unix.0.2.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.4"}
   "uuidm"
   "metrics" {= version}
-  "mtime"
+  "mtime" {< "1.4.0"}
   "lwt"
   "metrics-lwt" {=version & with-test}
   "conf-gnuplot"

--- a/packages/metrics-unix/metrics-unix.0.3.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.4"}
   "uuidm" {>= "0.9.6"}
   "metrics" {= version}
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & < "1.4.0"}
   "lwt"
   "metrics-lwt" {= version & with-test}
   "conf-gnuplot"

--- a/packages/metrics-unix/metrics-unix.0.4.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.4"}
   "uuidm" {>= "0.9.6"}
   "metrics" {= version}
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & < "1.4.0"}
   "lwt" {>= "2.4.7"}
   "metrics-lwt" {= version & with-test}
   "conf-gnuplot"

--- a/packages/mtime/mtime.1.4.0/opam
+++ b/packages/mtime/mtime.1.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Monotonic wall-clock time for OCaml"
+description: """\
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library
+or JavaScript runtime system. Mtime and its libraries are distributed
+under the ISC license.
+
+Home page: http://erratique.ch/software/mtime"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The mtime programmers"
+license: "ISC"
+tags: ["time" "monotonic" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/mtime"
+doc: "https://erratique.ch/software/mtime/doc/"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build & != "0.9.0"}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/mtime.git"
+url {
+  src: "https://erratique.ch/software/mtime/releases/mtime-1.4.0.tbz"
+  checksum:
+    "sha512=0492fa5f5187b909fe2b0550363c7dcb8cffef963d51072272ef3d876b51e1ddf8de4c4e221cffb0144658fccf6a0dc584a5c8094a4b2208156e43bad5b269d4"
+}

--- a/packages/progress/progress.0.1.0/opam
+++ b/packages/progress/progress.0.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/CraigFe/progress/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "mtime"
+  "mtime" {< "1.4.0"}
   "terminal_size"
   "alcotest" {>= "1.1.0" & with-test}
   "astring" {with-test}

--- a/packages/progress/progress.0.1.1/opam
+++ b/packages/progress/progress.0.1.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/CraigFe/progress/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "mtime"
+  "mtime" {< "1.4.0"}
   "terminal_size"
   "alcotest" {>= "1.1.0" & with-test}
   "astring" {with-test}


### PR DESCRIPTION
* Add: `mtime.1.4.0` [home](https://erratique.ch/software/mtime), [doc](https://erratique.ch/software/mtime/doc/), [issues](https://github.com/dbuenzli/mtime/issues)  
  *Monotonic wall-clock time for OCaml*


---

#### `mtime` v1.4.0 2022-02-17 La Forclaz (VS)

* Change the `js_of_ocaml` strategy for `Mtime_clock`'s JavaScript
  implementation. Primitives of `mtime.clock.os` are now implemented
  in pure JavaScript and linked by `js_of_ocaml`.  This means that the
  `mtime.clock.jsoo` library no longer exists, simply link against
  `mtime.clock.os` instead. Thanks to Hugo Heuzard for suggesting and
  implementing this.

* Add `Mtime.{min,max}_stamp`.
* Add durations `Mtime.Span.{ns,us,ms,s,min,hour,day,year}` and 
  the `Mtime.Span.(*)` operator ([#28](https://github.com/dbuenzli/mtime/issues/28)).
* Deprecate `Mtime.s_to_*` and `Mtime.*_to_s` floating point constants ([#28](https://github.com/dbuenzli/mtime/issues/28)).
* Require OCaml >= 4.08.
* Allow compiling with MSVC compiler. Thanks to Jonah Beckford for the patch.

---

Use `b0 cmd -- .opam.publish mtime.1.4.0` to update the pull request.