### PR TITLE
[new release] duff (0.5)

### DIFF
--- a/packages/duff/duff.0.5/opam
+++ b/packages/duff/duff.0.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/duff"
+bug-reports:  "https://github.com/mirage/duff/issues"
+dev-repo:     "git+https://github.com/mirage/duff.git"
+doc:          "https://mirage.github.io/duff/"
+license:      "MIT"
+synopsis:     "Rabin's fingerprint and diff algorithm in OCaml"
+description: """
+This library provides a pure implementation of Rabin's fingerprint and diff algorithm in OCaml.
+
+It follows libXdiff C library. It is used by ocaml-git project.
+"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"    {>= "4.07.0"}
+  "dune"     {>= "2.0.0"}
+  "fmt"      {>= "0.8.7"}
+  "alcotest"    {with-test}
+  "bigstringaf" {with-test}
+  "hxd"         {with-test & >= "0.3.1"}
+  "crowbar"     {with-test}
+]
+url {
+  src: "https://github.com/mirage/duff/releases/download/v0.5/duff-0.5.tbz"
+  checksum: [
+    "sha256=d1eaa97cf58d38762391c8d74676544d4145d3f2fd13e4cda0ea8a0844cde612"
+    "sha512=f66ba0016327236c6bdd29cbd3c3d62b96dbe8aa5cdbc88be956a6152c1fd1dcb70ec1f7598bcf4b56126f0edb127566617f49898e50b412be2fecbe93ce85d4"
+  ]
+}
+x-commit-hash: "20259ac3021f9675f12972e04871a45f6651d483"


### PR DESCRIPTION
Rabin's fingerprint and diff algorithm in OCaml

- Project page: <a href="https://github.com/mirage/duff">https://github.com/mirage/duff</a>
- Documentation: <a href="https://mirage.github.io/duff/">https://mirage.github.io/duff/</a>

##### CHANGES:

* `duff` works only for OCaml >= 4.07 (@hannesm, mirage/duff#11)
* Update with `ocamlformat.0.21.0` (@hannesm, mirage/duff#11)
* Remove the `bigarray-compat` dependency (@hannesm, mirage/duff#11)
