### PR TITLE
[new release] builder (0.3.1)

### DIFF
--- a/packages/builder/builder.0.3.1/opam
+++ b/packages/builder/builder.0.3.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/builder"
+dev-repo: "git+https://github.com/roburio/builder.git"
+bug-reports: "https://github.com/roburio/builder/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "asn1-combinators"
+  "bheap" {>= "2.0.0"}
+  "bos"
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "fmt" {>= "0.8.7"}
+  "fpath"
+  "logs"
+  "lwt"
+  "ptime"
+  "uuidm"
+  "http-lwt-client" {>= "0.0.4"}
+  "base64"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+
+synopsis: "Scheduling and executing shell jobs"
+description: """
+The builder server has a schedule of jobs to be executed, stored persistently
+on disk. Any number of workers can connect via TCP (using ASN.1 encoded
+messages) that execute a single job -- usually contained in a sandbox (FreeBSD
+jail or Docker container). A client is a command-line interface to modify the
+schedule. Access control is out of scope - run it locally on your build host.
+The server receives the output artifacts of each job, and either stores them
+on the local file system or upload them to a remote server via http.
+
+See https://builds.robur.coop for the live web frontend (builder-web).
+"""
+url {
+  src:
+    "https://github.com/roburio/builder/releases/download/v0.3.1/builder-0.3.1.tbz"
+  checksum: [
+    "sha256=0b85b4a8afcebbd82804234df72fa5f59ed9156ee56fcbfdbc883eb130c093fc"
+    "sha512=ab2d63a3a494b2f3710a13873a3c744c974e4f002aaf6ae8c2095c847205e2f8049ee9bf65cd28555353c4dce4ca56143fbc5da29aa65c1c5d48081ae7ad7521"
+  ]
+}
+x-commit-hash: "cf8366c3e79cfaa4cd48a93bb5ce38cc76c2c7a5"


### PR DESCRIPTION
Scheduling and executing shell jobs

- Project page: <a href="https://github.com/roburio/builder">https://github.com/roburio/builder</a>

##### CHANGES:

* Debian postinstall: create user/group conditionally, systemd daemon-reload
* FreeBSD packaging: add user/group for builder, create /var/db/builder
* Debian packaging: set architecture to DEB_TARGET_ARCH
* FreeBSD packaging: normalize version (. instead of -)
* Debian template: install dh-exec
* Refactor builder-worker.server: split long ExecStart line, use variables
  for builder platform and docker image, pass platform to builder-worker
* Update to cmdliner 1.1.0
