### PR TITLE
[new release] rfc1951 and decompress (1.4.3)

### DIFF
--- a/packages/decompress/decompress.1.4.3/opam
+++ b/packages/decompress/decompress.1.4.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "cmdliner"    {>= "1.1.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test & >= "0.8.7"}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.3/decompress-1.4.3.tbz"
+  checksum: [
+    "sha256=b22254ae5eb7747452267fc976a3a0ba408c5afdae0896cac4068b4d79ed5a3d"
+    "sha512=96f62147f4e0548bb7c4680c4f9d7492a2b4a9e15bc100447b16842e3d1b43ed902fdef03907e1416c174a0586428e515f2deef53ed04098a0443a535938dd6d"
+  ]
+}
+x-commit-hash: "058efcbb01c0c198f54cc38f34df3c8a82f37e9b"

--- a/packages/git/git.3.4.0/opam
+++ b/packages/git/git.3.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.5.0/opam
+++ b/packages/git/git.3.5.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.6.0/opam
+++ b/packages/git/git.3.6.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.7.0/opam
+++ b/packages/git/git.3.7.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic" {>= "0.0.4"}

--- a/packages/git/git.3.7.1/opam
+++ b/packages/git/git.3.7.1/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic" {>= "0.0.4"}

--- a/packages/git/git.3.8.0/opam
+++ b/packages/git/git.3.8.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic" {>= "0.0.4"}

--- a/packages/git/git.3.9.0/opam
+++ b/packages/git/git.3.9.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bigstringaf" {< "0.9.0"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.4.0"}
+  "decompress" {>= "1.4.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic" {>= "0.0.4"}

--- a/packages/rfc1951/rfc1951.1.4.3/opam
+++ b/packages/rfc1951/rfc1951.1.4.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.4.3/decompress-1.4.3.tbz"
+  checksum: [
+    "sha256=b22254ae5eb7747452267fc976a3a0ba408c5afdae0896cac4068b4d79ed5a3d"
+    "sha512=96f62147f4e0548bb7c4680c4f9d7492a2b4a9e15bc100447b16842e3d1b43ed902fdef03907e1416c174a0586428e515f2deef53ed04098a0443a535938dd6d"
+  ]
+}
+x-commit-hash: "058efcbb01c0c198f54cc38f34df3c8a82f37e9b"


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Replace deprecated function of `fmt` (@dinosaure, mirage/decompress#135)
- Remove `bigarray-compat`, `stdlib-shims` and support only
  OCaml >= 4.08.0 (@hannesm, mirage/decompress#138)
- Update to `cmdliner.1.1.0` (@hannesm, mirage/decompress#138)
