### PR TITLE
[new release] elpi and elpi-option-legacy-parser (1.15.2)

### DIFF
--- a/packages/elpi-option-legacy-parser/elpi-option-legacy-parser.1/opam
+++ b/packages/elpi-option-legacy-parser/elpi-option-legacy-parser.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/LPCIC/elpi.git"
 bug-reports: "https://github.com/LPCIC/elpi/issues"
 
 depends: [
-  "elpi" {post}
+  "elpi" {post & >= "1.15.2"}
   "camlp5" {> "7.99"}
   "ocaml" {< "4.14.0" }
 ]

--- a/packages/elpi-option-legacy-parser/elpi-option-legacy-parser.1/opam
+++ b/packages/elpi-option-legacy-parser/elpi-option-legacy-parser.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+depends: [
+  "elpi" {post}
+  "camlp5" {> "7.99"}
+  "ocaml" {< "4.14.0" }
+]
+flags: conf
+synopsis: "ELPI - option for legacy parser"
+description: """
+Enables the -legacy-parser flag, implemented on top of CamlP5"""

--- a/packages/elpi/elpi.1.15.2/opam
+++ b/packages/elpi/elpi.1.15.2/opam
@@ -1,0 +1,93 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Claudio Sacerdoti Coen" "Enrico Tassi" ]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/LPCIC/elpi"
+doc: "https://LPCIC.github.io/elpi/"
+dev-repo: "git+https://github.com/LPCIC/elpi.git"
+bug-reports: "https://github.com/LPCIC/elpi/issues"
+
+build: [
+  ["dune" "subst"] {dev}
+  [make "config" "LEGACY_PARSER=1"] {elpi-option-legacy-parser:installed}
+  [make "build" "DUNE_OPTS=-p %{name}% -j %{jobs}%"]
+  [make "tests" "DUNE_OPTS=-p %{name}%" "SKIP=performance_HO" "SKIP+=performance_FO"] {with-test & os != "macos" & os-distribution != "alpine" & os-distribution != "freebsd"}
+]
+
+depends: [
+  "ocaml" {>= "4.07.0" }
+  "stdlib-shims"
+  "ppxlib" {>= "0.12.0" }
+  "menhir" {>= "20211230" }
+  "re" {>= "1.7.2"}
+  "ppx_deriving" {>= "4.2"}
+  "ANSITerminal" {with-test}
+  "cmdliner" {with-test}
+  "dune" {>= "2.8.0"}
+  "conf-time" {with-test}
+]
+depopts: [
+  "elpi-option-legacy-parser"
+]
+conflicts: [
+  "elpi-option-legacy-parser" {!= "1"}
+]
+synopsis: "ELPI - Embeddable λProlog Interpreter"
+description: """
+ELPI implements a variant of λProlog enriched with Constraint Handling Rules,
+a programming language well suited to manipulate syntax trees with binders.
+
+ELPI is designed to be embedded into larger applications written in OCaml as
+an extension language. It comes with an API to drive the interpreter and 
+with an FFI for defining built-in predicates and data types, as well as
+quotations and similar goodies that are handy to adapt the language to the host
+application.
+
+This package provides both a command line interpreter (elpi) and a library to
+be linked in other applications (eg by passing -package elpi to ocamlfind).
+
+The ELPI programming language has the following features:
+
+- Native support for variable binding and substitution, via an Higher Order
+  Abstract Syntax (HOAS) embedding of the object language. The programmer
+  does not need to care about technical devices to handle bound variables,
+  like De Bruijn indices.
+
+- Native support for hypothetical context. When moving under a binder one can
+  attach to the bound variable extra information that is collected when the
+  variable gets out of scope. For example when writing a type-checker the
+  programmer needs not to care about managing the typing context.
+
+- Native support for higher order unification variables, again via HOAS.
+  Unification variables of the meta-language (λProlog) can be reused to
+  represent the unification variables of the object language. The programmer
+  does not need to care about the unification-variable assignment map and
+  cannot assign to a unification variable a term containing variables out of
+  scope, or build a circular assignment.
+
+- Native support for syntactic constraints and their meta-level handling rules.
+  The generative semantics of Prolog can be disabled by turning a goal into a
+  syntactic constraint (suspended goal). A syntactic constraint is resumed as
+  soon as relevant variables gets assigned. Syntactic constraints can be
+  manipulated by constraint handling rules (CHR).
+
+- Native support for backtracking. To ease implementation of search.
+
+- The constraint store is extensible.  The host application can declare
+  non-syntactic constraints and use custom constraint solvers to check their
+  consistency.
+
+- Clauses are graftable. The user is free to extend an existing program by
+  inserting/removing clauses, both at runtime (using implication) and at
+  "compilation" time by accumulating files.
+
+ELPI is free software released under the terms of LGPL 2.1 or above."""
+url {
+  src:
+    "https://github.com/LPCIC/elpi/releases/download/v1.15.2/elpi-1.15.2.tbz"
+  checksum: [
+    "sha256=fac4184223779fe765cd7ce2e68a4e8e190966aa6437094765c52369433afb14"
+    "sha512=2d3db5c41510aa2d32f89b8cfb32dcb690423ba79639c6f458b56c6379b840e487aba5cdc190222c9f3c998cdb75e1e810eee2e2601e375bd2bc956c81217d47"
+  ]
+}
+x-commit-hash: "f70e21132a59a2324c615e2af271cd25a18fabec"

--- a/packages/elpi/elpi.1.15.2/opam
+++ b/packages/elpi/elpi.1.15.2/opam
@@ -20,7 +20,7 @@ depends: [
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }
   "re" {>= "1.7.2"}
-  "ppx_deriving" {>= "4.2"}
+  "ppx_deriving" {>= "4.3"}
   "ANSITerminal" {with-test}
   "cmdliner" {with-test}
   "dune" {>= "2.8.0"}


### PR DESCRIPTION
ELPI - Embeddable λProlog Interpreter

- Project page: <a href="https://github.com/LPCIC/elpi">https://github.com/LPCIC/elpi</a>
- Documentation: <a href="https://LPCIC.github.io/elpi/">https://LPCIC.github.io/elpi/</a>

##### CHANGES:

Requires Menhir 20211230 and OCaml 4.07 or above.
Camlp5 8.0 or above is optional.

*warning: The parser used by default is not backward compatible with 1.14.x*

- Parser:
  - Change `pred foo i:A o:B` is valid, `pred foo i:A o :B` is not. This
    change restores backward compatibility of existing code.
