### PR TITLE
[new release] mirage-console-solo5 (0.8.0)

### DIFF
--- a/packages/mirage-console-solo5/mirage-console-solo5.0.8.0/opam
+++ b/packages/mirage-console-solo5/mirage-console-solo5.0.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-console-solo5"
+bug-reports:   "https://github.com/mirage/mirage-console-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-console-solo5.git"
+doc:           "https://mirage.github.io/mirage-console-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "mirage-console" {>= "3.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "cstruct"
+  "lwt"
+]
+synopsis: "Solo5 implementation of MirageOS console interface"
+description:
+  "This library implements the MirageOS console interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-console-solo5/releases/download/v0.8.0/mirage-console-solo5-0.8.0.tbz"
+  checksum: [
+    "sha256=dab4cafc90e4476c8a569f5ebdc48ba8c93fe0d6e505589d7e80aac4fae86415"
+    "sha512=12c3728d9bd805ad785c07dc421c076c48c64560e8f9d8615f687aee62dbcf67bba16f0cab12e27803450f8f4452e240998cca638df8b1608c8d87083e53fcfc"
+  ]
+}
+x-commit-hash: "172d375384ae0169150e1765fa3c2e9509027d33"


### PR DESCRIPTION
Solo5 implementation of MirageOS console interface

- Project page: <a href="https://github.com/mirage/mirage-console-solo5">https://github.com/mirage/mirage-console-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-console-solo5/">https://mirage.github.io/mirage-console-solo5/</a>

##### CHANGES:

* Rename the freestanding toolchain to solo5 (@dinosaure, mirage/mirage-console-solo5#23)
* Use ocamlformat (#@samoht, mirage/mirage-console-solo5#25)
