### PR TITLE
Package ometrics.0.1.1

### DIFF
--- a/packages/ometrics/ometrics.0.1.1/opam
+++ b/packages/ometrics/ometrics.0.1.1/opam
@@ -16,7 +16,8 @@ depends: [
   "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {<= "1.0.4"}
+  "digestif"
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}
 ]
@@ -32,9 +33,9 @@ authors: [
 ]
 url {
   src:
-    "https://github.com/vch9/ometrics/releases/download/0.1.1/ometrics-full.0.1.1.tar.gz"
+    "https://github.com/vch9/ometrics/releases/download/0.1.2/ometrics-full.0.1.2.tar.gz"
   checksum: [
-    "md5=2d31380b30aa90400e5faed1deeacd84"
-    "sha512=a7f74b97f04231c2454a2560e79ff102b507beed9f46d491a7b97ca8d063a934b05b5a66cb3b78a2aa2f88de82a9e223acc7cfd75acb3fffa1cf5836619e3455"
+    "md5=a51913990e4aebed26102fbd4f3b861c"
+    "sha512=afb560fdd836d0bab3f80bf9d57ff9ec336739b485820949f629d7b17ce831127d33035729d56b51966ff9cf21f6a4cd5bfb15e1c1ee2f5b957f36b5b1348559"
   ]
 }


### PR DESCRIPTION
### `ometrics.0.1.1`
OCaml analysis in a merge request changes



---
* Homepage: https://gitlab.com/nomadic-labs/ometrics
* Source repo: git+https://gitlab.com/nomadic-labs/ometrics.git
* Bug tracker: https://gitlab.com/nomadic-labs/ometrics/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0