### PR TITLE
[new release] elpi and elpi-option-legacy-parser (1.15.1)

### DIFF
--- a/packages/elpi-option-legacy-parser/elpi-option-legacy-parser.1/opam
+++ b/packages/elpi-option-legacy-parser/elpi-option-legacy-parser.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+depends: [
+  "camlp5" {> "7.99"}
+  "ocaml" {< "4.14.0" }
+]
+flags: conf
+synopsis: "ELPI - option for legacy parser"
+description: """
+Enables the -legacy-parser flag, implemented on top of CamlP5"""

--- a/packages/elpi/elpi.1.15.1/opam
+++ b/packages/elpi/elpi.1.15.1/opam
@@ -27,7 +27,7 @@ depends: [
   "conf-time" {with-test}
 ]
 depopts: [
-  "elpi-option-legacy-parser" {= "1"}
+  "elpi-option-legacy-parser"
 ]
 conflicts: [
   "elpi-option-legacy-parser" {!= "1"}

--- a/packages/elpi/elpi.1.15.1/opam
+++ b/packages/elpi/elpi.1.15.1/opam
@@ -1,0 +1,93 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  [make "config" "LEGACY_PARSER=1"] {elpi-option-legacy-parser:installed}
+  [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0" }
+  "stdlib-shims"
+  "ppxlib" {>= "0.12.0" }
+  "menhir" {>= "20211230" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.8.0"}
+  "conf-time" {with-test}
+]
+depopts: [
+  "elpi-option-legacy-parser" {= "1"}
+]
+conflicts: [
+  "elpi-option-legacy-parser" {!= "1"}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer
+  does not need to care about technical devices to handle bound variables,
+  like De Bruijn indices.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.15.1/elpi-1.15.1.tbz"
+  checksum: [
+    "sha256=eaea1f24532d9cb6bb7209725afca12955b27c4ff66ac945ca244ce792df427f"
+    "sha512=3a9faa5822593f672f7475ee8f2c0b03996031076ca79145b80e17b65f08ab0b68841daa2a36b7e046e9887683a01d47ac47c4a67820cdde2386d2c9ce81f204"
+  ]
+}
+x-commit-hash: "9e8c3abc8d102289ddc7fbbab6284319d952183b"


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

Requires Menhir 20211230 and OCaml 4.07 or above.
Camlp5 8.0 or above is optional.

*warning: The parser used by default is not backward compatible with 1.14.x*

- Build:
  - Change legacy parser not built by default
  - New `make config LEGACY_PARSER=1` to enable it
  - New opam package `elpi-option-legacy-parser` to install elpi with
    the legacy parser enabled

- Parser:
  - Fix missing infix `&` (synonym of `,`)
  - New comma separator is optional in `pred` declarations, eg
    `pred i:A o:B.` is valid syntax
