### PR TITLE
Cryptokit version 1.17

### DIFF
--- a/packages/cryptokit/cryptokit.1.17/opam
+++ b/packages/cryptokit/cryptokit.1.17/opam
@@ -2,13 +2,14 @@ opam-version: "2.0"
 synopsis: "A library of cryptographic primitives"
 description:
   "Cryptokit includes authenticated encryption (AES-GCM, Chacha20-Poly1305), block ciphers (AES, DES, 3DES), stream ciphers (Chacha20, ARCfour), public-key cryptography (RSA, DH), hashes (SHA-256, SHA-512, SHA-3, Blake2), MACs, compression, random number generation -- all presented with a compositional, extensible interface."
+license="GNU Library General Public License v2 or later with OCaml LGPL Linking Exception"
 maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
 authors: ["Xavier Leroy"]
 homepage: "https://github.com/xavierleroy/cryptokit"
 bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.5"}
   "dune-configurator"
   "zarith" {>= "1.4"}
   "conf-zlib"

--- a/packages/cryptokit/cryptokit.1.17/opam
+++ b/packages/cryptokit/cryptokit.1.17/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "A library of cryptographic primitives"
 description:
   "Cryptokit includes authenticated encryption (AES-GCM, Chacha20-Poly1305), block ciphers (AES, DES, 3DES), stream ciphers (Chacha20, ARCfour), public-key cryptography (RSA, DH), hashes (SHA-256, SHA-512, SHA-3, Blake2), MACs, compression, random number generation -- all presented with a compositional, extensible interface."
-license="GNU Library General Public License v2 or later with OCaml LGPL Linking Exception"
+license: "GNU Library General Public License v2 or later with OCaml LGPL Linking Exception"
 maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
 authors: ["Xavier Leroy"]
 homepage: "https://github.com/xavierleroy/cryptokit"

--- a/packages/cryptokit/cryptokit.1.17/opam
+++ b/packages/cryptokit/cryptokit.1.17/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A library of cryptographic primitives"
+description:
+  "Cryptokit includes authenticated encryption (AES-GCM, Chacha20-Poly1305), block ciphers (AES, DES, 3DES), stream ciphers (Chacha20, ARCfour), public-key cryptography (RSA, DH), hashes (SHA-256, SHA-512, SHA-3, Blake2), MACs, compression, random number generation -- all presented with a compositional, extensible interface."
+maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/cryptokit"
+bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "dune-configurator"
+  "zarith" {>= "1.4"}
+  "conf-zlib"
+  "conf-gmp-powm-sec"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
+url {
+  src: "https://github.com/xavierleroy/cryptokit/archive/release117.tar.gz"
+  checksum: [
+    "sha256=53e13043e3798e5e556a1ac50e687d6e5cf9ab2bf3ad9867b3090dcf17594f3f"
+    "sha512=b58bd5da8285fccd9ad15d9230afd1aae689d381f05a2c351207932bea21f1f8d2d7581edd6c109da74462caf8aae912a84c6c7f6b974e9df0b39a0b609bc5c1"
+  ]
+}

--- a/packages/cryptokit/cryptokit.1.17/opam
+++ b/packages/cryptokit/cryptokit.1.17/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "A library of cryptographic primitives"
 description:
   "Cryptokit includes authenticated encryption (AES-GCM, Chacha20-Poly1305), block ciphers (AES, DES, 3DES), stream ciphers (Chacha20, ARCfour), public-key cryptography (RSA, DH), hashes (SHA-256, SHA-512, SHA-3, Blake2), MACs, compression, random number generation -- all presented with a compositional, extensible interface."
-license: "GNU Library General Public License v2 or later with OCaml LGPL Linking Exception"
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: ["Xavier Leroy <xavier.leroy@college-de-france.fr>"]
 authors: ["Xavier Leroy"]
 homepage: "https://github.com/xavierleroy/cryptokit"


### PR DESCRIPTION
Release 1.17:
- Add interfaces for authenticated encryption (AEAD) and two implementations: AES-GCM and Chacha20-Poly1305.
- Use `getentropy()` for `system_rng` when available (Linux, macOS, BSD).
- Removed support for EGD (the Entropy Gathering Daemon).
- Added compile-time alerts on uses of broken or weak ciphers and hashes. (Can be silenced with "-alert -crypto".)
- Add the hmac_sha384 MAC.
- Add the SipHash MAC.
- Set file descriptor to close-on-exec in `device_rng`.
- Improve compatibility with OCaml 5.0.
- Make sure CryptokitBignum is installed like before the switch to Dune.
