### PR TITLE
Package binaryen.0.17.0

### DIFF
--- a/packages/binaryen/binaryen.0.17.0/opam
+++ b/packages/binaryen/binaryen.0.17.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0" & < "4.14.0"}
+  "dune" {>= "2.9.1" & < "3.0.0"}
+  "dune-configurator" {>= "2.9.1" & < "3.0.0"}
+  "js_of_ocaml-compiler" {>= "3.10.0" & < "4.0.0"}
+  "libbinaryen" {>= "107.0.0" & < "108.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.17.0/binaryen-archive-v0.17.0.tar.gz"
+  checksum: [
+    "md5=2a8289aae5154ba8d069099da0658bb2"
+    "sha512=616530b039a955382812ba1d64b3e21e77375087f129a980619d7f6dcdf02c6f8876b41f4e35c17b24bd12f6f3f372a5b19095ca5848c190a4837b16faae1340"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.17.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.17.0](https://github.com/grain-lang/binaryen.ml/compare/v0.16.0...v0.17.0) (2022-05-11)


### ⚠ BREAKING CHANGES

* Update libbinaryen to 107 ([#152](https://github.com/grain-lang/binaryen.ml/issues/152))

### Features

* Add merge_similar_functions pass ([#154](https://github.com/grain-lang/binaryen.ml/issues/154)) ([54b03fd](https://github.com/grain-lang/binaryen.ml/commit/54b03fd854311f49aa1821868a8265116be922c2))
* Add signature_pruning pass ([#155](https://github.com/grain-lang/binaryen.ml/issues/155)) ([206b6cf](https://github.com/grain-lang/binaryen.ml/commit/206b6cf0ade48a778f4e991cf5d2ab0daf559bf8))
* Add support for extended_const feature ([260c2a1](https://github.com/grain-lang/binaryen.ml/commit/260c2a131a08720eac0f21abf68689fd201eb753))
* Update libbinaryen to 107 ([#152](https://github.com/grain-lang/binaryen.ml/issues/152)) ([260c2a1](https://github.com/grain-lang/binaryen.ml/commit/260c2a131a08720eac0f21abf68689fd201eb753))

---
:camel: Pull-request generated by opam-publish v2.0.3