### PR TITLE
soupault < 2.7.0 requires Spelll.Index.retrieve_l

### DIFF
--- a/packages/soupault/soupault.1.10.0/opam
+++ b/packages/soupault/soupault.1.10.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.1.11.0/opam
+++ b/packages/soupault/soupault.1.11.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.1.12.0/opam
+++ b/packages/soupault/soupault.1.12.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.1.13.0/opam
+++ b/packages/soupault/soupault.1.13.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.1.6/opam
+++ b/packages/soupault/soupault.1.6/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {< "2.0.0"}
   "lua-ml"

--- a/packages/soupault/soupault.1.7.0/opam
+++ b/packages/soupault/soupault.1.7.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {< "2.0.0"}
   "lua-ml"

--- a/packages/soupault/soupault.1.8.0/opam
+++ b/packages/soupault/soupault.1.8.0/opam
@@ -37,7 +37,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.1.9.0/opam
+++ b/packages/soupault/soupault.1.9.0/opam
@@ -37,7 +37,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "mustache"
   "tsort" {< "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.2.0.0/opam
+++ b/packages/soupault/soupault.2.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "jingoo" {>= "1.3.0"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.2.1.0/opam
+++ b/packages/soupault/soupault.2.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "calendar" {>= "2.00"}
-  "spelll"
+  "spelll" {>= "0.3"}
   "jingoo" {>= "1.3.0"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.1"}

--- a/packages/soupault/soupault.2.2.0/opam
+++ b/packages/soupault/soupault.2.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}
   "lua-ml" {>= "0.9.2"}

--- a/packages/soupault/soupault.2.3.0/opam
+++ b/packages/soupault/soupault.2.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.3.1/opam
+++ b/packages/soupault/soupault.2.3.1/opam
@@ -31,7 +31,7 @@ depends: [
   "containers"
   "stringext"
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.4.0/opam
+++ b/packages/soupault/soupault.2.4.0/opam
@@ -36,7 +36,7 @@ depends: [
   "containers"
   "stringext"
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.5.0/opam
+++ b/packages/soupault/soupault.2.5.0/opam
@@ -36,7 +36,7 @@ depends: [
   "containers"
   "stringext"
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.6.0/opam
+++ b/packages/soupault/soupault.2.6.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ezjsonm"
   "containers"
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}

--- a/packages/soupault/soupault.2.7.0/opam
+++ b/packages/soupault/soupault.2.7.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ezjsonm"
   "containers" {>= "3.4"}
   "odate"
-  "spelll"
+  "spelll" {>= "0.3"}
   "base64"
   "jingoo" {>= "1.4.2"}
   "tsort" {>= "2.0.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling soupault.2.7.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/soupault.2.7.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p soupault -j 255
# exit-code            1
# env-file             ~/.opam/log/soupault-10-105925.env
# output-file          ~/.opam/log/soupault-10-105925.out
### output ###
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.soupault.eobjs/byte -I /home/opam/.opam/4.13/lib/ISO8601 -I /home/opam/.opam/4.13/lib/base64 -I /home/opam/.opam/4.13/lib/bigarray-compat -I /home/opam/.opam/4.13/lib/containers -I /home/opam/.opam/4.13/lib/containers/monomorphic -I /home/opam/.opam/4.13/lib/cstruct -I /home/opam/.opam/4.13/lib/either -I /home/opam/.opam/4.13/lib/ezjsonm -I /home/opam/.opam/4.13/lib/fileutils -I /home/opam/.opam/4.13/lib/fmt -I /home/opam/.opam/4.13/lib/hex -I /home/opam/.opam/4.13/lib/jingoo -I /home/opam/.opam/4.13/lib/jsonm -I /home/opam/.opam/4.13/lib/lambdasoup -I /home/opam/.opam/4.13/lib/logs -I /home/opam/.opam/4.13/lib/lua-ml -I /home/opam/.opam/4.13/lib/markup -I /home/opam/.opam/4.13/lib/odate -I /home/opam/.opam/4.13/lib/ppx_deriving/runtime -I /home/opam/.opam/4.13/lib/re -I /home/opam/.opam/4.13/lib/result -I /home/opam/.opam/4.13/lib/seq -I /home/opam/.opam/4.13/lib/sexplib0 -I /home/opam/.opam/4.13/lib/spelll -I /home/opam/.opam/4.13/lib/stdlib-shims -I /home/opam/.opam/4.13/lib/toml -I /home/opam/.opam/4.13/lib/tsort -I /home/opam/.opam/4.13/lib/uchar -I /home/opam/.opam/4.13/lib/uucp -I /home/opam/.opam/4.13/lib/uutf -no-alias-deps -open Dune__exe -o src/.soupault.eobjs/byte/dune__exe__Spellcheck.cmo -c -impl src/spellcheck.ml)
# File "src/spellcheck.ml", line 28, characters 20-43:
# 28 |   let suggestions = Spelll.Index.retrieve_l ~limit:max_distance index word in
#                          ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Spelll.Index.retrieve_l
# Hint: Did you mean retrieve?
```