### PR TITLE
Add new version 3.9 for conf-python-3

### DIFF
--- a/packages/conf-python-3/conf-python-3.9.0.0/files/test.py
+++ b/packages/conf-python-3/conf-python-3.9.0.0/files/test.py
@@ -1,0 +1,1 @@
+print('python-3 OK')

--- a/packages/conf-python-3/conf-python-3.9.0.0/opam
+++ b/packages/conf-python-3/conf-python-3.9.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://www.python.org/downloads/release/python-3910/"
+authors: "Python Software Foundation"
+license: "PSF-2.0"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+build: ["python3" "test.py"]
+depexts: [
+  ["python3"] {os-family = "debian"}
+  ["python3"] {os-distribution = "nixos"}
+  ["python3"] {os-distribution = "alpine"}
+  ["python39" "epel-release"] {os-distribution = "centos"}
+  ["python3"] {os-distribution = "fedora"}
+  ["python3"] {os-distribution = "ol"}
+  ["python"] {os-distribution = "arch"}
+  ["python3"] {os-family = "suse"}
+  ["dev-lang/python:3.6"] {os-distribution = "gentoo"}
+  ["python3"] {os = "openbsd"}
+  ["lang/python39"] {os = "netbsd"}
+  ["lang/python39"] {os = "freebsd"}
+  ["python39"] {os-distribution = "macports" & os = "macos"}
+  ["python@3"] {os-distribution = "homebrew" & os = "macos"}
+  ["system:python3"] {os-distribution = "cygwinports"}
+]
+synopsis: "Virtual package relying on Python-3 installation"
+description: """
+This package can only install if a Python-3 interpreter is available
+on the system.
+If a minor version needs to be specified for your operating system, then
+python-3.9 will be used.
+"""
+extra-files: ["test.py" "md5=db8829ab1f4aa1fc15f380afba9d01f5"]
+flags: conf


### PR DESCRIPTION
This PR adds a new version for the python 3 conf package (the latest available is 3.1 which is way too old).

I get btw a lint warning:
```
warning 62: License doesn't adhere to the SPDX standard, see https://spdx.org/licenses/: "PSF-2.0"
```
which I would say is a false positive. See (https://spdx.org/licenses/PSF-2.0.html).

Since this package hasn't been updated by the written maintainer, please feel free to put in my Github ID / email.