### PR TITLE
why3 >= 1.4.1: fix mlmpfr bounds

### DIFF
--- a/packages/why3/why3.1.4.1/opam
+++ b/packages/why3/why3.1.4.1/opam
@@ -56,13 +56,13 @@ depopts: [
   "sexplib"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
-  "mlmpfr" {< "4.1.0"}
+  "mlmpfr"
 ]
 
 conflicts: [
   "why3-base"
   "ocamlgraph" {< "1.8.2"}
-  "mlmpfr" {< "4.0.0"}
+  "mlmpfr" {< "4.0.0" | >= "4.1.0"}
   "base-effects"
 ]
 

--- a/packages/why3/why3.1.5.0/opam
+++ b/packages/why3/why3.1.5.0/opam
@@ -55,7 +55,7 @@ depopts: [
   "sexplib"
   "ppx_deriving" {build}
   "ppx_sexp_conv" {build}
-  "mlmpfr" {< "4.1.0"}
+  "mlmpfr"
 ]
 
 conflicts: [


### PR DESCRIPTION
See: https://github.com/ocaml/opam-repository/pull/21313
Version 1.4.1 fails with
```
# Error: The implementation src/util/mlmpfr_wrapper.ml
#        does not match the interface src/util/mlmpfr_wrapper.cmi: 
#        Values do not match:
#          val get_formatted_str :
#            ?rnd:mpfr_rnd_t ->
#            ?base:int -> ?size:int -> ?ktz:bool -> mpfr_float -> string
#        is not included in
#          val get_formatted_str :
#            ?rnd:mpfr_rnd_t -> ?base:int -> ?size:int -> mpfr_float -> string
#        The type
#          ?rnd:mpfr_rnd_t ->
#          ?base:int -> ?size:int -> ?ktz:bool -> mpfr_float -> string
#        is not compatible with the type
#          ?rnd:mpfr_rnd_t -> ?base:int -> ?size:int -> mpfr_float -> string
#        Type ?ktz:bool -> mpfr_float -> string is not compatible with type
#          mpfr_float -> string 
#        File "src/util/mlmpfr_wrapper.mli", line 66, characters 0-89:
#          Expected declaration
#        File "src/mpfr.mli", line 197, characters 0-102: Actual declaration
```
so requires the upper bound

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>