### PR TITLE
[new release] mirage-block-unix (2.14.0)

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.14.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.14.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+authors:      "Dave Scott <dave@recoil.org>"
+maintainer:   "dave@recoil.org"
+homepage:     "https://github.com/mirage/mirage-block-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-block-unix.git"
+doc:          "https://mirage.github.io/mirage-block-unix/"
+bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
+tags:         "org:mirage"
+license:      "ISC"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "rresult"
+  "uri" {>= "1.9.0"}
+  "logs"
+  "lwt" {>= "5.4.2"}
+  "io-page" {>= "2.4.0"}
+  "ounit2" {with-test}
+  "diet" {with-test & >= "0.4"}
+  "fmt" {with-test}
+  "conf-linux-libc-dev" {os = "linux"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "MirageOS disk block driver for Unix"
+description: """
+Unix implementation of the Mirage `BLOCK_DEVICE` interface.
+
+This module provides raw I/O to files and block devices with as little
+caching as possible.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unix/releases/download/v2.14.0/mirage-block-unix-2.14.0.tbz"
+  checksum: [
+    "sha256=c321b924621e306c71dd7b5b225f59ad0d389e6f5a3d2bd77fa08d76df723db5"
+    "sha512=46095af6866f8eb96570b44d1467a3b41d8c7f4fb9214b842f4d38297e897c04601686def5447106462a7bf708da9f2c062f12fbb02f1e58da704151887f0122"
+  ]
+}
+x-commit-hash: "73abd255ed9ae3aa6dd3f3cab272cca242a2c5e8"


### PR DESCRIPTION
MirageOS disk block driver for Unix

- Project page: <a href="https://github.com/mirage/mirage-block-unix">https://github.com/mirage/mirage-block-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-unix/">https://mirage.github.io/mirage-block-unix/</a>

##### CHANGES:

* OCaml 5.00 support (mirage/mirage-block-unix#112, @Sudha247)
* Remove io-page.unix dependency, require io-page >= 2.4.0 (mirage/mirage-block-unix#114 @hannesm)
