### PR TITLE
[new release] io-page (3.0.0)

### DIFF
--- a/packages/io-page/io-page.3.0.0/opam
+++ b/packages/io-page/io-page.3.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/io-page"
+bug-reports: "https://github.com/mirage/io-page/issues"
+doc: "https://mirage.github.io/io-page/"
+depends: [
+  "conf-pkg-config" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.6"}
+  "cstruct" {>= "2.0.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+]
+depopts: [
+  "ocaml-freestanding"
+]
+dev-repo: "git+https://github.com/mirage/io-page.git"
+synopsis: "Support for efficient handling of I/O memory pages"
+description: """
+IO pages are page-aligned, and wrapped in the `Cstruct` library to avoid
+copying the data contained within the page.
+"""
+url {
+  src:
+    "https://github.com/mirage/io-page/releases/download/v3.0.0/io-page-3.0.0.tbz"
+  checksum: [
+    "sha256=0e36ca74d9056ba6108090cb98bb2ebf2af079be3f4cdbea022820723ff786ee"
+    "sha512=777e5cf4cb82bfc21d026ea2a44a2c30f388a2daa570ad30a396d498b7e4845c0b887402fc002560e2bf17dd49ee7c9839675a3c587e6104f395997eef3c9667"
+  ]
+}
+x-commit-hash: "cc82c9cbd1e1caf7c40e12891b9e668d94b06b88"

--- a/packages/mirage-block-unix/mirage-block-unix.2.13.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.13.0/opam
@@ -16,7 +16,7 @@ depends: [
   "uri" {>= "1.9.0"}
   "logs"
   "lwt" {>= "5.4.2"}
-  "io-page" {>= "2.0.0"}
+  "io-page" {>= "2.0.0" & < "3.0.0"}
   "ounit2" {with-test}
   "diet" {with-test & >= "0.4"}
   "fmt" {with-test}


### PR DESCRIPTION
Support for efficient handling of I/O memory pages

- Project page: <a href="https://github.com/mirage/io-page">https://github.com/mirage/io-page</a>
- Documentation: <a href="https://mirage.github.io/io-page/">https://mirage.github.io/io-page/</a>

##### CHANGES:

* Skip unnecessary and missing unistd.h for MSVC compiler (@jonahbeckford, mirage/io-page#66)
* Remove deprecated io-page.unix library (@hannesm, mirage/io-page#67)
* Drop caml_ prefix from C symbols (@hannesm, mirage/io-page#64)
* Remove bigarray-compat dependency (@hannesm, mirage/io-page#67)
* Raise lower bound to OCaml 4.08.0 (@hannesm, mirage/io-page#67)
* Make freestanding compilation possible without opam (@sternenseemann, mirage/io-page#65)
