### PR TITLE
[new release] xdg, stdune, ordering, fiber, dyn, dune, dune-site, dune-rpc, dune-rpc-lwt, dune-private-libs, dune-glob, dune-configurator, dune-build-info and dune-action-plugin (3.0.1)

### DIFF
--- a/packages/dune-action-plugin/dune-action-plugin.3.0.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-glob"
+  "csexp" {>= "1.4.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-build-info/dune-build-info.3.0.1/opam
+++ b/packages/dune-build-info/dune-build-info.3.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-configurator/dune-configurator.3.0.1/opam
+++ b/packages/dune-configurator/dune-configurator.3.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.04.0"}
+  "csexp" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-glob/dune-glob.3.0.1/opam
+++ b/packages/dune-glob/dune-glob.3.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-private-libs/dune-private-libs.3.0.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "csexp" {>= "1.4.0"}
+  "pp"
+  "dyn"
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "result"
+  "dune-rpc" {= version}
+  "csexp" {>= "1.4.0"}
+  "lwt"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-rpc/dune-rpc.3.0.1/opam
+++ b/packages/dune-rpc/dune-rpc.3.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune-site/dune-site.3.0.1/opam
+++ b/packages/dune-site/dune-site.3.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations informations inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dune/dune.3.0.1/opam
+++ b/packages/dune/dune.3.0.1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
+  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/dyn/dyn.3.0.1/opam
+++ b/packages/dyn/dyn.3.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "ordering"
+  "pp"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/fiber/fiber.3.0.1/opam
+++ b/packages/fiber/fiber.3.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Structured concurrency library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "stdune"
+  "dyn"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/ordering/ordering.3.0.1/opam
+++ b/packages/ordering/ordering.3.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/stdune/stdune.3.0.1/opam
+++ b/packages/stdune/stdune.3.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "dyn"
+  "ordering"
+  "pp"
+  "csexp"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"

--- a/packages/xdg/xdg.3.0.1/opam
+++ b/packages/xdg/xdg.3.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.0.1/fiber-3.0.1.tbz"
+  checksum: [
+    "sha256=fa9d52e5d5d7c7b7e9e98eb5516c9f3778f69ead851e42f8f14042370c764494"
+    "sha512=25910830e72931b1e9ee0d9ef0f42377e0edf2a271f098df5c0bc02d0848f84a16233db84dc2ee47b4c5b591eb7c4843ae32905f5aa4c69278eeb4279843c2a8"
+  ]
+}
+x-commit-hash: "b6709437aa1b264826735963e0d7c199c4ddf82e"


### PR DESCRIPTION
XDG Base Directory Specification

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Fix compilation on MacOS SDK < 10.13. The native watch mode is disabled in
  such instances (ocaml/dune#5431 fix ocaml/dune#5430, @rgrinberg)

- Do no add workspace_root to `BUILD_PATH_PREFIX_MAP` for projects before 3.0
  (5448, @rgrinberg)

- Fix performance regression in incremental builds (ocaml/dune#5439, @snowleopard)
