### PR TITLE
[new release] merlin 4.5-414/413/412/411 and dot-merlin-reader 4.2

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.1" }
+  "dune" {>= "2.7.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+]
+description:
+  "Helper process: reads .merlin files and gives the normalized content to merlin"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.5-414/merlin-4.5-414.tbz"
+  checksum: [
+    "sha256=31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e"
+    "sha512=cc2cf2c208091b3ae435a8124617e56f2002b7091532002ab49a1f817d90a5c4f9cf0bc5741dc7f2526e0352c3ca95b42c3b3a17c6cbfb80ad73d42310a25d22"
+  ]
+}
+x-commit-hash: "cc1582373e5baea1d236a63be39493858032a182"

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.1" }
-  "dune" {>= "2.7.0"}
+  "dune" {>= "2.9.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}
   "csexp" {>= "1.2.3"}

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.06.1" }
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.9.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
 ]
 description:
   "Helper process: reads .merlin files and gives the normalized content to merlin"

--- a/packages/merlin/merlin.4.4.1~4.14preview/opam
+++ b/packages/merlin/merlin.4.4.1~4.14preview/opam
@@ -69,3 +69,4 @@ See https://github.com/OCamlPro/opam-user-setup
 url {
   src: "git+https://github.com/kit-ty-kate/merlin.git#414"
 }
+available: false # Preview

--- a/packages/merlin/merlin.4.5-411/opam
+++ b/packages/merlin/merlin.4.5-411/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.11.0" & < "4.12"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.5-411/merlin-4.5-411.tbz"
+  checksum: [
+    "sha256=f6ee7510ca16bfafe7091b187f98dcd54e3ff4d8ad9b8524053087948f37df16"
+    "sha512=9e68ebabdc0cc398edcd255516070d6459f3bf5738c0dbe332c11c6bc4070e7bf340bc086fa2ea58597972ebe9d15860ecd0e549444809be809f0509b41652c2"
+  ]
+}
+x-commit-hash: "5cb0e77fc3f65237b1b5159404fb7856b1b33c24"

--- a/packages/merlin/merlin.4.5-411/opam
+++ b/packages/merlin/merlin.4.5-411/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.5-411/opam
+++ b/packages/merlin/merlin.4.5-411/opam
@@ -21,6 +21,9 @@ depends: [
   "menhirLib" {dev}
   "menhirSdk" {dev}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
 description:

--- a/packages/merlin/merlin.4.5-412/opam
+++ b/packages/merlin/merlin.4.5-412/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.5-412/merlin-4.5-412.tbz"
+  checksum: [
+    "sha256=3f3868ede63b6277bb38e4d1963a16a36a3bfd2769bfa3bc6cbcdaf85d1eac44"
+    "sha512=f9edc3e1c9f753d7bacbdf1b92c118b54f9e9eff0bf752a2b44f39a2f7ecc76c4cd3bbe9227e910aea8b5ea947e8fe1b8d92ba0245fe47bc8cc2f45404cca973"
+  ]
+}
+x-commit-hash: "e7a03cc8f08fca45a509a4177e7da00d12a98090"

--- a/packages/merlin/merlin.4.5-412/opam
+++ b/packages/merlin/merlin.4.5-412/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.5-412/opam
+++ b/packages/merlin/merlin.4.5-412/opam
@@ -21,6 +21,9 @@ depends: [
   "menhirLib" {dev}
   "menhirSdk" {dev}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
 description:

--- a/packages/merlin/merlin.4.5-413/opam
+++ b/packages/merlin/merlin.4.5-413/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.13" & < "4.14"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.5-413/merlin-4.5-413.tbz"
+  checksum: [
+    "sha256=1a947222c8d676979e85924ee7230eac3223a9c3acc12377fe383c6755c2f0ea"
+    "sha512=b1db98c38a97ca0eef3051ab2b5d1b158e757863de6908a830308e7ea7f960eebd64b1a60bf51b10b7ea2eea3141ee0917a7c3570b63f9faa2e3f69c5d6fe0c2"
+  ]
+}
+x-commit-hash: "a196bc7a8b653c57268f379505fa6992b729d2a0"

