### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.0.1)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.0.1/opam
+++ b/packages/tar-mirage/tar-mirage.2.0.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "io-page"
+  "lwt"
+  "mirage-block"
+  "mirage-kv" {>= "3.0.0"}
+  "ptime"
+  "re" {>= "1.7.2"}
+  "tar" {= version}
+  "io-page-unix" {with-test}
+  "mirage-block-unix" {with-test & >= "2.5.0"}
+  "ounit2" {with-test}
+  "ounit2-lwt" {with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.0.1/tar-mirage-2.0.1.tbz"
+  checksum: [
+    "sha256=e9565fb43dab9e944d1860f9a3b5c681df72211b859c66ee1d7085cafc13ee9b"
+    "sha512=e4486274b44e6b34540afc9893bc0f2b604ba01c576b01aeb0b494f30791a0c353d1809de62e2f0ae04de771a2391affb17b98b1fc6c0d2fc2e963741bc65a55"
+  ]
+}
+x-commit-hash: "a6552cb5e82d3100de3a8d93d803ca1677b34207"

--- a/packages/tar-mirage/tar-mirage.2.0.1/opam
+++ b/packages/tar-mirage/tar-mirage.2.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct" {>= "1.9.0"}
   "io-page"
   "lwt"
-  "mirage-block"
+  "mirage-block" {>= "2.0.0"}
   "mirage-kv" {>= "3.0.0"}
   "ptime"
   "re" {>= "1.7.2"}

--- a/packages/tar-unix/tar-unix.2.0.1/opam
+++ b/packages/tar-unix/tar-unix.2.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.03.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "re" {>= "1.7.2"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.0.1/tar-mirage-2.0.1.tbz"
+  checksum: [
+    "sha256=e9565fb43dab9e944d1860f9a3b5c681df72211b859c66ee1d7085cafc13ee9b"
+    "sha512=e4486274b44e6b34540afc9893bc0f2b604ba01c576b01aeb0b494f30791a0c353d1809de62e2f0ae04de771a2391affb17b98b1fc6c0d2fc2e963741bc65a55"
+  ]
+}
+x-commit-hash: "a6552cb5e82d3100de3a8d93d803ca1677b34207"

--- a/packages/tar/tar.2.0.1/opam
+++ b/packages/tar/tar.2.0.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "re" {>= "1.7.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.0.1/tar-mirage-2.0.1.tbz"
+  checksum: [
+    "sha256=e9565fb43dab9e944d1860f9a3b5c681df72211b859c66ee1d7085cafc13ee9b"
+    "sha512=e4486274b44e6b34540afc9893bc0f2b604ba01c576b01aeb0b494f30791a0c353d1809de62e2f0ae04de771a2391affb17b98b1fc6c0d2fc2e963741bc65a55"
+  ]
+}
+x-commit-hash: "a6552cb5e82d3100de3a8d93d803ca1677b34207"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Set `O_CLOEXEC` on opened files and be sure to close opened files
  (@MisterDA, @talex5, mirage/ocaml-tar#83)
- OCaml 5.00 support (add a new dependecy `camlp-stream`) (@Sudha247, mirage/ocaml-tar#84)
- Missing padding in LongLing 'L' case (@dra27, mirage/ocaml-tar#82)
