### PR TITLE
Fix memtrace_viewer with dune 3.0.0

### DIFF
--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -24,8 +24,8 @@ depends: [
   "dune" {>= "2.7.1"}
   "dune-configurator" {>= "2.7.1"}
   "fmt" {>= "0.8.8"}
-  "js_of_ocaml" {>= "3.7.0"}
-  "js_of_ocaml-ppx" {>= "3.7.0"}
+  "js_of_ocaml" {>= "3.7.0" & < "4.0.0"}
+  "js_of_ocaml-ppx" {>= "3.7.0" & < "4.0.0"}
   "jsonm" {>= "1.0.1"}
   "lambdasoup" {>= "0.7.1"}
   "logs" {>= "0.7.0"}

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -11,6 +11,7 @@ build: [
      "--root" "." "--cache-transport=direct" {dune < "3.0.0"}]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
+conflicts: ["sexplib0" {< "v0.14.0"}]
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "conf-libssl"

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -8,7 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace_viewer/index.h
 license: "MIT"
 build: [
   ["dune" "build" "--profile" "release" "--default-target" "@install" "."
-     "--root" "." "--cache-transport=direct"]
+     "--root" "." "--cache-transport=direct" {dune < "3.0.0"}]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 depends: [

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -11,7 +11,10 @@ build: [
      "--root" "." "--cache-transport=direct" {dune < "3.0.0"}]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
-conflicts: ["sexplib0" {< "v0.14.0"}]
+conflicts: [
+   "sexplib0" {< "v0.14.0"}
+   "re" {< "1.9.0"}
+]
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "conf-libssl"

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -11,6 +11,7 @@ build: [
      "--root" "." "--cache-transport=direct" {dune < "3.0.0"}]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
+conflicts: ["sexplib0" {< "v0.14.0"}]
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "conf-libssl"

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -8,7 +8,7 @@ doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/memtrace_viewer/index.h
 license: "MIT"
 build: [
   ["dune" "build" "--profile" "release" "--default-target" "@install" "."
-     "--root" "." "--cache-transport=direct"]
+     "--root" "." "--cache-transport=direct" {dune < "3.0.0"}]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 depends: [

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -11,7 +11,10 @@ build: [
      "--root" "." "--cache-transport=direct" {dune < "3.0.0"}]
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
-conflicts: ["sexplib0" {< "v0.14.0"}]
+conflicts: [
+   "sexplib0" {< "v0.14.0"}
+   "re" {< "1.9.0"}
+]
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "conf-libssl"


### PR DESCRIPTION
Dune 3.0.0 removed the `--cache-transport` argument and made direct the default: https://github.com/ocaml/dune/pull/4493.

Initially I considered just adding an upper bound, but if this works (I'm hoping for the CI to say), then it would be more flexible.