### PR TITLE
Package ppx_cstubs.0.5.1

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.5.1/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "andreashauptmann@t-online.de"
+authors: [ "andreashauptmann@t-online.de" ]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://fdopen.github.io/ppx_cstubs/"
+dev-repo: "git+https://github.com/fdopen/ppx_cstubs.git"
+doc: "https://fdopen.github.io/ppx_cstubs/"
+bug-reports: "https://github.com/fdopen/ppx_cstubs/issues"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "bigarray-compat"
+  "ctypes" {>= "0.13.0" & < "0.21"}
+  "integers"
+  "num"
+  "result"
+  "containers" {>= "2.2"}
+  "cppo" {build & >= "1.3"}
+  "ocaml" {>= "4.02.3"}
+  "ocaml-migrate-parsetree" {>= "1.7.0"}
+  "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
+  "dune" {>= "1.6"}
+  "ppx_tools_versioned" {>= "5.4.0"}
+  "re" {>= "1.7.2"}
+]
+
+synopsis: "Preprocessor for easier stub generation with ctypes"
+description: """
+ppx_cstubs is a ppx-based preprocessor for stub generation with
+ctypes. ppx_cstubs creates two files from a single ml file: a file
+with c stub code and an OCaml file with all additional boilerplate
+code.
+"""
+url {
+  src: "https://github.com/fdopen/ppx_cstubs/archive/0.5.1.tar.gz"
+  checksum: [
+    "md5=af3eb3a834c666ef5fcb1ec40296d5eb"
+    "sha512=7a45475c3d0b00b2466ee432d1d9dc8c93b3d198c527bf83a9dea2358657003ad0eb84ec5ab8d222d74bf792ba5525bdb19313eeafccac5f4289246286571a8b"
+  ]
+}


### PR DESCRIPTION
### `ppx_cstubs.0.5.1`
Preprocessor for easier stub generation with ctypes
ppx_cstubs is a ppx-based preprocessor for stub generation with
ctypes. ppx_cstubs creates two files from a single ml file: a file
with c stub code and an OCaml file with all additional boilerplate
code.



---
* Homepage: https://fdopen.github.io/ppx_cstubs/
* Source repo: git+https://github.com/fdopen/ppx_cstubs.git
* Bug tracker: https://github.com/fdopen/ppx_cstubs/issues

---
:camel: Pull-request generated by opam-publish v2.0.3