### PR TITLE
[new release] shared-block-ring (3.0.1)

### DIFF
--- a/packages/shared-block-ring/shared-block-ring.3.0.1/opam
+++ b/packages/shared-block-ring/shared-block-ring.3.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "A single-consumer single-producer queue on a block device"
+description: """
+This is a simple queue containing variable-length items stored on a
+          disk, in the style of Xen shared-memory-ring."""
+maintainer: "jonathan.ludlam@citrix.com"
+authors: ["David Scott" "Jon Ludlam" "Si Beaumont" "Pau Ruiz Safont"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/shared-block-ring"
+bug-reports: "https://github.com/mirage/shared-block-ring/issues/"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "6.0.0"}
+  "dune" {>= "2.7.0"}
+  "duration"
+  "io-page" {>= "2.4.0"}
+  "logs"
+  "lwt"
+  "lwt_log"
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-clock-unix" {with-test}
+  "mirage-time" {>= "2.0.1"}
+  "mirage-time-unix"
+  "ounit2" {with-test}
+  "ppx_cstruct"
+  "ppx_sexp_conv" {>= "v0.10.0"}
+  "result"
+  "rresult"
+  "sexplib"
+  "sexplib0"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/shared-block-ring.git"
+url {
+  src:
+    "https://github.com/mirage/shared-block-ring/releases/download/v3.0.1/shared-block-ring-3.0.1.tbz"
+  checksum: [
+    "sha256=cf2ad61fbbf598f2aa6cb85fbea2e554a0a1fdaaadb0c8161eccbaa1910f3b83"
+    "sha512=274c9edaf7cc9bec72afd50f366bdc7287e354485649b5c29a9c4441356e222592573b31e2b5e3e28d98253d6303a77b8c353a3345d2664e5795ae35075f9b9c"
+  ]
+}
+x-commit-hash: "e780fd9ed2186c14dd49f9e8d00211be648aa762"

--- a/packages/shared-block-ring/shared-block-ring.3.0.1/opam
+++ b/packages/shared-block-ring/shared-block-ring.3.0.1/opam
@@ -37,7 +37,6 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/shared-block-ring.git"
 url {


### PR DESCRIPTION
A single-consumer single-producer queue on a block device

- Project page: <a href="https://github.com/mirage/shared-block-ring">https://github.com/mirage/shared-block-ring</a>

##### CHANGES:

- Avoid deprecated Cstruct.len (mirage/shared-block-ring#62 @hannesm)
- Adapt to mirage-block 3.0.0 changes (mirage/shared-block-ring#62 @hannesm)
- Update to cmdliner 1.1.0 (mirage/shared-block-ring#62 @hannesm)
- Remove io-page-unix dependency (mirage/shared-block-ring#62 @hannesm)
