### PR TITLE
[new release] macaddr, macaddr-sexp, macaddr-cstruct, ipaddr, ipaddr-sexp and ipaddr-cstruct (5.3.0)

### DIFF
--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.3.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.0/ipaddr-5.3.0.tbz"
+  checksum: [
+    "sha256=36979edf64b464d44055f3504b97d61e22050e7369d983052c4ecc3d2b1ab755"
+    "sha512=06b16e319672c8182210296ed005accd9a4e190f99bd019f24232e213be8de6d198f9e8cb40ee00ec226184e1dd4ebd7e589d890b1f88f40f17eaf785dae975c"
+  ]
+}
+x-commit-hash: "842b88da1b699f8c087e15696f76f6e0f47055c8"

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.3.0/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "ipaddr-cstruct" {with-test & = version}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.0/ipaddr-5.3.0.tbz"
+  checksum: [
+    "sha256=36979edf64b464d44055f3504b97d61e22050e7369d983052c4ecc3d2b1ab755"
+    "sha512=06b16e319672c8182210296ed005accd9a4e190f99bd019f24232e213be8de6d198f9e8cb40ee00ec226184e1dd4ebd7e589d890b1f88f40f17eaf785dae975c"
+  ]
+}
+x-commit-hash: "842b88da1b699f8c087e15696f76f6e0f47055c8"

--- a/packages/ipaddr/ipaddr.5.3.0/opam
+++ b/packages/ipaddr/ipaddr.5.3.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * oUnit-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "stdlib-shims"
+  "domain-name" {>= "0.3.0"}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.0/ipaddr-5.3.0.tbz"
+  checksum: [
+    "sha256=36979edf64b464d44055f3504b97d61e22050e7369d983052c4ecc3d2b1ab755"
+    "sha512=06b16e319672c8182210296ed005accd9a4e190f99bd019f24232e213be8de6d198f9e8cb40ee00ec226184e1dd4ebd7e589d890b1f88f40f17eaf785dae975c"
+  ]
+}
+x-commit-hash: "842b88da1b699f8c087e15696f76f6e0f47055c8"

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.3.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.0/ipaddr-5.3.0.tbz"
+  checksum: [
+    "sha256=36979edf64b464d44055f3504b97d61e22050e7369d983052c4ecc3d2b1ab755"
+    "sha512=06b16e319672c8182210296ed005accd9a4e190f99bd019f24232e213be8de6d198f9e8cb40ee00ec226184e1dd4ebd7e589d890b1f88f40f17eaf785dae975c"
+  ]
+}
+x-commit-hash: "842b88da1b699f8c087e15696f76f6e0f47055c8"

--- a/packages/macaddr-sexp/macaddr-sexp.5.3.0/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using sexp"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "macaddr-cstruct" {with-test & = version}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Sexp convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.0/ipaddr-5.3.0.tbz"
+  checksum: [
+    "sha256=36979edf64b464d44055f3504b97d61e22050e7369d983052c4ecc3d2b1ab755"
+    "sha512=06b16e319672c8182210296ed005accd9a4e190f99bd019f24232e213be8de6d198f9e8cb40ee00ec226184e1dd4ebd7e589d890b1f88f40f17eaf785dae975c"
+  ]
+}
+x-commit-hash: "842b88da1b699f8c087e15696f76f6e0f47055c8"

--- a/packages/macaddr/macaddr.5.3.0/opam
+++ b/packages/macaddr/macaddr.5.3.0/opam
@@ -13,7 +13,9 @@ depends: [
   "ounit" {with-test}
   "ppx_sexp_conv" {with-test & >= "v0.9.0"}
 ]
-conflicts: [ "ipaddr" {< "3.0.0"} ]
+conflicts: [
+  "ipaddr" {< "3.0.0"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/macaddr/macaddr.5.3.0/opam
+++ b/packages/macaddr/macaddr.5.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.9.0"}
+  "ounit" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * oUnit-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
+ """
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.0/ipaddr-5.3.0.tbz"
+  checksum: [
+    "sha256=36979edf64b464d44055f3504b97d61e22050e7369d983052c4ecc3d2b1ab755"
+    "sha512=06b16e319672c8182210296ed005accd9a4e190f99bd019f24232e213be8de6d198f9e8cb40ee00ec226184e1dd4ebd7e589d890b1f88f40f17eaf785dae975c"
+  ]
+}
+x-commit-hash: "842b88da1b699f8c087e15696f76f6e0f47055c8"


### PR DESCRIPTION
A library for manipulation of MAC address representations

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Add `with_port_of_string` function (@dinosaure, @hannesm, mirage/ocaml-ipaddr#108)
* **breaking-change** Be restrictive on `Ipaddr.of_string` (@dinosaure, @hannesm, mirage/ocaml-ipaddr#109)
  Before this release, `Ipaddr.of_string` accepts remaining bytes and returns
  a valid value such as `"127.0.0.1aaaa"` is valid. Now, `ipaddr` does not
  accept a string with remaining bytes.
