### PR TITLE
Package binaryen.0.14.0

### DIFF
--- a/packages/binaryen/binaryen.0.14.0/opam
+++ b/packages/binaryen/binaryen.0.14.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "104.0.0" & < "105.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.14.0/binaryen-archive-v0.14.0.tar.gz"
+  checksum: [
+    "md5=ec13ed64202f64ffc3629526371453cb"
+    "sha512=18de8ca173e10854c305a8525149b285b52167d9a7ccecbe7494e7535fc39401644d3b34c62d02b324430109b292ebc010153a58bdba29adca2dc4f87e9c3223"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.14.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.14.0](https://github.com/grain-lang/binaryen.ml/compare/v0.13.0...v0.14.0) (2022-03-04)


### ⚠ BREAKING CHANGES

* Update libbinaryen to v104 (#138)

### Features

* Update libbinaryen to v104 ([#138](https://github.com/grain-lang/binaryen.ml/issues/138)) ([81addf7](https://github.com/grain-lang/binaryen.ml/commit/81addf76dcc21dc1681b5a29b80ba31522911047))

---
:camel: Pull-request generated by opam-publish v2.0.3