### PR TITLE
[new release] opam-monorepo (0.3.0)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.3.0/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/opam-monorepo"
+doc: "https://ocamllabs.github.io/opam-monorepo"
+bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "dune-build-info" {= "2.7.0" | = "2.7.1"}
+  "dune-configurator" {= "2.7.0" | = "2.7.1"}
+]
+dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} ]
+flags: [ plugin ]
+depexts: [
+  ["devel/pkgconf"] {os = "openbsd"}
+  ["pkg-config"] {os-family = "debian"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+]
+url {
+  src:
+    "https://github.com/ocamllabs/opam-monorepo/releases/download/0.3.0/opam-monorepo-0.3.0.tbz"
+  checksum: [
+    "sha256=82e8241a5ff0e82cbbff28f1a41e77adc92bb544f62d5eb9ba6e7842e75a7e5c"
+    "sha512=3bb39cdaa257e22744b4349a0788286943fb47997d2e79f52c7497f936998f08e87d33e3637f58b62589cf4ef2c6b3547bbd66208e3c48085a1776fef59f5bbf"
+  ]
+}
+x-commit-hash: "268f77993146d83951dbc139147dc801cea8517c"


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/ocamllabs/opam-monorepo">https://github.com/ocamllabs/opam-monorepo</a>
- Documentation: <a href="https://ocamllabs.github.io/opam-monorepo">https://ocamllabs.github.io/opam-monorepo</a>

##### CHANGES:

### Added

- Add opam extensions `x-opam-monorepo-opam-repositories` and
  `x-opam-monorepo-global-opam-vars` to make `lock` fully reproducible.
  (ocamllabs/opam-monorepo#250, ocamllabs/opam-monorepo#253, @NathanReb)
- Show an error message when the solver can't find any version that satisfies
  the requested version constraint in the user's OPAM file (ocamllabs/opam-monorepo#215, ocamllabs/opam-monorepo#248,
  @Leonidas-from-XIV)
- Allow packages to be marked as being provided by Opam and not to be pulled by
  `opam-monorepo`. To control this a new optional Opam file field,
  `x-opam-monorepo-opam-provided` is introduced. Its value is a list of package
  names that are to be excluded from being pulled (ocamllabs/opam-monorepo#234, @Leonidas-from-XIV)
- Show an error message when the OCaml version of the lock file does not match
  the OCaml version of the switch (ocamllabs/opam-monorepo#267, ocamllabs/opam-monorepo#268, @Leonidas-from-XIV)
- Generate a `duniverse/README.md` file to explain the basics of
  `opam-monorepo` in the vendored directory (ocamllabs/opam-monorepo#272, ocamllabs/opam-monorepo#274, @Leonidas-from-XIV)
- Add a `--prefer-cross-compile` flag for the solver to select cross-compiling
  versions of packages when available. This is determined through the presence
  of the `"cross-compile"` tag in the opam metadata.

### Changed

- Bump lockfile version to 0.3 (ocamllabs/opam-monorepo#285, @NathanReb)
- Mark packages to be pulled by opam-monorepo with the `vendor` variable so
  using OPAM with `opam install --deps-only --locked .` will not install
  packages that will be installed with `opam-monorepo pull` (ocamllabs/opam-monorepo#237,
  @Leonidas-from-XIV)

### Deprecated

### Fixed

- Fix a bug where a package which had a single version that built with dune and got selected by the solver
  would be reported has having no version building with dune. (ocamllabs/opam-monorepo#245, @Leonidas-from-XIV)
- Fix the solver so it does not select beta versions of the compiler unless
  forced to by version constraints or `--ocaml-version`. (ocamllabs/opam-monorepo#269, @NathanReb)

### Removed

- Drop support for lockfile versions 0.2 and lower (ocamllabs/opam-monorepo#285, @NathanReb)

### Security
