### PR TITLE
[new release] ocamlformat, ocamlformat-rpc and ocamlformat-rpc-lib (0.21.0)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.21.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.21.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "csexp"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-rpc-lib-0.21.0.tbz"
+  checksum: [
+    "sha256=2a1817f6bc581ff0cce9f0aa9687b897b02726e2ab75749ee98d57637057332d"
+    "sha512=db47f843bfc5a438d43f7c482cde86bd13f05a6825e2a0afa80614b651a88ae8b3805cca45da6bcf9189e741e0c79d38652b0bc47efe636c1502a66676dcb28e"
+  ]
+}
+x-commit-hash: "63e478f1186a03c7e4dfeeb39b3d8fe2ef1cb429"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.21.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.21.0/opam
@@ -30,7 +30,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-rpc-lib-0.21.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-0.21.0.tbz"
   checksum: [
     "sha256=2a1817f6bc581ff0cce9f0aa9687b897b02726e2ab75749ee98d57637057332d"
     "sha512=db47f843bfc5a438d43f7c482cde86bd13f05a6825e2a0afa80614b651a88ae8b3805cca45da6bcf9189e741e0c79d38652b0bc47efe636c1502a66676dcb28e"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.21.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.21.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
-  "csexp"
+  "csexp" {>= "1.4.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.19.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.14"}
-  "ocamlformat-rpc-lib"
+  "ocamlformat-rpc-lib" {= version}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "base-unix"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
-  "ocamlformat-rpc-lib"
+  "ocamlformat-rpc-lib" {= version}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "cmdliner" {< "1.1.0"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.1/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.20.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08" & < "4.15"}
-  "ocamlformat-rpc-lib"
+  "ocamlformat-rpc-lib" {= version}
   "alcotest" {with-test}
   "base" {>= "v0.12.0" & < "v0.15"}
   "cmdliner" {< "1.1.0"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.21.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.21.0/opam
@@ -32,7 +32,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-rpc-lib-0.21.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-0.21.0.tbz"
   checksum: [
     "sha256=2a1817f6bc581ff0cce9f0aa9687b897b02726e2ab75749ee98d57637057332d"
     "sha512=db47f843bfc5a438d43f7c482cde86bd13f05a6825e2a0afa80614b651a88ae8b3805cca45da6bcf9189e741e0c79d38652b0bc47efe636c1502a66676dcb28e"

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.0.21.0/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.0.21.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.15"}
+  "alcotest" {with-test}
+  "ocamlformat" {= version}
+  "ocamlformat-rpc-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-rpc-lib-0.21.0.tbz"
+  checksum: [
+    "sha256=2a1817f6bc581ff0cce9f0aa9687b897b02726e2ab75749ee98d57637057332d"
+    "sha512=db47f843bfc5a438d43f7c482cde86bd13f05a6825e2a0afa80614b651a88ae8b3805cca45da6bcf9189e741e0c79d38652b0bc47efe636c1502a66676dcb28e"
+  ]
+}
+x-commit-hash: "63e478f1186a03c7e4dfeeb39b3d8fe2ef1cb429" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.21.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.21.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08" & < "4.15"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune" {with-test & < "3.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocp-indent"
+  "odoc-parser" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-rpc-lib-0.21.0.tbz"
+  checksum: [
+    "sha256=2a1817f6bc581ff0cce9f0aa9687b897b02726e2ab75749ee98d57637057332d"
+    "sha512=db47f843bfc5a438d43f7c482cde86bd13f05a6825e2a0afa80614b651a88ae8b3805cca45da6bcf9189e741e0c79d38652b0bc47efe636c1502a66676dcb28e"
+  ]
+}
+x-commit-hash: "63e478f1186a03c7e4dfeeb39b3d8fe2ef1cb429" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.21.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.21.0/opam
@@ -47,7 +47,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-rpc-lib-0.21.0.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.21.0/ocamlformat-0.21.0.tbz"
   checksum: [
     "sha256=2a1817f6bc581ff0cce9f0aa9687b897b02726e2ab75749ee98d57637057332d"
     "sha512=db47f843bfc5a438d43f7c482cde86bd13f05a6825e2a0afa80614b651a88ae8b3805cca45da6bcf9189e741e0c79d38652b0bc47efe636c1502a66676dcb28e"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Bug fixes

  + Add missing parentheses around variant class arguments (ocaml-ppx/ocamlformat#1967, @gpetiot)

  + Fix indentation of module binding RHS (ocaml-ppx/ocamlformat#1969, @gpetiot)

  + Fix position of `:=` when `assignment-operator=end-line` (ocaml-ppx/ocamlformat#1985, @gpetiot)

  + Fix position of comments attached to constructor decl (ocaml-ppx/ocamlformat#1986, @gpetiot)

  + Do not wrap docstrings, `wrap-comments` should only impact non-documentation comments, wrapping invalid docstrings would cause the whole file to not be formatted (ocaml-ppx/ocamlformat#1988, @gpetiot)

  + Do not break between 2 module items when the first one has a comment attached on the same line. Only a comment on the next line should induce a break to make it clear to which element it is attached to (ocaml-ppx/ocamlformat#1989, @gpetiot)

  + Preserve position of comments attached to the last node of a subtree (ocaml-ppx/ocamlformat#1667, @gpetiot)

  + Do not override the values of the following non-formatting options when a profile is set: `comment-check`, `disable`, `max-iters`, `ocaml-version`, and `quiet` (ocaml-ppx/ocamlformat#1995, @gpetiot).

  + Remove incorrect parentheses around polymorphic type constraint (ocaml-ppx/ocamlformat#2002, @gpetiot)

  + Handle cases where an attribute is added to a bind expression, e.g. `(x >>= (fun () -> ())) [@a]` (ocaml-ppx/ocamlformat#2013, @emillon)

  + Fix indentation of constraints of a package type pattern (ocaml-ppx/ocamlformat#2025, @gpetiot)

#### Changes

  + More expressions are considered "simple" (not inducing a break e.g. as an argument of an application):
    - Variants with no argument (ocaml-ppx/ocamlformat#1968, @gpetiot)
    - Empty or singleton arrays/lists (ocaml-ppx/ocamlformat#1943, @gpetiot)

  + Print odoc code block delimiters on their own line (ocaml-ppx/ocamlformat#1980, @gpetiot)

  + Make formatting of cons-list patterns consistent with cons-list expressions, (::) operators are aligned when possible, comments position also improved (ocaml-ppx/ocamlformat#1983, @gpetiot)

  + Apply 'sequence-style' to add a space before ';;' between toplevel items, consistently with the formatting of ';' in sequences (ocaml-ppx/ocamlformat#2004, @gpetiot)

#### New features

  + Format toplevel phrases and their output (ocaml-ppx/ocamlformat#1941, @Julow, @gpetiot).
    This feature is enabled with the flag `--parse-toplevel-phrases`.
    Toplevel phrases are supported when they are located in doc-comments blocks and cinaps comments.
    Whole input files can also be formatted as toplevel phrases with the flag `--repl-file`.

#### RPC

  + ocamlformat-rpc-lib is now functorized over the IO (ocaml-ppx/ocamlformat#1975, @gpetiot).
    Now handles `Csexp.t` types instead of `Sexplib0.Sexp.t`.

  + RPC v2 (ocaml-ppx/ocamlformat#1935, @panglesd):
    Define a 'Format' command parameterized with optionnal arguments to set or override the config and path, to format in the style of a file.

  + Prevent RPC to crash on version mismatch with `.ocamlformat` (ocaml-ppx/ocamlformat#2011, @panglesd, @Julow)
