### PR TITLE
[new release] yaml and yaml-sexp (3.1.0)

### DIFF
--- a/packages/yaml-sexp/yaml-sexp.3.1.0/opam
+++ b/packages/yaml-sexp/yaml-sexp.3.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse and generate YAML 1.1 files"
+description: "ocaml-yaml with sexp support"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Rizo Isrof <rizo@odis.io>"
+  "Patrick Ferris"
+  "favonia@gmail.com"
+  "Alan J Hu <alanh@ccs.neu.edu>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "yaml" {= version}
+  "mdx" {with-test & >= "2.1.0"}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+  "bos" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v3.1.0/yaml-3.1.0.tbz"
+  checksum: [
+    "sha256=d0a9e0ae2184a69e6d7202bfe3707d10439d31a71241860234b19f020452ecc7"
+    "sha512=69d0ff09abeac475981deefc5a2a09e8707aebe4c7e606671a5a8ffa7055d3519ee9e4823065d89c8c5eedb355015b8d9410286fac721af53d910d924a0711a3"
+  ]
+}
+x-commit-hash: "cc9d389b706f15df3578ba361e03f261972df9f4"

--- a/packages/yaml/yaml.3.1.0/opam
+++ b/packages/yaml/yaml.3.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "dune" {>= "2.0"}
   "dune-configurator"
-  "ctypes" {>= "0.12.0"}
+  "ctypes" {>= "0.14.0"}
   "bos"
   "fmt" {with-test}
   "logs" {with-test}

--- a/packages/yaml/yaml.3.1.0/opam
+++ b/packages/yaml/yaml.3.1.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Parse and generate YAML 1.1/1.2 files"
+description: """\
+This is an OCaml library to parse and generate the YAML file
+format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
+JSON handling library, if the simple common subset of Yaml
+is used.  Anchors and other advanced Yaml features are not
+implemented in the JSON compatibility layer.
+
+The [Yaml module docs](http://anil-code.recoil.org/ocaml-yaml/yaml/Yaml/index.html) are browseable online."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Rizo Isrof <rizo@odis.io>"
+  "Patrick Ferris"
+  "favonia@gmail.com"
+  "Alan J Hu <alanh@ccs.neu.edu>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/avsm/ocaml-yaml"
+doc: "https://avsm.github.io/ocaml-yaml/"
+bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "ctypes" {>= "0.12.0"}
+  "bos"
+  "fmt" {with-test}
+  "logs" {with-test}
+  "mdx" {with-test & >= "2.1.0"}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "junit_alcotest" {with-test}
+  "ezjsonm" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/avsm/ocaml-yaml.git"
+url {
+  src:
+    "https://github.com/avsm/ocaml-yaml/releases/download/v3.1.0/yaml-3.1.0.tbz"
+  checksum: [
+    "sha256=d0a9e0ae2184a69e6d7202bfe3707d10439d31a71241860234b19f020452ecc7"
+    "sha512=69d0ff09abeac475981deefc5a2a09e8707aebe4c7e606671a5a8ffa7055d3519ee9e4823065d89c8c5eedb355015b8d9410286fac721af53d910d924a0711a3"
+  ]
+}
+x-commit-hash: "cc9d389b706f15df3578ba361e03f261972df9f4"

--- a/packages/yaml/yaml.3.1.0/opam
+++ b/packages/yaml/yaml.3.1.0/opam
@@ -35,6 +35,9 @@ depends: [
   "junit_alcotest" {with-test}
   "ezjsonm" {with-test}
 ]
+conflicts:[
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Parse and generate YAML 1.1/1.2 files

- Project page: <a href="https://github.com/avsm/ocaml-yaml">https://github.com/avsm/ocaml-yaml</a>
- Documentation: <a href="https://avsm.github.io/ocaml-yaml/">https://avsm.github.io/ocaml-yaml/</a>

##### CHANGES:

* Support MSVC with .obj and .lib extensions, and defining
  -DDYAML_DECLARE_EXPORT (@jonahbeckford avsm/ocaml-yaml#53)

* Upgrade to dune 2 (@TheLortex, avsm/ocaml-yaml#54)

* Add ocamlformat (@samoht, avsm/ocaml-yaml#55)

* Make yaml compatible with opam-monorepo (@TheLortex, avsm/ocaml-yaml#56)
