### PR TITLE
Add a constraint on mirage.4.0.0 about opam-monorepo.0.3.0

### DIFF
--- a/packages/mirage/mirage.4.0.0/opam
+++ b/packages/mirage/mirage.4.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "logs"
   "mirage-runtime" {= version}
-  "opam-monorepo" {>= "0.2.6" & < "3.0.0"}
+  "opam-monorepo" {>= "0.2.6" & < "0.3.0"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
 ]

--- a/packages/mirage/mirage.4.0.0/opam
+++ b/packages/mirage/mirage.4.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "logs"
   "mirage-runtime" {= version}
-  "opam-monorepo" {>= "0.2.6"}
+  "opam-monorepo" {>= "0.2.6" & < "3.0.0"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
 ]


### PR DESCRIPTION
It's not obvious but the usage of `opam monorepo` by `mirage` is not compatible with `opam-monorepo.3.0.0`.