### PR TITLE
Package ppx_tools.6.5

### DIFF
--- a/packages/ppx_tools/ppx_tools.6.5/opam
+++ b/packages/ppx_tools/ppx_tools.6.5/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Tools for authors of ppx rewriters and other syntactic tools"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Alain Frisch <alain.frisch@lexifi.com>"
+license: "MIT"
+tags: "syntax"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.15.0"}
+  "dune" {>= "1.6"}
+  "cppo" {build & >= "1.1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_tools.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_tools/releases/download/6.5/ppx_tools-6.5.tar.gz"
+  checksum: [
+    "md5=57439259c19b1615588c613a4e7c10e3"
+    "sha512=9f24e5feb9d32a5f038e94db33b6a8ba22ef0f83964bf657ac12fd0d39ae2580769612b1ba8988a56a146e4ae5da99e089bda24a4944b18b1df6e146bb75237b"
+  ]
+}


### PR DESCRIPTION
### `ppx_tools.6.5`
Tools for authors of ppx rewriters and other syntactic tools



---
* Homepage: https://github.com/ocaml-ppx/ppx_tools
* Source repo: git+https://github.com/ocaml-ppx/ppx_tools.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_tools/issues

---
:camel: Pull-request generated by opam-publish v2.1.0