### PR TITLE
Package binaryen.0.15.0

### DIFF
--- a/packages/binaryen/binaryen.0.15.0/opam
+++ b/packages/binaryen/binaryen.0.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "105.1.0" & < "106.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.15.0/binaryen-archive-v0.15.0.tar.gz"
+  checksum: [
+    "md5=f95edaf3ca5668adacf1018bd41a2f76"
+    "sha512=dfe3bf1b68fbdafc7df874cc065e57c10ea8fbeef83573d47a9f269403252b84828d413acbdb9b7816cd0f3ec192d9429193feee60e9a18cab0e1de5e44c93ed"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.15.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.15.0](https://github.com/grain-lang/binaryen.ml/compare/v0.14.1...v0.15.0) (2022-03-16)


### ⚠ BREAKING CHANGES

* Rename segment name to data (#146)
* Add Passes module & require `Passes.t` in `Module.run_passes` (#145)
* Remove virtual modules
* Remove the "jsoo hack" API
* Update libbinaryen to v105 (#142)

### Features

* Add Passes module & require `Passes.t` in `Module.run_passes` ([#145](https://github.com/grain-lang/binaryen.ml/issues/145)) ([c3e751c](https://github.com/grain-lang/binaryen.ml/commit/c3e751c4f869b9481e18c85a525100fbdcfa9072))
* Remove the "jsoo hack" API ([3c81209](https://github.com/grain-lang/binaryen.ml/commit/3c81209763e3d09d51a5ab68ebd705582fe02c54))
* Remove unneeded js_of_ocaml & js_of_ocaml-ppx deps ([3c81209](https://github.com/grain-lang/binaryen.ml/commit/3c81209763e3d09d51a5ab68ebd705582fe02c54))
* Remove virtual modules ([3c81209](https://github.com/grain-lang/binaryen.ml/commit/3c81209763e3d09d51a5ab68ebd705582fe02c54))
* Rename segment name to data ([#146](https://github.com/grain-lang/binaryen.ml/issues/146)) ([d55e577](https://github.com/grain-lang/binaryen.ml/commit/d55e5773d39fd5f21f556e0f5493d6c60bbc2198))
* Rewrite JS bindings as js_of_ocaml externals ([3c81209](https://github.com/grain-lang/binaryen.ml/commit/3c81209763e3d09d51a5ab68ebd705582fe02c54))
* Update libbinaryen to v105 ([#142](https://github.com/grain-lang/binaryen.ml/issues/142)) ([3c81209](https://github.com/grain-lang/binaryen.ml/commit/3c81209763e3d09d51a5ab68ebd705582fe02c54))


### Bug Fixes

* Make memory segments work with js_of_ocaml ([3c81209](https://github.com/grain-lang/binaryen.ml/commit/3c81209763e3d09d51a5ab68ebd705582fe02c54))

---
:camel: Pull-request generated by opam-publish v2.0.3