--- a/packages/merlin/merlin.4.5-413/opam
+++ b/packages/merlin/merlin.4.5-413/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.5-413/opam
+++ b/packages/merlin/merlin.4.5-413/opam
@@ -21,6 +21,9 @@ depends: [
   "menhirLib" {dev}
   "menhirSdk" {dev}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
 description:

--- a/packages/merlin/merlin.4.5-414/opam
+++ b/packages/merlin/merlin.4.5-414/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.14" & < "4.15"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "1.6.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.5-414/opam
+++ b/packages/merlin/merlin.4.5-414/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "1.6.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.5-414/merlin-4.5-414.tbz"
+  checksum: [
+    "sha256=31587b422b5ebd3eebda730e946868807d829128f8dc7153fb05c0c82742058e"
+    "sha512=cc2cf2c208091b3ae435a8124617e56f2002b7091532002ab49a1f817d90a5c4f9cf0bc5741dc7f2526e0352c3ca95b42c3b3a17c6cbfb80ad73d42310a25d22"
+  ]
+}
+x-commit-hash: "cc1582373e5baea1d236a63be39493858032a182"

--- a/packages/merlin/merlin.4.5-414/opam
+++ b/packages/merlin/merlin.4.5-414/opam
@@ -21,6 +21,9 @@ depends: [
   "menhirLib" {dev}
   "menhirSdk" {dev}
 ]
+conflicts: [
+  "base-effects"
+]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
 description:


### PR DESCRIPTION
CHANGES for 414:

