### PR TITLE
Mark omod < 0.0.3 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/omod/omod.0.0.1/opam
+++ b/packages/omod/omod.0.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+http://erratique.ch/repos/omod.git"
 bug-reports: "https://github.com/dbuenzli/omod/issues"
 tags: [ "org:erratique" "dev" "toplevel" "repl" ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1"}

--- a/packages/omod/omod.0.0.2/opam
+++ b/packages/omod/omod.0.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+http://erratique.ch/repos/omod.git"
 bug-reports: "https://github.com/dbuenzli/omod/issues"
 tags: [ "org:erratique" "dev" "toplevel" "repl" ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.1"}


### PR DESCRIPTION
```
#=== ERROR while compiling omod.0.0.2 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/omod.0.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false --lib-dir /home/opam/.opam/5.0/lib
# exit-code            1
# env-file             ~/.opam/log/omod-10-d8fd3f.env
# output-file          ~/.opam/log/omod-10-d8fd3f.out
### output ###
# ocamlfind ocamldep -package bytes -modules src/omod.ml > src/omod.ml.depends
# ocamlfind ocamldep -package bytes -modules src/omod.mli > src/omod.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/omod.cmi src/omod.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/omod.cmi src/omod.mli
# File "src/omod.mli", line 144, characters 35-52:
# 144 |       ('a, Format.formatter, unit) Pervasives.format -> 'a
#                                          ^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/omod.a' 'src/omod.cmxs' 'src/omod.cmxa' 'src/omod.cma'
#      'src/omod.cmx' 'src/omod.cmi' 'src/omod.mli' 'src/omod_support.a'
#      'src/omod_support.cmxs' 'src/omod_support.cmxa' 'src/omod_support.cma'
#      'src/omod_support.cmx' 'src/omod_support.cmi' 'src/omod_support.mli'
#      'src/omod_ocamlc.cmx' 'src/omod_ocamlc.cmi' 'src/omod_ocamlc.mli'
#      'src/omod.top' 'src/omod.nattop' 'src/omod_bin.native']: exited with 10
```