### PR TITLE
ocp-index < 1.3.3 is not compatible with OCaml 4.14

### DIFF
--- a/packages/ocp-index/ocp-index.1.3.1/opam
+++ b/packages/ocp-index/ocp-index.1.3.1/opam
@@ -21,7 +21,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.14"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}

--- a/packages/ocp-index/ocp-index.1.3.2/opam
+++ b/packages/ocp-index/ocp-index.1.3.2/opam
@@ -21,7 +21,7 @@ tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "4.14"}
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}


### PR DESCRIPTION
(OCaml API change)
```
#=== ERROR while compiling ocp-index.1.3.2 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ocp-index.1.3.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocp-index -j 47
# exit-code            1
# env-file             ~/.opam/log/ocp-index-10-c0c138.env
# output-file          ~/.opam/log/ocp-index-10-c0c138.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I libs/.indexLib.objs/byte -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/byte/indexPredefined.cmo -c -impl libs/indexPredefined.pp.ml)
# File "libs/indexPredefined.ml", line 123, characters 20-34:
# Error: This expression has type 'a * 'b * 'c
#        but an expression was expected of type Outcometree.out_constructor
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I libs/.indexLib.objs/byte -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/byte/indexOut.cmo -c -impl libs/indexOut.pp.ml)
# File "libs/indexOut.ml", line 161, characters 14-21:
# Error: This expression has type Outcometree.out_constructor list
#        but an expression was expected of type
#          (string * Outcometree.out_type list * Outcometree.out_type option)
#          list
#        Type Outcometree.out_constructor is not compatible with type
#          string * Outcometree.out_type list * Outcometree.out_type option 
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I libs/.indexLib.objs/byte -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/byte/indexBuild.cmo -c -impl libs/indexBuild.pp.ml)
# File "libs/indexBuild.ml", line 245, characters 14-32:
# Error: This expression has type Outcometree.out_constructor list
#        but an expression was expected of type
#          ('a * Outcometree.out_type list * Outcometree.out_type option) list
#        Type Outcometree.out_constructor is not compatible with type
#          'a * Outcometree.out_type list * Outcometree.out_type option 
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -w -9 -g -I libs/.indexLib.objs/byte -I libs/.indexLib.objs/native -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/native/indexPredefined.cmx -c -impl libs/indexPredefined.pp.ml)
# File "libs/indexPredefined.ml", line 123, characters 20-34:
# Error: This expression has type 'a * 'b * 'c
#        but an expression was expected of type Outcometree.out_constructor
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I src/.grepMain.eobjs/byte -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/posix -I /home/opam/.opam/4.14/lib/seq -I libs/.indexLib.objs/byte -no-alias-deps -o src/.grepMain.eobjs/byte/grepMain.cmo -c -impl src/grepMain.pp.ml)
# File "src/grepMain.ml", line 201, characters 10-14:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/grepMain.ml", line 222, characters 10-14:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/grepMain.ml", line 314, characters 4-13:
# Alert deprecated: Cmdliner.Term.eval
# Use Cmd.v and one of Cmd.eval* instead.
# File "src/grepMain.ml", line 315, characters 13-17:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/grepMain.ml", line 317, characters 7-16:
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I src/.indexMain.eobjs/byte -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -I libs/.indexLib.objs/byte -I src/.indexOptions.objs/byte -no-alias-deps -o src/.indexMain.eobjs/byte/indexMain.cmo -c -impl src/indexMain.pp.ml)
# File "src/indexMain.ml", line 33, characters 13-17:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexMain.ml", line 34, characters 2-11:
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "src/indexMain.ml", line 144, characters 8-12:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexMain.ml", line 145, characters 2-11:
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "src/indexMain.ml", line 167, characters 8-12:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexMain.ml", line 168, characters 2-11:
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "src/indexMain.ml", line 209, characters 8-12:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexMain.ml", line 210, characters 2-11:
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "src/indexMain.ml", line 245, characters 8-12:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexMain.ml", line 246, characters 2-11:
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "src/indexMain.ml", line 251, characters 6-22:
# Alert deprecated: Cmdliner.Term.eval_choice
# Use Cmd.group and one of Cmd.eval* instead.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -w -9 -g -I libs/.indexLib.objs/byte -I libs/.indexLib.objs/native -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -intf-suffix .ml -no-alias-deps -o libs/.indexLib.objs/native/indexOut.cmx -c -impl libs/indexOut.pp.ml)
# File "libs/indexOut.ml", line 161, characters 14-21:
# Error: This expression has type Outcometree.out_constructor list
#        but an expression was expected of type
#          (string * Outcometree.out_type list * Outcometree.out_type option)
#          list
#        Type Outcometree.out_constructor is not compatible with type
#          string * Outcometree.out_type list * Outcometree.out_type option 
```