### PR TITLE
conf-*: Import all the depexts from the opam-repository-mingw fork

### DIFF
--- a/packages/conf-aclocal/conf-aclocal.1.0.0/opam
+++ b/packages/conf-aclocal/conf-aclocal.1.0.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["automake"] {os-family = "debian"}
   ["automake"] {os-distribution = "nixos"}
   ["automake"] {os-distribution = "arch"}
+  ["system:automake"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 depends: ["conf-which" {build}]
 synopsis: "Virtual package relying on aclocal"

--- a/packages/conf-asciidoc/conf-asciidoc.1/opam
+++ b/packages/conf-asciidoc/conf-asciidoc.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["app-text/asciidoc"] {os-family = "gentoo"}
   ["asciidoc"] {os = "macos" & os-distribution = "homebrew"}
   ["asciidoc"] {os = "macos" & os-distribution = "macports"}
+  ["system:asciidoc"] {os = "win32" & os-distribution = "cygwinports"}
   ["asciidoc"] {os = "freebsd"}
   ["asciidoc"] {os = "openbsd"}
   ["asciidoc"] {os = "netbsd"}

--- a/packages/conf-autoconf/conf-autoconf.0.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.0.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["autoconf"] {os-distribution = "alpine"}
   ["autoconf"] {os-distribution = "ol"}
   ["autoconf"] {os-distribution = "rhel"}
+  ["system:autoconf"] {os = "win32" & os-distribution = "cygwinports"}
   ["autoconf"] {os-family = "suse"}
 ]
 synopsis: "Virtual package relying on autoconf installation"

