### PR TITLE
irmin-unix: fix expect tests

### DIFF
--- a/packages/irmin-unix/irmin-unix.3.0.0/opam
+++ b/packages/irmin-unix/irmin-unix.3.0.0/opam
@@ -47,6 +47,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
+  "sexplib" {with-test & < "v0.15.0"}
 ]
 
 synopsis: "Unix backends for Irmin"

--- a/packages/irmin-unix/irmin-unix.3.1.0/opam
+++ b/packages/irmin-unix/irmin-unix.3.1.0/opam
@@ -48,6 +48,7 @@ depends: [
   "irmin-test"    {with-test & = version}
   "alcotest"      {with-test}
   "mdx" {>= "2.0.0" & with-test}
+  "sexplib" {with-test & < "v0.15.0"}
 ]
 
 synopsis: "Unix backends for Irmin"


### PR DESCRIPTION
Sexplib has changed the way it serialzed exceptions in https://github.com/janestreet/sexplib0/commit/05c52b57673aaf026495af72baf4092d13e077c4

```
=== ERROR while compiling irmin-unix.3.0.0 ===================================#
 context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.13.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.13/.opam-switch/build/irmin-unix.3.0.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p irmin-unix -j 31
 exit-code            1
 env-file             ~/.opam/log/irmin-unix-6392-c25781.env
 output-file          ~/.opam/log/irmin-unix-6392-c25781.out
 File "test/irmin-unix/test_command_line.t", line 1, characters 0-0:
 /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/cbcc84621f29ecffe884a351a946593a/default/test/irmin-unix/test_command_line.t _build/.sandbox/cbcc84621f29ecffe884a351a946593a/default/test/irmin-unix/test_command_line.t.corrected
 diff --git a/_build/.sandbox/cbcc84621f29ecffe884a351a946593a/default/test/irmin-unix/test_command_line.t b/_build/.sandbox/cbcc84621f29ecffe884a351a946593a/default/test/irmin-unix/test_command_line.t.corrected
 index 9e58267..08748fa 100644
 --- a/_build/.sandbox/cbcc84621f29ecffe884a351a946593a/default/test/irmin-unix/test_command_line.t
 +++ b/_build/.sandbox/cbcc84621f29ecffe884a351a946593a/default/test/irmin-unix/test_command_line.t.corrected
 @@ -86,5 +86,5 @@ Check mismatched hash function
    $ irmin set --root ./test-hash -s irf -h sha1 abc 123
    $ irmin snapshot --root ./test-hash -s irf -h blake2b
    irmin: [ERROR] Irmin_fs.value invalid hash size
 -  ERROR: (Invalid_argument "Irmin.head: no head")
 +  ERROR: Invalid_argument("Irmin.head: no head")
    [1]
 (cd _build/default && test/irmin-unix/test.exe -q --color=always)
```