### PR TITLE
[new release] ke (0.5)

### DIFF
--- a/packages/ke/ke.0.5/opam
+++ b/packages/ke/ke.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ke"
+bug-reports:  "https://github.com/mirage/ke/issues"
+dev-repo:     "git+https://github.com/mirage/ke.git"
+doc:          "https://mirage.github.io/ke/"
+license:      "MIT"
+synopsis:     "Queue implementation"
+description:  """Queue implementation in OCaml (functional and imperative queue)"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.0"}
+  "fmt"        {>= "0.8.7"}
+  "bigarray-compat"
+  "alcotest"          {with-test}
+  "bigstringaf"       {with-test}
+  "bechamel"          {with-test}
+  "bechamel-notty"    {with-test}
+  "bechamel-perf"     {with-test}
+  "ocplib-json-typed" {with-test}
+  "core_bench"        {with-test}
+  "lwt"               {with-test}
+  "crowbar"           {with-test}
+  "rresult"           {with-test}
+  "jsonm"             {with-test}
+  "psq"               {with-test}
+  "cmdliner"          {>= "1.1.0" & with-test}
+]
+url {
+  src: "https://github.com/mirage/ke/releases/download/v0.5/ke-0.5.tbz"
+  checksum: [
+    "sha256=504386757350feb9eb5f5000f9d5dd3ca1b41a91e1b91ec6c63972b09bb88229"
+    "sha512=fce23bbda005119020c4c6d38f2d95bc677e012026a1c65cc5fbaec6ded62b87ae6db756fa7822933e33e0cbb3b583a9cdc16771f1f590a3dec79933de7e5359"
+  ]
+}
+x-commit-hash: "415e79ea06497bf6bab97c9452f77d55c4182ca0"


### PR DESCRIPTION
Queue implementation

- Project page: <a href="https://github.com/mirage/ke">https://github.com/mirage/ke</a>
- Documentation: <a href="https://mirage.github.io/ke/">https://mirage.github.io/ke/</a>

##### CHANGES:

* Remove `{build}` directive into the OPAM file (@CraigFe, mirage/ke#10)
* Add `unsafe_bigarray` into `Rke.Weighted` (@anmonteiro, mirage/ke#11)
* Lint OPAM file (@kit-ty-kate, mirage/ke#12)
* Fix the distribution and the CI (@dinosaure, mirage/ke#13)
* Update the distribution with `cmdliner.1.1.0` (@dinosaure, mirage/ke#15)
