### PR TITLE
[new release] otoggl (0.3.2)

### DIFF
--- a/packages/otoggl/otoggl.0.3.2/opam
+++ b/packages/otoggl/otoggl.0.3.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Bindings for Toggl API in OCaml"
+description: "Bindings for Toggl API in OCaml"
+maintainer: ["Christophe Riolo Uusivaara"]
+authors: ["Christophe Riolo Uusivaara"]
+license: "MIT"
+homepage: "https://github.com/unitrack-time-tracking/OToggl"
+bug-reports: "https://github.com/unitrack-time-tracking/OToggl/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "atdgen" {build & >= "2.2" & < "3"}
+  "atdgen-runtime" {>= "2" & < "3"}
+  "base64" {>= "3" & < "4"}
+  "containers" {>= "3" & < "4"}
+  "dune" {>= "2.0"}
+  "piaf" {>= "0"}
+  "ppx_deriving" {>= "4" & < "5"}
+  "ptime" {>= "0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/unitrack-time-tracking/OToggl.git"
+url {
+  src:
+    "https://github.com/unitrack-time-tracking/OToggl/releases/download/0.3.2/dev-0.3.2.tbz"
+  checksum: [
+    "sha256=71edecdb91d19eb28e0fd95f9e5af1bf43ece394d339186eaa6a44dfe63ca3a7"
+    "sha512=dcaa97d633cdbefa14788cec66754e857faf5ee68036f1b28709df9be82b99e48e3256d938a9550a10bd3e72c1b9749ebcdbf18f273fef034009d0ff96adde33"
+  ]
+}
+x-commit-hash: "e55b87c19561114158bc274687a12dc7ea3263db"


### PR DESCRIPTION
Bindings for Toggl API in OCaml

- Project page: <a href="https://github.com/unitrack-time-tracking/OToggl">https://github.com/unitrack-time-tracking/OToggl</a>

##### CHANGES:

- Updated the CI workflows to test all the versions of the compiler and the lower bounds of dependencies.
- Updated the unit tests to run without the Toggl token.
- Updated the dependencies.
