### PR TITLE
Package multicont.1.0.0~rc.2

### DIFF
--- a/packages/multicont/multicont.1.0.0~rc.2/opam
+++ b/packages/multicont/multicont.1.0.0~rc.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+synopsis: "Multi-shot continuations in OCaml"
+description: "This library provides facilities for programming with multi-shot continuations in OCaml"
+homepage: "https://github.com/dhil/ocaml-multicont"
+dev-repo: "git+https://github.com/dhil/ocaml-multicont.git"
+bug-reports: "https://github.com/dhil/ocaml-multicont"
+license: "MIT"
+
+build: [
+  [ make "all" ]
+]
+
+depends: [
+  "ocaml" {>= "5.0"}
+]
+
+install: [
+  make "noop"
+]
+url {
+  src: "https://github.com/dhil/ocaml-multicont/archive/v1.0.0-rc.2.tar.gz"
+  checksum: [
+    "md5=1319a60d1596a644ab3b8f549fded552"
+    "sha512=23750587c061a645eab3ff06014b46d6435c7f5cdba026bc26064281229d4f43f17ac58ee6326b83a448ac45435021e247fd1f6081ea9ed516609040214466a4"
+  ]
+}


### PR DESCRIPTION
### `multicont.1.0.0~rc.2`
Multi-shot continuations in OCaml
This library provides facilities for programming with multi-shot continuations in OCaml

Release candidate 2 brings the fiber primitives of multicont in sync with those in [OCaml trunk @ b4cfe16](https://github.com/ocaml/ocaml/commit/b4cfe1630263961ce0a9411197032b28c3ac1471).

---
* Homepage: https://github.com/dhil/ocaml-multicont
* Source repo: git+https://github.com/dhil/ocaml-multicont.git
* Bug tracker: https://github.com/dhil/ocaml-multicont

---
:camel: Pull-request generated by opam-publish v2.1.0