### PR TITLE
[new release] mirage-xen (7.1.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.7.1.0/opam
+++ b/packages/mirage-xen/mirage-xen.7.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v7.1.0/mirage-xen-7.1.0.tbz"
+  checksum: [
+    "sha256=efc88c62ed32967373761afdbb038b056e57fd40e2f68c8c87e174e59645db51"
+    "sha512=dc92d01994cfeb5db55e8c038b6dc6058b216991f507900478ee15fb98c2f82d8bb663c1ef24b8e3ea7d4a29c6904b01f8e0a92ee8e5a5d31cc4f35e4c83544c"
+  ]
+}
+x-commit-hash: "8908c6691e4e854ae2ef58e3bf6c459690f08d7d"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Rename the freestanding toolchain to solo5
  (@dinosaure, @samoht, mirage/mirage-xen#39, mirage/mirage-xen#43)
* Use ocamlformat (@samoht, mirage/mirage-xen#42)
