### PR TITLE
p4pp is not compatible with core.v0.15

### DIFF
--- a/packages/p4pp/p4pp.0.1.10/opam
+++ b/packages/p4pp/p4pp.0.1.10/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.09.1"}
   "dune" {>= "1.4"}
   "menhir" {>= "20180523" & <= "20211230"}
-  "core" {>= "v0.13.0"}
+  "core" {>= "v0.13.0" & < "v0.15"}
 ]
 url {
   src: "https://github.com/cornell-netlab/p4pp/archive/v0.1.10.tar.gz"

--- a/packages/p4pp/p4pp.0.1.8/opam
+++ b/packages/p4pp/p4pp.0.1.8/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.09.1"}
   "dune" {>= "1.4"}
   "menhir" {= "20211230"}
-  "core" {>= "v0.13.0"}
+  "core" {>= "v0.13.0" & < "v0.15"}
 ]
 url {
   src: "https://github.com/cornell-netlab/p4pp/archive/v0.1.8.tar.gz"

--- a/packages/p4pp/p4pp.0.1.9/opam
+++ b/packages/p4pp/p4pp.0.1.9/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.09.1"}
   "dune" {>= "1.4"}
   "menhir" {>= "20180523" & <= "20211230"}
-  "core" {>= "v0.13.0"}
+  "core" {>= "v0.13.0" & < "v0.15"}
 ]
 url {
   src: "https://github.com/cornell-netlab/p4pp/archive/v0.1.9.tar.gz"


### PR DESCRIPTION
cc @hackedy 
```
#=== ERROR while compiling p4pp.0.1.10 ========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/p4pp.0.1.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p p4pp -j 31
# exit-code            1
# env-file             ~/.opam/log/p4pp-10790-9cdf11.env
# output-file          ~/.opam/log/p4pp-10790-9cdf11.out
### output ###
# File "lib/dune", line 10, characters 13-24:
# 10 |   (libraries core_kernel))
#                   ^^^^^^^^^^^
# Error: Library "core_kernel" not found.
# -> required by library "p4pp" in _build/default/lib
# -> required by _build/default/META.p4pp
# -> required by _build/install/default/lib/p4pp/META
# -> required by _build/default/p4pp.install
# -> required by alias install
# File "bin/dune", line 5, characters 13-24:
# 5 |   (libraries core_kernel p4pp core))
#                  ^^^^^^^^^^^
# Error: Library "core_kernel" not found.
# -> required by _build/default/bin/main.exe
# -> required by _build/install/default/bin/p4pp
# -> required by _build/default/p4pp.install
# -> required by alias install
```