### PR TITLE
res_tailwindcss is not compatible with core.v0.15

### DIFF
--- a/packages/res_tailwindcss/res_tailwindcss.0.1.3/opam
+++ b/packages/res_tailwindcss/res_tailwindcss.0.1.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.12.1"}
   "dune" { >= "2.8"}
   "ppxlib"
-  "core"
+  "core" {< "v0.15"}
   "ppx_inline_test"
   "ppx_expect"
   "ppx_deriving"


### PR DESCRIPTION
```
#=== ERROR while compiling res_tailwindcss.0.1.3 ==============================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/res_tailwindcss.0.1.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p res_tailwindcss -j 31
# exit-code            1
# env-file             ~/.opam/log/res_tailwindcss-11171-a830ed.env
# output-file          ~/.opam/log/res_tailwindcss-11171-a830ed.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9 -g -bin-annot -I src/.res_tailwindcss.objs/byte -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/variantslib -no-alias-deps -open Res_tailwindcss__ -o src/.res_tailwindcss.objs/byte/res_tailwindcss__Util.cmo -c -impl src/util.pp.ml)
# File "src/util.ml", line 5, characters 40-55:
# 5 |   match Filename.concat dir bsconfig |> Sys.file_exists with
#                                             ^^^^^^^^^^^^^^^
# Alert deprecated: Core.Sys.file_exists
# [since 2021-04] Use [Sys_unix]
# File "src/util.ml", line 5, characters 40-55:
# 5 |   match Filename.concat dir bsconfig |> Sys.file_exists with
#                                             ^^^^^^^^^^^^^^^
# Error: This expression has type [ `Use_Sys_unix ]
#        This is not a function; it cannot be applied.
```