### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.2)

### DIFF
--- a/packages/eio/eio.0.2/opam
+++ b/packages/eio/eio.0.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "base-domains"
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "1.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.2/eio_main-0.2.tbz"
+  checksum: [
+    "sha256=d09b63460ab8eb529b7e48c5a566ece58ae0d8f3c72ef6b55245cd8a8b3b304d"
+    "sha512=d644a0495923fc6c009d6ca95693ad93ed204604dcf84f43c68f3e83f4ab1bb6c4581c14b165ffaec2c194803a6dac38611e991133acdfc3388a7fa95a677d32"
+  ]
+}
+x-commit-hash: "85841dc0b779a920bc4b1daca9172456e33988ee"

--- a/packages/eio_linux/eio_linux.0.2/opam
+++ b/packages/eio_linux/eio_linux.0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "base-domains"
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "uring" {>= "0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.2/eio_main-0.2.tbz"
+  checksum: [
+    "sha256=d09b63460ab8eb529b7e48c5a566ece58ae0d8f3c72ef6b55245cd8a8b3b304d"
+    "sha512=d644a0495923fc6c009d6ca95693ad93ed204604dcf84f43c68f3e83f4ab1bb6c4581c14b165ffaec2c194803a6dac38611e991133acdfc3388a7fa95a677d32"
+  ]
+}
+x-commit-hash: "85841dc0b779a920bc4b1daca9172456e33988ee"

--- a/packages/eio_luv/eio_luv.0.2/opam
+++ b/packages/eio_luv/eio_luv.0.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "base-domains"
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.2/eio_main-0.2.tbz"
+  checksum: [
+    "sha256=d09b63460ab8eb529b7e48c5a566ece58ae0d8f3c72ef6b55245cd8a8b3b304d"
+    "sha512=d644a0495923fc6c009d6ca95693ad93ed204604dcf84f43c68f3e83f4ab1bb6c4581c14b165ffaec2c194803a6dac38611e991133acdfc3388a7fa95a677d32"
+  ]
+}
+x-commit-hash: "85841dc0b779a920bc4b1daca9172456e33988ee"

--- a/packages/eio_main/eio_main.0.2/opam
+++ b/packages/eio_main/eio_main.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.2/eio_main-0.2.tbz"
+  checksum: [
+    "sha256=d09b63460ab8eb529b7e48c5a566ece58ae0d8f3c72ef6b55245cd8a8b3b304d"
+    "sha512=d644a0495923fc6c009d6ca95693ad93ed204604dcf84f43c68f3e83f4ab1bb6c4581c14b165ffaec2c194803a6dac38611e991133acdfc3388a7fa95a677d32"
+  ]
+}
+x-commit-hash: "85841dc0b779a920bc4b1daca9172456e33988ee"


### PR DESCRIPTION
Effect-based direct-style IO mainloop for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

- Add support for UDP (@patricoferris ocaml-multicore/eio#171).

- Rename Fibre to Fiber (@talex5 ocaml-multicore/eio#195). This is to match the compiler's spelling.

- Switch to luv backend if uring can't be used (@talex5 ocaml-multicore/eio#203).
  Useful on Windows with WSL, and also in Docker containers on older systems.

- Eio_linux: cope with lack of fixed chunks (@talex5 ocaml-multicore/eio#200).
  - If we run out of fixed memory, just use regular memory instead of waiting (which might deadlock).
  - If we try to allocate a fixed buffer and fail, we now just log a warning and continue without one.

- Add support for FD passing with Eio_linux (@talex5 ocaml-multicore/eio#199).

- Add `Eio_unix.FD.as_socket` (@talex5 ocaml-multicore/eio#193).
  Useful for working with existing libraries that provide a `Unix.file_descr`, or for receiving FDs from elsewhere (e.g. socket activation).
  Also, the `Luv.{File,Handle}.of_luv` functions now allow controlling whether to close the wrapped FD.

- Add `Eio_unix.sleep` (@talex5 ocaml-multicore/eio#188). Based on feedback that some people don't want to treat time as a capability. Possibly also useful for debugging race conditions.

- Tidy up forking API (@talex5 ocaml-multicore/eio#192). Moves some common code out the the individual backends.

- Improve documentation (@talex5 ocaml-multicore/eio#197 ocaml-multicore/eio#194 ocaml-multicore/eio#186 ocaml-multicore/eio#185). In particular, explain more low-level details about how cancellation works.

- Add an example `Eio_null` backend (@talex5 ocaml-multicore/eio#189). This supports creating fibers, promises and cancellation, but provides no IO operations.

- `Effect.eff` is now `Effect.t` in OCaml trunk (@talex5 ocaml-multicore/eio#201).
