### PR TITLE
add missing cohttp and conduit upper bounds

### DIFF
--- a/packages/ez_api/ez_api.0.1.0/opam
+++ b/packages/ez_api/ez_api.0.1.0/opam
@@ -38,6 +38,7 @@ depopts: [
 conflicts: [
   "calendar" {< "2.03"}
   "cohttp-lwt-jsoo" {< "4.0.0"}
+  "conduit-lwt-unix" {> "5.0.0"}
   "httpaf-lwt-unix" {< "0.6.0"}
   "ezjs_fetch" {< "0.2.0"}
   "ocurl" {< "0.8.0"}

--- a/packages/ez_api/ez_api.0.1.0/opam
+++ b/packages/ez_api/ez_api.0.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.6"}
   "json-data-encoding" {>= "0.7.0"}
   "lwt" {>= "4.0.0"}
-  "ezjsonm" {>= "1.0.0"}
+  "ezjsonm" {>= "1.1.0"}
   "uuidm"
 ]
 depopts: [
@@ -42,6 +42,7 @@ conflicts: [
   "httpaf-lwt-unix" {< "0.6.0"}
   "ezjs_fetch" {< "0.2.0"}
   "ocurl" {< "0.8.0"}
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/gremlin/gremlin.0.1.1/opam
+++ b/packages/gremlin/gremlin.0.1.1/opam
@@ -9,7 +9,7 @@ license: "ISC"
 build: [ "dune" "build" "-j" jobs "-p" name ]
 depends: [
   "ocaml" {>= "4.07.1"}
-  "conduit-lwt-unix" {>= "1.4.0"}
+  "conduit-lwt-unix" {>= "1.4.0" & < "5.0.0"}
   "containers" {>= "2.6"}
   "core" {>= "v0.12.3" & < "v0.15"}
   "dune" {>= "1.10.0"}


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/20948

Fixes errors of the kind:
```
# 56 |   Conduit_lwt_unix.endp_to_client ~ctx >>= fun client ->
#                                         ^^^
# Error: This expression has type
#          Conduit_lwt_unix.ctx Lazy.t = Conduit_lwt_unix.ctx lazy_t
#        but an expression was expected of type Conduit_lwt_unix.ctx
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>