### PR TITLE
dolmen_type.0.5 expects spelll functions to return Seq.t

### DIFF
--- a/packages/dolmen_type/dolmen_type.0.5/opam
+++ b/packages/dolmen_type/dolmen_type.0.5/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "dolmen" {= version }
   "dune" { >= "2.7" }
-  "spelll"
+  "spelll" {>= "0.3"}
   "uutf"
   "odoc" { with-doc }
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling dolmen_type.0.5 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/dolmen_type.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dolmen_type -j 31
# exit-code            1
# env-file             ~/.opam/log/dolmen_type-11-6927bb.env
# output-file          ~/.opam/log/dolmen_type-11-6927bb.out
### output ###
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlopt.opt -w -40 -g -I src/typecheck/.dolmen_type.objs/byte -I src/typecheck/.dolmen_type.objs/native -I /home/opam/.opam/4.13/lib/dolmen -I /home/opam/.opam/4.13/lib/dolmen/intf -I /home/opam/.opam/4.13/lib/dolmen/smtlib2 -I /home/opam/.opam/4.13/lib/dolmen/std -I /home/opam/.opam/4.13/lib/dolmen/tptp -I /home/opam/.opam/4.13/lib/spelll -I /home/opam/.opam/4.13/lib/uutf -intf-suffix .ml -no-alias-deps -open Dolmen_type -o src/typecheck/.dolmen_type.objs/native/dolmen_type__Misc.cmx -c -impl src/typecheck/misc.ml)
# File "src/typecheck/misc.ml", line 241, characters 23-48:
# 241 |     match seq_to_list_ (I.retrieve ~limit:0 t s) with
#                              ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type 'a Spelll.klist
#        but an expression was expected of type 'b Seq.t = unit -> 'b Seq.node
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/typecheck/.dolmen_type.objs/byte -I /home/opam/.opam/4.13/lib/dolmen -I /home/opam/.opam/4.13/lib/dolmen/intf -I /home/opam/.opam/4.13/lib/dolmen/smtlib2 -I /home/opam/.opam/4.13/lib/dolmen/std -I /home/opam/.opam/4.13/lib/dolmen/tptp -I /home/opam/.opam/4.13/lib/spelll -I /home/opam/.opam/4.13/lib/uutf -intf-suffix .ml -no-alias-deps -open Dolmen_type -o src/typecheck/.dolmen_type.objs/byte/dolmen_type__Misc.cmo -c -impl src/typecheck/misc.ml)
# File "src/typecheck/misc.ml", line 241, characters 23-48:
# 241 |     match seq_to_list_ (I.retrieve ~limit:0 t s) with
#                              ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type 'a Spelll.klist
#        but an expression was expected of type 'b Seq.t = unit -> 'b Seq.node
```