### PR TITLE
lablqml.0.7: Unlock ppxlib >= 0.23.0

### DIFF
--- a/packages/lablqml/lablqml.0.7/opam
+++ b/packages/lablqml/lablqml.0.7/opam
@@ -25,7 +25,7 @@ depends: [
   "stdio"
   "conf-pkg-config" { build }
   "conf-qt" { >= "5.2.1"}
-  "ppxlib"  { >= "0.20.0" & < "0.23.0" }
+  "ppxlib"  { >= "0.20.0" }
 ]
 
 url {


### PR DESCRIPTION
Upstreaming in: https://github.com/Kakadu/lablqml/pull/66

Necessary for OCaml 4.14 support
cc @Kakadu 