### PR TITLE
[new release] prettym (0.0.3)

### DIFF
--- a/packages/prettym/prettym.0.0.3/opam
+++ b/packages/prettym/prettym.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/prettym"
+bug-reports:  "https://github.com/dinosaure/prettym/issues"
+dev-repo:     "git+https://github.com/dinosaure/prettym.git"
+doc:          "https://dinosaure.github.io/prettym/"
+license:      "MIT"
+synopsis:     "An memory-bounded encoder according to RFC 822"
+description:  """A best effort memory-bounded encoder to respect the 80 column limitation"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"            {>= "4.08.0"}
+  "dune"             {>= "2.8"}
+  "bigarray-overlap"
+  "fmt"              {>= "0.8.7"}
+  "ke"               {>= "0.4"}
+  "bigstringaf"      {>= "0.2"}
+  "ptime"            {with-test}
+  "alcotest"         {with-test}
+  "jsonm"            {with-test}
+  "base64"           {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/prettym/releases/download/0.0.3/prettym-0.0.3.tbz"
+  checksum: [
+    "sha256=9170f1a11ade7f4d98a584a5be52bb6b91415f971c6e75894331b46b18b98f09"
+    "sha512=ccb5985daedfb6cae74192090644e81c525df3e0653bb06492f836ca4291275d3ce75079237574200ecab8dacf62304521592d4baebbe4b0d17277b5e200c6a8"
+  ]
+}
+x-commit-hash: "a22c4d46c11e2c4c0605ff7151b957785c795593"


### PR DESCRIPTION
An memory-bounded encoder according to RFC 822

- Project page: <a href="https://github.com/dinosaure/prettym">https://github.com/dinosaure/prettym</a>
- Documentation: <a href="https://dinosaure.github.io/prettym/">https://dinosaure.github.io/prettym/</a>

##### CHANGES:

- Remove `bigarray-compat` and support only OCaml >= 4.08 (@hannesm, dinosaure/prettym#3)
