### PR TITLE
zmq-async supports async_kernel/async_unix 0.15.0

### DIFF
--- a/packages/zmq-async/zmq-async.5.1.5/opam
+++ b/packages/zmq-async/zmq-async.5.1.5/opam
@@ -9,9 +9,9 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.04.1"}
   "zmq" {= version}
-  "async_unix" {>= "v0.11.0" & < "v0.15"}
-  "async_kernel" {>= "v0.11.0" & < "v0.15"}
-  "base" {>= "v0.11.0" & < "v0.15"}
+  "async_unix" {>= "v0.11.0"}
+  "async_kernel" {>= "v0.11.0"}
+  "base" {>= "v0.11.0"}
   "ounit2" {with-test}
 ]
 build: [


### PR DESCRIPTION
Older versions of zmq-async are already installable with this version of async. cc @Leonidas-from-XIV 