### PR TITLE
[new release] mirage-net-solo5 (0.7.1)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.7.1/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.7.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.7.1/mirage-net-solo5-0.7.1.tbz"
+  checksum: [
+    "sha256=9f8b980ec6ba1a765bd0084fc47d5d0190d4d1bafeb5db7b68dae9fad3b61f8d"
+    "sha512=182feee79a1aad0536d4638ebc9996571e2d5c714d1ed4f0d39f6040684cc17dc535e59373f0a649c17b7723577a9d2a70c3470169c87b0ba3271b2050de6ee3"
+  ]
+}
+x-commit-hash: "ea5f6c62cca4b2d32cbfc29904fc18060919a489"


### PR DESCRIPTION
Solo5 implementation of MirageOS network interface

- Project page: <a href="https://github.com/mirage/mirage-net-solo5">https://github.com/mirage/mirage-net-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-solo5/">https://mirage.github.io/mirage-net-solo5/</a>

##### CHANGES:

* Do not `Lwt.catch` on the listen callback (@hannesm, @dinosaure, mirage/mirage-net-solo5#41)
