### PR TITLE
[new-release] domainslib (0.4.2)

### DIFF
--- a/packages/domainslib/domainslib.0.4.2/opam
+++ b/packages/domainslib/domainslib.0.4.2/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+tags: ["org:ocamllabs"]
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "1.8"}
+  "mirage-clock-unix" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/ocaml-multicore/domainslib/archive/0.4.2.tar.gz"
+  checksum: "md5=a079b8b5b676e8d38d713f02b25b14db"
+}


### PR DESCRIPTION
Includes `Effect.eff` -> `Effect.t` change from OCaml trunk. (https://github.com/ocaml-multicore/domainslib/pull/65)