### PR TITLE
Package pyml_bindgen.0.3.0

### DIFF
--- a/packages/pyml_bindgen/pyml_bindgen.0.3.0/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.3.0/opam
@@ -26,9 +26,6 @@ depends: [
   "ppx_expect" {>= "v0.12" & with-test}
   "pyml" {with-test}
   "shexp" {>= "v0.14" & with-test}
-  "bisect_ppx" {dev}
-  "core" {>= "v0.12" & dev}
-  "core_bench" {>= "v0.12" & dev}
   "odoc" {with-doc}
 ]
 build: [
@@ -40,11 +37,12 @@ build: [
     name
     "-j"
     jobs
-    "@install" {arch != "x86_32"}
-    "@runtest" {with-test & arch != "x86_32"}
+    "@install"
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]
+available: arch != "x86_32"
 dev-repo: "git+https://github.com/mooreryan/ocaml_python_bindgen.git"
 url {
   src:

--- a/packages/pyml_bindgen/pyml_bindgen.0.3.0/opam
+++ b/packages/pyml_bindgen/pyml_bindgen.0.3.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Generate pyml bindings from OCaml value specifications"
+maintainer: "Ryan M. Moore"
+authors: "Ryan M. Moore"
+license: ["MIT" "Apache-2.0"]
+homepage: "https://github.com/mooreryan/ocaml_python_bindgen"
+doc: "https://mooreryan.github.io/ocaml_python_bindgen/"
+bug-reports: "https://github.com/mooreryan/ocaml_python_bindgen/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "angstrom" {>= "0.15.0"}
+  "base" {>= "v0.12"}
+  "cmdliner" {>= "1.1.0"}
+  "ppx_let" {>= "v0.12"}
+  "ppx_sexp_conv" {>= "v0.12"}
+  "ppx_string" {>= "v0.12"}
+  "re2" {>= "v0.12"}
+  "stdio" {>= "v0.12"}
+  "ocaml" {>= "4.08.0"}
+  "cmdliner" {= "1.1.0" & with-test}
+  "conf-python-3-dev" {>= "1" & with-test}
+  "core_kernel" {>= "v0.12" & with-test}
+  "ocamlformat" {>= "0.20.0" & < "0.21.0" & with-test}
+  "ppx_assert" {>= "v0.12" & with-test}
+  "ppx_inline_test" {>= "v0.12" & with-test}
+  "ppx_expect" {>= "v0.12" & with-test}
+  "pyml" {with-test}
+  "shexp" {>= "v0.14" & with-test}
+  "bisect_ppx" {dev}
+  "core" {>= "v0.12" & dev}
+  "core_bench" {>= "v0.12" & dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install" {arch != "x86_32"}
+    "@runtest" {with-test & arch != "x86_32"}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mooreryan/ocaml_python_bindgen.git"
+url {
+  src:
+    "https://github.com/mooreryan/ocaml_python_bindgen/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=d9e771921a4d253b6041d3a99408fa3e"
+    "sha512=9ec4aad1307505395154d1c64665be6392292ea9fba60580d3927869427c432502bf4bb4b9102f0fdb0f177bab2950ed1f2a91219ef2e577acc2a1971858cbed"
+  ]
+}


### PR DESCRIPTION
### `pyml_bindgen.0.3.0`
Generate pyml bindings from OCaml value specifications



---
* Homepage: https://github.com/mooreryan/ocaml_python_bindgen
* Source repo: git+https://github.com/mooreryan/ocaml_python_bindgen.git
* Bug tracker: https://github.com/mooreryan/ocaml_python_bindgen/issues

---
:camel: Pull-request generated by opam-publish v2.1.0