### PR TITLE
Package data-encoding.0.5.2

### DIFF
--- a/packages/data-encoding/data-encoding.0.5.2/opam
+++ b/packages/data-encoding/data-encoding.0.5.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/data-encoding/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/data-encoding.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "2.0" }
+  "ezjsonm"
+  "zarith" {>= "1.4"}
+  "zarith_stubs_js"
+  "hex" {>= "1.3.0"}
+  "json-data-encoding" { = "0.11" }
+  "json-data-encoding-bson" { = "0.11" }
+  "alcotest" { with-test }
+  "crowbar" { >= "0.2" & with-test }
+  "either"
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+  "js_of_ocaml-compiler" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Library of JSON and binary encoding combinators"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v0.5.2/data-encoding-v0.5.2.tar.gz"
+  checksum: [
+    "md5=9ada8b4e50aeb27d404039d3504d4d53"
+    "sha512=4d7c06c69661c9b288465ffb0e418257bfa7e8dd83da22be2a542e9156078fc8c1e93826fbd5bd89dcecf72f7af2deefa019ecaba7d32af4e9e90ddf9ef6d4b8"
+  ]
+}


### PR DESCRIPTION
### `data-encoding.0.5.2`
Library of JSON and binary encoding combinators



---
* Homepage: https://gitlab.com/nomadic-labs/data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/data-encoding.git
* Bug tracker: https://gitlab.com/nomadic-labs/data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0