### PR TITLE
Relax dependency version constraint in resto-cohttp-server

### DIFF
--- a/packages/resto-cohttp-server/resto-cohttp-server.0.6.1/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.6.1/opam
@@ -17,8 +17,8 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" { >= "2.0.0"}
-  "conduit-lwt-unix" { >= "2.0.0" & < "3.0.0" }
+  "cohttp-lwt-unix" { >= "2.0.0" }
+  "conduit-lwt-unix" { >= "2.0.0" }
   "lwt" { >= "3.0.0" & < "6.0.0" }
 ]
 url {


### PR DESCRIPTION
One of the dependency constraint for resto-cohttp-server is tighter than necessary. The project's CI is all green with this change: https://gitlab.com/nomadic-labs/resto/-/pipelines/487831799