### PR TITLE
protocol-9p-tool: restrict to cstruct < 6.1.0

### DIFF
--- a/packages/protocol-9p-tool/protocol-9p-tool.0.12.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.12.0/opam
@@ -23,6 +23,7 @@ depends: [
   "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
+  "cstruct" {< "6.1.0"}
 ]
 synopsis: "A simple command-line tool for accessing 9P servers"
 url {

--- a/packages/protocol-9p-tool/protocol-9p-tool.2.0.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.2.0.0/opam
@@ -17,6 +17,7 @@ depends: [
   "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
+  "cstruct" {< "6.1.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/protocol-9p-tool/protocol-9p-tool.2.0.1/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.2.0.1/opam
@@ -17,6 +17,7 @@ depends: [
   "lambda-term" {< "2.0"}
   "win-error"
   "cmdliner"
+  "cstruct" {< "6.1.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
observed in #21109 -- the latest release is not affected