### PR TITLE
[new release] solo5-elftool (0.3.1)

### DIFF
--- a/packages/solo5-elftool/solo5-elftool.0.3.1/opam
+++ b/packages/solo5-elftool/solo5-elftool.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage: "https://git.robur.io/robur/ocaml-solo5-elftool"
+dev-repo: "git+https://git.robur.io/robur/ocaml-solo5-elftool.git"
+bug-reports: "https://github.com/roburio/ocaml-solo5-elftool/issues"
+doc: "https://roburio.github.io/ocaml-solo5-elftool/doc"
+maintainer: [ "team@robur.coop" ]
+authors: [ "Reynir Björnsson <reynir@reynir.dk>" ]
+license: "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.8.0"}
+  "dune" {>= "2.9"}
+  "owee" {>= "0.4"}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.7"}
+  "cmdliner" {>= "1.1.0"}
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+synopsis: "OCaml Solo5 elftool for querying solo5 manifests"
+description: """
+OCaml Solo5 elftool is a library and executable for reading solo5 device
+manifests from solo5 ELF executables.
+"""
+url {
+  src:
+    "https://github.com/roburio/ocaml-solo5-elftool/releases/download/v0.3.1/solo5-elftool-0.3.1.tbz"
+  checksum: [
+    "sha256=8e8186f006c634fe5a7822f10aead39db7b36d540dbb17a67550252cfcbace8e"
+    "sha512=6911a3786c7255973a77ac9ff3da913d751d981a1841b349ae0b2cbf6bd31257912adba8fd270b4354d4ab2344241e1e7644e3d2d3d32a4920ccc4d137462bd7"
+  ]
+}
+x-commit-hash: "cce5571c95d77eb8374159b1851f78dd25a3c2e9"


### PR DESCRIPTION
OCaml Solo5 elftool for querying solo5 manifests

- Project page: <a href="https://git.robur.io/robur/ocaml-solo5-elftool">https://git.robur.io/robur/ocaml-solo5-elftool</a>
- Documentation: <a href="https://roburio.github.io/ocaml-solo5-elftool/doc">https://roburio.github.io/ocaml-solo5-elftool/doc</a>

##### CHANGES:

* Update to cmdliner 1.1.0
