### PR TITLE
[new release] checkseum (0.3.3)

### DIFF
--- a/packages/checkseum/checkseum.0.3.3/opam
+++ b/packages/checkseum/checkseum.0.3.3/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/checkseum"
+bug-reports:  "https://github.com/mirage/checkseum/issues"
+dev-repo:     "git+https://github.com/mirage/checkseum.git"
+doc:          "https://mirage.github.io/checkseum/"
+license:      "MIT"
+synopsis:     "Adler-32, CRC32 and CRC32-C implementation in C and OCaml"
+description: """
+Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C
+in C and OCaml.
+
+This library use the linking trick to choose between the C implementation
+(checkseum.c) or the OCaml implementation (checkseum.ocaml). This library is on
+top of optint to get the best representation of an int32. """
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "%{ocaml:bin}%/ocaml" "./install/install.ml" ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+install: [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "%{ocaml:bin}%/ocaml" "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.6.0"}
+  "conf-pkg-config" {build}
+  "dune-configurator"
+  "optint"        {>= "0.2.0"}
+  "alcotest"      {with-test}
+  "bos"           {with-test}
+  "astring"       {with-test}
+  "fmt"           {with-test}
+  "fpath"         {with-test}
+  "rresult"       {with-test}
+  "ocamlfind"     {with-test}
+]
+
+depopts: [
+  "ocaml-freestanding"
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.3"}
+]
+url {
+  src:
+    "https://github.com/mirage/checkseum/releases/download/v0.3.3/checkseum-0.3.3.tbz"
+  checksum: [
+    "sha256=c2ac7f7332dc86bdaf67ff78e7fd6bc4016f5fa556b083516db9d0c40eae8811"
+    "sha512=b931d201df1953f9fce5c64cf11af62690d25ad791cfcf7d1cde39f86f8b80c19c90e99fa389f4deca35d85518abdd0e4b9235e199d87d96f49975e498356f41"
+  ]
+}
+x-commit-hash: "331397e2ae70662238606dfee446bfef84c652c8"


### PR DESCRIPTION
Adler-32, CRC32 and CRC32-C implementation in C and OCaml

- Project page: <a href="https://github.com/mirage/checkseum">https://github.com/mirage/checkseum</a>
- Documentation: <a href="https://mirage.github.io/checkseum/">https://mirage.github.io/checkseum/</a>

##### CHANGES:

- Use canonical `_WIN32` macro to detect Windows (@jonahbeckford, mirage/checkseum#61)
- Fix Windows support with cygpath (@MisterDA, mirage/checkseum#60)
- Use `ocaml` variable to execute `install.ml` instead of a shebang with `env`
  (@vapourismo, @dinosaure, mirage/checkseum#62)
- Upgrade to `ocamlformat.0.21.0` (@hannesm, mirage/checkseum#63)
- Remove `bigarray-compat` package (@hannesm, mirage/checkseum#63)
- Support only OCaml >= 4.07 (@hannesm, mirage/checkseum#63)
- Optimize `checkseum.c` and use the advantage of `[@untagged]` and `[@unboxed]`
  `checkseum` requires `optint.0.2.0` now (@dinosaure, mirage/checkseum#64)
- Update the `README.md` (@dinosaure, mirage/checkseum#65)
- Use `caml_copy_int32` instead of `copy_int32` (@dinosaure, mirage/checkseum#66)
