### PR TITLE
Add: ttweetnacl.0.1.0

### DIFF
--- a/packages/ttweetnacl/ttweetnacl.0.1.0/opam
+++ b/packages/ttweetnacl/ttweetnacl.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to TweetNaCl cryptography for OCaml"
+description: """\
+Ttweetnacl is an OCaml module providing thin bindings to the
+[TweetNaCl][tweetnacl] cryptographic library.
+
+Ttweetnacl has no dependencies. The binding code is distributed under
+the ISC license and the integrated TweetNaCl C code is in the public
+domain.
+
+Homepage: <https://erratique.ch/software/ttweetnacl>
+
+[tweetnacl]: https://tweetnacl.cr.yp.to/"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The ttweetnacl programmers"
+license: "ISC"
+tags: ["cryptography" "bindings" "nacl" "org:erratique"]
+homepage: "https://erratique.ch/software/ttweetnacl"
+doc: "https://erratique.ch/software/ttweetnacl/doc"
+bug-reports: "https://github.com/dbuenzli/ttweetnacl/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/ttweetnacl.git"
+url {
+  src:
+    "https://erratique.ch/software/ttweetnacl/releases/ttweetnacl-0.1.0.tbz"
+  checksum:
+    "sha512=8c82799c3dcaef77d28b08ec24db94863c268e477443e6642b16d7188004d46a5146fa0b86967c3ace339a94283f2f61d7eab842d745eadf1951f9001b6dcee6"
+}


### PR DESCRIPTION
* Add: `ttweetnacl.0.1.0` [home](https://erratique.ch/software/ttweetnacl), [doc](https://erratique.ch/software/ttweetnacl/doc), [issues](https://github.com/dbuenzli/ttweetnacl/issues)  
  *Thin bindings to TweetNaCl cryptography for OCaml*


---

#### `ttweetnacl` v0.1.0 2022-03-01 La Forclaz (VS)


First release.


---

Use `b0 cmd -- .opam.publish ttweetnacl.0.1.0` to update the pull request.