### PR TITLE
xapi-stdext-threads: not compatible with 4.14

### DIFF
--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.14.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.14.0/opam
@@ -9,7 +9,7 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "4.14"}
   "dune" {>= "1.11"}
   "base-threads"
   "base-unix"

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.16.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.16.0/opam
@@ -9,7 +9,7 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "4.14"}
   "dune" {>= "1.11"}
   "base-threads"
   "base-unix"


### PR DESCRIPTION
Fails with
```
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lib/xapi-stdext-threads/.xapi_stdext_threads.objs/byte -I lib/xapi-stdext-threads/.xapi_stdext_threads.objs/native -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rpclib -I /home/opam/.opam/4.14/lib/rpclib/core -I /home/opam/.opam/4.14/lib/rpclib/internals -I /home/opam/.opam/4.14/lib/rpclib/json -I /home/opam/.opam/4.14/lib/rpclib/xml -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/xapi-backtrace -I /home/opam/.opam/4.14/lib/xapi-stdext-pervasives -I /home/opam/.opam/4.14/lib/xmlm -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Xapi_stdext_threads -o lib/xapi-stdext-threads/.xapi_stdext_threads.objs/native/xapi_stdext_threads__Threadext.cmx -c -impl lib/xapi-stdext-threads/threadext.ml)
# File "lib/xapi-stdext-threads/threadext.ml", line 242, characters 6-17:
# 242 |       Thread.kill t
#             ^^^^^^^^^^^
# Alert deprecated: Thread.kill
# Not implemented, do not use
# File "lib/xapi-stdext-threads/threadext.ml", line 245, characters 8-19:
# 245 |         Thread.kill (Lazy.force pt)
#               ^^^^^^^^^^^
# Alert deprecated: Thread.kill
# Not implemented, do not use
# File "lib/xapi-stdext-threads/threadext.ml", line 250, characters 36-47:
# 250 |              if Lazy.is_val pt then Thread.kill (Lazy.force pt)
#                                           ^^^^^^^^^^^
# Alert deprecated: Thread.kill
# Not implemented, do not use
# File "lib/xapi-stdext-threads/threadext.ml", line 255, characters 18-34:
# 255 |   let wait_read = Thread.wait_read
#                         ^^^^^^^^^^^^^^^^
# Alert deprecated: Thread.wait_read
# This function no longer does anything
# File "lib/xapi-stdext-threads/threadext.ml", line 256, characters 19-36:
# 256 |   let wait_write = Thread.wait_write
#                          ^^^^^^^^^^^^^^^^^
# Alert deprecated: Thread.wait_write
# This function no longer does anything
# File "lib/xapi-stdext-threads/threadext.ml", line 1:
# Error: The implementation lib/xapi-stdext-threads/threadext.ml
#        does not match the interface lib/xapi-stdext-threads/.xapi_stdext_threads.objs/byte/xapi_stdext_threads__Threadext.cmi:
#         ... The exception `Exit' is required but not provided
#        The value `default_uncaught_exception_handler' is required but not provided
#        File "lib/xapi-stdext-threads/threadext.mli", line 63, characters 10-48:
#          Expected declaration
#        In module Thread:
#        The value `set_uncaught_exception_handler' is required but not provided
#        File "lib/xapi-stdext-threads/threadext.mli", line 63, characters 10-48:
#          Expected declaration
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>