### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.2.0)

### DIFF
--- a/packages/git-mirage/git-mirage.3.7.0/opam
+++ b/packages/git-mirage/git-mirage.3.7.0/opam
@@ -20,7 +20,7 @@ depends: [
   "tls-mirage"
   "uri"
   "hex"
-  "happy-eyeballs-mirage" {>= "0.1.2"}
+  "happy-eyeballs-mirage" {>= "0.1.2" & < "0.2.0"}
   "happy-eyeballs" {>= "0.1.2"}
   "ca-certs-nss"
   "mirage-crypto"

--- a/packages/git-mirage/git-mirage.3.8.0/opam
+++ b/packages/git-mirage/git-mirage.3.8.0/opam
@@ -21,7 +21,7 @@ depends: [
   "tls-mirage"
   "uri"
   "hex"
-  "happy-eyeballs-mirage" {>= "0.1.2"}
+  "happy-eyeballs-mirage" {>= "0.1.2" & < "0.2.0"}
   "happy-eyeballs" {>= "0.1.2"}
   "ca-certs-nss"
   "mirage-crypto"

--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.2.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.2.0/happy-eyeballs-0.2.0.tbz"
+  checksum: [
+    "sha256=5d7f023e6d81db76251273ff06f4f19f0f56e5f17bb697da3c99e4cc79c9b7b1"
+    "sha512=8087b53c52ef658846bbfa8f5841d5d5211c73e8b9b9020e856c63e98820749c32c50890f4eb1372a1947890a670d939f3970f90c98c905530f35a996cd63a7a"
+  ]
+}
+x-commit-hash: "a4df20ca74dc268173758b0a59394a138db64186"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.2.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.2.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.2.0/happy-eyeballs-0.2.0.tbz"
+  checksum: [
+    "sha256=5d7f023e6d81db76251273ff06f4f19f0f56e5f17bb697da3c99e4cc79c9b7b1"
+    "sha512=8087b53c52ef658846bbfa8f5841d5d5211c73e8b9b9020e856c63e98820749c32c50890f4eb1372a1947890a670d939f3970f90c98c905530f35a996cd63a7a"
+  ]
+}
+x-commit-hash: "a4df20ca74dc268173758b0a59394a138db64186"

--- a/packages/happy-eyeballs/happy-eyeballs.0.2.0/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.2.0/happy-eyeballs-0.2.0.tbz"
+  checksum: [
+    "sha256=5d7f023e6d81db76251273ff06f4f19f0f56e5f17bb697da3c99e4cc79c9b7b1"
+    "sha512=8087b53c52ef658846bbfa8f5841d5d5211c73e8b9b9020e856c63e98820749c32c50890f4eb1372a1947890a670d939f3970f90c98c905530f35a996cd63a7a"
+  ]
+}
+x-commit-hash: "a4df20ca74dc268173758b0a59394a138db64186"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Happy_eyeballs_mirage: add a module type signature to allow creation of
  a MirageOS device (roburio/happy-eyeballs#22 @dinosaure)
* happy-eyeballs-lwt: update to cmdliner 1.1.0 (@hannesm)
