### PR TITLE
[new release] tcpip (7.1.0)

### DIFF
--- a/packages/tcpip/tcpip.7.1.0/opam
+++ b/packages/tcpip/tcpip.7.1.0/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "result" {< "1.5"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "ppx_cstruct"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "ipaddr-cstruct" {with-test}
+  "lru" {>= "0.3.0"}
+  "metrics"
+]
+depopts: [
+  "ocaml-freestanding"
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v7.1.0/tcpip-7.1.0.tbz"
+  checksum: [
+    "sha256=e2777639565ae30db62386e08259d2f25acd7e34e4e343cbe67e8e87a9fea2cc"
+    "sha512=fae605ba30b0bb5ae28cbedc32f220c5a5166db4af9e060d82007cd020132f1e334fa8fcb7e9bd68851fc838f7e6fb1b4e1d3cba8fb787dcec79d2107b8ffd4a"
+  ]
+}
+x-commit-hash: "d17fe5a187e4cef2bc7dde60d6d5b525f826c600"


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Work with MSVC compiler (@jonahbeckford, mirage/mirage-tcpip#476)
* Skip `Lwt_bytes` UDP tests on Windows (@MisterDA, mirage/mirage-tcpip#469)
* Run `PKG_CONFIG_PATH` through cypath (@MisterDA, mirage/mirage-tcpip#469)
* Add Windows CI via GitHub Action (@MisterDA, mirage/mirage-tcpip#469)
* Remove `which` command and replace it by `command -v` (@hannesm, mirage/mirage-tcpip#472)
* Fix some typos (@MisterDA, mirage/mirage-tcpip#471)
* Update binaries to `cmdliner.1.1.0` (@dinosaure, mirage/mirage-tcpip#475)
* Be able to extract via _functor_/`functoria` the TCP/IP stack (@dinosaure, mirage/mirage-tcpip#474)
* Remove missing deprecated usage of `Cstruct.len` (@dinosaure, mirage/mirage-tcpip#477)
