### PR TITLE
Package lua-ml.0.9.4

### DIFF
--- a/packages/lua-ml/lua-ml.0.9.4/opam
+++ b/packages/lua-ml/lua-ml.0.9.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>"
+  "Christian Lindig <lindig@gmail.com>"
+  "Daniil Baturin <daniil+lua-ml@baturin.org>"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.07.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/lindig/lua-ml.git"
+url {
+  src: "https://github.com/lindig/lua-ml/archive/refs/tags/0.9.4.tar.gz"
+  checksum: [
+    "md5=ccc750966b4fbc925a9bfb802fd848a4"
+    "sha512=3127b73bff078a40825fc5216559e3fe37fb1c4faf0121adc3a06acac6fb77dec82ba150d1f78ac1953266720ea3bedd4f7e2b21ddce1e0250417b36e1327eee"
+  ]
+}


### PR DESCRIPTION
### `lua-ml.0.9.4`
An embeddable Lua 2.5 interpreter implemented in OCaml



---
* Homepage: https://github.com/lindig/lua-ml
* Source repo: git+https://github.com/lindig/lua-ml.git
* Bug tracker: https://github.com/lindig/lua-ml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0