### PR TITLE
[new release] netchannel and mirage-net-xen (2.1.1)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.1/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.1/mirage-net-xen-2.1.1.tbz"
+  checksum: [
+    "sha256=918b007fa9edc16294a76e9d31ca7905271d50e686a4ce3ad39d235597ba81fb"
+    "sha512=684cb2feee4ca1445318bbb527c7237272c20b47fc2ed2543547e1ccf189eedaacf55a44aa29ba369c16381e9d8f5ebe15155ea767c050a1c3027fa563281d03"
+  ]
+}
+x-commit-hash: "92716b795ade110afe87c1cf1ba06f07d6bee660"

--- a/packages/netchannel/netchannel.2.1.1/opam
+++ b/packages/netchannel/netchannel.2.1.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "lwt-dllist"
+  "result" {>= "1.5"}
+  "macaddr" {>= "5.2.0"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.1/mirage-net-xen-2.1.1.tbz"
+  checksum: [
+    "sha256=918b007fa9edc16294a76e9d31ca7905271d50e686a4ce3ad39d235597ba81fb"
+    "sha512=684cb2feee4ca1445318bbb527c7237272c20b47fc2ed2543547e1ccf189eedaacf55a44aa29ba369c16381e9d8f5ebe15155ea767c050a1c3027fa563281d03"
+  ]
+}
+x-commit-hash: "92716b795ade110afe87c1cf1ba06f07d6bee660"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Do not `Lwt.catch` on the listen callback (@hannesm, @dinosaure, mirage/mirage-net-xen#103)
