### PR TITLE
Mark bos < 0.2.1 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/bos/bos.0.1.0/opam
+++ b/packages/bos/bos.0.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.5"}

--- a/packages/bos/bos.0.1.1/opam
+++ b/packages/bos/bos.0.1.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.5"}

--- a/packages/bos/bos.0.1.2/opam
+++ b/packages/bos/bos.0.1.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.4"}

--- a/packages/bos/bos.0.1.3/opam
+++ b/packages/bos/bos.0.1.3/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.4"}

--- a/packages/bos/bos.0.1.4/opam
+++ b/packages/bos/bos.0.1.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.4"}

--- a/packages/bos/bos.0.1.5/opam
+++ b/packages/bos/bos.0.1.5/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/bos/bos.0.1.6/opam
+++ b/packages/bos/bos.0.1.6/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/bos/bos.0.2.0/opam
+++ b/packages/bos/bos.0.2.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/bos/issues"
 tags: [ "os" "system" "cli" "command" "file" "path" "log" "unix" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling bos.0.2.0 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/bos.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false
# exit-code            1
# env-file             ~/.opam/log/bos-11-cf6850.env
# output-file          ~/.opam/log/bos-11-cf6850.out
### output ###
# ocamlfind ocamldep -package bytes -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_base.ml > src/bos_base.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_base.cmo src/bos_base.ml
# ocamlfind ocamldep -package bytes -package rresult -package astring -package fpath -package fmt -package logs -package unix -modules src/bos_pat.ml > src/bos_pat.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_pat.cmo src/bos_pat.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package rresult -package astring -package fpath -package fmt -package logs -package unix -I src -I test -o src/bos_pat.cmo src/bos_pat.ml
# File "src/bos_pat.ml", line 26, characters 19-37:
# 26 | let compare p p' = Pervasives.compare p p'
#                         ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/bos.a' 'src/bos.cmxs' 'src/bos.cmxa' 'src/bos.cma'
#      'src/bos.cmx' 'src/bos.cmi' 'src/bos.mli' 'src/bos_os_arg.cmx'
#      'src/bos_os_env.cmx' 'src/bos_os_cmd.cmx' 'src/bos_os_dir.cmx'
#      'src/bos_os_file.cmx' 'src/bos_os_path.cmx' 'src/bos_os_tmp.cmx'
#      'src/bos_os_u.cmx' 'src/bos_cmd.cmx' 'src/bos_log.cmx' 'src/bos_pat.cmx'
#      'src/bos_base.cmx' 'src/bos_setup.a' 'src/bos_setup.cmxs'
#      'src/bos_setup.cmxa' 'src/bos_setup.cma' 'src/bos_setup.cmx'
#      'src/bos_setup.cmi' 'src/bos_setup.mli' 'src/bos_top.a'
#      'src/bos_top.cmxs' 'src/bos_top.cmxa' 'src/bos_top.cma'
#      'src/bos_top.cmx' 'src/bos_top_init.ml']: exited with 10
```