### PR TITLE
[new release] pyml.20220322

### DIFF
--- a/packages/pyml/pyml.20220322/opam
+++ b/packages/pyml/pyml.20220322/opam
@@ -26,7 +26,7 @@ depends: [
   "ocaml" {>= "3.12.1"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
-  "stdcompat" {>= "17"}
+  "stdcompat" {>= "18"}
   "conf-python-3-dev" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/pyml/pyml.20220322/opam
+++ b/packages/pyml/pyml.20220322/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+run-test: [make "test"]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "dune" {>= "2.8.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "17"}
+  "conf-python-3-dev" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/releases/download/20220322/pyml-20220322.tar.gz"
+  checksum: "sha512=a7835061afab1e092f44c1e03dc7898ed570443939f7deb2ad5e530aed0ac486b944df0cbd96c5d6371a1e129d0851dec5c4c6967d2a4bb0950532d48ab6e9a5"
+}


### PR DESCRIPTION
This pull-request publishes a new release for pyml (2022-03-22):

- New function `Py.Import.exec_code_module_from_string`
  (suggested by Francois Berenger, https://github.com/thierry-martinez/pyml/issues/78)

- New function `Py.Module.compile` provides a better API than `Py.compile`.

- `Py.Object.t` can now be serialized (with Marshal or output_value), using Python
  pickle module

- Cross-compiling friendly architecture detection
  (suggested by @EduardoRFS, https://discuss.ocaml.org/t/a-zoo-of-values-for-system/8525/20)

- Detect macro `unix` instead of `__linux__`, to handle *BSD OSes
  (reported by Chris Pinnock, https://github.com/thierry-martinez/pyml/issues/74)

- Fix bug in Windows

- Null checks for many functions raising OCaml exceptions, instead of segmentation fault
  (initial implementation by Laurent Mazare, https://github.com/thierry-martinez/pyml/pull/72)

- Fix wide character conversion bugs leading to segmentation fault in Py_wfopen
  (fixed by Jerry James, https://github.com/thierry-martinez/pyml/pull/75)

- `Gc.full_major ()` before unloading `libpython` in `Py.finalize`, to prevent
  segfaulting on finalizing dangling references to Python values after the library
  had been unloaded
  (reported by Denis Efremov on coccinelle mailing list)

- Fix segmentation fault when `~debug_build:true` was passed to `Py.initialize`
  (reported by Stéphane Glondu, https://github.com/thierry-martinez/pyml/issues/79)