### PR TITLE
[new release] mirage-solo5 (0.8.0)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.8.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.8.0/opam
@@ -17,7 +17,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {>= "2.6.0"}
+  "dune" {>= "2.7.0"}
   "bheap" {>= "2.0.0"}
   "ocaml" {>= "4.08.0"}
   "cstruct" {>= "1.0.1"}

--- a/packages/mirage-solo5/mirage-solo5.0.8.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.8.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.6.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.8.0/mirage-solo5-0.8.0.tbz"
+  checksum: [
+    "sha256=728dbcdf38041d3efce42987349085ece82f2dac166031421575b29fec9ba44d"
+    "sha512=23ca68040c208f4ce73a2ca48d811cfe931cedb62ad489fe03bc96f4c63a228857cc7bad9cbfb3ab6e2465fcff0d945b3ef005ce439d7486b7f0addb79771332"
+  ]
+}
+x-commit-hash: "3e3cdeacf1b85ff44f9901774aabb950db79dd90"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Rename the freestanding toolchain to solo5 (@dinosaure, @samoht, mirage/mirage-solo5#84, mirage/mirage-solo5#88)
* Use ocamlformat (@samoht, mirage/mirage-solo5#87)
