### PR TITLE
Package utop.2.9.1

### DIFF
--- a/packages/utop/utop.2.9.1/opam
+++ b/packages/utop/utop.2.9.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Universal toplevel for OCaml"
+description: """\
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs."""
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/utop"
+doc: "https://ocaml-community.github.io/utop/"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lwt"
+  "lwt_react"
+  "camomile"
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.9.1/utop-2.9.1.tbz"
+  checksum: [
+    "md5=470dd7d91f8624be5af2868c9616eabe"
+    "sha512=002fa809d4924419f51b81df968b653a111ae5992837792fcb867adf2e44c15d40fadccc9784ef61f21ea3233f9da74016433920bf909d808752b7f825f8cdb1"
+  ]
+}


### PR DESCRIPTION
### `utop.2.9.1`
Universal toplevel for OCaml
utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
OCaml.  It can run in a terminal or in Emacs. It supports line
edition, history, real-time and context sensitive completion, colors,
and more.  It integrates with the Tuareg mode in Emacs.



---
* Homepage: https://github.com/ocaml-community/utop
* Source repo: git+https://github.com/ocaml-community/utop.git
* Bug tracker: https://github.com/ocaml-community/utop/issues

---
:camel: Pull-request generated by opam-publish v2.1.0