### PR TITLE
[new release] domainslib (0.4.1)

### DIFF
--- a/packages/domainslib/domainslib.0.4.1/opam
+++ b/packages/domainslib/domainslib.0.4.1/opam
@@ -9,12 +9,12 @@ dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: ["org:ocamllabs"]
 depends: [
-  "ocaml" {>= 5.00}
+  "ocaml" {>= "5.00"}
   "dune" {>= "1.8"}
-  "base-domains"
   "mirage-clock-unix" {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
 url {
   src: "https://github.com/ocaml-multicore/domainslib/archive/0.4.1.tar.gz"
   checksum: "md5=7514b4f9c7bcc2d5c20bb1143cf0b77a"

--- a/packages/domainslib/domainslib.0.4.1/opam
+++ b/packages/domainslib/domainslib.0.4.1/opam
@@ -9,6 +9,7 @@ dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
 tags: ["org:ocamllabs"]
 depends: [
+  "ocaml" {>= 5.00}
   "dune" {>= "1.8"}
   "base-domains"
   "mirage-clock-unix" {with-test}

--- a/packages/domainslib/domainslib.0.4.1/opam
+++ b/packages/domainslib/domainslib.0.4.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "dune" {>= "1.8"}
+  "base-domains"
+  "mirage-clock-unix" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.4.1.tar.gz"
+  checksum: "md5=7514b4f9c7bcc2d5c20bb1143cf0b77a"
+}


### PR DESCRIPTION
This release fixes compatibility with OCaml `5.00.0+trunk` in https://github.com/ocaml-multicore/domainslib/pull/61. Breaks compatibility with older Multicore variants `4.12.0+domains` and `4.12.0+domains+effects`.