### PR TITLE
[new release] clangml.4.6.0

### DIFF
--- a/packages/clangml/clangml.4.5.0/opam
+++ b/packages/clangml/clangml.4.5.0/opam
@@ -10,7 +10,7 @@ homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
 doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
 bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
 depends: [
-  "conf-libclang" {<= 13}
+  "conf-libclang" {<= "13"}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}

--- a/packages/clangml/clangml.4.5.0/opam
+++ b/packages/clangml/clangml.4.5.0/opam
@@ -10,7 +10,7 @@ homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
 doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
 bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
 depends: [
-  "conf-libclang"
+  "conf-libclang" {<= 13}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}

--- a/packages/clangml/clangml.4.6.0/opam
+++ b/packages/clangml/clangml.4.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
+doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
+bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "13"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test & >= "1.0.1"}
+  "pattern" {with-test & >= "0.2.0"}
+  "metapp" {>= "0.4.0"}
+  "metaquot" {>= "0.4.0"}
+  "refl" {>= "0.4.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+  "ppxlib" {>= "0.23"}
+  "ocaml-migrate-parsetree" {>= "2.2.0"}
+]
+x-ci-accept-failures: [
+   "centos-7" # GCC does not support --std=c++14
+   "archlinux" # LLVM not detected
+   "oraclelinux-7" # LLVM not detected
+]
+available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.6.0/clangml-v4.6.0.tar.gz"
+  checksum: "sha512=70fc8a1e83e5c96d742c8517c6e30a2e08c233e622a493417c31688dbab25d4e1edd8e54abdcb60438b8e5c942206d34e7b64fa2f45aaafcd44411959a06857f"
+}

--- a/packages/clangml/clangml.4.6.0/opam
+++ b/packages/clangml/clangml.4.6.0/opam
@@ -10,7 +10,7 @@ homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
 doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
 bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
 depends: [
-  "conf-libclang"
+  "conf-libclang" {<= 14}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}
@@ -31,7 +31,7 @@ x-ci-accept-failures: [
    "archlinux" # LLVM not detected
    "oraclelinux-7" # LLVM not detected
 ]
-available: arch != "arm32" & arch != "ppc64" # Compiler segfaults on those architectures
+available: arch != "arm32" & arch != "arm64" & arch != "ppc64" # Compiler segfaults on those architectures
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
 build: [
   ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]

