### PR TITLE
Package herdtools7, version 7.56.2

### DIFF
--- a/packages/herdtools7/herdtools7.7.56.2/opam
+++ b/packages/herdtools7/herdtools7.7.56.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+license: "CECILL-B"
+build: ["sh" "./dune-build.sh" "%{prefix}%"]
+install: ["sh" "./dune-install.sh" "%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune"  {>= "1.4" }
+  "menhir" {>= "20181026"}
+]
+url {
+  src: "https://github.com/herd/herdtools7/archive/refs/tags/7.56.2.tar.gz"
+  checksum: [
+    "md5=0c3520131bf7e6519dd80b7b5d5bf3a6"
+    "sha512=97bc8dc91a9a6eb440aeabb3597c0503e50a36c4a7b5a619a2edc18c4f45667cb56aa5aa2ce3e42a364588acd4929a874220ed3194898fcaf13c9c13a1a01b1a"
+   ]
+}


### PR DESCRIPTION
Option `-version` was not working properly in previous 7.56.1. Version 7.56.2 backports a change that fixes the problem.