### PR TITLE
Package atomic.0.1

### DIFF
--- a/packages/atomic/atomic.0.1/opam
+++ b/packages/atomic/atomic.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis:
+  "Compatibility package for OCaml's Atomic module, from 4.12"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "LGPL-2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03" & < "4.12"}
+  "dune" {>= "1.1.0"}
+]
+tags: [ "atomic" "threads" "compatibility" ]
+homepage: "https://github.com/c-cube/ocaml-atomic/"
+bug-reports: "https://github.com/c-cube/ocaml-atomic/issues"
+dev-repo: "git+https://github.com/c-cube/ocaml-atomic.git"
+authors: "OCaml maintainers"
+url {
+  src: "https://github.com/c-cube/ocaml-atomic/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=ef7764c9932e403faaec545372e54cb2"
+    "sha512=61746b050033f700f9a41ce0c68efa8d007abc9ef490001a1108a646c1b7ffdaa08f0df659b28f2a396cee011cb25aa52a7a65be3d217697f70b66b634cbe956"
+  ]
+}

--- a/packages/atomic/atomic.base/files/META.atomic
+++ b/packages/atomic/atomic.base/files/META.atomic
@@ -1,0 +1,4 @@
+name="atomic"
+version="[distributed with OCaml 4.12 or above]"
+description="dummy backward-compatibility package for Atomic"
+requires=""

--- a/packages/atomic/atomic.base/files/atomic.install
+++ b/packages/atomic/atomic.base/files/atomic.install
@@ -1,0 +1,3 @@
+lib:[
+  "META.atomic" {"META"}
+]

--- a/packages/atomic/atomic.base/opam
+++ b/packages/atomic/atomic.base/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+maintainer: " "
+authors: " "
+homepage: " "
+depends: [
+  "ocaml" {>= "4.12.0"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://caml.inria.fr/mantis/main_page.php"
+synopsis:
+  "Compatibility package for OCaml's Atomic module starting from 4.12"
+extra-files: [
+  ["atomic.install" "md5=07d4c6139af25547d07d3349554928fe"]
+  ["META.atomic" "md5=711dbdefd03b934132b4ac0ab39e7c98"]
+]


### PR DESCRIPTION
### `atomic.0.1`
Compatibility package for OCaml's Atomic module, from 4.12



---
* Homepage: https://github.com/c-cube/ocaml-atomic/
* Source repo: git+https://github.com/c-cube/ocaml-atomic.git
* Bug tracker: https://github.com/c-cube/ocaml-atomic/issues

---
:camel: Pull-request generated by opam-publish v2.1.0