### PR TITLE
CSV-Lwt needs at least Lwt 2.4.7

### DIFF
--- a/packages/csv-lwt/csv-lwt.2.0/opam
+++ b/packages/csv-lwt/csv-lwt.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "jbuilder"
   "base-bytes"
   "base-unix"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "A pure OCaml library to read and write CSV files, LWT version."
 description: """

--- a/packages/csv-lwt/csv-lwt.2.1/opam
+++ b/packages/csv-lwt/csv-lwt.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "A pure OCaml library to read and write CSV files, LWT version."
 description: """

--- a/packages/csv-lwt/csv-lwt.2.2/opam
+++ b/packages/csv-lwt/csv-lwt.2.2/opam
@@ -19,7 +19,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "A pure OCaml library to read and write CSV files, LWT version"
 description: """

--- a/packages/csv-lwt/csv-lwt.2.2/opam
+++ b/packages/csv-lwt/csv-lwt.2.2/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "csv"
+  "csv" {>= "2.2" & < "2.4"}
   "dune"
   "base-bytes"
   "base-unix"

--- a/packages/csv-lwt/csv-lwt.2.3/opam
+++ b/packages/csv-lwt/csv-lwt.2.3/opam
@@ -19,7 +19,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "A pure OCaml library to read and write CSV files, LWT version"
 description: """

--- a/packages/csv-lwt/csv-lwt.2.3/opam
+++ b/packages/csv-lwt/csv-lwt.2.3/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "csv"
+  "csv" {>= "2.2" & < "2.4"}
   "dune"
   "base-bytes"
   "base-unix"

--- a/packages/csv-lwt/csv-lwt.2.4/opam
+++ b/packages/csv-lwt/csv-lwt.2.4/opam
@@ -19,7 +19,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "A pure OCaml library to read and write CSV files, LWT version"
 description: """


### PR DESCRIPTION
While working on #21333 I ran across an issue where `Lwt_io.read_into` needs to be `bytes` not `string`. This is the case starting from Lwt 2.4.7.