### PR TITLE
mirage-vnetif >= 0.4.1: Add missing dependency

### DIFF
--- a/packages/mirage-vnetif/mirage-vnetif.0.4.1/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.4.1/opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-profile"
   "duration"
   "logs"
+  "result"
 ]
 tags: ["org:mirage"]
 synopsis: "Virtual network interface and software switch for Mirage"

--- a/packages/mirage-vnetif/mirage-vnetif.0.4.2/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.4.2/opam
@@ -25,6 +25,7 @@ depends: [
   "mirage-profile"
   "duration"
   "logs"
+  "result"
 ]
 tags: ["org:mirage"]
 synopsis: "Virtual network interface and software switch for Mirage"

--- a/packages/mirage-vnetif/mirage-vnetif.0.5.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.5.0/opam
@@ -25,6 +25,7 @@ depends: [
   "mirage-profile"
   "duration"
   "logs"
+  "result"
 ]
 tags: ["org:mirage"]
 synopsis: "Virtual network interface and software switch for Mirage"


### PR DESCRIPTION
(previously pulled by lwt < 5.6.0)
```
#=== ERROR while compiling mirage-vnetif.0.5.0 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.13/.opam-switch/build/mirage-vnetif.0.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mirage-vnetif -j 255
# exit-code            1
# env-file             ~/.opam/log/mirage-vnetif-10-c38d8e.env
# output-file          ~/.opam/log/mirage-vnetif-10-c38d8e.out
### output ###
# File "src/dune", line 7, characters 12-18:
# 7 |    duration result mirage-time mirage-net logs))
#                 ^^^^^^
# Error: Library "result" not found.
# -> required by library "mirage-vnetif" in _build/default/src
# -> required by _build/default/META.mirage-vnetif
# -> required by _build/install/default/lib/mirage-vnetif/META
# -> required by _build/default/mirage-vnetif.install
# -> required by alias install
```