### PR TITLE
[new release] mirage-net-macosx (1.10.0)

### DIFF
--- a/packages/mirage-net-macosx/mirage-net-macosx.1.10.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.10.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:  "Anil Madhavapeddy <anil@recoil.org>"
+authors:     "Anil Madhavapeddy <anil@recoil.org>"
+homepage:    "https://github.com/mirage/mirage-net-macosx"
+bug-reports: "https://github.com/mirage/mirage-net-macosx/issues"
+dev-repo:    "git+https://github.com/mirage/mirage-net-macosx.git"
+doc:         "https://mirage.github.io/mirage-net-macosx/"
+
+license: "ISC"
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "1.4.0"}
+  "macaddr"
+  "sexplib"
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "vmnet" {>= "1.5.1"}
+]
+tags: "org:mirage"
+
+synopsis: "MacOS implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using the
+[Vmnet](https://github.com/mirage/ocaml-vmnet) framework that
+is available on MacOS X Yosemite onwards.  It is suitable for
+use with an OCaml network stack such as the one found at
+<https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-macosx/releases/download/v1.10.0/mirage-net-macosx-1.10.0.tbz"
+  checksum: [
+    "sha256=8285cd3c8e49afec4fa4b72d23430071aa1832971c0b0bcdd0b62587f90ba4cc"
+    "sha512=b5b521b4339ef1e932b7b512338c84d0baaea09a4aa3e8748eac4d7063a79eeb3c72fdfc44ff6c3d5dca8680aee403ba63202337c0fb1f4e50d4ac128d975225"
+  ]
+}
+x-commit-hash: "ee5745d8b8c28af48958edf6df08c58a9c95ec1e"


### PR DESCRIPTION
MacOS implementation of the Mirage_net_lwt interface

- Project page: <a href="https://github.com/mirage/mirage-net-macosx">https://github.com/mirage/mirage-net-macosx</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-macosx/">https://mirage.github.io/mirage-net-macosx/</a>

##### CHANGES:

- Do not Lwt.catch on the listen callback (mirage/mirage-net-macosx#40, @hannesm)
- Do not use the deprecated Cstruct.len (mirage/mirage-net-macosx#41, @samoht)
