### PR TITLE
2 packages from c-cube/tiny_httpd at 0.12

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.12/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.12/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-threads"
+  "result"
+  "seq"
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+  "qtest" { >= "2.9" & with-test}
+  "conf-libcurl" {with-test}
+  "qcheck" {with-test & >= "0.9" }
+  "ounit2" {with-test}
+  "ptime" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.12.tar.gz"
+  checksum: [
+    "md5=9ceac00dcd214ad562446b81abbf6734"
+    "sha512=99b4d01d4f4d138b122c689b8b3bc5043fc386d6686675311f625bf5fec72c6e1a7513712b00889fe17cd392b8c475440d4f89ee46392aff32ac6ccc39cefe09"
+  ]
+}

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.12/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.12/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Interface to camlzip for tiny_httpd"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "camlzip" {>= "1.06"}
+  "tiny_httpd" { = version }
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "gzip" "camlzip" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.12.tar.gz"
+  checksum: [
+    "md5=9ceac00dcd214ad562446b81abbf6734"
+    "sha512=99b4d01d4f4d138b122c689b8b3bc5043fc386d6686675311f625bf5fec72c6e1a7513712b00889fe17cd392b8c475440d4f89ee46392aff32ac6ccc39cefe09"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`tiny_httpd.0.12`: Minimal HTTP server using good old threads
-`tiny_httpd_camlzip.0.12`: Interface to camlzip for tiny_httpd



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.1.0