### PR TITLE
Fix conf-gmp to play nice with Nix

### DIFF
--- a/packages/conf-gmp/conf-gmp.4.1.0/files/test.c
+++ b/packages/conf-gmp/conf-gmp.4.1.0/files/test.c
@@ -1,0 +1,10 @@
+#include <gmp.h>
+#ifndef __GMP_H__
+#error "No GMP header"
+#endif
+
+void test(void) {
+  mpz_t n;
+  mpz_init(n);
+  mpz_clear(n);
+}

--- a/packages/conf-gmp/conf-gmp.4.1.0/opam
+++ b/packages/conf-gmp/conf-gmp.4.1.0/opam
@@ -29,6 +29,7 @@ depexts: [
   ["gmp-dev"] {os-distribution = "alpine"}
   ["gmp-devel"] {os-family = "suse"}
   ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gmp"] {os-distribution = "nixos"}
 ]
 synopsis: "Virtual package relying on a GMP lib system installation"
 description:

--- a/packages/conf-gmp/conf-gmp.4.1.0/opam
+++ b/packages/conf-gmp/conf-gmp.4.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "nbraud"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-exc" "cc -c $CFLAGS -I/usr/local/include test.c"] {os != "macos" & os != "win32"}
+  [
+		"sh"
+		"-exc"
+		"$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
+	] {os = "win32" & os-distribution = "cygwinports"}
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/homebrew/include -I/opt/local/include -I/usr/local/include test.c"
+  ] {os = "macos"}
+]
+depexts: [
+  ["libgmp-dev"] {os-family = "debian"}
+  ["libgmp-dev"] {os-family = "ubuntu"}
+  ["gmp"] {os = "macos" & os-distribution = "homebrew"}
+  ["gmp"] {os-distribution = "macports" & os = "macos"}
+  ["gmp" "gmp-devel"] {os-distribution = "centos"}
+  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-distribution = "ol"}
+  ["gmp"] {os = "openbsd"}
+  ["gmp"] {os = "freebsd"}
+  ["gmp-dev"] {os-distribution = "alpine"}
+  ["gmp-devel"] {os-family = "suse"}
+  ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
+]
+synopsis: "Virtual package relying on a GMP lib system installation"
+description:
+  "This package can only install if the GMP lib is installed on the system."
+authors: "nbraud"
+extra-files: ["test.c" "md5=2fd2970c293c36222a6d299ec155823f"]
+flags: conf

--- a/packages/conf-gmp/conf-gmp.4.1.0/opam
+++ b/packages/conf-gmp/conf-gmp.4.1.0/opam
@@ -35,5 +35,5 @@ synopsis: "Virtual package relying on a GMP lib system installation"
 description:
   "This package can only install if the GMP lib is installed on the system."
 authors: "nbraud"
-extra-files: ["test.c" "md5=2fd2970c293c36222a6d299ec155823f"]
+extra-files: ["test.c" "sha256=54a30735f1f271a2531526747e75716f4490dd7bc1546efd6498ccfe3cc4d6fb"]
 flags: conf


### PR DESCRIPTION
1. Copies `conf-gmp.4.1.0` from `conf-gmp.4`
2. Adds a depexts entry for Nix (`os-distribution = "nix"`)
3. Switches the checksum algo for extra files to SHA256 

Ultimately version 4.1.0 aims to make it easier to use this package programatically with Nix.