### PR TITLE
[new release] lockfree (0.2.0)

### DIFF
--- a/packages/lockfree/lockfree.0.2.0/opam
+++ b/packages/lockfree/lockfree.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage: "https://github.com/ocaml-multicore/lockfree"
+doc: "https://kayceesrk.github.io/lockfree/doc"
+synopsis: "Lock-free data structures for multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
+bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "1.8"}
+]
+build: [
+  "dune" "build" "-p" name
+  ]
+url {
+  src:
+    "https://github.com/ocaml-multicore/lockfree/releases/download/0.2.0/lockfree-0.2.0.tbz"
+  checksum: [
+    "sha256=248215e053c4ddb87af1fc31ce482797610f8c9afbeec153f0bbcc6cfad55cb8"
+    "sha512=8db3776989693ba91d75cf80c38a25f2d22bab26c4ba5102ab370849c9d59519660a2dd9fb02975dacb6340719a92f05073de80d902638df3812ce0a8c1686ce"
+  ]
+}
+x-commit-hash: "09a580995c3cf086d795cda5441fede8fb0b8f50"


### PR DESCRIPTION
Lock-free data structures for multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/lockfree">https://github.com/ocaml-multicore/lockfree</a>
- Documentation: <a href="https://kayceesrk.github.io/lockfree/doc">https://kayceesrk.github.io/lockfree/doc</a>

##### CHANGES:

--------------------------

* Add Chase-Lev Work-stealing deque `Ws_deque`. (@ctk21)
