### PR TITLE
3 packages from andersfugmann/aws-s3 at 4.7.0

### DIFF
--- a/packages/aws-s3-async/aws-s3-async.4.7.0/opam
+++ b/packages/aws-s3-async/aws-s3-async.4.7.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+doc: "https://andersfugmann.github.io/aws-s3/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "aws-s3" {= version}
+  "async_kernel" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "conduit-async" {>= "4.0.0"}
+  "core" {>= "v0.14.0"}
+  "core_unix" {>= "v0.14.0"}
+]
+synopsis: "Ocaml library for accessing Amazon S3 - Async version"
+description: """
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* HEAD operation on single objects
+* Streaming transfer to and from aws.
+* Multi part upload (including s3 -> s3 copy)
+* Fetching machine role/credentials (though IAM)
+
+This library uses async for concurrency"""
+url {
+  src: "https://github.com/andersfugmann/aws-s3/archive/4.7.0.tar.gz"
+  checksum: [
+    "md5=3eb5023419ad81946e3742272a3dec62"
+    "sha512=787dc08207c9ea5aee9dbb1f17ba7b316cc3e9139d5428a02131fa11238d2928f723971dadd93ea8f71e8a8adb9340ac3c6566f870afb51523dea078c8fc014e"
+  ]
+}

--- a/packages/aws-s3-lwt/aws-s3-lwt.4.7.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.7.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "2.0.0"}
+  "aws-s3" {= version}
+  "lwt"
+  "conduit-lwt-unix" {>= "5.0.0"}
+]
+synopsis: "Ocaml library for accessing Amazon S3 - Lwt version"
+description: """
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* HEAD operation on single objects
+* Streaming transfer to and from aws.
+* Multi part upload (including s3 -> s3 copy)
+* Fetching machine role/credentials (though IAM)
+
+This library uses lwt for concurrency"""
+url {
+  src: "https://github.com/andersfugmann/aws-s3/archive/4.7.0.tar.gz"
+  checksum: [
+    "md5=3eb5023419ad81946e3742272a3dec62"
+    "sha512=787dc08207c9ea5aee9dbb1f17ba7b316cc3e9139d5428a02131fa11238d2928f723971dadd93ea8f71e8a8adb9340ac3c6566f870afb51523dea078c8fc014e"
+  ]
+}

--- a/packages/aws-s3/aws-s3.4.7.0/opam
+++ b/packages/aws-s3/aws-s3.4.7.0/opam
@@ -19,8 +19,8 @@ depends: [
   "ptime"
   "uri"
   "ezxmlm" {>= "1.1.0"}
-  "ppx_protocol_conv_xmlm" {>= "5.0.0" & < "6.0.0"}
-  "ppx_protocol_conv_json" {>= "5.0.0" & < "6.0.0"}
+  "ppx_protocol_conv_xmlm" {>= "5.0.0"}
+  "ppx_protocol_conv_json" {>= "5.0.0"}
   "cmdliner" {>= "1.1.0"}
   "ppx_inline_test" {with-test}
   "base64" {>= "3.1.0"}

--- a/packages/aws-s3/aws-s3.4.7.0/opam
+++ b/packages/aws-s3/aws-s3.4.7.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Anders Fugmann <anders@fugmann.net>"
+authors: "Anders Fugmann"
+license: "BSD-3-Clause"
+homepage: "https://github.com/andersfugmann/aws-s3"
+dev-repo: "git+https://github.com/andersfugmann/aws-s3"
+bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
+doc: "https://andersfugmann.github.io/aws-s3/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml-inifiles"
+  "digestif" {>= "0.7"}
+  "ptime"
+  "uri"
+  "ezxmlm" {>= "1.1.0"}
+  "ppx_protocol_conv_xmlm" {>= "5.0.0" & < "6.0.0"}
+  "ppx_protocol_conv_json" {>= "5.0.0" & < "6.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "ppx_inline_test" {with-test}
+  "base64" {>= "3.1.0"}
+]
+synopsis: "Ocaml library for accessing Amazon S3"
+description: """
+This library provides access to Amazon Simple Storage Solution (S3).
+The library supports:
+* Copying file to and from s3
+* List files in S3 (from root)
+* Delete single/multi object in S3
+* HEAD operation on single objects
+* Streaming transfer to and from aws.
+* Multi part upload (including s3 -> s3 copy)
+* Fetching machine role/credentials (though IAM)
+
+The library supports both lwt and async concurrency models.
+* For lwt, please install `aws-s3-lwt` package
+* For Async, please install `aws-s3-async` package"""
+url {
+  src: "https://github.com/andersfugmann/aws-s3/archive/4.7.0.tar.gz"
+  checksum: [
+    "md5=3eb5023419ad81946e3742272a3dec62"
+    "sha512=787dc08207c9ea5aee9dbb1f17ba7b316cc3e9139d5428a02131fa11238d2928f723971dadd93ea8f71e8a8adb9340ac3c6566f870afb51523dea078c8fc014e"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`aws-s3.4.7.0`: Ocaml library for accessing Amazon S3
-`aws-s3-async.4.7.0`: Ocaml library for accessing Amazon S3 - Async version
-`aws-s3-lwt.4.7.0`: Ocaml library for accessing Amazon S3 - Lwt version



---
* Homepage: https://github.com/andersfugmann/aws-s3
* Source repo: git+https://github.com/andersfugmann/aws-s3
* Bug tracker: https://github.com/andersfugmann/aws-s3/issues

---
:camel: Pull-request generated by opam-publish v2.1.0