### PR TITLE
[new release] mirage-net-unix (3.0.0)

### DIFF
--- a/packages/mirage-net-unix/mirage-net-unix.3.0.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.3.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "macaddr"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/mirage/mirage-net-unix.git"

--- a/packages/mirage-net-unix/mirage-net-unix.3.0.0/opam
+++ b/packages/mirage-net-unix/mirage-net-unix.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "David Scott" "Thomas Gazagnaire" "Hannes Mehnert"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-net-unix"
+doc: "https://mirage.github.io/mirage-net-unix/"
+bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.7.1"}
+  "cstruct-lwt"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "tuntap" {>= "1.8.0"}
+  "alcotest" {with-test}
+  "logs"
+  "macaddr"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-net-unix.git"
+synopsis: "Unix implementation of the Mirage_net_lwt interface"
+description: """
+This interface exposes raw Ethernet frames using `ocaml-tuntap`,
+suitable for use with an OCaml network stack such as the one
+found at <https://github.com/mirage/mirage-tcpip>.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-unix/releases/download/v3.0.0/mirage-net-unix-3.0.0.tbz"
+  checksum: [
+    "sha256=87a9ea89634d24707952c5bfa1bda1be17e030377c90dca4ed0feadee55293cc"
+    "sha512=f42039d4937e07db8a2b267b2c46ceeaeee6b621eafe1641759efa7697d07924ac833082711420aac8f3b8e7959a0093d17881b0ff3d60a3a691c2304cea6868"
+  ]
+}
+x-commit-hash: "22901f7e833837b0d72cdaf93afc9a86ae1ddd46"


### PR DESCRIPTION
Unix implementation of the Mirage_net_lwt interface

- Project page: <a href="https://github.com/mirage/mirage-net-unix">https://github.com/mirage/mirage-net-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-unix/">https://mirage.github.io/mirage-net-unix/</a>

##### CHANGES:

* Netif.listen: do not catch exceptions (mirage/mirage-net-unix#50 @hannesm)
