### PR TITLE
Package catala.0.6.0

### DIFF
--- a/packages/catala/catala.0.6.0/opam
+++ b/packages/catala/catala.0.6.0/opam
@@ -60,7 +60,7 @@ dev-repo: "git+https://github.com/CatalaLang/catala.git"
 url {
   src: "https://github.com/CatalaLang/catala/archive/0.6.0.tar.gz"
   checksum: [
-    "md5=8d7360b0f6f2f98fab8bf6edb05bfbc7"
-    "sha512=8cc7adc6fc2c2540719ec7561a0fe15783a3e7f5907ee15f428d3d68f046a537b4cccec0bf455874fdc6103586242d71fb7f8b1d52e44570c713affde69d9a13"
+    "md5=b22e238d5d5c8452067109e9c7c0f427"
+    "sha512=ccc8c557c67c2f9d1bed4b957b2367f0f6afc0ef9b8b83237cf2a2912b3e8829b7e8af78ea7fe00b20ecf28b436ad04b591e5fff4f82fd08725d40a18c9924d0"
   ]
 }

--- a/packages/catala/catala.0.6.0/opam
+++ b/packages/catala/catala.0.6.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description: """
+Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information
+"""
+maintainer: ["contact@catala-lang.org"]
+authors: [
+  "Denis Merigoux"
+  "Nicolas Chataing"
+  "Emile Rolley"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Alain Delaët-Tixeuil"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "ANSITerminal" {>= "0.8.2"}
+  "sedlex" {>= "2.4"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "unionFind" {>= "20200320"}
+  "bindlib" {>= "5.0.1"}
+  "cmdliner" {= "1.0.4"}
+  "re" {>= "1.9.0"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "calendar" {>= "2.04"}
+  "visitors" {>= "20200210"}
+  "benchmark" {>= "1.6"}
+  "js_of_ocaml-ppx" {>= "3.8.0"}
+  "camomile" {>= "1.0.2"}
+  "z3" {>= "4.8.11"}
+  "cppo" {>= "1"}
+  "obelisk" {dev}
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocamlformat" {dev & = "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.6.0.tar.gz"
+  checksum: [
+    "md5=8d7360b0f6f2f98fab8bf6edb05bfbc7"
+    "sha512=8cc7adc6fc2c2540719ec7561a0fe15783a3e7f5907ee15f428d3d68f046a537b4cccec0bf455874fdc6103586242d71fb7f8b1d52e44570c713affde69d9a13"
+  ]
+}

--- a/packages/catala/catala.0.6.0/opam
+++ b/packages/catala/catala.0.6.0/opam
@@ -37,9 +37,7 @@ depends: [
   "camomile" {>= "1.0.2"}
   "z3" {>= "4.8.11"}
   "cppo" {>= "1"}
-  "obelisk" {dev}
   "alcotest" {with-test & >= "1.5.0"}
-  "ocamlformat" {dev & = "0.19.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
### `catala.0.6.0`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.0.3