### PR TITLE
Mark uunf < 2.0.0 incompatible with OCaml 5.0 (uses Array.create)

### DIFF
--- a/packages/uunf/uunf.0.9.0/opam
+++ b/packages/uunf/uunf.0.9.0/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "uunf"]]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "5.0"}
   "ocamlfind"
   "uutf" {<= "0.9.4"}
   "ocamlbuild" {build}

--- a/packages/uunf/uunf.0.9.2/opam
+++ b/packages/uunf/uunf.0.9.2/opam
@@ -10,7 +10,7 @@ tags: [
 ]
 build: "./pkg/pkg-git"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/uunf/uunf.0.9.3/opam
+++ b/packages/uunf/uunf.0.9.3/opam
@@ -9,7 +9,7 @@ license: "BSD-3-Clause"
 depopts: [ "uutf" ]
 conflicts: [ "uutf" {> "0.9.4"} ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while installing uunf.0.9.3 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/uunf.0.9.3
# command              ~/.opam/opam-init/hooks/sandbox.sh install ./pkg/build true false
# exit-code            10
# env-file             ~/.opam/log/uunf-10-1a71e1.env
# output-file          ~/.opam/log/uunf-10-1a71e1.out
### output ###
# ocamlfind ocamldep -modules src/uunf.mli > src/uunf.mli.depends
# ocamlfind ocamlc -c -annot -I src -I test -o src/uunf.cmi src/uunf.mli
# ocamlfind ocamldep -modules src/uunf.ml > src/uunf.ml.depends
# ocamlfind ocamlopt -c -annot -I src -I test -o src/uunf.cmx src/uunf.ml
# + ocamlfind ocamlopt -c -annot -I src -I test -o src/uunf.cmx src/uunf.ml
# File "src/uunf.ml", line 3876, characters 20-32:
# 3876 | let create_acc () = Array.create 35 ux_eoi
#                            ^^^^^^^^^^^^
# Error: Unbound value Array.create
# Command exited with code 2.
```