--- a/packages/clangml/clangml.4.6.0/opam
+++ b/packages/clangml/clangml.4.6.0/opam
@@ -10,7 +10,7 @@ homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
 doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
 bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
 depends: [
-  "conf-libclang" {<= 14}
+  "conf-libclang" {<= "14"}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -10,7 +10,11 @@ build: [
 depexts: [
   ["llvm"] {os = "macos"}
   ["llvm" "clang"] {os-distribution = "arch"}
-  ["libclang-dev" "llvm-dev"] {os-family = "debian"}
+  ["libclang-13-dev" "llvm-13-dev"]
+    {os-distribution = "ubuntu" & os-version >= "22.04"}
+  ["libclang-dev" "llvm-dev"] {
+     os-family = "debian" &
+     !(os-distribution = "ubuntu" & os-version >= "22.04")}
   ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "centos"}

--- a/packages/conf-libclang/conf-libclang.14/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.14/files/configure.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -ex
+
+clean_tempdir () {
+    rm -f "$tempdir/test_libclang.c" "$tempdir/test_libclang.o" \
+       "$tempdir/test_libclang"
+    rmdir "$tempdir"
+}
+
+shopt -s nullglob
+for version in default 14 13 12 11 10 9 8 7 6 5 4 3; do
+    if [ "$version" = default ]; then
+        llvm_config=llvm-config
+        llvm_version="$($llvm_config --version)" || continue
+        if [ $(printf "${llvm_version%%.*}\n14" | sort -n | head -n1) = 14 ]; then
+            continue
+        fi
+    else
+        if hash brew 2>/dev/null; then
+           brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+        fi
+        for llvm_config in \
+            llvm-config-${version} llvm-config-${version}.0 \
+            llvm-config${version}0 llvm-config${version} \
+            llvm-config-${version}-32 llvm-config-${version}-64 \
+            llvm-config-mp-$version \
+            llvm-config-mp-${version}.0 $brew_llvm_config \
+            /usr/lib64/llvm/${version}/bin/llvm-config \
+            /usr/lib/llvm/${version}/bin/llvm-config; do
+            llvm_version="$($llvm_config --version)" || continue
+            break
+        done
+        if [ -z "$llvm_version" ]; then
+            continue
+        fi
+    fi
+
+    LLVM_CFLAGS="$($llvm_config --cflags)"
+    LLVM_LDFLAGS="$($llvm_config --ldflags)"
+    LLVM_LIBDIR="$($llvm_config --libdir)"
+    
+    # These filters enable compilation with gcc.
+    # Filter -Wstring-conversion for OpenSUSE
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Wstring-conversion //')"
+    
+    # Filter -Werror=unguarded-availability-new and -Wcovered-switch-default
+    # (which appear with LLVM 7)
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Werror=unguarded-availability-new //')"
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Wcovered-switch-default //')"
+    
+    # Filter "-Wdelete-non-virtual-dtor" (warning only)
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Wdelete-non-virtual-dtor //')"
+
+    tempdir="$(mktemp -d)"        
+    cat >"$tempdir/test_libclang.c" <<EOF
+#include <clang-c/Index.h>
+#include <stdlib.h>
+
+int
+main(int argc, char *argv[])
+{
+  CXIndex idx = clang_createIndex(1, 1);
+  clang_disposeIndex(idx);
+  return EXIT_SUCCESS;
+}
+EOF
+
+    CC=cc
+    if "$CC" -o "$tempdir/test_libclang.o" -c $LLVM_CFLAGS \
+        "$tempdir/test_libclang.c" &&
+      "$CC" -o "$tempdir/test_libclang" \
+          $LLVM_LDFLAGS "$tempdir/test_libclang.o" \
+          "-lclang" "-Wl,-rpath,$LLVM_LIBDIR" &&
+      "$tempdir/test_libclang"; then
+        true
+    else
+        clean_tempdir
+        continue
+    fi
+
+    clean_tempdir
+    
+    echo "config: \"$llvm_config\"" >> conf-libclang.config
+    echo "version: \"$llvm_version\"" >> conf-libclang.config
+    exit 0
+done
+
+echo "Error: No usable version of LLVM <=13.0.x found."
+exit 1
+

--- a/packages/conf-libclang/conf-libclang.14/opam
+++ b/packages/conf-libclang/conf-libclang.14/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "-ex" "configure.sh" version]
+]
+depexts: [
+  ["llvm"] {os = "macos"}
+  ["llvm" "clang"] {os-distribution = "arch"}
+  ["libclang-dev" "llvm-dev"] {os-family = "debian"}
+  ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
+  ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
+    {os-distribution = "centos"}
+  ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
+    {os-distribution = "fedora"}
+  ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
+    {os-distribution = "ol" & os-version >= "8"}
+  ["llvm-clang-devel"] {os-family = "suse"}
+  ["devel/llvm13"] {os = "freebsd"}
+  ["sys-devel/clang"] {os-distribution = "gentoo"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # clang-devel is not available
+  "alpine-3.13" # unavailable system package 'llvm-dev'
+  "alpine-3.14" # unavailable system package 'llvm-dev'
+  "opensuse-15.3" # unavailable system package 'llvm-clang-devel'
+]
+extra-files: [[
+  "configure.sh" "sha512=d1c17388e1523e84a363ab348149caff13bea715d110b0d1ee021855ba1d3049862f6646ae763b144d98b71b3405c320683f7ad67dbe255db49f80ee5c2e4a9f"
+]]
+synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 14.0.x)"
+flags: conf


### PR DESCRIPTION
This pull request publishes a new release for clangml (4.6.0).

- Support for Clang/LLVM 14.0.0

- Fix bug with compound literals: when compound literals refer to a defined type,
  the AST was `UnknownExpr`.
  (reported by Arthur Charguéraud, https://gitlab.inria.fr/tmartine/clangml/-/issues/2)