### PR TITLE
functoria.2.2.1 is not compatible with fmt 0.8.10 (uses -warn-error)

### DIFF
--- a/packages/functoria/functoria.2.2.1/opam
+++ b/packages/functoria/functoria.2.2.1/opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "0.9.8" & < "1.1.0"}
   "rresult"
   "astring"
-  "fmt"
+  "fmt" {< "0.8.10"}
   "ocamlgraph"
   "logs"
   "bos"


### PR DESCRIPTION
```
#=== ERROR while compiling functoria.2.2.1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/functoria.2.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p functoria -j 255
# exit-code            1
# env-file             ~/.opam/log/functoria-10-d10e35.env
# output-file          ~/.opam/log/functoria-10-d10e35.out
### output ###
#       ocamlc lib/.functoria.objs/functoria_misc.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -bin-annot -safe-string -w A-40-42-44-48 -warn-error +1..49 -warn-error -15 -g -bin-annot -I lib/.functoria.objs -I /home/opam/.opam/4.13/lib/astring -I /home/opam/.opam/4.13/lib/cmdliner -I /home/opam/.opam/4.13/lib/fmt -I /home/opam/.opam/4.13/lib/fpath -I /home/opam/.opam/4.13/lib/rresult -no-alias-deps -o lib/.functoria.objs/functoria_misc.cmo -c -impl lib/functoria_misc.ml)
# File "lib/functoria_misc.ml", line 145, characters 20-24:
# 145 |     Fmt.(iter ~sep:(unit ", ")) map_iter pp_elt
#                           ^^^^
# Error (alert deprecated): Fmt.unit
```