### PR TITLE
[new release] xen-gnt and xen-gnt-unix (4.0.1)

### DIFF
--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "john.else@citrix.com"
+authors: [
+  "Anil Madhavapeddy"
+  "John Else"
+  "Thomas Leonard"
+  "Andrew Cooper"
+  "David Scott"
+]
+homepage: "https://github.com/mirage/ocaml-gnt"
+doc: "https://mirage.github.io/ocaml-gnt/"
+bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "xen-gnt" {= version}
+  "conf-xen"
+]
+available: [ arch != "s390x" & arch != "ppc64" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-gnt.git"
+synopsis: "Xen grant table bindings for OCaml"
+description: """
+These are used to create Xen device driver "backends" (servers)
+and "frontends" (clients).
+
+This library can be used in both kernelspace (via Mirage) or in userspace
+(on Linux). To see a concrete example, have a look at [mirage/ocaml-vchan]
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gnt/releases/download/v4.0.1/xen-gnt-4.0.1.tbz"
+  checksum: [
+    "sha256=1faef511d25047b131f2028561a9316acff66d480bae0369f8d0fdc5a645b2f9"
+    "sha512=24d34dc8d21eb65a0ead77b47a772120c084844732d3c4243aa7a6b61a269668c380eb8e625faf06d7d53fe69fc986cc19caec9a188717bdcf850ddee968f839"
+  ]
+}
+x-commit-hash: "d6b47b3e4c5029eb596b49e22b6657ee088b0863"

--- a/packages/xen-gnt/xen-gnt.4.0.1/opam
+++ b/packages/xen-gnt/xen-gnt.4.0.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "john.else@citrix.com"
+authors: [
+  "Anil Madhavapeddy"
+  "John Else"
+  "Thomas Leonard"
+  "Andrew Cooper"
+  "David Scott"
+]
+homepage: "https://github.com/mirage/ocaml-gnt"
+doc: "https://mirage.github.io/ocaml-gnt/"
+bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "1.0.1"}
+  "io-page" {>= "2.4.0"}
+  "lwt" {>= "2.4.3"}
+  "lwt-dllist"
+  "cmdliner"
+  "mirage-profile" {>= "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-gnt.git"
+synopsis: "Xen grant table bindings for OCaml"
+description: """
+These are used to create Xen device driver "backends" (servers)
+and "frontends" (clients).
+
+This library can be used in both kernelspace (via Mirage) or in userspace
+(on Linux) via the xen-gnt-unix library.
+To see a concrete example, have a look at [mirage/ocaml-vchan]
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gnt/releases/download/v4.0.1/xen-gnt-4.0.1.tbz"
+  checksum: [
+    "sha256=1faef511d25047b131f2028561a9316acff66d480bae0369f8d0fdc5a645b2f9"
+    "sha512=24d34dc8d21eb65a0ead77b47a772120c084844732d3c4243aa7a6b61a269668c380eb8e625faf06d7d53fe69fc986cc19caec9a188717bdcf850ddee968f839"
+  ]
+}
+x-commit-hash: "d6b47b3e4c5029eb596b49e22b6657ee088b0863"


### PR DESCRIPTION
Xen grant table bindings for OCaml

- Project page: <a href="https://github.com/mirage/ocaml-gnt">https://github.com/mirage/ocaml-gnt</a>
- Documentation: <a href="https://mirage.github.io/ocaml-gnt/">https://mirage.github.io/ocaml-gnt/</a>

##### CHANGES:

- Use the conf-xen opam package for depext (mirage/ocaml-gnt#41, by @hannesm)
- Require OCaml 4.08.0, remove deprecated io-page-unix, deprecation fixes
  (mirage/ocaml-gnt#43, by @hannesm)
- Remove deprecation from Gnt.with_gntshr (reported by @psafont in mirage/ocaml-gnt#38)
