### PR TITLE
[new release] metapp.0.4.3 and metaquot 0.5.1

### DIFF
--- a/packages/metapp/metapp.0.4.3/opam
+++ b/packages/metapp/metapp.0.4.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Meta-preprocessor for OCaml"
+description: """
+Meta-preprocessor for OCaml: extends the language with [%meta ... ]
+construction where ... stands for OCaml code evaluated at
+compile-time.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/metapp"
+doc: "https://github.com/thierry-martinez/metapp"
+bug-reports: "https://github.com/thierry-martinez/metapp"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "stdcompat" {>= "12"}
+  "ppxlib" {>= "0.18.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
+url {
+  src: "https://github.com/thierry-martinez/metapp/releases/download/v0.4.3/metapp.0.4.3.tar.gz"
+  checksum: "sha512=4c22ceff2d70219263f27b3dc5bc6586d7db2b02310f0534851e2ac6efb493c5107ea7c51b7cc1888e89a4df3f3067336d5c58dc7468c0f26b32c926482267dc"
+}

--- a/packages/metaquot/metaquot.0.5.1/opam
+++ b/packages/metaquot/metaquot.0.5.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "OCaml syntax extension for quoting code"
+description: """
+metaquot allows to quote OCaml code.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/metaquot"
+doc: "https://github.com/thierry-martinez/metaquot"
+bug-reports: "https://github.com/thierry-martinez/metaquot"
+depends: [
+  "ocaml" {>= "4.08.0" & < "4.14"}
+  "stdcompat" {>= "12"}
+  "ppxlib" {>= "0.22.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "1.11.0"}
+  "metapp" {>= "0.4.3"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+conflicts: ["ocaml-variants" { = "4.12.0+domains" }] # Compiler segfaults with ppx
+dev-repo: "git+https://github.com/thierry-martinez/metaquot.git"
+url {
+  src: "https://github.com/thierry-martinez/metaquot/releases/download/v0.5.1/metaquot.0.5.1.tar.gz"
+  checksum: "sha512=96c864805f6d1a562780ea23b46eb8b886b9aba2214948824b7051c3e4058bf8170a5bca43c9c1b35c4b29bb347ccb2858c3ffe665e880ad276f6d0ec1bb2990"
+}


### PR DESCRIPTION
This pull-request publishes new releases for `metapp` (0.4.3) and `metaquot` (0.5.1), making them compatible with OCaml 4.14.