### PR TITLE
Package bwd.1.0.0

### DIFF
--- a/packages/bwd/bwd.1.0.0/opam
+++ b/packages/bwd/bwd.1.0.0/opam
@@ -1,7 +1,10 @@
 opam-version: "2.0"
 synopsis: "Backward lists"
 description: """
-This OCaml package defines backward lists that are isomorphic to lists. They are useful when one wishes to give a different type to the lists that are semantically in reverse. In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present. With backward lists having a different type, it is impossible to make these mistakes.
+This OCaml package defines backward lists that are isomorphic to lists.
+They are useful when one wishes to give a different type to the lists that are semantically in reverse.
+In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
+With backward lists having a different type, it is impossible to make these mistakes.
 """
 maintainer: "favonia <favonia@gmail.com>"
 authors: "The RedPRL Development Team"

--- a/packages/bwd/bwd.1.0.0/opam
+++ b/packages/bwd/bwd.1.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Backward lists"
+description: """
+This OCaml package defines backward lists that are isomorphic to lists. They are useful when one wishes to give a different type to the lists that are semantically in reverse. In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present. With backward lists having a different type, it is impossible to make these mistakes.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/ocaml-bwd"
+bug-reports: "https://github.com/RedPRL/ocaml-bwd/issues"
+dev-repo: "git+https://github.com/RedPRL/ocaml-bwd.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/ocaml-bwd/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=e06992507455ffb10a1c379322d7fb6e"
+    "sha512=85066a9866dc90a0d138cc4d0688476a3ca96ce7454dc953fdadee51cb061201d0dc07db0b1c2ff2335f45dbfaaa9cbe53fc7724221f15d58604fd7fa1bbd22d"
+  ]
+}


### PR DESCRIPTION
### `bwd.1.0.0`
Backward lists
This OCaml package defines backward lists that are isomorphic to lists. They are useful when one wishes to give a different type to the lists that are semantically in reverse. In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present. With backward lists having a different type, it is impossible to make these mistakes.



---
* Homepage: https://github.com/RedPRL/ocaml-bwd
* Source repo: git+https://github.com/RedPRL/ocaml-bwd.git
* Bug tracker: https://github.com/RedPRL/ocaml-bwd/issues

---
:camel: Pull-request generated by opam-publish v2.1.0