### PR TITLE
Require older mdx version that installs the `mdx` binary

### DIFF
--- a/packages/printbox/printbox.0.2/opam
+++ b/packages/printbox/printbox.0.2/opam
@@ -4,6 +4,7 @@ synopsis:
 maintainer: "simon.cruanes.2007@m4x.org"
 authors: ["Simon Cruanes" "Guillaume Bury"]
 tags: ["print" "box" "table" "tree"]
+license: "BSD-2-Clause"
 homepage: "https://github.com/c-cube/printbox/"
 bug-reports: "https://github.com/c-cube/printbox/issues/"
 depends: [

--- a/packages/printbox/printbox.0.2/opam
+++ b/packages/printbox/printbox.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "base-bytes"
   "odoc" {with-doc}
   "ocaml" {>= "4.03" & < "5.0"}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 depopts: ["tyxml"]
 build: [

--- a/packages/printbox/printbox.0.2/opam
+++ b/packages/printbox/printbox.0.2/opam
@@ -7,7 +7,7 @@ tags: ["print" "box" "table" "tree"]
 homepage: "https://github.com/c-cube/printbox/"
 bug-reports: "https://github.com/c-cube/printbox/issues/"
 depends: [
-  "dune" {< "3.0"}
+  "dune" {>= "1.1" & < "3.0"}
   "base-bytes"
   "odoc" {with-doc}
   "ocaml" {>= "4.03" & < "5.0"}


### PR DESCRIPTION
The error I ran across in #21333 is the following:
```
File "dune", line 6, characters 15-18:
6 |           (run mdx test %{deps})
                   ^^^
Error: Program mdx not found in the tree or in PATH
 (context: default)
```

It has nothing to do with the original PR so this is a separate fix.