### PR TITLE
odoc.2.0.0 is not compatible with OCaml 4.14

### DIFF
--- a/packages/odoc/odoc.2.0.0/opam
+++ b/packages/odoc/odoc.2.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.14"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"


### PR DESCRIPTION
```
#=== ERROR while compiling odoc.2.0.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/odoc.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p odoc -j 31
# exit-code            1
# env-file             ~/.opam/log/odoc-10-76df4d.env
# output-file          ~/.opam/log/odoc-10-76df4d.out
### output ###
#       ocamlc src/loader/.odoc_loader.objs/byte/odoc_loader__Cmi.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/odoc-parser -I /home/opam/.opam/4.14/lib/result -I src/model/.odoc_model.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Cmi.cmo -c -impl src/loader/cmi.pp.ml)
# File "src/loader/cmi.ml", line 94, characters 12-14:
# Error: This expression has type Types.type_expr
#        but an expression was expected of type Types.transient_expr
#       ocamlc src/loader/.odoc_loader.objs/byte/odoc_loader__Cmti.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/odoc-parser -I /home/opam/.opam/4.14/lib/result -I src/model/.odoc_model.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Cmti.cmo -c -impl src/loader/cmti.pp.ml)
# File "src/loader/cmti.ml", line 297, characters 4-24:
# Error: The constructor Text_decl expects 3 argument(s),
#        but is applied here to 2 argument(s)
#     ocamlopt src/loader/.odoc_loader.objs/native/odoc_loader__Cmi.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -w -18-53 -g -I src/loader/.odoc_loader.objs/byte -I src/loader/.odoc_loader.objs/native -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/odoc-parser -I /home/opam/.opam/4.14/lib/result -I src/model/.odoc_model.objs/byte -I src/model/.odoc_model.objs/native -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/native/odoc_loader__Cmi.cmx -c -impl src/loader/cmi.pp.ml)
# File "src/loader/cmi.ml", line 94, characters 12-14:
# Error: This expression has type Types.type_expr
#        but an expression was expected of type Types.transient_expr
```