### PR TITLE
lru: doesn't work with OCaml 5

### DIFF
--- a/packages/lru/lru.0.1.0/opam
+++ b/packages/lru/lru.0.1.0/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+https://github.com/pqwy/lru.git"
 bug-reports: "https://github.com/pqwy/lru/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.00"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/lru/lru.0.1.1/opam
+++ b/packages/lru/lru.0.1.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/pqwy/lru.git"
 bug-reports: "https://github.com/pqwy/lru/issues"
 tags: ["data-structure"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.00"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/lru/lru.0.2.0/opam
+++ b/packages/lru/lru.0.2.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/pqwy/lru.git"
 bug-reports: "https://github.com/pqwy/lru/issues"
 tags: ["data-structure"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.00"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/lru/lru.0.3.0/opam
+++ b/packages/lru/lru.0.3.0/opam
@@ -11,7 +11,7 @@ build: [ [ "dune" "subst" ] {dev}
          [ "dune" "build" "-p" name "-j" jobs ]
          [ "dune" "runtest" "-p" name ] {with-test} ]
 depends: [
-  "ocaml" {>="4.03.0"}
+  "ocaml" {>="4.03.0" & < "5.00"}
   "dune"  {>= "1.7"}
   "psq"   {>="0.2.0"}
   "qcheck-core"     {with-test}


### PR DESCRIPTION
```
=== ERROR while compiling lru.0.3.0 ==========================================#
 context     2.1.2 | macos/arm64 | ocaml.5.0.0 | https://opam.ocaml.org#21aa7ced
 path        ~/git/irmin/_opam/.opam-switch/build/lru.0.3.0
 command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lru -j 9
 exit-code   1
 env-file    ~/.opam/log/lru-6831-6979b4.env
 output-file ~/.opam/log/lru-6831-6979b4.out
 ## output ###
 [...]
 File "src/lru.ml", line 308, characters 10-45:
 308 |     Bake (Hashtbl.MakeSeeded (SeededHash (K))) (V)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: Modules do not match:
        sig
          type t = K.t
          val equal : t -> t -> bool
          val hash : 'a -> t -> int
        end
      is not included in Hashtbl.SeededHashedType
      The value `seeded_hash' is required but not provided
      File "hashtbl.mli", line 399, characters 4-36: Expected declaration
```