### PR TITLE
[new release] otoggl (0.3.1)

### DIFF
--- a/packages/otoggl/otoggl.0.3.1/opam
+++ b/packages/otoggl/otoggl.0.3.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings for Toggl API in OCaml"
+description: "Bindings for Toggl API in OCaml"
+maintainer: ["Christophe Riolo Uusivaara"]
+authors: ["Christophe Riolo Uusivaara"]
+license: "MIT"
+homepage: "https://github.com/unitrack-time-tracking/OToggl"
+bug-reports: "https://github.com/unitrack-time-tracking/OToggl/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "atdgen" {build & >= "2.2" & < "3"}
+  "atdgen-runtime" {>= "2" & < "3"}
+  "base64" {>= "3" & < "4"}
+  "containers" {>= "3" & < "4"}
+  "dune" {>= "2.0"}
+  "piaf" {>= "0"}
+  "ppx_deriving" {>= "4" & < "5"}
+  "ptime" {>= "0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/unitrack-time-tracking/OToggl.git"
+url {
+  src:
+    "https://github.com/unitrack-time-tracking/OToggl/releases/download/0.3.1/dev-0.3.1.tbz"
+  checksum: [
+    "sha256=bed72d891f41ed2a90c4e92e71274d5bcc0b76bbeff2e16ad8e7bd4a1ae56d50"
+    "sha512=f064d4e179873deaf3192f0f6e923a9f5e422acb8a7275c0a2957601a7293571d8ed616ed0e95a8c5bcb98dbb6f86695eba2df03723b4d96d8a9544cc26f6abc"
+  ]
+}
+x-commit-hash: "dec14cc0845c5af40213d1c99cc3193c311cbfbd"


### PR DESCRIPTION
Bindings for Toggl API in OCaml

- Project page: <a href="https://github.com/unitrack-time-tracking/OToggl">https://github.com/unitrack-time-tracking/OToggl</a>

##### CHANGES:

## Changed

- unitrack-time-tracking/OToggl#1 Update release script to publish only otoggl.opam and not dev.opam
