### PR TITLE
[new release] bigarray-overlap (0.2.1)

### DIFF
--- a/packages/bigarray-overlap/bigarray-overlap.0.2.1/opam
+++ b/packages/bigarray-overlap/bigarray-overlap.0.2.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/overlap"
+bug-reports:  "https://github.com/dinosaure/overlap/issues"
+dev-repo:     "git+https://github.com/dinosaure/overlap.git"
+doc:          "https://dinosaure.github.io/overlap/"
+license:      "MIT"
+synopsis:     "Bigarray.overlap"
+description: """A minimal library to know that 2 bigarray share physically the same memory or not."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+install: [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"       {>= "4.08.0"}
+  "dune"        {>= "2.6"}
+  "alcotest"        {with-test}
+  "astring"         {with-test}
+  "fpath"           {with-test}
+  "bos"             {with-test}
+  "ocamlfind"       {with-test}
+  "conf-pkg-config" {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+  "mirage-xen-posix"
+  "js_of_ocaml-compiler"
+]
+
+conflicts: [
+  "mirage-xen-posix" {< "3.1.0"}
+  "ocaml-freestanding" {< "0.4.3"}
+]
+url {
+  src:
+    "https://github.com/dinosaure/overlap/releases/download/v0.2.1/bigarray-overlap-0.2.1.tbz"
+  checksum: [
+    "sha256=2f520ac470054e335883eba9254bf28b6676ddb57753cfb58b22cf84ae1a66e0"
+    "sha512=223f15f815cd944cf2e9955ed9e3cf5608a9db36103e9bb017c2fe452dfb319908228b419f416f6239b8562208027068b7c44e8fb4be6c6a7858ecba540d5439"
+  ]
+}
+x-commit-hash: "ebdd14f8c399ffab0a111bb5a62a0f9aff72bf85"


### PR DESCRIPTION
Bigarray.overlap

- Project page: <a href="https://github.com/dinosaure/overlap">https://github.com/dinosaure/overlap</a>
- Documentation: <a href="https://dinosaure.github.io/overlap/">https://dinosaure.github.io/overlap/</a>

##### CHANGES:

- Remove `bigarray-compat`, revise C compilation for MirageOS 3,
  remove the Xen support (merged into Solo5),
  and support only OCaml >= 4.08 (@hannesm, dinosaure/overlap#3)
