### PR TITLE
gopcaml-mode.0.0.2 is not compatible with OCaml 4.13

### DIFF
--- a/packages/gopcaml-mode/gopcaml-mode.0.0.2/opam
+++ b/packages/gopcaml-mode/gopcaml-mode.0.0.2/opam
@@ -9,7 +9,7 @@ license: "GPL-3.0-only"
 homepage: "https://gitlab.com/gopiandcode/gopcaml-mode"
 bug-reports: "https://gitlab.com/gopiandcode/gopcaml-mode/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.13"}
   "dune" {>= "1.10"}
   "core" {>= "v0.13.0"}
   "ppx_deriving" {>= "4.4"}


### PR DESCRIPTION
```
#=== ERROR while compiling gopcaml-mode.0.0.2 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/gopcaml-mode.0.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gopcaml-mode -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/gopcaml-mode-10-df0bb1.env
# output-file          ~/.opam/log/gopcaml-mode-10-df0bb1.out
### output ###
# File "_build/.dune/default/parser/dune", line 2, characters 13-25:
# 2 | (copy_files# 413/*.ml{,i})
#                  ^^^^^^^^^^^^
# Error: Cannot find directory: parser/413
```