### PR TITLE
Package ometrics.0.1.3

### DIFF
--- a/packages/ometrics/ometrics.0.1.3/opam
+++ b/packages/ometrics/ometrics.0.1.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
-  "cmdliner" {<= "1.0.0"}
+  "cmdliner" {>= "1.0.0"}
   "digestif" {>= "0.7.2"}
   "qcheck-alcotest" {with-test & >= "0.18"}
   "bisect_ppx" {dev & >= "2.6.0"}

--- a/packages/ometrics/ometrics.0.1.3/opam
+++ b/packages/ometrics/ometrics.0.1.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+homepage: "https://gitlab.com/nomadic-labs/ometrics"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ometrics.git"
+bug-reports: "https://gitlab.com/nomadic-labs/ometrics/-/issues"
+synopsis: "OCaml analysis in a merge request changes"
+
+depends: [
+  "ocaml" {>= "4.12" & < "4.14"}
+  "dune" {>= "2.9.1"}
+  "yojson" {>= "1.7.0"}
+  "menhirSdk"
+  "menhirLib"
+  "menhir"
+  "dot-merlin-reader" {>= "4.1"}
+  "csexp" {>= "1.5.1"}
+  "result" {>= "1.5"}
+  "cmdliner" {<= "1.0.0"}
+  "digestif" {>= "0.7.2"}
+  "qcheck-alcotest" {with-test & >= "0.18"}
+  "bisect_ppx" {dev & >= "2.6.0"}
+]
+conflicts: [
+  "menhir" {!= "20211012"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+authors: [
+  "Thomas Letan <lthms@nomadic-labs.com>"
+  "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+]
+url {
+  src:
+    "https://github.com/vch9/ometrics/releases/download/0.1.3/ometrics-full.0.1.3.tar.gz"
+  checksum: [
+    "md5=09bdf9060c94937b96ec4d8a4fe34801"
+    "sha512=e38c5841522e5dcb63b8f005c3b1dac0a44fc3fb6f6b214f37240ca020ab679bb57d5263ead771786c633fc0ee9a6ad6d0e476d9076c3e7e8d9ffb39053f8b5b"
+  ]
+}


### PR DESCRIPTION
### `ometrics.0.1.3`
OCaml analysis in a merge request changes

Some others bug fixes since https://github.com/ocaml/opam-repository/pull/20787. The `.opam` should be fine I guess, I did not change dependencies.



---
* Homepage: https://gitlab.com/nomadic-labs/ometrics
* Source repo: git+https://gitlab.com/nomadic-labs/ometrics.git
* Bug tracker: https://gitlab.com/nomadic-labs/ometrics/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0