### PR TITLE
Package ometrics.0.1.2

### DIFF
--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "digestif" {>= "0.7"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -17,7 +17,7 @@ depends: [
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
   "cmdliner" {>= "1.0.0"}
-  "digestif" {>= "0.7"}
+  "digestif" {>= "0.7.2"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}
 ]

--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner" {<= "1.0.4"}
+  "cmdliner"
   "digestif" {>= "0.7"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+homepage: "https://gitlab.com/nomadic-labs/ometrics"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ometrics.git"
+bug-reports: "https://gitlab.com/nomadic-labs/ometrics/-/issues"
+synopsis: "OCaml analysis in a merge request changes"
+
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.1"}
+  "yojson" {>= "1.7.0"}
+  "menhirSdk"
+  "menhirLib"
+  "menhir"
+  "dot-merlin-reader" {>= "4.1"}
+  "csexp" {>= "1.5.1"}
+  "result" {>= "1.5"}
+  "cmdliner" {<= "1.0.4"}
+  "digestif"
+  "qcheck-alcotest" {with-test & >= "0.18"}
+  "bisect_ppx" {dev & >= "2.6.0"}
+]
+conflicts: [
+  "menhir" {!= "20211012"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+authors: [
+  "Thomas Letan <lthms@nomadic-labs.com>"
+  "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+]
+url {
+  src:
+    "https://github.com/vch9/ometrics/releases/download/0.1.2/ometrics-full.0.1.2.tar.gz"
+  checksum: [
+    "md5=a51913990e4aebed26102fbd4f3b861c"
+    "sha512=afb560fdd836d0bab3f80bf9d57ff9ec336739b485820949f629d7b17ce831127d33035729d56b51966ff9cf21f6a4cd5bfb15e1c1ee2f5b957f36b5b1348559"
+  ]
+}

--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -7,7 +7,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ometrics/-/issues"
 synopsis: "OCaml analysis in a merge request changes"
 
 depends: [
-  "ocaml" {>= "4.12" & < "4.13"}
+  "ocaml" {>= "4.12" & < "4.14"}
   "dune" {>= "2.9.1"}
   "yojson" {>= "1.7.0"}
   "menhirSdk"

--- a/packages/ometrics/ometrics.0.1.2/opam
+++ b/packages/ometrics/ometrics.0.1.2/opam
@@ -17,7 +17,7 @@ depends: [
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
   "cmdliner" {<= "1.0.4"}
-  "digestif"
+  "digestif" {>= "0.7"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}
 ]


### PR DESCRIPTION
### `ometrics.0.1.2`
OCaml analysis in a merge request changes



---
* Homepage: https://gitlab.com/nomadic-labs/ometrics
* Source repo: git+https://gitlab.com/nomadic-labs/ometrics.git
* Bug tracker: https://gitlab.com/nomadic-labs/ometrics/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0