### PR TITLE
Mark react.1.2.1 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/react/react.1.2.1/opam
+++ b/packages/react/react.1.2.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/react/issues"
 tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling react.1.2.1 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/react.1.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false
# exit-code            1
# env-file             ~/.opam/log/react-11-abb5a9.env
# output-file          ~/.opam/log/react-11-abb5a9.out
### output ###
# ocamlfind ocamldep -package bytes -modules src/react.ml > src/react.ml.depends
# ocamlfind ocamldep -package bytes -modules src/react.mli > src/react.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/react.cmi src/react.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/react.cmx src/react.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package bytes -I src -I test -o src/react.cmx src/react.ml
# File "src/react.ml", line 1437, characters 29-43:
# 1437 |         | Some _ -> supdate (Pervasives.not (sval m')) m' c
#                                     ^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/react.a' 'src/react.cmxs' 'src/react.cmxa'
#      'src/react.cma' 'src/react.cmx' 'src/react.cmi' 'src/react.mli'
#      'src/react_top.a' 'src/react_top.cmxs' 'src/react_top.cmxa'
#      'src/react_top.cma' 'src/react_top.cmx' 'src/react_top_init.ml']: exited with 10
```