### PR TITLE
Add new package for Z3 TPTP

### DIFF
--- a/packages/z3_tptp/z3_tptp.4.8.13/opam
+++ b/packages/z3_tptp/z3_tptp.4.8.13/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.8.13" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.13.tar.gz"
+  checksum: [
+    "sha256=59a0b35711fa7ae48dd535116d2067a6a16955fcbf2623c516a3f630cd2832d8"
+    "sha512=c5e8f34525ed3b6b2935d7f01ce2f90f5dd99b4cdd035664b36c967fb1c7f3b05abed45c7288e2261723e73d68728ee91a0f67d92012d86b04598d7b54369c30"
+  ]
+}

--- a/packages/z3_tptp/z3_tptp.4.8.14/opam
+++ b/packages/z3_tptp/z3_tptp.4.8.14/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.8.14" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src: "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.14.tar.gz"
+  checksum: [
+    "sha256=96a1f49a7701120cc38bfa63c02ff93be4d64c7926cea41977dedec7d87a1364"
+    "sha512=10170516ca472258d2f9df28cd036e43023a76a25f1e1670290c62f3890d935bf82770970054a5fd3a0f02559409e7ed4b18fb08347c040ff2f9e0918e152aab"
+  ]
+}


### PR DESCRIPTION
This PR adds a new package which contains the TPTP front end for Z3. It uses the existing opam z3 package and z3 shared library.

TPTP is a front end common in automatic theorem provers like Eprover. It is used by the Coq Hammer tactic.

The build instructions are not as clean as I would like it, but I couldn't find a way to build it with Z3's python based build system with an existing opam Z3 and the front end is a single C++ file + the Z3 library, so I guess this explicit compiler call might be more robust than hacking into the Z3 build system.

This is yet another of my "why not build interesting C++ software with opam" PRs and quite Coq centric. If you think it is not so useful for the wider OCaml world, I can also keep it in Coq's own opam repo, but I always ask here first.

@k4rtik : FYI.