### PR TITLE
Package SZXX.2.1.2

### DIFF
--- a/packages/SZXX/SZXX.2.1.2/opam
+++ b/packages/SZXX/SZXX.2.1.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
+SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
+"""
+license: "MIT"
+tags: ["Stream" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "4.08.1" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core_kernel" { >= "v0.13.0" }
+  "decompress" { >= "1.4.1" }
+  "lwt" { >= "5.3.0" }
+
+  "alcotest-lwt" { with-test }
+  # "ppx_jane" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocaml-lsp-server" { with-test }
+  # "ocamlformat" { = "0.15.0" & with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/v2.1.2.tar.gz"
+  checksum: [
+    "md5=a183a1921d111a930ae51d4a1beb34a2"
+    "sha512=e1846a0b25b71bfb5374d5cd1078c50e4bf766a9413dcea6596620678c905c63933025da327165a9846821e74789a307335e23923ae47386e12bbcea49af76c2"
+  ]
+}


### PR DESCRIPTION
### `SZXX.2.1.2`
Streaming ZIP XML XLSX parser
SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.1.0