### PR TITLE
Package cps_toolbox.0.3

### DIFF
--- a/packages/cps_toolbox/cps_toolbox.0.3/opam
+++ b/packages/cps_toolbox/cps_toolbox.0.3/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A partial OCaml standard library replacement written with continuation passing style in mind"
+maintainer: "Soren Norbaek <sorennorbaek@gmail.com>"
+authors: "Soren Norbaek <sorennorbaek@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/soren-n/cps-toolbox"
+bug-reports: "https://github.com/soren-n/cps-toolbox/issues"
+dev-repo: "git+https://github.com/soren-n/cps-toolbox.git"
+build: [
+  "dune" "build" "-p" name "-j" jobs "@install"
+  "@runtest" {with-test}
+]
+depends: [
+  "dune" {>= "3.0"}
+  "qcheck" {with-test & >= "0.18"}
+]
+url {
+  src: "https://github.com/soren-n/cps-toolbox/archive/0.3.tar.gz"
+  checksum: [
+    "md5=28b053a785663c0c07d966c11c0cd7a0"
+    "sha512=1dea5c679bc6c95c6c7a288618a2ffd00ad4d8538d977ba5441d9f86d37098b75d005077fd5f06bd3fb38f4da80387e762c42f6d28bb63ffa48e8bb104b9f74f"
+  ]
+}

--- a/packages/typeset/typeset.0.3/opam
+++ b/packages/typeset/typeset.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
   "qcheck" {with-test & >= "0.17"}
-  "cps_toolbox" {>= "0.2"}
+  "cps_toolbox" {>= "0.2" & < "0.3"}
 ]
 url {
   src: "https://github.com/soren-n/typeset-ocaml/archive/0.3.tar.gz"


### PR DESCRIPTION
### `cps_toolbox.0.3`
A partial OCaml standard library replacement written with continuation passing style in mind



---
* Homepage: https://github.com/soren-n/cps-toolbox
* Source repo: git+https://github.com/soren-n/cps-toolbox.git
* Bug tracker: https://github.com/soren-n/cps-toolbox/issues

---
:camel: Pull-request generated by opam-publish v2.1.0