### PR TITLE
Package ometrics.0.2.0

### DIFF
--- a/packages/ometrics/ometrics.0.2.0/opam
+++ b/packages/ometrics/ometrics.0.2.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+homepage: "https://gitlab.com/nomadic-labs/ometrics"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ometrics.git"
+bug-reports: "https://gitlab.com/nomadic-labs/ometrics/-/issues"
+synopsis: "OCaml analysis in a merge request changes"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.9.1"}
+  "ppxlib" {>= "0.26.0"}
+  "cmdliner" {>= "1.0.0"}
+  "digestif" {>= "0.7.2"}
+  "qcheck-alcotest" {with-test & >= "0.18"}
+  "bisect_ppx" {dev & >= "2.6.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+authors: [
+  "Thomas Letan <lthms@nomadic-labs.com>"
+  "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+]
+url {
+  src: "https://github.com/vch9/ometrics/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=f0655344f0313f7d8ed06dcb16819fc0"
+    "sha512=a1663599fc773b07a927adefdfb934348a5130547fadd8329b19a7123251b4b624068256cbf750b115d773cf6d8edf37bd3ca73e208d6eef6b99250d99464dbf"
+  ]
+}


### PR DESCRIPTION
### `ometrics.0.2.0`
OCaml analysis in a merge request changes



---
* Homepage: https://gitlab.com/nomadic-labs/ometrics
* Source repo: git+https://gitlab.com/nomadic-labs/ometrics.git
* Bug tracker: https://gitlab.com/nomadic-labs/ometrics/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0