### PR TITLE
3 packages from andersfugmann/aws-s3 at 4.6.0

### DIFF
--- a/packages/aws-s3-async/aws-s3-async.4.6.0/opam
+++ b/packages/aws-s3-async/aws-s3-async.4.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "aws-s3" {= version}
   "async_kernel" {>= "v0.9.0"}
   "async_unix" {>= "v0.9.0"}
-  "conduit-async" {>= "5.1.0"}
+  "conduit-async" {>= "4.0.0"}
   "core" {>= "v0.15.0"}
   "core_unix" {>= "v0.15.0"}
 ]

--- a/packages/aws-s3-async/aws-s3-async.4.6.0/opam
+++ b/packages/aws-s3-async/aws-s3-async.4.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+doc: "https://andersfugmann.github.io/aws-s3/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "aws-s3" {= version}
+  "async_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "conduit-async" {>= "5.1.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+]
+synopsis: "Ocaml library for accessing Amazon S3 - Async version"
+description: """
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* HEAD operation on single objects
+* Streaming transfer to and from aws.
+* Multi part upload (including s3 -> s3 copy)
+* Fetching machine role/credentials (though IAM)
+
+This library uses async for concurrency"""
+url {
+  src: "https://github.com/andersfugmann/aws-s3/archive/4.6.0.tar.gz"
+  checksum: [
+    "md5=dd96d98ca52d378881e3bf7a1179bb45"
+    "sha512=a8f5ed6e605be62e074d85c125315c41c4481a1cea850f26d8fb62f3d0f601925d782ff31fab87c59d7a853e777755689bca61c4892a8832a13cb2359cc36bc8"
+  ]
+}

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.6.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.0.0"}
+  "aws-s3" {= version}
+  "lwt"
+  "conduit-lwt-unix"
+]
+synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"
+description: """
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* HEAD operation on single objects
+* Streaming transfer to and from aws.
+* Multi part upload (including s3 -> s3 copy)
+* Fetching machine role/credentials (though IAM)
+
+This library uses lwt for concurrency"""
+url {
+  src: "https://github.com/andersfugmann/aws-s3/archive/4.6.0.tar.gz"
+  checksum: [
+    "md5=dd96d98ca52d378881e3bf7a1179bb45"
+    "sha512=a8f5ed6e605be62e074d85c125315c41c4481a1cea850f26d8fb62f3d0f601925d782ff31fab87c59d7a853e777755689bca61c4892a8832a13cb2359cc36bc8"
+  ]
+}

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.6.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "aws-s3" {= version}
   "lwt"
-  "conduit-lwt-unix"
+  "conduit-lwt-unix" {>= "5.0.0"}
 ]
 synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"
 description: """

--- a/packages/aws-s3/aws-s3.4.6.0/opam
+++ b/packages/aws-s3/aws-s3.4.6.0/opam
@@ -18,6 +18,7 @@ depends: [
   "digestif" {>= "0.7"}
   "ptime"
   "uri"
+  "ezxmlm" {>= "1.1.0"}
   "ppx_protocol_conv_xmlm" {>= "5.0.0" & < "6.0.0"}
   "ppx_protocol_conv_json" {>= "5.0.0" & < "6.0.0"}
   "cmdliner" {>= "1.1.0"}

--- a/packages/aws-s3/aws-s3.4.6.0/opam
+++ b/packages/aws-s3/aws-s3.4.6.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+doc: "https://andersfugmann.github.io/aws-s3/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml-inifiles"
+  "digestif" {>= "0.7"}
+  "ptime"
+  "uri"
+  "ppx_protocol_conv_xmlm" {>= "5.0.0" & < "6.0.0"}
+  "ppx_protocol_conv_json" {>= "5.0.0" & < "6.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "ppx_inline_test" {with-test}
+  "base64" {>= "3.1.0"}
+]
+synopsis: "Ocaml library for accessing Amazon S3"
+description: """
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* HEAD operation on single objects
+* Streaming transfer to and from aws.
+* Multi part upload (including s3 -> s3 copy)
+* Fetching machine role/credentials (though IAM)
+
+The library supports both lwt and async concurrency models.
+* For lwt, please install `aws-s3-lwt` package
+* For Async, please install `aws-s3-async` package"""
+url {
+  src: "https://github.com/andersfugmann/aws-s3/archive/4.6.0.tar.gz"
+  checksum: [
+    "md5=dd96d98ca52d378881e3bf7a1179bb45"
+    "sha512=a8f5ed6e605be62e074d85c125315c41c4481a1cea850f26d8fb62f3d0f601925d782ff31fab87c59d7a853e777755689bca61c4892a8832a13cb2359cc36bc8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`aws-s3.4.6.0`: Ocaml library for accessing Amazon S3
-`aws-s3-async.4.6.0`: Ocaml library for accessing Amazon S3 - Async version
-`aws-s3-lwt.4.6.0`: Ocaml library for accessing Amazon S3 - Lwt version



---
* Homepage: https://github.com/andersfugmann/aws-s3
* Source repo: git+https://github.com/andersfugmann/aws-s3
* Bug tracker: https://github.com/andersfugmann/aws-s3/issues

---
:camel: Pull-request generated by opam-publish v2.1.0