### PR TITLE
bechamel-js.0.1.0 requires ocplib-json-typed.0.7.1 at least

### DIFF
--- a/packages/bechamel-js/bechamel-js.0.1.0/opam
+++ b/packages/bechamel-js/bechamel-js.0.1.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune"       {>= "2.0.0"}
   "bechamel"   {= version}
   "rresult"
-  "ocplib-json-typed"
+  "ocplib-json-typed" {>= "0.7.1"}
   "jsonm"
   "fmt"
 ]

--- a/packages/bechamel-js/bechamel-js.0.1.0/opam
+++ b/packages/bechamel-js/bechamel-js.0.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "rresult"
   "ocplib-json-typed" {>= "0.7.1"}
   "jsonm"
-  "fmt"
+  "fmt" {>= "0.8.4"}
 ]
 x-commit-hash: "0d49a0955c69627ae7e1eda0748868e4df15d9fa"
 url {


### PR DESCRIPTION
See on the `bigstringaf` PR:
```
The following actions will be performed:
  - install result             1.5
  - install ocamlfind          1.9.3
  - install ocaml-syntax-shims 1.0.0
  - install ocamlbuild         0.14.1
  - install stdlib-shims       0.3.0
  - install base-bytes         base
  - install angstrom           0.15.0
  - install uchar              0.0.2
  - install topkg              1.0.5
  - install stringext          1.6.0
  - install uutf               1.0.3
  - install rresult            0.7.0
  - install fmt                0.9.0
  - install uri                4.2.0
  - install jsonm              1.0.1
  - install bechamel           0.1.0
  - install ocplib-json-typed  0.6
===== 17 to install =====

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> retrieved angstrom.0.15.0  (cached)
-> retrieved bechamel.0.1.0  (cached)
-> retrieved fmt.0.9.0  (cached)
-> retrieved jsonm.1.0.1  (cached)
-> retrieved ocaml-syntax-shims.1.0.0  (cached)
-> retrieved ocamlbuild.0.14.1  (cached)
-> retrieved ocamlfind.1.9.3  (cached)
-> retrieved ocplib-json-typed.0.6  (cached)
-> retrieved result.1.5  (cached)
-> retrieved rresult.0.7.0  (cached)
-> retrieved stdlib-shims.0.3.0  (cached)
-> retrieved stringext.1.6.0  (cached)
-> retrieved topkg.1.0.5  (cached)
-> retrieved uchar.0.0.2  (cached)
-> retrieved uri.4.2.0  (cached)
-> retrieved uutf.1.0.3  (cached)
-> installed stdlib-shims.0.3.0
-> installed result.1.5
-> installed ocaml-syntax-shims.1.0.0
-> installed angstrom.0.15.0
-> installed ocamlfind.1.9.3
-> installed base-bytes.base
-> installed ocamlbuild.0.14.1
-> installed stringext.1.6.0
-> installed uchar.0.0.2
-> installed uri.4.2.0
-> installed ocplib-json-typed.0.6
-> installed topkg.1.0.5
-> installed uutf.1.0.3
-> installed rresult.0.7.0
-> installed fmt.0.9.0
-> installed jsonm.1.0.1
-> installed bechamel.0.1.0
Done.
# Run eval $(opam env) to update the current shell environment
The following actions will be performed:
  - install bechamel-js 0.1.0

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/3:
-> retrieved bechamel-js.0.1.0  (cached)
Processing  2/3: [bechamel-js: dune build]
+ /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "dune" "build" "-p" "bechamel-js" "-j" "31" (CWD=/home/opam/.opam/4.14/.opam-switch/build/bechamel-js.0.1.0)
- (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/js/.bechamel_js.objs/byte -I /home/opam/.opam/4.14/lib/bechamel -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/ocplib-json-typed -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -no-alias-deps -open Bechamel_js__ -o lib/js/.bechamel_js.objs/byte/bechamel_js__Desc.cmo -c -impl lib/js/desc.ml)
- File "lib/js/desc.ml", line 18, characters 53-58:
- 18 |   conv Time.span_to_uint64_ns Time.span_of_uint64_ns int53
-                                                           ^^^^^
- Error: Unbound value int53
- Hint: Did you mean int or int32?
[ERROR] The compilation of bechamel-js.0.1.0 failed at "dune build -p bechamel-js -j 31".

#=== ERROR while compiling bechamel-js.0.1.0 ==================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/bechamel-js.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bechamel-js -j 31
# exit-code            1
# env-file             ~/.opam/log/bechamel-js-2097-68e166.env
# output-file          ~/.opam/log/bechamel-js-2097-68e166.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/js/.bechamel_js.objs/byte -I /home/opam/.opam/4.14/lib/bechamel -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/ocplib-json-typed -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -no-alias-deps -open Bechamel_js__ -o lib/js/.bechamel_js.objs/byte/bechamel_js__Desc.cmo -c -impl lib/js/desc.ml)
# File "lib/js/desc.ml", line 18, characters 53-58:
# 18 |   conv Time.span_to_uint64_ns Time.span_of_uint64_ns int53
#                                                           ^^^^^
# Error: Unbound value int53
# Hint: Did you mean int or int32?
```