--- a/packages/conf-blas/conf-blas.1/opam
+++ b/packages/conf-blas/conf-blas.1/opam
@@ -19,6 +19,7 @@ depexts: [
   ["lapack-dev"] {os-distribution = "alpine"}
   ["blas-devel"] {os-family = "suse"}
   ["blas" "gcc"] {os = "freebsd"}
+  ["blas"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package for BLAS configuration"
 description: """

--- a/packages/conf-boost/conf-boost.1/opam
+++ b/packages/conf-boost/conf-boost.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["boost"] {os = "macos" & os-distribution = "homebrew"}
   ["boost"] {os-distribution = "macports" & os = "macos"}
   ["boost-all"] {os = "freebsd"}
+  ["boost"] {os = "win32" & os-distribution = "cygwinports"}
   ["boost"] {os = "netbsd"}
   ["boost"] {os = "openbsd"}
 ]

--- a/packages/conf-c++/conf-c++.1.0/opam
+++ b/packages/conf-c++/conf-c++.1.0/opam
@@ -12,6 +12,7 @@ depexts: [
   ["g++"] {os-family = "debian"}
   ["gcc"] {os-distribution = "nixos"}
   ["gcc"] {os-distribution = "arch"}
+  ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on the c++ compiler"
 description:

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["graphics/cairo"] {os = "openbsd"}
   ["cairo"] {os-family = "arch"}
   ["cairo"] {os = "macos" & os-distribution = "homebrew"}
+  ["cairo"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a Cairo system installation"
 description:

--- a/packages/conf-expat/conf-expat.1/opam
+++ b/packages/conf-expat/conf-expat.1/opam
@@ -9,6 +9,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libexpat1-dev"] {os-family = "debian"}
   ["libexpat1-devel"] {os-distribution = "mageia"}
+  ["expat"] {os = "win32" & os-distribution = "cygwinports"}
   ["expat-devel"] {os-distribution = "fedora"}
   ["expat"] {os-distribution = "nixos"}
 ]

--- a/packages/conf-fftw3/conf-fftw3.1/opam
+++ b/packages/conf-fftw3/conf-fftw3.1/opam
@@ -19,7 +19,7 @@ depexts: [
   ["math/fftw3"] {os = "freebsd"}
   ["math/fftw3"] {os = "openbsd"}
   ["fftw"] {os = "macos" & os-distribution = "homebrew"}
-  ["fftw3-devel"] {os-distribution = "cygwinports"}
+  ["fftw3"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a FFTW3 lib system installation"
 description:

--- a/packages/conf-findutils/conf-findutils.1/opam
+++ b/packages/conf-findutils/conf-findutils.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["findutils"] {os-family = "suse"}
   ["findutils"] {os-distribution = "ol"}
   ["findutils"] {os-distribution = "arch"}
+  ["system:findutils"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on findutils"
 description:

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -17,6 +17,7 @@ depexts: [
   ["print/freetype2"] {os = "freebsd"}
   ["print/freetype2"] {os = "openbsd"}
   ["freetype"] {os = "macos" & os-distribution = "homebrew"}
+  ["freetype2"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a freetype lib system installation"
 description:

--- a/packages/conf-g++/conf-g++.1.0/opam
+++ b/packages/conf-g++/conf-g++.1.0/opam
@@ -13,6 +13,7 @@ depexts: [
   ["gcc"] {os-distribution = "nixos"}
   ["gcc"] {os-distribution = "arch"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
+  ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on the g++ compiler (for C++)"
 description:

--- a/packages/conf-gcc/conf-gcc.1.0/opam
+++ b/packages/conf-gcc/conf-gcc.1.0/opam
@@ -14,6 +14,7 @@ depexts: [
   ["gcc"] {os-distribution = "nixos"}
   ["gcc"] {os-distribution = "archlinux"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
+  ["gcc-core"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on the gcc compiler (for C)"
 description:

--- a/packages/conf-gd/conf-gd.1/opam
+++ b/packages/conf-gd/conf-gd.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["libgd-dev"] {os-family = "debian"}
   ["gd"] {os-distribution = "nixos"}
   ["gd"] {os = "macos" & os-distribution = "homebrew"}
+  ["gd"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a libgd system installation"
 description:

--- a/packages/conf-gfortran/conf-gfortran.0/opam
+++ b/packages/conf-gfortran/conf-gfortran.0/opam
@@ -19,5 +19,5 @@ depexts: [
   ["lang/gcc"] {os = "openbsd"}
   ["gcc"] {os = "macos" & os-distribution = "homebrew"}
   ["gcc"] {os = "macos" & os-distribution = "macports"}
-  ["mingw64-x86_64-gcc-fortran"] {os = "cygwin"}
+  ["gcc-fortran"] {os = "win32" & os-distribution = "cygwinports"}
 ]

--- a/packages/conf-git/conf-git.1.0/opam
+++ b/packages/conf-git/conf-git.1.0/opam
@@ -16,6 +16,7 @@ depexts: [
   ["git"] {os-distribution = "nixos"}
   ["git"] {os-distribution = "arch"}
   ["git"] {os = "macos" & os-distribution = "homebrew"}
+  ["system:git"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on git"
 description:

--- a/packages/conf-git/conf-git.1.1/opam
+++ b/packages/conf-git/conf-git.1.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["git"] {os-distribution = "nixos"}
   ["git"] {os-family = "arch"}
   ["git"] {os-family = "alpine"}
+  ["system:git"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on git"
 description:

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -7,6 +7,7 @@ license: "LGPL-2.1-or-later"
 build: [["pkg-config" "libglade-2.0"]]
 depexts: [
   ["libglade2-dev"] {os-family = "debian"}
+  ["libglade2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["libglade2-devel"] {os-distribution = "fedora"}
   ["gnome2.libglade"] {os-distribution = "nixos"}
 ]

--- a/packages/conf-glew/conf-glew.1/opam
+++ b/packages/conf-glew/conf-glew.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libglew-dev"] {os-family = "debian"}
   ["libglew-dev"] {os-family = "ubuntu"}
   ["libglew-devel"] {os-distribution = "mageia"}
+  ["glew"] {os = "win32" & os-distribution = "cygwinports"}
   ["glew-devel"] {os-distribution = "fedora"}
   ["glew-devel"] {os-distribution = "centos"}
   ["glu-devel" "glew-devel"] {os-family = "suse"}

--- a/packages/conf-glib-2/conf-glib-2.1/opam
+++ b/packages/conf-glib-2/conf-glib-2.1/opam
@@ -12,6 +12,7 @@ depexts: [
   ["glib-dev"] {os-distribution = "alpine"}
   ["glib"] {os = "macos" & os-distribution = "homebrew"}
   ["glib2-devel"] {os = "macos" & os-distribution = "macports"}
+  ["glib2.0"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 post-messages: [
   "This package requires GLib 2 development files installed on your system"

--- a/packages/conf-gmp/conf-gmp.1/opam
+++ b/packages/conf-gmp/conf-gmp.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}
   ["gmp-devel"] {os-family = "suse"}
+  ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-gmp/conf-gmp.2/opam
+++ b/packages/conf-gmp/conf-gmp.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}
   ["gmp-devel"] {os-family = "suse"}
+  ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-gmp/conf-gmp.4/opam
+++ b/packages/conf-gmp/conf-gmp.4/opam
@@ -28,7 +28,7 @@ depexts: [
   ["gmp"] {os = "freebsd"}
   ["gmp-dev"] {os-distribution = "alpine"}
   ["gmp-devel"] {os-family = "suse"}
-  ["mingw64-x86_64-gmp"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -10,6 +10,7 @@ depexts: [
   ["libgnomecanvas-devel"] {os-family = "fedora" | os-family = "rhel"}
   ["libgnomecanvas"] {os = "macos" & os-distribution = "homebrew"}
   ["libgnomecanvas-dev@testing" "libart-lgpl-dev"] {os-family = "alpine"}
+  ["libgnomecanvas2"] {os = "win32" & os-distribution = "cygwinports"}
   ["libgnomecanvas"] {os-family = "arch"}
   ["libgnomecanvas"] {os = "freebsd"}
   ["libgnomecanvas"] {os = "openbsd"}

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -9,6 +9,7 @@ depexts: [
   ["gnutls-dev"] {os-distribution = "alpine"}
   ["gnutls-devel" "nettle-devel"] {os-distribution = "fedora"}
   ["gnutls"] {os = "macos" & os-distribution = "homebrew"}
+  ["gnutls"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a gnutls system installation"
 description:

--- a/packages/conf-graphviz/conf-graphviz.0.1/opam
+++ b/packages/conf-graphviz/conf-graphviz.0.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["media-gfx/graphviz"] {os-distribution = "gentoo"}
   ["graphviz"] {os = "macos" & os-distribution = "homebrew"}
   ["graphviz"] {os = "openbsd"}
+  ["system:graphviz"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on graphviz installation"
 description:

--- a/packages/conf-gsl/conf-gsl.1/opam
+++ b/packages/conf-gsl/conf-gsl.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["gsl"] {os-distribution = "arch"}
   ["gsl"] {os = "freebsd"}
   ["gsl"] {os = "macos" & os-distribution = "homebrew"}
+  ["gsl"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a GSL lib system installation"
 description:

--- a/packages/conf-gstreamer/conf-gstreamer.1/opam
+++ b/packages/conf-gstreamer/conf-gstreamer.1/opam
@@ -19,6 +19,8 @@ depexts: [
   ["libgstreamer1.0-dev" "libgstreamer-plugins-base1.0-dev"]
     {os-family = "debian"}
   ["gstreamer1" "gstreamer1-plugins-core"] {os = "freebsd"}
+  ["gstreamer1.0" "gstreamer1.0-plugins-base"]
+    {os = "win32" & os-distribution = "cygwinports"}
   ["gstreamer" "gst-plugins-base"]
     {os = "macos" & os-distribution = "homebrew"}
 ]

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["gtk2-devel"] {os-family = "suse"}
   ["gtk2"] {os-family = "arch"}
   ["gtk2"] {os-distribution = "nixos"}
+  ["gtk2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["gtk+" "expat"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis: "Virtual package relying on gtk2"

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -14,6 +14,7 @@ depexts: [
   ["gtk3-devel"] {os-distribution = "ol"}
   ["gtk+3.0-dev"] {os-distribution = "alpine"}
   ["gtk3-devel"] {os-family = "suse"}
+  ["gtk3"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 post-messages: [
   "This package requires gtk+ 3.0 development packages installed on your system"

--- a/packages/conf-gtksourceview/conf-gtksourceview.2/opam
+++ b/packages/conf-gtksourceview/conf-gtksourceview.2/opam
@@ -16,6 +16,7 @@ depexts: [
   ["gtksourceview"] {os = "openbsd"}
   ["gtksourceview2-devel"] {os-family = "suse"}
   ["gtksourceview" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+  ["gtksourceview2.0"] {os = "win32" & os-distribution = "cygwinports"}
   ["gnome2.gtksourceview" "gtk2"] {os-distribution = "nixos"}
 ]
 x-ci-accept-failures: [

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview-devel"] {os-family = "suse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+  ["gtksourceview3.0"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"
 description:

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -17,6 +17,7 @@ depexts: [
   ["gtksourceview-devel"] {os-family = "suse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
   ["gtksourceview3 +quartz" "libxml2"] {os = "macos" & os-distribution = "macports"}
+  ["gtksourceview3.0"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0/opam
@@ -16,6 +16,7 @@ depexts: [
   ["gtksourceview3"] {os = "openbsd"}
   ["gtksourceview3-devel"] {os-family = "suse"}
   ["gtksourceview3" "libxml2"] {os = "macos" & os-distribution = "homebrew"}
+  ["gtksourceview3.0"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a GtkSourceView-3 system installation"
 description:

--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["jq"] {os-distribution = "arch"}
   ["jq"] {os = "freebsd"}
   ["jq"] {os = "macos" & os-distribution = "homebrew"}
+  ["system:jq"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on jq"
 description:

--- a/packages/conf-lame/conf-lame.1/opam
+++ b/packages/conf-lame/conf-lame.1/opam
@@ -8,6 +8,7 @@ depexts: [
   ["lame-dev"] {os-distribution = "alpine"}
   ["lame-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
   ["libmp3lame-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["lame"] {os = "win32" & os-distribution = "cygwinports"}
   ["lame"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on lame"

--- a/packages/conf-lapack/conf-lapack.1/opam
+++ b/packages/conf-lapack/conf-lapack.1/opam
@@ -19,6 +19,7 @@ depexts: [
   ["lapack-dev"] {os-distribution = "alpine"}
   ["lapack-devel"] {os-family = "suse"}
   ["lapack" "gcc"] {os = "freebsd"}
+  ["lapack"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package for LAPACK configuration"
 description: """

--- a/packages/conf-libbz2/conf-libbz2.1/opam
+++ b/packages/conf-libbz2/conf-libbz2.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["bzip2"] {os = "freebsd"}
   ["bzip2"] {os = "openbsd"}
   ["bzip2"] {os = "netbsd"}
+  ["bzip2"] {os = "win32" & os-distribution = "cygwinports"}
   ["bzip2"] {os = "macos" & os-distribution = "homebrew"}
   ["bzip2"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -11,6 +11,7 @@ depexts: [
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
   ["curl"] {os-distribution = "nixos"}
   ["curl"] {os-distribution = "arch"}
+  ["curl"] {os = "win32" & os-distribution = "cygwinports"}
   ["curl-dev"] {os-distribution = "alpine"}
   ["libcurl-devel"] {os-family = "suse"}
   ["libcurl-devel"] {os-distribution = "fedora"}

--- a/packages/conf-libevent/conf-libevent.1/opam
+++ b/packages/conf-libevent/conf-libevent.1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["libevent"] {os = "freebsd"}
   ["libevent"] {os = "openbsd"}
   ["libevent"] {os = "netbsd"}
+  ["libevent"] {os = "win32" & os-distribution = "cygwinports"}
   ["libevent"] {os = "macos" & os-distribution = "homebrew"}
   ["libevent"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-libffi/conf-libffi.1/opam
+++ b/packages/conf-libffi/conf-libffi.1/opam
@@ -7,6 +7,7 @@ build: [["pkg-config" "libffi"]]
 depexts: [
   ["libffi-dev"] {os-family = "debian"}
   ["libffi5-devel"] {os-distribution = "mageia"}
+  ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a libffi system installation"
 description:

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -15,6 +15,7 @@ depexts: [
   ["libffi-devel"] {os-distribution = "ol"}
   ["libffi-devel"] {os-family = "suse"}
   ["libffi"] {os = "freebsd"}
+  ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libffi system installation"
 description: "This package can only install if libffi is installed on the system."

--- a/packages/conf-libflac/conf-libflac.1/opam
+++ b/packages/conf-libflac/conf-libflac.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["flac"] {os-distribution = "arch"}
   ["flac"] {os = "freebsd"}
   ["flac"] {os = "macos" & os-distribution = "homebrew"}
+  ["flac"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libFLAC"
 description:

--- a/packages/conf-libgif/conf-libgif.1/opam
+++ b/packages/conf-libgif/conf-libgif.1/opam
@@ -18,6 +18,7 @@ license: "GIFLIB"
 depexts: [
   ["libgif-dev"] {os-family = "debian"}
   ["giflib"] {os = "macos" & os-distribution = "homebrew"}
+  ["giflib"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a libgif system installation"
 description:

--- a/packages/conf-libjpeg/conf-libjpeg.1/opam
+++ b/packages/conf-libjpeg/conf-libjpeg.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libjpeg-dev"] {os-family = "debian"}
   ["libjpeg-devel"] {os-family = "mageia"}
   ["jpeg"] {os = "macos" & os-distribution = "homebrew"}
+  ["libjpeg-turbo"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a libjpeg system installation"
 description:

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -14,6 +14,7 @@ depexts: [
   ["lz4-dev"] {os-distribution = "alpine"}
   ["liblz4-devel"] {os-family = "suse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}
+  ["lz4"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on liblz4 system installation"
 flags: conf

--- a/packages/conf-liblzma/conf-liblzma.1/opam
+++ b/packages/conf-liblzma/conf-liblzma.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["xz"] {os-family = "arch"}
   ["xz"] {os = "macos" & os-distribution = "homebrew"}
   ["xz"] {os = "macos" & os-distribution = "macports"}
+  ["xz"] {os = "win32" & os-distribution = "cygwinports"}
   # Shipped as part of FreeBSD
   ["xz"] {os = "openbsd"}
   ["xz"] {os = "netbsd"}

--- a/packages/conf-libogg/conf-libogg.1/opam
+++ b/packages/conf-libogg/conf-libogg.1/opam
@@ -18,6 +18,7 @@ depexts: [
   ["libogg"] {os-distribution = "nixos"}
   ["libogg"] {os-family = "bsd"}
   ["libogg"] {os = "macos" & os-distribution = "homebrew"}
+  ["libogg"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libogg"
 description:

--- a/packages/conf-libopus/conf-libopus.1/opam
+++ b/packages/conf-libopus/conf-libopus.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libopus0"] {os-family = "suse"}
   ["libopusenc"] {os = "macos" & os-distribution = "homebrew"}
   ["opus-devel"] {os-distribution="centos" | os-family = "fedora"}
+  ["opus"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libopus"
 description:

--- a/packages/conf-libpcre/conf-libpcre.1/opam
+++ b/packages/conf-libpcre/conf-libpcre.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["pcre"] {os-family = "arch"}
   ["pcre"] {os = "freebsd"}
   ["pcre"] {os = "macos" & os-distribution = "homebrew"}
+  ["pcre"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a libpcre system installation"
 description:

--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libpng-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
   ["libpng-devel"] {os-distribution = "mageia"}
   ["libpng12-dev"] {os-distribution = "ubuntu"}
+  ["libpng"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a libpng system installation"
 description:

--- a/packages/conf-librsvg2/conf-librsvg2.0/opam
+++ b/packages/conf-librsvg2/conf-librsvg2.0/opam
@@ -17,6 +17,7 @@ depexts: [
   ["librsvg-devel"] {os-family = "suse"}
   ["librsvg"] {os = "macos" & os-distribution = "homebrew"}
   ["librsvg +quartz" "libxml2"] {os = "macos" & os-distribution = "macports"}
+  ["librsvg2"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"

--- a/packages/conf-libsamplerate/conf-libsamplerate.1/opam
+++ b/packages/conf-libsamplerate/conf-libsamplerate.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libsamplerate-devel"] {os-distribution="centos" | os-family = "fedora" | os-family = "suse"}
   ["samplerate"] {os-distribution = "nixos"}
   ["libsamplerate"] {os-family = "arch" | os = "freebsd" | os = "macos" & os-distribution = "homebrew"}
+  ["libsamplerate"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libsamplerate"
 description:

--- a/packages/conf-libspeex/conf-libspeex.1/opam
+++ b/packages/conf-libspeex/conf-libspeex.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libspeex-dev"] {os-family = "debian"}
   ["speex"] {os-family = "bsd"}
   ["speex"] {os = "macos" & os-distribution = "homebrew"}
+  ["speex"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libspeex"
 description:

--- a/packages/conf-libssl/conf-libssl.1/opam
+++ b/packages/conf-libssl/conf-libssl.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
+  ["openssl"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on an OpenSSL library system installation"
 description:

--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -22,6 +22,7 @@ depexts: [
   ["openssl"] {os-distribution = "nixos"}
   ["openssl"] {os-distribution = "arch"}
   ["libopenssl-devel"] {os-family = "suse"}
+  ["openssl"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 post-messages: [
   "Make sure libssl/openssl is installed and accessible using pkg-config." {failure}

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -28,6 +28,7 @@ depexts: [
   ["openssl"] {os-distribution = "homebrew"}
   ["openssl"] {os-distribution = "macports"}
   ["openssl"] {os-distribution = "nixos"}
+  ["openssl"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on an OpenSSL library system installation"
 description:

--- a/packages/conf-libtheora/conf-libtheora.1/opam
+++ b/packages/conf-libtheora/conf-libtheora.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libtheora"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
   ["theora"] {os = "macos" & os-distribution = "homebrew"}
   ["libtheora-devel"] {os-distribution="centos" | os-family = "fedora" | os-family = "suse"}
+  ["libtheora"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libtheora"
 description:

--- a/packages/conf-libtool/conf-libtool.1/opam
+++ b/packages/conf-libtool/conf-libtool.1/opam
@@ -22,6 +22,7 @@ depexts: [
   ["libtool"] {os-distribution = "alpine"}
   ["libtool"] {os-distribution = "ol"}
   ["libtool"] {os-distribution = "rhel"}
+  ["system:libtool"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on libtool installation"
 description: """

--- a/packages/conf-mad/conf-mad.1/opam
+++ b/packages/conf-mad/conf-mad.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libmad"] {os-distribution = "archlinux" | os-distribution = "nixos"}
   ["libmad-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
   ["libmad0-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libmad"] {os = "win32" & os-distribution = "cygwinports"}
   ["mad"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on mad"

--- a/packages/conf-mariadb/conf-mariadb.1/opam
+++ b/packages/conf-mariadb/conf-mariadb.1/opam
@@ -15,6 +15,7 @@ depends: [
 depexts: [
   ["mariadb" "mariadb-connector-c"] {os-distribution = "nixos"}
   ["libmariadbclient-dev"] {os-family = "debian"}
+  ["mariadb-connector-c"] {os = "win32" & os-distribution = "cygwinports"}
   ["mariadb-devel"] {os-distribution = "centos"}
   ["mariadb-connector-c"] {os = "macos" & os-distribution = "homebrew"}
   ["mariadb-dev"] {os-distribution = "alpine"}

--- a/packages/conf-mpfr/conf-mpfr.1/opam
+++ b/packages/conf-mpfr/conf-mpfr.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
   ["mpfr"] {os = "freebsd"}
   ["mpfr"] {os = "openbsd"}
+  ["mpfr"] {os = "win32" & os-distribution = "cygwinports"}
   ["mpfr-dev"] {os-distribution = "alpine"}
   ["mpfr-devel"] {os-distribution = "centos"}
   ["mpfr-devel"] {os-family = "suse"}

--- a/packages/conf-mpfr/conf-mpfr.3/opam
+++ b/packages/conf-mpfr/conf-mpfr.3/opam
@@ -24,6 +24,7 @@ depexts: [
   ["mpfr"] {os-family = "arch"}
   ["mpfr-dev"] {os-family = "alpine"}
   ["mpfr-devel"] {os-family = "suse"}
+  ["mpfr"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on library MPFR installation"
 description:

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["ncurses-devel"] {os-distribution = "rhel"}
   ["ncurses-devel"] {os-family = "suse"}
   ["ncurses"] {os-distribution = "arch"}
+  ["ncurses"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on ncurses"
 description:

--- a/packages/conf-pango/conf-pango.1/opam
+++ b/packages/conf-pango/conf-pango.1/opam
@@ -20,6 +20,7 @@ depexts: [
   ["pango"] {os-distribution = "arch"}
   ["pango"] {os = "freebsd"}
   ["pango"] {os = "macos" & os-distribution = "homebrew"}
+  ["pango1.0"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a Pango system installation"
 description:

--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.1/opam
@@ -19,6 +19,7 @@ depexts: [
   ["perl-IPC-System-Simple"] {os-family = "suse"}
   ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
   ["perl-ipc-system-simple"] {os-family = "arch"}
+  ["system:perl-IPC-System-Simple"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"

--- a/packages/conf-pkg-config/conf-pkg-config.1.0/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
-  ["pkg-config"] {os-distribution = "cygwinports"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 available: [ os != "openbsd" ]
 synopsis: "Virtual package relying on pkg-config installation"

--- a/packages/conf-pkg-config/conf-pkg-config.1.1/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.1/opam
@@ -29,7 +29,7 @@ depexts: [
   ["devel/pkgconf"] {os = "openbsd"}
   ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
   ["pkgconf"] {os = "freebsd"}
-  ["pkg-config"] {os-distribution = "cygwinports"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on pkg-config installation"
 description: """

--- a/packages/conf-pkg-config/conf-pkg-config.1.2/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.2/opam
@@ -31,7 +31,7 @@ depexts: [
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkg-config"] {os-distribution = "cygwinports"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on pkg-config installation"
 description: """

--- a/packages/conf-pkg-config/conf-pkg-config.1.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.1.3/opam
@@ -32,7 +32,7 @@ depexts: [
   ["pkgconf"] {os = "freebsd"}
   ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
   ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
-  ["pkg-config"] {os-distribution = "cygwinports"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on pkg-config installation"
 description: """

--- a/packages/conf-portaudio/conf-portaudio.1/opam
+++ b/packages/conf-portaudio/conf-portaudio.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["portaudio-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
   ["portaudio"] {os = "macos" & os-distribution = "homebrew"}
   ["portaudio"] {os = "freebsd" | os-family = "arch" | os-distribution = "nixos" | os-distribution = "oraclelinux"}
+  ["portaudio"] {os = "win32" & os-distribution = "cygwinports"}
   ["portaudio19-dev"] {os-family = "debian" | os-family = "ubuntu"}
 ]
 synopsis: "Virtual package relying on portaudio"

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -21,6 +21,7 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
   ["postgresql-server-devel"] {os-family = "suse"}
   ["postgresql-dev"] {os-distribution = "alpine"}
+  ["postgresql"] {os = "win32" & os-distribution = "cygwinports"}
   ["postgresql-libs"] {os-family = "arch"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-samplerate/conf-samplerate.1/opam
+++ b/packages/conf-samplerate/conf-samplerate.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libsamplerate-dev"] {os-distribution = "alpine"}
   ["libsamplerate0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libsamplerate"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos" | os = "macos" & os-distribution = "homebrew"}
+  ["libsamplerate"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on samplerate"
 description:

--- a/packages/conf-sdl-image/conf-sdl-image.1/opam
+++ b/packages/conf-sdl-image/conf-sdl-image.1/opam
@@ -7,6 +7,7 @@ depexts: [
   ["sdl_image-dev"] {os-distribution = "alpine"}
   ["libsdl-image1.2-dev"] {os-family = "debian"}
   ["libSDL_image-devel"] {os-distribution = "mageia"}
+  ["SDL_image"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_image"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a sdl-image system installation"

--- a/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
+++ b/packages/conf-sdl-mixer/conf-sdl-mixer.1/opam
@@ -7,6 +7,7 @@ depexts: [
   ["sdl_mixer-dev"] {os-distribution = "alpine"}
   ["libsdl-mixer1.2-dev"] {os-family = "debian"}
   ["libSDL_mixer-devel"] {os-distribution = "mageia"}
+  ["SDL_mixer"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_mixer"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a sdl-mixer system installation"

--- a/packages/conf-sdl-net/conf-sdl-net.1/opam
+++ b/packages/conf-sdl-net/conf-sdl-net.1/opam
@@ -6,6 +6,7 @@ build: [["pkg-config" "SDL_net"]]
 depexts: [
   ["libsdl-net1.2-dev"] {os-family = "debian"}
   ["libSDL_net-devel"] {os-distribution = "mageia"}
+  ["SDL_net"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_net"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a sdl-net system installation"

--- a/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
+++ b/packages/conf-sdl-ttf/conf-sdl-ttf.1/opam
@@ -6,6 +6,7 @@ build: [["pkg-config" "SDL_ttf"]]
 depexts: [
   ["libsdl-ttf2.0-dev"] {os-family = "debian"}
   ["libSDL_ttf-devel"] {os-distribution = "mageia"}
+  ["SDL_ttf"] {os = "win32" & os-distribution = "cygwinports"}
   ["sdl_ttf"] {os = "macos" & os-distribution = "homebrew"}
 ]
 synopsis: "Virtual package relying on a sdl-ttf system installation"

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -25,6 +25,7 @@ depexts: [
   ["sqlite"] {os-distribution = "nixos"}
   ["sqlite"] {os = "macos" & os-distribution = "homebrew"}
   ["sqlite3"] {os = "macos" & os-distribution = "macports"}
+  ["sqlite3"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on an SQLite3 system installation"
 description:

--- a/packages/conf-tcl/conf-tcl.1/opam
+++ b/packages/conf-tcl/conf-tcl.1/opam
@@ -8,6 +8,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["tcl-dev"] {os-family = "debian"}
   ["tcl"] {os-distribution = "nixos"}
+  ["tcl"] {os = "win32" & os-distribution = "cygwinports"}
   ["tcl-dev"] {os-family = "alpine"}
   ["tcl-devel"] {os-family = "rhel"}
   ["tcl-devel"] {os-family = "fedora"}

--- a/packages/conf-time/conf-time.1/opam
+++ b/packages/conf-time/conf-time.1/opam
@@ -7,6 +7,7 @@ license: "GPL-1.0-or-later"
 build: [["which" "time"]]
 depends: ["conf-which" {build}]
 depexts: [
+  ["system:time"] {os = "win32" & os-distribution = "cygwinports"}
   ["time"] {os-family = "debian"}
   ["time"] {os-family = "ubuntu"}
   ["time"] {os-distribution = "centos"}

--- a/packages/conf-tk/conf-tk.1/opam
+++ b/packages/conf-tk/conf-tk.1/opam
@@ -8,6 +8,7 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["tk-dev"] {os-family = "debian"}
   ["tk"] {os-distribution = "nixos"}
+  ["tk"] {os = "win32" & os-distribution = "cygwinports"}
   ["tk"] {os-family = "alpine"}
   ["tk-dev"] {os-family = "alpine"}
   ["tk-devel"] {os-family = "rhel"}

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["zlib"] {os-distribution = "nixos"}
   ["zlib"] {os-distribution = "homebrew" & os = "macos"}
   ["zlib"] {os-family = "arch"}
+  ["zlib"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on zlib"
 description:

--- a/packages/conf-zmq/conf-zmq.0.1/opam
+++ b/packages/conf-zmq/conf-zmq.0.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["zeromq"] {os = "macos" & os-distribution = "homebrew"}
   ["zmq"] {os = "macos" & os-distribution = "macports"}
   ["zeromq-dev"] {os-distribution = "alpine"}
+  ["zeromq"] {os = "win32" & os-distribution = "cygwinports"}
   ["epel-release" "zeromq-devel"] {os-distribution = "centos"}
   ["zeromq"] {os-distribution = "arch"}
   ["zeromq-devel"] {os-distribution = "fedora"}

--- a/packages/conf-zstd/conf-zstd.0.1/opam
+++ b/packages/conf-zstd/conf-zstd.0.1/opam
@@ -13,6 +13,7 @@ depexts: [
   ["libzstd-devel"] {os-distribution = "fedora"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}
+  ["zstd"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on zstd"
 description:"

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libzstd-devel"] {os-family = "suse"}
   ["zstd-dev"] {os-distribution = "alpine"}
   ["zstd"] {os-distribution = "homebrew" & os = "macos"}
+  ["zstd"] {os = "win32" & os-distribution = "cygwinports"}
   ["zstd"] {os = "freebsd"}
 ]
 synopsis: "Virtual package relying on zstd"


### PR DESCRIPTION
We have no way of testing that at the moment but adding just the depexts for now seems to be a good easy first step.

cc @fdopen 

cc @kkirstein to double check the only meaningful change. Regarding `conf-gmp.4`, added in https://github.com/ocaml/opam-repository/pull/20471, this PR modifies it by replacing `mingw64-x86_64-gmp` by simply `gmp`.