### PR TITLE
[new release] ssh-agent and ssh-agent-unix (0.4.0)

### DIFF
--- a/packages/ssh-agent-unix/ssh-agent-unix.0.4.0/opam
+++ b/packages/ssh-agent-unix/ssh-agent-unix.0.4.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation for unix platforms"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+license: "BSD-2-clause"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "ssh-agent" {= version}
+  "angstrom-unix"
+  "faraday"
+]
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/v0.4.0/ssh-agent-0.4.0.tbz"
+  checksum: [
+    "sha256=f3e931d8c7eeac926cf353079d653a2a2757e238af3a45555d5cab1d8460a956"
+    "sha512=66d520e731f04690baa846d78f1c01f9eefb7e61e58a2326725f96c174ecd43335982af33649f8ac34c952a7f45577f023a6a1856a41cc9fedc99770a5a2eca3"
+  ]
+}
+x-commit-hash: "de26d8f99b645b5f0c641fec80ff857aedb0ecfb"

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "ppx_cstruct" {build}
   "angstrom" {>= "0.14.0"}

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -21,6 +21,9 @@ depends: [
   "cstruct"
   "alcotest" {with-test}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 authors: "Reynir Björnsson <reynir@reynir.dk>"
 url {
   src:

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
-  "ppx_cstruct" {build}
+  "ppx_cstruct" {build & >= "5.2.0"}
   "angstrom" {>= "0.15.0"}
   "faraday" {>= "0.6"}
   "mirage-crypto"

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -23,6 +23,7 @@ depends: [
 ]
 conflicts: [
   "result" {< "1.5"}
+  "ppxlib" {< "0.9.0"}
 ]
 authors: "Reynir Björnsson <reynir@reynir.dk>"
 url {

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+license: "BSD-2-clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "ppx_cstruct" {build}
+  "angstrom" {>= "0.14.0"}
+  "faraday" {>= "0.6"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "cstruct"
+  "alcotest" {with-test}
+]
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/v0.4.0/ssh-agent-0.4.0.tbz"
+  checksum: [
+    "sha256=f3e931d8c7eeac926cf353079d653a2a2757e238af3a45555d5cab1d8460a956"
+    "sha512=66d520e731f04690baa846d78f1c01f9eefb7e61e58a2326725f96c174ecd43335982af33649f8ac34c952a7f45577f023a6a1856a41cc9fedc99770a5a2eca3"
+  ]
+}
+x-commit-hash: "de26d8f99b645b5f0c641fec80ff857aedb0ecfb"

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
   "ppx_cstruct" {build}
-  "angstrom" {>= "0.14.0"}
+  "angstrom" {>= "0.15.0"}
   "faraday" {>= "0.6"}
   "mirage-crypto"
   "mirage-crypto-pk"


### PR DESCRIPTION
Ssh-agent protocol parser and serialization implementation

- Project page: <a href="https://github.com/reynir/ocaml-ssh-agent/">https://github.com/reynir/ocaml-ssh-agent/</a>

##### CHANGES:

**breaking changes**
* Sexp has been removed.
* New ssh-ed25519 support, and new constructors `Ssh_agent.Pubkey.Ssh_ed25519` and `Ssh_agent.Privkey.Ssh_ed25519`.

* Support for signing with ed25519 keys.
