### PR TITLE
`EndianBytes` exists since ocplib-endian 0.6

### DIFF
--- a/packages/afl-persistent/afl-persistent.1.1/opam
+++ b/packages/afl-persistent/afl-persistent.1.1/opam
@@ -10,7 +10,7 @@ build:
            "--pinned" "%{pinned}%"]]
 depends: [
   "ocaml" {>= "4.05"}
-  "topkg" {build & >= "0.7.4"}
+  "topkg" {build & >= "0.7.6"}
   "base-unix"
 ]
 synopsis: "use afl-fuzz in persistent mode"

--- a/packages/cohttp/cohttp.5.0.0/opam
+++ b/packages/cohttp/cohttp.5.0.0/opam
@@ -44,7 +44,7 @@ depends: [
   "fmt" {with-test}
   "jsonm" {build}
   "alcotest" {with-test}
-  "crowbar" {with-test}
+  "crowbar" {with-test & >= "0.2"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -32,7 +32,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "jbuilder" {>= "1.0+beta6"}
-  "ocplib-endian"
+  "ocplib-endian" {>= "0.6"}
   "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "afl-persistent" {>= "1.1"}
   "calendar" {with-test & >= "2.00"}

--- a/packages/crowbar/crowbar.0.2.1/opam
+++ b/packages/crowbar/crowbar.0.2.1/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/stedolan/crowbar/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
-  "ocplib-endian"
+  "ocplib-endian" {>= "0.6"}
   "cmdliner" {>= "1.1.0"}
   "afl-persistent" {>= "1.1"}
   "calendar" {>= "2.00" & with-test}

--- a/packages/crowbar/crowbar.0.2/opam
+++ b/packages/crowbar/crowbar.0.2/opam
@@ -20,7 +20,7 @@ run-test: [
 depends: [
   "dune" {>= "1.1"}
   "ocaml" {>= "4.08"}
-  "ocplib-endian"
+  "ocplib-endian" {> "0.6"}
   "cmdliner" {>= "0.9.8" & < "1.1.0"}
   "afl-persistent" {>= "1.1"}
   "calendar" {with-test & >= "2.00"}

--- a/packages/optint/optint.0.0.3/opam
+++ b/packages/optint/optint.0.0.3/opam
@@ -24,6 +24,7 @@ depends: [
   "crowbar" {with-test & >= "0.2"}
   "fmt" {with-test}
 ]
+available: arch != "arm32" & arch != "x86_32"
 url {
   src:
     "https://github.com/mirage/optint/releases/download/v0.0.3/optint-v0.0.3.tbz"

--- a/packages/optint/optint.0.0.3/opam
+++ b/packages/optint/optint.0.0.3/opam
@@ -21,7 +21,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
-  "crowbar" {with-test}
+  "crowbar" {with-test & >= "0.2"}
   "fmt" {with-test}
 ]
 url {

--- a/packages/optint/optint.0.0.4/opam
+++ b/packages/optint/optint.0.0.4/opam
@@ -16,7 +16,7 @@ Implementation depends on target architecture.
 """
 
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {arch != "arm32" & arch != "x86_32"}
 
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/optint/optint.0.0.4/opam
+++ b/packages/optint/optint.0.0.4/opam
@@ -21,7 +21,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune"
-  "crowbar" {with-test}
+  "crowbar" {with-test & >= "0.2"}
   "fmt" {with-test}
 ]
 url {

--- a/packages/tezos-stdlib/tezos-stdlib.8.0/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.8.0/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib/tezos-stdlib.8.1/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.8.1/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib/tezos-stdlib.8.2/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.8.2/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib/tezos-stdlib.8.3/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.8.3/opam
@@ -16,7 +16,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/tezos-stdlib/tezos-stdlib.9.0/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-stdlib/tezos-stdlib.9.1/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.1/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-stdlib/tezos-stdlib.9.2/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.2/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-stdlib/tezos-stdlib.9.3/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.3/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-stdlib/tezos-stdlib.9.4/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.4/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-stdlib/tezos-stdlib.9.7/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.9.7/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_log" { with-test }
   "alcotest" { with-test & >= "1.1.0" }
   "alcotest-lwt" { with-test & >= "1.1.0" }
-  "crowbar" { with-test }
+  "crowbar" { with-test & >= "0.2" }
 ]
 build: [
   ["rm" "-r" "vendors"]


### PR DESCRIPTION
While working on #21333 I ran across the issue that crowbar uses `EndianBytes`, but that module only exists since ocplib-endian 0.6.

This fixes the dependency.