### PR TITLE
Mark markup < 1.0.3 incompatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/markup/markup.0.5/opam
+++ b/packages/markup/markup.0.5/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/aantron/markup.ml/issues"
 dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "uutf" {<= "0.9.4"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/markup/markup.0.6/opam
+++ b/packages/markup/markup.0.6/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/aantron/markup.ml/issues"
 dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "uutf" {<= "0.9.4"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/markup/markup.0.7.1/opam
+++ b/packages/markup/markup.0.7.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/aantron/markup.ml/issues"
 dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "uutf" {<= "0.9.4"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/markup/markup.0.7.2/opam
+++ b/packages/markup/markup.0.7.2/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/aantron/markup.ml/issues"
 dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "uutf" {<= "0.9.4"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/markup/markup.0.7.6/opam
+++ b/packages/markup/markup.0.7.6/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta17"}
   "ounit" {with-test}
   "lwt" {with-test}

--- a/packages/markup/markup.0.7.7/opam
+++ b/packages/markup/markup.0.7.7/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta17"}
   "ounit" {with-test}
   "uchar"

--- a/packages/markup/markup.0.7/opam
+++ b/packages/markup/markup.0.7/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/aantron/markup.ml/issues"
 dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "uutf" {<= "0.9.4"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/markup/markup.0.8.0/opam
+++ b/packages/markup/markup.0.8.0/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 license: "BSD-3-Clause"
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "dune"
   "ounit" {with-test}
   "uchar"

--- a/packages/markup/markup.0.8.1/opam
+++ b/packages/markup/markup.0.8.1/opam
@@ -12,6 +12,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/aantron/markup.ml.git"
 
 depends: [
+  "ocaml" {< "5.0"}
   "dune"
   "uchar"
   "uutf" {>= "1.0.0"}

--- a/packages/markup/markup.0.8.2/opam
+++ b/packages/markup/markup.0.8.2/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 
 depends: [
   "dune"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "uchar"
   "uutf" {>= "1.0.0"}
 

--- a/packages/markup/markup.1.0.0-1/opam
+++ b/packages/markup/markup.1.0.0-1/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 
 depends: [
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "uchar"
   "uutf" {>= "1.0.0"}
 

--- a/packages/markup/markup.1.0.0/opam
+++ b/packages/markup/markup.1.0.0/opam
@@ -15,7 +15,7 @@ available: false
 
 depends: [
   "dune"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "uchar"
   "uutf" {>= "1.0.0"}
 

--- a/packages/markup/markup.1.0.1/opam
+++ b/packages/markup/markup.1.0.1/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 
 depends: [
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "uchar"
   "uutf" {>= "1.0.0"}
 

--- a/packages/markup/markup.1.0.2/opam
+++ b/packages/markup/markup.1.0.2/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/markup.ml.git"
 
 depends: [
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "uchar"
   "uutf" {>= "1.0.0"}
 


### PR DESCRIPTION
```
#=== ERROR while compiling markup.1.0.2 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/markup.1.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p markup -j 31
# exit-code            1
# env-file             ~/.opam/log/markup-12-e3f3c1.env
# output-file          ~/.opam/log/markup-12-e3f3c1.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +A-4-9-44-48 -warn-error -3-4-9-44-48 -safe-string -g -bin-annot -I src/.markup.objs/byte -I /home/opam/.opam/5.0/lib/uutf -no-alias-deps -open Markup__ -o src/.markup.objs/byte/markup__Common.cmo -c -impl src/common.ml)
# File "src/common.ml", line 8, characters 18-27:
# 8 |   let lowercase = lowercase [@ocaml.warning "-3"]
#                       ^^^^^^^^^
# Error: Unbound value lowercase
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +A-4-9-44-48 -warn-error -3-4-9-44-48 -safe-string -g -bin-annot -I src/.markup.objs/byte -I /home/opam/.opam/5.0/lib/uutf -no-alias-deps -open Markup__ -o src/.markup.objs/byte/markup__Trie.cmo -c -impl src/trie.ml)
# File "src/trie.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +A-4-9-44-48 -warn-error -3-4-9-44-48 -safe-string -g -bin-annot -I src/.markup.objs/byte -I /home/opam/.opam/5.0/lib/uutf -no-alias-deps -open Markup__ -o src/.markup.objs/byte/markup__Entities.cmo -c -impl src/entities.ml)
# File "src/entities.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
```