### PR TITLE
[new release] multipart_form and multipart_form-lwt (0.4.1)

### DIFF
--- a/packages/multipart_form-lwt/multipart_form-lwt.0.4.1/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.4.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom"
+  "bigstringaf"
+  "ke"
+  "lwt"
+  "multipart_form" {= version}
+  "alcotest-lwt" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "unstrctrd" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.4.1/multipart_form-0.4.1.tbz"
+  checksum: [
+    "sha256=36268ee6fec4c53273c2c0b977a4a9f441a5c6ce586773d91d28b599b45540db"
+    "sha512=65843e8371adf80d5d52b510dd819774c0251bb36031126a77fd473e384bc873fd80000adaa8944a2e1fbb68d39a009edd18468239d87c25811cf99d56709d00"
+  ]
+}
+x-commit-hash: "2969c8ff1f7cd6caf292adb7c32a83b230016a72"

--- a/packages/multipart_form/multipart_form.0.4.1/opam
+++ b/packages/multipart_form/multipart_form.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "unstrctrd" {>= "0.2"}
+  "rresult"
+  "uutf"
+  "pecu" {>= "0.4"}
+  "prettym"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ke" {>= "0.4"}
+  "alcotest" {with-test}
+  "rosetta" {with-test}
+  "bigstringaf" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.4.1/multipart_form-0.4.1.tbz"
+  checksum: [
+    "sha256=36268ee6fec4c53273c2c0b977a4a9f441a5c6ce586773d91d28b599b45540db"
+    "sha512=65843e8371adf80d5d52b510dd819774c0251bb36031126a77fd473e384bc873fd80000adaa8944a2e1fbb68d39a009edd18468239d87c25811cf99d56709d00"
+  ]
+}
+x-commit-hash: "2969c8ff1f7cd6caf292adb7c32a83b230016a72"


### PR DESCRIPTION
Multipart-form: RFC2183, RFC2388 & RFC7578

- Project page: <a href="https://github.com/dinosaure/multipart_form">https://github.com/dinosaure/multipart_form</a>
- Documentation: <a href="https://dinosaure.github.io/multipart_form/">https://dinosaure.github.io/multipart_form/</a>

##### CHANGES:

- Remove redundant `bigarray` dependency (@patricoferris, dinosaure/multipart_form#29)
- Remove `bigarray-compat` and `stdlib-shims` and support only OCaml >= 4.08 (@hannesm, dinosaure/multipart_form#30)
