### PR TITLE
Mark note.0.0.1 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/note/note.0.0.1/opam
+++ b/packages/note/note.0.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/dbuenzli/note/issues"
 tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
 depends:
 [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling note.0.0.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/note.0.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false
# exit-code            1
# env-file             ~/.opam/log/note-11-73f276.env
# output-file          ~/.opam/log/note-11-73f276.out
### output ###
# ocamlfind ocamldep -package bytes -modules src/note.ml > src/note.ml.depends
# ocamlfind ocamldep -package bytes -modules src/note.mli > src/note.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/note.cmi src/note.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/note.cmx src/note.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/note.cmx src/note.ml
# File "src/note.ml", line 30, characters 29-47:
# 30 |   let compare (V s) (V t) = (Pervasives.compare : int -> int -> int) s.id t.id
#                                   ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/note.a' 'src/note.cmxs' 'src/note.cmxa' 'src/note.cma'
#      'src/note.cmx' 'src/note.cmi' 'src/note.mli' 'doc/index.mld']: exited with 10
```