### PR TITLE
[new release] tailwindcss (3.0.23)

### DIFF
--- a/packages/tailwindcss/tailwindcss.3.0.23/opam
+++ b/packages/tailwindcss/tailwindcss.3.0.23/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "TailwindCSS prebuild command line on opam"
+description: """TailwindCSS prebuild command line on opam."""
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "ISC"
+homepage: "https://github.com/tmattio/opam-tailwindcss"
+doc: "https://tmattio.github.io/opam-tailwindcss/"
+bug-reports: "https://github.com/tmattio/opam-tailwindcss/issues"
+dev-repo: "git+https://github.com/tmattio/opam-tailwindcss.git"
+install: [ 
+  "cp" 
+  "bin/tailwindcss-linux-arm64" {os = "linux" & arch = "arm64"}
+  "bin/tailwindcss-linux-x64" {os = "linux" & arch = "x86_64"}
+  "bin/tailwindcss-macos-arm64" {os = "macos" & arch = "arm64"}
+  "bin/tailwindcss-macos-x64" {os = "macos" & arch = "x86_64"}
+  "bin/tailwindcss-windows-x64.exe" {os = "windows" & arch = "x86_64"}
+  "%{bin}%/tailwindcss"
+]
+available: [
+  ( (os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "macos" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "windows" &  arch = "x86_64"))
+]
+url {
+  src:
+    "https://github.com/tmattio/opam-tailwindcss/releases/download/3.0.23/tailwindcss-3.0.23.tbz"
+  checksum: [
+    "sha256=a6e047be6cf6305ef39f24bb479f6f71a83849dfbe5d3c5070499aec17fa47b5"
+    "sha512=d3f93cc05fb46566b4b22a603543c1de3d021ccbd7f26235d293148e243012660424e05e22a1f272deea183a2516d7d65a62a5a9904768d21fac40c19b8464b2"
+  ]
+}
+x-commit-hash: "f6218b20708da46f8c56a077c946d094cfb98004"


### PR DESCRIPTION
TailwindCSS prebuild command line on opam

- Project page: <a href="https://github.com/tmattio/opam-tailwindcss">https://github.com/tmattio/opam-tailwindcss</a>
- Documentation: <a href="https://tmattio.github.io/opam-tailwindcss/">https://tmattio.github.io/opam-tailwindcss/</a>

##### CHANGES:

### Fixed

- Remove opacity variables from `:visited` pseudo class ([tmattio/opam-tailwindcss#7458](https://github.com/tailwindlabs/tailwindcss/pull/7458))
- Support arbitrary values + calc + theme with quotes ([tmattio/opam-tailwindcss#7462](https://github.com/tailwindlabs/tailwindcss/pull/7462))
- Don't duplicate layer output when scanning content with variants + wildcards ([tmattio/opam-tailwindcss#7478](https://github.com/tailwindlabs/tailwindcss/pull/7478))
- Implement `getClassOrder` instead of `sortClassList` ([tmattio/opam-tailwindcss#7459](https://github.com/tailwindlabs/tailwindcss/pull/7459))
