### PR TITLE
Add conf package to require LAPACKE for `owl`

### DIFF
--- a/packages/conf-lapacke/conf-lapacke.1/opam
+++ b/packages/conf-lapacke/conf-lapacke.1/opam
@@ -1,0 +1,16 @@
+opam-version: "2.0"
+maintainer: "Marek Kubica <marek@xivilization.net>"
+authors: "Marek Kubica <marek@xivilization.net>"
+homepage: "http://www.netlib.org/lapack"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+depexts: [
+  ["liblapacke-dev"] {os-family = "debian"}
+  ["lapack-dev"] {os-distribution = "alpine"}
+  ["lapacke" "gcc"] {os = "freebsd"}
+]
+synopsis: "Virtual package for LAPACKE configuration"
+description: """
+Virtual package relying on a LAPACKE (Linear Algebra) library installation.
+This package requires a LAPACKE installation on the system."""
+flags: conf

--- a/packages/owl/owl.1.0.0/opam
+++ b/packages/owl/owl.1.0.0/opam
@@ -27,6 +27,7 @@ depends: [
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.1"}
+  "conf-lapacke"
   "ctypes" {>= "0.16.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"

--- a/packages/owl/owl.1.0.1/opam
+++ b/packages/owl/owl.1.0.1/opam
@@ -27,6 +27,7 @@ depends: [
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.1"}
+  "conf-lapacke"
   "ctypes" {>= "0.16.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"

--- a/packages/owl/owl.1.0.2/opam
+++ b/packages/owl/owl.1.0.2/opam
@@ -27,6 +27,7 @@ depends: [
   "base" {build}
   "base-bigarray"
   "conf-openblas" {>= "0.2.1"}
+  "conf-lapacke"
   "ctypes" {>= "0.16.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"


### PR DESCRIPTION
As I was going through my failing revdeps in #21333, one of them was `owl`, which was failing because LAPACKE did not exist. It's always a bit of a hassle with C libraries on the CI so this PR attempts to pull the dependency out into `conf-lapacke`.

LAPACKE does not seem to be commonly packaged, but Debian has its separate package, so does FreeBSD. Alpine seems to lump it into the regular LAPACK package.