### PR TITLE
Package binaryen.0.16.0

### DIFF
--- a/packages/binaryen/binaryen.0.16.0/opam
+++ b/packages/binaryen/binaryen.0.16.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0" & < "4.14.0"}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "106.0.0" & < "107.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.16.0/binaryen-archive-v0.16.0.tar.gz"
+  checksum: [
+    "md5=5b29322e070385ab7cf527c6b251fa3d"
+    "sha512=ba9df794edc571f0ef4bfa03076f57106b05aaf9132bd6bd9b1677083ea15edebe7810860ac875c2de482e4331b099cfa33936eb490c531c410f1f627bb8795b"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.16.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.16.0](https://github.com/grain-lang/binaryen.ml/compare/v0.15.0...v0.16.0) (2022-05-11)


### ⚠ BREAKING CHANGES

* Restrict OCaml < 4.14 temporarily
* Update libbinaryen to 106 ([#151](https://github.com/grain-lang/binaryen.ml/issues/151))
* Expression.Return.get_value can be null ([#149](https://github.com/grain-lang/binaryen.ml/issues/149))

### Features

* Update libbinaryen to 106 ([#151](https://github.com/grain-lang/binaryen.ml/issues/151)) ([453b9de](https://github.com/grain-lang/binaryen.ml/commit/453b9dea8f0bda026b70f67d7c99311f9f6601e3))


### Bug Fixes

* Expression.Return.get_value can be null ([#149](https://github.com/grain-lang/binaryen.ml/issues/149)) ([559341d](https://github.com/grain-lang/binaryen.ml/commit/559341d13a7ba5abb8521f6d0d982d4f25b86ce0))


### Miscellaneous Chores

* Restrict OCaml < 4.14 temporarily ([453b9de](https://github.com/grain-lang/binaryen.ml/commit/453b9dea8f0bda026b70f67d7c99311f9f6601e3))

---
:camel: Pull-request generated by opam-publish v2.0.3