### PR TITLE
Package eliom.10.0.0

### DIFF
--- a/packages/eliom/eliom.10.0.0/opam
+++ b/packages/eliom/eliom.10.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "dev@ocsigen.org"
+authors: "dev@ocsigen.org"
+synopsis: "Client/server Web framework"
+description: """
+Eliom is a framework for implementing client/server Web applications.
+It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
+Eliom allows implementing the whole application as a single program that includes both the client and the server code.
+We use a syntax extension to distinguish between the two sides.
+The client-side code is compiled to JS using Ocsigen Js_of_ocaml.
+"""
+homepage: "http://ocsigen.org/eliom/"
+bug-reports: "https://github.com/ocsigen/eliom/issues/"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/ocsigen/eliom.git"
+build: [make]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "ppx_deriving"
+  "ppxlib" {>= "0.15.0"}
+  "js_of_ocaml-compiler" {>= "3.6.0"}
+  "js_of_ocaml" {>= "3.6.0"}
+  "js_of_ocaml-lwt" {>= "3.6.0"}
+  "js_of_ocaml-ocamlbuild" {build}
+  "js_of_ocaml-ppx" {>= "3.6.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "3.6.0"}
+  "js_of_ocaml-tyxml" {>= "3.6.0"}
+  "lwt_log"
+  "lwt_ppx" {>= "1.2.3"}
+  "tyxml" {>= "4.4.0" & < "5.0.0"}
+  "ocsigenserver" {>= "5.0.0" & < "6.0.0"}
+  "ipaddr" {>= "2.1"}
+  "reactiveData" {>= "0.2.1"}
+  "base-bytes"
+  "ocsipersist" {>= "1.0" & < "2.0"}
+]
+url {
+  src: "https://github.com/ocsigen/eliom/archive/10.0.0.tar.gz"
+  checksum: [
+    "md5=d7f3f51e24285ba352b9c4e2707ad6ec"
+    "sha512=9b580bd73e2dd5f687428d02dc9abdde5eef4a8d8d0f69309b29fa34389363b5f18f79f1f646e5efca324743096c1124c862fdd4427bc9d97adef6f72bd03f16"
+  ]
+}


### PR DESCRIPTION
### `eliom.10.0.0`
Client/server Web framework
Eliom is a framework for implementing client/server Web applications.
It introduces new concepts to simplify the implementation of common behaviors, and uses advanced static typing features of OCaml to check many properties of the Web application at compile-time.
Eliom allows implementing the whole application as a single program that includes both the client and the server code.
We use a syntax extension to distinguish between the two sides.
The client-side code is compiled to JS using Ocsigen Js_of_ocaml.



---
* Homepage: http://ocsigen.org/eliom/
* Source repo: git+https://github.com/ocsigen/eliom.git
* Bug tracker: https://github.com/ocsigen/eliom/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0