### PR TITLE
Fix ppx_deriving.4.5 with dune >= 3

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.4.5-1/files/fix_dune_3.patch
+++ b/packages/ppx_deriving/ppx_deriving.4.5-1/files/fix_dune_3.patch
@@ -1,0 +1,19 @@
+diff --git a/src_plugins/map/dune b/src_plugins/map/dune
+--- a/src_plugins/map/dune
++++ b/src_plugins/map/dune
+@@ -1,5 +1,5 @@
+ (rule
+- (deps ppx_deriving_map.cppo.ml)
++ (deps ../compat_macros.cppo ppx_deriving_map.cppo.ml)
+  (targets ppx_deriving_map.ml)
+  (action (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
+ 
+diff --git a/src_plugins/map/ppx_deriving_map.cppo.ml b/src_plugins/map/ppx_deriving_map.cppo.ml
+--- a/src_plugins/map/ppx_deriving_map.cppo.ml
++++ b/src_plugins/map/ppx_deriving_map.cppo.ml
+@@ -1,5 +1,3 @@
+-#include "../compat_macros.cppo"
+-
+ open Longident
+ open Location
+ open Asttypes

--- a/packages/ppx_deriving/ppx_deriving.4.5-1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.5-1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "thierry.martinez@inria.fr"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune"     {>= "1.6.3"}
+  "cppo"     {build & >= "1.2.2"}
+  "ppxfind"  {build}
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "ppx_derivers"
+  "ppx_tools"  {>= "4.02.3"}
+  "result"
+  "ounit"      {with-test}
+  "ocaml" {>= "4.02" & < "4.13.0"}
+]
+patches: [
+  "fix_dune_3.patch"
+]
+extra-files: [
+  "fix_dune_3.patch" "sha256=8f1c8bf4b882993decedf599b82ced119c0a1a822fd2d08dfea90e659f1a1b08"
+]
+synopsis: "Type-driven code generation for OCaml >=4.02.2"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src: "https://github.com/ocaml-ppx/ppx_deriving/archive/v4.5.tar.gz"
+  checksum: "sha512=f79153c5231ba1e03a3491fde95ca82ecb62fe05b60a649a374d2fbc5ea5dd9242126de7dfbe917c22fd7077c026c940e18c6b36c5ce0ec4bb6e07f11d2b710b"}


### PR DESCRIPTION
Patch ppx_deriving 4.5 to correctly specify the dep, to fix it on dune 3.

- Fix ppx_deriving.4.5 on dune >= 3
- Revert "ppx_deriving.4.5 is not compatible with dune 3.0"
