### PR TITLE
Add LAPACKE-containing packages of Alpine and FreeBSD

### DIFF
--- a/packages/conf-openblas/conf-openblas.0.2.1/opam
+++ b/packages/conf-openblas/conf-openblas.0.2.1/opam
@@ -22,14 +22,14 @@ build: [
     {os-distribution != "fedora" & os-distribution != "centos" & os-family != "suse" & os != "macos" & os-family != "arch" & os != "freebsd" & os != "win32"}
 ]
 depexts: [
-  ["libc-dev" "openblas-dev"] {os-distribution = "alpine"}
+  ["libc-dev" "openblas-dev" "lapack-dev"] {os-distribution = "alpine"}
   ["epel-release" "openblas-devel"] {os-distribution = "centos"}
   ["libopenblas-dev" "liblapacke-dev"] {os-family = "debian"}
   ["openblas-devel"] {os-distribution = "fedora"}
   ["openblas-devel"] {os-family = "suse"}
   ["openblas" "lapacke" "cblas"] {os-distribution = "arch"}
   ["openblas"] {os = "macos" & os-distribution = "homebrew"}
-  ["openblas"] {os = "freebsd"}
+  ["openblas" "lapacke"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7"


### PR DESCRIPTION
As discussed in #21358 this adds the packages that contain LAPACKE in Alpine and FreeBSD. Debian already had `liblapacke-dev`, so no change required there.