### PR TITLE
Package twostep.1.0.1

### DIFF
--- a/packages/twostep/twostep.1.0.1/opam
+++ b/packages/twostep/twostep.1.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HOTP and TOTP algorithms for 2-step verification (for OCaml)"
+description: """
+This project implements algorithms for 2-step verification, being the
+HMAC-based One-Time Password (RFC4226) and the Time-based One-Time Password
+(RFC 6238).
+"""
+license: "MIT"
+maintainer: "Marco Aurélio da Silva <marcoonroad@gmail.com>"
+authors: ["Marco Aurélio da Silva <marcoonroad@gmail.com>"]
+homepage: "https://github.com/marcoonroad/twostep"
+bug-reports: "https://github.com/marcoonroad/twostep/issues"
+dev-repo: "git+https://github.com/marcoonroad/twostep.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base" {>= "v0.9.3"}
+  "hex" {>= "1.2.0"}
+  "mirage-crypto" {>= "0.6.1"}
+  "mirage-crypto-rng" {>= "0.6.1"}
+  "mirage-crypto-pk" {>= "0.6.1"}
+  "dune" {>= "1.7.0"}
+  "alcotest" {with-test & >= "0.8.4"}
+]
+url {
+  src: "https://github.com/marcoonroad/twostep/archive/1.0.1.tar.gz"
+  checksum: [
+    "md5=ae8f791e8c3cd0a49cc9711ca0dc334b"
+    "sha512=a720c2e5cc907784db233618c6482a4faa26cc44fa82dc0c3f6370f975cdd96976489e95610d88bb984d61a577fd8c3e23ccc5cc7fdbe9452107d5dd05cd376a"
+  ]
+}

--- a/packages/twostep/twostep.1.0.1/opam
+++ b/packages/twostep/twostep.1.0.1/opam
@@ -20,6 +20,8 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
 
+available: [ arch != "arm32" & arch != "x86_32" ]
+
 depends: [
   "ocaml" {>= "4.08.0"}
   "base" {>= "v0.9.3"}
@@ -33,7 +35,7 @@ depends: [
 url {
   src: "https://github.com/marcoonroad/twostep/archive/1.0.1.tar.gz"
   checksum: [
-    "md5=ae8f791e8c3cd0a49cc9711ca0dc334b"
-    "sha512=a720c2e5cc907784db233618c6482a4faa26cc44fa82dc0c3f6370f975cdd96976489e95610d88bb984d61a577fd8c3e23ccc5cc7fdbe9452107d5dd05cd376a"
+    "md5=6af79936f7a0d04d2954ea768a01cf2a"
+    "sha512=087509e0d4a7d53f0aa968a013444c645d7a08bdd6a3c707176cfca47d695315344c54e425887009ea3c12a2a7e4b084837b8a52cb7a6a8b34a955cfb57f1f31"
   ]
 }


### PR DESCRIPTION
### `twostep.1.0.1`
HOTP and TOTP algorithms for 2-step verification (for OCaml)
This project implements algorithms for 2-step verification, being the
HMAC-based One-Time Password (RFC4226) and the Time-based One-Time Password
(RFC 6238).



---
* Homepage: https://github.com/marcoonroad/twostep
* Source repo: git+https://github.com/marcoonroad/twostep.git
* Bug tracker: https://github.com/marcoonroad/twostep/issues

---
:camel: Pull-request generated by opam-publish v2.1.0