### PR TITLE
[new package] conf-libpcre2: pcre library is no longer maintained

### DIFF
--- a/packages/conf-libpcre2/conf-libpcre2.1/opam
+++ b/packages/conf-libpcre2/conf-libpcre2.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Philip Hazel"
+  "Zoltan Herczeg"
+]
+homepage: "https://www.pcre.org/"
+dev-repo: "git+https://github.com/PCRE2Project/pcre2.git"
+license: "BSD-3-Clause"
+build: [["pkg-config" "libpcre2"]]
+depends: ["conf-pkg-config" {build}]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depexts: [
+  ["libpcre2-dev"] {os-family = "debian"}
+  ["libpcre2-devel"] {os-distribution = "mageia"}
+  ["pcre2-devel"] {os-distribution = "centos"}
+  ["pcre2-devel"] {os-distribution = "fedora"}
+  ["pcre2-devel"] {os-distribution = "rhel"}
+  ["pcre2-devel"] {os-distribution = "ol"}
+  ["pcre2-dev"] {os-distribution = "alpine"}
+  ["pcre2-devel"] {os-family = "suse"}
+  ["pcre2"] {os-family = "arch"}
+  ["pcre2"] {os = "freebsd"}
+  ["pcre2"] {os = "macos" & os-distribution = "homebrew"}
+  ["pcre2"] {os = "win32" & os-distribution = "cygwinports"}
+]
+synopsis: "Virtual package relying on a libpcre2 system installation"
+description:
+  "This package can only install if the libpcre2 is installed on the system."
+flags: conf


### PR DESCRIPTION
pcre is no longer maintained with last release being "8.45 2021-06-15"
pcre2 was first released as "10.00 2014-01-05" and current last release "10.40 2022-04-14"
See:
- https://www.pcre.org/
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1000004

Currently, there is no such thing as a packages/pcre2 binding to succeed packages/pcre but this paves the way for such a future.
See mmottl/pcre-ocaml#25
