### PR TITLE
Package sortedseq_intersect.0.1.0

### DIFF
--- a/packages/sortedseq_intersect/sortedseq_intersect.0.1.0/opam
+++ b/packages/sortedseq_intersect/sortedseq_intersect.0.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Fermin Reig"
+authors: ["Fermin Reig"]
+homepage: "https://github.com/ferminr/ocaml_sortedseq_intersect"
+bug-reports: "https://github.com/ferminr/ocaml_sortedseq_intersect/issues"
+dev-repo: "git+https://github.com/ferminr/ocaml_sortedseq_intersect.git"
+doc: "https://github.com/ferminr/ocaml_sortedseq_intersect"
+license: "MIT"
+synopsis: "A divide-and-conquer algorithm in OCaml for the intersection of sorted sequences"
+description: """
+The algorithm is described in this paper:
+
+Fast Intersection Algorithms for Sorted Sequences
+Ricardo Baeza-Yates and Alejandro Salinger
+Algorithms and Applications 2010 (LNCS 6060, pp. 45–61)
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "2.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/ferminr/ocaml_sortedseq_intersect/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=57f23144c9ac13ff526c21d59b3e1a21"
+    "sha512=e124cfbb04db5a0f26e81c4c824c58a9ea4a11670ded7380065d316e79887f6b3494210cbfc406bf8b825c269512106a080e39b2575231ae8fa97b9ec9a79c81"
+  ]
+}


### PR DESCRIPTION
### `sortedseq_intersect.0.1.0`
A divide-and-conquer algorithm in OCaml for the intersection of sorted sequences
The algorithm is described in this paper:

Fast Intersection Algorithms for Sorted Sequences
Ricardo Baeza-Yates and Alejandro Salinger
Algorithms and Applications 2010 (LNCS 6060, pp. 45–61)



---
* Homepage: https://github.com/ferminr/ocaml_sortedseq_intersect
* Source repo: git+https://github.com/ferminr/ocaml_sortedseq_intersect.git
* Bug tracker: https://github.com/ferminr/ocaml_sortedseq_intersect/issues

---
:camel: Pull-request generated by opam-publish v2.1.0