### PR TITLE
Mark ounit and ounit2 < 2.2.6 incompatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/ounit/ounit.2.0.0/opam
+++ b/packages/ounit/ounit.2.0.0/opam
@@ -8,7 +8,7 @@ doc: ["http://ounit.forge.ocamlcore.org/api-ounit/index.html"]
 build: [make "build"]
 remove: [["ocamlfind" "remove" "oUnit"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/ounit/ounit.2.0.5/opam
+++ b/packages/ounit/ounit.2.0.5/opam
@@ -8,7 +8,7 @@ doc: ["http://ounit.forge.ocamlcore.org/api-ounit/index.html"]
 build: [make "build"]
 remove: [["ocamlfind" "remove" "oUnit"]]
 depends: [
-  "ocaml" {>= "3.11.0"}
+  "ocaml" {>= "3.11.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ounit/ounit.2.0.6/opam
+++ b/packages/ounit/ounit.2.0.6/opam
@@ -8,7 +8,7 @@ doc: ["http://ounit.forge.ocamlcore.org/api-ounit/index.html"]
 build: [make "build"]
 remove: [["ocamlfind" "remove" "oUnit"]]
 depends: [
-  "ocaml" {>= "3.11.0"}
+  "ocaml" {>= "3.11.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ounit/ounit.2.0.7/opam
+++ b/packages/ounit/ounit.2.0.7/opam
@@ -8,7 +8,7 @@ doc: ["http://ounit.forge.ocamlcore.org/api-ounit/index.html"]
 build: [make "build"]
 remove: [["ocamlfind" "remove" "oUnit"]]
 depends: [
-  "ocaml" {>= "3.11.0"}
+  "ocaml" {>= "3.11.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ounit/ounit.2.0.8/opam
+++ b/packages/ounit/ounit.2.0.8/opam
@@ -8,7 +8,7 @@ doc: ["http://ounit.forge.ocamlcore.org/api-ounit/index.html"]
 build: [make "build"]
 remove: [["ocamlfind" "remove" "oUnit"]]
 depends: [
-  "ocaml" {>= "3.11.0"}
+  "ocaml" {>= "3.11.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/ounit/ounit.2.1.2/opam
+++ b/packages/ounit/ounit.2.1.2/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"

--- a/packages/ounit2/ounit2.2.2.0/opam
+++ b/packages/ounit2/ounit2.2.2.0/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"

--- a/packages/ounit2/ounit2.2.2.1/opam
+++ b/packages/ounit2/ounit2.2.2.1/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"

--- a/packages/ounit2/ounit2.2.2.2/opam
+++ b/packages/ounit2/ounit2.2.2.2/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"

--- a/packages/ounit2/ounit2.2.2.3/opam
+++ b/packages/ounit2/ounit2.2.2.3/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"

--- a/packages/ounit2/ounit2.2.2.4/opam
+++ b/packages/ounit2/ounit2.2.2.4/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"

--- a/packages/ounit2/ounit2.2.2.5/opam
+++ b/packages/ounit2/ounit2.2.2.5/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/gildor478/ounit.git"
 bug-reports: "https://github.com/gildor478/ounit/issues"
 doc: "https://gildor478.github.io/ounit/"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune" {>= "1.11.0"}
   "base-bytes"
   "base-unix"


### PR DESCRIPTION
```
#=== ERROR while compiling ounit2.2.2.5 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ounit2.2.2.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ounit2 -j 255
# exit-code            1
# env-file             ~/.opam/log/ounit2-10-b5c457.env
# output-file          ~/.opam/log/ounit2-10-b5c457.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/ounit2/advanced/.oUnitAdvanced.objs/byte -I /home/opam/.opam/5.0/lib/stdlib-shims -no-alias-deps -o src/lib/ounit2/advanced/.oUnitAdvanced.objs/byte/oUnitAssert.cmo -c -impl src/lib/ounit2/advanced/oUnitAssert.ml)
# File "src/lib/ounit2/advanced/oUnitAssert.ml", line 130, characters 13-27:
# 130 |     ?(sinput=Stream.of_list [])
#                    ^^^^^^^^^^^^^^
# Error: Unbound module Stream
```