### PR TITLE
Mark ptime < 0.8.6 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/ptime/ptime.0.8.1/opam
+++ b/packages/ptime/ptime.0.8.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/ptime/ptime.0.8.2/opam
+++ b/packages/ptime/ptime.0.8.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/ptime/ptime.0.8.3/opam
+++ b/packages/ptime/ptime.0.8.3/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/ptime/ptime.0.8.4/opam
+++ b/packages/ptime/ptime.0.8.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/ptime/ptime.0.8.5/opam
+++ b/packages/ptime/ptime.0.8.5/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/ptime/issues"
 tags: [ "time" "posix" "system" "org:erratique" ]
 license: "ISC"
 depends: [
- "ocaml" {>= "4.01.0"}
+ "ocaml" {>= "4.01.0" & < "5.0"}
  "ocamlfind" {build}
  "ocamlbuild" {build}
  "topkg" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling ptime.0.8.5 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ptime.0.8.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --with-js_of_ocaml false
# exit-code            1
# env-file             ~/.opam/log/ptime-10-de6106.env
# output-file          ~/.opam/log/ptime-10-de6106.out
### output ###
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamldep -package result -modules src/ptime.ml > src/ptime.ml.depends
# ocamlfind ocamldep -package result -modules src/ptime.mli > src/ptime.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package result -I src -o src/ptime.cmi src/ptime.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package result -I src -o src/ptime.cmx src/ptime.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package result -I src -o src/ptime.cmx src/ptime.ml
# File "src/ptime.ml", line 128, characters 12-26:
# 128 |     let d = Pervasives.abs secs in
#                   ^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/ptime.a' 'src/ptime.cmxs' 'src/ptime.cmxa'
#      'src/ptime.cma' 'src/ptime.cmx' 'src/ptime.cmi' 'src/ptime.mli'
#      'src/ptime_top.a' 'src/ptime_top.cmxs' 'src/ptime_top.cmxa'
#      'src/ptime_top.cma' 'src/ptime_top.cmx' 'src/ptime_top_init.ml'
#      'src-os/ptime_clock.a' 'src-os/ptime_clock.cmxs'
#      'src-os/ptime_clock.cmxa' 'src-os/ptime_clock.cma'
#      'src-os/ptime_clock.cmx' 'src-os/ptime_clock.cmi'
#      'src-os/ptime_clock.mli' 'src-os/dllptime_clock_stubs.so'
#      'src-os/libptime_clock_stubs.a' 'src-os/ptime_clock_top.a'
#      'src-os/ptime_clock_top.cmxs' 'src-os/ptime_clock_top.cmxa'
#      'src-os/ptime_clock_top.cma' 'src-os/ptime_clock_top.cmx'
#      'test-os/min_clock_os.ml' 'test-jsoo/min_clock_jsoo.ml'
#      'test-jsoo/min_clock_jsoo.html']: exited with 10
```