### PR TITLE
LablTk 8.06.12 and OCamlBrowser 4.14.0

### DIFF
--- a/packages/labltk/labltk.8.06.12/opam
+++ b/packages/labltk/labltk.8.06.12/opam
@@ -6,15 +6,14 @@ bug-reports: "https://github.com/garrigue/labltk/issues"
 dev-repo: "git+https://github.com/garrigue/labltk.git"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [
-  ["./configure" "-use-findlib" "-installbindir" bin]
-  [make "all"]
+  ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
+  [make "library" "opt"]
 ]
 install: [
-  [make "install-browser"]
+  [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.13" & < "4.14"}
-  "labltk" {>= "8.06.11" & <= "8.06.12"}
+  "ocaml" {>= "4.08"}
   "ocamlfind" {build}
   "conf-tcl"
   "conf-tk"
@@ -22,9 +21,10 @@ depends: [
 post-messages: [
   "This package requires Tcl/Tk with its development packages installed on your system" {failure}
 ]
-synopsis: "OCamlBrowser Library Explorer"
-description: "Require LablTk. For details, see https://garrigue.github.io/labltk/"
+synopsis: "OCaml interface to Tcl/Tk"
+description: "ocamlbrowser is now a separate package.\n\
+             For details, see https://garrigue.github.io/labltk/"
 url {
-  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.11.tar.gz"
-  checksum: "md5=defe77d470e6705456c767675d4560e7"
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.12.tar.gz"
+  checksum: "md5=871e823b78ae07f5fe2423bbecb83558"
 }

--- a/packages/ocamlbrowser/ocamlbrowser.4.14.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.4.14.0/opam
@@ -13,7 +13,7 @@ install: [
   [make "install-browser"]
 ]
 depends: [
-  "ocaml" {>= "4.13" & < "4.14"}
+  "ocaml" {>= "4.14" & < "4.15"}
   "labltk" {>= "8.06.11" & <= "8.06.12"}
   "ocamlfind" {build}
   "conf-tcl"
@@ -25,6 +25,6 @@ post-messages: [
 synopsis: "OCamlBrowser Library Explorer"
 description: "Require LablTk. For details, see https://garrigue.github.io/labltk/"
 url {
-  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.11.tar.gz"
-  checksum: "md5=defe77d470e6705456c767675d4560e7"
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.12.tar.gz"
+  checksum: "md5=871e823b78ae07f5fe2423bbecb83558"
 }


### PR DESCRIPTION
LablTk itself is unchanged, but OCamlBrowser must be updated for OCaml 4.14.