### PR TITLE
[new release] mirage-block-solo5 (0.6.2)

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.6.2/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.6.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+doc:           "https://mirage.github.io/mirage-block-solo5/"
+license:       "ISC"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-solo5" {>= "0.6.0" & < "0.7.0"}
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-block-solo5/releases/download/v0.6.2/mirage-block-solo5-0.6.2.tbz"
+  checksum: [
+    "sha256=7635f478436bf1b09274ccab6765ec145fce86da1c637c6ff0e01a85c72d0479"
+    "sha512=dd81f2dd01a8ee215a6dea96ff4a68859d0ad0acd7b17bc286fcd60358c17b66b7fe86e5e1ee827242b7b3dd483960784bb753e347383ff8426d4af1e0db0682"
+  ]
+}
+x-commit-hash: "1f48d45c2c9b877fd6bd51005731e478ef430f4e"


### PR DESCRIPTION
Solo5 implementation of MirageOS block interface

- Project page: <a href="https://github.com/mirage/mirage-block-solo5">https://github.com/mirage/mirage-block-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-solo5/">https://mirage.github.io/mirage-block-solo5/</a>

##### CHANGES:

* Avoid deprecated fmt and cstruct functions, requires cstruct 6.0.0 and
  fmt 0.8.7 (@hannesm, mirage/mirage-block-solo5#20)
