### PR TITLE
Package data-encoding.0.5.1

### DIFF
--- a/packages/data-encoding/data-encoding.0.5.1/opam
+++ b/packages/data-encoding/data-encoding.0.5.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/data-encoding/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/data-encoding.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "2.0" }
+  "ezjsonm"
+  "zarith" {>= "1.4"}
+  "zarith_stubs_js"
+  "hex" {>= "1.3.0"}
+  "json-data-encoding" { = "0.11" }
+  "json-data-encoding-bson" { = "0.11" }
+  "alcotest" { with-test }
+  "crowbar" { >= "0.2" & with-test }
+  "either"
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+  "js_of_ocaml-compiler" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Library of JSON and binary encoding combinators"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v0.5.1/data-encoding-v0.5.1.tar.gz"
+  checksum: [
+    "md5=c91116d318ffd0e3f5d75f307d9cc2ce"
+    "sha512=495bc4058b8fc1051d16e64ab77dea288675c39574acb603be514ee7c497be26baa0944bdc081f4faa34ba03c0b3dbd6059544375d2f2bee6c634a5ec11d899b"
+  ]
+}


### PR DESCRIPTION
### `data-encoding.0.5.1`
Library of JSON and binary encoding combinators



---
* Homepage: https://gitlab.com/nomadic-labs/data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/data-encoding.git
* Bug tracker: https://gitlab.com/nomadic-labs/data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0