### PR TITLE
Package libbinaryen.107.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.107.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.107.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "3.10.0" & < "4.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v107.0.0/libbinaryen-v107.0.0.tar.gz"
+  checksum: [
+    "md5=48dc4d70cea0afa1e9b0e65c145d68db"
+    "sha512=aae9a0ab47459e1494226c0adb3ba50d464fce42b9dfa9e73c48f3c5ef92a53b2dcc709335cbba9e80411bc09007daa3ba5b07874aae4eed5f6a6dda934af402"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.107.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [107.0.0](https://github.com/grain-lang/libbinaryen/compare/v106.0.0...v107.0.0) (2022-05-06)


### ⚠ BREAKING CHANGES

* Update binaryen to version_107 ([#57](https://github.com/grain-lang/libbinaryen/issues/57))

### Features

* Update binaryen to version_107 ([#57](https://github.com/grain-lang/libbinaryen/issues/57)) ([48090d5](https://github.com/grain-lang/libbinaryen/commit/48090d541df71df4a13766543beca7a5b559c10f))

---
:camel: Pull-request generated by opam-publish v2.0.3