### PR TITLE
Nix depexts for conf-hidapi, conf-libev and conf-postgresql

### DIFF
--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -18,6 +18,7 @@ depexts: [
   ["hidapi"] {os = "freebsd"}
   ["hidapi-dev"] {os-distribution = "alpine"}
   ["epel-release" "hidapi-devel"] {os-distribution = "centos"}
+  ["hidapi"] {os-distribution = "nixos"}
 ]
 synopsis: "Virtual package relying on a hidapi system installation"
 description:

--- a/packages/conf-libev/conf-libev.4-12/opam
+++ b/packages/conf-libev/conf-libev.4-12/opam
@@ -20,6 +20,7 @@ depexts: [
   ["libev"] {os = "freebsd"}
   ["libev"] {os = "openbsd"}
   ["libev"] {os-distribution = "arch"}
+  ["libev"] {os-distribution = "nixos"}
 ]
 synopsis: "High-performance event loop/event model with lots of features"
 description: """

--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -25,6 +25,7 @@ depexts: [
   ["postgresql-libs"] {os-family = "arch"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}
   ["postgresql96"] {os = "macos" & os-distribution = "macports"}
+  ["postgresql"] {os-distribution = "nixos"}
 ]
 synopsis: "Virtual package relying on a PostgreSQL system installation"
 description:


### PR DESCRIPTION
This adds `depexts` entries so that these may be built on Nix. 