### PR TITLE
[new release] git, git-mirage, git-unix and git-paf (3.9.0)

### DIFF
--- a/packages/git-mirage/git-mirage.3.9.0/opam
+++ b/packages/git-mirage/git-mirage.3.9.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mimic-happy-eyeballs" {>= "0.0.5"}
+  "base64" {>= "3.5.0"}
+  "git" {= version}
+  "git-paf" {= version}
+  "awa" {>= "0.1.0"}
+  "awa-mirage" {>= "0.1.0"}
+  "dns" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3"}
+  "tls"
+  "tls-mirage"
+  "uri"
+  "hex"
+  "happy-eyeballs-mirage" {>= "0.1.2"}
+  "happy-eyeballs" {>= "0.1.2"}
+  "ca-certs-nss"
+  "mirage-crypto"
+  "ptime"
+  "x509"
+  "cstruct"
+  "tcpip" {>= "7.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.7.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.9.0/git-3.9.0.tbz"
+  checksum: [
+    "sha256=abfa25889ef8d0a3269014fa8e8489eed1a10329ec1f2aec102fdd677498d663"
+    "sha512=84bbcfcf389a6f04ac9548a5ca26463f7af9b3d1c6aea66e7bd1f393724fadf68c96cc091a74ed9a1768b3da45655429a20fab4359d276cf0a9b3704a99e1747"
+  ]
+}
+x-commit-hash: "9fa5cb6cd6b05a16abbf65f8ab16b6ce1bdcd373"

--- a/packages/git-paf/git-paf.3.9.0/opam
+++ b/packages/git-paf/git-paf.3.9.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "mimic" {>= "0.0.4"}
+  "paf" {>= "0.0.7"}
+  "ca-certs-nss"
+  "fmt"
+  "ipaddr"
+  "logs"
+  "lwt"
+  "mirage-clock"
+  "tcpip" {>= "7.0.0"}
+  "mirage-time"
+  "result"
+  "rresult"
+  "tls" {>= "0.14.0"}
+  "uri"
+  "bigarray-compat"
+  "bigstringaf"
+  "domain-name"
+  "httpaf"
+  "mirage-flow"
+  "tls-mirage"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.9.0/git-3.9.0.tbz"
+  checksum: [
+    "sha256=abfa25889ef8d0a3269014fa8e8489eed1a10329ec1f2aec102fdd677498d663"
+    "sha512=84bbcfcf389a6f04ac9548a5ca26463f7af9b3d1c6aea66e7bd1f393724fadf68c96cc091a74ed9a1768b3da45655429a20fab4359d276cf0a9b3704a99e1747"
+  ]
+}
+x-commit-hash: "9fa5cb6cd6b05a16abbf65f8ab16b6ce1bdcd373"

--- a/packages/git-unix/git-unix.3.9.0/opam
+++ b/packages/git-unix/git-unix.3.9.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mmap" {>= "1.1.0"}
+  "git" {= version}
+  "git-mirage" {= version}
+  "happy-eyeballs-lwt" {>= "0.1.2"}
+  "rresult"
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "0.8.1"}
+  "logs"
+  "lwt"
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "mirage-clock" {>= "4.1.0"}
+  "mirage-clock-unix" {>= "4.1.0"}
+  "astring" {>= "0.8.5"}
+  "awa" {>= "0.1.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-unix" {>= "5.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "decompress" {>= "1.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "7.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "awa-mirage" {>= "0.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ptime"
+  "mimic"
+  "ca-certs-nss" {>= "3.60"}
+  "tls" {>= "0.14.0"}
+  "tls-mirage" {>= "0.14.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.9.0/git-3.9.0.tbz"
+  checksum: [
+    "sha256=abfa25889ef8d0a3269014fa8e8489eed1a10329ec1f2aec102fdd677498d663"
+    "sha512=84bbcfcf389a6f04ac9548a5ca26463f7af9b3d1c6aea66e7bd1f393724fadf68c96cc091a74ed9a1768b3da45655429a20fab4359d276cf0a9b3704a99e1747"
+  ]
+}
+x-commit-hash: "9fa5cb6cd6b05a16abbf65f8ab16b6ce1bdcd373"

--- a/packages/git/git.3.9.0/opam
+++ b/packages/git/git.3.9.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic" {>= "0.0.4"}
+  "cstruct" {>= "6.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.3"}
+  "carton-lwt" {>= "0.4.3"}
+  "carton-git" {>= "0.4.3"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "base-unix" {with-test}
+  "fpath"
+  "hxd" {>= "0.3.2"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.9.0/git-3.9.0.tbz"
+  checksum: [
+    "sha256=abfa25889ef8d0a3269014fa8e8489eed1a10329ec1f2aec102fdd677498d663"
+    "sha512=84bbcfcf389a6f04ac9548a5ca26463f7af9b3d1c6aea66e7bd1f393724fadf68c96cc091a74ed9a1768b3da45655429a20fab4359d276cf0a9b3704a99e1747"
+  ]
+}
+x-commit-hash: "9fa5cb6cd6b05a16abbf65f8ab16b6ce1bdcd373"


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Fix `ocaml-git` with OCaml 5.00.0 (@dinosaure, @stedolan, mirage/ocaml-git#559)
- Update binaries with `cmdliner.1.1.0` (@MisterDA, @dinosaure, mirage/ocaml-git#558)
- Fix the `reset` function and properly delete PACK files (@dinosaure, @patricoferris, @dinakajoy, mirage/ocaml-git#561)
- Fix dependencies of `guit` (@maiste, @dinosaure, mirage/ocaml-git#560)
- Move the `happy-eyeballs` layer needed by MirageOS into `mimic.0.0.5` (@dinosaure, mirage/ocaml-git#563)
