### PR TITLE
[new release] dream-livereload (0.2.0)

### DIFF
--- a/packages/dream-livereload/dream-livereload.0.2.0/opam
+++ b/packages/dream-livereload/dream-livereload.0.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Live reloading for Dream applications"
+description: "Live reloading for Dream applications"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/dream-livereload"
+doc: "https://tmattio.github.io/dream-livereload/"
+bug-reports: "https://github.com/tmattio/dream-livereload/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "dream" {>= "1.0.0~alpha3"}
+  "lambdasoup" {>= "0.6.1"}
+  "markup" {>= "1.0.2"}
+  "lwt_ppx"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/dream-livereload.git"
+url {
+  src:
+    "https://github.com/tmattio/dream-livereload/releases/download/0.2.0/dream-livereload-0.2.0.tbz"
+  checksum: [
+    "sha256=f9650347225b2e42b2e45419f4b98435c432c0a295b25fd7e1a7dc219024f8de"
+    "sha512=ab19e04bd6f941b769f75fc10114f3f1948cb55ed65e6f4ab8ddbf51987b18594cbb5ad4af24eeb3eb24f735e967d9e0a07112f5b7e53c2fc976cb3e5b5cdee7"
+  ]
+}
+x-commit-hash: "33a489e0808550ebfb05822162937718ce4562b4"


### PR DESCRIPTION
Live reloading for Dream applications

- Project page: <a href="https://github.com/tmattio/dream-livereload">https://github.com/tmattio/dream-livereload</a>
- Documentation: <a href="https://tmattio.github.io/dream-livereload/">https://tmattio.github.io/dream-livereload/</a>

##### CHANGES:

## Changed

- Support for dream.1.0.0~alpha3
- Change default timeout to 10 seconds

## Fixed

- Add constraint to markup.ml that fixes a bug that caused the inject_script middleware to mutates the HTML. (tmattio/dream-livereload#5)
