### PR TITLE
Fix Sihl 0.3.0 tarball src

### DIFF
--- a/packages/sihl/sihl.0.3.0/opam
+++ b/packages/sihl/sihl.0.3.0/opam
@@ -52,7 +52,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/oxidizing/sihl.git"
 url {
-  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  src: "https://github.com/oxidizing/sihl/archive/refs/tags/0.3.0.tar.gz"
   checksum: [
     "md5=3265ccfac470edc97a524259ec98e15b"
     "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"


### PR DESCRIPTION
Related to https://github.com/oxidizing/sihl/issues/533

I don't know why this stopped working, but the correct tarball src can be found under releases.