### PR TITLE
Mark the solo5-kernel-* packages as deprecated

### DIFF
--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/opam
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/opam
@@ -21,6 +21,7 @@ conflicts: [
   "solo5-kernel-virtio"
 ]
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available:
   (arch = "x86_64" | arch = "x86_64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")

--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.1/opam
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.1/opam
@@ -21,6 +21,7 @@ conflicts: [
   "solo5-kernel-virtio"
 ]
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available:
   (arch = "x86_64" | arch = "x86_64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.1.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.1.1/opam
@@ -24,6 +24,7 @@ depexts: [
 ]
 conflicts: "solo5-kernel-virtio"
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available: arch = "x86_64" & os = "linux"
 synopsis: "Solo5 unikernel base (ukvm target)"
 description:

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.1/opam
@@ -24,6 +24,7 @@ depexts: [
 ]
 conflicts: "solo5-kernel-virtio"
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available: arch = "x86_64" & os = "linux"
 synopsis: "Solo5 unikernel base (ukvm target)"
 description: """

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2-1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2-1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: "solo5-kernel-virtio"
+flags: deprecated
 available: arch = "x86_64" & os = "linux"
 patches: [ "solo5-no-werror.diff" "solo5-no-asm-msr-index.diff" ]
 synopsis: "Solo5 unikernel base (ukvm target)"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.2.2/opam
@@ -23,6 +23,7 @@ depexts: [
   ["kernel-headers"] {os-distribution = "rhel"}
 ]
 conflicts: "solo5-kernel-virtio"
+flags: deprecated
 x-ci-accept-failures: ["debian-unstable"]
 available: arch = "x86_64" & os = "linux"
 synopsis: "Solo5 unikernel base (ukvm target)"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
@@ -27,6 +27,7 @@ conflicts: [
   "solo5-kernel-muen"
 ]
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available:
   (arch = "x86_64" | arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
@@ -27,6 +27,7 @@ conflicts: [
   "solo5-kernel-virtio"
   "solo5-kernel-muen"
 ]
+flags: deprecated
 available:
   (arch = "x86_64" | arch = "x86_64" | arch = "arm64") &
   (os = "linux" | os = "freebsd" | os = "openbsd")

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: "solo5-kernel-ukvm"
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available: arch = "x86_64" & os != "macos"
 synopsis: "Solo5 unikernel base (virtio target)"
 description:

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.1/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: "solo5-kernel-ukvm"
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available: (arch = "x86_64" | arch = "x86_64") & os != "macos"
 synopsis: "Solo5 unikernel base (virtio target)"
 description: """

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2-1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2-1/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: "solo5-kernel-ukvm"
 available: (arch = "x86_64" | arch = "x86_64") & os != "macos"
+flags: deprecated
 patches: [ "solo5-no-werror.diff" ]
 synopsis: "Solo5 unikernel base (virtio target)"
 description: """

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/opam
@@ -18,6 +18,7 @@ depends: [
 ]
 conflicts: "solo5-kernel-ukvm"
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available: (arch = "x86_64" | arch = "x86_64") & os != "macos"
 synopsis: "Solo5 unikernel base (virtio target)"
 description: """

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/opam
@@ -21,6 +21,7 @@ conflicts: [
   "solo5-kernel-muen"
 ]
 x-ci-accept-failures: ["debian-unstable"]
+flags: deprecated
 available: (arch = "x86_64" | arch = "x86_64") & os != "macos"
 synopsis: "Solo5 sandboxed execution environment (virtio target)"
 description: """

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.1/opam
@@ -22,6 +22,7 @@ conflicts: [
   "solo5-kernel-muen"
 ]
 available: (arch = "x86_64" | arch = "x86_64") & os != "macos"
+flags: deprecated
 synopsis: "Solo5 sandboxed execution environment (virtio target)"
 description: """
 Solo5 is a sandboxed execution environment primarily intended for, but not


### PR DESCRIPTION
They don’t seem to be updated anymore and all fail with:
```
#=== ERROR while compiling solo5-kernel-ukvm.0.3.1 ============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/solo5-kernel-ukvm.0.3.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make ukvm
# exit-code            2
# env-file             ~/.opam/log/solo5-kernel-ukvm-10-6b7602.env
# output-file          ~/.opam/log/solo5-kernel-ukvm-10-6b7602.out
### output ###
# ./configure.sh
# ./configure.sh: Only 'gcc' 4.x+ is supported on Linux
# Makefile.common:22: /home/opam/.opam/4.13/.opam-switch/build/solo5-kernel-ukvm.0.3.1/Makeconf: No such file or directory
# make: *** [GNUmakefile:21: /home/opam/.opam/4.13/.opam-switch/build/solo5-kernel-ukvm.0.3.1/Makeconf] Error 1
```
on systems with GCC >= 10