### PR TITLE
Mark uuidm < 0.9.8 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/uuidm/uuidm.0.9.6/opam
+++ b/packages/uuidm/uuidm.0.9.6/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/uuidm/issues"
 tags: [ "uuid" "codec" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/uuidm/uuidm.0.9.7/opam
+++ b/packages/uuidm/uuidm.0.9.7/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/uuidm/issues"
 tags: [ "uuid" "codec" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build} ]


### PR DESCRIPTION
```
#=== ERROR while compiling uuidm.0.9.7 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/uuidm.0.9.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --with-cmdliner false
# exit-code            1
# env-file             ~/.opam/log/uuidm-10-458df5.env
# output-file          ~/.opam/log/uuidm-10-458df5.out
### output ###
# ocamlfind ocamldep -package bytes -modules src/uuidm.ml > src/uuidm.ml.depends
# ocamlfind ocamldep -package bytes -modules src/uuidm.mli > src/uuidm.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmi src/uuidm.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmx src/uuidm.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmx src/uuidm.ml
# File "src/uuidm.ml", line 186, characters 40-58:
# 186 | let compare : string -> string -> int = Pervasives.compare
#                                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/uuidm.a' 'src/uuidm.cmxs' 'src/uuidm.cmxa'
#      'src/uuidm.cma' 'src/uuidm.cmx' 'src/uuidm.cmi' 'src/uuidm.mli']: exited with 10
```