### PR TITLE
[new release] hex (1.5.0)

### DIFF
--- a/packages/hex/hex.1.5.0/opam
+++ b/packages/hex/hex.1.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "thomas@gazagnaire.org"
+authors: ["Thomas Gazagnaire" "Trevor Summers Smith"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hex"
+doc: "https://mirage.github.io/ocaml-hex/"
+bug-reports: "https://github.com/mirage/ocaml-hex/issues"
+depends: [
+  "ocaml" {>="4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-hex.git"
+synopsis: "Library providing hexadecimal converters"
+description: """
+```ocaml
+#require "hex";;
+# Hex.of_string "Hello world!";;
+- : Hex.t = "48656c6c6f20776f726c6421"
+# Hex.to_string "dead-beef";;
+- : string = "ޭ��"
+# Hex.hexdump (Hex.of_string "Hello world!\n")
+00000000: 4865 6c6c 6f20 776f 726c 6421 0a        Hello world!.
+- : unit = ()
+```
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-hex/releases/download/v1.5.0/hex-1.5.0.tbz"
+  checksum: [
+    "sha256=2e67eeca1b03049307a30831b5cd694bcb2d3e7f2a6b4fb597fbdb647351b4dc"
+    "sha512=baa09b47a90f0a54ad2becfb272f0674219e4fc0c03559deff26aaf13ccd59258b31bf98e56c44a5a8fa03437e3eba2bf5f0cd76e52d184d26cfb1170c490462"
+  ]
+}
+x-commit-hash: "036cdf98cd20109f3f1408b816e59b21e9da294b"


### PR DESCRIPTION
Library providing hexadecimal converters

- Project page: <a href="https://github.com/mirage/ocaml-hex">https://github.com/mirage/ocaml-hex</a>
- Documentation: <a href="https://mirage.github.io/ocaml-hex/">https://mirage.github.io/ocaml-hex/</a>

##### CHANGES:

* Only print printable ASCII characters (mirage/ocaml-hex#17 @copy)
* Improve error message with odd number of characters (mirage/ocaml-hex#35 @dialohq)
* Raise lower bound to OCaml 4.08 (mirage/ocaml-hex#37 @hannesm)
* Remove bigarray-compat dependency (mirage/ocaml-hex#37 @hannesm)
* Remove "build" from dune dependency (mirage/ocaml-hex#34 @CraigFE)
* Improve documentation of `of_string` (mirage/ocaml-hex#37 @hannesm, fixes mirage/ocaml-hex#33 mirage/ocaml-hex#36)
