### PR TITLE
[new release] mirage-xen (7.2.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.7.2.0/opam
+++ b/packages/mirage-xen/mirage-xen.7.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v7.2.0/mirage-xen-7.2.0.tbz"
+  checksum: [
+    "sha256=e59773a2ead0b211c6b583cf749b492e91fc3fa64b35b8d05b2ed30f1718dce0"
+    "sha512=a7b8f217c4b2532ed4cfdb427e4f7f353f372e365c036d10434a9d1fe1f14e607979662ff7a07da87dd580821061c869b46422c775c82c89c1ce214b0afd5751"
+  ]
+}
+x-commit-hash: "f9740fbdd8fe97ec186a6cc6f3499cda7da25ad7"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* lib/bindings: pass CFLAGS from 6.x for compiling libimrage-xen_bindings.a
  (@palainp, mirage/mirage-xen#47, solves mirage/mirage#1299)
