### PR TITLE
Package ppx_deriving_encoding.0.3.0

### DIFF
--- a/packages/ez_api/ez_api.1.0.0/opam
+++ b/packages/ez_api/ez_api.1.0.0/opam
@@ -47,6 +47,7 @@ conflicts: [
   "digestif" {< "1.0.0"}
   "result" {< "1.5"}
   "ppxlib" {< "0.22"}
+  "ppx_deriving_encoding" {>= "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.3.0/opam
+++ b/packages/ppx_deriving_encoding/ppx_deriving_encoding.0.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for json-encoding"
+maintainer: "contact@origin-labs.com"
+authors: "Maxime Levillain <maxime.levillain@origin-labs.com"
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_encoding"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "json-data-encoding" {>= "0.9"}
+  "ppxlib" {>= "0.18.0"}
+  "ocamlfind" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_encoding"
+url {
+  src:
+    "https://gitlab.com/o-labs/ppx_deriving_encoding/-/archive/0.3.0/ppx_deriving_encoding-0.3.0.tar.gz"
+  checksum: [
+    "md5=3e928d75f5b165a0ad511d806cab11e5"
+    "sha512=97ecaca0f2fad0ad8c5e82d910f665f381796995ee1133f26032f9caa036bcf2a9249c4020e90e935946aafff7e7adedac1bcf817391c35ca00bb97dcffe677b"
+  ]
+}


### PR DESCRIPTION
### `ppx_deriving_encoding.0.3.0`
Ppx deriver for json-encoding



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_encoding
* Source repo: git://gitlab.com/o-labs/ppx_deriving_encoding
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_encoding/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0