### PR TITLE
[new release] arg-complete (0.1.0)

### DIFF
--- a/packages/arg-complete/arg-complete.0.1.0/opam
+++ b/packages/arg-complete/arg-complete.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Bash completion support for Stdlib.Arg"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ocaml-arg-complete"
+doc: "https://sim642.github.io/ocaml-arg-complete"
+bug-reports: "https://github.com/sim642/ocaml-arg-complete/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "cppo" {>= "1.1.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ocaml-arg-complete.git"
+url {
+  src:
+    "https://github.com/sim642/ocaml-arg-complete/releases/download/0.1.0/arg-complete-0.1.0.tbz"
+  checksum: [
+    "sha256=f30e5785e63ca905ab554e45a7ee043c888ae71f8181e4ead22f19ceba5a22bc"
+    "sha512=cfeed80b93e8420695b0b4824524b9bf06ed8cfadb0522bb03c4307eb03045acdb8d4ceac5b59357a1ec47d7a5874a5fa0f2117de94717349c3c19e9a68bec3a"
+  ]
+}
+x-commit-hash: "77d1e98e483e3fe0aaf4b67c075175e9aee79a3e"


### PR DESCRIPTION
Bash completion support for Stdlib.Arg

- Project page: <a href="https://github.com/sim642/ocaml-arg-complete">https://github.com/sim642/ocaml-arg-complete</a>
- Documentation: <a href="https://sim642.github.io/ocaml-arg-complete">https://sim642.github.io/ocaml-arg-complete</a>

##### CHANGES:

Initial release.
