### PR TITLE
Mark otfm < 0.4.0 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/otfm/otfm.0.1.0/opam
+++ b/packages/otfm/otfm.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
   ["./pkg/build" "true"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "uutf" {<= "0.9.4"}
   "ocamlfind"
   "ocamlbuild" {build}

--- a/packages/otfm/otfm.0.2.0/opam
+++ b/packages/otfm/otfm.0.2.0/opam
@@ -8,7 +8,7 @@ doc: "http://erratique.ch/software/otfm/doc/Otfm"
 tags: [ "OpenType" "ttf" "font" "decoder" "graphics" "org:erratique" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "uutf" {<= "0.9.4"}
   "ocamlbuild" {build}

--- a/packages/otfm/otfm.0.3.0/opam
+++ b/packages/otfm/otfm.0.3.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/otfm/issues"
 tags: [ "OpenType" "ttf" "font" "decoder" "graphics" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling otfm.0.3.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/otfm.0.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false
# exit-code            1
# env-file             ~/.opam/log/otfm-10-20dc2f.env
# output-file          ~/.opam/log/otfm-10-20dc2f.out
### output ###
# ocamlfind ocamldep -package 'bytes uchar result uutf' -modules src/otfm.ml > src/otfm.ml.depends
# ocamlfind ocamldep -package 'bytes uchar result uutf' -modules src/otfm.mli > src/otfm.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package 'bytes uchar result uutf' -I src -I test -o src/otfm.cmi src/otfm.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package 'bytes uchar result uutf' -I src -I test -o src/otfm.cmx src/otfm.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package 'bytes uchar result uutf' -I src -I test -o src/otfm.cmx src/otfm.ml
# File "src/otfm.ml", line 113, characters 40-58:
# 113 |   let compare : int32 -> int32 -> int = Pervasives.compare
#                                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/otfm.a' 'src/otfm.cmxs' 'src/otfm.cmxa' 'src/otfm.cma'
#      'src/otfm.cmx' 'src/otfm.cmi' 'src/otfm.mli' 'test/otftrip.native'
#      'test/examples.ml']: exited with 10
```