### PR TITLE
conf-libcurl:  use curl-config for detection

### DIFF
--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+authors: ["Daniel Stenberg"]
+homepage: "http://curl.haxx.se/"
+license: "BSD-like"
+build: ["curl-config" "--libs"]
+depexts: [
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
+  ["libcurl-devel"] {os-distribution = "mageia"}
+  ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
+  ["curl"] {os-distribution = "nixos"}
+  ["curl"] {os-distribution = "arch"}
+  ["curl"] {os = "win32" & os-distribution = "cygwinports"}
+  ["curl-dev"] {os-distribution = "alpine"}
+  ["libcurl-devel"] {os-family = "suse"}
+  ["libcurl-devel"] {os-distribution = "fedora"}
+  ["libcurl-devel"] {os-distribution = "ol"}
+  ["curl"] {os-distribution = "homebrew" & os = "macos"}
+  ["curl"] {os-distribution = "macports" & os = "macos"}
+]
+synopsis: "Virtual package relying on a libcurl system installation"
+description:
+  "This package can only install if the libcurl is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf


### PR DESCRIPTION
This is more robust since pkgconfig is not always supported and
libcurl always comes with curl-config anyway

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>