### PR TITLE
ometrics: remove the dependency to dot-merlin-reader

### DIFF
--- a/packages/ometrics/ometrics.0.1.3/opam
+++ b/packages/ometrics/ometrics.0.1.3/opam
@@ -13,7 +13,6 @@ depends: [
   "menhirSdk"
   "menhirLib"
   "menhir"
-  "dot-merlin-reader" {>= "4.1"}
   "csexp" {>= "1.5.1"}
   "result" {>= "1.5"}
   "cmdliner" {>= "1.0.0"}


### PR DESCRIPTION
Having dot-merlin-reader and vendoring merlin in my repo causes issues with an opam-mono-repo including ometrics.

Thus I'm trying to remove the dependency to dot-merlin-reader and use the executable from my vendor.
(If I remember correctly, I added the dependency because the opam ci complained about the missing executable)