### PR TITLE
magic-trace is only available on x86 architectures

### DIFF
--- a/packages/magic-trace/magic-trace.1.0.1/opam
+++ b/packages/magic-trace/magic-trace.1.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "owee"         {>= "0.6"}
   "re"           {>= "1.8.0"}
 ]
-available: arch = "x86_64" | arch = "x86_32"
+available: arch = "x86_64"
 synopsis: "Collects and displays high-resolution traces of what a process is doing"
 description: "https://github.com/janestreet/magic-trace"
 url {

--- a/packages/magic-trace/magic-trace.1.0.1/opam
+++ b/packages/magic-trace/magic-trace.1.0.1/opam
@@ -23,6 +23,7 @@ depends: [
   "owee"         {>= "0.6"}
   "re"           {>= "1.8.0"}
 ]
+available: arch = "x86_64" | arch = "x86_32"
 synopsis: "Collects and displays high-resolution traces of what a process is doing"
 description: "https://github.com/janestreet/magic-trace"
 url {


### PR DESCRIPTION
```
#=== ERROR while compiling magic-trace.1.0.1 ==================================#
# context              2.1.2 | linux/arm64 | ocaml-base-compiler.4.14.0 | pinned(https://github.com/janestreet/magic-trace/archive/refs/tags/v1.0.1.tar.gz)
# path                 ~/.opam/4.14/.opam-switch/build/magic-trace.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p magic-trace -j 159
# exit-code            1
# env-file             ~/.opam/log/magic-trace-18508-682ffa.env
# output-file          ~/.opam/log/magic-trace-18508-682ffa.out
### output ###
# (cd _build/default/bin && ./gen-versions.sh version_stubs.c)
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# File "src/dune", line 6, characters 9-25:
# 6 |   (names breakpoint_stubs boot_time_stubs ptrace_stubs))
#              ^^^^^^^^^^^^^^^^
# (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14/lib/ocaml -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/async -I /home/opam/.opam/4.14/lib/async/async_command -I /home/opam/.opam/4.14/lib/async/async_quickcheck -I /home/opam/.opam/4.14/lib/async/async_rpc -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_kernel/read_write_pair -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/async_unix -I /home/opam/.opam/4.14/lib/async_unix/thread_pool -I /home/opam/.opam/4.14/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-async -I /home/opam/.opam/4.14/lib/cohttp_static_handler -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-async -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/ansi_kernel -I /home/opam/.opam/4.14/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_kernel/iobuf -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/nonempty_list -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/uuid -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/bigstring_unix -I /home/opam/.opam/4.14/lib/core_unix/core_thread -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/iobuf_unix -I /home/opam/.opam/4.14/lib/core_unix/linux_ext -I /home/opam/.opam/4.14/lib/core_unix/nano_mutex -I /home/opam/.opam/4.14/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/squeue -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/core_unix/time_ns_unix -I /home/opam/.opam/4.14/lib/core_unix/time_stamp_counter -I /home/opam/.opam/4.14/lib/core_unix/time_unix -I /home/opam/.opam/4.14/lib/core_unix/uuid -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocaml_intrinsics -I /home/opam/.opam/4.14/lib/owee -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/shell -I /home/opam/.opam/4.14/lib/shell/low_level_process -I /home/opam/.opam/4.14/lib/shell/shell_internal -I /home/opam/.opam/4.14/lib/shell/unix_extended -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/textutils/console -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/timezone -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/variantslib -I ../core -I ../lib/magic_trace/src -I ../vendor/fzf/src -I ../vendor/tracing/src -I ../vendor/tracing/zero -o breakpoint_stubs.o -c breakpoint_stubs.c)
# breakpoint_stubs.c: In function 'magic_breakpoint_create_stub':
# breakpoint_stubs.c:90:35: error: 'PERF_REG_X86_DI' undeclared (first use in this function); did you mean 'PERF_REG_ARM64_PC'?
#    90 |   attr.sample_regs_user = (1ul << PERF_REG_X86_DI) | (1ul << PERF_REG_X86_SI);
#       |                                   ^~~~~~~~~~~~~~~
#       |                                   PERF_REG_ARM64_PC
# breakpoint_stubs.c:90:35: note: each undeclared identifier is reported only once for each function it appears in
# breakpoint_stubs.c:90:62: error: 'PERF_REG_X86_SI' undeclared (first use in this function); did you mean 'PERF_REG_ARM64_SP'?
#    90 |   attr.sample_regs_user = (1ul << PERF_REG_X86_DI) | (1ul << PERF_REG_X86_SI);
#       |                                                              ^~~~~~~~~~~~~~~
#       |                                                              PERF_REG_ARM64_SP
# File "src/dune", line 6, characters 26-41:
# 6 |   (names breakpoint_stubs boot_time_stubs ptrace_stubs))
#                               ^^^^^^^^^^^^^^^
# (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/4.14/lib/ocaml -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/async -I /home/opam/.opam/4.14/lib/async/async_command -I /home/opam/.opam/4.14/lib/async/async_quickcheck -I /home/opam/.opam/4.14/lib/async/async_rpc -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_kernel/read_write_pair -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/async_unix -I /home/opam/.opam/4.14/lib/async_unix/thread_pool -I /home/opam/.opam/4.14/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-async -I /home/opam/.opam/4.14/lib/cohttp_static_handler -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-async -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/ansi_kernel -I /home/opam/.opam/4.14/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_kernel/iobuf -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/nonempty_list -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/uuid -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/bigstring_unix -I /home/opam/.opam/4.14/lib/core_unix/core_thread -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/iobuf_unix -I /home/opam/.opam/4.14/lib/core_unix/linux_ext -I /home/opam/.opam/4.14/lib/core_unix/nano_mutex -I /home/opam/.opam/4.14/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/squeue -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/core_unix/time_ns_unix -I /home/opam/.opam/4.14/lib/core_unix/time_stamp_counter -I /home/opam/.opam/4.14/lib/core_unix/time_unix -I /home/opam/.opam/4.14/lib/core_unix/uuid -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocaml_intrinsics -I /home/opam/.opam/4.14/lib/owee -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/shell -I /home/opam/.opam/4.14/lib/shell/low_level_process -I /home/opam/.opam/4.14/lib/shell/shell_internal -I /home/opam/.opam/4.14/lib/shell/unix_extended -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/textutils/console -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/timezone -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/variantslib -I ../core -I ../lib/magic_trace/src -I ../vendor/fzf/src -I ../vendor/tracing/src -I ../vendor/tracing/zero -o boot_time_stubs.o -c boot_time_stubs.c)
# boot_time_stubs.c: In function 'magic_clock_gettime_perf_ns':
# boot_time_stubs.c:17:3: error: impossible constraint in 'asm'
#    17 |   __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
#       |   ^~~~~~~
```