### PR TITLE
[new release] mimic and mimic-happy-eyeballs (0.0.5)

### DIFF
--- a/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.5/opam
+++ b/packages/mimic-happy-eyeballs/mimic-happy-eyeballs.0.0.5/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "A happy-eyeballs integration into mimic"
+description: "A happy-eyeballs integration into mimic for MirageOS"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: "Romain Calascibetta"
+license: "ISC"
+homepage: "https://github.com/dinosaure/mimic"
+doc: "https://dinosaure.github.io/mimic/"
+bug-reports: "https://github.com/dinosaure/mimic/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mimic" {= version}
+  "happy-eyeballs-mirage" {>= "0.3.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/mimic.git"
+url {
+  src:
+    "https://github.com/dinosaure/mimic/releases/download/0.0.5/mimic-0.0.5.tbz"
+  checksum: [
+    "sha256=dea163b6d54b8172873acafbd79e74cfb69505c1cf633c1d15e329c078163dad"
+    "sha512=154ae5d3a1ff6561dc6f5562ad96be1ba34f54ed5fc1428fda57bd839b78ee39ebf978c6d2d31338f85882a11fa14d056d8636e7b5142c664b75d43077d6699b"
+  ]
+}
+x-commit-hash: "35829c70b4baac5b1b17cfa2339cb7f1ab962abe"

--- a/packages/mimic/mimic.0.0.5/opam
+++ b/packages/mimic/mimic.0.0.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A simple protocol dispatcher"
+description: "A middleware to dispatch protocols"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: "Romain Calascibetta"
+license: "ISC"
+homepage: "https://github.com/dinosaure/mimic"
+doc: "https://dinosaure.github.io/mimic/"
+bug-reports: "https://github.com/dinosaure/mimic/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.3.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+dev-repo: "git+https://github.com/dinosaure/mimic.git"
+url {
+  src:
+    "https://github.com/dinosaure/mimic/releases/download/0.0.5/mimic-0.0.5.tbz"
+  checksum: [
+    "sha256=dea163b6d54b8172873acafbd79e74cfb69505c1cf633c1d15e329c078163dad"
+    "sha512=154ae5d3a1ff6561dc6f5562ad96be1ba34f54ed5fc1428fda57bd839b78ee39ebf978c6d2d31338f85882a11fa14d056d8636e7b5142c664b75d43077d6699b"
+  ]
+}
+x-commit-hash: "35829c70b4baac5b1b17cfa2339cb7f1ab962abe"


### PR DESCRIPTION
A simple protocol dispatcher

- Project page: <a href="https://github.com/dinosaure/mimic">https://github.com/dinosaure/mimic</a>
- Documentation: <a href="https://dinosaure.github.io/mimic/">https://dinosaure.github.io/mimic/</a>

##### CHANGES:

* Add support of OCaml 5.00.0 (dinosaure/mimic#10, @dinosaure)
* Add `happy-eyeballs` device for MirageOS 4 (dinosaure/mimic#11, @dinosaure)
* Add `{= version}` constraint on `mimic-happy-eyeballs` (@hannesm, dinosaure/mimic#12)
