### PR TITLE
atdgen 2.2.1 refuses to build with re.1.10.3

### DIFF
--- a/packages/atdgen/atdgen.2.2.1/opam
+++ b/packages/atdgen/atdgen.2.2.1/opam
@@ -39,6 +39,7 @@ depends: [
   "atdgen-codec-runtime" {with-test}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
+  "re" {< "1.10.0"}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"
 build: [


### PR DESCRIPTION
The error reported by 'opam install atdgen' is:
```
### output ###
#     ocamlopt
#     atdgen/src/.atdgen_emit.objs/native/atdgen_emit__Ocaml.{cmx,o} (exit 2)
# (cd _build/default && /home/martin/.opam/4.12.0/bin/ocamlopt.opt -w
# -40 -w -27 -safe-string -g -I atdgen/src/.atdgen_emit.objs/byte -I atdgen/src/.atdgen_emit.objs/native -I /home/martin/.opam/4.12.0/lib/atd -I /home/martin/.opam/4.12.0/lib/biniou -I /home/martin/.opam/4.12.0/lib/easy-format -I /home/martin/.opam/4.12.0/lib/yojson -intf-suffix .ml -no-alias-deps -open Atdgen_emit -o atdgen/sr[...]
# File "atdgen/src/ocaml.ml", line 618, characters 12-24:
# 618 | let split = Re.Str.split (Re.Str.regexp " ")
#                   ^^^^^^^^^^^^
# Error: Unbound module Re
```

I don't understand what's happening. Maybe it's because `re` is not listed as dependency in the `dune` file but is only an indirect dependency (?).

Locally, I have an older install which uses re.1.9.0 without an error, so I'm hoping that the version constraint (re < 1.10.0) is good enough.

Note that this is independent from the release of atdgen 2.3.x which is pending.