### PR TITLE
Do not depend on `ocamlfind` in `base-bytes`

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "base-unix"
 ]

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.10.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.10.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "angstrom"
   "lwt"
   "base-unix"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.11.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.11.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "angstrom"
   "lwt"
   "base-unix"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "angstrom"
   "lwt"
   "base-unix"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.1/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "angstrom"
   "lwt"
   "base-unix"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.9.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.9.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "angstrom"
   "lwt"
   "base-unix"

--- a/packages/angstrom/angstrom.0.6.0/opam
+++ b/packages/angstrom/angstrom.0.6.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "alcotest" {with-test & >= "0.6.0" & < "0.8.0"}
   "cstruct" {>= "0.7.0" & < "6.1.0"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/base-bytes/base-bytes.backport/opam
+++ b/packages/base-bytes/base-bytes.backport/opam
@@ -4,6 +4,8 @@ authors: " "
 homepage: " "
 depends: [
   "ocaml" {< "4.02.0"}
-  "ocamlfind" {>= "1.5.3"}
+]
+conflicts: [
+  "ocamlfind" {< "1.5.3"}
 ]
 synopsis: "Bytes compatibility library distributed with ocamlfind"

--- a/packages/base-bytes/base-bytes.base/opam
+++ b/packages/base-bytes/base-bytes.base/opam
@@ -4,6 +4,8 @@ authors: " "
 homepage: " "
 depends: [
   "ocaml" {>= "4.02.0"}
-  "ocamlfind" {>= "1.5.3"}
+]
+conflicts: [
+  "ocamlfind" {< "1.5.3"}
 ]
 synopsis: "Bytes library distributed with the OCaml compiler"

--- a/packages/base64/base64.2.2.0/opam
+++ b/packages/base64/base64.2.2.0/opam
@@ -11,7 +11,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
 depends: [
   "ocaml"
   "base-bytes"
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "bos" {with-test}
   "rresult" {with-test}
   "alcotest" {with-test & >= "0.4.0"}

--- a/packages/bigstring/bigstring.0.2/opam
+++ b/packages/bigstring/bigstring.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta19.1"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bigarray"
   "base-bytes"
 ]

--- a/packages/biniou/biniou.1.1.0/opam
+++ b/packages/biniou/biniou.1.1.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "conf-which" {build}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "easy-format"
   "base-bytes"
 ]

--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder" {>= "1.0+beta6"}
+  "dune" {>= "1.4" & < "2.0"}
   "ocplib-endian" {>= "0.6"}
   "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "afl-persistent" {>= "1.1"}

--- a/packages/csv-lwt/csv-lwt.2.0/opam
+++ b/packages/csv-lwt/csv-lwt.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "csv" {= "2.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "base-unix"
   "lwt" {>= "2.4.7"}

--- a/packages/csv/csv.2.0/opam
+++ b/packages/csv/csv.2.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {>= "1.0+beta9"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "base-unix"
 ]

--- a/packages/dokeysto/dokeysto.2.0.0/opam
+++ b/packages/dokeysto/dokeysto.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta19"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "base-unix"
   "extunix"

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.6.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.6.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday-lwt"
   "lwt" {>= "2.7.0"}
   "base-unix"

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.6.1/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.6.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday-lwt"
   "lwt" {>= "2.7.0"}
   "base-unix"

--- a/packages/faraday-lwt-unix/faraday-lwt-unix.0.7.0/opam
+++ b/packages/faraday-lwt-unix/faraday-lwt-unix.0.7.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday-lwt"
   "lwt" {>= "2.7.0"}
   "base-unix"

--- a/packages/faraday-lwt/faraday-lwt.0.3.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.3.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.3.0" & < "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday-lwt/faraday-lwt.0.4.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.4.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.3.0" & < "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday-lwt/faraday-lwt.0.5.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.5.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday-lwt/faraday-lwt.0.5.1/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.5.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday-lwt/faraday-lwt.0.6.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.6.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday-lwt/faraday-lwt.0.6.1/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.6.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday-lwt/faraday-lwt.0.7.0/opam
+++ b/packages/faraday-lwt/faraday-lwt.0.7.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "faraday" {>= "0.5.0"}
   "lwt"
 ]

--- a/packages/faraday/faraday.0.3.0/opam
+++ b/packages/faraday/faraday.0.3.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "alcotest" {with-test & >= "0.4.1"}
   "ocplib-endian" {>= "0.8"}
 ]

--- a/packages/faraday/faraday.0.4.0/opam
+++ b/packages/faraday/faraday.0.4.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "alcotest" {with-test & >= "0.4.1"}
   "ocplib-endian" {>= "0.8"}
 ]

--- a/packages/irc-client-lwt/irc-client-lwt.0.6.0/opam
+++ b/packages/irc-client-lwt/irc-client-lwt.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "irc-client" {>= "0.4.0" & < "0.7.0"}
   "result"
   "lwt" {>= "2.4.7"}

