### PR TITLE
[new release] mirage-clock, mirage-clock-unix and mirage-clock-solo5 (4.2.0)

### DIFF
--- a/packages/mirage-clock-solo5/mirage-clock-solo5.4.2.0/opam
+++ b/packages/mirage-clock-solo5/mirage-clock-solo5.4.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Paravirtual implementation of the MirageOS Clock interface"
+description: """
+This 'freestanding' implementation of the MirageOS CLOCK interface
+is designed to be linked against an embedded runtime that provides
+a concrete implementation of the clock source. Example implementations
+include the [Solo5](https://github.com/solo5/solo5) backend of
+MirageOS.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "mirage-clock" {= version}
+]
+conflicts: [
+  "mirage-solo5" {< "0.7.0"}
+  "mirage-xen" {< "7.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz"
+  checksum: [
+    "sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847"
+    "sha512=05a359dc8400d4ca200ff255dbd030acd33d2c4acb5020838f772c02cdb5f243f3dbafbc43a8cd51e6b5923a140f84c9e7ea25b2c0fa277bb68b996190d36e3b"
+  ]
+}
+x-commit-hash: "f457572bfedb9586c8bf9eaa9ece7e53677856e3"

--- a/packages/mirage-clock-unix/mirage-clock-unix.4.2.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.4.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Unix-based implementation for the MirageOS Clock interface"
+description: """
+The Unix implementation of the MirageOS Clock interface uses
+`gettimeofday` or `clock_gettime`, depending on
+which OS is in use (see [clock_stubs.c](https://github.com/mirage/mirage-clock/blob/master/unix/clock_stubs.c)).
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator"
+  "mirage-clock" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz"
+  checksum: [
+    "sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847"
+    "sha512=05a359dc8400d4ca200ff255dbd030acd33d2c4acb5020838f772c02cdb5f243f3dbafbc43a8cd51e6b5923a140f84c9e7ea25b2c0fa277bb68b996190d36e3b"
+  ]
+}
+x-commit-hash: "f457572bfedb9586c8bf9eaa9ece7e53677856e3"

--- a/packages/mirage-clock/mirage-clock.4.2.0/opam
+++ b/packages/mirage-clock/mirage-clock.4.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Daniel C. Bünzli" "Matthew Gray"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-clock"
+doc: "https://mirage.github.io/mirage-clock/"
+bug-reports: "https://github.com/mirage/mirage-clock/issues"
+synopsis: "Libraries and module types for portable clocks"
+description: """
+This library implements portable support for an operating system timesource
+that is compatible with the [MirageOS](https://mirage.io) library interfaces
+found in: <https://github.com/mirage/mirage>
+
+It implements an `MCLOCK` module that represents a monotonic timesource
+since an arbitrary point, and `PCLOCK` which counts time since the Unix
+epoch.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-clock.git"
+url {
+  src:
+    "https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz"
+  checksum: [
+    "sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847"
+    "sha512=05a359dc8400d4ca200ff255dbd030acd33d2c4acb5020838f772c02cdb5f243f3dbafbc43a8cd51e6b5923a140f84c9e7ea25b2c0fa277bb68b996190d36e3b"
+  ]
+}
+x-commit-hash: "f457572bfedb9586c8bf9eaa9ece7e53677856e3"


### PR DESCRIPTION
Libraries and module types for portable clocks

- Project page: <a href="https://github.com/mirage/mirage-clock">https://github.com/mirage/mirage-clock</a>
- Documentation: <a href="https://mirage.github.io/mirage-clock/">https://mirage.github.io/mirage-clock/</a>

##### CHANGES:

* Rename the freestanding toolchain to solo5 (@dinosaure, mirage/mirage-clock#51)
* Use ocamlformat (@samoht, mirage/mirage-clock#54)
