### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.11.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.11.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.11.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.11.0/jsonrpc-1.11.0.tbz"
+  checksum: [
+    "sha256=8d8a75bccb55e8f4b8ec5376fcb5cd04faa43dfbd0717c67e95b7232e848d4de"
+    "sha512=4470b9bee7505d2530198709e626200e9bec82d81ac06a91c691215ca21e00173362ca66ef02843062a3d9a3155c4bc1e10215f3f2a242f9d36a21a5d94782f8"
+  ]
+}
+x-commit-hash: "423345e2dd4d485bc91e762d3f89746d4882040b"

--- a/packages/lsp/lsp.1.11.0/opam
+++ b/packages/lsp/lsp.1.11.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "jsonrpc" {= version}
+  "dyn"
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "stdune"
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.11.0/jsonrpc-1.11.0.tbz"
+  checksum: [
+    "sha256=8d8a75bccb55e8f4b8ec5376fcb5cd04faa43dfbd0717c67e95b7232e848d4de"
+    "sha512=4470b9bee7505d2530198709e626200e9bec82d81ac06a91c691215ca21e00173362ca66ef02843062a3d9a3155c4bc1e10215f3f2a242f9d36a21a5d94782f8"
+  ]
+}
+x-commit-hash: "423345e2dd4d485bc91e762d3f89746d4882040b"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.11.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.11.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc"
+  "dyn"
+  "stdune"
+  "fiber"
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "omd" {<= "1.3.1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14" & < "4.15"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.11.0/jsonrpc-1.11.0.tbz"
+  checksum: [
+    "sha256=8d8a75bccb55e8f4b8ec5376fcb5cd04faa43dfbd0717c67e95b7232e848d4de"
+    "sha512=4470b9bee7505d2530198709e626200e9bec82d81ac06a91c691215ca21e00173362ca66ef02843062a3d9a3155c4bc1e10215f3f2a242f9d36a21a5d94782f8"
+  ]
+}
+x-commit-hash: "423345e2dd4d485bc91e762d3f89746d4882040b"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add support for dune in watch mode. The lsp server will now display build
  errors in the diagnostics and offer promotion code actions.

- Re-introduce ocamlformat-rpc (ocaml/ocaml-lsp#599, fixes ocaml/ocaml-lsp#495)

## Fixes

- Fix workspace symbols that could have a wrong path in some cases
  ([ocaml/ocaml-lsp#675](https://github.com/ocaml/ocaml-lsp/pull/671))
