### PR TITLE
pcap-format.0.5.2: Remove unused dependency

### DIFF
--- a/packages/pcap-format/pcap-format.0.5.2/opam
+++ b/packages/pcap-format/pcap-format.0.5.2/opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/mirage/ocaml-pcap/issues"
 depends: [
   "ocaml" {>="4.03.0"}
   "dune" {>= "1.0"}
-  "ppx_tools"
   "cstruct" {>= "1.9.0"}
   "ppx_cstruct" {> "0"}
   "ounit" {with-test}


### PR DESCRIPTION
Upstreaming in https://github.com/mirage/ocaml-pcap/pull/35