### PR TITLE
Package conf-libclang: Use file-depends to track llvm-config

### DIFF
--- a/packages/conf-libclang/conf-libclang.14/opam
+++ b/packages/conf-libclang/conf-libclang.14/opam
@@ -29,7 +29,7 @@ x-ci-accept-failures: [
   "opensuse-15.3" # unavailable system package 'llvm-clang-devel'
 ]
 extra-files: [[
-  "configure.sh" "sha512=d1c17388e1523e84a363ab348149caff13bea715d110b0d1ee021855ba1d3049862f6646ae763b144d98b71b3405c320683f7ad67dbe255db49f80ee5c2e4a9f"
+  "configure.sh" "sha512=5b4f4ea8b4062158c299ca5697c0081baf1e43995297be8dfaaea07fb5a802628b0d5815e0ca418258788bda1780d827789212abf9ce15da9b84a42efb0480ae"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 14.0.x)"
 flags: conf


### PR DESCRIPTION
This PR improves `conf-libclang` by using `file-depends` to track changes to `llvm-config` in order to reinstall the package and its reverse-dependencies if the underlying system package changes.

Suggested by Louis Gesbert:
https://discuss.ocaml.org/t/reinstall-conf-packages-when-related-external-dependencies-are-upgraded/9716/3