### PR TITLE
Mark fmt < 0.9.0 incompatible with OCaml 5.0

### DIFF
--- a/packages/fmt/fmt.0.8.0/opam
+++ b/packages/fmt/fmt.0.8.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.5"}

--- a/packages/fmt/fmt.0.8.1/opam
+++ b/packages/fmt/fmt.0.8.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.10/opam
+++ b/packages/fmt/fmt.0.8.10/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://erratique.ch/repos/fmt.git"
 bug-reports: "https://github.com/dbuenzli/fmt/issues"
 license: ["ISC"]
 tags: ["string" "format" "pretty-print" "org:erratique"]
-depends: ["ocaml" {>= "4.08.0"}
+depends: ["ocaml" {>= "4.08.0" & < "5.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "topkg" {build & >= "1.0.3"}]

--- a/packages/fmt/fmt.0.8.2/opam
+++ b/packages/fmt/fmt.0.8.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.3/opam
+++ b/packages/fmt/fmt.0.8.3/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.4/opam
+++ b/packages/fmt/fmt.0.8.4/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.5/opam
+++ b/packages/fmt/fmt.0.8.5/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.6/opam
+++ b/packages/fmt/fmt.0.8.6/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.7/opam
+++ b/packages/fmt/fmt.0.8.7/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.8/opam
+++ b/packages/fmt/fmt.0.8.8/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/fmt/fmt.0.8.9/opam
+++ b/packages/fmt/fmt.0.8.9/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/fmt/issues"
 tags: [ "string" "format" "pretty-print" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling fmt.0.8.10 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/fmt.0.8.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false --with-base-unix true --with-cmdliner false
# exit-code            1
# env-file             ~/.opam/log/fmt-10-0cca64.env
# output-file          ~/.opam/log/fmt-10-0cca64.out
### output ###
# ocamlfind ocamldep -modules src/fmt.ml > src/fmt.ml.depends
# ocamlfind ocamldep -modules src/fmt.mli > src/fmt.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -I src -I test -o src/fmt.cmi src/fmt.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -I src -I test -o src/fmt.cmx src/fmt.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -I src -I test -o src/fmt.cmx src/fmt.ml
# File "src/fmt.ml", line 619, characters 14-20:
# 619 |       let e = create () and v = ref Imap.empty in
#                     ^^^^^^
# Error: Unbound value create
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/fmt.a' 'src/fmt.cmxs' 'src/fmt.cmxa' 'src/fmt.cma'
#      'src/fmt.cmx' 'src/fmt.cmi' 'src/fmt.mli' 'src/fmt_tty.a'
#      'src/fmt_tty.cmxs' 'src/fmt_tty.cmxa' 'src/fmt_tty.cma'
#      'src/fmt_tty.cmx' 'src/fmt_tty.cmi' 'src/fmt_tty.mli' 'src/fmt_top.a'
#      'src/fmt_top.cmxs' 'src/fmt_top.cmxa' 'src/fmt_top.cma'
#      'src/fmt_top.cmx' 'src/fmt_tty_top_init.ml']: exited with 10
```