### PR TITLE
Package ansi-parse.0.4.0

### DIFF
--- a/packages/ansi-parse/ansi-parse.0.4.0/opam
+++ b/packages/ansi-parse/ansi-parse.0.4.0/opam
@@ -16,7 +16,6 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs]
   [
     "dune"
     "build"

--- a/packages/ansi-parse/ansi-parse.0.4.0/opam
+++ b/packages/ansi-parse/ansi-parse.0.4.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune"          { >= "2.9" }
   "angstrom"      { >= "0.15.0" }
   "ppx_deriving"  { >= "5.0" }
-  "tyxml"         { >= "4.0" }
+  "tyxml"         { >= "4.3" }
   "ppx_expect"    { >= "v0.14.1" & with-test }
   "odoc"          { >= "2.0.0" & with-doc }
 ]

--- a/packages/ansi-parse/ansi-parse.0.4.0/opam
+++ b/packages/ansi-parse/ansi-parse.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license: "ISC"
+maintainer: ["opensource+ansi-parse@support.diskuv.com"]
+authors: "Joel Jakubovic"
+dev-repo: "git+https://github.com/diskuv/ansi-parse.git"
+homepage: "https://github.com/diskuv/ansi-parse"
+bug-reports: "https://github.com/diskuv/ansi-parse/issues"
+depends: [
+  "ocaml"         { >= "4.03" }
+  "dune"          { >= "2.9" }
+  "angstrom"      { >= "0.15.0" }
+  "ppx_deriving"  { >= "5.0" }
+  "tyxml"         { >= "4.0" }
+  "ppx_expect"    { >= "v0.14.1" & with-test }
+  "odoc"          { >= "2.0.0" & with-doc }
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+# FIXME: doc: "https://diskuv.github.io/ansi-parse/doc"
+synopsis: "Ansiparse is a library for converting raw terminal output, replete with escape codes, into formatted HTML"
+url {
+  src: "https://github.com/diskuv/ansi-parse/archive/0.4.0.tar.gz"
+  checksum: [
+    "md5=5683e4ac14bc065a3a5bcf72d5e8b530"
+    "sha512=9e7286aaa9a04bef29b5acefef1f0700e054e06418b99e9cba444afdb9a81222f42f8cd8d2c7d9a91b64c4fff0c49a4c0fd7fd7e052694a02484c9dce5d6a5c7"
+  ]
+}


### PR DESCRIPTION
### `ansi-parse.0.4.0`
Ansiparse is a library for converting raw terminal output, replete with escape codes, into formatted HTML



---
* Homepage: https://github.com/diskuv/ansi-parse
* Source repo: git+https://github.com/diskuv/ansi-parse.git
* Bug tracker: https://github.com/diskuv/ansi-parse/issues

---
:camel: Pull-request generated by opam-publish v2.1.0