### PR TITLE
Rename OCaml compiler from 5.00.0 to 5.0.0

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -7,7 +7,7 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
 depends: [
-  "ocaml" {= "5.00.0" & post}
+  "ocaml" {= "5.0.0" & post}
   "base-unix" {post}
   "base-bigarray" {post}
   "base-threads" {post}

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -7,9 +7,9 @@ and polls it to initialise specific variables like `ocaml:native-dynlink`"""
 maintainer: "platform@lists.ocaml.org"
 depends: [
   "ocaml-config" {>= "2"}
-  "ocaml-base-compiler" {= "5.00.0"} |
-  "ocaml-variants" {>= "5.00.0" & < "5.00.1~"} |
-  "ocaml-system" {>= "5.00.0" & < "5.00.1~"}
+  "ocaml-base-compiler" {= "5.0.0"} |
+  "ocaml-variants" {>= "5.0.0" & < "5.0.1~"} |
+  "ocaml-system" {>= "5.0.0" & < "5.0.1~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]


### PR DESCRIPTION
After https://github.com/ocaml/ocaml/pull/11049 trying to install a trunk compiler would lead to:

```
$ opam switch create 5.00.0+trunk
OCaml version mismatch: 5.0.0, expected 5.00.0
```

This seems to fix it locally for me, I don't know if all of the various version constraints (like `< "5.00"`) also need changed across the repository?