### PR TITLE
syslog.2.0.0 is not compatible with dune 3.0

### DIFF
--- a/packages/syslog/syslog.2.0.0/opam
+++ b/packages/syslog/syslog.2.0.0/opam
@@ -18,7 +18,7 @@ license: "LGPL-2.0-or-later"
 build: [ "dune" "build" ]
 
 depends: [
-  "dune"
+  "dune" {< "3.0"}
   "ocaml" {>= "4.03.0"}
 ]
 url {


### PR DESCRIPTION
does not have a dune-project file
```
#=== ERROR while compiling syslog.2.0.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/syslog.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build
# exit-code            1
# env-file             ~/.opam/log/syslog-10-245b0e.env
# output-file          ~/.opam/log/syslog-10-245b0e.out
### output ###
# Error: I cannot find the root of the current workspace/project.
# If you would like to create a new dune project, you can type:
# 
#     dune init project NAME
# 
# Otherwise, please make sure to run dune inside an existing project or
# workspace. For more information about how dune identifies the root of the
# current workspace/project, please refer to
# https://dune.readthedocs.io/en/stable/usage.html#finding-the-root
```