### PR TITLE
[new release] elpi (1.15.0)

### DIFF
--- a/packages/elpi/elpi.1.15.0/opam
+++ b/packages/elpi/elpi.1.15.0/opam
@@ -26,7 +26,10 @@ depends: [
   "conf-time" {with-test}
 ]
 depopts: [
-  "camlp5" {> "7.99"}
+  "camlp5"
+]
+conflicts: [
+  "camlp5" {< "8"}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"
 description: """

--- a/packages/elpi/elpi.1.15.0/opam
+++ b/packages/elpi/elpi.1.15.0/opam
@@ -1,0 +1,89 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0" }
+  "stdlib-shims"
+  "ppxlib" {>= "0.12.0" }
+  "menhir" {>= "20211230" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.2.0"}
+  "conf-time" {with-test}
+]
+depopts: [
+  "camlp5" {> "7.99"}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer
+  does not need to care about technical devices to handle bound variables,
+  like De Bruijn indices.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.15.0/elpi-1.15.0.tbz"
+  checksum: [
+    "sha256=be94336e40ea24f0a66819977019f3956192edd8d6f705aff31b2590895780fd"
+    "sha512=8f6877f14570eb0ff73b40a41682d39eaaec643251e06a6201e084940707eb812ebe68f115a93b6fd3c0378b272d3164b64c55cf6735d5761876a77ca0e16020"
+  ]
+}
+x-commit-hash: "0f01538839a6aee7f7d075c8a302e9267d9cc5c3"


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

Requires Menhir 20211230 and OCaml 4.07 or above.
Camlp5 is now optional.

*warning: The parser used by default is not backward compatible*

- Parser:
  - New parser based on Menhir
    + The grammar is not extensible anymore; token families are used to provide
      open ended infix symbols, see the [documentation](src/parser/README.md)
    + Custom error messages suggesting examples with a valid syntax
    + Faster on large files
  - Old parser available via `-legacy-parser`
    + Only compiled when `camlp5` is available
    + Supports `infix` and similar mixfix directives

- API:
  - `Parse.goal_from_stream` -> `Parse.goal_from`
  - `Parse.program_from_stream` -> `Parse.program_from`
  - `Parse.resolve_file` now takes an `~elpi` argument
  - `Setup.init` resolver argument takes a `~unit` instead of `~file`
  - `Setup.init` takes `?legacy_parser`
  - `Setup.legacy_parser_avaiable`
  - `Pp.query` -> `Pp.program` and `Pp.goal`

- REPL:
  - New `-parse-term`
  - New `-legacy-parser`
  - New `-legacy-parser-available`
  - Removed `-print-accumulated-files`
