### PR TITLE
Add License to conf-libev and conf-pam packages

### DIFF
--- a/packages/conf-libev/conf-libev.4-11/opam
+++ b/packages/conf-libev/conf-libev.4-11/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://software.schmorp.de/pkg/libev.html"
 authors: "Marc Lehmann"
+license: "BSD-2-Clause"
 build: [["sh" "./build.sh"]]
 depends: [
   "ocaml" {>= "3.11.0"}

--- a/packages/conf-libev/conf-libev.4-12/opam
+++ b/packages/conf-libev/conf-libev.4-12/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://software.schmorp.de/pkg/libev.html"
 authors: "Marc Lehmann"
+license: "BSD-2-Clause"
 build: [["sh" "./build.sh"]]
 depends: [
   "ocaml" {>= "3.11.0"}

--- a/packages/conf-pam/conf-pam.1/opam
+++ b/packages/conf-pam/conf-pam.1/opam
@@ -3,7 +3,7 @@ homepage: "https://github.com/linux-pam/linux-pam"
 author: "https://github.com/linux-pam"
 maintainer: "Jane Street developers"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-
+license: "BSD-3-Clause"
 depexts: [
   ["libpam0g-dev"] {os-family = "debian"}
   ["pam-devel"] {os-distribution = "centos"}


### PR DESCRIPTION
Conf-libev actually lets the user choose between the BSD and the GPL license, but the base is the BSD license.
Conf-pam has a similar license but doesn't specify which GPL version to choose.

I didn't see a way to express this kind of dual license using SPDX, so I opted to pick the base license.