### PR TITLE
Package libbinaryen.105.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.105.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.105.0.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v105.0.0/libbinaryen-v105.0.0.tar.gz"
+  checksum: [
+    "md5=e8343526699cbf3daa9ad4f0da353464"
+    "sha512=c59d546b5a017a1f779e99db33a64555964bf1c437925ee717138a9599f58877cc5e16c45fe27799e7f35a4a18646c7bd9ba02ded77150b66428c895d0ed2010"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.105.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [105.0.0](https://github.com/grain-lang/libbinaryen/compare/v104.0.0...v105.0.0) (2022-03-04)


### ⚠ BREAKING CHANGES

* Upgrade binaryen to version_105 (#46)

### Features

* Remove unnecessary conf-python-3 dependency ([e1d386e](https://github.com/grain-lang/libbinaryen/commit/e1d386e3c8f219ecf8f3c50064302b818e5bd951))
* Upgrade binaryen to version_105 ([#46](https://github.com/grain-lang/libbinaryen/issues/46)) ([e1d386e](https://github.com/grain-lang/libbinaryen/commit/e1d386e3c8f219ecf8f3c50064302b818e5bd951))

---
:camel: Pull-request generated by opam-publish v2.0.3