### PR TITLE
[new release] pp_loc (2.0.0)

### DIFF
--- a/packages/pp_loc/pp_loc.2.0.0/opam
+++ b/packages/pp_loc/pp_loc.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Quote and highlight input fragments at a given source location"
+description: """
+Decent error reporting (for example, in a parser, a compiler, ...) typically involves collecting locations, in order to indicate to the user the position of an error in the source file.
+This library provides support for quoting and highlighting the input fragment that corresponds to a given source location (or set of source locations).
+"""
+maintainer: [
+  "Armaël Guéneau <armael.gueneau@ens-lyon.org>, Steffen Smolka <smolka@cs.cornell.edu>"
+]
+authors: ["Armaël Guéneau <armael.gueneau@ens-lyon.org>"]
+license: "MIT"
+homepage: "https://github.com/Armael/pp_loc"
+doc: "https://Armael.github.io/pp_loc/pp_loc/"
+bug-reports: "https://github.com/Armael/pp_loc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Armael/pp_loc.git"
+url {
+  src:
+    "https://github.com/Armael/pp_loc/releases/download/v2.0.0/pp_loc-2.0.0.tbz"
+  checksum: [
+    "sha256=1bb7e9717a8b88f48b2fc8c8cb72d43a124a41e76619a1c3e1f7c7aa1d7580a4"
+    "sha512=e7830948cb7dd4becb0b94c3a13f7d134d4c817b64a1cac980b40c0efd369e15ec4cd3b2ba63476b844330ec52d6f37a385346e6bb3ad125591f2405ed7a7a60"
+  ]
+}
+x-commit-hash: "131eefa32219a717852e1d4479f097014e6c4923"


### PR DESCRIPTION
Quote and highlight input fragments at a given source location

- Project page: <a href="https://github.com/Armael/pp_loc">https://github.com/Armael/pp_loc</a>
- Documentation: <a href="https://Armael.github.io/pp_loc/pp_loc/">https://Armael.github.io/pp_loc/pp_loc/</a>

##### CHANGES:

Generalize the type of locations to offer more flexibility.

As before, a location corresponds to a pair of begin-end positions.
However, positions are now abstract. A position can be created as
before from a Lexing.position. Alternatively, a position can be created
from a (line,column) pair, or directly from an offset in the file,
or by shifting an existing position by a given offset.

(contributed by Simon Cruanes)
