### PR TITLE
[new release] docteur, docteur-unix and docteur-solo5 (0.0.5)

### DIFF
--- a/packages/docteur-solo5/docteur-solo5.0.0.5/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.5/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-solo5" {>= "0.7.0"}
+  "mirage-block-solo5"
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "hxd" {>= "0.3.1"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "3.0.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.5/docteur-0.0.5.tbz"
+  checksum: [
+    "sha256=41bf2d7b493276f62cbdfa394c8f574727f1dee4c266dc94b587e7cad8cbcb8b"
+    "sha512=2be62425cd57c3a161d0346d29b9091045019446b16bacc298b101bf6861c5fcd5e6b19c71fb4e78be79dc182a3f79df3fcd81c2fc84ee618555ea21976d23fb"
+  ]
+}
+x-commit-hash: "e72bfa65078fa7f84a413f210a92f370f8fb9253"

--- a/packages/docteur-unix/docteur-unix.0.0.5/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-unix" {>= "5.0.0"}
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "3.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.5/docteur-0.0.5.tbz"
+  checksum: [
+    "sha256=41bf2d7b493276f62cbdfa394c8f574727f1dee4c266dc94b587e7cad8cbcb8b"
+    "sha512=2be62425cd57c3a161d0346d29b9091045019446b16bacc298b101bf6861c5fcd5e6b19c71fb4e78be79dc182a3f79df3fcd81c2fc84ee618555ea21976d23fb"
+  ]
+}
+x-commit-hash: "e72bfa65078fa7f84a413f210a92f370f8fb9253"

--- a/packages/docteur/docteur.0.0.5/opam
+++ b/packages/docteur/docteur.0.0.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+description: """An opiniated file-system for MirageOS"""
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.0"}
+  "git" {>= "3.7.0"}
+  "git-unix" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mtime" {>= "1.2.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "carton" {>= "0.4.0"}
+  "art" {>= "0.1.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.5/docteur-0.0.5.tbz"
+  checksum: [
+    "sha256=41bf2d7b493276f62cbdfa394c8f574727f1dee4c266dc94b587e7cad8cbcb8b"
+    "sha512=2be62425cd57c3a161d0346d29b9091045019446b16bacc298b101bf6861c5fcd5e6b19c71fb4e78be79dc182a3f79df3fcd81c2fc84ee618555ea21976d23fb"
+  ]
+}
+x-commit-hash: "e72bfa65078fa7f84a413f210a92f370f8fb9253"


### PR DESCRIPTION
A simple read-only Key/Value from Git to MirageOS

- Project page: <a href="https://github.com/dinosaure/docteur">https://github.com/dinosaure/docteur</a>
- Documentation: <a href="https://dinosaure.github.io/docteur/">https://dinosaure.github.io/docteur/</a>

##### CHANGES:

- Remove `bigarray-compat` and `mmap` package, support only OCaml >= 4.08 (@dinosaure, dinosaure/docteur#22)
- Be able to use a relative path (instead of an absolute one) when we want to make an image (@dinosaure, dinosaure/docteur#23)
