### PR TITLE
[new release] mirage-block-xen (2.1.1)

### DIFF
--- a/packages/mirage-block-xen/mirage-block-xen.2.1.1/opam
+++ b/packages/mirage-block-xen/mirage-block-xen.2.1.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Anil Madhavapeddy" "David Scott" "Thomas Leonard"]
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/mirage-block-xen"
+doc: "https://mirage.github.io/mirage-block-xen/"
+bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "logs"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_cstruct" {>= "3.6.0"}
+  "shared-memory-ring"
+  "shared-memory-ring-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "io-page" {>= "2.0.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "xenstore"
+  "fmt" {>= "0.8.7"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block-xen.git"
+synopsis: "MirageOS block driver for Xen that implements the blkfront/back protocol"
+description: """
+This library allows a Mirage OCaml application to
+
+  1. read and write blocks from any Xen "backend" (server)
+  2. service block requests from any Xen "frontend" (client)
+
+This library can be used in both kernelspace (on Xen)
+or in userspace (using libraries that come with Xen).
+
+This library depends on the
+[shared-memory-ring](https://github.com/mirage/shared-memory-ring)
+library which enables high-throughput, low-latency data
+transfers over shared memory on both x86 and ARM architectures,
+using the standard Xen RPC and event channel semantics.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-xen/releases/download/v2.1.1/mirage-block-xen-2.1.1.tbz"
+  checksum: [
+    "sha256=6877737cd55470aca27ce0daf967ddcd0ad369678c8a65f4d3716d34d5bc43f3"
+    "sha512=2cdbd0e1851c22925d46f87353931252b813a0462338363a43291c3dc0a8449d7015789934117701a20ad6b4b672a192de3df3499ef575a78c54fa65458f5f79"
+  ]
+}
+x-commit-hash: "5dd724f1cf6392a46105910b7e5963c259473ccb"


### PR DESCRIPTION
MirageOS block driver for Xen that implements the blkfront/back protocol

- Project page: <a href="https://github.com/mirage/mirage-block-xen">https://github.com/mirage/mirage-block-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-xen/">https://mirage.github.io/mirage-block-xen/</a>

##### CHANGES:

* Adapt to `cstruct.6.0.0` and `fmt.0.8.7` (@hannesm, mirage/mirage-block-xen#91)
