### PR TITLE
Package SZXX.2.1.1

### DIFF
--- a/packages/SZXX/SZXX.2.1.1/opam
+++ b/packages/SZXX/SZXX.2.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
+SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
+"""
+license: "MIT"
+tags: ["Stream" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "4.08.1" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core_kernel" { >= "v0.13.0" }
+  "decompress" { >= "1.4.1" }
+  "lwt" { >= "5.3.0" }
+
+  "alcotest-lwt" { with-test }
+  # "ppx_jane" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocaml-lsp-server" { with-test }
+  # "ocamlformat" { = "0.15.0" & with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/v2.1.1.tar.gz"
+  checksum: [
+    "md5=0d83e2f9ea2c120b4017090fe5726347"
+    "sha512=ac3196d9405122c56b4a92a161db6f8ef02f446c379d755d92e11754b0206c35602d131327b29175d9f46f3e9d70797c6836ce83bedba30245b32bc851b12540"
+  ]
+}


### PR DESCRIPTION
### `SZXX.2.1.1`
Streaming ZIP XML XLSX parser
SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.1.0