### PR TITLE
Package opam-file-format.2.1.4

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.4/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+]
+depopts: ["dune"]
+conflicts: [
+  "dune" {< "1.3.0"}
+]
+build: [
+  [make "byte" {!ocaml:native} "all" {ocaml:native}] {!dune:installed}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+    {dune:installed}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:installed}
+]
+install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src:
+    "https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.4.tar.gz"
+  checksum: [
+    "md5=cd9dac41c2153d07067c5f30cdcf77db"
+    "sha512=fb5e584080d65c5b5d04c7d2ac397b69a3fd077af3f51eb22967131be22583fea507390eb0d7e6f5c92035372a9e753adbfbc8bfd056d8fd4697c6f95dd8e0ad"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.1.4`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.1.0