### PR TITLE
[new release] mirage-kv (4.0.1)

### DIFF
--- a/packages/mirage-kv/mirage-kv.4.0.1/opam
+++ b/packages/mirage-kv/mirage-kv.4.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v4.0.1/mirage-kv-4.0.1.tbz"
+  checksum: [
+    "sha256=a7a8b8cd4560c6d4e75220488dbf16eaef71453733565e16c1f15c979b55aa71"
+    "sha512=e6ac8b8638eac760d245edb0159366c313ff9f5986fd310557fa6bec6f9fb87a3bb59d73065b42d2a798779d7b41cb81da235624db8e836f44801c4ae20c0293"
+  ]
+}
+x-commit-hash: "64ced5981acdb3b4299e674f24ced1a18c5fe74b"


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Return `/` for `parent /` and `basename /` (@yomimono, @talex5, mirage/mirage-kv#25)
