### PR TITLE
asn1-combinators.0.2.3 is incompatible with cstruct.6.1.0

### DIFF
--- a/packages/asn1-combinators/asn1-combinators.0.2.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.3/opam
@@ -13,7 +13,7 @@ build: [ ["dune" "subst"] {dev}
 depends: [
   "ocaml" {>= "4.05.0" & < "4.12.0"}
   "dune" {>= "1.2.0"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.1.0"}
   "zarith"
   "bigarray-compat"
   "stdlib-shims"

--- a/packages/asn1-combinators/asn1-combinators.0.2.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.3/opam
@@ -17,7 +17,7 @@ depends: [
   "zarith"
   "bigarray-compat"
   "stdlib-shims"
-  "ptime" {< "0.8.6" & > "0.8.1"}
+  "ptime" {>= "0.8.1" & < "0.8.6"}
   "alcotest" {with-test}
 ]
 description: """

--- a/packages/asn1-combinators/asn1-combinators.0.2.3/opam
+++ b/packages/asn1-combinators/asn1-combinators.0.2.3/opam
@@ -17,7 +17,7 @@ depends: [
   "zarith"
   "bigarray-compat"
   "stdlib-shims"
-  "ptime" {< "0.8.6"}
+  "ptime" {< "0.8.6" & > "0.8.1"}
   "alcotest" {with-test}
 ]
 description: """


### PR DESCRIPTION
A simple fix for this error reported by #21181:
```
#=== ERROR while compiling asn1-combinators.0.2.3 =============================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/asn1-combinators.0.2.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p asn1-combinators -j 31
# exit-code            1
# env-file             ~/.opam/log/asn1-combinators-24-10ab7c.env
# output-file          ~/.opam/log/asn1-combinators-24-10ab7c.out
### output ###
#       ocamlc src/.asn1_combinators.objs/byte/asn_prim.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.asn1_combinators.objs/byte -I src/.asn1_combinators.objs/public_cmi -I /home/opam/.opam/4.08/lib/bigarray-compat -I /home/opam/.opam/4.08/lib/cstruct -I /home/opam/.opam/4.08/lib/ptime -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/stdlib-shims -I /home/opam/.opam/4.08/lib/zarith -no-alias-deps -o src/.asn1_combinators.objs/byte/asn_prim.cmo -c -impl src/asn_prim.ml)
# File "src/asn_prim.ml", line 174, characters 15-26:
# 174 |   let length = Cstruct.len
#                      ^^^^^^^^^^^
# Error: Unbound value Cstruct.len
# Hint: Did you mean lenv?
#       ocamlc src/.asn1_combinators.objs/byte/asn_writer.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.asn1_combinators.objs/byte -I src/.asn1_combinators.objs/public_cmi -I /home/opam/.opam/4.08/lib/bigarray-compat -I /home/opam/.opam/4.08/lib/cstruct -I /home/opam/.opam/4.08/lib/ptime -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/stdlib-shims -I /home/opam/.opam/4.08/lib/zarith -intf-suffix .ml -no-alias-deps -o src/.asn1_combinators.objs/byte/asn_writer.cmo -c -impl src/asn_writer.ml)
# File "src/asn_writer.ml", line 5, characters 26-29:
# 5 |   let (s1, s2) = Cstruct.(len cs1, len cs2) in
#                               ^^^
# Error: Unbound value len
# Hint: Did you mean lenv?
#     ocamlopt src/.asn1_combinators.objs/native/asn_writer.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlopt.opt -w -40 -g -I src/.asn1_combinators.objs/byte -I src/.asn1_combinators.objs/native -I src/.asn1_combinators.objs/public_cmi -I /home/opam/.opam/4.08/lib/bigarray-compat -I /home/opam/.opam/4.08/lib/cstruct -I /home/opam/.opam/4.08/lib/ptime -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/stdlib-shims -I /home/opam/.opam/4.08/lib/zarith -intf-suffix .ml -no-alias-deps -o src/.asn1_combinators.objs/native/asn_writer.cmx -c -impl src/asn_writer.ml)
# File "src/asn_writer.ml", line 5, characters 26-29:
# 5 |   let (s1, s2) = Cstruct.(len cs1, len cs2) in
#                               ^^^
# Error: Unbound value len
# Hint: Did you mean lenv?
```