### PR TITLE
OCaml 4.14.0~rc1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0~rc1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "First release candidate of OCaml 4.14.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+depends: [
+  "ocaml" {= "4.14.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0-rc1.tar.gz"
+  checksum: "sha256=d09733aec2cbf0f387888e00c8c723dab8822ea99872e15928223c2db8297260"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate of OCaml 4.14.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
+depends: [
+  "ocaml" {= "4.14.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--enable-spacetime" {ocaml-option-spacetime:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.0-rc1.tar.gz"
+  checksum: "sha256=d09733aec2cbf0f387888e00c8c723dab8822ea99872e15928223c2db8297260"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-spacetime"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]


### PR DESCRIPTION
This PR adds the two usual opam packages for the first release candidate for 4.14.0 .

Compared to the last beta, this release candidate includes two backend fixes (one for the frame-pointer mode and the other one for the RISC-V architecture), one configuration fix for musl/arm64, and the manual chapter for the TMC transformation.

Changes compared to the last beta
----------------------------------------------

+ 181, 9760, +10740: opt-in tail-modulo-cons (TMC) transformation
     let[@tail_mod_cons] rec map f li = ...
   (Frédéric Bour, Gabriel Scherer, Basile Clément,
    review by Basile Clément and Pierre Chambart,

- 10688: Move frame descriptor table from `rodata` to `data` section on
  RISC-V.  Improves support for building DLLs and PIEs. In particular, this
  applies to all binaries in distributions that build PIEs by default (eg
  Gentoo and Alpine).
  (Alex Fan, review by Gabriel Scherer)

- 11031: Exception handlers restore the rbp register when using frame-pointers
  on amd64.
  (Fabrice Buoro, with help from Stephen Dolan, Tom Kelly and Mark Shinwell,
  review by Xavier Leroy)

- 11025, 11036: Do not pass -no-pie to the C compiler on musl/arm64
  (omni, Kate Deplaix and Antonio Nuno Monteiro, review by Xavier Leroy)
