### PR TITLE
memtrace: doesn't work with OCaml 5

### DIFF
--- a/packages/memtrace/memtrace.0.1.1/opam
+++ b/packages/memtrace/memtrace.0.1.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.00"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/memtrace/memtrace.0.1.2/opam
+++ b/packages/memtrace/memtrace.0.1.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.00"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/memtrace/memtrace.0.2.1.2/opam
+++ b/packages/memtrace/memtrace.0.2.1.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.00"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/memtrace/memtrace.0.2.2/opam
+++ b/packages/memtrace/memtrace.0.2.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/janestreet/memtrace"
 bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.00"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
```
 context     2.1.2 | macos/arm64 | ocaml.5.0.0 | https://opam.ocaml.org#21aa7ced
 path        ~/git/irmin/_opam/.opam-switch/build/memtrace.0.2.2
 command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p memtrace -j 9 @install
 exit-code   1
 env-file    ~/.opam/log/memtrace-6831-fed1d4.env
 output-file ~/.opam/log/memtrace-6831-fed1d4.out
 ## output ###
 [...]
 353 |     h lxor (h lsr 23)
 354 |   let equal (a : t) (b : t) = a = b
 355 | end)
 Error: Modules do not match:
        sig
          type t = int
          val hash : 'a -> t -> int
          val equal : t -> t -> bool
        end
      is not included in Hashtbl.SeededHashedType
      The value `seeded_hash' is required but not provided
      File "hashtbl.mli", line 399, characters 4-36: Expected declaration
```