### PR TITLE
3 packages from c-cube/printbox at 0.6.1

### DIFF
--- a/packages/printbox-html/printbox-html.0.6.1/opam
+++ b/packages/printbox-html/printbox-html.0.6.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Printbox unicode handling"
+description: """
+Adds html output handling to the printbox package.
+Printbox allows to print nested boxes, lists, arrays, tables in several formats
+"""
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "odoc" {with-doc}
+  "printbox" {= version}
+  "tyxml" {>="4.3"}
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src: "https://github.com/c-cube/printbox/archive/v0.6.1.tar.gz"
+  checksum: [
+    "md5=6e065332d7db622572bd963dbd530589"
+    "sha512=7c0882333d2b297c235ee73f09e8b95cdd6013909db0f1b7e07a1b90153e6a3e68249715c90030e033ced6ab3a40aab41d4470d686164676acb544ccbe6ba715"
+  ]
+}

--- a/packages/printbox-text/printbox-text.0.6.1/opam
+++ b/packages/printbox-text/printbox-text.0.6.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Text renderer for printbox, using unicode edges"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+  "printbox" { = version }
+  "uutf" { >= "1.0" }
+  "uucp" { >= "2.0" }
+  "mdx" {with-test & >= "1.4" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src: "https://github.com/c-cube/printbox/archive/v0.6.1.tar.gz"
+  checksum: [
+    "md5=6e065332d7db622572bd963dbd530589"
+    "sha512=7c0882333d2b297c235ee73f09e8b95cdd6013909db0f1b7e07a1b90153e6a3e68249715c90030e033ced6ab3a40aab41d4470d686164676acb544ccbe6ba715"
+  ]
+}

--- a/packages/printbox/printbox.0.6.1/opam
+++ b/packages/printbox/printbox.0.6.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes" "Guillaume Bury"]
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Allows to print nested boxes, lists, arrays, tables in several formats"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-bytes"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03" }
+]
+license: "BSD-2-Clause"
+tags: [ "print" "box" "table" "tree" ]
+homepage: "https://github.com/c-cube/printbox/"
+dev-repo: "git+https://github.com/c-cube/printbox.git"
+bug-reports: "https://github.com/c-cube/printbox/issues/"
+url {
+  src: "https://github.com/c-cube/printbox/archive/v0.6.1.tar.gz"
+  checksum: [
+    "md5=6e065332d7db622572bd963dbd530589"
+    "sha512=7c0882333d2b297c235ee73f09e8b95cdd6013909db0f1b7e07a1b90153e6a3e68249715c90030e033ced6ab3a40aab41d4470d686164676acb544ccbe6ba715"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`printbox.0.6.1`: Allows to print nested boxes, lists, arrays, tables in several formats
-`printbox-html.0.6.1`: Printbox unicode handling
-`printbox-text.0.6.1`: Text renderer for printbox, using unicode edges



---
* Homepage: https://github.com/c-cube/printbox/
* Source repo: git+https://github.com/c-cube/printbox.git
* Bug tracker: https://github.com/c-cube/printbox/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0