### PR TITLE
[new release] mirage, mirage-runtime, functoria and functoria-runtime (4.1.0)

### DIFF
--- a/packages/functoria-runtime/functoria-runtime.4.1.0/opam
+++ b/packages/functoria-runtime/functoria-runtime.4.1.0/opam
@@ -33,8 +33,8 @@ url {
   src:
     "https://github.com/mirage/mirage/releases/download/v4.1.0/mirage-4.1.0.tbz"
   checksum: [
-    "sha256=7597f798e44cccdf34fb3d493ba3f67a6a3bf9aa81bdd5a1ba748c0ec9819fbd"
-    "sha512=aedd3f2b8a43d56f0f0a7c8029b4ca7ec60bc25f20f8cda172a0542dffefda72257a507cde66627818435e5a0a80468be3ee510a591fed7cfad1ff9a2815b413"
+    "sha256=9cd2195fd3f7cd96e21e27a32b84fd799d6d4fde31e2d8a12adf1c52c711e8d8"
+    "sha512=a47faac92ad1f9d3292cb0071be025a1f996bd170c2499cec39b2fb1b86198a30df325099645f409f7e5908043df6f464fc4b9b1306b67079ab831dfd1b020af"
   ]
 }
-x-commit-hash: "e07fe328dd1186987e8ddad6060bac1c1a178905"
+x-commit-hash: "cfe0b017c1f2572202fc2a70080b8df768f8504c"

--- a/packages/functoria/functoria.4.1.0/opam
+++ b/packages/functoria/functoria.4.1.0/opam
@@ -50,8 +50,8 @@ url {
   src:
     "https://github.com/mirage/mirage/releases/download/v4.1.0/mirage-4.1.0.tbz"
   checksum: [
-    "sha256=7597f798e44cccdf34fb3d493ba3f67a6a3bf9aa81bdd5a1ba748c0ec9819fbd"
-    "sha512=aedd3f2b8a43d56f0f0a7c8029b4ca7ec60bc25f20f8cda172a0542dffefda72257a507cde66627818435e5a0a80468be3ee510a591fed7cfad1ff9a2815b413"
+    "sha256=9cd2195fd3f7cd96e21e27a32b84fd799d6d4fde31e2d8a12adf1c52c711e8d8"
+    "sha512=a47faac92ad1f9d3292cb0071be025a1f996bd170c2499cec39b2fb1b86198a30df325099645f409f7e5908043df6f464fc4b9b1306b67079ab831dfd1b020af"
   ]
 }
-x-commit-hash: "e07fe328dd1186987e8ddad6060bac1c1a178905"
+x-commit-hash: "cfe0b017c1f2572202fc2a70080b8df768f8504c"

--- a/packages/mirage-runtime/mirage-runtime.4.1.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.1.0/opam
@@ -34,8 +34,8 @@ url {
   src:
     "https://github.com/mirage/mirage/releases/download/v4.1.0/mirage-4.1.0.tbz"
   checksum: [
-    "sha256=7597f798e44cccdf34fb3d493ba3f67a6a3bf9aa81bdd5a1ba748c0ec9819fbd"
-    "sha512=aedd3f2b8a43d56f0f0a7c8029b4ca7ec60bc25f20f8cda172a0542dffefda72257a507cde66627818435e5a0a80468be3ee510a591fed7cfad1ff9a2815b413"
+    "sha256=9cd2195fd3f7cd96e21e27a32b84fd799d6d4fde31e2d8a12adf1c52c711e8d8"
+    "sha512=a47faac92ad1f9d3292cb0071be025a1f996bd170c2499cec39b2fb1b86198a30df325099645f409f7e5908043df6f464fc4b9b1306b67079ab831dfd1b020af"
   ]
 }
-x-commit-hash: "e07fe328dd1186987e8ddad6060bac1c1a178905"
+x-commit-hash: "cfe0b017c1f2572202fc2a70080b8df768f8504c"

--- a/packages/mirage/mirage.4.1.0/opam
+++ b/packages/mirage/mirage.4.1.0/opam
@@ -47,8 +47,8 @@ url {
   src:
     "https://github.com/mirage/mirage/releases/download/v4.1.0/mirage-4.1.0.tbz"
   checksum: [
-    "sha256=7597f798e44cccdf34fb3d493ba3f67a6a3bf9aa81bdd5a1ba748c0ec9819fbd"
-    "sha512=aedd3f2b8a43d56f0f0a7c8029b4ca7ec60bc25f20f8cda172a0542dffefda72257a507cde66627818435e5a0a80468be3ee510a591fed7cfad1ff9a2815b413"
+    "sha256=9cd2195fd3f7cd96e21e27a32b84fd799d6d4fde31e2d8a12adf1c52c711e8d8"
+    "sha512=a47faac92ad1f9d3292cb0071be025a1f996bd170c2499cec39b2fb1b86198a30df325099645f409f7e5908043df6f464fc4b9b1306b67079ab831dfd1b020af"
   ]
 }
-x-commit-hash: "e07fe328dd1186987e8ddad6060bac1c1a178905"
+x-commit-hash: "cfe0b017c1f2572202fc2a70080b8df768f8504c"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

#### Changed

- Be able to make a docteur image with a relative path (@dinosaure, mirage/mirage#1324)
- Update the project with `ocamlformat.0.21.0` (@gpetiot, @dinosaure, mirage/mirage#1286)
- Upgrade the `mirage` tool with `opam-monorepo.0.3.0` and generate
  a single OPAM file (@TheLortex, @hannesm, @dinosaure, mirage/mirage#1327)

  You should check the `opam-monorepo.0.3.0` release to get more details about
  updates and fixes.

#### Added

- Add `chamelon` device, a filesystem with `littlefs` (@dinosaure, @yomimono, mirage/mirage#1300)
- Add `pair` combinator for MirageOS key (@dinosaure, mirage/mirage#1328)
