### PR TITLE
[new release] ppx_yojson (1.2.0)

### DIFF
--- a/packages/ppx_yojson/ppx_yojson.1.2.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.2.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "PPX extension for Yojson literals and patterns"
 maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
 authors: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
-license: "BSD-2"
+license: "BSD-2-Clause"
 homepage: "https://github.com/NathanReb/ppx_yojson"
 bug-reports: "https://github.com/NathanReb/ppx_yojson/issues"
 depends: [

--- a/packages/ppx_yojson/ppx_yojson.1.2.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "PPX extension for Yojson literals and patterns"
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+license: "BSD-2"
+homepage: "https://github.com/NathanReb/ppx_yojson"
+bug-reports: "https://github.com/NathanReb/ppx_yojson/issues"
+depends: [
+  "dune" {>= "2.2"}
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "ppxlib" {>= "0.18.0"}
+  "ezjsonm" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/NathanReb/ppx_yojson.git"
+url {
+  src:
+    "https://github.com/NathanReb/ppx_yojson/releases/download/1.2.0/ppx_yojson-1.2.0.tbz"
+  checksum: [
+    "sha256=d12b59c88b8866d38a40d0e3eb3465727db35a19b27fdea739e9875628a10651"
+    "sha512=d3ec6e18e60eff1c3a7fbbadb852fbe2953f26735034c8aea494a7f1af3620a8d3a05e38d8ad7427871451e439fa359e1b96cf7a3ff936071e91e48a9fa4831f"
+  ]
+}
+x-commit-hash: "fdbea680c877ce4afeff92fc018d75de26d672ad"

--- a/packages/ppx_yojson/ppx_yojson.1.2.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "yojson" {with-test & >= "1.6.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
PPX extension for Yojson literals and patterns

- Project page: <a href="https://github.com/NathanReb/ppx_yojson">https://github.com/NathanReb/ppx_yojson</a>

##### CHANGES:

### Added

- Support `%ezjsonm` extension to output Ezjsonm-compatible values.
  (NathanReb/ppx_yojson#31, @mefyl)
- Add generic antiquotation syntax `[%aq ...]` (NathanReb/ppx_yojson#32, @NathanReb)
