### PR TITLE
Replace 'typeof OCaml system' with the equivalent valid SPDX

### DIFF
--- a/packages/stdlib-shims/stdlib-shims.0.1.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.1.0/opam
@@ -6,7 +6,7 @@ doc: "https://ocaml.github.io/stdlib-shims/"
 dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
 bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
 tags: ["stdlib" "compatibility" "org:ocaml"]
-license: ["typeof OCaml system"]
+license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune"

--- a/packages/stdlib-shims/stdlib-shims.0.3.0/opam
+++ b/packages/stdlib-shims/stdlib-shims.0.3.0/opam
@@ -6,7 +6,7 @@ doc: "https://ocaml.github.io/stdlib-shims/"
 dev-repo: "git+https://github.com/ocaml/stdlib-shims.git"
 bug-reports: "https://github.com/ocaml/stdlib-shims/issues"
 tags: ["stdlib" "compatibility" "org:ocaml"]
-license: ["typeof OCaml system"]
+license: ["LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 depends: [
   "dune"
   "ocaml" {>= "4.02.3"}

--- a/packages/uchar/uchar.0.0.1/opam
+++ b/packages/uchar/uchar.0.0.1/opam
@@ -6,7 +6,7 @@ doc: "https://ocaml.github.io/uchar/"
 dev-repo: "git+https://github.com/ocaml/uchar.git"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
-license: "typeof OCaml system"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: [
   ["ocaml" "pkg/git.ml"]
   [

--- a/packages/uchar/uchar.0.0.2/opam
+++ b/packages/uchar/uchar.0.0.2/opam
@@ -6,7 +6,7 @@ doc: "https://ocaml.github.io/uchar/"
 dev-repo: "git+https://github.com/ocaml/uchar.git"
 bug-reports: "https://github.com/ocaml/uchar/issues"
 tags: [ "text" "character" "unicode" "compatibility" "org:ocaml.org" ]
-license: "typeof OCaml system"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "ocaml" {>= "3.12.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
i.e. LGPL-2.1-only WITH OCaml-LGPL-linking-exception

https://github.com/ocaml/uchar/pull/4
https://github.com/ocaml/stdlib-shims/pull/21