### PR TITLE
Package monadlib.2.0.0

### DIFF
--- a/packages/monadlib/monadlib.2.0.0/opam
+++ b/packages/monadlib/monadlib.2.0.0/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "dev@besport.com"
+homepage: "https://github.com/besport/monadlib"
+dev-repo: "git+https://github.com/besport/monadlib.git"
+bug-reports: "https://github.com/besport/monadlib/issues"
+authors: ["Phil Scott" "Jan Rochel"]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {build & >= "1.11.0"}
+  "batteries" {>= "3.3.0"}
+  "ocamlbuild" {build}
+]
+synopsis: "A starter library for monads, with transformers and applicatives"
+url {
+  src: "https://github.com/besport/monadlib/archive/2.0.tar.gz"
+  checksum: [
+    "md5=31c35e0ed0f51340d36c0af16506979c"
+    "sha512=648f3dff528b2ac1df3a6e28f4f54705574f6ecfb7c730edbcc9d29972a28eeb1216cfe39a544af65d39c4f35cc3b78dc3e2813ae928aceb193244d5473ee909"
+  ]
+}


### PR DESCRIPTION
### `monadlib.2.0.0`
A starter library for monads, with transformers and applicatives



---
* Homepage: https://github.com/besport/monadlib
* Source repo: git+https://github.com/besport/monadlib.git
* Bug tracker: https://github.com/besport/monadlib/issues

---
:camel: Pull-request generated by opam-publish v2.1.0