### PR TITLE
[new release] ocaml-solo5 and ocaml-solo5-cross-aarch64 (0.8.0)

### DIFF
--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.0.8.0/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.0.8.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=aarch64-solo5-none-static"
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+   "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install" ]
+depends: [
+  "conf-which" {build}
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.15.0"}
+  "solo5" {>= "0.7.0"}
+  "solo5-cross-aarch64" {>= "0.7.0" }
+]
+conflicts: [
+  "ocaml-solo5"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/releases/download/v0.8.0/ocaml-solo5-0.8.0.tbz"
+  checksum: [
+    "sha256=0a6a801b06f18e0887063817c64777a4ea34dd11f23a34e52a4a98e8a6eca935"
+    "sha512=8daa29b8019f0d0dc6e4bb9626dac1830aa08fe27e8cd2e8a02d7e67c339e2ce98b7a66053c03713f6fedec5b635c8b60bb1333efc10a481937baccb7c686b9c"
+  ]
+}
+x-commit-hash: "a9884ed6ecac9e0b472e9c9b3d70317f94bed309"

--- a/packages/ocaml-solo5/ocaml-solo5.0.8.0/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.0.8.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=x86_64-solo5-none-static" { arch = "x86_64" }
+   "--target=aarch64-solo5-none-static" { arch = "arm64" }
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+   "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install" ]
+depends: [
+  "conf-which" {build}
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.15.0"}
+  "solo5" {>= "0.7.0"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/releases/download/v0.8.0/ocaml-solo5-0.8.0.tbz"
+  checksum: [
+    "sha256=0a6a801b06f18e0887063817c64777a4ea34dd11f23a34e52a4a98e8a6eca935"
+    "sha512=8daa29b8019f0d0dc6e4bb9626dac1830aa08fe27e8cd2e8a02d7e67c339e2ce98b7a66053c03713f6fedec5b635c8b60bb1333efc10a481937baccb7c686b9c"
+  ]
+}
+x-commit-hash: "a9884ed6ecac9e0b472e9c9b3d70317f94bed309"


### PR DESCRIPTION
Freestanding OCaml compiler

- Project page: <a href="https://github.com/mirage/ocaml-solo5">https://github.com/mirage/ocaml-solo5</a>

##### CHANGES:

* Rename freestanding to solo5 (mirage/ocaml-solo5#114, mirage/ocaml-solo5#115, @dinosaure, @samoht)
* Disable build of ocamltest (mirage/ocaml-solo5#108, @hannesm)
* vfprintf: change long double to double to fix a floating point exception
  (mirage/ocaml-solo5#110, @palainp)
* Add conf-which as a dependency (mirage/ocaml-solo5#113, @dinosaure)
