### PR TITLE
Mark uucp < 13.0.0 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/uucp/uucp.10.0.0/opam
+++ b/packages/uucp/uucp.10.0.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/uucp/uucp.10.0.1/opam
+++ b/packages/uucp/uucp.10.0.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/uucp/uucp.11.0.0/opam
+++ b/packages/uucp/uucp.11.0.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}

--- a/packages/uucp/uucp.12.0.0/opam
+++ b/packages/uucp/uucp.12.0.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "ISC"
 depends: [
- "ocaml" {>= "4.01.0"}
+ "ocaml" {>= "4.01.0" & < "5.0"}
  "ocamlfind" {build}
  "ocamlbuild" {build}
  "topkg" {build & >= "0.9.0"}

--- a/packages/uucp/uucp.2.0.0/opam
+++ b/packages/uucp/uucp.2.0.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/uucp/issues"
 tags: [ "unicode" "text" "character" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling uucp.12.0.0 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/uucp.12.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false --with-uutf false --with-uunf false --with-cmdliner false
# exit-code            1
# env-file             ~/.opam/log/uucp-10-312e62.env
# output-file          ~/.opam/log/uucp-10-312e62.out
### output ###
# ocamlfind ocamldep -package bytes -package uchar -modules src/uucp.ml > src/uucp.ml.depends
# ocamlfind ocamldep -package bytes -package uchar -modules src/uucp.mli > src/uucp.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uucp.cmi src/uucp.mli
# ocamlfind ocamldep -package bytes -package uchar -modules src/uucp_age.ml > src/uucp_age.ml.depends
# ocamlfind ocamldep -package bytes -package uchar -modules src/uucp_age_data.ml > src/uucp_age_data.ml.depends
# ocamlfind ocamldep -package bytes -package uchar -modules src/uucp_rmap.ml > src/uucp_rmap.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uucp_rmap.cmo src/uucp_rmap.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uucp_age_data.cmo src/uucp_age_data.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uucp_age.cmo src/uucp_age.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uucp_age.cmo src/uucp_age.ml
# File "src/uucp_age.ml", line 9, characters 14-32:
# 9 | let compare = Pervasives.compare
#                   ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/uucp.a' 'src/uucp.cmxs' 'src/uucp.cmxa' 'src/uucp.cma'
#      'src/uucp_white_data.cmx' 'src/uucp_white.cmx' 'src/uucp_tmapbyte.cmx'
#      'src/uucp_tmapbool.cmx' 'src/uucp_tmap4bytes.cmx' 'src/uucp_tmap.cmx'
#      'src/uucp_script_data.cmx' 'src/uucp_script_base.cmx'
#      'src/uucp_script.cmx' 'src/uucp_rmap.cmx' 'src/uucp_num_data.cmx'
#      'src/uucp_num_base.cmx' 'src/uucp_num.cmx' 'src/uucp_name_data.cmx'
#      'src/uucp_name_base.cmx' 'src/uucp_name.cmx' 'src/uucp_id_data.cmx'
#      'src/uucp_id.cmx' 'src/uucp_hangul_data.cmx' 'src/uucp_hangul.cmx'
#      'src/uucp_hangul_base.cmx' 'src/uucp_gen_data.cmx' 'src/uucp_gen.cmx'
#      'src/uucp_gc_data.cmx' 'src/uucp_gc_base.cmx' 'src/uucp_gc.cmx'
#      'src/uucp_func_data.cmx' 'src/uucp_func.cmx' 'src/uucp_crmap.cmx'
#      'src/uucp_cmap.cmx' 'src/uucp_cjk_data.cmx' 'src/uucp_cjk.cmx'
#      'src/uucp_case_nfkc_data.cmx' 'src/uucp_case_nfkc.cmx'
#      'src/uucp_case_map_data.cmx' 'src/uucp_case_map.cmx'
#      'src/uucp_case_fold_data.cmx' 'src/uucp_case_fold.cmx'
#      'src/uucp_case_data.cmx' 'src/uucp_case.cmx' 'src/uucp_break_data.cmx'
#      'src/uucp_break_base.cmx' 'src/uucp_break.cmx' 'src/uucp_block_data.cmx'
#      'src/uucp_block_base.cmx' 'src/uucp_block.cmx' 'src/uucp_alpha_data.cmx'
#      'src/uucp_alpha.cmx' 'src/uucp_age_data.cmx' 'src/uucp_age.cmx'
#      'src/uucp.cmx' 'src/uucp.cmi' 'src/uucp.mli' 'DEVEL.md'
#      'test/examples.ml']: exited with 10
```