### PR TITLE
Mark uutf < 1.0.3 incompatible with OCaml 5.0 (uses String.uppercase)

### DIFF
--- a/packages/uutf/uutf.1.0.1/opam
+++ b/packages/uutf/uutf.1.0.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/uutf/uutf.1.0.2/opam
+++ b/packages/uutf/uutf.1.0.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/uutf/issues"
 tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling uutf.1.0.2 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/uutf.1.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --with-cmdliner false
# exit-code            1
# env-file             ~/.opam/log/uutf-10-d5e5da.env
# output-file          ~/.opam/log/uutf-10-d5e5da.out
### output ###
# ocamlfind ocamldep -package bytes -package uchar -modules src/uutf.ml > src/uutf.ml.depends
# ocamlfind ocamldep -package bytes -package uchar -modules src/uutf.mli > src/uutf.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uutf.cmi src/uutf.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uutf.cmx src/uutf.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -package uchar -I src -I test -o src/uutf.cmx src/uutf.ml
# File "src/uutf.ml", line 34, characters 33-49:
# 34 | let encoding_of_string s = match String.uppercase s with      (* IANA names. *)
#                                       ^^^^^^^^^^^^^^^^
# Error: Unbound value String.uppercase
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/uutf.a' 'src/uutf.cmxs' 'src/uutf.cmxa' 'src/uutf.cma'
#      'src/uutf.cmx' 'src/uutf.cmi' 'src/uutf.mli']: exited with 10
```