### PR TITLE
The atd library won't build with menhir 20211230

### DIFF
--- a/packages/atd/atd.2.3.3/opam
+++ b/packages/atd/atd.2.3.3/opam
@@ -32,7 +32,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "menhir" {>= "20180523"}
+  "menhir" {>= "20180523" & != "20211230"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/atd/atd.2.4.0/opam
+++ b/packages/atd/atd.2.4.0/opam
@@ -66,7 +66,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180523"}
+  "menhir" {>= "20180523" & != "20211230"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/atd/atd.2.4.1/opam
+++ b/packages/atd/atd.2.4.1/opam
@@ -66,7 +66,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "menhir" {>= "20180523"}
+  "menhir" {>= "20180523" & != "20211230"}
   "easy-format"
   "alcotest" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
See the upstream issue: https://github.com/ahrefs/atd/pull/272

Sorry for the back and forth on this!