### PR TITLE
Mark printbox < 0.6 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/printbox/printbox.0.1/opam
+++ b/packages/printbox/printbox.0.1/opam
@@ -13,7 +13,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "printbox"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/printbox/printbox.0.2/opam
+++ b/packages/printbox/printbox.0.2/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {< "3.0"}
   "base-bytes"
   "odoc" {with-doc}
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "mdx" {with-test}
 ]
 depopts: ["tyxml"]

--- a/packages/printbox/printbox.0.3/opam
+++ b/packages/printbox/printbox.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.1" }
   "base-bytes"
   "odoc" {with-doc}
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.0" }
   "uutf" {with-test}
   "uucp" {with-test}
 ]

--- a/packages/printbox/printbox.0.4/opam
+++ b/packages/printbox/printbox.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.1" }
   "base-bytes"
   "odoc" {with-doc}
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.0" }
   "uutf" {with-test}
   "uucp" {with-test}
 ]

--- a/packages/printbox/printbox.0.5/opam
+++ b/packages/printbox/printbox.0.5/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" { >= "1.1" }
   "base-bytes"
   "odoc" {with-doc}
-  "ocaml" { >= "4.03" }
+  "ocaml" { >= "4.03" & < "5.0" }
   "uutf" {with-test}
   "uucp" {with-test}
   "mdx" {with-test & >= "1.4" & < "1.6" }


### PR DESCRIPTION
```

#=== ERROR while compiling printbox.0.5 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/printbox.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p printbox -j 47
# exit-code            1
# env-file             ~/.opam/log/printbox-10-206bec.env
# output-file          ~/.opam/log/printbox-10-206bec.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -a+8 -safe-string -g -bin-annot -I src/.printbox.objs/byte -intf-suffix .ml -no-alias-deps -o src/.printbox.objs/byte/printBox_text.cmo -c -impl src/PrintBox_text.ml)
# File "src/PrintBox_text.ml", line 56, characters 10-28:
# 56 |     match Pervasives.compare pos1.y pos2.y with
#                ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -warn-error -a+8 -safe-string -g -I src/.printbox.objs/byte -I src/.printbox.objs/native -intf-suffix .ml -no-alias-deps -o src/.printbox.objs/native/printBox_text.cmx -c -impl src/PrintBox_text.ml)
# File "src/PrintBox_text.ml", line 56, characters 10-28:
# 56 |     match Pervasives.compare pos1.y pos2.y with
#                ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```