### PR TITLE
[new release] mirage-net-solo5 (0.8.0)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.8.0/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.8.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.8.0/mirage-net-solo5-0.8.0.tbz"
+  checksum: [
+    "sha256=e9ff307dfa73bc11a2b971ba67e2e609f4bc361eda984cc6e76770f131a2e826"
+    "sha512=d3e9dba2788d4f51325287705ada780a8a06523b89220a55f4abf708bb76a8a4aa917755d4862c540618052558f4d1a741fe31bb772741c3dd997c1598ed5437"
+  ]
+}
+x-commit-hash: "08eb65ad6b554f494c4744f6300d6b7af400f9c2"


### PR DESCRIPTION
Solo5 implementation of MirageOS network interface

- Project page: <a href="https://github.com/mirage/mirage-net-solo5">https://github.com/mirage/mirage-net-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-solo5/">https://mirage.github.io/mirage-net-solo5/</a>

##### CHANGES:

* Rename the freestanding toolchain to solo5 (@dinosaure, mirage/mirage-net-solo5#42)
* Use ocamlformat (@samoht, mirage/mirage-net-solo5#45)
