### PR TITLE
[new release] tyxml-lwd, nottui, nottui-pretty, nottui-lwt, lwd and brr-lwd (0.2)

### DIFF
--- a/packages/brr-lwd/brr-lwd.0.2/opam
+++ b/packages/brr-lwd/brr-lwd.0.2/opam
@@ -8,7 +8,7 @@ doc: "https://let-def.github.io/lwd/doc"
 bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
-  "lwd" {>= "0.2"}
+  "lwd" {= version}
   "brr"
   "js_of_ocaml"
   "odoc" {with-doc}

--- a/packages/brr-lwd/brr-lwd.0.2/opam
+++ b/packages/brr-lwd/brr-lwd.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Make reactive webpages in Js_of_ocaml using Brr and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwd" {>= "0.2"}
+  "brr"
+  "js_of_ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src:
+    "https://github.com/let-def/lwd/releases/download/v0.2/nottui-lwt-0.2.tbz"
+  checksum: [
+    "sha256=09d9ebbffb172789938869136562d7b70818d6167f4bb05b8b187c08af3b3221"
+    "sha512=a88cfbdce6ecd280d10c34a712b685b44c712981ac85e500dab1518e513f9ac0bc02d0469184df927ab86f29e330b3439bb7eb8fb9a11f90a0a37bf46fdaa53e"
+  ]
+}
+x-commit-hash: "4f6c9ea3872859f352fd2fa3af864c457233f675"

--- a/packages/lwd/lwd.0.2/opam
+++ b/packages/lwd/lwd.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Lightweight reactive documents"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "seq"
+  "ocaml" {>= "4.03"}
+  "qtest" {with-test}
+  "qcheck" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src:
+    "https://github.com/let-def/lwd/releases/download/v0.2/nottui-lwt-0.2.tbz"
+  checksum: [
+    "sha256=09d9ebbffb172789938869136562d7b70818d6167f4bb05b8b187c08af3b3221"
+    "sha512=a88cfbdce6ecd280d10c34a712b685b44c712981ac85e500dab1518e513f9ac0bc02d0469184df927ab86f29e330b3439bb7eb8fb9a11f90a0a37bf46fdaa53e"
+  ]
+}
+x-commit-hash: "4f6c9ea3872859f352fd2fa3af864c457233f675"

--- a/packages/nottui-lwt/nottui-lwt.0.1/opam
+++ b/packages/nottui-lwt/nottui-lwt.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "2.0"}
   "notty"
   "lwt"
-  "nottui"
+  "nottui" {= version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/nottui-lwt/nottui-lwt.0.2/opam
+++ b/packages/nottui-lwt/nottui-lwt.0.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Run Nottui UIs in Lwt"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwt"
+  "nottui" {>= "0.2"}
+  "notty" {>= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src:
+    "https://github.com/let-def/lwd/releases/download/v0.2/nottui-lwt-0.2.tbz"
+  checksum: [
+    "sha256=09d9ebbffb172789938869136562d7b70818d6167f4bb05b8b187c08af3b3221"
+    "sha512=a88cfbdce6ecd280d10c34a712b685b44c712981ac85e500dab1518e513f9ac0bc02d0469184df927ab86f29e330b3439bb7eb8fb9a11f90a0a37bf46fdaa53e"
+  ]
+}
+x-commit-hash: "4f6c9ea3872859f352fd2fa3af864c457233f675"

--- a/packages/nottui-lwt/nottui-lwt.0.2/opam
+++ b/packages/nottui-lwt/nottui-lwt.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
   "lwt"
-  "nottui" {>= "0.2"}
+  "nottui" {= version}
   "notty" {>= "0.2"}
   "odoc" {with-doc}
 ]

--- a/packages/nottui-pretty/nottui-pretty.0.1/opam
+++ b/packages/nottui-pretty/nottui-pretty.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.0"}
   "notty"
-  "nottui"
+  "nottui" {= version}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/nottui-pretty/nottui-pretty.0.2/opam
+++ b/packages/nottui-pretty/nottui-pretty.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A pretty-printer based on PPrint rendering UIs"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "nottui" {>= "0.2"}
+  "notty" {>= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src:
+    "https://github.com/let-def/lwd/releases/download/v0.2/nottui-lwt-0.2.tbz"
+  checksum: [
+    "sha256=09d9ebbffb172789938869136562d7b70818d6167f4bb05b8b187c08af3b3221"
+    "sha512=a88cfbdce6ecd280d10c34a712b685b44c712981ac85e500dab1518e513f9ac0bc02d0469184df927ab86f29e330b3439bb7eb8fb9a11f90a0a37bf46fdaa53e"
+  ]
+}
+x-commit-hash: "4f6c9ea3872859f352fd2fa3af864c457233f675"

