### PR TITLE
capnp-rpc < 1.2.2 is not compatible with OCaml 4.14

### DIFF
--- a/packages/capnp-rpc/capnp-rpc.0.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "uint" {< "2.0.0"}
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.2/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "uint" {< "2.0.0"}
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.3.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.1/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "uint" {< "2.0.0"}
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.3.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "uint" {< "2.0.0"}
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.3.3/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3.3/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "uint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.3/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.3/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "uint" {< "2.0.0"}
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.4.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.4.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.5.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.5.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.6.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.6.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.7.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.7.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.8.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.8.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.0.9.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.0.9.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.1.0/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.1.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt"

--- a/packages/capnp-rpc/capnp-rpc.1.2.1/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.2.1/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt" {>= "0.8.7"}

--- a/packages/capnp-rpc/capnp-rpc.1.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/capnp-rpc"
 bug-reports: "https://github.com/mirage/capnp-rpc/issues"
 doc: "https://mirage.github.io/capnp-rpc/"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.14"}
   "stdint"
   "astring"
   "fmt" {>= "0.8.7"}


### PR DESCRIPTION
(see https://github.com/ocaml/ocaml/issues/10773)
```
#=== ERROR while compiling capnp-rpc.1.2.1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/capnp-rpc.1.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p capnp-rpc -j 31
# exit-code            1
# env-file             ~/.opam/log/capnp-rpc-10-ef4d2f.env
# output-file          ~/.opam/log/capnp-rpc-10-ef4d2f.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I capnp-rpc/.capnp_rpc.objs/byte -I /home/opam/.opam/4.14/lib/asetmap -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/stdint -no-alias-deps -open Capnp_rpc__ -o capnp-rpc/.capnp_rpc.objs/byte/capnp_rpc__Struct_proxy.cmo -c -impl capnp-rpc/struct_proxy.ml)
# File "capnp-rpc/struct_proxy.ml", line 1:
# Error: The implementation capnp-rpc/struct_proxy.ml
#        does not match the interface (inferred signature):  ... ...
#        In module Make:
#        Class declarations do not match:
#          class virtual ['promise] t :
#            'promise ->
#            object
#              val mutable blocker : C.base_ref option
#              val id : Capnp_rpc__.Debug.OID.t
#              val virtual name : string
#              val mutable state : 'promise state
#              method blocker : C.base_ref option
#              method cap : C.Wire.Path.t -> C.cap
#              method check_invariants : unit
#              method clear_blocker : unit
#              method private virtual do_pipeline :
#                'promise ->
#                C.Wire.Path.t -> C.struct_resolver -> C.Wire.Request.t -> unit
#              method field_blocker : C.Wire.Path.t -> C.base_ref option
#              method field_check_invariants : Field_map.key -> unit
#              method field_dec_ref : Field_map.key -> unit
#              method field_pp : Field_map.key -> Format.formatter -> unit
#              method private field_resolved : C.cap -> unit
#              method virtual field_sealed_dispatch :
#                C.Wire.Path.t -> 'a Capnp_rpc__.S.brand -> 'a option
#              method field_update_rc : Field_map.key -> int -> unit
#              method field_when_resolved :
#                C.Wire.Path.t -> (C.cap -> unit) -> unit
#              method private virtual on_resolve :
#                'promise -> C.struct_ref -> unit
#              method pipeline :
#                C.Wire.Path.t -> C.struct_resolver -> C.Wire.Request.t -> unit
#              method pp : Format.formatter -> unit
#              method private virtual pp_unresolved : 'promise Fmt.t
#              method resolve : C.struct_ref -> unit
#              method resolver : C.struct_resolver
#              method response : C.Wire.Response.t C.or_error option
#              method sealed_dispatch : 'a Capnp_rpc__S.brand -> 'a option
#              method private virtual send_cancel : 'promise -> unit
#              method set_blocker : C.base_ref -> (unit, [> `Cycle ]) result
#              method update_rc : int -> unit
#              method private update_target : 'promise -> unit
#              method when_resolved :
#                (C.Wire.Response.t C.or_error -> unit) -> unit
#            end
#        does not match
#          class virtual ['promise] t :
#            'promise ->
#            object
#              val mutable blocker : C.base_ref option
#              val id : Capnp_rpc__.Debug.OID.t
#              val virtual name : string
#              val mutable state : 'promise state
#              method blocker : C.base_ref option
#              method cap : C.Wire.Path.t -> C.cap
#              method check_invariants : unit
#              method clear_blocker : unit
#              method private virtual do_pipeline :
#                'promise ->
#                C.Wire.Path.t -> C.struct_resolver -> C.Wire.Request.t -> unit
#              method field_blocker : C.Wire.Path.t -> C.base_ref option
#              method field_check_invariants : Field_map.key -> unit
#              method field_dec_ref : Field_map.key -> unit
#              method field_pp : Field_map.key -> Format.formatter -> unit
#              method private field_resolved : C.cap -> unit
#              method virtual field_sealed_dispatch :
#                C.Wire.Path.t -> 'a Capnp_rpc__.S.brand -> 'a option
#              method field_update_rc : Field_map.key -> int -> unit
#              method field_when_resolved :
#                C.Wire.Path.t -> (C.cap -> unit) -> unit
#              method private virtual on_resolve :
#                'promise -> C.struct_ref -> unit
#              method pipeline :
#                C.Wire.Path.t -> C.struct_resolver -> C.Wire.Request.t -> unit
#              method pp : Format.formatter -> unit
#              method private virtual pp_unresolved : 'promise Fmt.t
#              method resolve : C.struct_ref -> unit
#              method resolver : C.struct_resolver
#              method response : C.Wire.Response.t C.or_error option
#              method sealed_dispatch : 'a Capnp_rpc__S.brand -> 'a option
#              method private virtual send_cancel : 'promise -> unit
#              method set_blocker : C.base_ref -> (unit, [> `Cycle ]) result
#              method update_rc : int -> unit
#              method private update_target : 'promise -> unit
#              method when_resolved :
#                (C.Wire.Response.t C.or_error -> unit) -> unit
#            end
#        The method set_blocker has type
#          C.base_ref -> (unit, [> `Cycle ]) result
#        but is expected to have type C.base_ref -> (unit, [> `Cycle ]) result
#        Type [> `Cycle ] is not compatible with type [> `Cycle ] 
```