### PR TITLE
[new release] opam-0install and opam-0install-cudf (0.4.3)

### DIFF
--- a/packages/opam-0install-cudf/opam-0install-cudf.0.4.3/opam
+++ b/packages/opam-0install-cudf/opam-0install-cudf.0.4.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Opam solver using 0install backend using the CUDF interface"
+description: """
+Opam's default solver is designed to maintain a set of packages
+over time, minimising disruption when installing new programs and
+finding a compromise solution across all packages.
+
+In many situations (e.g. CI, local roots or duniverse builds) this
+is not necessary, and we can get a solution much faster by using
+a different algorithm.
+
+This package uses 0install's solver algorithm with opam packages using
+the CUDF interface.
+"""
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "ISC"
+homepage: "https://github.com/ocaml-opam/opam-0install-solver"
+doc: "https://ocaml-opam.github.io/opam-0install-solver/"
+bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "cudf"
+  "ocaml" {>= "4.08.0"}
+  "0install-solver"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-opam/opam-0install-solver.git"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.3/opam-0install-cudf-0.4.3.tbz"
+  checksum: [
+    "sha256=d59e0ebddda58f798ff50ebe213c83893b5a7c340c38c20950574d67e6145b8a"
+    "sha512=f29cd54e31229050b5404e66a915ec4087d0a06de573c6449a459f8a5f831256f5f8584ba4b8c81a21de4b897afad726c795b6483eb7927c754dfd7ed62ab564"
+  ]
+}
+x-commit-hash: "b759d7c1c2f140724020f57599ead9ee394a8f7a"

--- a/packages/opam-0install/opam-0install.0.4.3/opam
+++ b/packages/opam-0install/opam-0install.0.4.3/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Opam solver using 0install backend"
+description: """
+Opam's default solver is designed to maintain a set of packages
+over time, minimising disruption when installing new programs and
+finding a compromise solution across all packages.
+
+In many situations (e.g. CI, local roots or duniverse builds) this
+is not necessary, and we can get a solution much faster by using
+a different algorithm.
+
+This package uses 0install's solver algorithm with opam packages.
+"""
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "ISC"
+homepage: "https://github.com/ocaml-opam/opam-0install-solver"
+doc: "https://ocaml-opam.github.io/opam-0install-solver/"
+bug-reports: "https://github.com/ocaml-opam/opam-0install-solver/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "fmt" {>= "0.8.7"}
+  "cmdliner" {>= "1.1.0"}
+  "opam-state" {>= "2.1.0~rc"}
+  "ocaml" {>= "4.08.0"}
+  "0install-solver"
+  "opam-file-format" {>= "2.1.1"}
+  "opam-client" {with-test}
+  "opam-solver" {with-test}
+  "astring" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-opam/opam-0install-solver.git"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-0install-solver/releases/download/v0.4.3/opam-0install-cudf-0.4.3.tbz"
+  checksum: [
+    "sha256=d59e0ebddda58f798ff50ebe213c83893b5a7c340c38c20950574d67e6145b8a"
+    "sha512=f29cd54e31229050b5404e66a915ec4087d0a06de573c6449a459f8a5f831256f5f8584ba4b8c81a21de4b897afad726c795b6483eb7927c754dfd7ed62ab564"
+  ]
+}
+x-commit-hash: "b759d7c1c2f140724020f57599ead9ee394a8f7a"


### PR DESCRIPTION
Opam solver using 0install backend

- Project page: <a href="https://github.com/ocaml-opam/opam-0install-solver">https://github.com/ocaml-opam/opam-0install-solver</a>
- Documentation: <a href="https://ocaml-opam.github.io/opam-0install-solver/">https://ocaml-opam.github.io/opam-0install-solver/</a>

##### CHANGES:

- Add `?opam_version` to `Dir_context.std_env` (@emillon ocaml-opam/opam-0install-solver#36).
  It defaults to the version of opam libraries, but in some cases (e.g.
  ocaml-ci) it is useful to inject a value that comes from an external
  opam process.

- Sort `Reject` after `RealImpl` (@emillon ocaml-opam/opam-0install-solver#33).
  This improves error messages by displaying Rejects first.

- Expose diagnostics rolemap in Solver (@NathanReb ocaml-opam/opam-0install-solver#31).
  Allows library users to provide extra help on error.

- Cmdliner 1.1.0 compatibility (@dra27 ocaml-opam/opam-0install-solver#40)

- Fix compiler warnings from new fmt (@talex5 ocaml-opam/opam-0install-solver#32).
