### PR TITLE
Mark cmdliner < 1.0.4 incompatible with OCaml 5.0

### DIFF
--- a/packages/cmdliner/cmdliner.0.9.4/opam
+++ b/packages/cmdliner/cmdliner.0.9.4/opam
@@ -6,7 +6,7 @@ doc: "http://erratique.ch/software/cmdliner/doc/Cmdliner"
 tags: [ "cli" "system" "declarative" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/cmdliner/cmdliner.1.0.0/opam
+++ b/packages/cmdliner/cmdliner.1.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {>= "0.8.1" & build}

--- a/packages/cmdliner/cmdliner.1.0.1/opam
+++ b/packages/cmdliner/cmdliner.1.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {>= "0.8.1" & build}

--- a/packages/cmdliner/cmdliner.1.0.2/opam
+++ b/packages/cmdliner/cmdliner.1.0.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {>= "0.8.1" & build}

--- a/packages/cmdliner/cmdliner.1.0.3/opam
+++ b/packages/cmdliner/cmdliner.1.0.3/opam
@@ -7,7 +7,7 @@ dev-repo: "git+http://erratique.ch/repos/cmdliner.git"
 bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
 tags: [ "cli" "system" "declarative" "org:erratique" ]
 license: "ISC"
-depends:[ "ocaml" {>= "4.03.0"} ]
+depends:[ "ocaml" {>= "4.03.0" & < "5.0"} ]
 build: [[ make "all" "PREFIX=%{prefix}%" ]]
 install:
 [[make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%" ]


### PR DESCRIPTION
```
#=== ERROR while compiling cmdliner.1.0.3 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/cmdliner.1.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all PREFIX=/home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/cmdliner-10-fed480.env
# output-file          ~/.opam/log/cmdliner-10-fed480.out
### output ###
# ocaml build.ml cma
# File "cmdliner_base.ml", line 14, characters 16-32:
# 14 | let lowercase = String.lowercase
#                      ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
# exited with 2: 'ocamlc.opt' '-g' '-bin-annot' '-safe-string' '-w' '-3' 'cmdliner_trie.mli' 'cmdliner_trie.ml' 'cmdliner_suggest.mli' 'cmdliner_suggest.ml' 'cmdliner_manpage.mli' 'cmdliner_info.mli' 'cmdliner_docgen.mli' 'cmdliner_cline.mli' 'cmdliner_base.mli' 'cmdliner_base.ml' 'cmdliner.mli' 'cmdliner_manpage.ml' 'cmdliner_msg.mli' 'cmdliner_term.mli' 'cmdliner_info.ml' 'cmdliner_docgen.ml' 'cmdliner_arg.mli' 'cmdliner_msg.ml' 'cmdliner_cline.ml' 'cmdliner_term.ml' 'cmdliner_arg.ml' 'cmdliner.ml' '-a' '-o' 'cmdliner.cma'
# make: *** [Makefile:44: build-byte] Error 1

'opam install -vy cmdliner.1.0.3' failed.
- ocaml build.ml cma
- File "cmdliner_base.ml", line 14, characters 16-32:
- 14 | let lowercase = String.lowercase
-                      ^^^^^^^^^^^^^^^^
- Error: Unbound value String.lowercase
- exited with 2: 'ocamlc.opt' '-g' '-bin-annot' '-safe-string' '-w' '-3' 'cmdliner_trie.mli' 'cmdliner_trie.ml' 'cmdliner_suggest.mli' 'cmdliner_suggest.ml' 'cmdliner_manpage.mli' 'cmdliner_info.mli' 'cmdliner_docgen.mli' 'cmdliner_cline.mli' 'cmdliner_base.mli' 'cmdliner_base.ml' 'cmdliner.mli' 'cmdliner_manpage.ml' 'cmdliner_msg.mli' 'cmdliner_term.mli' 'cmdliner_info.ml' 'cmdliner_docgen.ml' 'cmdliner_arg.mli' 'cmdliner_msg.ml' 'cmdliner_cline.ml' 'cmdliner_term.ml' 'cmdliner_arg.ml' 'cmdliner.ml' '-a' '-o' 'cmdliner.cma'
- make: *** [Makefile:44: build-byte] Error 1
```