### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.11.5)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.11.5/opam
+++ b/packages/jsonrpc/jsonrpc.1.11.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.11.5/jsonrpc-1.11.5.tbz"
+  checksum: [
+    "sha256=567c8c89a511ee511c6c11dfbe920f2cea11b8701081a692f4b032f9ba8e03fd"
+    "sha512=e3436c8a7fca4b63306bbbfd64eecfcc00dd68b7e25a99511a32a7877f336622bf73a5be0058c55613c14efafa54da16e22acbd12e7904bb8f3496693f191980"
+  ]
+}
+x-commit-hash: "55d06b21fbb0597f2406e5441cf3c13d1c9b7250"

--- a/packages/lsp/lsp.1.11.5/opam
+++ b/packages/lsp/lsp.1.11.5/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "jsonrpc" {= version}
+  "dyn"
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "menhir" {"20211230" >= with-test}
+  "ppx_expect" {"v0.14.0" >= with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.11.5/jsonrpc-1.11.5.tbz"
+  checksum: [
+    "sha256=567c8c89a511ee511c6c11dfbe920f2cea11b8701081a692f4b032f9ba8e03fd"
+    "sha512=e3436c8a7fca4b63306bbbfd64eecfcc00dd68b7e25a99511a32a7877f336622bf73a5be0058c55613c14efafa54da16e22acbd12e7904bb8f3496693f191980"
+  ]
+}
+x-commit-hash: "55d06b21fbb0597f2406e5441cf3c13d1c9b7250"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.11.5/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.11.5/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinerg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc"
+  "dyn"
+  "stdune"
+  "fiber"
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "omd" {<= "1.3.1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14" & < "4.15"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.11.5/jsonrpc-1.11.5.tbz"
+  checksum: [
+    "sha256=567c8c89a511ee511c6c11dfbe920f2cea11b8701081a692f4b032f9ba8e03fd"
+    "sha512=e3436c8a7fca4b63306bbbfd64eecfcc00dd68b7e25a99511a32a7877f336622bf73a5be0058c55613c14efafa54da16e22acbd12e7904bb8f3496693f191980"
+  ]
+}
+x-commit-hash: "55d06b21fbb0597f2406e5441cf3c13d1c9b7250"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

- Fix process termination. Once the lsp server is stepped, the process will
  gracefully terminate (ocaml/ocaml-lsp#697, fixes ocaml/ocaml-lsp#694)

- Forward stderr from dune's merlin configuration to the lsp server's stderr
  (ocaml/ocaml-lsp#697)
