### PR TITLE
http_async can build on arm64 as well

### DIFF
--- a/packages/http_async/http_async.0.0.2/opam
+++ b/packages/http_async/http_async.0.0.2/opam
@@ -30,7 +30,7 @@ build: [
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/anuragsoni/http_async.git"
-available: [ arch = "x86_64" ]
+available: [ arch = "x86_64" | arch = "arm64" ]
 url {
   src:
     "https://github.com/anuragsoni/http_async/releases/download/0.0.2/http_async-0.0.2.tbz"


### PR DESCRIPTION
I missed `arm64` when proposing the original opam file. The package builds and installs without issues on arm. I can cut a new release instead of modifying the existing opam file if that's preferable.

Reference: https://github.com/ocaml/opam-repository/pull/21095