### PR TITLE
[new release] pratter (1.2.1)

### DIFF
--- a/packages/lambdapi/lambdapi.2.0.0/opam
+++ b/packages/lambdapi/lambdapi.2.0.0/opam
@@ -56,6 +56,7 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
+conflicts: [ "camlp-streams" ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/lambdapi/lambdapi.2.1.0/opam
+++ b/packages/lambdapi/lambdapi.2.1.0/opam
@@ -57,6 +57,7 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
+conflicts: [ "camlp-streams" ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/lambdapi/lambdapi.2.2.0/opam
+++ b/packages/lambdapi/lambdapi.2.2.0/opam
@@ -60,6 +60,7 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
+conflicts: [ "camlp-streams" ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/pratter/pratter.1.2.1/opam
+++ b/packages/pratter/pratter.1.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "An extended Pratt parser"
+description: """
+Pratter is a library that provides a parser that transforms
+streams of terms to applied terms.  Terms may contain infix or prefix operators
+and native applications.  The parser is based on the Pratt parsing
+algorithm and extended to handle term application and non associative
+operators."""
+maintainer: ["koizel#pratter@aleeas.com"]
+authors: ["Gabriel Hondet"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/gabrielhdt/pratter"
+bug-reports: "https://github.com/gabrielhdt/pratter/issues"
+depends: [
+  "ocaml" {>= "4.02" | with-test & >= "4.03"}
+  "dune" {>= "2.7"}
+  "camlp-streams"
+  "alcotest" {with-test}
+  "qcheck" {with-test}
+  "qcheck-alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gabrielhdt/pratter.git"
+url {
+  src:
+    "https://github.com/gabrielhdt/pratter/releases/download/1.2.1/pratter-1.2.1.tbz"
+  checksum: [
+    "sha256=7dd9a7b970d3f660a957a54ae257ac2228f8203a133f8ceb7a73ce61f0663833"
+    "sha512=040a36c6d61761701d7f93d620f5a466caa0d578f6dfb0a93028fd8f693b4abef8b22c9b7695971e21ce347865dfc84f26cc032f1c4bfc070ee6e87cd9a72318"
+  ]
+}
+x-commit-hash: "b50c511ccc2344c509076723774779db805aec88"


### PR DESCRIPTION
An extended Pratt parser

- Project page: <a href="https://github.com/gabrielhdt/pratter">https://github.com/gabrielhdt/pratter</a>

##### CHANGES:
- Property based testing with QCheck.
- Depends on `camlp-streams` (because `Stdlib.Stream` becomes deprecated in OCaml 4.14).
- New continuous integration recipe.
