### PR TITLE
metaquot is not compatible with OCaml 4.14

### DIFF
--- a/packages/metaquot/metaquot.0.5.0/opam
+++ b/packages/metaquot/metaquot.0.5.0/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/thierry-martinez/metaquot"
 doc: "https://github.com/thierry-martinez/metaquot"
 bug-reports: "https://github.com/thierry-martinez/metaquot"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "4.14"}
   "stdcompat" {>= "12"}
   "ppxlib" {>= "0.22.0"}
   "ocamlfind" {>= "1.8.1"}


### PR DESCRIPTION
(OCaml API change)
```
#=== ERROR while compiling metaquot.0.5.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/metaquot.0.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p metaquot -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/metaquot-10-6e702b.env
# output-file          ~/.opam/log/metaquot-10-6e702b.out
### output ###
# File "metaquot/dune", line 3, characters 14-53:
# 3 |   (preprocess (pps metapp metapp.ppx ppxlib.metaquot))
#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# (cd _build/default && .ppx/502dc45323f5502107696d0317a21fde/ppx.exe --cookie 'library-name="metaquot"' -o metaquot/metaquot.pp.ml --impl metaquot/metaquot.ml -corrected-suffix .ppx-corrected -diff-cmd - -dump-ast)
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# File "metaquot/metaquot.ml", line 110, characters 11-15:
# 110 |   match ty.desc with
#                  ^^^^
# Error: Unbound record field desc
# File "_none_", line 1:
# Error: Unable to compile preprocessor: command-line
#        "'ocamlfind' 'ocamlopt' '-package' 'metapp.preutils,metapp.api,ppxlib,metapp,findlib' '-open' 'Stdcompat' '-I' '+compiler-libs' '-w' '-40' '-shared' '/opam-tmp/build_72a024_dune/metapp050521.ml' '-o' '/opam-tmp/build_72a024_dune/metapp050521.cmxs'"
#        failed with exit-code 2
```