### PR TITLE
ocp-build.1.99.21: add cmdliner upper bound

### DIFF
--- a/packages/ocp-build/ocp-build.1.99.21/opam
+++ b/packages/ocp-build/ocp-build.1.99.21/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {< "4.12"}
   ("seq" {>= "base"} & "ocaml" {>= "4.07.0"} | "seq" & "ocaml")
   "ocamlfind"
-  "cmdliner" {>= "1"}
+  "cmdliner" {>= "1" & < "1.1.0"}
   "re" {>= "1.7.3"}
 ]
 conflicts: [


### PR DESCRIPTION
```
#=== ERROR while compiling ocp-build.1.99.21 ==================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.11.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.11/.opam-switch/build/ocp-build.1.99.21
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ocp-build-23-8390d5.env
# output-file          ~/.opam/log/ocp-build-23-8390d5.out
### output ###
# make create-booter
# make[1]: Entering directory '/home/opam/.opam/4.11/.opam-switch/build/ocp-build.1.99.21'
# cp -f libs/ocplib-compat/4.03.0/ocpCompat.ml \
# 	libs/ocplib-compat/string-compat/ocpCompat.ml
# ocamllex.opt libs/ocplib-lang/ocamllexer.mll
# 82 states, 1371 transitions, table size 5976 bytes
# ocamlyacc tools/ocp-build/lang-ocp/buildOCPParser.mly
# 12 shift/reduce conflicts, 22 reduce/reduce conflicts.
# ocamllex.opt tools/ocp-build/lang-ocp2/buildOCP2Lexer.mll
# 82 states, 1404 transitions, table size 6108 bytes
# ocamlyacc tools/ocp-build/lang-ocp2/buildOCP2Parser.mly
# echo "let version=\"1.99.21-beta\"" > tools/ocp-build/buildVersion.ml
# ocamllex.opt tools/ocp-build/meta/metaLexer.mll
# 22 states, 692 transitions, table size 2900 bytes
# ocamlopt.opt -c -o libs/ocplib-compat/string-compat/ocpCompat.cmx -I /home/opam/.opam/4.11/lib/cmdliner -I /home/opam/.opam/4.11/lib/re   -I libs/ocplib-debug  -I libs/ocplib-lang  -I libs/ocplib-maxunix  -I libs/ocplib-file  -I libs/ocplib-system  -I libs/ocplib-config  -I libs/ocplib-compat/string-compat -I tools/ocp-build -I libs/ezcmd -I tools/ocp-build/misc -I tools/ocp-build/lang-ocp -I tools/ocp-build/lang-ocp2 -I tools/ocp-build/engine -I tools/ocp-build/actions -I tools/ocp-build/meta -I tools/ocp-build/ocaml  libs/ocplib-compat/string-compat/ocpCompat.ml
# ocamlc.opt -c -o libs/ezcmd/ezcmd.cmi -I /home/opam/.opam/4.11/lib/cmdliner -I /home/opam/.opam/4.11/lib/re   -I libs/ocplib-debug  -I libs/ocplib-lang  -I libs/ocplib-maxunix  -I libs/ocplib-file  -I libs/ocplib-system  -I libs/ocplib-config  -I libs/ocplib-compat/string-compat -I tools/ocp-build -I libs/ezcmd -I tools/ocp-build/misc -I tools/ocp-build/lang-ocp -I tools/ocp-build/lang-ocp2 -I tools/ocp-build/engine -I tools/ocp-build/actions -I tools/ocp-build/meta -I tools/ocp-build/ocaml  libs/ezcmd/ezcmd.mli
# ocamlopt.opt -c -o libs/ezcmd/ezcmd.cmx -I /home/opam/.opam/4.11/lib/cmdliner -I /home/opam/.opam/4.11/lib/re   -I libs/ocplib-debug  -I libs/ocplib-lang  -I libs/ocplib-maxunix  -I libs/ocplib-file  -I libs/ocplib-system  -I libs/ocplib-config  -I libs/ocplib-compat/string-compat -I tools/ocp-build -I libs/ezcmd -I tools/ocp-build/misc -I tools/ocp-build/lang-ocp -I tools/ocp-build/lang-ocp2 -I tools/ocp-build/engine -I tools/ocp-build/actions -I tools/ocp-build/meta -I tools/ocp-build/ocaml  libs/ezcmd/ezcmd.ml
# File "libs/ezcmd/ezcmd.ml", line 17, characters 13-35:
# 17 |   type env = Cmdliner.Term.env_info
#                   ^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.env_info
# Use Cmd.Env.info instead.
# File "libs/ezcmd/ezcmd.ml", line 58, characters 10-23:
# 58 | let env = Term.env_info
#                ^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.env_info
# Use Cmd.Env.info instead.
# File "libs/ezcmd/ezcmd.ml", line 150, characters 16-34:
# 150 | let cmd_exits = Term.default_exits
#                       ^^^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.default_exits
# Use Cmd.Exit.defaults or Cmd.info's defaults ~exits value instead.
# File "libs/ezcmd/ezcmd.ml", line 157, characters 2-11:
# 157 |   Term.info sub.cmd_name ?version ~doc
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "libs/ezcmd/ezcmd.ml", line 192, characters 2-11:
# 192 |   Term.info "help" ~doc ~exits:Term.default_exits ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "libs/ezcmd/ezcmd.ml", line 192, characters 31-49:
# 192 |   Term.info "help" ~doc ~exits:Term.default_exits ~man
#                                      ^^^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.default_exits
# Use Cmd.Exit.defaults or Cmd.info's defaults ~exits value instead.
# File "libs/ezcmd/ezcmd.ml", line 196, characters 14-32:
# 196 |   let exits = Term.default_exits in
#                     ^^^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.default_exits
# Use Cmd.Exit.defaults or Cmd.info's defaults ~exits value instead.
# File "libs/ezcmd/ezcmd.ml", line 198, characters 2-11:
# 198 |   Term.info name ?version ~doc ~sdocs ~exits ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "libs/ezcmd/ezcmd.ml", line 230, characters 8-24:
# 230 |   match Term.eval_choice ~catch:false ~argv default_cmd cmds with
#               ^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.eval_choice
# Use Cmd.group and one of Cmd.eval* instead.
# File "libs/ezcmd/ezcmd.ml", line 232, characters 9-18:
# 232 |   | t -> Term.exit t
#                ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.exit
# Use Stdlib.exit and Cmd.eval instead.
# File "libs/ezcmd/ezcmd.ml", line 236, characters 16-25:
# 236 |           match Term.eval ~catch:false ?argv cmd with
#                       ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.eval
# Use Cmd.v and one of Cmd.eval* instead.
# File "libs/ezcmd/ezcmd.ml", line 239, characters 17-26:
# 239 |           | t -> Term.exit t
#                        ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.exit
# Use Stdlib.exit and Cmd.eval instead.
# File "libs/ezcmd/ezcmd.ml", line 283, characters 18-26:
# 283 |                   cmd_args;
#                         ^^^^^^^^
# Error: This expression has type
#          (string list * spec *
#           (?deprecated:string ->
#            ?absent:string -> string list -> Cmdliner.Arg.info))
#          list
#        but an expression was expected of type
#          arg_list = (string list * spec * info) list
#        Type
#          ?deprecated:string ->
#          ?absent:string -> string list -> Cmdliner.Arg.info
#        is not compatible with type info = string list -> Cmdliner.Arg.info 
# make[1]: *** [Makefile:349: libs/ezcmd/ezcmd.cmx] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.11/.opam-switch/build/ocp-build.1.99.21'
# make: *** [Makefile:215: boot/ocp-build.asm] Error 2
```
Seen on #21062 the last time

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>