### PR TITLE
[new release] ppxlib (0.26.0)

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.6.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.6.0/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0"}
-  "ppxlib" {>= "0.21.0"}
+  "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/packages/bisect_ppx/bisect_ppx.2.7.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.0/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0"}
-  "ppxlib" {>= "0.21.0"}
+  "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/packages/bisect_ppx/bisect_ppx.2.7.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.1/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0"}
-  "ppxlib" {>= "0.21.0"}
+  "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/packages/bisect_ppx/bisect_ppx.2.8.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.0/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.02.0"}
-  "ppxlib" {>= "0.21.0"}
+  "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/packages/bisect_ppx/bisect_ppx.2.8.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.1/opam
@@ -22,7 +22,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
   "ocaml" {>= "4.03.0"}
-  "ppxlib" {>= "0.21.0"}
+  "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}
 ]

--- a/packages/gen_js_api/gen_js_api.1.0.8/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.8/opam
@@ -21,6 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.22"}
+  "ppxlib" {with-test & < "0.26.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs"

--- a/packages/gen_js_api/gen_js_api.1.0.9/opam
+++ b/packages/gen_js_api/gen_js_api.1.0.9/opam
@@ -21,6 +21,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.22"}
+  "ppxlib" {with-test & < "0.26.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs"

--- a/packages/gen_js_api/gen_js_api.1.1.0/opam
+++ b/packages/gen_js_api/gen_js_api.1.1.0/opam
@@ -22,6 +22,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.22"}
+  "ppxlib" {with-test & < "0.26.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs" {= "1.1.0"}

--- a/packages/gospel/gospel.0.1.0/opam
+++ b/packages/gospel/gospel.0.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "fmt" {>= "0.8.7"}
   "ocaml-compiler-libs" {>= "v0.12.0"}
-  "ppxlib" {>= "0.23.0"}
+  "ppxlib" {>= "0.23.0" & < "0.26.0"}
 ]
 
 synopsis: "A tool-agnostic formal specification language for OCaml"

--- a/packages/metapp/metapp.0.4.0/opam
+++ b/packages/metapp/metapp.0.4.0/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "odoc" {with-doc & >= "1.5.1"}

--- a/packages/metapp/metapp.0.4.1/opam
+++ b/packages/metapp/metapp.0.4.1/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "odoc" {with-doc & >= "1.5.1"}

--- a/packages/metapp/metapp.0.4.2/opam
+++ b/packages/metapp/metapp.0.4.2/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "odoc" {with-doc & >= "1.5.1"}

--- a/packages/metapp/metapp.0.4.3/opam
+++ b/packages/metapp/metapp.0.4.3/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
   "stdcompat" {>= "12"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}
   "odoc" {with-doc & >= "1.5.1"}

--- a/packages/obus/obus.1.2.3/opam
+++ b/packages/obus/obus.1.2.3/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt_ppx"
   "lwt_log"
   "lwt_react"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.26.0"}
 ]
 
 url {

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.6.0/opam
@@ -28,7 +28,7 @@ depends: [
   "result"
   "ppx_deriving" {>= "5.0"}
   "dune"
-  "ppxlib"       {>= "0.18.0"}
+  "ppxlib"       {>= "0.18.0" & < "0.26.0"}
   "alcotest"     {with-test}
 ]
 synopsis: "Cmdliner.Term.t generator"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "5.1"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.14.0" & < "0.26.0"}
   "ounit" {with-test & >= "2.0.0"}
 ]
 synopsis:

--- a/packages/ppx_import/ppx_import.1.9.0/opam
+++ b/packages/ppx_import/ppx_import.1.9.0/opam
@@ -13,7 +13,7 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {              >= "4.05.0" & < "4.14" }
   "dune"                    {              >= "1.11"  }
-  "ppxlib"                  {              >= "0.24.0"  }
+  "ppxlib"                  {              >= "0.24.0" & < "0.26.0" }
   "ounit"                   { with-test                }
   "ppx_deriving"            { with-test  & >= "4.2.1"  }
   "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }

--- a/packages/ppx_import/ppx_import.1.9.1/opam
+++ b/packages/ppx_import/ppx_import.1.9.1/opam
@@ -12,7 +12,7 @@ tags: [ "syntax" ]
 depends: [
   "ocaml"                   {              >= "4.05.0"  }
   "dune"                    {              >= "1.11.0"  }
-  "ppxlib"                  {              >= "0.24.0"  }
+  "ppxlib"                  {              >= "0.24.0"  & < "0.26.0" }
   "ounit"                   { with-test                 }
   "ppx_deriving"            { with-test  & >= "4.2.1"   }
   "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }

--- a/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.9.0/opam
+++ b/packages/ppx_jsobject_conv/ppx_jsobject_conv.0.9.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.7"}
   "js_of_ocaml" {>= "3.8.0"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.26.0"}
   "webtest" {with-test}
   "webtest-js" {with-test}
 ]

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.3/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.14.3/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.14" & < "v0.15"}
   "sexplib0" {>= "v0.14" & < "v0.15"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.22.0"}
+  "ppxlib"   {>= "0.22.0" & < "0.26.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.15.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.15.0/opam
@@ -14,7 +14,7 @@ depends: [
   "base"     {>= "v0.15" & < "v0.16"}
   "sexplib0" {>= "v0.15" & < "v0.16"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.23.0"}
+  "ppxlib"   {>= "0.23.0" & < "0.26.0"}
 ]
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "

--- a/packages/ppxlib/ppxlib.0.26.0/opam
+++ b/packages/ppxlib/ppxlib.0.26.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory reprensation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "4.15"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & < "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.26.0/ppxlib-0.26.0.tbz"
+  checksum: [
+    "sha256=63117b67ea5863935455fe921f88fe333c0530f0483f730313303a93af817efd"
+    "sha512=9cfc9587657d17cdee5483e2a03292f872c42886e512bcc7442652e6418ce74c0135c731d8a68288c7fecae7f1b2defd93fe5acf8edb41e25144a8cec2806227"
+  ]
+}
+x-commit-hash: "18b1ad68b59d151d662147661e43b159ac491f68"

--- a/packages/sedlex/sedlex.2.3/opam
+++ b/packages/sedlex/sedlex.2.3/opam
@@ -24,7 +24,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.8"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "gen"
   "uchar"
 ]

--- a/packages/sedlex/sedlex.2.4/opam
+++ b/packages/sedlex/sedlex.2.4/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "2.8"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "gen"
   "uchar"
   "odoc" {with-doc}

--- a/packages/sedlex/sedlex.2.5/opam
+++ b/packages/sedlex/sedlex.2.5/opam
@@ -17,7 +17,7 @@ bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "2.8"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "gen"
   "uchar"
   "odoc" {with-doc}


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Bump ppxlib's AST to 4.14/5.00 (ocaml-ppx/ppxlib#320, @pitag-ha)
