### PR TITLE
[new release] albatross (1.4.3)

### DIFF
--- a/packages/albatross/albatross.1.4.3/opam
+++ b/packages/albatross/albatross.1.4.3/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune"
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+available: os != "macos"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.4.3/albatross-1.4.3.tbz"
+  checksum: [
+    "sha256=fd235fedabdbc7b7523bfc3afab2b878dd862314b52fcc80604076a2cff9eb2b"
+    "sha512=86939f0e444f49ed52398efeef8d5382a66b8529d084c22b83cd5c2bc860b2df0d9827093f96ed9bde4d586694dd758d9fb0e6800aedcd761f244c55a6a549f3"
+  ]
+}
+x-commit-hash: "340f0e4771b57e50f4d7ff63d3115f353db50527"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- Debian packaging: set architecture to DEB_TARGET_ARCH (@reynir)
- FreeBSD packaging: normalize version number (. instead of -) (@hannesm)
- Add systemd service script for albatross_influx (@hannesm)
- Update to cmdliner 1.1.0 (roburio/albatross#104 @hannesm)
- Support IPv6 in daemon (albatross_tls_endpoint) and influx (roburio/albatross#104 @hannesm)
