### PR TITLE
sundialsml.6.1.1p0 is not compatible with OCaml 4.14

### DIFF
--- a/packages/sundialsml/sundialsml.6.1.1p0/opam
+++ b/packages/sundialsml/sundialsml.6.1.1p0/opam
@@ -29,7 +29,7 @@ install: [
   [make "install-doc"] {with-doc}
 ]
 depends: [
-    "ocaml" {>= "4.03.0"}
+    "ocaml" {>= "4.03.0" & < "4.14"}
     "base-bigarray"
     "ocamlfind" {build}
     "conf-sundials" {>= "2" & build}


### PR DESCRIPTION
```
#=== ERROR while compiling sundialsml.6.1.1p0 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/sundialsml.6.1.1p0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j31
# exit-code            2
# env-file             ~/.opam/log/sundialsml-10-81d18d.env
# output-file          ~/.opam/log/sundialsml-10-81d18d.out
### output ###
# make -C src
# make[1]: Entering directory '/home/opam/.opam/4.14/.opam-switch/build/sundialsml.6.1.1p0/src'
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_configuration.ml
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_impl.mli
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_Index.mli
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_Config.mli
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_RealArray.mli
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_LintArray.mli
# ocamlc.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_ROArray.mli
# ocamlopt.opt -no-alias-deps  -w +a-4-9-30-41-42-70 -bin-annot -I sundials -I nvectors -I lsolvers -I cvode -I cvodes -I ida -I idas -I arkode -I kinsol  -c sundials/sundials_configuration.ml
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o sundials/sundials_ml.o -c sundials/sundials_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o lsolvers/sundials_matrix_ml.o -c lsolvers/sundials_matrix_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o lsolvers/sundials_linearsolver_ml.o -c lsolvers/sundials_linearsolver_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o lsolvers/sundials_nonlinearsolver_ml.o -c lsolvers/sundials_nonlinearsolver_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o nvectors/nvector_ml.o -c nvectors/nvector_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o kinsol/kinsol_ml.o -c kinsol/kinsol_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o arkode/arkode_ml.o -c arkode/arkode_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o nvectors/nvector_many_ml.o -c nvectors/nvector_many_ml.c
# cc -DSUNDIALSML_WITHSENS -I /home/opam/.opam/4.14/lib/ocaml \
#      -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o cvodes/cvode_ml_s.o -c cvode/cvode_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -Icvode -o cvodes/cvodes_ml.o -c cvodes/cvodes_ml.c
# cc -DSUNDIALSML_WITHSENS -I /home/opam/.opam/4.14/lib/ocaml \
#      -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o cvodes/cvode_klu_ml_s.o -c cvode/cvode_klu_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -Icvode -o cvodes/cvodes_klu_ml.o -c cvodes/cvodes_klu_ml.c
# cc -DSUNDIALSML_WITHSENS -I /home/opam/.opam/4.14/lib/ocaml \
#      -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o cvodes/cvode_superlumt_ml_s.o -c cvode/cvode_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -Icvode -o cvodes/cvodes_superlumt_ml.o -c cvodes/cvodes_superlumt_ml.c
# cc -DSUNDIALSML_WITHSENS -I /home/opam/.opam/4.14/lib/ocaml \
#      -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o idas/ida_ml_s.o -c ida/ida_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -Iida -o idas/idas_ml.o -c idas/idas_ml.c
# cc -DSUNDIALSML_WITHSENS -I /home/opam/.opam/4.14/lib/ocaml \
#      -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o idas/ida_klu_ml_s.o -c ida/ida_klu_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -Iida -o idas/idas_klu_ml.o -c idas/idas_klu_ml.c
# cc -DSUNDIALSML_WITHSENS -I /home/opam/.opam/4.14/lib/ocaml \
#      -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o idas/ida_superlumt_ml_s.o -c ida/ida_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o idas/idas_superlumt_ml.o -c idas/idas_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o kinsol/kinsol_klu_ml.o -c kinsol/kinsol_klu_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o kinsol/kinsol_superlumt_ml.o -c kinsol/kinsol_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o arkode/arkode_klu_ml.o -c arkode/arkode_klu_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o arkode/arkode_superlumt_ml.o -c arkode/arkode_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o cvode/cvode_ml.o -c cvode/cvode_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o cvode/cvode_klu_ml.o -c cvode/cvode_klu_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o cvode/cvode_superlumt_ml.o -c cvode/cvode_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o ida/ida_ml.o -c ida/ida_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o ida/ida_klu_ml.o -c ida/ida_klu_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o ida/ida_superlumt_ml.o -c ida/ida_superlumt_ml.c
# cc -I /home/opam/.opam/4.14/lib/ocaml  -O3 -Wall -Werror  -DNDEBUG=1 -fPIC -isystem /home/opam/.opam/4.14/lib/ocaml -isystem /usr/include/suitesparse/  -o nvectors/nvector_openmp_ml.o -c nvectors/nvector_openmp_ml.c
# lsolvers/sundials_nonlinearsolver_ml.c: In function 'custom_make':
# lsolvers/sundials_nonlinearsolver_ml.c:2080:13: error: "initialize" is deprecated: use "caml_initialize" instead [-Werror]
#  2080 |     ops->initialize      = (Field(vops, RECORD_NLSOLVER_OPS_INIT)
#       |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    
```