--- a/packages/irc-client-lwt/irc-client-lwt.0.6.1/opam
+++ b/packages/irc-client-lwt/irc-client-lwt.0.6.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "irc-client" {>= "0.4.0" & < "0.7.0"}
   "result"
   "lwt"  {>= "2.4.7"}

--- a/packages/irc-client-unix/irc-client-unix.0.6.0/opam
+++ b/packages/irc-client-unix/irc-client-unix.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-unix"
   "irc-client" {>= "0.6.0" & < "0.7.0"}
   "result"

--- a/packages/irc-client-unix/irc-client-unix.0.6.1/opam
+++ b/packages/irc-client-unix/irc-client-unix.0.6.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-unix"
   "irc-client" {>= "0.6.0" & < "0.7.0"}
   "result"

--- a/packages/irc-client/irc-client.0.6.0/opam
+++ b/packages/irc-client/irc-client.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "result"
   "ounit" {with-test}

--- a/packages/irc-client/irc-client.0.6.1/opam
+++ b/packages/irc-client/irc-client.0.6.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "result"
   "ounit" {with-test}

--- a/packages/kafka/kafka.0.3/opam
+++ b/packages/kafka/kafka.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "base-unix"
   "lwt"
   "cmdliner"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
 ]
 depexts: [
   ["zlib-dev" "librdkafka-dev"] {os-distribution = "alpine"}

--- a/packages/kafka/kafka.0.4/opam
+++ b/packages/kafka/kafka.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "base-unix"
   "lwt"
   "cmdliner"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
 ]
 depexts: [
   ["librdkafka-dev" "zlib-dev"] {os-distribution = "alpine"}

--- a/packages/lwt_glib/lwt_glib.1.1.0/opam
+++ b/packages/lwt_glib/lwt_glib.1.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-unix"
   "conf-glib-2" {build}
   "conf-pkg-config" {build}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "lwt" {>= "3.0.0"}
 ]
 synopsis: "GLib integration for Lwt"

--- a/packages/lwt_log/lwt_log.1.1.0/opam
+++ b/packages/lwt_log/lwt_log.1.1.0/opam
@@ -12,7 +12,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/aantron/lwt_log.git"
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "lwt" {>= "4.0.0"}
 ]
 build: [

--- a/packages/lwt_ssl/lwt_ssl.1.1.1/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.1/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml"
   "base-unix"
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "lwt" {>= "3.0.0"}
   "ssl" {>= "0.5.0"}
 ]

--- a/packages/lwt_ssl/lwt_ssl.1.1.2/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.2/opam
@@ -13,7 +13,7 @@ dev-repo: "git+https://github.com/aantron/lwt_ssl.git"
 depends: [
   "ocaml"
   "base-unix"
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "lwt" {>= "3.0.0"}
   "ssl" {>= "0.5.0"}
 ]

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.3/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.3/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta9"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bigarray"
   "base-bytes"
   "mesh" {= "0.9.3"}

--- a/packages/mesh-easymesh/mesh-easymesh.0.9.4/opam
+++ b/packages/mesh-easymesh/mesh-easymesh.0.9.4/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta9"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bigarray"
   "base-bytes"
   "mesh" {= "0.9.4"}

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "mesh" {= "0.9.3"}
   "graphics"
 ]

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.4" & < "2.0"}
   "mesh" {= "0.9.3"}
-  "graphics"
+  "graphics" {>= "5.0.0"}
 ]
 synopsis: "Triangular mesh representation using the graphics module"
 url {

--- a/packages/mesh-graphics/mesh-graphics.0.9.4/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.4/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "mesh" {= "0.9.4"}
   "graphics"
 ]

--- a/packages/mesh-graphics/mesh-graphics.0.9.4/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.4/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.4" & < "2.0"}
   "mesh" {= "0.9.4"}
