### PR TITLE
biotk is not compatible with core.v0.15 (uses Core.Unix.open_connection)

### DIFF
--- a/packages/biotk/biotk.0.1.0/opam
+++ b/packages/biotk/biotk.0.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "angstrom" {>= "0.15.0"}
   "angstrom-unix" {>= "0.15.0"}
   "biocaml"
-  "core" {>= "v0.14.0"}
+  "core" {>= "v0.14.0" & < "v0.15"}
   "crunch" {>= "3.2.0"}
   "fmt"
   "ocaml" {>= "4.11.0"}


### PR DESCRIPTION
cc @pveber 
```
#=== ERROR while compiling biotk.0.1.0 ========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/biotk.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p biotk -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/biotk-24277-a7f9cc.env
# output-file          ~/.opam/log/biotk-24277-a7f9cc.out
### output ###
# File "lib/igv.ml", line 46, characters 26-41:
# 46 |   let ic, oc = Core.Unix.(open_connection (ADDR_INET (Inet_addr.of_string addr, port))) in
#                                ^^^^^^^^^^^^^^^
# Error: Unbound value open_connection
```