### PR TITLE
[new release] dump_ocamlformat (0.2.2)

### DIFF
--- a/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
+++ b/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/diohabara/dump_ocamlformat"
 bug-reports: "https://github.com/diohabara/dump_ocamlformat/issues"
 depends: [
   "dune" {>= "3.0"}
-  "core" {<= "v0.14.1"}
+  "core" {>= "v0.14.1"}
   "ocaml" {>= "4.10.0"}
   "ocamlformat" {>= "0.20.1"}
   "odoc" {>= "2.1.0"}

--- a/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
+++ b/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
@@ -9,9 +9,9 @@ bug-reports: "https://github.com/diohabara/dump_ocamlformat/issues"
 depends: [
   "dune" {>= "3.0"}
   "core" {<= "v0.14.1"}
-  "ocaml" {<= "4.13.1" | >= "4.10.0"}
-  "ocamlformat" {<= "0.20.1"}
-  "odoc" {<= "2.1.0"}
+  "ocaml" {>= "4.10.0"}
+  "ocamlformat" {>= "0.20.1"}
+  "odoc" {>= "2.1.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
+++ b/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dump preset configuration files for ocamlformat"
+description: "Dump preset configuration files for ocamlformat"
+maintainer: ["diohabara@gmail.com"]
+authors: ["diohabara"]
+license: "MIT"
+homepage: "https://github.com/diohabara/dump_ocamlformat"
+bug-reports: "https://github.com/diohabara/dump_ocamlformat/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "core" {<= "v0.14.1"}
+  "ocaml" {<= "4.13.1" | >= "4.10.0"}
+  "ocamlformat" {<= "0.20.1"}
+  "odoc" {<= "2.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/diohabara/dump_ocamlformat.git"
+url {
+  src:
+    "https://github.com/diohabara/dump_ocamlformat/releases/download/0.2.2/dump_ocamlformat-0.2.2.tbz"
+  checksum: [
+    "sha256=3605a661b5fa437ef43f6c343395c0104c97c91d1c38e915ddf99324079e88d0"
+    "sha512=39e64d6c9fb0ea5d160621cfacf6bc9d5f07e87e038f5358e0f59d486d02e28a360492ca96f40396cb80d2c1bf46dd3b011ec80a3e5c0d44e3e009c26aa22b25"
+  ]
+}
+x-commit-hash: "fdfd3723df796596485669ad081f7c5b0820f1df"


### PR DESCRIPTION
Dump preset configuration files for ocamlformat

- Project page: <a href="https://github.com/diohabara/dump_ocamlformat">https://github.com/diohabara/dump_ocamlformat</a>

##### CHANGES:

Change dependencies.
