### PR TITLE
Release of Solo5 0.7.1

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.1/solo5-v0.7.1.tar.gz"
+  checksum: "sha512=ccbe136a402b856dc99e5da449f62c1ed24f49b676ebae0a715a1f043cb0762ac404754f0887039d3dbdef1cd413a0a7e4d92b8dee562f06d3932fcb668180ed"
+}

--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.1/opam
@@ -28,6 +28,8 @@ depexts: [
 ]
 available: [
   (arch != "arm64") &
+  (arch != "arm32") &
+  (arch != "s390x") &
   (os = "linux" & os-family = "debian")
 ]
 synopsis: "Solo5 sandboxed execution environment"

--- a/packages/solo5/solo5.0.7.1/opam
+++ b/packages/solo5/solo5.0.7.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.1/solo5-v0.7.1.tar.gz"
+  checksum: "sha512=ccbe136a402b856dc99e5da449f62c1ed24f49b676ebae0a715a1f043cb0762ac404754f0887039d3dbdef1cd413a0a7e4d92b8dee562f06d3932fcb668180ed"
+}


### PR DESCRIPTION
## v0.7.1 (2022-03-14)

* Use `note.not_openbsd` instead of `note.not-openbsd` as section name in
  `solo5-stubs.ld` to be compatible with GNU ld 2.37 on e.g. Arch Linux, Fedora
  35, Alpine 3.15 (@TheLortex, solo5/solo5#509)
* Fix `opam-release.sh`: the second variant is `-cross-aarch64`
  (@dinosaure, solo5/solo5#511)
* elftool: support manifests read from stdin or written to stdout using the `-`
  character (@ehmry, solo5/solo5#510)
* Fix the compilation of `test_tls` on `ppc64` architecture (@dinosaure,
  @hannesm, solo5/solo5#514)