### PR TITLE
Add missing OCaml 5 preview for dot-merlin-reader

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.4~5.0.preview/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.4~5.0.preview/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.5.1"}
+]
+description:
+  "Helper process: reads .merlin files and gives the normalized content to merlin"
+url {
+  src: "git+https://github.com/kit-ty-kate/merlin.git#500"
+}


### PR DESCRIPTION
/cc @kit-ty-kate ; not sure how this was supposed to work with that package.

The error I got while installing `merlin` on OCaml 5 without this:

```
#=== ERROR while compiling dot-merlin-reader.4.2 ==============================#
# context     2.1.2 | macos/arm64 | ocaml.5.0.0 | https://opam.ocaml.org#483693a9
# path        ~/git/irmin/_opam/.opam-switch/build/dot-merlin-reader.4.2
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dot-merlin-reader -j 9
# exit-code   1
# env-file    ~/.opam/log/dot-merlin-reader-83280-f64304.env
# output-file ~/.opam/log/dot-merlin-reader-83280-f64304.out
### output ###
# (cd _build/default && /Users/thomas/git/irmin/_opam/bin/ocamlc.opt -w -40 -g -bin-annot -I src/utils/.merlin_utils.objs/byte -I /Users/thomas/git/irmin/_opam/lib/yojson -no-alias-deps -open Merlin_utils -o src/utils/.merlin_utils.objs/byte/merlin_utils__Std.cmo -c -impl src/utils/std.ml)
# File "src/utils/std.ml", line 449, characters 19-29:
# 449 |   let capitalize = capitalize
#                          ^^^^^^^^^^
# Error: Unbound value capitalize
```