### PR TITLE
[new release] capnp (3.5.0)

### DIFF
--- a/packages/capnp/capnp.3.5.0/opam
+++ b/packages/capnp/capnp.3.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Paul Pelzl <pelzlpj@gmail.com>"
+authors: "Paul Pelzl <pelzlpj@gmail.com>"
+homepage: "https://github.com/capnproto/capnp-ocaml"
+bug-reports: "https://github.com/capnproto/capnp-ocaml/issues"
+license: "BSD-2-Clause"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.3"}
+  "result"
+  "base" {>= "v0.11"}
+  "stdio"
+  "base_quickcheck" {with-test}
+  "ocplib-endian" {>= "0.7"}
+  "res"
+  "stdint" {>= "0.5.1"}
+  "ounit" {with-test}
+  "conf-capnproto" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/capnproto/capnp-ocaml.git"
+synopsis:
+  "OCaml code generation plugin for the Cap'n Proto serialization framework"
+description: """
+Cap'n Proto is a multi-language code generation framework designed for
+high performance through the use of lazy parsing and arena allocation.
+This package provides a plugin for the Cap'n Proto compiler which enables
+OCaml code generation, as well as corresponding runtime library support."""
+url {
+  src:
+    "https://github.com/capnproto/capnp-ocaml/releases/download/v3.5.0/capnp-3.5.0.tbz"
+  checksum: [
+    "sha256=d3060f4b6bebb69d74608519da20dab1d59c88557ebcfce8c66a8f3f7f5f6035"
+    "sha512=43d6f06d99b4c54e8784ab3de83e1f538ff732831b4014ba983fd932e4ecbd5460837374bcf454961e4ee6de374b5169a89a417463f109dc00346d6980d2e038"
+  ]
+}
+x-commit-hash: "301fb375547ebab3036d6ea88efd07ab812b89ee"


### PR DESCRIPTION
OCaml code generation plugin for the Cap'n Proto serialization framework

- Project page: <a href="https://github.com/capnproto/capnp-ocaml">https://github.com/capnproto/capnp-ocaml</a>

##### CHANGES:

New features:

* Add Codecs.serialize_{fold,iter}_copyless (@Cjen1, capnproto/capnp-ocaml#71).
  Avoids a copy when writing out fragments.

Documentation:

* Add example of how to use the library (@rottened23, capnproto/capnp-ocaml#62).

* Extract LICENSE and identify as BSD-2-Clause (@tmcgilchrist, capnproto/capnp-ocaml#80).

Build system:

* Remove compiler flags for flambda (@talex5, capnproto/capnp-ocaml#83).
  This was very slow to compile on OCaml 4.14, and the performance benefit is minimal.

* Update to dune 2 (@talex5, capnproto/capnp-ocaml#77).

* Dune should not be a build dependency (@talex5, capnproto/capnp-ocaml#67).

* Replace `Uint32.of_int` in unit-tests with `of_string` (@talex5, capnproto/capnp-ocaml#73).
  Fixed tests on 32-bit systems.

* Remove Travis CI (@talex5, capnproto/capnp-ocaml#74). Replaced by ocaml-ci.

* Switch from "capnpc" to "capnp compile" (@talex5, capnproto/capnp-ocaml#75).

* Benchmarks: remove incorrect test for 64-bit on Windows (@dra27, capnproto/capnp-ocaml#72).
