### PR TITLE
fix sihl-*.0.3.0 tarball url

### DIFF
--- a/packages/sihl-cache/sihl-cache.0.3.0/opam
+++ b/packages/sihl-cache/sihl-cache.0.3.0/opam
@@ -32,7 +32,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/oxidizing/sihl.git"
 url {
-  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  src: "https://github.com/oxidizing/sihl/archive/refs/tags/0.3.0.tar.gz"
   checksum: [
     "md5=3265ccfac470edc97a524259ec98e15b"
     "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"

--- a/packages/sihl-queue/sihl-queue.0.3.0/opam
+++ b/packages/sihl-queue/sihl-queue.0.3.0/opam
@@ -32,7 +32,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/oxidizing/sihl.git"
 url {
-  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  src: "https://github.com/oxidizing/sihl/archive/refs/tags/0.3.0.tar.gz"
   checksum: [
     "md5=3265ccfac470edc97a524259ec98e15b"
     "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"

--- a/packages/sihl-storage/sihl-storage.0.3.0/opam
+++ b/packages/sihl-storage/sihl-storage.0.3.0/opam
@@ -32,7 +32,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/oxidizing/sihl.git"
 url {
-  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  src: "https://github.com/oxidizing/sihl/archive/refs/tags/0.3.0.tar.gz"
   checksum: [
     "md5=3265ccfac470edc97a524259ec98e15b"
     "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"

--- a/packages/sihl-token/sihl-token.0.3.0/opam
+++ b/packages/sihl-token/sihl-token.0.3.0/opam
@@ -31,7 +31,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/oxidizing/sihl.git"
 url {
-  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  src: "https://github.com/oxidizing/sihl/archive/refs/tags/0.3.0.tar.gz"
   checksum: [
     "md5=3265ccfac470edc97a524259ec98e15b"
     "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"

--- a/packages/sihl-user/sihl-user.0.3.0/opam
+++ b/packages/sihl-user/sihl-user.0.3.0/opam
@@ -31,7 +31,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/oxidizing/sihl.git"
 url {
-  src: "https://github.com/oxidizing/sihl/archive/0.3.0.tar.gz"
+  src: "https://github.com/oxidizing/sihl/archive/refs/tags/0.3.0.tar.gz"
   checksum: [
     "md5=3265ccfac470edc97a524259ec98e15b"
     "sha512=0e6b184d5077a444a0583b65e5b99ba69e798321a34bc99bcc121eb82a3555b86ce8d1c7d3fc6afdcadf87d76f2d903702e5e6252b6b06fd7c1311b712298cc9"


### PR DESCRIPTION
Fixes the tarball url for sihl-*.0.3.0 releases. The fetch failures were seen on https://github.com/ocaml/opam-repository/pull/21160


Signed-off-by: Marcello Seri <marcello.seri@gmail.com>