### PR TITLE
2 packages from mransan/ocaml-protoc at 2.2

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+post-messages: [
+"The runtime library is now called \"pbrt\"."
+]
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="2.0"}
+  "stdlib-shims"
+  "pbrt" {= version}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.2.0.tar.gz"
+  checksum: [
+    "md5=fe2b09744a5a6bd1ca9fb6f6fb411cc1"
+    "sha512=ee368b2be9ddb40dc3ef15eea7e96af9595c93fc8d92b1ad7f50e018cbda6ed6fc613bf41fcf4729974b2ce9dfbcd78ccbcb8a38d59d17bf4ceb24f581392303"
+  ]
+}

--- a/packages/pbrt/pbrt.2.2/opam
+++ b/packages/pbrt/pbrt.2.2/opam
@@ -18,7 +18,7 @@ license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "@install" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" "pbrt,ocaml-protoc" "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [

--- a/packages/pbrt/pbrt.2.2/opam
+++ b/packages/pbrt/pbrt.2.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Runtime library for Protobuf tooling"
+description: "Runtime library for Protobuf tooling"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+post-messages: [
+"Pbrt: runtime library for ocaml-protoc.
+
+A shim library named \"ocaml-protoc\" still exists, to ease the
+migration."
+]
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="2.0"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.2.0.tar.gz"
+  checksum: [
+    "md5=fe2b09744a5a6bd1ca9fb6f6fb411cc1"
+    "sha512=ee368b2be9ddb40dc3ef15eea7e96af9595c93fc8d92b1ad7f50e018cbda6ed6fc613bf41fcf4729974b2ce9dfbcd78ccbcb8a38d59d17bf4ceb24f581392303"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocaml-protoc.2.2`: Protobuf compiler for OCaml
-`pbrt.2.2`: Runtime library for Protobuf tooling



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.1.0