### PR TITLE
[new release] ke (0.6)

### DIFF
--- a/packages/ke/ke.0.6/opam
+++ b/packages/ke/ke.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ke"
+bug-reports:  "https://github.com/mirage/ke/issues"
+dev-repo:     "git+https://github.com/mirage/ke.git"
+doc:          "https://mirage.github.io/ke/"
+license:      "MIT"
+synopsis:     "Queue implementation"
+description:  """Queue implementation in OCaml (functional and imperative queue)"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0"}
+  "fmt"        {>= "0.8.7"}
+  "alcotest"          {with-test}
+  "bigstringaf"       {with-test}
+  "bechamel"          {with-test}
+  "bechamel-notty"    {with-test}
+  "bechamel-perf"     {with-test}
+  "ocplib-json-typed" {with-test}
+  "core_bench"        {with-test & >= "v0.15"}
+  "lwt"               {with-test}
+  "crowbar"           {with-test}
+  "rresult"           {with-test}
+  "jsonm"             {with-test}
+  "psq"               {with-test}
+  "cmdliner"          {>= "1.1.0" & with-test}
+]
+url {
+  src: "https://github.com/mirage/ke/releases/download/v0.6/ke-0.6.tbz"
+  checksum: [
+    "sha256=61217207e2200b04b17759736610ff9208269a647f854cb5ae72cdac0d672305"
+    "sha512=be277780a7a6c9109068b6c8d54fa88c35180802ff86951516a32a6b7c0335fd6584753d1c670e02632b3956c09ae31bfec70e3dd5ea94697e9e032ba3b9248b"
+  ]
+}
+x-commit-hash: "7678aee5921580378f543a11101b2b0118f2cf6c"


### PR DESCRIPTION
Queue implementation

- Project page: <a href="https://github.com/mirage/ke">https://github.com/mirage/ke</a>
- Documentation: <a href="https://mirage.github.io/ke/">https://mirage.github.io/ke/</a>

##### CHANGES:

* Require OCaml 4.08 and remove `bigarray-compat` dependency (@hannesm, mirage/ke#17)
