### PR TITLE
atd >= 2.3.3 works fine with up-to-date menhir

### DIFF
--- a/packages/atd/atd.2.3.3/opam
+++ b/packages/atd/atd.2.3.3/opam
@@ -32,7 +32,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "menhir" {>= "20180523" & < "20211215"}
+  "menhir" {>= "20180523"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/atd/atd.2.4.0/opam
+++ b/packages/atd/atd.2.4.0/opam
@@ -66,7 +66,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180523" & < "20211215"}
+  "menhir" {>= "20180523"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/atd/atd.2.4.1/opam
+++ b/packages/atd/atd.2.4.1/opam
@@ -66,7 +66,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180523" & < "20211215"}
+  "menhir" {>= "20180523"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
I’m not sure why these constraints have been added (it’s even upstream for some reason?)

cc @mjambon could you remove them upstream?