### PR TITLE
Package sifun.3.0.0

### DIFF
--- a/packages/sifun/sifun.3.0.0/opam
+++ b/packages/sifun/sifun.3.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Interpreter for SiFun (Simple Functional) Language with three different type systems (supports Higher Rank Polymorphism)"
+maintainer: ["Krzysztof Druciarek <kkd26@cam.ac.uk>"]
+authors: ["Krzysztof Druciarek <kkd26@cam.ac.uk>"]
+license: "gpl-3.0"
+homepage: "https://github.com/kkd26/SiFun"
+bug-reports: "https://github.com/kkd26/SiFun/issues"
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+  "menhir" {>= "20180523"}
+  "ounit2" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/kkd26/SiFun"
+url {
+  src: "https://github.com/kkd26/SiFun/archive/3.0.0.tar.gz"
+  checksum: [
+    "md5=0314c1c1b0922e47ec33b040b16b87bb"
+    "sha512=357ded7e85079a24a45daf390bcead56ff5d4e62676759973452abb648cddcb684f3dfa48317c0a4233520981c81a0542b58250aeef84871c0381cb7514dc35b"
+  ]
+}


### PR DESCRIPTION
### `sifun.3.0.0`
Interpreter for SiFun (Simple Functional) Language with three different type systems (supports Higher Rank Polymorphism)



---
* Homepage: https://github.com/kkd26/SiFun
* Source repo: git+https://github.com/kkd26/SiFun
* Bug tracker: https://github.com/kkd26/SiFun/issues

---
:camel: Pull-request generated by opam-publish v2.1.0