### PR TITLE
2 packages from gitlab.com/nomadic-labs/ringo/-/archive/v0.9/ringo-v0.9.tar.gz

### DIFF
--- a/packages/ringo-lwt/ringo-lwt.0.9/opam
+++ b/packages/ringo-lwt/ringo-lwt.0.9/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+  "ringo" {= version }
+  "lwt"
+  "base-unix" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Lwt-wrappers for Ringo caches"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.9/ringo-v0.9.tar.gz"
+  checksum: [
+    "md5=e3bc59c3738c2d8cd4ef4bcc2ef1a97c"
+    "sha512=f34d8bfdf80bca4251dda98706f266e015674f0e5822128b89b6d26c3928e02c37071625f292b5dfa8484cb15a7e530bc33965f6489aa85bd15c2d4d2fd71a54"
+  ]
+}

--- a/packages/ringo/ringo.0.9/opam
+++ b/packages/ringo/ringo.0.9/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/ringo"
+bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.05" }
+  "dune" { >= "1.7" }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Caches (bounded-size key-value stores) and other bounded-size stores"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ringo/-/archive/v0.9/ringo-v0.9.tar.gz"
+  checksum: [
+    "md5=e3bc59c3738c2d8cd4ef4bcc2ef1a97c"
+    "sha512=f34d8bfdf80bca4251dda98706f266e015674f0e5822128b89b6d26c3928e02c37071625f292b5dfa8484cb15a7e530bc33965f6489aa85bd15c2d4d2fd71a54"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ringo.0.9`: Caches (bounded-size key-value stores) and other bounded-size stores
-`ringo-lwt.0.9`: Lwt-wrappers for Ringo caches



---
* Homepage: https://gitlab.com/nomadic-labs/ringo
* Source repo: git+https://gitlab.com/nomadic-labs/ringo.git
* Bug tracker: https://gitlab.com/nomadic-labs/ringo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0