### PR TITLE
Do not run tests of `docker-api.0.1`

### DIFF
--- a/packages/docker-api/docker-api.0.1/opam
+++ b/packages/docker-api/docker-api.0.1/opam
@@ -8,9 +8,6 @@ bug-reports: "https://github.com/Chris00/ocaml-docker/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 install: ["ocaml" "setup.ml" "-install"]
@@ -22,7 +19,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "ocamlbuild" {build}
-  "ocamlfind" {build & >= "1.5"}
+  "ocamlfind" {build & >= "1.5.3"}
   "yojson"
 ]
 synopsis: "Binding to the Docker Remote API"


### PR DESCRIPTION
`docker-api.0.1` seems to be failing to build. Upon checking it is due to the tests not being included in the tarball. This PR removes the calls to build and run tests.