### PR TITLE
[new release] http-lwt-client (0.0.6)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.6/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.8.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.6/http-lwt-client-0.0.6.tbz"
+  checksum: [
+    "sha256=b4b14aa5ead3d6d27827b90c4827268169c176b5c52ba3e08c0f1e519599fb49"
+    "sha512=a1093a5d24b10ce89cb1062d43964e2611e118f00e918cea927ab0ad2cf5beccb8f6269849c90f8e1a1dd495032becd185466e10bcb97bb7984b8edc27765c40"
+  ]
+}
+x-commit-hash: "20a06b2bac4f7c096eb064e841488bdccc462ed6"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* upgrade to cmdliner 1.1.0 API (@hannesm)
