### PR TITLE
Remove spacetime option from 4.12+

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
@@ -27,7 +27,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha1+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
@@ -73,6 +72,5 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha2+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
@@ -73,6 +72,5 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~alpha3+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
@@ -73,6 +72,5 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta1+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~beta2+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0~rc1+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.1+options/opam
@@ -27,7 +27,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.12.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.2+trunk/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -27,7 +27,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha1+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~alpha2+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~beta1+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc1+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0~rc2+options/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -27,7 +27,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -28,7 +28,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -27,7 +27,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -73,7 +72,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha1+options/opam
@@ -29,7 +29,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -75,7 +74,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~alpha2+options/opam
@@ -29,7 +29,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -75,7 +74,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~beta1+options/opam
@@ -29,7 +29,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -75,7 +74,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc1+options/opam
@@ -29,7 +29,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -75,7 +74,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0~rc2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0~rc2+options/opam
@@ -29,7 +29,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -75,7 +74,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+trunk/opam
@@ -29,7 +29,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "--disable-naked-pointers" {ocaml-option-nnp:installed}
     "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
@@ -74,7 +73,6 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
   "ocaml-option-nnp"
   "ocaml-option-nnpchecker"
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -31,7 +31,6 @@ build: [
     "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
     "--enable-flambda" {ocaml-option-flambda:installed}
     "--enable-frame-pointers" {ocaml-option-fp:installed}
-    "--enable-spacetime" {ocaml-option-spacetime:installed}
     "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
     "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
     "CFLAGS=-Os" {ocaml-option-musl:installed}
@@ -74,5 +73,4 @@ depopts: [
   "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
-  "ocaml-option-spacetime"
 ]


### PR DESCRIPTION
Reported by @jmid - the package lists are reporting `ocaml-option-spacetime` as a depopt of the options packages, which is confusing as it's not installable on 4.12+!