### PR TITLE
carton.0.{3,4} is incompatible with >= cmdliner.1.1.0

### DIFF
--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "bigstringaf" {>= "0.7.0"}
   "bigarray-compat"
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "result"
   "rresult"
   "hxd" {>= "0.3.0"}

--- a/packages/carton/carton.0.4.0/opam
+++ b/packages/carton/carton.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "bigstringaf" {>= "0.7.0"}
   "bigarray-compat"
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "hxd" {>= "0.3.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}

--- a/packages/carton/carton.0.4.1/opam
+++ b/packages/carton/carton.0.4.1/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "bigstringaf" {>= "0.7.0"}
   "bigarray-compat"
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "hxd" {>= "0.3.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}

--- a/packages/carton/carton.0.4.2/opam
+++ b/packages/carton/carton.0.4.2/opam
@@ -22,7 +22,7 @@ depends: [
   "logs"
   "bigstringaf" {>= "0.7.0"}
   "bigarray-compat"
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "hxd" {>= "0.3.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}

--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -22,7 +22,7 @@ depends: [
   "checkseum" {>= "0.3.2"}
   "logs"
   "bigarray-compat"
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.0.4" & < "1.1.0"}
   "hxd" {>= "0.3.0"}
   "psq" {>= "0.2.0"}
   "fmt" {>= "0.8.9"}


### PR DESCRIPTION
Fix this initial issue:
```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
Processing  1/3:
-> retrieved carton.0.4.3  (cached)
Processing  2/3: [carton: dune build]
+ /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "dune" "build" "-p" "carton" "-j" "31" (CWD=/home/opam/.opam/4.14/.opam-switch/build/carton.0.4.3)
- (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/carton/.hxd_cmdliner.objs/byte -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -no-alias-deps -o bin/carton/.hxd_cmdliner.objs/byte/hxd_cmdliner.cmo -c -impl bin/carton/hxd_cmdliner.ml)
- File "bin/carton/hxd_cmdliner.ml", line 124, characters 12-23:
- 124 |   let env = Arg.env_var "HXD_COLOR" in
-                   ^^^^^^^^^^^
- Alert deprecated: Cmdliner.Arg.env_var
- Use Cmd.Env.info instead.
```