### PR TITLE
[new release] shuttle_ssl and shuttle (0.4.0)

### DIFF
--- a/packages/shuttle/shuttle.0.4.0/opam
+++ b/packages/shuttle/shuttle.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.14" & < "v0.16"}
+  "core" {>= "v0.14" & < "v0.16"}
+  "core_unix" {>= "v0.14" & < "v0.16"}
+  "ppx_jane" {>= "v0.14" & < "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.4.0/shuttle-0.4.0.tbz"
+  checksum: [
+    "sha256=e701a36d3383156f5b1d16f6676622377ab148e39c44b96821ea45fb7e22abb7"
+    "sha512=8405350a606782d8cda314b86327bb6823e5635fd6f72fb8cb2d734a91a10b81e50d468f5539fdbce4f71f67b0aed91fb012a85ec4673b2e9f2bfff477d881e7"
+  ]
+}
+x-commit-hash: "d46bf92c08e707f72c120ea6f7c45d667cbe3e49"

--- a/packages/shuttle/shuttle.0.4.0/opam
+++ b/packages/shuttle/shuttle.0.4.0/opam
@@ -9,10 +9,10 @@ bug-reports: "https://github.com/anuragsoni/shuttle/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.11.0"}
-  "async" {>= "v0.14" & < "v0.16"}
-  "core" {>= "v0.14" & < "v0.16"}
-  "core_unix" {>= "v0.14" & < "v0.16"}
-  "ppx_jane" {>= "v0.14" & < "v0.16"}
+  "async" {>= "v0.14"}
+  "core" {>= "v0.14"}
+  "core_unix" {>= "v0.14"}
+  "ppx_jane" {>= "v0.14"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/shuttle_ssl/shuttle_ssl.0.4.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.14" & < "v0.16"}
+  "async_ssl" {>= "v0.14" & < "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.4.0/shuttle-0.4.0.tbz"
+  checksum: [
+    "sha256=e701a36d3383156f5b1d16f6676622377ab148e39c44b96821ea45fb7e22abb7"
+    "sha512=8405350a606782d8cda314b86327bb6823e5635fd6f72fb8cb2d734a91a10b81e50d468f5539fdbce4f71f67b0aed91fb012a85ec4673b2e9f2bfff477d881e7"
+  ]
+}
+x-commit-hash: "d46bf92c08e707f72c120ea6f7c45d667cbe3e49"

--- a/packages/shuttle_ssl/shuttle_ssl.0.4.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.4.0/opam
@@ -10,8 +10,8 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.11.0"}
   "shuttle" {= version}
-  "ppx_jane" {>= "v0.14" & < "v0.16"}
-  "async_ssl" {>= "v0.14" & < "v0.16"}
+  "ppx_jane" {>= "v0.14"}
+  "async_ssl" {>= "v0.14"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Async_ssl support for shuttle

- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Remove Bytebuffer from public api
* Deprecate `schedule_bigstring`, `write_string`
* Support reading lines from an input channel
* Use Core_unix.IOVec to represent a view inside the input channel
* Support file descriptors that don't support nonblocking IO
* Remove the `read_one_chunk_at_a_time` interface from input channel
* Adapt to 0.15 series of core and async
