### PR TITLE
Do not allow co-installation with ounit1 with different version

### DIFF
--- a/packages/ounit2/ounit2.2.2.0/opam
+++ b/packages/ounit2/ounit2.2.2.0/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}

--- a/packages/ounit2/ounit2.2.2.1/opam
+++ b/packages/ounit2/ounit2.2.2.1/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}

--- a/packages/ounit2/ounit2.2.2.2/opam
+++ b/packages/ounit2/ounit2.2.2.2/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}

--- a/packages/ounit2/ounit2.2.2.3/opam
+++ b/packages/ounit2/ounit2.2.2.3/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/ounit2/ounit2.2.2.4/opam
+++ b/packages/ounit2/ounit2.2.2.4/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/ounit2/ounit2.2.2.5/opam
+++ b/packages/ounit2/ounit2.2.2.5/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/ounit2/ounit2.2.2.6/opam
+++ b/packages/ounit2/ounit2.2.2.6/opam
@@ -14,6 +14,9 @@ depends: [
   "seq"
   "stdlib-shims"
 ]
+conflicts: [
+  "ounit" {!= version}
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}


### PR DESCRIPTION
While building
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/aa898f09e7ffe95265651b4b2dda4d21d91baa19/variant/opam-2.1,compilers,4.14,ounit.2.1.2,revdeps,bencode.2.0 it turns out that ounit 2.1.2 was installed via one dependency and ounit2 2.2.6 via another. This fails to link since the symbols exist twice.

So while ounit1 should depend on ounit2 after the transition, ounit2 should fail to install if version of ounit1 does not match its own version (that is, these versions are known to be compatible).