### PR TITLE
Bump ocamlformat's Jane Street dependencies to include 0.15

### DIFF
--- a/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
+++ b/packages/dump_ocamlformat/dump_ocamlformat.0.2.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/diohabara/dump_ocamlformat"
 bug-reports: "https://github.com/diohabara/dump_ocamlformat/issues"
 depends: [
   "dune" {>= "3.0"}
-  "core" {>= "v0.14.1"}
+  "core" {>= "v0.14.1" & < "v0.15"}
   "ocaml" {>= "4.10.0"}
   "ocamlformat" {>= "0.20.1"}
   "odoc" {>= "2.1.0"}

--- a/packages/ocamlformat/ocamlformat.0.21.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.21.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
-  "base" {>= "v0.12.0" & < "v0.15"}
+  "base" {>= "v0.12.0" & < "v0.16"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
   "dune" {with-test & < "3.0"}
@@ -24,7 +24,7 @@ depends: [
   "ocp-indent"
   "odoc-parser" {>= "1.0.0"}
   "re" {>= "1.7.2"}
-  "stdio" {< "v0.15"}
+  "stdio" {< "v0.16"}
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
   "odoc" {with-doc}

--- a/packages/ocamlformat/ocamlformat.0.21.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.21.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
 depends: [
   "ocaml" {>= "4.08" & < "4.15"}
   "alcotest" {with-test}
-  "base" {>= "v0.12.0" & < "v0.16"}
+  "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
   "dune" {with-test & < "3.0"}
@@ -24,7 +24,7 @@ depends: [
   "ocp-indent"
   "odoc-parser" {>= "1.0.0"}
   "re" {>= "1.7.2"}
-  "stdio" {< "v0.16"}
+  "stdio"
   "uuseg" {>= "10.0.0"}
   "uutf" {>= "1.0.1"}
   "odoc" {with-doc}

--- a/packages/ocp-build/ocp-build.1.99.21/opam
+++ b/packages/ocp-build/ocp-build.1.99.21/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {< "4.12"}
   ("seq" {>= "base"} & "ocaml" {>= "4.07.0"} | "seq" & "ocaml")
   "ocamlfind"
-  "cmdliner" {>= "1"}
+  "cmdliner" {>= "1" & < "1.1.0"}
   "re" {>= "1.7.3"}
 ]
 conflicts: [


### PR DESCRIPTION
Ref: https://github.com/ocaml-ppx/ocamlformat/pull/2059