### PR TITLE
Package plato.1.1.2

### DIFF
--- a/packages/plato/plato.1.1.2/opam
+++ b/packages/plato/plato.1.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Python Library Adapted To OCaml"
+maintainer: "Marc Chevalier <github@marc.chevalier.com>"
+authors: "Marc Chevalier <github@marc.chevalier.com>"
+homepage: "https://github.com/marc-chevalier/plato"
+dev-repo: "git://github.com/marc-chevalier/plato"
+bug-reports: "https://github.com/marc-chevalier/plato/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "re" {>= "1.9.0"}
+  "stdcompat" {>= "13"}
+  "cppo" {>= "1.6.6"}
+  "ounit2" {with-test & >= "2.0.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+license: "MIT"
+description: """
+Python Library Adapted To Ocaml
+
+Plato provides some parts of Python standard library I was missing in OCaml.
+That means things relevant in OCaml (typically, not GC related), without a
+existing great OCaml library (like `re` for `re` or `yojson` for `json`).
+"""
+url {
+  src: "https://github.com/marc-chevalier/plato/archive/1.1.2.tar.gz"
+  checksum: [
+    "md5=bbd6a77ebd7c4273ab63277648a05792"
+    "sha512=fc31900a273dbdd5dd5ee63a5553a4d937cc6d984245e649b452b1a42e43ebe27340314d1f3c0fdf0c0cc246da28a624b2bcd82152a90debffcf10025aa520f1"
+  ]
+}


### PR DESCRIPTION
### `plato.1.1.2`
Python Library Adapted To OCaml
Python Library Adapted To Ocaml

Plato provides some parts of Python standard library I was missing in OCaml.
That means things relevant in OCaml (typically, not GC related), without a
existing great OCaml library (like `re` for `re` or `yojson` for `json`).



---
* Homepage: https://github.com/marc-chevalier/plato
* Bug tracker: https://github.com/marc-chevalier/plato/issues

---
:camel: Pull-request generated by opam-publish v2.1.0