### PR TITLE
3 packages from c-cube/ocaml-containers at 3.7

### DIFF
--- a/packages/containers-data/containers-data.3.7/opam
+++ b/packages/containers-data/containers-data.3.7/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.7.tar.gz"
+  checksum: [
+    "md5=58298b6d26c5198157e19b583e9eca2c"
+    "sha512=70f99a062f7696d4ed7a6336532261c93c49a9858a84a12f7f3d60190a5c664198e70be6281dc7c7932c07325dc9c579ff521367e4c7e083566910ba0f9ea760"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.7/opam
+++ b/packages/containers-thread/containers-thread.3.7/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.7.tar.gz"
+  checksum: [
+    "md5=58298b6d26c5198157e19b583e9eca2c"
+    "sha512=70f99a062f7696d4ed7a6336532261c93c49a9858a84a12f7f3d60190a5c664198e70be6281dc7c7932c07325dc9c579ff521367e4c7e083566910ba0f9ea760"
+  ]
+}

--- a/packages/containers/containers.3.7/opam
+++ b/packages/containers/containers.3.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "dune-configurator"
+  "seq" # compat
+  "either" # compat
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "csexp" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.7.tar.gz"
+  checksum: [
+    "md5=58298b6d26c5198157e19b583e9eca2c"
+    "sha512=70f99a062f7696d4ed7a6336532261c93c49a9858a84a12f7f3d60190a5c664198e70be6281dc7c7932c07325dc9c579ff521367e4c7e083566910ba0f9ea760"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.7`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.7`: A set of advanced datatypes for containers
-`containers-thread.3.7`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0