### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.3.0)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.3.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.3.0/happy-eyeballs-0.3.0.tbz"
+  checksum: [
+    "sha256=a60ea0a1ef7d160a6fd62d63991b9e84e35ca5a9c07e5c7fa035e0fd428bb69e"
+    "sha512=0c43180c635c1ac807bd6a2abbb0403afca646870936baa451f6eadcd37d1b32ceea916d7b441b190392c4b32d32292bf6196de00faa198e2e8e59c3b4fdef56"
+  ]
+}
+x-commit-hash: "2511dbfa650146bd18cb34cf0c3da8503d9f3328"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.3.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.2.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.3.0/happy-eyeballs-0.3.0.tbz"
+  checksum: [
+    "sha256=a60ea0a1ef7d160a6fd62d63991b9e84e35ca5a9c07e5c7fa035e0fd428bb69e"
+    "sha512=0c43180c635c1ac807bd6a2abbb0403afca646870936baa451f6eadcd37d1b32ceea916d7b441b190392c4b32d32292bf6196de00faa198e2e8e59c3b4fdef56"
+  ]
+}
+x-commit-hash: "2511dbfa650146bd18cb34cf0c3da8503d9f3328"

--- a/packages/happy-eyeballs/happy-eyeballs.0.3.0/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.3.0/happy-eyeballs-0.3.0.tbz"
+  checksum: [
+    "sha256=a60ea0a1ef7d160a6fd62d63991b9e84e35ca5a9c07e5c7fa035e0fd428bb69e"
+    "sha512=0c43180c635c1ac807bd6a2abbb0403afca646870936baa451f6eadcd37d1b32ceea916d7b441b190392c4b32d32292bf6196de00faa198e2e8e59c3b4fdef56"
+  ]
+}
+x-commit-hash: "2511dbfa650146bd18cb34cf0c3da8503d9f3328"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Happy_eyeballs_mirage.connect_device: remove int64 argument (timestamp), use
  monotonic clocks `C.elapsed_ns ()` instead (noticed by @dinosaure)
