### PR TITLE
conf-rust: Require 'rustc' depext on Nix

### DIFF
--- a/packages/conf-rust/conf-rust.0.1/opam
+++ b/packages/conf-rust/conf-rust.0.1/opam
@@ -14,7 +14,7 @@ depexts: [
   ["cargo"] {os-distribution = "fedora"}
   ["cargo"] {os-family = "suse"}
   ["cargo"] {os-family = "debian"}
-  ["cargo"] {os-distribution = "nixos"}
+  ["cargo" "rustc"] {os-distribution = "nixos"}
   ["cargo"] {os-distribution = "alpine"}
   ["rust"] {os-distribution = "arch"}
   ["rust"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
Cargo does not ship with the Rust compiler itself on Nix.