### PR TITLE
[new release] dream-cli (0.2.0)

### DIFF
--- a/packages/dream-cli/dream-cli.0.2.0/opam
+++ b/packages/dream-cli/dream-cli.0.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Command Line Interface for Dream applications"
+description: "Command Line Interface for Dream applications"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/dream-cli"
+doc: "https://tmattio.github.io/dream-cli/"
+bug-reports: "https://github.com/tmattio/dream-cli/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "dream" {>= "1.0.0~alpha3"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/dream-cli.git"
+url {
+  src:
+    "https://github.com/tmattio/dream-cli/releases/download/0.2.0/dream-cli-0.2.0.tbz"
+  checksum: [
+    "sha256=918293fbe8870b382a0e4a8a8c34bf4316851aa5111406b66db83ad5d4bd3aeb"
+    "sha512=7126d54143ec4cd83cf6c2f511132891e945c55b167a0d692dd853f50c7b631aeda3cda3fa15b2382f95425ac7196e4a0175606c8b43a9edc75951ae45b15d9f"
+  ]
+}
+x-commit-hash: "5d0744061065148fe1ac8f5cf7cbf3070c6f1906"


### PR DESCRIPTION
Command Line Interface for Dream applications

- Project page: <a href="https://github.com/tmattio/dream-cli">https://github.com/tmattio/dream-cli</a>
- Documentation: <a href="https://tmattio.github.io/dream-cli/">https://tmattio.github.io/dream-cli/</a>

##### CHANGES:

- Support cmdliner.1.1.0
- Support for dream.1.0.0~alpha3
