### PR TITLE
Add upper bound on sexplib0 to memtrace_viewer

### DIFF
--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.0/opam
@@ -12,7 +12,7 @@ build: [
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 conflicts: [
-   "sexplib0" {< "v0.14.0"}
+   "sexplib0" {>= "v0.15.0" | < "v0.14.0"}
    "re" {< "1.9.0"}
 ]
 depends: [

--- a/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
+++ b/packages/memtrace_viewer/memtrace_viewer.v0.14.1/opam
@@ -12,7 +12,7 @@ build: [
   ["cp" "_build/default/memtrace_viewer.install" "."]
 ]
 conflicts: [
-   "sexplib0" {< "v0.14.0"}
+   "sexplib0" {>= "v0.15.0" | < "v0.14.0"}
    "re" {< "1.9.0"}
 ]
 depends: [


### PR DESCRIPTION
It seems that the v0.14 versions of memtrace_viewer do not work with version v0.15 of sexplib0. I'm not sure why the relationship between these packages is expressed as a conflict rather than a dependency, but I'd rather not change it.