### PR TITLE
[new release] current_incr (0.6.0)

### DIFF
--- a/packages/current_incr/current_incr.0.6.0/opam
+++ b/packages/current_incr/current_incr.0.6.0/opam
@@ -17,7 +17,7 @@ doc: "https://ocurrent.github.io/current_incr/"
 bug-reports: "https://github.com/ocurrent/current_incr/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.8"}
   "alcotest" {with-test}
   "mdx" {>= "1.10.0" & with-test}
 ]

--- a/packages/current_incr/current_incr.0.6.0/opam
+++ b/packages/current_incr/current_incr.0.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Self-adjusting computations"
+description: """\
+This is a small, self-contained library for self-adjusting (incremental) computations.
+It was written for OCurrent, but can be used separately too.
+
+It is similar to Jane Street's incremental library, but much smaller and
+has no external dependencies.
+
+It is also similar to the react library, but the results do not depend on the
+behaviour of the garbage collector. In particular, functions stop being called
+as soon as they are no longer needed."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/current_incr"
+doc: "https://ocurrent.github.io/current_incr/"
+bug-reports: "https://github.com/ocurrent/current_incr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "alcotest" {with-test}
+  "mdx" {>= "1.10.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/current_incr.git"
+license: "Apache-2.0"
+url {
+  src:
+    "https://github.com/ocurrent/current_incr/releases/download/0.6.0/current_incr-0.6.0.tbz"
+  checksum: [
+    "sha256=bf762d7fd3df75a85d12858ae58f0a02e7ef0c9106d46cf40559bb23e97aa62e"
+    "sha512=deab1d7b6e599ae8827c5b869eadf5bac7ed8e9b8301d0d2395ed921d31ae14c1a50b391cba94ad1b39444cef00731fd6563e974ec98380c15e86e4aebcee7a7"
+  ]
+}
+x-commit-hash: "eb29308601e8cf12f1f7f5efe2340a6df4376141"


### PR DESCRIPTION
Self-adjusting computations

- Project page: <a href="https://github.com/ocurrent/current_incr">https://github.com/ocurrent/current_incr</a>
- Documentation: <a href="https://ocurrent.github.io/current_incr/">https://ocurrent.github.io/current_incr/</a>

##### CHANGES:

* First separate release after extraction from the ocurrent repository
* Memory optimization for `Time.after` (ocurrent/current_incr#3, @art-w)
* Add mdx tests (ocurrent/current_incr#1, @talex5)
