### PR TITLE
Prepare the release of decompress.1.4.3 which remove the bigarray-compat dependency

### DIFF
--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "duff" {>= "0.3"}
   "decompress" {>= "1.3.0"}
   "decompress" {with-test & < "1.4.3"}
-  "cstruct" {>= "5.0.0"}
+  "cstruct" {>= "5.0.0" & < "6.1.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}
   "logs"

--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -15,7 +15,8 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0" & < "1.4.3"}
+  "decompress" {>= "1.3.0"}
+  "decompress" {with-test & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.3.0/opam
+++ b/packages/carton/carton.0.3.0/opam
@@ -22,6 +22,7 @@ depends: [
   "checkseum" {>= "0.2.1"}
   "logs"
   "bigstringaf" {>= "0.7.0"}
+  "bigstringaf" {with-test & < "0.9.0"}
   "bigarray-compat"
   "cmdliner" {>= "1.0.4"}
   "result"

--- a/packages/carton/carton.0.4.0/opam
+++ b/packages/carton/carton.0.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.4.0/opam
+++ b/packages/carton/carton.0.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "duff" {>= "0.3"}
   "decompress" {>= "1.3.0"}
   "decompress" {with-test & < "1.4.3"}
-  "cstruct" {>= "5.0.0"}
+  "cstruct" {>= "5.0.0" & < "6.1.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}
   "logs"

--- a/packages/carton/carton.0.4.0/opam
+++ b/packages/carton/carton.0.4.0/opam
@@ -22,6 +22,7 @@ depends: [
   "checkseum" {>= "0.2.1"}
   "logs"
   "bigstringaf" {>= "0.7.0"}
+  "bigstringaf" {with-test & < "0.9.0"}
   "bigarray-compat"
   "cmdliner" {>= "1.0.4"}
   "hxd" {>= "0.3.0"}

--- a/packages/carton/carton.0.4.0/opam
+++ b/packages/carton/carton.0.4.0/opam
@@ -15,7 +15,8 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0" & < "1.4.3"}
+  "decompress" {>= "1.3.0"}
+  "decompress" {with-test & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.4.1/opam
+++ b/packages/carton/carton.0.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.4.1/opam
+++ b/packages/carton/carton.0.4.1/opam
@@ -17,7 +17,7 @@ depends: [
   "duff" {>= "0.3"}
   "decompress" {>= "1.3.0"}
   "decompress" {with-test & < "1.4.3"}
-  "cstruct" {>= "5.0.0"}
+  "cstruct" {>= "5.0.0" & < "6.1.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}
   "logs"

--- a/packages/carton/carton.0.4.1/opam
+++ b/packages/carton/carton.0.4.1/opam
@@ -22,6 +22,7 @@ depends: [
   "checkseum" {>= "0.2.1"}
   "logs"
   "bigstringaf" {>= "0.7.0"}
+  "bigstringaf" {with-test & < "0.9.0"}
   "bigarray-compat"
   "cmdliner" {>= "1.0.4"}
   "hxd" {>= "0.3.0"}

--- a/packages/carton/carton.0.4.1/opam
+++ b/packages/carton/carton.0.4.1/opam
@@ -15,7 +15,8 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0" & < "1.4.3"}
+  "decompress" {>= "1.3.0"}
+  "decompress" {with-test & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.4.2/opam
+++ b/packages/carton/carton.0.4.2/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.4.2/opam
+++ b/packages/carton/carton.0.4.2/opam
@@ -17,7 +17,7 @@ depends: [
   "duff" {>= "0.3"}
   "decompress" {>= "1.3.0"}
   "decompress" {with-test & < "1.4.3"}
-  "cstruct" {>= "5.0.0"}
+  "cstruct" {>= "5.0.0" & < "6.1.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}
   "logs"

--- a/packages/carton/carton.0.4.2/opam
+++ b/packages/carton/carton.0.4.2/opam
@@ -22,6 +22,7 @@ depends: [
   "checkseum" {>= "0.2.1"}
   "logs"
   "bigstringaf" {>= "0.7.0"}
+  "bigstringaf" {with-test & < "0.9.0"}
   "bigarray-compat"
   "cmdliner" {>= "1.0.4"}
   "hxd" {>= "0.3.0"}

--- a/packages/carton/carton.0.4.2/opam
+++ b/packages/carton/carton.0.4.2/opam
@@ -15,7 +15,8 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.3.0" & < "1.4.3"}
+  "decompress" {>= "1.3.0"}
+  "decompress" {with-test & < "1.4.3"}
   "cstruct" {>= "5.0.0"}
   "optint" {>= "0.0.4"}
   "checkseum" {>= "0.2.1"}

--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -15,7 +15,8 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.4.1" & < "1.4.3"}
+  "decompress" {>= "1.4.1"}
+  "decompress" {with-test & < "1.4.3"}
   "cstruct" {>= "6.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf" {>= "0.7.0" & < "0.9.0"}

--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}
-  "decompress" {>= "1.4.1"}
+  "decompress" {>= "1.4.1" & < "1.4.3"}
   "cstruct" {>= "6.0.0"}
   "optint" {>= "0.0.4"}
   "bigstringaf" {>= "0.7.0" & < "0.9.0"}


### PR DESCRIPTION
See this error:
```
- Error: This expression has type
-          Bigstringaf.t =
-            (char, Bigarray_compat.int8_unsigned_elt,
-             Bigarray_compat.c_layout)
-            Bigarray_compat.Array1.t
-        but an expression was expected of type
-          Zl.bigstring =
-            (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout)
-            Bigarray.Array1.t
- (cd _build/default/fuzz && ./binary_search.exe)
- binary search: PASS
- 
[ERROR] The compilation of carton.0.4.3 failed at "dune runtest -p carton -j 31".
```

`decompress.1.4.3` deletes the `bigarray-compat` dependency and the result is an incompatibility with packages such as `carton`. /cc @kit-ty-kate 