### PR TITLE
[new release] pcap-format (0.6.0)

### DIFF
--- a/packages/pcap-format/pcap-format.0.6.0/opam
+++ b/packages/pcap-format/pcap-format.0.6.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Dave Scott <dave@recoil.org>"
+authors: ["Anil Madhavapeddy" "Dave Scott" "Richard Mortier"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-pcap"
+doc: "https://mirage.github.io/ocaml-pcap/"
+bug-reports: "https://github.com/mirage/ocaml-pcap/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {> "0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-pcap.git"
+synopsis: "Decode and encode PCAP (packet capture) files"
+description: """
+pcap-format provides an interface to encode and decode pcap files, dealing with
+both endianess, including endianess detection.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-pcap/releases/download/v0.6.0/pcap-format-0.6.0.tbz"
+  checksum: [
+    "sha256=2d48f2f179ba56c9ccab51472b398983bba8ae44efedc393b282f09ad34791a6"
+    "sha512=6c46b314b665eff3e46550e28a88f6de5370ed5299e88fa76f612330fa704bea5e436608e4f0eff489b444cc8b534e1f5710a0d92083469ec52f375d6435baf8"
+  ]
+}
+x-commit-hash: "bcb22e4ae0ad88b72a182819961534548e82df86"


### PR DESCRIPTION
Decode and encode PCAP (packet capture) files

- Project page: <a href="https://github.com/mirage/ocaml-pcap">https://github.com/mirage/ocaml-pcap</a>
- Documentation: <a href="https://mirage.github.io/ocaml-pcap/">https://mirage.github.io/ocaml-pcap/</a>

##### CHANGES:

* Remove the "build" directive on dune dependency (@CraigFE, mirage/ocaml-pcap#33)
* Remove unused "ppx_tools" dependency (@kit-ty-kate, mirage/ocaml-pcap#35)
* Remove "mmap" dependency, require OCaml 4.08.0 (@hannesm, mirage/ocaml-pcap#36)
