### PR TITLE
2 packages from gitlab.com/nomadic-labs/ringo/-/archive/v0.8/ringo-v0.8.tar.gz

### DIFF
--- a/packages/ringo-lwt/ringo-lwt.0.8/opam
+++ b/packages/ringo-lwt/ringo-lwt.0.8/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+  "ringo" {= version }
+  "lwt"
+  "base-unix" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt-wrappers for Ringo caches"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.8/ringo-v0.8.tar.gz"
+  checksum: [
+    "md5=a0b3e072bbc3541b60196de967ed266a"
+    "sha512=b6a12de26fa58ac5f5c3a49963d3b76dfbe391f86ef14c97715d2fccb439daf7c2e602c15b48e1db9d933832f3ee2171adb1f990f3c15be5f33ae815ce5cf7a8"
+  ]
+}

--- a/packages/ringo/ringo.0.8/opam
+++ b/packages/ringo/ringo.0.8/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.8/ringo-v0.8.tar.gz"
+  checksum: [
+    "md5=a0b3e072bbc3541b60196de967ed266a"
+    "sha512=b6a12de26fa58ac5f5c3a49963d3b76dfbe391f86ef14c97715d2fccb439daf7c2e602c15b48e1db9d933832f3ee2171adb1f990f3c15be5f33ae815ce5cf7a8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ringo.0.8`: Caches (bounded-size key-value stores) and other bounded-size stores
-`ringo-lwt.0.8`: Lwt-wrappers for Ringo caches



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0