### PR TITLE
mirage-crypto-rng 0.7.0: mark unavailable (to reduce revdeps)

### DIFF
--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.7.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.7.0/opam
@@ -12,6 +12,7 @@ build: [ ["dune" "subst"] {dev}
          ["dune" "build" "-p" name "-j" jobs ]
          ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
 
+available: false
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.7"}


### PR DESCRIPTION
//cc @kit-ty-kate as noticed in https://github.com/ocaml/opam-repository/pull/20581#issuecomment-1024919336

I hope this will help the CI system to have less load. The 0.7.0 release is very old (and not maintained anyways) --> it'd as wel be fine with me to completely remove it from opam-repository.

Yes, some will talk about "opam lock" -- but tbh the lock feature is ill-designed if it does not include the entire metadata from opam-repo or a commit of the repositories.