### PR TITLE
ppx_sexp_conv v0.15.1

### DIFF
--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.15.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.15.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_sexp_conv"
+bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_sexp_conv/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "4.08.0"}
+  "base"     {>= "v0.15" & < "v0.16"}
+  "sexplib0" {>= "v0.15" & < "v0.16"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.26.0"}
+]
+synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src: "https://github.com/janestreet/ppx_sexp_conv/archive/refs/tags/v0.15.1.tar.gz"
+  checksum: "sha256=e34647850c58992a463f29b11b863f9b1322adc0a98d3b16028012507e0c2e9d"
+}


### PR DESCRIPTION
Fixes ppxlib compatibility as per https://github.com/janestreet/ppx_sexp_conv/pull/37

Signed-off-by: Cameron Wong <cwong@janestreet.com>