### PR TITLE
[new release] decoders, decoders-yojson, decoders-sexplib, decoders-msgpck, decoders-jsonm, decoders-ezjsonm, decoders-cbor and decoders-bencode (0.7.0)

### DIFF
--- a/packages/decoders-bencode/decoders-bencode.0.7.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders-bencode/decoders-bencode.0.7.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bencode backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Simon Cruanes <simon@imandra.ai>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "bencode"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders-bencode/decoders-bencode.0.7.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.7.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
   "decoders" {= version}
-  "bencode" {>= "0.2"}
+  "bencode" {>= "2.0"}
   "odoc" {with-doc}
   "containers" {with-test & >= "0.16"}
   "ounit" {with-test}

--- a/packages/decoders-bencode/decoders-bencode.0.7.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.7.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
   "decoders" {= version}
-  "bencode"
+  "bencode" {>= "0.2"}
   "odoc" {with-doc}
   "containers" {with-test & >= "0.16"}
   "ounit" {with-test}

--- a/packages/decoders-cbor/decoders-cbor.0.7.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.7.0/opam
@@ -17,8 +17,8 @@ depends: [
   "containers" {with-test & >= "0.16"}
   "ounit" {with-test}
 ]
+build: [
   ["dune" "subst"] {dev}
-  ["dune" "subst"] {pinned}
   [
     "dune"
     "build"

--- a/packages/decoders-cbor/decoders-cbor.0.7.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "CBOR backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "cbor"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders-cbor/decoders-cbor.0.7.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.7.0/opam
@@ -17,7 +17,7 @@ depends: [
   "containers" {with-test & >= "0.16"}
   "ounit" {with-test}
 ]
-build: [
+  ["dune" "subst"] {dev}
   ["dune" "subst"] {pinned}
   [
     "dune"

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.7.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.7.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Ezjsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "ezjsonm" {>= "0.4.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders-jsonm/decoders-jsonm.0.7.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders-jsonm/decoders-jsonm.0.7.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Jsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "jsonm"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
@@ -30,7 +30,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version >= "4.08"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Msgpck backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: [
+  "Matt Bray <mattjbray@gmail.com>" "Simon Cruanes <simon@imandra.ai>"
+]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "msgpck"
+  "ocplib-endian" {>= "0.6"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
   "decoders" {= version}
-  "msgpck"
+  "msgpck" {>= "1.3"}
   "ocplib-endian" {>= "0.6"}
   "odoc" {with-doc}
   "containers" {with-test & >= "0.16"}

--- a/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.7.0/opam
@@ -21,7 +21,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders-sexplib/decoders-sexplib.0.7.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.7.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders-sexplib/decoders-sexplib.0.7.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.7.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Sexplib backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "sexplib0"
+  "sexplib"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders-yojson/decoders-yojson.0.7.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ounit" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders-yojson/decoders-yojson.0.7.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yojson backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "decoders" {= version}
+  "yojson" {>= "1.6.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"

--- a/packages/decoders/decoders.0.7.0/opam
+++ b/packages/decoders/decoders.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "containers" {with-test & >= "0.16"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/decoders/decoders.0.7.0/opam
+++ b/packages/decoders/decoders.0.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elm-inspired decoders for Ocaml"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v0.7.0/decoders-0.7.0.tbz"
+  checksum: [
+    "sha256=913db33fd532ee7a322e08db7ffef2bfb1aaa7a5fe63ae50ff92e6fdff6651a5"
+    "sha512=2954b1cd17f8b314ffc5ef88b8afeae0cbe1fa8adcd7fd224499d0fb7c9555ea15deb83030e54660d9e4a4eb4e50840978904a2479ade326ed8568ef49112bd7"
+  ]
+}
+x-commit-hash: "c3e4f487b80915b41d4c902a703f454b67d92dea"


### PR DESCRIPTION
Elm-inspired decoders for Ocaml

- Project page: <a href="https://github.com/mattjbray/ocaml-decoders">https://github.com/mattjbray/ocaml-decoders</a>
- Documentation: <a href="https://mattjbray.github.io/ocaml-decoders/">https://mattjbray.github.io/ocaml-decoders/</a>

##### CHANGES:

* Add `Decode.field_opt_or` (mattjbray/ocaml-decoders#43, @c-cube)
* Add `Decode.pick` (mattjbray/ocaml-decoders#43, @c-cube)
* Add `Decode.decode_sub` (mattjbray/ocaml-decoders#45, @c-cube)

### `bs-decoders`

* Improve `int` decoder (@actionshrimp)

### `decoders-yojson`

* Move away from deprecated `Yojson.json` to `Yojson.t` (mattjbray/ocaml-decoders#37, @idkjs)
