### PR TITLE
cinaps < v0.14.0 is not compatible with OCaml 4.14

### DIFF
--- a/packages/cinaps/cinaps.v0.10.0/opam
+++ b/packages/cinaps/cinaps.v0.10.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.14"}
   "jbuilder" {>= "1.0+beta12"}
   "re" {>= "1.5.0"}
 ]

--- a/packages/cinaps/cinaps.v0.11.0/opam
+++ b/packages/cinaps/cinaps.v0.11.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 conflicts: [ "jbuilder" { = "1.0+beta19" } ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "4.14"}
   "jbuilder" {>= "1.0+beta18.1"}
   "re" {>= "1.5.0"}
 ]

--- a/packages/cinaps/cinaps.v0.12.0/opam
+++ b/packages/cinaps/cinaps.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.14"}
   "dune"  {>= "1.5.1"}
   "re"    {>= "1.8.0"}
 ]

--- a/packages/cinaps/cinaps.v0.12.1/opam
+++ b/packages/cinaps/cinaps.v0.12.1/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.14"}
   "dune" {>= "1.11.0"}
   "re"   {>= "1.8.0"}
 ]

--- a/packages/cinaps/cinaps.v0.13.0/opam
+++ b/packages/cinaps/cinaps.v0.13.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "4.14"}
   "dune"  {>= "1.5.1"}
   "re"    {>= "1.8.0"}
 ]


### PR DESCRIPTION
uses Toploop.use_silently
```
#=== ERROR while compiling cinaps.v0.13.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.4.14.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/cinaps.v0.13.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p cinaps -j 255
# exit-code            1
# env-file             ~/.opam/log/cinaps-11-632861.env
# output-file          ~/.opam/log/cinaps-11-632861.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.cinaps.objs/byte -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I src/runtime/.cinaps_runtime.objs/byte -no-alias-deps -open Cinaps__ -o src/.cinaps.objs/byte/cinaps.cmo -c -impl src/cinaps.ml)
# File "src/cinaps.ml", line 109, characters 54-58:
# 109 |     ignore (Toploop.use_silently Format.err_formatter name : bool)))
#                                                             ^^^^
# Error: This expression has type string but an expression was expected of type
#          Toploop.input
```