### PR TITLE
Add Nix depext entry for conf-libffi

### DIFF
--- a/packages/conf-libffi/conf-libffi.2.1.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+authors: ["Anthony Green"]
+homepage: "http://sourceware.org/libffi/"
+license: "MIT"
+build: ["pkg-config" "libffi"]
+depexts: [
+  ["libffi"] {os = "macos" & os-distribution = "homebrew"}
+  ["libffi"] {os = "macos" & os-distribution = "macports"}
+  ["libffi-dev"] {os-distribution = "alpine"}
+  ["libffi-dev"] {os-family = "debian"}
+  ["libffi-devel"] {os-distribution = "centos"}
+  ["libffi-devel"] {os-distribution = "fedora"}
+  ["libffi-devel"] {os-distribution = "mageia"}
+  ["libffi-devel"] {os-distribution = "ol"}
+  ["libffi-devel"] {os-family = "suse"}
+  ["libffi"] {os = "freebsd"}
+  ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
+]
+synopsis: "Virtual package relying on libffi system installation"
+description: "This package can only install if libffi is installed on the system."
+depends: ["conf-pkg-config" {build}]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libffi/conf-libffi.2.1.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.1.0/opam
@@ -16,6 +16,7 @@ depexts: [
   ["libffi-devel"] {os-family = "suse"}
   ["libffi"] {os = "freebsd"}
   ["libffi"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libffi"] {os-distribution = "nixos"}
 ]
 synopsis: "Virtual package relying on libffi system installation"
 description: "This package can only install if libffi is installed on the system."


### PR DESCRIPTION
1. Copies conf-libffi.2.1.0 from conf-libffi.2.0.0
2. Adds a depexts entry for Nix (os-distribution = "nix")

The goal is to make this package easier to integrate on Nix.