### PR TITLE
Package libbinaryen.105.1.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.105.1.0/opam
+++ b/packages/libbinaryen/libbinaryen.105.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "3.10.0" & < "4.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v105.1.0/libbinaryen-v105.1.0.tar.gz"
+  checksum: [
+    "md5=8ae773fd2dda335184b131a513dace6e"
+    "sha512=a73306ed308ea2e7d277dba9bf4bf8f505e254ee58c16d92e1a8ad7c62f7d5979c07f4c4069fb9f561274dc2299f766563238a1f4accb6bc8b2fb1e0f3c4e4ad"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.105.1.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [105.1.0](https://github.com/grain-lang/libbinaryen/compare/v105.0.0...v105.1.0) (2022-03-09)


### Features

* Provide binaryen.js with library ([#48](https://github.com/grain-lang/libbinaryen/issues/48)) ([f389527](https://github.com/grain-lang/libbinaryen/commit/f389527a95ff845996e2ecaa5118c4bbe30a1ab9))

---
:camel: Pull-request generated by opam-publish v2.0.3