### PR TITLE
Update ocaml-config to 3rd version

### DIFF
--- a/packages/ocaml-config/ocaml-config.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-config/ocaml-config.3/files/gen_ocaml_config.ml.in
@@ -1,0 +1,59 @@
+let () =
+  let ocaml_version =
+    let v = Sys.ocaml_version in
+    let l = String.length v in
+    let plus = try String.index v '+' with Not_found -> l in
+    (* Introduced in 4.11.0; used from 4.12.0 *)
+    let tilde = try String.index v '~' with Not_found -> l in
+    String.sub v 0 (min (min plus tilde) l)
+  in
+  if ocaml_version <> Sys.argv.(1) then
+    (Printf.eprintf
+       "OCaml version mismatch: %%s, expected %s"
+       ocaml_version Sys.argv.(1);
+     exit 1)
+  else
+  let oc = open_out (Sys.argv.(2) ^ ".config") in
+  let exe = ".exe" in
+  let (ocaml, suffix) =
+    let s = Sys.executable_name in
+    if Filename.check_suffix s exe then
+      (Filename.chop_suffix s exe, exe)
+    else
+      (s, "")
+  in
+  let ocamlc = ocaml^"c"^suffix in
+  let libdir =
+    if Sys.command (ocamlc^" -where > where") = 0 then
+      (* Must be opened in text mode for Windows *)
+      let ic = open_in "where" in
+      let r = input_line ic in
+      close_in ic; r
+    else
+      failwith "Bad return from 'ocamlc -where'"
+  in
+  let stubsdir =
+    let ic = open_in (Filename.concat libdir "ld.conf") in
+    let rec r acc = try r (input_line ic::acc) with End_of_file -> acc in
+    let lines = List.rev (r []) in
+    close_in ic;
+    let sep = if Sys.os_type = "Win32" then ";" else ":" in
+    String.concat sep lines
+  in
+  let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
+  p "opam-version: \"2.0\"";
+  p "variables {";
+  p "  native: %%b"
+    (Sys.file_exists (ocaml^"opt"^suffix));
+  p "  native-tools: %%b"
+    (* The variable [ocamlc] already has a suffix on Windows
+       (ex. '...\bin\ocamlc.exe') so we use [ocaml] to check *)
+    (Sys.file_exists (ocaml^"c.opt"^suffix));
+  p "  native-dynlink: %%b"
+    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+  p "  stubsdir: %%S"
+    stubsdir;
+  p "  preinstalled: %{ocaml-system:installed}%";
+  p "  compiler: \"%{ocaml-system:installed?system:}%%{ocaml-base-compiler:version}%%{dkml-base-compiler:version}%%{ocaml-variants:version}%%{ocaml-option-32bit:installed?+32bit:}%%{ocaml-option-afl:installed?+afl:}%%{ocaml-option-bytecode-only:installed?+bytecode-only:}%%{ocaml-option-default-unsafe-string:installed?+default-unsafe-string:}%%{ocaml-option-fp:installed?+fp:}%%{ocaml-option-flambda:installed?+flambda:}%%{ocaml-option-musl:installed?+musl:}%%{ocaml-option-nnp:installed?+nnp:}%%{ocaml-option-no-flat-float-array:installed?+no-flat-float-array:}%%{ocaml-option-spacetime:installed?+spacetime:}%%{ocaml-option-static:installed?+static:}%\"";
+  p "}";
+  close_out oc

--- a/packages/ocaml-config/ocaml-config.3/files/ocaml-config.install
+++ b/packages/ocaml-config/ocaml-config.3/files/ocaml-config.install
@@ -1,0 +1,1 @@
+share: ["gen_ocaml_config.ml"]

--- a/packages/ocaml-config/ocaml-config.3/opam
+++ b/packages/ocaml-config/ocaml-config.3/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "OCaml Switch Configuration"
+description: """
+This package is used by the OCaml package to set-up its variables."""
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+]
+homepage: "https://opam.ocaml.org/"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml-base-compiler" {>= "5.0.0~"} |
+  "ocaml-variants" {>= "5.0.0~"} |
+  "ocaml-system" {>= "5.0.0~"} |
+  "dkml-base-compiler" {>= "4.12.0~"}
+]
+substs: "gen_ocaml_config.ml"
+extra-files: [
+  ["gen_ocaml_config.ml.in" "md5=1b6c14b465e104ca6641c6899e097143"]
+  ["ocaml-config.install"   "md5=8e50c5e2517d3463b3aad649748cafd7"]
+]

--- a/packages/ocaml-config/ocaml-config.3/opam
+++ b/packages/ocaml-config/ocaml-config.3/opam
@@ -7,6 +7,7 @@ authors: [
   "Louis Gesbert <louis.gesbert@ocamlpro.com>"
   "David Allsopp <david.allsopp@metastack.com>"
 ]
+license: "ISC"
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [


### PR DESCRIPTION
### Changes
* ocaml-(base-compiler|variants|system) require OCaml 5+
* dkml-base-compiler, a new addition to 3rd version, requires OCaml
  4.12+
* Fix reading of ld.conf separator on Win32 (should be ; not :)
* Check existence of correct ocamlc.opt.exe to set [native-tools]
  Opam variable on Win32

~~Also added sha256 checksums.~~ (Can only choose one type of checksum for extra-files, so I guess it will have to be md5 for portability)

### Testing Status

- [x] Has this PR been tested with an [updated dkml-base-compiler PR](https://github.com/ocaml/opam-repository/pull/20536)? ETA: By 2022-04-30

### Related

* Originally in https://github.com/ocaml/opam-repository/pull/20536
* One of the changes is in https://github.com/dra27/opam-repository/commit/ae7a53c6bba5db465254a15543e5a3da29abb95d