### PR TITLE
[new release] dump_ocamlformat (0.2.1)

### DIFF
--- a/packages/dump_ocamlformat/dump_ocamlformat.0.2.1/opam
+++ b/packages/dump_ocamlformat/dump_ocamlformat.0.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dump preset configuration files for ocamlformat"
+description: "Dump preset configuration files for ocamlformat"
+maintainer: ["diohabara@gmail.com"]
+authors: ["diohabara"]
+license: "MIT"
+homepage: "https://github.com/diohabara/dump_ocamlformat"
+bug-reports: "https://github.com/diohabara/dump_ocamlformat/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "core" {<= "v0.14.1"}
+  "ocaml" {<= "4.13.1"}
+  "ocamlformat" {<= "0.20.1"}
+  "odoc" {<= "2.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/diohabara/dump_ocamlformat.git"
+url {
+  src:
+    "https://github.com/diohabara/dump_ocamlformat/releases/download/0.2.1/dump_ocamlformat-0.2.1.tbz"
+  checksum: [
+    "sha256=6c653f53b15e05abe34a0afe9d7ec56d83b805624b1427348f68b8a7699983b2"
+    "sha512=781a441a292d21a71efe13a1ba65e9c22674e2df65decc2d14e7a19751f60bdcd96ee44280134a8962c11152ecd0687f71254de04511f21ea0d3309be51b3f61"
+  ]
+}
+x-commit-hash: "0cddfe4a30c85e2ea6384459fcf4962bb92ab7eb"


### PR DESCRIPTION
Dump preset configuration files for ocamlformat

- Project page: <a href="https://github.com/diohabara/dump_ocamlformat">https://github.com/diohabara/dump_ocamlformat</a>

##### CHANGES:

Initial release.

## references

- <https://github.com/ocaml/opam-repository/pull/20849>