### PR TITLE
[new release] ansi (0.5.0)

### DIFF
--- a/packages/ansi/ansi.0.5.0/opam
+++ b/packages/ansi/ansi.0.5.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.10.0"}
   "astring"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "tyxml"
   "dune" {>= "2.0"}
 ]

--- a/packages/ansi/ansi.0.5.0/opam
+++ b/packages/ansi/ansi.0.5.0/opam
@@ -5,6 +5,7 @@ This package provides a basic ANSI escape parser,
 allowing the OCurrent web UI to show logs in colour."""
 maintainer: "talex5@gmail.com"
 authors: "talex5@gmail.com"
+license: "Apache-2.0"
 homepage: "https://github.com/ocurrent/ansi"
 bug-reports: "https://github.com/ocurrent/ansi/issues"
 dev-repo: "git+https://github.com/ocurrent/ansi.git"

--- a/packages/ansi/ansi.0.5.0/opam
+++ b/packages/ansi/ansi.0.5.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "ANSI escape sequence parser"
+description: """
+This package provides a basic ANSI escape parser,
+allowing the OCurrent web UI to show logs in colour."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/ansi"
+bug-reports: "https://github.com/ocurrent/ansi/issues"
+dev-repo: "git+https://github.com/ocurrent/ansi.git"
+doc: "https://ocurrent.github.io/ansi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "astring"
+  "fmt"
+  "tyxml"
+  "dune" {>= "2.0"}
+]
+url {
+  src:
+    "https://github.com/ocurrent/ansi/releases/download/0.5.0/ansi-0.5.0.tbz"
+  checksum: [
+    "sha256=dda7678ee90c48dd58391328c4e5bb6607f38759260c4103b76412d53d069abd"
+    "sha512=b8e00e86ff55a3218c85be5fb57a5a2c615c291aa6425ed312f23e97e78aaf305c85b3ebba24ba37f276e7c74c2ad1736e7be51244e2bc7c599345f8f961f1d6"
+  ]
+}
+x-commit-hash: "e313e9e947dd3d71bd62832cb1593c2034180ae4"


### PR DESCRIPTION
ANSI escape sequence parser

- Project page: <a href="https://github.com/ocurrent/ansi">https://github.com/ocurrent/ansi</a>
- Documentation: <a href="https://ocurrent.github.io/ansi/">https://ocurrent.github.io/ansi/</a>

##### CHANGES:

* Rename to `ansi` (ocurrent/ansi#2, @samoht)
* ansi: 24-bit colour parsing (ocurrent/ansi#1, @copy)
* Split into its own repository.
