### PR TITLE
[new release] vchan, vchan-xen and vchan-unix (6.0.1)

### DIFF
--- a/packages/vchan-unix/vchan-unix.6.0.1/opam
+++ b/packages/vchan-unix/vchan-unix.6.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"

--- a/packages/vchan-unix/vchan-unix.6.0.1/opam
+++ b/packages/vchan-unix/vchan-unix.6.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "vchan" {= version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "xen-evtchn-unix"
+  "xen-gnt-unix"
+  "sexplib"
+  "xen-evtchn"
+  "xen-gnt"
+  "cmdliner" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.1/vchan-6.0.1.tbz"
+  checksum: [
+    "sha256=e44edd2133158ab628c54929f196a6440a25ca103a6af5c624d022a31781b95d"
+    "sha512=8507095e49d2c47d3aa71a62a2856dea3bce0607ee3f03cd9c4a7a93b2a0f6b53788ef0345ce1193a10048251f4bd0f6d1af74ba2191682686ec463653b17622"
+  ]
+}
+x-commit-hash: "4bc5ad6b26dac4337f1fe7f3e523568245ad38c5"

--- a/packages/vchan-unix/vchan-unix.6.0.1/opam
+++ b/packages/vchan-unix/vchan-unix.6.0.1/opam
@@ -24,6 +24,7 @@ depends: [
   "sexplib"
   "xen-evtchn"
   "xen-gnt"
+  "fmt" {>= "0.8.7"}
   "cmdliner" {with-test}
   "ounit" {with-test}
 ]

--- a/packages/vchan-xen/vchan-xen.6.0.1/opam
+++ b/packages/vchan-xen/vchan-xen.6.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "vchan" {=version}
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "mirage-xen" {>= "7.0.0"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "ounit" {with-test}
+  "cmdliner" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.1/vchan-6.0.1.tbz"
+  checksum: [
+    "sha256=e44edd2133158ab628c54929f196a6440a25ca103a6af5c624d022a31781b95d"
+    "sha512=8507095e49d2c47d3aa71a62a2856dea3bce0607ee3f03cd9c4a7a93b2a0f6b53788ef0345ce1193a10048251f4bd0f6d1af74ba2191682686ec463653b17622"
+  ]
+}
+x-commit-hash: "4bc5ad6b26dac4337f1fe7f3e523568245ad38c5"

--- a/packages/vchan-xen/vchan-xen.6.0.1/opam
+++ b/packages/vchan-xen/vchan-xen.6.0.1/opam
@@ -25,7 +25,7 @@ depends: [
   "cmdliner" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"

--- a/packages/vchan/vchan.6.0.1/opam
+++ b/packages/vchan/vchan.6.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Xen Vchan implementation"
+description: """
+This is an implementation of the Xen "libvchan" or "vchan" communication
+protocol in OCaml. It allows fast inter-domain communication using shared
+memory.
+"""
+maintainer: "jonathan.ludlam@eu.citrix.com"
+authors: ["Vincent Bernardoff" "Jon Ludlam" "David Scott"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-vchan"
+doc: "https://mirage.github.io/ocaml-vchan"
+bug-reports: "https://github.com/mirage/ocaml-vchan/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "lwt" {>= "2.5.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "io-page"
+  "mirage-flow" {>= "2.0.0"}
+  "xenstore" {>= "1.2.2"}
+  "xenstore_transport" {>= "1.0.0"}
+  "sexplib"
+  "cmdliner" {with-test}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-vchan.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-vchan/releases/download/v6.0.1/vchan-6.0.1.tbz"
+  checksum: [
+    "sha256=e44edd2133158ab628c54929f196a6440a25ca103a6af5c624d022a31781b95d"
+    "sha512=8507095e49d2c47d3aa71a62a2856dea3bce0607ee3f03cd9c4a7a93b2a0f6b53788ef0345ce1193a10048251f4bd0f6d1af74ba2191682686ec463653b17622"
+  ]
+}
+x-commit-hash: "4bc5ad6b26dac4337f1fe7f3e523568245ad38c5"

--- a/packages/vchan/vchan.6.0.1/opam
+++ b/packages/vchan/vchan.6.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune"
   "lwt" {>= "2.5.0"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "6.0.0"}
   "ppx_sexp_conv"
   "ppx_cstruct"
   "io-page"

--- a/packages/vchan/vchan.6.0.1/opam
+++ b/packages/vchan/vchan.6.0.1/opam
@@ -28,7 +28,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]


### PR DESCRIPTION
Xen Vchan implementation

- Project page: <a href="https://github.com/mirage/ocaml-vchan">https://github.com/mirage/ocaml-vchan</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vchan">https://mirage.github.io/ocaml-vchan</a>

##### CHANGES:

* Adapt to mirage-xen.7.0.0 API changes (mirage/ocaml-vchan#138 @dinosaure)
