### PR TITLE
[new release] hxd (0.3.2)

### DIFF
--- a/packages/hxd/hxd.0.3.2/opam
+++ b/packages/hxd/hxd.0.3.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"          {>= "1.1.0"}
+]
+
+depopts: [
+  "lwt"
+]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.3.2/hxd-0.3.2.tbz"
+  checksum: [
+    "sha256=a00290abb8538e79b32ddc22ed9b301b9806bc4c03eb1e5105b14af47dabec9f"
+    "sha512=1340fc747ef88b679e08e0b63f7b33f9ff6b7c5a03a03a029ba45be4f8837ebe22dc784e4e692074bfcc961b8709af9f586ed9f92bc936ae46bac0724c7b7a23"
+  ]
+}
+x-commit-hash: "9f4460bfe4528fec4700adfb1650e4970fcd44e6"


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

* Prevent tests using yes from failing if SIGPIPE is trapped (@sternenseemann, dinosaure/hxd#11)
* Upgrade `hxd` with `cmdliner.1.1.0` (@MisterDA, dinosaure/hxd#12)
