### PR TITLE
Package bwd.1.1.0

### DIFF
--- a/packages/bwd/bwd.1.1.0/opam
+++ b/packages/bwd/bwd.1.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Backward lists"
+description: """
+This OCaml package defines backward lists that are isomorphic to lists.
+They are useful when one wishes to give a different type to the lists that are semantically in reverse.
+In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
+With backward lists having a different type, it is impossible to make these mistakes.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/ocaml-bwd"
+bug-reports: "https://github.com/RedPRL/ocaml-bwd/issues"
+dev-repo: "git+https://github.com/RedPRL/ocaml-bwd.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/ocaml-bwd/archive/1.1.0.tar.gz"
+  checksum: [
+    "md5=779085781c174f736ce891cd04445169"
+    "sha512=bdae4e858986ad508f429ee98e189b5ea5b4c89cd164e87768728b0a2a567ac994ac2baa136e47dad56301fbd2263155e320087d3df9ff58a7f734a0da3cbcb6"
+  ]
+}


### PR DESCRIPTION
### `bwd.1.1.0`
Backward lists
This OCaml package defines backward lists that are isomorphic to lists.
They are useful when one wishes to give a different type to the lists that are semantically in reverse.
In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
With backward lists having a different type, it is impossible to make these mistakes.



---
* Homepage: https://github.com/RedPRL/ocaml-bwd
* Source repo: git+https://github.com/RedPRL/ocaml-bwd.git
* Bug tracker: https://github.com/RedPRL/ocaml-bwd/issues

---
:camel: Pull-request generated by opam-publish v2.1.0