### PR TITLE
Package binaryen.0.14.1

### DIFF
--- a/packages/binaryen/binaryen.0.14.1/opam
+++ b/packages/binaryen/binaryen.0.14.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-ppx" {>= "3.10.0" & < "4.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "104.0.0" & < "105.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.14.1/binaryen-archive-v0.14.1.tar.gz"
+  checksum: [
+    "md5=c9d4411fc8eb1681ab75b517cb098a6d"
+    "sha512=c057cbae9790340c4bd120899c6cd6cbad79cde05cb7015c2987755ede5bf7ab4ac0e269951d22626f8421c3ad8988a934f7903bb8320019b9fdf0dbf42782b3"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.14.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
### [0.14.1](https://github.com/grain-lang/binaryen.ml/compare/v0.14.0...v0.14.1) (2022-03-08)


### Bug Fixes

* Update binaryen JS to v104 ([#140](https://github.com/grain-lang/binaryen.ml/issues/140)) ([eb9049e](https://github.com/grain-lang/binaryen.ml/commit/eb9049e4ec0ec2406e72c5bb9190b993a187f2d0))

---
:camel: Pull-request generated by opam-publish v2.0.3