### PR TITLE
An hot-fix for git.3.7.0 about the push process

### DIFF
--- a/packages/git/git.3.7.0-1/files/0001-Fix-the-push-process.patch
+++ b/packages/git/git.3.7.0-1/files/0001-Fix-the-push-process.patch
@@ -1,0 +1,25 @@
+From 573ae4a09460a1018dd09de80be5018b760b79c2 Mon Sep 17 00:00:00 2001
+From: Romain Calascibetta <romain.calascibetta@gmail.com>
+Date: Wed, 6 Apr 2022 18:50:33 +0200
+Subject: [PATCH] Fix the push process with a copy of illegal shared bigarray
+
+---
+ src/git/sync.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/git/sync.ml b/src/git/sync.ml
+index be1e7a00c..0dbc27511 100644
+--- a/src/git/sync.ml
++++ b/src/git/sync.ml
+@@ -177,7 +177,7 @@ struct
+           | `Blob -> `C
+           | `Tag -> `D
+         in
+-        let raw = Bigstringaf.sub buffer ~off ~len in
++        let raw = Bigstringaf.copy buffer ~off ~len in
+         Lwt.return (Carton.Dec.v ~kind raw)
+     | None -> Lwt.fail Not_found
+ 
+-- 
+2.35.0
+

--- a/packages/git/git.3.7.0-1/opam
+++ b/packages/git/git.3.7.0-1/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "0.8.1"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf"
+  "bigarray-compat"
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic" {>= "0.0.4"}
+  "cstruct" {>= "6.0.0" & < "6.1.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.3"}
+  "carton-lwt" {>= "0.4.3"}
+  "carton-git" {>= "0.4.3"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.2.1"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test}
+  "base-unix" {with-test}
+  "fpath"
+  "hxd" {>= "0.3.1"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+]
+patches: [
+  "0001-Fix-the-push-process.patch"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.7.0/git-3.7.0.tbz"
+  checksum: [
+    "sha256=ee30231a00f0a3548d3c2e1266537afe5f2a877d2c24369ed771cb91ec47610d"
+    "sha512=e0b0d209cf35edead52916fb215ef83739f0be00501b6898a91a14503544d96718b1c248febc1abbe9bf5bd9e07eb0ea3ea5f120c32065fd32a20632b534c481"
+  ]
+}
+x-commit-hash: "45d90b8792ab8f3866751f462619c7dd7860e5d5"
+extra-files: [
+  [
+    "0001-Fix-the-push-process.patch"
+    "md5=554c71f18feef932b0edf1af4b081037"
+  ]
+]


### PR DESCRIPTION
This fix permits to us to still use `git.3.7.0` (due to `irmin.3.2.0`) and be able to correctly push without a bug. It includes a really small patch which fix the initial issue (which will be surely re-applied into 3.8.0 and 3.9.0).