### PR TITLE
[new release] mirage-block-solo5 (0.8.0)

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.8.0/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.8.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+doc:           "https://mirage.github.io/mirage-block-solo5/"
+license:       "ISC"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "2.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-block-solo5/releases/download/v0.8.0/mirage-block-solo5-0.8.0.tbz"
+  checksum: [
+    "sha256=0619677d13a44246383ca32dfe4c2554652e9650ca4c4a5d35b1b00c58b411e7"
+    "sha512=5473130ddc9a324ab50d2de54d446bfe184c44b1ec1b14b2fc2be5d9ce7e9fce3063e26bbbbd2439aa803af79eac9741a768ca01d61fd5f10362328c2f17a04f"
+  ]
+}
+x-commit-hash: "398f88ccaa564bf07828266bb330a734e260859e"


### PR DESCRIPTION
Solo5 implementation of MirageOS block interface

- Project page: <a href="https://github.com/mirage/mirage-block-solo5">https://github.com/mirage/mirage-block-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-solo5/">https://mirage.github.io/mirage-block-solo5/</a>

##### CHANGES:

* Rename the freestanding toolchain to solo5 (@dinosaure, mirage/mirage-block-solo5#24)
* Use ocamlformat (@samoht, mirage/mirage-block-solo5#26)