Tue Apr  5 20:51:42 CEST 2022

  + merlin binary
    - don't reset the environment when running merlin in single mode so that the
      parent environement is forwarded the the child processes (ocaml/merlin#1425)
    - filter dups in source paths (ocaml/merlin#1218)
    - improve load path performance (ocaml/merlin#1323)
    - fix handlink of ppx's under Windows (ocaml/merlin#1413)
    - locate: look for original source files before looking for preprocessed
      files (ocaml/merlin#1219 by @ddickstein, fixes ocaml/merlin#894)
    - handle `=` syntax in compiler flags (ocaml/merlin#1409)
    - expose all destruct exceptions in the api (ocaml/merlin#1437)
    - fix superfluous break in error reporting (ocaml/merlin#1432)
    - recognise binding operators in locate and occurrences (ocaml/merlin#1398, @mattiase)
    - remove dependency on Result (ocaml/merlin#1441, @kit-ty-kate)
    - use the new "shapes" generated by the compiler to perform precise
      jump-to-definition (ocaml/merlin#1431)
  + editor modes
    - fix an issue in Neovim where the current line jumps to the top of the
      window on repeated calls to `MerlinTypeOf` (ocaml/merlin#1433 by @ddickstein, fixes
      ocaml/merlin#1221)
    - add module, module type, and class imenu items for emacs (ocaml/merlin#1244, @ivg)
    - add prefix argument to force or prevent opening in a new buffer in locate
      command (ocaml/merlin#1426, @panglesd)
    - add type-on-hover functionality for vim (ocaml/merlin#1439, @nilsbecker)
    - add a dedicated buffer `*merlin-errors*` containing the last viewed error
      (ocaml/merlin#1414, @panglesd)
  + test suite
    - make `merlin-wrapper` create a default `.merlin` file  only when there is
      no `dune-project` to let tests use `dune ocaml-merlin` reader. (ocaml/merlin#1425)
    - cover locate calls on module aliases with and without dune
    - Add a test expliciting the interaction between locate and Dune's generated
      source files (ocaml/merlin#1444)

CHANGES for 413:

Tue Apr  5 20:59:42 CEST 2022

  + merlin binary
    - don't reset the environment when running merlin in single mode so that the
      parent environement is forwarded the the child processes (ocaml/merlin#1425)
    - filter dups in source paths (ocaml/merlin#1218)
    - improve load path performance (ocaml/merlin#1323)
    - fix handlink of ppx's under Windows (ocaml/merlin#1413)
    - locate: look for original source files before looking for preprocessed
      files (ocaml/merlin#1219 by @ddickstein, fixes ocaml/merlin#894)
    - handle `=` syntax in compiler flags (ocaml/merlin#1409)
    - expose all destruct exceptions in the api (ocaml/merlin#1437)
    - fix superfluous break in error reporting (ocaml/merlin#1432)
    - recognise binding operators in locate and occurrences (ocaml/merlin#1398, @mattiase)
    - remove dependency on Result (ocaml/merlin#1441, @kit-ty-kate)
  + editor modes
    - fix an issue in Neovim where the current line jumps to the top of the
      window on repeated calls to `MerlinTypeOf` (ocaml/merlin#1433 by @ddickstein, fixes
      ocaml/merlin#1221)
    - add module, module type, and class imenu items for emacs (ocaml/merlin#1244, @ivg)
    - add prefix argument to force or prevent opening in a new buffer in locate
      command (ocaml/merlin#1426, @panglesd)
    - add type-on-hover functionality for vim (ocaml/merlin#1439, @nilsbecker)
    - add a dedicated buffer `*merlin-errors*` containing the last viewed error
      (ocaml/merlin#1414, @panglesd)
  + test suite
    - make `merlin-wrapper` create a default `.merlin` file  only when there is
      no `dune-project` to let tests use `dune ocaml-merlin` reader. (ocaml/merlin#1425)
    - cover locate calls on module aliases with and without dune
    - Add a test expliciting the interaction between locate and Dune's generated
      source files (ocaml/merlin#1444)

CHANGES for 412:

Tue Apr  5 21:12:42 CEST 2022

  + merlin binary
    - don't reset the environment when running merlin in single mode so that the
      parent environement is forwarded the the child processes (ocaml/merlin#1425)
    - locate: look for original source files before looking for preprocessed
      files (ocaml/merlin#1219 by @ddickstein, fixes ocaml/merlin#894)
    - fix handlink of ppx's under Windows (ocaml/merlin#1413)
    - handle `=` syntax in compiler flags (ocaml/merlin#1409)
    - fix superfluous break in error reporting (ocaml/merlin#1432)
    - recognise binding operators in locate and occurrences (ocaml/merlin#1398, @mattiase)
    - improve load path performance (ocaml/merlin#1323)
    - remove dependency on Result (ocaml/merlin#1441, @kit-ty-kate)
  + editor modes
    - fix an issue in Neovim where the current line jumps to the top of the
      window on repeated calls to `MerlinTypeOf` (ocaml/merlin#1433 by @ddickstein, fixes
      ocaml/merlin#1221)
    - add module, module type, and class imenu items for emacs (ocaml/merlin#1244, @ivg)
    - add prefix argument to force or prevent opening in a new buffer in locate
      command (ocaml/merlin#1426, @panglesd)
    - add type-on-hover functionality for vim (ocaml/merlin#1439, @nilsbecker)
    - add a dedicated buffer `*merlin-errors*` containing the last viewed error
      (ocaml/merlin#1414, @panglesd)
  + test suite
    - make `merlin-wrapper` create a default `.merlin` file  only when there is
      no `dune-project` to let tests use `dune ocaml-merlin` reader. (ocaml/merlin#1425)

CHANGES for 411:

Tue Apr 5 21:17:21 PM CET 2022

  + merlin binary
    - don't reset the environment when running merlin in single mode so that the
      parent environement is forwarded the the child processes (ocaml/merlin#1425)
    - locate: look for original source files before looking for preprocessed
      files (ocaml/merlin#1219 by @ddickstein, fixes ocaml/merlin#894)
    - fix handling of ppx's under Windows (ocaml/merlin#1413)
    - handle `=` syntax in compiler flags (ocaml/merlin#1409)
    - fix superfluous break in error reporting (ocaml/merlin#1432)
    - recognise binding operators in locate and occurrences (ocaml/merlin#1398, @mattiase)
    - remove dependency on Result (ocaml/merlin#1441, @kit-ty-kate)
  + editor modes
    - update quick setup instructions for emacs (ocaml/merlin#1380, @ScriptDevil)
    - fix an issue in Neovim where the current line jumps to the top of the
      window on repeated calls to `MerlinTypeOf` (ocaml/merlin#1433 by @ddickstein, fixes
      ocaml/merlin#1221)
    - add module, module type, and class imenu items for emacs (ocaml/merlin#1244, @ivg)
    - add prefix argument to force or prevent opening in a new buffer in locate
      command (ocaml/merlin#1426, @panglesd)
    - add type-on-hover functionality for vim (ocaml/merlin#1439, @nilsbecker)
    - add a dedicated buffer `*merlin-errors*` containing the last viewed error
      (ocaml/merlin#1414, @panglesd)
  + test suite
    - make `merlin-wrapper` create a default `.merlin` file  only when there is
      no `dune-project` to let tests use `dune ocaml-merlin` reader. (ocaml/merlin#1425)