### PR TITLE
optint.0.1.0 is not compatible with pprint.20220103 (uses PPrintOCaml)

### DIFF
--- a/packages/optint/optint.0.1.0/opam
+++ b/packages/optint/optint.0.1.0/opam
@@ -23,6 +23,7 @@ depends: [
   "dune"
   "crowbar" {with-test & >= "0.2"}
   "monolith" {with-test}
+  "pprint" {with-test & < "20220103"}
   "fmt" {with-test}
 ]
 x-commit-hash: "34f6f88360df1b71870d471088e1dbb581578f20"


### PR DESCRIPTION
```
#=== ERROR while compiling optint.0.1.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/optint.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p optint -j 127
# exit-code            1
# env-file             ~/.opam/log/optint-2071-10e7de.env
# output-file          ~/.opam/log/optint-2071-10e7de.out
### output ###
# (cd _build/default && /home/opam/.opam/4.13/bin/ocamlopt.opt -w -40 -g -I fuzz/.fuzz_int63.eobjs/byte -I fuzz/.fuzz_int63.eobjs/native -I /home/opam/.opam/4.13/lib/afl-persistent -I /home/opam/.opam/4.13/lib/monolith -I /home/opam/.opam/4.13/lib/pprint -I /home/opam/.opam/4.13/lib/seq -I src/.optint.objs/byte -I src/.optint.objs/native -intf-suffix .ml -no-alias-deps -o fuzz/.fuzz_int63.eobjs/native/fuzz_int63.cmx -c -impl fuzz/fuzz_int63.ml)
# File "fuzz/fuzz_int63.ml", line 11, characters 44-61:
# 11 |   let pos = easily_constructible gen_random PPrintOCaml.int32 in
#                                                  ^^^^^^^^^^^^^^^^^
# Error: Unbound module PPrintOCaml
# (cd _build/default/fuzz && ./fuzz.exe)
# identity with int32: PASS
# 
# identity with int: PASS
# 
# computation: PASS
# 
```