### PR TITLE
Mark xmlm < 1.4.0 incompatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/xmlm/xmlm.1.3.0/opam
+++ b/packages/xmlm/xmlm.1.3.0/opam
@@ -8,7 +8,7 @@ doc: "http://erratique.ch/software/xmlm/doc/Xmlm"
 tags: [ "xml" "codec" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling xmlm.1.3.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/xmlm.1.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false
# exit-code            1
# env-file             ~/.opam/log/xmlm-10-cd750c.env
# output-file          ~/.opam/log/xmlm-10-cd750c.out
### output ###
# ocamlfind ocamldep -modules src/xmlm.ml > src/xmlm.ml.depends
# ocamlfind ocamldep -modules src/xmlm.mli > src/xmlm.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -I src -I test -o src/xmlm.cmi src/xmlm.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -I src -I test -o src/xmlm.cmx src/xmlm.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -I src -I test -o src/xmlm.cmx src/xmlm.ml
# File "src/xmlm.ml", line 1128, characters 18-34:
# 1128 |   let lowercase = String.lowercase
#                          ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/xmlm.a' 'src/xmlm.cmxs' 'src/xmlm.cmxa' 'src/xmlm.cma'
#      'src/xmlm.cmx' 'src/xmlm.cmi' 'src/xmlm.mli' 'test/xmltrip.native'
#      'test/examples.ml' 'test/xhtml.ml']: exited with 10
```