### PR TITLE
opam-file-format: Pass %{lib}% var explicitly to Makefile

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.0.0/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0/opam
@@ -10,7 +10,7 @@ build: [
   "byte" {!ocaml:native}
   "all" {ocaml:native}
 ]
-install: [make "install" "PREFIX=%{prefix}%"]
+install: [make "install" "PREFIX=%{prefix}%" "LIBDIR=%{lib}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
 depends: ["ocaml"]


### PR DESCRIPTION
The Makefile derives `LIBDIR=%{prefix}%/lib` which isn't always correct.

This only affects `opam-file-format` prior to version 2.1. Does this need to be backported?