### PR TITLE
Further bounds cleanup

### DIFF
--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.1/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "ppx_jane"
-  "menhir" {build & >= "20170607" & < "20211215"}
+  "menhir" {build & >= "20180523" & < "20211215"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.1/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.1/opam
@@ -18,6 +18,7 @@ depends: [
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "ppx_jane"
+  "menhir" {build & >= "20170607" & < "20211215"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.1/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/tari3x/webgpu"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.2"}
-  "core" {>= "v0.12" & < "v0.15"}
+  "core" {>= "v0.13" & < "v0.15"}
   "async" {>= "v0.12" & < "v0.15"}
   "webidl"
   "ppx_deriving"

--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "ppx_jane"
-  "menhir" {build & >= "20170607" & < "20211215"}
+  "menhir" {build & >= "20180523" & < "20211215"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
@@ -18,6 +18,7 @@ depends: [
   "js_of_ocaml-lwt"
   "js_of_ocaml-ppx"
   "ppx_jane"
+  "menhir" {build & >= "20170607" & < "20211215"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
+++ b/packages/js_of_ocaml-webidl/js_of_ocaml-webidl.0.2/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/tari3x/webgpu"
 depends: [
   "dune" {>= "2.2"}
   "ocaml" {>= "4.08"}
-  "core" {>= "v0.12" & < "v0.15"}
+  "core" {>= "v0.13" & < "v0.15"}
   "async" {>= "v0.12" & < "v0.15"}
   "webidl"
   "ppx_deriving"

--- a/packages/webidl/webidl.1.0/opam
+++ b/packages/webidl/webidl.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.7.1"}
   "ocamlbuild" {build & >= "0.9.3"}
-  "menhir" {build & >= "20170101" & < "20211215"}
+  "menhir" {build & >= "20170101"}
   "ppx_deriving" {>= "4.1"}
 ]
 synopsis: "Web IDL parser"

--- a/packages/webidl/webidl.1.1/opam
+++ b/packages/webidl/webidl.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.7.1"}
   "ocamlbuild" {build & >= "0.11.0"}
-  "menhir" {build & >= "20170101" & < "20211215"}
+  "menhir" {build & >= "20170101"}
   "ppx_deriving" {>= "4.1"}
 ]
 synopsis: "Web IDL parser"

--- a/packages/webidl/webidl.1.2/opam
+++ b/packages/webidl/webidl.1.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.7.1"}
   "ocamlbuild" {build & >= "0.9.3"}
-  "menhir" {build & >= "20170607" & < "20211215"}
+  "menhir" {build & >= "20170607"}
   "ppx_deriving" {>= "4.1"}
 ]
 synopsis: "Web IDL parser"

--- a/packages/webidl/webidl.1.2/opam
+++ b/packages/webidl/webidl.1.2/opam
@@ -11,7 +11,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.7.1"}
   "ocamlbuild" {build & >= "0.9.3"}
-  "menhir" {build & >= "20170607"}
   "ppx_deriving" {>= "4.1"}
 ]
 synopsis: "Web IDL parser"


### PR DESCRIPTION
This removes the upper bound on menhir in webidl 1.0-1.2, added erroneously by #21011

1.0, 1.1 should succeed
1.2 we need to check (UPDATE: it is fine as well)

Once this is checked, I will add the commit adding those bounds to `js_of_ocaml-webidl` which depends on webidl but also vendors a version of webidl which needs the bounds.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>
