### PR TITLE
[new release] docteur, docteur-unix and docteur-solo5 (0.0.4)

### DIFF
--- a/packages/docteur-solo5/docteur-solo5.0.0.4/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-solo5" {>= "0.7.0"}
+  "mirage-block-solo5"
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "hxd" {>= "0.3.1"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "3.0.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.4/docteur-0.0.4.tbz"
+  checksum: [
+    "sha256=0e261323b84639f7fc5d8ef11919c02f184d202e07e1b87f5a0d74939f79b6f8"
+    "sha512=11a78591a5e279b7e6ce0526b821206dbfbc4a4edb0d358701a7e5d0bd9a47194ab1449ecb0db7c4e8695e5a8c79e62ada87bb35179ab371fd57f539327a29f7"
+  ]
+}
+x-commit-hash: "0c4e4b35c861eed962fb88240caed91dd68a2c1c"

--- a/packages/docteur-unix/docteur-unix.0.0.4/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.4/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-unix" {>= "5.0.0"}
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "3.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.4/docteur-0.0.4.tbz"
+  checksum: [
+    "sha256=0e261323b84639f7fc5d8ef11919c02f184d202e07e1b87f5a0d74939f79b6f8"
+    "sha512=11a78591a5e279b7e6ce0526b821206dbfbc4a4edb0d358701a7e5d0bd9a47194ab1449ecb0db7c4e8695e5a8c79e62ada87bb35179ab371fd57f539327a29f7"
+  ]
+}
+x-commit-hash: "0c4e4b35c861eed962fb88240caed91dd68a2c1c"

--- a/packages/docteur/docteur.0.0.4/opam
+++ b/packages/docteur/docteur.0.0.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+description: """An opiniated file-system for MirageOS"""
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "bigarray-compat" {>= "1.0.0"}
+  "bigstringaf" {>= "0.7.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.0"}
+  "git" {>= "3.7.0"}
+  "git-unix" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mmap" {>= "1.1.0"}
+  "mtime" {>= "1.2.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "carton" {>= "0.4.0"}
+  "art" {>= "0.1.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.4/docteur-0.0.4.tbz"
+  checksum: [
+    "sha256=0e261323b84639f7fc5d8ef11919c02f184d202e07e1b87f5a0d74939f79b6f8"
+    "sha512=11a78591a5e279b7e6ce0526b821206dbfbc4a4edb0d358701a7e5d0bd9a47194ab1449ecb0db7c4e8695e5a8c79e62ada87bb35179ab371fd57f539327a29f7"
+  ]
+}
+x-commit-hash: "0c4e4b35c861eed962fb88240caed91dd68a2c1c"


### PR DESCRIPTION
A simple read-only Key/Value from Git to MirageOS

- Project page: <a href="https://github.com/dinosaure/docteur">https://github.com/dinosaure/docteur</a>
- Documentation: <a href="https://dinosaure.github.io/docteur/">https://dinosaure.github.io/docteur/</a>

##### CHANGES:

- Update `docteur` with `cmdliner.1.1.0` (@dinosaure, dinosaure/docteur#20)
