### PR TITLE
Mark menhir < 20200123 incompatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/menhir/menhir.20130911/opam
+++ b/packages/menhir/menhir.20130911/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20140422/opam
+++ b/packages/menhir/menhir.20140422/opam
@@ -16,7 +16,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20141215/opam
+++ b/packages/menhir/menhir.20141215/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20150914/opam
+++ b/packages/menhir/menhir.20150914/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "menhirLib"]]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20150921/opam
+++ b/packages/menhir/menhir.20150921/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "menhirLib"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151005/opam
+++ b/packages/menhir/menhir.20151005/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "menhirLib"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151012/opam
+++ b/packages/menhir/menhir.20151012/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151023/opam
+++ b/packages/menhir/menhir.20151023/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151026/opam
+++ b/packages/menhir/menhir.20151026/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151030/opam
+++ b/packages/menhir/menhir.20151030/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151103/opam
+++ b/packages/menhir/menhir.20151103/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20151112/opam
+++ b/packages/menhir/menhir.20151112/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & < "0.9.1"}
 ]

--- a/packages/menhir/menhir.20160303/opam
+++ b/packages/menhir/menhir.20160303/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20160504/opam
+++ b/packages/menhir/menhir.20160504/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20160526/opam
+++ b/packages/menhir/menhir.20160526/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20160808/opam
+++ b/packages/menhir/menhir.20160808/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20160825/opam
+++ b/packages/menhir/menhir.20160825/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20161114/opam
+++ b/packages/menhir/menhir.20161114/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20161115/opam
+++ b/packages/menhir/menhir.20161115/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20170101/opam
+++ b/packages/menhir/menhir.20170101/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20170418/opam
+++ b/packages/menhir/menhir.20170418/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20170509/opam
+++ b/packages/menhir/menhir.20170509/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20170607/opam
+++ b/packages/menhir/menhir.20170607/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20170712/opam
+++ b/packages/menhir/menhir.20170712/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20171013/opam
+++ b/packages/menhir/menhir.20171013/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20171206/opam
+++ b/packages/menhir/menhir.20171206/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20171222/opam
+++ b/packages/menhir/menhir.20171222/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20180528/opam
+++ b/packages/menhir/menhir.20180528/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20180530/opam
+++ b/packages/menhir/menhir.20180530/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20180703/opam
+++ b/packages/menhir/menhir.20180703/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20180905/opam
+++ b/packages/menhir/menhir.20180905/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20181006/opam
+++ b/packages/menhir/menhir.20181006/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20181026/opam
+++ b/packages/menhir/menhir.20181026/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20181113/opam
+++ b/packages/menhir/menhir.20181113/opam
@@ -17,7 +17,7 @@ remove: [
   [make "-f" "Makefile" "uninstall" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20190613/opam
+++ b/packages/menhir/menhir.20190613/opam
@@ -14,7 +14,7 @@ install: [
   [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20190620/opam
+++ b/packages/menhir/menhir.20190620/opam
@@ -14,7 +14,7 @@ install: [
   [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20190626/opam
+++ b/packages/menhir/menhir.20190626/opam
@@ -14,7 +14,7 @@ install: [
   [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/menhir/menhir.20190924/opam
+++ b/packages/menhir/menhir.20190924/opam
@@ -14,7 +14,7 @@ install: [
   [make "-f" "Makefile" "install" "PREFIX=%{prefix}%" "docdir=%{doc}%/menhir" "libdir=%{lib}%/menhir" "mandir=%{man}%/man1"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling menhir.20190924 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/menhir.20190924
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -f Makefile PREFIX=/home/opam/.opam/5.0 USE_OCAMLFIND=true docdir=/home/opam/.opam/5.0/doc/menhir libdir=/home/opam/.opam/5.0/lib/menhir mandir=/home/opam/.opam/5.0/man/man1
# exit-code            2
# env-file             ~/.opam/log/menhir-10-91e967.env
# output-file          ~/.opam/log/menhir-10-91e967.out
### output ###
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/menhir.20190924/src'
# make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/menhir.20190924/src'
# /home/opam/.opam/5.0/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules General.mli > General.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o General.cmi General.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules General.ml > General.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules Convert.mli > Convert.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o Convert.cmi Convert.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules Convert.ml > Convert.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules IncrementalEngine.ml > IncrementalEngine.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules EngineTypes.ml > EngineTypes.ml.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o IncrementalEngine.cmo IncrementalEngine.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules Engine.mli > Engine.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o EngineTypes.cmo EngineTypes.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o Engine.cmi Engine.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules Engine.ml > Engine.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ErrorReports.mli > ErrorReports.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o ErrorReports.cmi ErrorReports.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ErrorReports.ml > ErrorReports.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules Printers.mli > Printers.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o Printers.cmi Printers.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules Printers.ml > Printers.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InfiniteArray.mli > InfiniteArray.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o InfiniteArray.cmi InfiniteArray.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InfiniteArray.ml > InfiniteArray.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules PackedIntArray.mli > PackedIntArray.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o PackedIntArray.cmi PackedIntArray.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules PackedIntArray.ml > PackedIntArray.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules RowDisplacement.mli > RowDisplacement.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o RowDisplacement.cmi RowDisplacement.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules RowDisplacement.ml > RowDisplacement.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules LinearizedArray.mli > LinearizedArray.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o LinearizedArray.cmi LinearizedArray.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules LinearizedArray.ml > LinearizedArray.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules TableFormat.ml > TableFormat.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InspectionTableFormat.ml > InspectionTableFormat.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InspectionTableInterpreter.mli > InspectionTableInterpreter.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o InspectionTableFormat.cmo InspectionTableFormat.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o TableFormat.cmo TableFormat.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o InspectionTableInterpreter.cmi InspectionTableInterpreter.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InspectionTableInterpreter.ml > InspectionTableInterpreter.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules TableInterpreter.mli > TableInterpreter.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o TableInterpreter.cmi TableInterpreter.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules TableInterpreter.ml > TableInterpreter.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules StaticVersion.mli > StaticVersion.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o StaticVersion.cmi StaticVersion.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules StaticVersion.ml > StaticVersion.ml.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o General.cmo General.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o Convert.cmo Convert.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o Engine.cmo Engine.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o ErrorReports.cmo ErrorReports.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o Printers.cmo Printers.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o InfiniteArray.cmo InfiniteArray.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o PackedIntArray.cmo PackedIntArray.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o RowDisplacement.cmo RowDisplacement.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o LinearizedArray.cmo LinearizedArray.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o InspectionTableInterpreter.cmo InspectionTableInterpreter.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o TableInterpreter.cmo TableInterpreter.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o StaticVersion.cmo StaticVersion.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -pack -g -bin-annot General.cmo Convert.cmo IncrementalEngine.cmo EngineTypes.cmo Engine.cmo ErrorReports.cmo Printers.cmo InfiniteArray.cmo PackedIntArray.cmo RowDisplacement.cmo LinearizedArray.cmo TableFormat.cmo InspectionTableFormat.cmo InspectionTableInterpreter.cmo TableInterpreter.cmo StaticVersion.cmo -o menhirLib.cmo
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o General.cmx General.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o IncrementalEngine.cmx IncrementalEngine.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o EngineTypes.cmx EngineTypes.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o InfiniteArray.cmx InfiniteArray.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o PackedIntArray.cmx PackedIntArray.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o InspectionTableFormat.cmx InspectionTableFormat.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o LinearizedArray.cmx LinearizedArray.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o TableFormat.cmx TableFormat.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o RowDisplacement.cmx RowDisplacement.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o Convert.cmx Convert.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o Engine.cmx Engine.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o ErrorReports.cmx ErrorReports.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o Printers.cmx Printers.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o InspectionTableInterpreter.cmx InspectionTableInterpreter.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o TableInterpreter.cmx TableInterpreter.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -for-pack MenhirLib -o StaticVersion.cmx StaticVersion.ml
# touch menhirLib.mli  ; if  /home/opam/.opam/5.0/bin/ocamlopt.opt -pack -g -bin-annot General.cmx Convert.cmx IncrementalEngine.cmx EngineTypes.cmx Engine.cmx ErrorReports.cmx Printers.cmx InfiniteArray.cmx PackedIntArray.cmx RowDisplacement.cmx LinearizedArray.cmx TableFormat.cmx InspectionTableFormat.cmx InspectionTableInterpreter.cmx TableInterpreter.cmx StaticVersion.cmx -o menhirLib.cmx  ; then  rm -f menhirLib.mli  ; else  rm -f menhirLib.mli  ; exit 1; fi
# /home/opam/.opam/5.0/bin/ocamlopt.opt -a menhirLib.cmx -o menhirLib.cmxa
# /home/opam/.opam/5.0/bin/ocamlopt.opt -shared -linkall menhirLib.cmxa -o menhirLib.cmxs
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules menhir.ml > menhir.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules back.mli > back.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o back.cmi back.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o menhir.cmo menhir.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules back.ml > back.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cmly_read.ml > cmly_read.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cmly_read.mli > cmly_read.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cmly_api.ml > cmly_api.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules keyword.mli > keyword.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o keyword.cmi keyword.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o cmly_api.cmo cmly_api.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o cmly_read.cmi cmly_read.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules keyword.ml > keyword.ml.depends
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o keyword.cmx keyword.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cmly_format.ml > cmly_format.ml.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o cmly_format.cmo cmly_format.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules version.ml > version.ml.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o version.cmo version.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o cmly_api.cmx cmly_api.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o cmly_format.cmx cmly_format.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o version.cmx version.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cmly_write.ml > cmly_write.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules cmly_write.mli > cmly_write.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o cmly_write.cmi cmly_write.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules action.ml > action.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules action.mli > action.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules IL.mli > IL.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules stretch.mli > stretch.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o stretch.cmi stretch.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o IL.cmi IL.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o action.cmi action.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules codeBits.ml > codeBits.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules codeBits.mli > codeBits.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o codeBits.cmi codeBits.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules settings.ml > settings.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules settings.mli > settings.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules stringSet.mli > stringSet.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o stringSet.cmi stringSet.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o settings.cmi settings.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules installation.ml > installation.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules installation.mli > installation.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o installation.cmi installation.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules stringSet.ml > stringSet.ml.depends
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o installation.cmx installation.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o stringSet.cmx stringSet.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o settings.cmx settings.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o codeBits.cmx codeBits.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules basicSyntax.ml > basicSyntax.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules positions.mli > positions.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules stringMap.mli > stringMap.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules syntax.ml > syntax.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InputFile.mli > InputFile.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o positions.cmi positions.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o stringMap.cmi stringMap.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o InputFile.cmi InputFile.mli
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o syntax.cmo syntax.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -g -bin-annot -safe-string -o basicSyntax.cmo basicSyntax.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules positions.ml > positions.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules stringMap.ml > stringMap.ml.depends
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o action.cmx action.ml
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules InputFile.ml > InputFile.ml.depends
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o positions.cmx positions.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o stringMap.cmx stringMap.ml
# /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o InputFile.cmx InputFile.ml
# + /home/opam/.opam/5.0/bin/ocamlopt.opt -c -g -bin-annot -safe-string -o InputFile.cmx InputFile.ml
# File "InputFile.ml", line 52, characters 2-20:
# 52 |   Pervasives.compare file1.input_file_index file2.input_file_index
#        ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# make[2]: *** [Makefile:44: stage1] Error 10
# make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/menhir.20190924/src'
# make[1]: *** [Makefile:34: bootstrap] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/menhir.20190924/src'
# make: *** [Makefile:120: all] Error 2
```