### PR TITLE
[new release] links, links-postgresql, links-sqlite3 and links-mysql (0.9.6)

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.6/opam
+++ b/packages/links-mysql/links-mysql.0.9.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "MySQL database driver for the Links Programming Language"
+description: "MySQL database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "conf-mysql"
+  "mysql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.6/links-0.9.6.tbz"
+  checksum: [
+    "sha256=1d573072729709287b40068971d9a0a1ed0490d24af8d8c2667f5dd174dd19c1"
+    "sha512=e83e785db688b05a42ff4f2c908fa9254f412609879a98db9420ae7cd7906b79a43bccd1ffaf0f6a0e214ec147d458e6870131eb9dd7c116fb30145eae8ecc21"
+  ]
+}
+x-commit-hash: "3e3ce088154476a219689a2868216b04281d1793"

--- a/packages/links-postgresql/links-postgresql.0.9.6/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "Postgresql database driver for the Links Programming Language"
+description: "Postgresql database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "postgresql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.6/links-0.9.6.tbz"
+  checksum: [
+    "sha256=1d573072729709287b40068971d9a0a1ed0490d24af8d8c2667f5dd174dd19c1"
+    "sha512=e83e785db688b05a42ff4f2c908fa9254f412609879a98db9420ae7cd7906b79a43bccd1ffaf0f6a0e214ec147d458e6870131eb9dd7c116fb30145eae8ecc21"
+  ]
+}
+x-commit-hash: "3e3ce088154476a219689a2868216b04281d1793"

--- a/packages/links-sqlite3/links-sqlite3.0.9.6/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.6/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "SQLite database driver for the Links Programming Language"
+description: "SQLite database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "sqlite3"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.6/links-0.9.6.tbz"
+  checksum: [
+    "sha256=1d573072729709287b40068971d9a0a1ed0490d24af8d8c2667f5dd174dd19c1"
+    "sha512=e83e785db688b05a42ff4f2c908fa9254f412609879a98db9420ae7cd7906b79a43bccd1ffaf0f6a0e214ec147d458e6870131eb9dd7c116fb30145eae8ecc21"
+  ]
+}
+x-commit-hash: "3e3ce088154476a219689a2868216b04281d1793"

--- a/packages/links/links.0.9.6/opam
+++ b/packages/links/links.0.9.6/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "5.0.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "tls"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir" {>= "20210419"}
+  "ppx_sexp_conv"
+  "calendar" {>= "2.0.4"}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.6/links-0.9.6.tbz"
+  checksum: [
+    "sha256=1d573072729709287b40068971d9a0a1ed0490d24af8d8c2667f5dd174dd19c1"
+    "sha512=e83e785db688b05a42ff4f2c908fa9254f412609879a98db9420ae7cd7906b79a43bccd1ffaf0f6a0e214ec147d458e6870131eb9dd7c116fb30145eae8ecc21"
+  ]
+}
+x-commit-hash: "3e3ce088154476a219689a2868216b04281d1793"


### PR DESCRIPTION
The Links Programming Language

- Project page: <a href="https://github.com/links-lang/links">https://github.com/links-lang/links</a>

##### CHANGES:

This release extends the core features of Links and resolves various
minor bugs.

* Links now supports System F-style explicit type abstractions:
  For instance, writing `/\ [a, e::Row] { foo }` abstracts the expression `foo`
  over type variable `a` and row variable `e`. Here, `foo` must have a unique
  type and must be pure (to satisfy the value restriction).
* Fixed a bug in "mixing" query normalisation, which prevented certain queries using
  concatenation inside `for` statements from being correctly converted to SQL.
* Links now has basic support for temporal database operations. More information
  can be found on the [Wiki](https://github.com/links-lang/links/wiki/Temporal-Databases).
  There are new keywords: `valid`, `to`, `vt_insert`, `tt_insert`, and `TemporalTable`.
* A new commandline option `--compile` (shorthand `-c`) has been
  added, which runs Links in a "compile only" mode. In this mode the
  JavaScript compilation artefact can be saved to a file (the naming
  of this file is controlled via the commandline option `-o`). Note
  that the generated file may not be directly runnable without linking
  the runtime system first. Currently, the runtime system must be
  linked manually.
* Fixed a bug where calling either of `newAP`, `newClientAP`, and
  `newServerAP` on the client-side would crash the client.
* It is now possible to dispatch an MVU message from outside of the
  event loop. This is particularly useful, for example, when dealing
  with a persistent, stateful thread which is receiving messages from
  a server. New things include:
  + A new type alias `MvuHandle(msg)`.
  + A family of runners: `runHandle`, `runCmdHandle`,
    `runSimpleHandle` which return an `MvuHandle(msg)` rather than the
    unit value.
  + A new dispatcher `Mvu.dispatch : (msg, MvuHandle(msg)) ~> ()`,
    which directly dispatches a message to the MVU loop.

* The built-in webserver now supports SSL connections.  To enable
  secure connections, you must first obtain an adequate certificate
  and key, e.g. via Let's Encrypt or a self-signed certificate. The
  latter can be useful for testing, e.g. the following command starts
  an interactive process to create a self-signed certificate (that
  uses 4096 bits RSA encryption and is valid for 365 days):
```shell
openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes
```
  After obtaining a valid certificate, you must tell Links to run in SSL
  mode and you must also tell it how to locate the `key` and `crt`
  file. This can be done via a configuration file, e.g.

```
# ssl.config
ssl=true
ssl_cert_file=server.crt
ssl_key_file=server.key
```
  Then running `./links --config=ssl.config <file.links>` will cause
  the webserver to only serve requests via https.

  When a webpage is served via https, then the websocket layer will
  automatically communicate via the wss protocol.
* Other various bug fixes.
