### PR TITLE
[new release] mirage-vnetif and mirage-vnetif-stack (0.6.0)

### DIFF
--- a/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.0/opam
+++ b/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@test/vnetif-stack/runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.9"}
+  "result" {>= "1.5"}
+  "lwt"
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "mirage-random"
+  "mirage-vnetif" {= version}
+  "tcpip" {>= "7.0.0"}
+  "ethernet"
+  "cstruct" {>="6.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr"
+  "mirage-profile"
+  "arp" {>= "3.0.0"}
+  "duration"
+  "logs"
+  "mirage-time-unix" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random-test" {with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {with-test}
+]
+tags: ["org:mirage"]
+synopsis: "Vnetif implementation of mirage-stack for Mirage TCP/IP"
+description: """
+Provides Vnetif_stack, a mirage-stack implementation using Vnetif and the
+Mirage TCP/IP stack. The virtual stack can be used to test and record Mirage
+TCP/IP connections over a virtual network interface, as a process or VM.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.0/mirage-vnetif-0.6.0.tbz"
+  checksum: [
+    "sha256=7f3468345a9d9e3e0a7be78d768e5caef6e7283c7affe750caef8adeb0f9758c"
+    "sha512=c3202e2e2d5025d8f71fab8aea60495ad7b2f864d1bee6e0909cde088a8a080305279537b3f412ea3050dc35b4e39ce224e34a0c6b944f80c7d28a524ef56111"
+  ]
+}
+x-commit-hash: "5913b93d096e0cab7b9e870233cbcd09c94c47d4"

--- a/packages/mirage-vnetif/mirage-vnetif.0.6.0/opam
+++ b/packages/mirage-vnetif/mirage-vnetif.0.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Magnus Skjegstad <magnus@skjegstad.com>"
+authors: "Magnus Skjegstad <magnus@skjegstad.com>"
+homepage: "https://github.com/mirage/mirage-vnetif"
+bug-reports: "https://github.com/mirage/mirage-vnetif/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-vnetif.git"
+doc: "https://mirage.github.io/mirage-vnetif/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune"  {>= "1.9"}
+  "result" {>= "1.5"}
+  "lwt"
+  "mirage-net" {>= "3.0.0"}
+  "cstruct" {>="6.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "macaddr"
+  "mirage-profile"
+  "duration"
+  "logs"
+]
+tags: ["org:mirage"]
+synopsis: "Virtual network interface and software switch for Mirage"
+description: """
+Provides the module `Vnetif` which can be used as a replacement for the regular
+`Netif` implementation in Xen and Unix. Stacks built using `Vnetif` are
+connected to a software switch that allows the stacks to communicate as if they
+were connected to the same LAN.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-vnetif/releases/download/v0.6.0/mirage-vnetif-0.6.0.tbz"
+  checksum: [
+    "sha256=7f3468345a9d9e3e0a7be78d768e5caef6e7283c7affe750caef8adeb0f9758c"
+    "sha512=c3202e2e2d5025d8f71fab8aea60495ad7b2f864d1bee6e0909cde088a8a080305279537b3f412ea3050dc35b4e39ce224e34a0c6b944f80c7d28a524ef56111"
+  ]
+}
+x-commit-hash: "5913b93d096e0cab7b9e870233cbcd09c94c47d4"


### PR DESCRIPTION
Virtual network interface and software switch for Mirage

- Project page: <a href="https://github.com/mirage/mirage-vnetif">https://github.com/mirage/mirage-vnetif</a>
- Documentation: <a href="https://mirage.github.io/mirage-vnetif/">https://mirage.github.io/mirage-vnetif/</a>

##### CHANGES:

- add option for capturing packets directly on the interface (mirage/mirage-vnetif#30, @MagnusS)
- add option for unlocking a mutex when the interface is in listen mode (mirage/mirage-vnetif#30, @MagnusS)
- add package mirage-vnetif-stack to provide a preassembled ipv4 stack (mirage/mirage-vnetif#30, @MagnusS)
- add initial connect test for the vnetif-stack (mirage/mirage-vnetif#30, @MagnusS)
- clean up opam dependencies (mirage/mirage-vnetif#30, @MagnusS)
- drop mirage protocols and adapt to arp, ipaddr, tcpip interface
  changes (mirage/mirage-vnetif#33, @MisterDA)
