### PR TITLE
Package bwd.1.2.0

### DIFF
--- a/packages/bwd/bwd.1.2.0/opam
+++ b/packages/bwd/bwd.1.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Backward lists"
+description: """
+This OCaml package defines backward lists that are isomorphic to lists.
+They are useful when one wishes to give a different type to the lists that are semantically in reverse.
+In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
+With backward lists having a different type, it is impossible to make these mistakes.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/ocaml-bwd"
+bug-reports: "https://github.com/RedPRL/ocaml-bwd/issues"
+dev-repo: "git+https://github.com/RedPRL/ocaml-bwd.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/ocaml-bwd/archive/1.2.0.tar.gz"
+  checksum: [
+    "md5=8f22a165c41d650ab734063441c83d22"
+    "sha512=525342b74934494a8c1b8e8208ae9125c218abd447373b47e876c281e7c947da80003e81a28e563c55714c4742bce9c8ac36e3c6747c317fc7714cedaa883e60"
+  ]
+}


### PR DESCRIPTION
### `bwd.1.2.0`
Backward lists
This OCaml package defines backward lists that are isomorphic to lists.
They are useful when one wishes to give a different type to the lists that are semantically in reverse.
In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
With backward lists having a different type, it is impossible to make these mistakes.



---
* Homepage: https://github.com/RedPRL/ocaml-bwd
* Source repo: git+https://github.com/RedPRL/ocaml-bwd.git
* Bug tracker: https://github.com/RedPRL/ocaml-bwd/issues

---
:camel: Pull-request generated by opam-publish v2.1.0