### PR TITLE
notty is not compatible with OCaml 4.14

### DIFF
--- a/packages/notty/notty.0.2.1/opam
+++ b/packages/notty/notty.0.2.1/opam
@@ -11,7 +11,7 @@ build: [
           "--with-lwt" "%{lwt:installed}%"
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/notty/notty.0.2.2/opam
+++ b/packages/notty/notty.0.2.2/opam
@@ -17,7 +17,7 @@ build: [
           "--with-lwt" "%{lwt:installed}%"
 ]
 depends: [
-  "ocaml" { >= "4.05.0" }
+  "ocaml" { >= "4.05.0" & < "4.14"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}


### PR DESCRIPTION
uses `Toploop.use_silently`
```
#=== ERROR while compiling notty.0.2.2 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/notty.0.2.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --with-lwt false
# exit-code            1
# env-file             ~/.opam/log/notty-10-2fadc9.env
# output-file          ~/.opam/log/notty-10-2fadc9.out
### output ###
# ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package ocb-stubblr myocamlbuild.ml /home/opam/.opam/4.14/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamldep -package 'uchar uucp uuseg uutf' -modules src/notty.ml > src/notty.ml.depends
# ocamlfind ocamldep -package 'uchar uucp uuseg uutf' -modules src/notty.mli > src/notty.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty.cmi src/notty.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty.cmx src/notty.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty.cmx src/notty.ml
# File "src/notty.ml", line 432, characters 6-36:
# 432 |       pp_set_formatter_tag_functions fmt
#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Format.pp_set_formatter_tag_functions
# This function will erase non-string tag formatting functions. Use Format.pp_set_formatter_stag_functions.
# File "src/notty.ml", line 441, characters 41-52:
# 441 |     let pp_open_attribute_tag fmt attr = pp_open_tag fmt (A.to_tag attr)
#                                                ^^^^^^^^^^^
# Alert deprecated: Stdlib.Format.pp_open_tag
# Use Format.pp_open_stag.
# File "src/notty.ml", line 458, characters 47-59:
# 458 |       pp_open_attribute_tag fmt attr; f fmt a; pp_close_tag fmt ()
#                                                      ^^^^^^^^^^^^
# Alert deprecated: Stdlib.Format.pp_close_tag
# Use Format.pp_close_stag.
# ocamlfind ocamlopt -a -package 'uchar uucp uuseg uutf' -I src src/notty.cmx -o src/notty.cmxa
# ocamlfind ocamlopt -shared -linkall -I . -I unix -I src -I lwt -package 'uchar uucp uuseg uutf' -I src src/notty.cmxa -o src/notty.cmxs
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty.cmo src/notty.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty.cmo src/notty.ml
# File "src/notty.ml", line 432, characters 6-36:
# 432 |       pp_set_formatter_tag_functions fmt
#             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Format.pp_set_formatter_tag_functions
# This function will erase non-string tag formatting functions. Use Format.pp_set_formatter_stag_functions.
# File "src/notty.ml", line 441, characters 41-52:
# 441 |     let pp_open_attribute_tag fmt attr = pp_open_tag fmt (A.to_tag attr)
#                                                ^^^^^^^^^^^
# Alert deprecated: Stdlib.Format.pp_open_tag
# Use Format.pp_open_stag.
# File "src/notty.ml", line 458, characters 47-59:
# 458 |       pp_open_attribute_tag fmt attr; f fmt a; pp_close_tag fmt ()
#                                                      ^^^^^^^^^^^^
# Alert deprecated: Stdlib.Format.pp_close_tag
# Use Format.pp_close_stag.
# ocamlfind ocamlc -a -package 'uchar uucp uuseg uutf' -I src src/notty.cmo -o src/notty.cma
# ocamlfind ocamldep -package compiler-libs.toplevel -package 'uchar uucp uuseg uutf' -modules src/notty_top.ml > src/notty_top.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty_top.cmo src/notty_top.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -package 'uchar uucp uuseg uutf' -w A-4-44-48-58 -color always -I src -I unix -I lwt -o src/notty_top.cmo src/notty_top.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# File "src/notty_top.ml", line 4, characters 50-69:
# 4 | let _ = Toploop.use_silently Format.err_formatter "notty_top_init.ml"
#                                                       ^^^^^^^^^^^^^^^^^^^
# Error: This expression has type string but an expression was expected of type
#          Toploop.input
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' '-plugin-tag' 'package(ocb-stubblr)' 'opam'
#      'pkg/META' 'CHANGES.md' 'LICENSE.md' 'README.md' 'src/notty.a'
#      'src/notty.cmxs' 'src/notty.cmxa' 'src/notty.cma' 'src/notty.cmx'
#      'src/notty.cmi' 'src/notty.mli' 'src/notty_top.a' 'src/notty_top.cmxs'
#      'src/notty_top.cmxa' 'src/notty_top.cma' 'src/notty_top.cmx'
#      'src/notty_top_init.ml' 'unix/notty_unix.a' 'unix/notty_unix.cmxs'
#      'unix/notty_unix.cmxa' 'unix/notty_unix.cma' 'unix/notty_unix.cmx'
#      'unix/notty_unix.cmi' 'unix/notty_unix.mli'
#      'unix/dllnotty_unix_stubs.so' 'unix/libnotty_unix_stubs.a']: exited with 10
```