### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.0.9)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.0.9/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.9/paf-0.0.9.tbz"
+  checksum: [
+    "sha256=7b4e56372b20c3c3f193298464efbd4ed1b369b872cedc8d00bec9b904930fff"
+    "sha512=c8c522242838e51989206f30891baaf4454967926689a5ae5f3bf6374ecb2508539ee292338bd991373e31ef2cdf2ad0a9568537a3280eecbcd2c94f28ab8d01"
+  ]
+}
+x-commit-hash: "fdc8d0d34f4e6a2fe111182a69c7e70cec2c08d1"

--- a/packages/paf-le/paf-le.0.0.9/opam
+++ b/packages/paf-le/paf-le.0.0.9/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.9/paf-0.0.9.tbz"
+  checksum: [
+    "sha256=7b4e56372b20c3c3f193298464efbd4ed1b369b872cedc8d00bec9b904930fff"
+    "sha512=c8c522242838e51989206f30891baaf4454967926689a5ae5f3bf6374ecb2508539ee292338bd991373e31ef2cdf2ad0a9568537a3280eecbcd2c94f28ab8d01"
+  ]
+}
+x-commit-hash: "fdc8d0d34f4e6a2fe111182a69c7e70cec2c08d1"

--- a/packages/paf/paf.0.0.9/opam
+++ b/packages/paf/paf.0.0.9/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.9/paf-0.0.9.tbz"
+  checksum: [
+    "sha256=7b4e56372b20c3c3f193298464efbd4ed1b369b872cedc8d00bec9b904930fff"
+    "sha512=c8c522242838e51989206f30891baaf4454967926689a5ae5f3bf6374ecb2508539ee292338bd991373e31ef2cdf2ad0a9568537a3280eecbcd2c94f28ab8d01"
+  ]
+}
+x-commit-hash: "fdc8d0d34f4e6a2fe111182a69c7e70cec2c08d1"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Fix unikernels (@hannesm, dinosaure/paf-le-chien#58)
- Improve the API and documentation (@dinosaure, dinosaure/paf-le-chien#59)
- Add TCPV4V6 module to be able to provide a simple functoria device (@dinosaure, dinosaure/paf-le-chien#59)
- The HTTP server requires a TCP/IP implementation instead of a Stack implementation (@dinosaure, dinosaure/paf-le-chien#59)
- Extend the API by an _handshake_ function which handle the TLS handshake (@TheLortex, dinosaure/paf-le-chien#59)
