### PR TITLE
[new release] easy-format (1.3.3)

### DIFF
--- a/packages/easy-format/easy-format.1.3.3/opam
+++ b/packages/easy-format/easy-format.1.3.3/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis:
+  "High-level and functional interface to the Format module of the OCaml standard library"
+description: """
+
+This module offers a high-level and functional interface to the Format module of
+the OCaml standard library. It is a pretty-printing facility, i.e. it takes as
+input some code represented as a tree and formats this code into the most
+visually satisfying result, breaking and indenting lines of code where
+appropriate.
+
+Input data must be first modelled and converted into a tree using 3 kinds of
+nodes:
+
+* atoms
+* lists
+* labelled nodes
+
+Atoms represent any text that is guaranteed to be printed as-is. Lists can model
+any sequence of items such as arrays of data or lists of definitions that are
+labelled with something like "int main", "let x =" or "x:"."""
+maintainer: ["martin@mjambon.com" "rudi.grinberg@gmail.com"]
+authors: ["Martin Jambon"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/mjambon/easy-format"
+doc: "https://mjambon.github.io/easy-format/"
+bug-reports: "https://github.com/mjambon/easy-format/issues"
+depends: [
+  "dune" {>= "2.9" & >= "1.10"}
+  "ocaml" {>= "4.02.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mjambon/easy-format.git"
+url {
+  src:
+    "https://github.com/mjambon/easy-format/releases/download/1.3.3/easy-format-1.3.3.tbz"
+  checksum: [
+    "sha256=eafccae911c26ca23e4ddacee3eaa54654d20f973b8680f84b708cef43adc416"
+    "sha512=611b3124f6a0ec6406b7bda8018a94c9c4a9da9d22495a5c34a6312bf7f0f0607a9529b276f7039ce3f3b15a955dac413d6d1229a55d5ac291302a3ddd5807e5"
+  ]
+}
+x-commit-hash: "56c57e69ef067d1cc4e31029d31e77e55b46be95"

--- a/packages/easy-format/easy-format.1.3.3/opam
+++ b/packages/easy-format/easy-format.1.3.3/opam
@@ -27,7 +27,7 @@ doc: "https://mjambon.github.io/easy-format/"
 bug-reports: "https://github.com/mjambon/easy-format/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.08"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/easy-format/easy-format.1.3.3/opam
+++ b/packages/easy-format/easy-format.1.3.3/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/mjambon/easy-format"
 doc: "https://mjambon.github.io/easy-format/"
 bug-reports: "https://github.com/mjambon/easy-format/issues"
 depends: [
-  "dune" {>= "2.9" & >= "1.10"}
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.02.3"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
High-level and functional interface to the Format module of the OCaml standard library

- Project page: <a href="https://github.com/mjambon/easy-format">https://github.com/mjambon/easy-format</a>
- Documentation: <a href="https://mjambon.github.io/easy-format/">https://mjambon.github.io/easy-format/</a>

##### CHANGES:

- OCaml 5.0 compatibility (mjambon/easy-format#27)
