### PR TITLE
Package chamo.3.0

### DIFF
--- a/packages/chamo/chamo.3.0/opam
+++ b/packages/chamo/chamo.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Chamo is a source code editor, even if it can be used to edit any text file"
+maintainer: "Zoggy <zoggy@bat8.org>"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["editor" "gtk" "development"]
+homepage: "https://zoggy.frama.io/chamo"
+doc: "https://zoggy.frama.io/chamo/doc.html"
+bug-reports: "https://framagit.org/zoggy/chamo/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "ocamlfind" {build}
+  "ocf" {>= "0.7.0"}
+  "pcre" {>= "7.4.6"}
+  "lablgtk3" {>= "3.1.1"}
+  "lablgtk3-sourceview3" {>= "3.1.1"}
+  "lablgtk3-extras" {>= "3.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "uutf" {>= "1.0.0"}
+  "sedlex" {>= "2.3"}
+  "xmlm" {>= "1.3.0"}
+]
+build: [
+  ["./configure" "--prefix" prefix]
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://framagit.org/zoggy/chamo.git"
+url {
+  src: "https://framagit.org/zoggy/chamo/-/archive/3.0/chamo-3.0.tar.bz2"
+  checksum: [
+    "md5=fbd7d56177cd3e15475403f364bb6086"
+    "sha512=f5d2980bf67c5e8b98dd8e0d8eaa7fdf96c762c2bc5907d7eba3737978d27dfff76a37cea29d1470a78b77aa0114655a65c723d4eeebad8198d23703294d724d"
+  ]
+}


### PR DESCRIPTION
### `chamo.3.0`
Chamo is a source code editor, even if it can be used to edit any text file



---
* Homepage: https://zoggy.frama.io/chamo
* Source repo: git+https://framagit.org/zoggy/chamo.git
* Bug tracker: https://framagit.org/zoggy/chamo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0