### PR TITLE
Mark down < 0.1.0 incompatible with OCaml 4.14

### DIFF
--- a/packages/down/down.0.0.1/opam
+++ b/packages/down/down.0.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://erratique.ch/repos/down.git"
 bug-reports: "https://github.com/dbuenzli/down/issues"
 tags: [ "org:erratique" "dev" "toplevel" "repl" ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.14"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1" } ]

--- a/packages/down/down.0.0.2/opam
+++ b/packages/down/down.0.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://erratique.ch/repos/down.git"
 bug-reports: "https://github.com/dbuenzli/down/issues"
 tags: [ "org:erratique" "dev" "toplevel" "repl" ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.14"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1" } ]

--- a/packages/down/down.0.0.3/opam
+++ b/packages/down/down.0.0.3/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://erratique.ch/repos/down.git"
 bug-reports: "https://github.com/dbuenzli/down/issues"
 tags: [ "org:erratique" "dev" "toplevel" "repl" ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "4.14"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1" } ]


### PR DESCRIPTION
```
#=== ERROR while compiling down.0.0.3 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/down.0.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false --lib-dir /home/opam/.opam/4.14/lib
# exit-code            1
# env-file             ~/.opam/log/down-10-ca3354.env
# output-file          ~/.opam/log/down-10-ca3354.out
### output ###
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/4.14/lib/ocamlbuild /home/opam/.opam/4.14/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/4.14/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamlc -g -package compiler-libs.toplevel -c src/down_stubs.c
# + ocamlfind ocamlc -g -package compiler-libs.toplevel -c src/down_stubs.c
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# mv down_stubs.o src/down_stubs.o
# ocamlfind ocamlmklib -o src/down_stubs -g src/down_stubs.o
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down_tty_width.ml > src/down_tty_width.ml.depends
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down_tty_width.mli > src/down_tty_width.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_tty_width.cmi src/down_tty_width.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_tty_width.cmi src/down_tty_width.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down_std.ml > src/down_std.ml.depends
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down_std.mli > src/down_std.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_std.cmi src/down_std.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_std.cmi src/down_std.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_tty_width.cmx src/down_tty_width.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_tty_width.cmx src/down_tty_width.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down.ml > src/down.ml.depends
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down.mli > src/down.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down.cmi src/down.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down.cmi src/down.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_std.cmx src/down_std.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_std.cmx src/down_std.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# File "src/down_std.ml", line 626, characters 43-53:
# 626 |     Result.bind (if s = "" then Ok () else File.write tmp s) @@ fun () ->
#                                                  ^^^^^^^^^^
# Warning 6 [labels-omitted]: label file was omitted in the application of this function.
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down_top.ml > src/down_top.ml.depends
# ocamlfind ocamldep -package compiler-libs.toplevel -modules src/down_top.mli > src/down_top.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_top.cmi src/down_top.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_top.cmi src/down_top.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down.cmx src/down.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down.cmx src/down.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# File "src/down.ml", line 151, characters 23-28:
# 151 |   let insert bytes p = subst p.cursor p.cursor bytes p
#                              ^^^^^
# Warning 6 [labels-omitted]: labels start, stop were omitted in the application of this function.
# File "src/down.ml", line 724, characters 19-32:
# 724 |           p.txt <- Pstring.subst start (start + String.length old) w p.txt
#                          ^^^^^^^^^^^^^
# Warning 6 [labels-omitted]: labels start, stop were omitted in the application of this function.
# File "src/down.ml", line 726, characters 19-36:
# 726 |         let word = Pstring.txt_range start (Pstring.cursor p.txt - 1) p.txt in
#                          ^^^^^^^^^^^^^^^^^
# Warning 6 [labels-omitted]: labels first, last were omitted in the application of this function.
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_top.cmx src/down_top.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package compiler-libs.toplevel -I src -I test -o src/down_top.cmx src/down_top.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.14/lib/ocaml, /home/opam/.opam/4.14/lib/ocaml/compiler-libs
# File "src/down_top.ml", line 6, characters 64-71:
# 6 | let () = if !Sys.interactive then (Down.Private.set_top (module Toploop))
#                                                                     ^^^^^^^
# Error: Signature mismatch:
#        ...
#        Values do not match:
#          val use_silently : Format.formatter -> input -> bool
#        is not included in
#          val use_silently : Format.formatter -> string -> bool
#        The type Format.formatter -> input -> bool
#        is not compatible with the type Format.formatter -> string -> bool
#        Type input = Toploop.input is not compatible with type string 
#        File "src/down.mli", line 115, characters 4-57: Expected declaration
#        File "toplevel/toploop.mli", line 96, characters 0-45:
#          Actual declaration
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/down.a' 'src/down.cmxs' 'src/down.cmxa' 'src/down.cma'
#      'src/down_top.cmx' 'src/down.cmx' 'src/down.cmi' 'src/down.mli'
#      'src/down_std.cmx' 'src/down_tty_width.cmx' 'src/dlldown_stubs.so'
#      'src/libdown_stubs.a' 'doc/index.mld' 'doc/manual.mld' 'src/down.top']: exited with 10
```