### PR TITLE
[new release] optint (0.2.0)

### DIFF
--- a/packages/optint/optint.0.2.0/opam
+++ b/packages/optint/optint.0.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/mirage/optint"
+bug-reports:  "https://github.com/mirage/optint/issues"
+dev-repo:     "git+https://github.com/mirage/optint.git"
+doc:          "https://mirage.github.io/optint/"
+synopsis:     "Efficient integer types on 64-bit architectures"
+description: """
+This library provides two new integer types, `Optint.t` and `Int63.t`, which
+guarantee efficient representation on 64-bit architectures and provide a
+best-effort boxed representation on 32-bit architectures.
+
+Implementation depends on target architecture.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "crowbar" {with-test & >= "0.2"}
+  "monolith" {with-test}
+  "fmt" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/optint/releases/download/v0.2.0/optint-0.2.0.tbz"
+  checksum: [
+    "sha256=1dcbe0b6b6031f77db33028c87138fdb3bf90f92915e3b6629ddeb30a0d3000b"
+    "sha512=7d4b63c82b1dc1e363a892895c1a612bac3dcd33c27e2c27e8ea2e8868d659413226c7a0d7bdcac423f7fb016069d0de90c3eaa68986da6aea69e1f1ca583f18"
+  ]
+}
+x-commit-hash: "4b71b6b2afbd8374a08121466f7ff41e4680d38c"


### PR DESCRIPTION
Efficient integer types on 64-bit architectures

- Project page: <a href="https://github.com/mirage/optint">https://github.com/mirage/optint</a>
- Documentation: <a href="https://mirage.github.io/optint/">https://mirage.github.io/optint/</a>

##### CHANGES:

- Fix the README.md (@sidkshatriya, mirage/optint#19)
- Fix fuzzers (@dinosaure, mirage/optint#20)
- Add a proof to introspect the type of `Optint.t` (@dinosaure, mirage/optint#21)
