### PR TITLE
Dream alpha4: easy-to-use Web framework

### DIFF
--- a/packages/dream-pure/dream-pure.1.0.0~alpha2/opam
+++ b/packages/dream-pure/dream-pure.1.0.0~alpha2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+
+synopsis: "Internal: shared HTTP types for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base64" {>= "3.1.0"}  # Base64.encode_string.
+  "bigstringaf" {>= "0.5.0"}  # Bigstringaf.to_string.
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "hmap"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.weekday.
+  "uri" {>= "4.2.0"}
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "ppx_expect" {with-test}
+  "ppx_yojson_conv" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha4/dream-1.0.0-alpha4.tar.gz"
+  checksum: "md5=20aaa93b13c210324e9dcceeba3c3b21"
+}

--- a/packages/dream/dream.1.0.0~alpha3/opam
+++ b/packages/dream/dream.1.0.0~alpha3/opam
@@ -53,7 +53,7 @@ depends: [
   "caqti-lwt"
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
-  "dream-pure"
+  "dream-pure" {< "1.0.0~alpha2"}
   "dream-httpaf"
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha4/opam
+++ b/packages/dream/dream.1.0.0~alpha4/opam
@@ -1,0 +1,101 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "camlp-streams"
+  "caqti" {>= "1.6.0"}  # https://github.com/aantron/dream/issues/44.
+  "caqti-lwt"
+  "conf-libev" {os != "win32"}
+  "cstruct" {>= "6.0.0"}
+  "dream-httpaf"
+  "dream-pure" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
+  "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
+  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.v.
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "lambdasoup" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+  "tyxml-jsx" {with-test & >= "4.5.0"}
+  "tyxml-ppx" {with-test & >= "4.5.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha4/dream-1.0.0-alpha4.tar.gz"
+  checksum: "md5=20aaa93b13c210324e9dcceeba3c3b21"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/dream/releases/tag/1.0.0-alpha4):

> Additions
>
> - [`Dream.set_status`](https://aantron.github.io/dream/#val-set_status) (aantron/dream@67e91f1).
> - Automatically close streams ([`Dream.stream`](https://aantron.github.io/dream/#val-stream)) and WebSockets ([`Dream.websocket`](https://aantron.github.io/dream/#val-websocket)) unless `~close:false` is passed (aantron/dream@cfacc84, prompted by Yawar Amin).
>
> Bugs fixed
>
> - [`Dream.form`](https://aantron.github.io/dream/#val-form) should accept all `Content-Type`s that have the right prefix (aantron/dream#203, Yawar Amin).
> - [`Dream.set_cookie`](https://aantron.github.io/dream/#val-set_cookie) should use `SameSite=Lax` by default (aantron/dream#190, reported by Chas Emerick, Andrey Popp).
> - Depend on `camlp-streams` for OCaml 5.00.0 compatibility (aantron/dream#210, Patrick Ferris).
>
> Changes
>
> - Improve `Content-Length` and `Transfer-Encoding` handling (aantron/dream@2621045).
>
> Removals
>
> - `Dream.content_length` middleware (aantron/dream@2621045).
> - `Dream.lowercase_headers` middleware (aantron/dream@5f50acf).
> - `Dream.version` accessor (aantron/dream@2162ec7).
>
> Docs
>
> - Catch up routers in some of the examples with Dream `alpha3` (aantron/dream#205, Thomas Haessle).
> - Update docs for [`Dream.form_result`](https://aantron.github.io/dream/#type-form_result) constructor `` `Expired`` (aantron/dream#206, Yawar Amin).
> - Fix remaining mentions of `~secret` (aantron/dream#207, reported by Tuomas Lukka).
