### PR TITLE
phylogenetics 0.1.0: add upper bound on core

### DIFF
--- a/packages/phylogenetics/phylogenetics.0.1.0/opam
+++ b/packages/phylogenetics/phylogenetics.0.1.0/opam
@@ -9,8 +9,8 @@ bug-reports: "https://github.com/biocaml/phylogenetics/issues"
 depends: [
   "alcotest" {with-test}
   "angstrom-unix"
-  "biocaml" {>= "0.8.0" & < "0.11.2"}
-  "core" {>= "v0.14.0"}
+  "biocaml" {>= "0.8.0"}
+  "core" {>= "v0.14.0" & < "v0.15"}
   "dune" {>= "2.7.0"}
   "gsl"
   "lacaml" {>= "10.0.2"}

--- a/packages/phylogenetics/phylogenetics.0.1.0/opam
+++ b/packages/phylogenetics/phylogenetics.0.1.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/biocaml/phylogenetics/issues"
 depends: [
   "alcotest" {with-test}
   "angstrom-unix"
-  "biocaml" {>= "0.8.0"}
+  "biocaml" {>= "0.8.0" & < "0.11.2"}
   "core" {>= "v0.14.0"}
   "dune" {>= "2.7.0"}
   "gsl"


### PR DESCRIPTION
It brings a ppx incompatibility with its update to js v0.15 ecosystem.
Seen on https://github.com/ocaml/opam-repository/pull/21338

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>