### PR TITLE
lwt 5.5.0 also requires result on Windows

### DIFF
--- a/packages/lwt/lwt.5.5.0/opam
+++ b/packages/lwt/lwt.5.5.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.02.0" & "os" != "win32 " | >= "4.06.0"}
   ("ocaml" {>= "4.08.0"} | "ocaml-syntax-shims")
   "ocplib-endian"
-  "result" {os != "win32"} # result is needed as long as Lwt supports OCaml 4.02.
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
   "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
 
   # Until https://github.com/aantron/bisect_ppx/pull/327.


### PR DESCRIPTION
Without the `result` dependency [the `lwt.5.5.0 build` fails on `win32`](https://github.com/ocamllabs/ocaml-ctypes/runs/5389850187?check_suite_focus=true#step:4:127):

```
 #=== ERROR while compiling lwt.5.5.0 ==========================================#
# context     2.0.10 | win32/x86_64 | ocaml-variants.4.13.1+mingw64c | git+https://github.com/fdopen/opam-repository-mingw.git#opam2
# path        D:/a/ocaml-ctypes/ocaml-ctypes/_opam/.opam-switch/build/lwt.5.5.0
# command     D:\a\ocaml-ctypes\ocaml-ctypes\_opam\bin\dune.exe build -p lwt -j 2
# exit-code   1
# env-file    D:/.opam/log/lwt-3040-58a313.env
# output-file D:/.opam/log/lwt-3040-58a313.out
### output ###
# File "_build/.dune/default/src/core/dune", line 8, characters 18-24:
# 8 |  (libraries bytes result seq)
#                       ^^^^^^
# Error: Library "result" not found.
# -> required by library "lwt" in _build/default/src/core
# -> required by _build/default/META.lwt
# -> required by _build/install/default/lib/lwt/META
# -> required by _build/default/lwt.install
# -> required by alias install
```

/cc: @raphael-proust