### PR TITLE
OCaml 4.14.0~beta1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~beta1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 4.14.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+depends: [
+  "ocaml" {= "4.14.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0-beta1.tar.gz"
+  checksum: "sha256=1b02000867fd20af59c2afa1eda411d064f02cf96227f7f3e07fbeb5492abe95"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 4.14.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
+depends: [
+  "ocaml" {= "4.14.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0-beta1.tar.gz"
+  checksum: "sha256=1b02000867fd20af59c2afa1eda411d064f02cf96227f7f3e07fbeb5492abe95"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]


### PR DESCRIPTION
This PR adds the usual two packages for 4.14.0~beta1.

Compared to the last alpha we have a last minute fix in the standard library API,
some internal compiler check, few build and documentation tweaks:

## Standard library

* 10583, 10998: Add over 40 new functions in Seq.
  (François Pottier and Simon Cruanes, review by Nicolás Ojeda Bär,
  Daniel Bünzli, Naëla Courant, Craig Ferguson, Wiktor Kuchta,
  Xavier Leroy, Guillaume Munch-Maccagnoni, Raphaël Proust, Gabriel Scherer
  and Thierry Martinez)

## Build System

- 10828 Build native-code compilers on OpenBSD/aarch64
  (Christopher Zimmermann)

- 10835 Disable DT_TEXTREL warnings on x86 32 bit architecture by passing
  -Wl,-z,notext in mksharedlib and mkmaindll. Fixes relocation issues, reported
  in 9800, making local patches in Debian, Alpine, and FreeBSD superfluous.
  (Hannes Mehnert with Kate Deplaix and Stéphane Glondu, review by Xavier Leroy)

## Documentation

- 10397: Document exceptions raised by Unix module functions on Windows
  (Martin Jambon, review by Daniel Bünzli, David Alsopp, Damien Doligez,
   Xavier Leroy, and Florian Angeletti)

- 10794: Clarify warning 57 (Ambiguous or-pattern variables under guard)
  (Wiktor Kuchta, review by Gabriel Scherer)

## Code generation

- 10719: Ensure that build_apply respects Lambda.max_arity
  (Stephen Dolan, review by Xavier Leroy)

## Internal/compiler-libs changes

- 10718, 11012: Add "Shape" information to the cmt files. Shapes are an
  abstraction of modules that can be used by external tooling to perform
  definition-aware operations.
  (Ulysse Gérard, Thomas Refis and Leo White, review by Florian Angeletti)
