### PR TITLE
sifun is not compatible with core.v0.15

### DIFF
--- a/packages/sifun/sifun.1.0.0/opam
+++ b/packages/sifun/sifun.1.0.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/kkd26/SiFun"
 bug-reports: "https://github.com/kkd26/SiFun/issues"
 depends: [
   "ocaml" {>= "4.06"}
-  "core" {>= "v0.11.3"}
+  "core" {>= "v0.11.3" & < "v0.15"}
   "dune" {>= "2.9"}
   "odoc" {with-doc}
   "menhir" {>= "20180523"}

--- a/packages/sifun/sifun.1.0.1/opam
+++ b/packages/sifun/sifun.1.0.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/kkd26/SiFun"
 bug-reports: "https://github.com/kkd26/SiFun/issues"
 depends: [
   "ocaml" {>= "4.06"}
-  "core" {>= "v0.11.3"}
+  "core" {>= "v0.11.3" & < "v0.15"}
   "dune" {>= "2.9"}
   "odoc" {with-doc}
   "menhir" {>= "20180523"}

--- a/packages/sifun/sifun.2.0.0/opam
+++ b/packages/sifun/sifun.2.0.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/kkd26/SiFun"
 bug-reports: "https://github.com/kkd26/SiFun/issues"
 depends: [
   "ocaml" {>= "4.06"}
-  "core" {>= "v0.11.3"}
+  "core" {>= "v0.11.3" & < "v0.15"}
   "dune" {>= "2.9"}
   "odoc" {with-doc}
   "menhir" {>= "20180523"}


### PR DESCRIPTION
```
#=== ERROR while compiling sifun.2.0.0 ========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/sifun.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sifun -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/sifun-10790-2260c6.env
# output-file          ~/.opam/log/sifun-10790-2260c6.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/.main.eobjs/byte -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/variantslib -I lib/.sifun.objs/byte -no-alias-deps -open Dune__exe -o bin/.main.eobjs/byte/dune__exe__Main.cmo -c -impl bin/main.ml)
# File "bin/main.ml", line 32, characters 5-16:
# 32 |   |> Command.run
#           ^^^^^^^^^^^
# Alert deprecated: Core.Command.run
# [since 2021-03] Use [Command_unix]
# File "bin/main.ml", line 32, characters 5-16:
# 32 |   |> Command.run
#           ^^^^^^^^^^^
# Error: This expression has type [ `Use_Command_unix ]
#        This is not a function; it cannot be applied.
```