### PR TITLE
magic-trace 1.0.1

### DIFF
--- a/packages/magic-trace/magic-trace.1.0.1/opam
+++ b/packages/magic-trace/magic-trace.1.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://magic-trace.org"
+bug-reports: "https://github.com/janestreet/magic-trace/issues"
+dev-repo: "git+https://github.com/janestreet/magic-trace.git"
+doc: "https://github.com/janestreet/magic-trace/wiki"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"        {>= "4.12"}
+  "async"
+  "cohttp"
+  "cohttp_static_handler"
+  "core"
+  "core_unix"
+  "expect_test_helpers_async"
+  "ppx_jane"
+  "shell"
+  "dune"         {>= "2.0.0"}
+  "owee"         {>= "0.6"}
+  "re"           {>= "1.8.0"}
+]
+synopsis: "Collects and displays high-resolution traces of what a process is doing"
+description: "https://github.com/janestreet/magic-trace"
+url {
+  src: "https://github.com/janestreet/magic-trace/archive/refs/tags/v1.0.1.tar.gz"
+  checksum: [
+    "sha256=77b2e4b3bc769910656d0fdee4839250548aa49486fd3554f6c057f1d64abe99"
+    "sha512=1f111db6348673c22a110611182a92c8aa999668dc077c44bc4abcaa72ccb197899ff2577047888627b50fcc9890824de6c82b4fe9f06129190b8b487ec3f716"
+  ]
+}
+x-commit-hash: "87c8f2d7fdab6be4eb79755c479fd69616a67829"


### PR DESCRIPTION
New version of magic-trace: 1.0 (and 1.0.1 to fix a small error in the dune file). Release notes are here:

https://github.com/janestreet/magic-trace/releases/tag/v1.0.0