### PR TITLE
Package res_tailwindcss.0.1.3

### DIFF
--- a/packages/res_tailwindcss/res_tailwindcss.0.1.3/opam
+++ b/packages/res_tailwindcss/res_tailwindcss.0.1.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "PPX validates the tailwindcss class names"
+description: """
+ppx_tailwindcss validates the tailwindcss class names in compile time.
+"""
+maintainer: "Greenlabs Dev <developer@greenlabs.co.kr>"
+authors: "Greenlabs Dev <developer@greenlabs.co.kr>"
+license: "MIT"
+homepage: "https://github.com/green-labs/res_tailwindcss"
+bug-reports: "https://github.com/green-labs/res_tailwindcss/issues"
+dev-repo: "git+https://github.com/green-labs/res_tailwindcss.git"
+depends: [
+  "ocaml" {>= "4.12.1"}
+  "dune" { >= "2.8"}
+  "ppxlib"
+  "core"
+  "ppx_inline_test"
+  "ppx_expect"
+  "ppx_deriving"
+  "menhir" { >= "20211230"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mattdamon108/res_tailwindcss/archive/opam-0.1.3.tar.gz"
+  checksum: [
+    "md5=23b68b1a1871fc87bb121e022aa8be89"
+    "sha512=964f61834cf0292e69cc189bece4e5d35874fd29aea17b97750570b870d349da28b284f150a1382ad37b033b1fe8e3397cc744458805617ec5d9b1121a859d38"
+  ]
+}


### PR DESCRIPTION
### `res_tailwindcss.0.1.3`
PPX validates the tailwindcss class names
ppx_tailwindcss validates the tailwindcss class names in compile time.



---
* Homepage: https://github.com/green-labs/res_tailwindcss
* Source repo: git+https://github.com/green-labs/res_tailwindcss.git
* Bug tracker: https://github.com/green-labs/res_tailwindcss/issues

---
:camel: Pull-request generated by opam-publish v2.1.0