-  "graphics"
+  "graphics" {>= "5.0.0"}
 ]
 synopsis: "Triangular mesh representation using the graphics module"
 url {

--- a/packages/mesh/mesh.0.9.3/opam
+++ b/packages/mesh/mesh.0.9.3/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta9"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bigarray"
   "base-bytes"
   "lacaml" {with-test}

--- a/packages/mesh/mesh.0.9.4/opam
+++ b/packages/mesh/mesh.0.9.4/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta9"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bigarray"
   "base-bytes"
   "lacaml" {with-test}

--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -16,7 +16,7 @@ install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
 depends: [
   "ocaml" {>= "4.04"}
-  "ocamlfind"
+  "ocamlfind" {>= "1.5.3"}
   "oasis"
 ]
 depexts: [

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -16,7 +16,7 @@ install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
 depends: [
   "ocaml" {>= "4.04"}
-  "ocamlfind"
+  "ocamlfind" {>= "1.5.3"}
   "oasis"
 ]
 depexts: [

--- a/packages/mlmpfr/mlmpfr.4.0.1/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.1/opam
@@ -16,7 +16,7 @@ install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
 depends: [
   "ocaml" {>= "4.04"}
-  "ocamlfind"
+  "ocamlfind" {>= "1.5.3"}
   "oasis"
 ]
 depexts: [

--- a/packages/mlmpfr/mlmpfr.4.0.2/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.2/opam
@@ -16,7 +16,7 @@ install: [make "install"]
 remove:  ["ocamlfind" "remove" "mlmpfr"]
 depends: [
   "ocaml" {>= "4.04"}
-  "ocamlfind"
+  "ocamlfind" {>= "1.5.3"}
   "oasis"
 ]
 x-ci-accept-failures: ["debian-unstable"]

--- a/packages/moss/moss.0.1/opam
+++ b/packages/moss/moss.0.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-unix"
   "base-bytes"
   "uri"

--- a/packages/msgpck/msgpck.1.3/opam
+++ b/packages/msgpck/msgpck.1.3/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/vbmithr/ocaml-msgpck"
 bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta8"}
+  "dune" {>= "1.4" & < "2.0"}
   "ocplib-endian" {>= "1.0"}
 ]
 flags: light-uninstall

--- a/packages/msgpck/msgpck.1.4/opam
+++ b/packages/msgpck/msgpck.1.4/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/vbmithr/ocaml-msgpck"
 bug-reports: "https://github.com/vbmithr/ocaml-msgpck/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {>= "1.0+beta8"}
+  "dune" {>= "1.4" & < "2.0"}
   "ocplib-endian" {>= "1.0"}
 ]
 flags: light-uninstall

--- a/packages/ocaml-version/ocaml-version.0.1.0/opam
+++ b/packages/ocaml-version/ocaml-version.0.1.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/avsm/ocaml-version/issues"
 tags: ["org:ocamllabs"]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta10"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
 ]
 build: [

--- a/packages/orocksdb/orocksdb.0.2.2/opam
+++ b/packages/orocksdb/orocksdb.0.2.2/opam
@@ -12,7 +12,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "rocks"]
 depends: [
   "ocaml" {>= "4.02.1"}
-  "ocamlfind" {build}
+  "ocamlfind" {>= "1.5.3"}
   "conf-rocksdb"
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign" {>= "0.4.0"}

--- a/packages/ounit-lwt/ounit-lwt.2.1.2/opam
+++ b/packages/ounit-lwt/ounit-lwt.2.1.2/opam
@@ -8,6 +8,7 @@ doc: "https://gildor478.github.io/ounit/"
 depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.11.0"}
+  "ocamlfind" {>= "1.5.3"}
   "lwt"
   "ounit" {= version}
 ]

--- a/packages/ounit/ounit.2.1.2/opam
+++ b/packages/ounit/ounit.2.1.2/opam
@@ -8,6 +8,7 @@ doc: "https://gildor478.github.io/ounit/"
 depends: [
   "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.11.0"}
+  "ocamlfind" {>= "1.5.3"}
   "base-bytes"
   "base-unix"
   "stdlib-shims"

--- a/packages/re/re.1.7.2/opam
+++ b/packages/re/re.1.7.2/opam
@@ -18,7 +18,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "base-bytes"
   "ounit" {with-test}
 ]

--- a/packages/rope/rope.0.6.1/opam
+++ b/packages/rope/rope.0.6.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "benchmark" {with-test}
 ]
 synopsis: "Ropes (\"heavyweight strings\")"

--- a/packages/rope/rope.0.6/opam
+++ b/packages/rope/rope.0.6/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "base-bytes"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
   "benchmark" {with-test}
 ]
 synopsis: "Ropes (\"heavyweight strings\")"

--- a/packages/stdint/stdint.0.5.1/opam
+++ b/packages/stdint/stdint.0.5.1/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml"
   "base-bytes"
-  "jbuilder" {>= "1.0+beta7"}
+  "dune" {>= "1.4" & < "2.0"}
 ]
 synopsis: "signed and unsigned integer types having specified widths"
 description: """

--- a/packages/tube/tube.4.3.0/opam
+++ b/packages/tube/tube.4.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/alinpopa/tube.git"
 build: ["jbuilder" "build" "-p" "tube"]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder" {>= "1.0+beta15"}
+  "dune" {>= "1.4" & < "2.0"}
   "lwt" {>= "2.4.7"}
 ]
 synopsis: "Typesafe abstraction on top of Lwt_io channels"

--- a/packages/wamp-msgpck/wamp-msgpck.1.2/opam
+++ b/packages/wamp-msgpck/wamp-msgpck.1.2/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/vbmithr/ocaml-wamp"
 bug-reports: "https://github.com/vbmithr/ocaml-wamp/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {>= "1.0+beta8"}
+  "dune" {>= "1.4" & < "2.0"}
   "msgpck" {>= "1.2"}
   "wamp" {= "1.2"}
 ]


### PR DESCRIPTION
The current status is probably because `ocamlfind` before 1.5.3 did not know about bytes, but this leads to `ocamlfind` always being installed when `base-bytes` is installed - even when `ocamlfind` is not used, e.g. in setups where everything is built using dune and vendored dependencies like with opam-monorepo.

This PR changes the dependency into a conflict. Another option could be to just conflict all `ocamlfind` versions prior to 1.5.3 with `base-bytes`.