### PR TITLE
Remove three previous releases of feat.

### DIFF
--- a/packages/feat/feat.20201231/opam
+++ b/packages/feat/feat.20201231/opam
@@ -25,3 +25,4 @@ url {
     "sha512=9031651c9b2ce9c9d6bfa2a913e5df7ae993bccd6790cdae07768762258e2f942495033921f996fd8ed6885c177c7e3207bd24d27d25a0afbe358d82eda74fa2"
   ]
 }
+available: false # serious bug in Enum.sample

--- a/packages/feat/feat.20211224/opam
+++ b/packages/feat/feat.20211224/opam
@@ -22,3 +22,4 @@ url {
     "sha512=6c53ad4f898c074b888018269fe2c00bf001fb5b22ceade1e7e26479fbe9ef55fe97d04a757b10232565a6af8f51d960b6f5f494552df4205aba046b075c513b"
   ]
 }
+available: false # serious bug in Enum.sample

--- a/packages/feat/feat.20220101/opam
+++ b/packages/feat/feat.20220101/opam
@@ -22,3 +22,4 @@ url {
     "sha512=b70b9d9da3c36907d2c5d6cb9028e69e1ec5c1335b838cb2da3d388fcf90123ea3c2c6a52ea76592c3802126832960af295a128b759acb47bb5500e7e4861116"
   ]
 }
+available: false # serious bug in Enum.sample


### PR DESCRIPTION
These three releases contain a serious bug in `Enum.sample` so I would like to remove them. Today's release fixes the bug.