### PR TITLE
[new release] fat-filesystem (0.15.1)

### DIFF
--- a/packages/fat-filesystem/fat-filesystem.0.15.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.15.1/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-block" {>= "3.0.0"}
   "mirage-block-unix" {>= "2.13.0"}
-  "mirage-kv"
+  "mirage-kv" {>= "4.0.0"}
   "mirage-block-combinators" {with-test}
   "io-page" {>= "2.4.0"}
   "re" {>= "1.7.2"}

--- a/packages/fat-filesystem/fat-filesystem.0.15.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.15.1/opam
@@ -5,6 +5,7 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-fat"
 doc: "https://mirage.github.io/ocaml-fat/"
 bug-reports: "https://github.com/mirage/ocaml-fat/issues"
+license: "ISC"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.15.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.15.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Anil Madhavapeddy"]
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-fat"
+doc: "https://mirage.github.io/ocaml-fat/"
+bug-reports: "https://github.com/mirage/ocaml-fat/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_cstruct"
+  "rresult"
+  "lwt" {>= "2.4.3"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-kv"
+  "mirage-block-combinators" {with-test}
+  "io-page" {>= "2.4.0"}
+  "re" {>= "1.7.2"}
+  "cmdliner" {>= "1.1.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fat.git"
+synopsis: "Pure OCaml implementation of the FAT filesystem"
+description: """
+This library has two purposes:
+1. to allow the easy preparation of bootable disk images
+     containing [mirage](https://mirage.io) kernels
+2. to provide a simple key=value layer for MirageOS applications
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-fat/releases/download/v0.15.1/fat-filesystem-0.15.1.tbz"
+  checksum: [
+    "sha256=6211952a8dd008ab7d02cdb3a6545a65a5ff8047e71dd8ce48a09fb500fe10a3"
+    "sha512=cddfa7e43dbd6ecab23113b3136c91f60c3890efc773603e6a3c3dd531c19e437a8e10b0923e1ce7fbc1d2ca77e6f098040e94678f79f04cec98c56ecef4b5cd"
+  ]
+}
+x-commit-hash: "8032004a650698b3fe04d644b02795148c274fa7"
+


### PR DESCRIPTION
Pure OCaml implementation of the FAT filesystem

- Project page: <a href="https://github.com/mirage/ocaml-fat">https://github.com/mirage/ocaml-fat</a>
- Documentation: <a href="https://mirage.github.io/ocaml-fat/">https://mirage.github.io/ocaml-fat/</a>

##### CHANGES:

- update to fmt 0.8.7, cstruct 6.0.0, cmdliner 1.1.0 (mirage/ocaml-fat#89, @hannesm)
- remove deprecated io-page-unix/io-page.unix dependency (mirage/ocaml-fat#89, @hannesm)
