### PR TITLE
[new release] ppx_deriving_yaml (0.1.1)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.1/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Derivier"
+description: "Build Yaml types from OCaml types"
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "mdx" {with-test}
+  "ezjsonm" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.14.0"}
+  "yaml"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.1.1/ppx_deriving_yaml-0.1.1.tbz"
+  checksum: [
+    "sha256=9d1df9ebc50b33a8da186e07e3e94b053109aa1fc02c73e2271bdee348cf531c"
+    "sha512=fdc7685628258b312471742bc626b78f7ac21fe9104d95af8ebae361db5cfc2956ba6865167a44c666eee2bf3d3d5c81c75cb4b59d576d9b5e7c04d2aac4634f"
+  ]
+}
+x-commit-hash: "7df5bfcd1b5fbc0881162adfd301d54b2daa1933"

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.1/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "yaml"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Yaml PPX Derivier

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

- Remove rresult dependency (patricoferris/ppx_deriving_yaml#27, @patricoferris)
