### PR TITLE
ocaml-manual: 4.14 manual

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.4.14.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.14.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "CC-BY-SA-4.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install:
+[
+ [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {>= "4.14.0" & < "4.15.0"}
+]
+url {
+  src: "http://caml.inria.fr/distrib/ocaml-4.14/ocaml-4.14-refman-html.tar.gz"
+  checksum: "sha256=f9d20b8f3c573bbf7bfc99155731472b91b9bf084e9dd2b5539d2ae473406ca7"
+}

--- a/packages/ocaml-manual/ocaml-manual.4.14.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.4.14.0/opam
@@ -13,8 +13,8 @@ dev-repo: "git+https://github.com/ocaml/ocaml.git"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 install:
 [
- [ "cp" "-R" "." ocaml-manual:doc ] {os != "win32"}
- [ "robocopy" "/E" "." ocaml-manual:doc ] {os = "win32"}
+ [ "cp" "-R" "." _:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." _:doc ] {os = "win32"}
 ]
 synopsis: "The OCaml system manual"
 depends: [


### PR DESCRIPTION
This package adds the `ocaml-manual` package for OCaml 4.14 now that the manual archive is online.