### PR TITLE
[new release] dune-release (1.6.1)

### DIFF
--- a/packages/dune-release/dune-release.1.6.1/opam
+++ b/packages/dune-release/dune-release.1.6.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com)."""
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: [
+  "Daniel Bünzli"
+  "Thomas Gazagnaire"
+  "Nathan Rebours"
+  "Guillaume Petiot"
+  "Sonja Heinze"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/dune-release"
+bug-reports: "https://github.com/ocamllabs/dune-release/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "curly"
+  "fmt" {>= "0.8.7"}
+  "fpath" {>= "0.7.3"}
+  "bos"
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "astring"
+  "opam-file-format" {>= "2.1.2"}
+  "opam-format" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-core" {>= "2.1.0"}
+  "rresult"
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+  "yojson" {>= "1.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamllabs/dune-release.git"
+url {
+  src:
+    "https://github.com/ocamllabs/dune-release/releases/download/1.6.1/dune-release-1.6.1.tbz"
+  checksum: [
+    "sha256=2af62ecb4b06ce3cd5a588b0a08f105cebeb1d8df58fc67036178f1544ceb763"
+    "sha512=66cd70f33c71f1670ae39c6cea5e81b8c404ed9351b0d02e6a8248587cf4976f42c79e3d720c00eb5e716ed227dde854a9d7e4b0f9e3eac32f5edc33f94ffc54"
+  ]
+}
+x-commit-hash: "55f78718b7374e7f9bceb110e99be1ca7cbcecd0"


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/ocamllabs/dune-release">https://github.com/ocamllabs/dune-release</a>

##### CHANGES:

### Fixed

- Fix compatibility with Cmdliner 1.1.0. This also unfortunately means that the
  minimum OCaml version is 4.08 now. (ocamllabs/dune-release#429, @NathanReb)
