### PR TITLE
Package lwt-watcher.0.2

### DIFF
--- a/packages/lwt-watcher/lwt-watcher.0.2/opam
+++ b/packages/lwt-watcher/lwt-watcher.0.2/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/nomadic-labs/lwt-watcher.git"
 license: "MIT"
 depends: [
   "ocaml"
-  "dune"
+  "dune" {>= "1.11"}
   "lwt"
 ]
 build: [

--- a/packages/lwt-watcher/lwt-watcher.0.2/opam
+++ b/packages/lwt-watcher/lwt-watcher.0.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: [ "Tezos devteam" ]
+homepage: "https://gitlab.com/nomadic-labs/lwt-watcher"
+bug-reports: "https://gitlab.com/nomadic-labs/lwt-watcher/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/lwt-watcher.git"
+license: "MIT"
+depends: [
+  "ocaml"
+  "dune"
+  "lwt"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "One-to-many broadcast in Lwt"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/lwt-watcher/-/archive/v0.2/lwt-watcher-v0.2.tar.gz"
+  checksum: [
+    "md5=2922ce8459eeacbd3d8819b2915d7128"
+    "sha512=11b16761ff025c39adbd177de511b1a4c8cc3e307d96111e04ed3058ae5d7577f940e2fe7fc9cbdc54ef0923aab62820f87f457c95ba18ebd2050ff7b9f075f9"
+  ]
+}


### PR DESCRIPTION
### `lwt-watcher.0.2`
One-to-many broadcast in Lwt



---
* Homepage: https://gitlab.com/nomadic-labs/lwt-watcher
* Source repo: git+https://gitlab.com/nomadic-labs/lwt-watcher.git
* Bug tracker: https://gitlab.com/nomadic-labs/lwt-watcher/issues

---
:camel: Pull-request generated by opam-publish v2.1.0