### PR TITLE
Package ocaml-protoc.2.1

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.1/opam
@@ -2,12 +2,12 @@ opam-version: "2.0"
 synopsis: "Protobuf compiler for OCaml"
 description: "Protobuf compiler for OCaml"
 maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
-authors:[
+authors: [
   "Maxime Ransan <maxime.ransan@gmail.com>"
 ]
 homepage: "https://github.com/mransan/ocaml-protoc"
-bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
-dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+bug-reports: "https://github.com/mransan/ocaml-protoc/issues"
+dev-repo: "git+https://github.com/mransan/ocaml-protoc.git"
 license: "MIT"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ocaml-protoc/ocaml-protoc.2.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="1.11"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=d060da85f0d2b1aa34a17bf5f1c0772b"
+    "sha512=a7661f4e59656907739625a185fbe3084429b6a2371d57d566def42090d66695fd09c6e6e8bdf86b4652d6e3cc59e5c8bcb3f185b93819b9593affab6afb6568"
+  ]
+}

--- a/packages/ocaml-protoc/ocaml-protoc.2.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.1/opam
@@ -10,14 +10,14 @@ bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
 dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
 license: "MIT"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "@install" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>="4.03.0"}
-  "dune"  {>="1.11"}
+  "ocaml" {>= "4.03.0"}
+  "dune"  {>= "1.11"}
   "stdlib-shims"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
### `ocaml-protoc.2.1`
Protobuf compiler for OCaml
Protobuf compiler for OCaml



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.1.0