### PR TITLE
[new release] dream-encoding (0.2.0)

### DIFF
--- a/packages/dream-encoding/dream-encoding.0.2.0/opam
+++ b/packages/dream-encoding/dream-encoding.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Encoding primitives for Dream"
+description: "Encoding primitives for Dream."
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/dream-encoding"
+doc: "https://tmattio.github.io/dream-encoding/"
+bug-reports: "https://github.com/tmattio/dream-encoding/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "dream" {>= "1.0.0~alpha3"}
+  "decompress" {>= "1.4.1"}
+  "lwt_ppx"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/dream-encoding.git"
+conflicts: [
+  "result" {< "1.5"} # Might use result through lwt and explicitly uses Result.bind 
+]
+url {
+  src:
+    "https://github.com/tmattio/dream-encoding/releases/download/0.2.0/dream-encoding-0.2.0.tbz"
+  checksum: [
+    "sha256=ca6c5d4a2dd31e1cca75f4ce9c95134b7f339ff2f4ea56d88ea859d57b82aa06"
+    "sha512=589eef320af6093100491ad86b318c0667a0bb594144630b80a0f2ba3c1f12d7c9655a30c41d8fffd6200baeb9c33289c6405d7bd887473fad76feb5458f09e9"
+  ]
+}
+x-commit-hash: "0085ff4115f66723bd35d275f98c14075ffa7327"


### PR DESCRIPTION
Encoding primitives for Dream

- Project page: <a href="https://github.com/tmattio/dream-encoding">https://github.com/tmattio/dream-encoding</a>
- Documentation: <a href="https://tmattio.github.io/dream-encoding/">https://tmattio.github.io/dream-encoding/</a>

##### CHANGES:

- Support for dream.1.0.0~alpha3
