### PR TITLE
[new release] tls, tls-mirage and tls-async (0.15.3)

### DIFF
--- a/packages/tls-async/tls-async.0.15.3/opam
+++ b/packages/tls-async/tls-async.0.15.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.14.0"}
+  "ptime" {>= "0.8.1"}
+  "async" {>= "v0.15"}
+  "async_unix" {>= "v0.15"}
+  "core" {>= "v0.15"}
+  "cstruct-async"
+  "ppx_jane" {>= "v0.15"}
+  "mirage-crypto-rng-async"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Async layer"
+description: """
+Tls-async provides Async-friendly tls bindings
+"""
+authors: [
+  "David Kaloper <david@numm.org>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Eric Ebinger <github@eric.theebingers.com>"
+  "Calascibetta Romain <romain.calascibetta@gmail.com>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.15.3/tls-0.15.3.tbz"
+  checksum: [
+    "sha256=5db456f98a2da3778296152f33dfb73e900c691c958805899fc8e6981f74465a"
+    "sha512=371b85c6afebeda0fcc8cc5252e3333d9c3ef3a6bdbee160bb194e2a5928fd537c811c6eec729f16852070944e627257d44c97142a259d00d0db66956a95df49"
+  ]
+}
+x-commit-hash: "9e05cbb8c61f1dd3e9707c530a7697cd2e63f45f"

--- a/packages/tls-mirage/tls-mirage.0.15.3/opam
+++ b/packages/tls-mirage/tls-mirage.0.15.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "tls" {= version}
+  "x509" {>= "0.13.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.15.3/tls-0.15.3.tbz"
+  checksum: [
+    "sha256=5db456f98a2da3778296152f33dfb73e900c691c958805899fc8e6981f74465a"
+    "sha512=371b85c6afebeda0fcc8cc5252e3333d9c3ef3a6bdbee160bb194e2a5928fd537c811c6eec729f16852070944e627257d44c97142a259d00d0db66956a95df49"
+  ]
+}
+x-commit-hash: "9e05cbb8c61f1dd3e9707c530a7697cd2e63f45f"

--- a/packages/tls/tls.0.15.3/opam
+++ b/packages/tls/tls.0.15.3/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "ppx_cstruct" {>= "3.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-sexp"
+  "sexplib"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.15.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "lwt" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "hkdf"
+  "logs"
+  "ipaddr"
+  "ipaddr-sexp"
+  "alcotest" {with-test}
+  "randomconv" {with-test}
+  "cmdliner" {dev & > "1.1.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.15.3/tls-0.15.3.tbz"
+  checksum: [
+    "sha256=5db456f98a2da3778296152f33dfb73e900c691c958805899fc8e6981f74465a"
+    "sha512=371b85c6afebeda0fcc8cc5252e3333d9c3ef3a6bdbee160bb194e2a5928fd537c811c6eec729f16852070944e627257d44c97142a259d00d0db66956a95df49"
+  ]
+}
+x-commit-hash: "9e05cbb8c61f1dd3e9707c530a7697cd2e63f45f"


### PR DESCRIPTION
Transport Layer Security purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* Upgrade to v0.15 of Jane Street packages (mirleft/ocaml-tls#444 @bcc32)
* Use cmdliner 1.1.0 in lwt/examples (mirleft/ocaml-tls#445 @hannesm)
