### PR TITLE
Mark tgls < 0.8.6 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/tgls/tgls.0.8.0/opam
+++ b/packages/tgls/tgls.0.8.0/opam
@@ -6,7 +6,7 @@ doc: "http://erratique.ch/software/tgls/doc/"
 tags: [ "bindings" "opengl" "opengl-es" "graphics" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "ocamlfind"
   "ctypes"
   "ctypes" {>= "0.2.3" & < "0.3"}

--- a/packages/tgls/tgls.0.8.1/opam
+++ b/packages/tgls/tgls.0.8.1/opam
@@ -6,7 +6,7 @@ doc: "http://erratique.ch/software/tgls/doc/"
 tags: [ "bindings" "opengl" "opengl-es" "graphics" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "ocamlfind"
   "ctypes" {>= "0.3" & < "0.4.0"}
   "ocamlbuild" {build}

--- a/packages/tgls/tgls.0.8.2/opam
+++ b/packages/tgls/tgls.0.8.2/opam
@@ -8,7 +8,7 @@ doc: "http://erratique.ch/software/tgls/doc/"
 tags: [ "bindings" "opengl" "opengl-es" "graphics" "org:erratique" ]
 license: "BSD-3-Clause"
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "ocamlfind"
   "ctypes" {>= "0.3" & < "0.4.0"}
   "ocamlbuild" {build}

--- a/packages/tgls/tgls.0.8.4/opam
+++ b/packages/tgls/tgls.0.8.4/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/tgls/issues"
 tags: [ "bindings" "opengl" "opengl-es" "graphics" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/tgls/tgls.0.8.5/opam
+++ b/packages/tgls/tgls.0.8.5/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/tgls/issues"
 tags: [ "bindings" "opengl" "opengl-es" "graphics" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling tgls.0.8.5 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/tgls.0.8.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false
# exit-code            1
# env-file             ~/.opam/log/tgls-10-cfb887.env
# output-file          ~/.opam/log/tgls-10-cfb887.out
### output ###
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamldep -package ctypes -package bytes -modules src/tgl3.ml > src/tgl3.ml.depends
# ocamlfind ocamldep -package ctypes -package bytes -modules src/tgl3.mli > src/tgl3.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -thread -package ctypes -package bytes -I src -I test -o src/tgl3.cmi src/tgl3.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -thread -package ctypes -package bytes -I src -I test -o src/tgl3.cmx src/tgl3.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -thread -package ctypes -package bytes -I src -I test -o src/tgl3.cmx src/tgl3.ml
# File "src/tgl3.ml", line 133, characters 50-68:
# 133 |          ~write:(fun b -> Unsigned.UChar.(of_int (Pervasives.compare b false)))
#                                                         ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/tgl3.a' 'src/tgl3.cmxs' 'src/tgl3.cmxa' 'src/tgl3.cma'
#      'src/tgl3.cmx' 'src/tgl3.cmi' 'src/tgl3.mli' 'src/tgl4.a'
#      'src/tgl4.cmxs' 'src/tgl4.cmxa' 'src/tgl4.cma' 'src/tgl4.cmx'
#      'src/tgl4.cmi' 'src/tgl4.mli' 'src/tgles2.a' 'src/tgles2.cmxs'
#      'src/tgles2.cmxa' 'src/tgles2.cma' 'src/tgles2.cmx' 'src/tgles2.cmi'
#      'src/tgles2.mli' 'src/tgles3.a' 'src/tgles3.cmxs' 'src/tgles3.cmxa'
#      'src/tgles3.cma' 'src/tgles3.cmx' 'src/tgles3.cmi' 'src/tgles3.mli'
#      'src/dlltgl3.so' 'src/libtgl3.a' 'src/dlltgl4.so' 'src/libtgl4.a'
#      'src/dlltgles2.so' 'src/libtgles2.a' 'src/dlltgles3.so'
#      'src/libtgles3.a' 'src/tgl3_top.a' 'src/tgl3_top.cmxs'
#      'src/tgl3_top.cmxa' 'src/tgl3_top.cma' 'src/tgl3_top.cmx'
#      'src/tgl4_top.a' 'src/tgl4_top.cmxs' 'src/tgl4_top.cmxa'
#      'src/tgl4_top.cma' 'src/tgl4_top.cmx' 'src/tgles2_top.a'
#      'src/tgles2_top.cmxs' 'src/tgles2_top.cmxa' 'src/tgles2_top.cma'
#      'src/tgles2_top.cmx' 'src/tgles3_top.a' 'src/tgles3_top.cmxs'
#      'src/tgles3_top.cmxa' 'src/tgles3_top.cma' 'src/tgles3_top.cmx'
#      'test/assert_sizes.c' 'test/trigl3.ml' 'test/trigl4.ml'
#      'test/trigles2.ml' 'test/trigles3.ml' 'test/linkgl3.ml'
#      'test/linkgl4.ml' 'test/linkgles2.ml' 'test/linkgles3.ml']: exited with 10
```