### PR TITLE
Update `ACGtk` 1.5.3 compatibility with `Cmdliner` 1.1.0

### DIFF
--- a/packages/acgtk/acgtk.1.5.3/opam
+++ b/packages/acgtk/acgtk.1.5.3/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt"
   "logs"
   "mtime" {>= "1.0.0"}
-  "cmdliner" {>= "1.0.0" & < "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
   "conf-freetype"
   "conf-pkg-config"
   "conf-cairo"


### PR DESCRIPTION
`Cmdliner` version 1.1.0 required to build the project