### PR TITLE
[new release] terminal_size (0.2.0)

### DIFF
--- a/packages/terminal_size/terminal_size.0.2.0/opam
+++ b/packages/terminal_size/terminal_size.0.2.0/opam
@@ -17,7 +17,7 @@ run-test: [
 ]
 depends: [
   "alcotest" {with-test}
-  "dune" {build & >= "2.0.0"}
+  "dune" {>= "2.0.0"}
   "ocaml" {>= "4.08.0"}
 ]
 synopsis: "Get the dimensions of the terminal"

--- a/packages/terminal_size/terminal_size.0.2.0/opam
+++ b/packages/terminal_size/terminal_size.0.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
+authors: [
+    "Cryptosense <opensource@cryptosense.com>"
+    "Etienne Millon <etienne@cryptosense.com>"
+]
+homepage: "https://github.com/cryptosense/terminal_size"
+bug-reports: "https://github.com/cryptosense/terminal_size/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/cryptosense/terminal_size.git"
+doc: "https://cryptosense.github.io/terminal_size/doc"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "alcotest" {with-test}
+  "dune" {build & >= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+]
+synopsis: "Get the dimensions of the terminal"
+description: """
+You can use this small library to detect the dimensions of the terminal window
+attached to a process.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/terminal_size/releases/download/v0.2.0/terminal_size-0.2.0.tbz"
+  checksum: [
+    "sha256=d6b62cd28c4071ac85ca9528088745c124c9094efeae91722514736f9973b0fb"
+    "sha512=fd91266b156f52c28338fc8ba5c5c0626b93afa6388fb9e0f98d0f7c200ded02eac56af82b10a3da8d7ec2ef7a91a95fcb113f051a8ec077e155e2ffda75d1c0"
+  ]
+}
+x-commit-hash: "9eb137173b2c9885e75e156494f9f508fdaff379"


### PR DESCRIPTION
Get the dimensions of the terminal

- Project page: <a href="https://github.com/cryptosense/terminal_size">https://github.com/cryptosense/terminal_size</a>
- Documentation: <a href="https://cryptosense.github.io/terminal_size/doc">https://cryptosense.github.io/terminal_size/doc</a>

##### CHANGES:

*2022-04-26*

- Add compatibility with Windows.
- Require Dune >= 2.0 and OCaml >= 4.08.