--- a/packages/nottui-pretty/nottui-pretty.0.2/opam
+++ b/packages/nottui-pretty/nottui-pretty.0.2/opam
@@ -8,7 +8,7 @@ doc: "https://let-def.github.io/lwd/doc"
 bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
-  "nottui" {>= "0.2"}
+  "nottui" {= version}
   "notty" {>= "0.2"}
   "odoc" {with-doc}
 ]

--- a/packages/nottui/nottui.0.1/opam
+++ b/packages/nottui/nottui.0.1/opam
@@ -8,7 +8,7 @@ doc: "https://let-def.github.io/lwd/doc"
 bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.0"}
-  "lwd"
+  "lwd" {= version}
   "notty"
 ]
 build: [

--- a/packages/nottui/nottui.0.2/opam
+++ b/packages/nottui/nottui.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "UI toolkit for the terminal built on top of Notty and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwd" {>= "0.2"}
+  "notty" {>= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src:
+    "https://github.com/let-def/lwd/releases/download/v0.2/nottui-lwt-0.2.tbz"
+  checksum: [
+    "sha256=09d9ebbffb172789938869136562d7b70818d6167f4bb05b8b187c08af3b3221"
+    "sha512=a88cfbdce6ecd280d10c34a712b685b44c712981ac85e500dab1518e513f9ac0bc02d0469184df927ab86f29e330b3439bb7eb8fb9a11f90a0a37bf46fdaa53e"
+  ]
+}
+x-commit-hash: "4f6c9ea3872859f352fd2fa3af864c457233f675"

--- a/packages/nottui/nottui.0.2/opam
+++ b/packages/nottui/nottui.0.2/opam
@@ -8,7 +8,7 @@ doc: "https://let-def.github.io/lwd/doc"
 bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
-  "lwd" {>= "0.2"}
+  "lwd" {= version}
   "notty" {>= "0.2"}
   "odoc" {with-doc}
 ]

--- a/packages/tyxml-lwd/tyxml-lwd.0.1/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
-  "lwd"
+  "lwd" {= version}
   "tyxml" {< "4.5.0"}
   "js_of_ocaml" {< "3.9.0"}
   "js_of_ocaml-ppx" {< "3.9.0"}

--- a/packages/tyxml-lwd/tyxml-lwd.0.2/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Make reactive webpages in Js_of_ocaml using Tyxml and Lwd"
+maintainer: ["fred@tarides.com"]
+authors: ["Frédéric Bour"]
+license: "MIT"
+homepage: "https://github.com/let-def/lwd"
+doc: "https://let-def.github.io/lwd/doc"
+bug-reports: "https://github.com/let-def/lwd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwd" {>= "0.2"}
+  "tyxml" {>= "4.5.0"}
+  "js_of_ocaml"
+  "js_of_ocaml-ppx"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/let-def/lwd.git"
+url {
+  src:
+    "https://github.com/let-def/lwd/releases/download/v0.2/nottui-lwt-0.2.tbz"
+  checksum: [
+    "sha256=09d9ebbffb172789938869136562d7b70818d6167f4bb05b8b187c08af3b3221"
+    "sha512=a88cfbdce6ecd280d10c34a712b685b44c712981ac85e500dab1518e513f9ac0bc02d0469184df927ab86f29e330b3439bb7eb8fb9a11f90a0a37bf46fdaa53e"
+  ]
+}
+x-commit-hash: "4f6c9ea3872859f352fd2fa3af864c457233f675"

--- a/packages/tyxml-lwd/tyxml-lwd.0.2/opam
+++ b/packages/tyxml-lwd/tyxml-lwd.0.2/opam
@@ -8,7 +8,7 @@ doc: "https://let-def.github.io/lwd/doc"
 bug-reports: "https://github.com/let-def/lwd/issues"
 depends: [
   "dune" {>= "2.7"}
-  "lwd" {>= "0.2"}
+  "lwd" {= version}
   "tyxml" {>= "4.5.0"}
   "js_of_ocaml"
   "js_of_ocaml-ppx"


### PR DESCRIPTION
Make reactive webpages in Js_of_ocaml using Tyxml and Lwd

- Project page: <a href="https://github.com/let-def/lwd">https://github.com/let-def/lwd</a>
- Documentation: <a href="https://let-def.github.io/lwd/doc">https://let-def.github.io/lwd/doc</a>

##### CHANGES:

Sun Feb 20 20:49:47 JST 2022

- Lwd.fix operator helps working with graphs that cannot be evaluated in a
  single pass
- brr-lwd library integrates Lwd with Brr library, for writing javascript
  applications

Bug fixes:
- fixed invalidation in Lwd
- restored some internal invariants in Lwd_seq
- fixed behavior of Notty sensors
