### PR TITLE
Re-enable ocaml_intrinsics on macos

### DIFF
--- a/packages/core_unix/core_unix.v0.15.0/opam
+++ b/packages/core_unix/core_unix.v0.15.0/opam
@@ -24,6 +24,7 @@ depends: [
   "dune"                     {>= "2.0.0"}
   "spawn"                    {>= "v0.15"}
 ]
+available: os != "macos"
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].

--- a/packages/ocaml_intrinsics/ocaml_intrinsics.v0.15.1/opam
+++ b/packages/ocaml_intrinsics/ocaml_intrinsics.v0.15.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+available: (arch = "x86_32" | arch = "x86_64") & os != "win32"
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)
+     when available, or compatible software implementation on other targets.
+"
+url {
+src: "https://github.com/janestreet/ocaml_intrinsics/archive/refs/tags/v0.15.1.tar.gz"
+checksum: "sha256=837186acef28c51d92a55a58eaa32b0e07a06a0ca1d13fb5403736011f175ad4"
+}

--- a/packages/ocaml_intrinsics/ocaml_intrinsics.v0.15.1/opam
+++ b/packages/ocaml_intrinsics/ocaml_intrinsics.v0.15.1/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]
-available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
+available: (arch = "x86_32" | arch = "x86_64") & os != "win32"
 synopsis: "Intrinsics"
 description: "
 Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)

--- a/packages/ocaml_intrinsics/ocaml_intrinsics.v0.15.1/opam
+++ b/packages/ocaml_intrinsics/ocaml_intrinsics.v0.15.1/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]
-available: (arch = "x86_32" | arch = "x86_64") & os != "win32"
+available: (arch = "x86_32" | arch = "x86_64" | arch = "arm64") & os != "win32"
 synopsis: "Intrinsics"
 description: "
 Provides functions to invoke amd64 instructions (such as clz,popcnt,rdtsc,rdpmc)


### PR DESCRIPTION
 I'd like to re-enable `ocaml_intrinsics`  after the fix in https://github.com/janestreet/ocaml_intrinsics/pull/5 is merged. 