### PR TITLE
misuja: update url, the old one is no longer accessible

### DIFF
--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -31,6 +31,6 @@ which is manipulated with an OCaml API (communicating through
 ring-buffers provided by the Jack API)."""
 url {
   src:
-    "https://gitlab.com/smondet/misuja/repository/misuja.0.0.0/archive.tar.gz"
-  checksum: "md5=a30de68e28d4edd1073b1bb6110e613b"
+    "https://gitlab.com/smondet/misuja/-/archive/misuja.0.0.0/misuja-misuja.0.0.0.tar.gz"
+  checksum: "md5=9118c0141b46a46ec73e0afef3cc6cb5"
 }


### PR DESCRIPTION
Ping @smondet @toots 
Unfortunately I don't have a way to compare the contents (after logging in, the old url fails with 404 not found), is one of you able to do that, or to make the old tarball available again?