### PR TITLE
Mark b0.0.0.0 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/b0/b0.0.0.0/opam
+++ b/packages/b0/b0.0.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/b0-system/b0/issues"
 tags: ["dev" "org:erratique" "org:b0-system" "build" ]
 depends:
 [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling b0.0.0.0 ===========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/b0.0.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build
# exit-code            1
# env-file             ~/.opam/log/b0-12-5b83b4.env
# output-file          ~/.opam/log/b0-12-5b83b4.out
### output ###
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamldep -package unix -modules src-b00/b00.ml > src-b00/b00.ml.depends
# ocamlfind ocamldep -package unix -modules src-b00/b00.mli > src-b00/b00.mli.depends
# ocamlfind ocamldep -package unix -modules src-std/b0_std.mli > src-std/b0_std.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -keep-locs -package unix -I src-std -I tools -I test -I src-care -I src-b00 -I examples -o src-std/b0_std.cmi src-std/b0_std.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -keep-locs -package unix -I src-std -I tools -I test -I src-care -I src-b00 -I examples -o src-std/b0_std.cmi src-std/b0_std.mli
# File "src-std/b0_std.mli", line 118, characters 44-61:
# 118 |   val unit : (unit, Format.formatter, unit) Pervasives.format -> unit t
#                                                   ^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src-b00/b00.a' 'src-b00/b00.cmxs' 'src-b00/b00.cmxa'
#      'src-b00/b00.cma' 'src-b00/b00.cmx' 'src-b00/b00.cmi' 'src-b00/b00.mli'
#      'src-std/b0_std.a' 'src-std/b0_std.cmxs' 'src-std/b0_std.cmxa'
#      'src-std/b0_std.cma' 'src-std/b0_std.cmx' 'src-std/b0_std.cmi'
#      'src-std/b0_std.mli' 'src-care/b0_care.a' 'src-care/b0_care.cmxs'
#      'src-care/b0_care.cmxa' 'src-care/b0_care.cma' 'src-care/b0_web.cmx'
#      'src-care/b0_web.cmi' 'src-care/b0_web.mli' 'src-care/b0_vcs.cmx'
#      'src-care/b0_vcs.cmi' 'src-care/b0_vcs.mli' 'src-care/b0_ui.cmx'
#      'src-care/b0_ui.cmi' 'src-care/b0_ui.mli' 'src-care/b0_trace.cmx'
#      'src-care/b0_trace.cmi' 'src-care/b0_trace.mli' 'src-care/b0_odoc.cmx'
#      'src-care/b0_odoc.cmi' 'src-care/b0_odoc.mli' 'src-care/b0_machine.cmx'
#      'src-care/b0_machine.cmi' 'src-care/b0_machine.mli'
#      'src-care/b0_github.cmx' 'src-care/b0_github.cmi'
#      'src-care/b0_github.mli' 'src-std/b0_std_top_init.ml'
#      'src-std/dllb0_stubs.so' 'src-std/libb0_stubs.a'
#      'tools/b00_cache.native' 'tools/show_uri.native' 'doc/index.mld']: exited with 10

- ocamlfind ocamldep -package unix -modules src-std/b0_std.mli > src-std/b0_std.mli.depends
- ocamlfind ocamlc -c -g -bin-annot -safe-string -keep-locs -package unix -I src-std -I tools -I test -I src-care -I src-b00 -I examples -o src-std/b0_std.cmi src-std/b0_std.mli
- + ocamlfind ocamlc -c -g -bin-annot -safe-string -keep-locs -package unix -I src-std -I tools -I test -I src-care -I src-b00 -I examples -o src-std/b0_std.cmi src-std/b0_std.mli
- File "src-std/b0_std.mli", line 118, characters 44-61:
- 118 |   val unit : (unit, Format.formatter, unit) Pervasives.format -> unit t
-                                                   ^^^^^^^^^^^^^^^^^
- Error: Unbound module Pervasives
- Command exited with code 2.
- pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
-      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
-      'README.md' 'src-b00/b00.a' 'src-b00/b00.cmxs' 'src-b00/b00.cmxa'
-      'src-b00/b00.cma' 'src-b00/b00.cmx' 'src-b00/b00.cmi' 'src-b00/b00.mli'
-      'src-std/b0_std.a' 'src-std/b0_std.cmxs' 'src-std/b0_std.cmxa'
-      'src-std/b0_std.cma' 'src-std/b0_std.cmx' 'src-std/b0_std.cmi'
-      'src-std/b0_std.mli' 'src-care/b0_care.a' 'src-care/b0_care.cmxs'
-      'src-care/b0_care.cmxa' 'src-care/b0_care.cma' 'src-care/b0_web.cmx'
-      'src-care/b0_web.cmi' 'src-care/b0_web.mli' 'src-care/b0_vcs.cmx'
-      'src-care/b0_vcs.cmi' 'src-care/b0_vcs.mli' 'src-care/b0_ui.cmx'
-      'src-care/b0_ui.cmi' 'src-care/b0_ui.mli' 'src-care/b0_trace.cmx'
-      'src-care/b0_trace.cmi' 'src-care/b0_trace.mli' 'src-care/b0_odoc.cmx'
-      'src-care/b0_odoc.cmi' 'src-care/b0_odoc.mli' 'src-care/b0_machine.cmx'
-      'src-care/b0_machine.cmi' 'src-care/b0_machine.mli'
-      'src-care/b0_github.cmx' 'src-care/b0_github.cmi'
-      'src-care/b0_github.mli' 'src-std/b0_std_top_init.ml'
-      'src-std/dllb0_stubs.so' 'src-std/libb0_stubs.a'
-      'tools/b00_cache.native' 'tools/show_uri.native' 'doc/index.mld']: exited with 10
```