### PR TITLE
use zip archive as source of ocaml-lsp-server.1.9.2~4.14preview

### DIFF
--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.9.2~4.14preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.9.2~4.14preview/opam
@@ -45,5 +45,5 @@ build: [
   ]
 ]
 url {
-  src: "git+https://github.com/kit-ty-kate/ocaml-lsp.git#414"
+  src: "https://github.com/kit-ty-kate/ocaml-lsp/archive/c5def3b700522caa8536f3d255d5d706482f158d.zip"
 }


### PR DESCRIPTION
With the source being `git+https://github.com/kit-ty-kate/ocaml-lsp.git#414` every `opam update` will have to do a git fetch which is kind of slow and adds some noise. So I replaced the url to point to the zip archive generated by github for the same commit.