### PR TITLE
Package bls12-381.3.0.2

### DIFF
--- a/packages/bls12-381/bls12-381.3.0.2/opam
+++ b/packages/bls12-381/bls12-381.3.0.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: """\
+Implementation of BLS12-381 and some cryptographic primitives built
+on top of it"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "zarith_stubs_js" {with-test}
+  "hex" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "integers"
+  "integers_stubs_js" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
+]
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/3.0.2/ocaml-bls12-381-3.0.2.tar.bz2"
+  checksum: [
+    "md5=6725d524fac86fcb701ec5f94d2045f2"
+    "sha512=3622cdd98179091df3f563e3c5117313f1ad8e95d9f9713b6fe327b0b9ec404ea94499bf44309e377f189dfaf5adefd5b1aff0681bcb250bb08cb761415cafe6"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381.3.0.2`
Implementation of BLS12-381 and some cryptographic primitives built
on top of it

Built on top of 3.0.1. Removing JS stubs in library deps to be compatible with ocaml-multicore



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381/issues

---
:camel: Pull-request generated by opam-publish v2.1.0