### PR TITLE
Add ocaml-lsp-server.1.9.2~4.14preview upper bound for ocamlformat-rpc-lib

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.9.2~4.14preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.9.2~4.14preview/opam
@@ -28,7 +28,7 @@ depends: [
   "pp" {>= "1.1.2"}
   "csexp" {>= "1.5"}
   "result" {>= "1.5"}
-  "ocamlformat-rpc-lib" {>= "0.20.0"}
+  "ocamlformat-rpc-lib" {>= "0.20.0" & < "0.21.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.14" & < "4.15"}
 ]


### PR DESCRIPTION
See https://github.com/ocaml/ocaml-lsp/issues/637.

This preview is currently the only ocaml-lsp-server compatible with OCaml 4.14, but fails to install on a fresh switch:
```
#=== ERROR while compiling ocaml-lsp-server.1.9.2~4.14preview =================#
# context     2.1.0 | linux/x86_64 | ocaml-base-compiler.4.14.0 | https://opam.ocaml.org#41c64785
# path        ~/.opam/4.14.0/.opam-switch/build/ocaml-lsp-server.1.9.2~4.14preview
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -j 15 ocaml-lsp-server.install --release
# exit-code   1
# env-file    ~/.opam/log/ocaml-lsp-server-577814-2641c4.env
# output-file ~/.opam/log/ocaml-lsp-server-577814-2641c4.out
### output ###
# (cd _build/default && /home/simmo/.opam/4.14.0/bin/ocamlopt.opt -w -40 -alert -unstable -g -I ocaml-lsp-server/src/.ocaml_lsp_server.objs/byte -I ocaml-lsp-server/src/.ocaml_lsp_server.objs/native -I /home/simmo/.opam/4.14.0/lib/csexp -I /home/simmo/.opam/4.14.0/lib/dune-build-info -I /home/simmo/.opam/4.14.0/lib/ocamlformat-rpc-lib -I /home/simmo/.opam/4.14.0/lib/pp -I /home/simmo/.opam/4.14[...]
# File "ocaml-lsp-server/src/ocamlformat_rpc.ml", line 26, characters 15-41:
# 26 |     ; client : Ocamlformat_rpc_lib.client
#                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Ocamlformat_rpc_lib.client
```

Adding the upper bound fixes installation of ocaml-lsp-server on OCaml 4.14 until a non-preview release I guess.

Other ocaml-lsp-server versions already have stricter upper bounds for ocamlformat-rpc-lib, so shouldn't have the issue.