### PR TITLE
Package unison.2.52.0

### DIFF
--- a/packages/unison/unison.2.52.0/opam
+++ b/packages/unison/unison.2.52.0/opam
@@ -12,7 +12,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.3"}
   "lablgtk" {>= "2.18.6"}
 ]

--- a/packages/unison/unison.2.52.0/opam
+++ b/packages/unison/unison.2.52.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "File-synchronization tool for Unix and Windows"
+description: """\
+Unison is a file-synchronization tool for Unix and Windows. It allows
+two replicas of a collection of files and directories to be stored on
+different hosts (or different disks on the same host), modified
+separately, and then brought up to date by propagating the changes in
+each replica to the other."""
+maintainer: "juergen@hoetzel.info"
+authors: ["Trevor Jim" "Benjamin C. Pierce" "Jérôme Vouillon"]
+license: "GPL-3.0-or-later"
+homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
+bug-reports: "https://github.com/bcpierce00/unison/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {>= "2.3"}
+  "lablgtk" {>= "2.18.6"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git://github.com/bcpierce00/unison.git"
+url {
+  src:
+    "https://github.com/bcpierce00/unison/archive/refs/tags/v2.52.0.tar.gz"
+  checksum: [
+    "md5=895418bd80ef15570da669b4a0900eee"
+    "sha512=24cfb43b40a05f85164c43e8744216142db4cd74d9d09ba7178f25f794b0dcce252597fa1eb49a4133e63d891c8d23fd7472669cf9f52777bc6aa86b0a50e6f5"
+  ]
+}


### PR DESCRIPTION
### `unison.2.52.0`
File-synchronization tool for Unix and Windows
Unison is a file-synchronization tool for Unix and Windows. It allows
two replicas of a collection of files and directories to be stored on
different hosts (or different disks on the same host), modified
separately, and then brought up to date by propagating the changes in
each replica to the other.



---
* Homepage: https://www.cis.upenn.edu/~bcpierce/unison/
* Source repo: git://github.com/bcpierce00/unison.git
* Bug tracker: https://github.com/bcpierce00/unison/issues

---
:camel: Pull-request generated by opam-publish v2.1.0