### PR TITLE
fix conf-perl-XX build for macos homebrew

### DIFF
--- a/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.3/opam
+++ b/packages/conf-perl-ipc-system-simple/conf-perl-ipc-system-simple.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "chetsky@gmail.com"
+homepage: "https://www.perl.org/"
+bug-reports: "chesky@gmail.com"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall et. al."
+depends: [
+  "conf-perl"
+]
+build: [
+  ["perl" "--version"]
+  ["perl" "-MIPC::System::Simple" "-e" "1"] { os-distribution != "homebrew" }
+]
+depexts: [
+  ["libipc-system-simple-perl"] {os-family = "debian"}
+  ["perl-ipc-system-simple"] {os-distribution = "alpine"}
+  ["epel-release" "perl-IPC-System-Simple"] {os-distribution = "centos"}
+  ["perl-IPC-System-Simple"] {os-distribution = "ol" & os-version >= "8"}
+  ["perl-IPC-System-Simple"] {os-family = "suse"}
+  ["perl-IPC-System-Simple"] {os-distribution = "fedora"}
+  ["perl-ipc-system-simple"] {os-family = "arch"}
+  ["p5-ipc-system-simple"] {os-distribution = "macports" & os = "macos"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7"
+]
+synopsis: "Virtual package relying on perl's IPC::System::Simple"
+description:
+  "This package can only install if the specified perl packages are on the system."
+flags: conf

--- a/packages/conf-perl-string-shellquote/conf-perl-string-shellquote.3/opam
+++ b/packages/conf-perl-string-shellquote/conf-perl-string-shellquote.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "chetsky@gmail.com"
+homepage: "https://www.perl.org/"
+bug-reports: "chesky@gmail.com"
+license: "GPL-1.0-or-later"
+authors: "Larry Wall et. al."
+depends: [
+  "conf-perl"
+]
+build: [
+  ["perl" "--version"]
+  ["perl" "-MString::ShellQuote" "-e" "1"] { os-distribution != "homebrew" }
+]
+depexts: [
+  ["libstring-shellquote-perl"] {os-family = "debian"}
+  ["perl-string-shellquote"] {os-distribution = "alpine"}
+  ["perl-String-ShellQuote"] {os-distribution = "centos"}
+  ["perl-String-ShellQuote"] {os-distribution = "ol"}
+  ["perl-String-ShellQuote"] {os-family = "suse"}
+  ["perl-String-ShellQuote"] {os-family = "fedora"}
+  ["perl-string-shellquote"] {os-family = "arch"}
+  ["p5-string-shellquote"] {os-distribution = "macports" & os = "macos"}
+]
+synopsis: "Virtual package relying on perl's String::ShellQuote"
+description:
+  "This package can only install if the specified perl packages are on the system."
+flags: conf


### PR DESCRIPTION
The build scripts in conf-perl-XX packages were wrong for homebrew.  This should fix.