### PR TITLE
Package multicont.1.0.0~rc.2

### DIFF
--- a/packages/multicont/multicont.1.0.0~rc.2/opam
+++ b/packages/multicont/multicont.1.0.0~rc.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+synopsis: "Multi-shot continuations in OCaml"
+description: "This library provides facilities for programming with multi-shot continuations in OCaml"
+homepage: "https://github.com/dhil/ocaml-multicont"
+dev-repo: "git+https://github.com/dhil/ocaml-multicont.git"
+bug-reports: "https://github.com/dhil/ocaml-multicont"
+license: "MIT"
+
+build: [
+  [ make "all" ]
+]
+
+depends: [
+  "ocaml" {>= "5.0"}
+]
+
+install: [
+  [ make "VERSION=1.0.0~rc.2" "install" ]
+]
+url {
+  src: "https://github.com/dhil/ocaml-multicont/archive/v1.0.0-rc.2.tar.gz"
+  checksum: [
+    "md5=1b1c31fdbba0c3fd45a7959bdaeda772"
+    "sha512=75d89542a9f197e9b9416fab9fece2ea39a7b200d2e9dd17fd8b98048c491972243d1b8537d10a6b3d8e7be05a69998589423bb6ffe58ef6c123c7a6da1f84e9"
+  ]
+}


### PR DESCRIPTION
### `multicont.1.0.0~rc.2`
Multi-shot continuations in OCaml
This library provides facilities for programming with multi-shot continuations in OCaml

Release candidate 2 brings the fiber primitives of multicont in sync with those in [OCaml trunk @ b4cfe16](https://github.com/ocaml/ocaml/commit/b4cfe1630263961ce0a9411197032b28c3ac1471).

**Full Changelog**: https://github.com/dhil/ocaml-multicont/compare/v1.0.0-rc.1...v1.0.0-rc.2

---
* Homepage: https://github.com/dhil/ocaml-multicont
* Source repo: git+https://github.com/dhil/ocaml-multicont.git
* Bug tracker: https://github.com/dhil/ocaml-multicont

---
:camel: Pull-request generated by opam-publish v2.1.0