### PR TITLE
[new release] digestif (1.1.1)

### DIFF
--- a/packages/digestif/digestif.1.1.1/opam
+++ b/packages/digestif/digestif.1.1.1/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "ocaml" "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+install:  [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.05.0"}
+  "dune"            {>= "2.6.0"}
+  "conf-pkg-config" {build}
+  "eqaf"
+  "base-bytes"
+  "bigarray-compat"
+  "stdlib-shims"
+  "fmt"            {with-test}
+  "alcotest"       {with-test}
+  "bos"            {with-test}
+  "astring"        {with-test}
+  "fpath"          {with-test}
+  "rresult"        {with-test}
+  "ocamlfind"      {with-test}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.6.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v1.1.1/digestif-1.1.1.tbz"
+  checksum: [
+    "sha256=858fcaaf983c528f8e744f81accc7b0dd254c96b17222f12e1f270e8521d3799"
+    "sha512=019dfc8dd4a5e5f01fd142729d09135aca3d77a463c2910449203661f7e808ded68c9078b2cc1eb0f7acac7dcf21fa6250a93d8976ac94cd2cfd44b82eac8242"
+  ]
+}
+x-commit-hash: "17b0dbc2d2b84769e63edcada0befaf0381809ff"


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Hide C functions (`sha3_keccakf`) (@hannesm, mirage/digestif#125)
- Use `ocaml` to run `install.ml` instead of a shebang (@Nymphium, mirage/digestif#127)
- Use `command -v` instead of `which` (@Numphium, mirage/digestif#126)
- Add `@since` meta-data in documentation (@c-cube, @dinosaure, mirage/digestif#128)
- Update the README.md (@dinosaure, @mimoo, mirage/digestif#130)
- `ocaml-solo5` provides `__ocaml_solo5__` instead of `__ocaml_freestanding__` (@dinosaure, mirage/digestif#131)
