### PR TITLE
pprint.20220103 requires OCaml 4.02.2.

### DIFF
--- a/packages/pprint/pprint.20220103/opam
+++ b/packages/pprint/pprint.20220103/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02.2"}
   "dune" {>= "1.3"}
 ]
 synopsis: "A pretty-printing combinator library and rendering engine"


### PR DESCRIPTION
Due to the use of `type nonrec`.