### PR TITLE
Fix cmdliner dependency on docteur.0.0.{1,2,3}

### DIFF
--- a/packages/docteur/docteur.0.0.1/opam
+++ b/packages/docteur/docteur.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "bigarray-compat" {>= "1.0.0"}
   "bigstringaf" {>= "0.7.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "digestif" {>= "1.0.0"}
   "fmt" {>= "0.8.9"}
   "fpath" {>= "0.7.3"}

--- a/packages/docteur/docteur.0.0.2/opam
+++ b/packages/docteur/docteur.0.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "bigarray-compat" {>= "1.0.0"}
   "bigstringaf" {>= "0.7.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "digestif" {>= "1.0.0"}
   "fmt" {>= "0.8.9"}
   "fpath" {>= "0.7.0"}

--- a/packages/docteur/docteur.0.0.3/opam
+++ b/packages/docteur/docteur.0.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "bigarray-compat" {>= "1.0.0"}
   "bigstringaf" {>= "0.7.0"}
   "bos" {>= "0.2.0"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "digestif" {>= "1.0.0"}
   "fmt" {>= "0.8.9"}
   "fpath" {>= "0.7.0"}


### PR DESCRIPTION
These constratins was missing on the `cmdliner` release.