### PR TITLE
Fix minimal version of `irc-client-lwt`

### DIFF
--- a/packages/irc-client/irc-client.0.4.0/opam
+++ b/packages/irc-client/irc-client.0.4.0/opam
@@ -29,7 +29,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.00.1"}
-  "oasis" {build & >= "0.4.11"}
+  "oasis" {build & >= "0.4.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "result"

--- a/packages/irc-client/irc-client.0.5.0/opam
+++ b/packages/irc-client/irc-client.0.5.0/opam
@@ -29,7 +29,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.00.1"}
-  "oasis" {build & >= "0.4.11"}
+  "oasis" {build & >= "0.4.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "result"

--- a/packages/irc-client/irc-client.0.5.1/opam
+++ b/packages/irc-client/irc-client.0.5.1/opam
@@ -29,7 +29,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.00.1"}
-  "oasis" {build & >= "0.4.11"}
+  "oasis" {build & >= "0.4.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "result"

--- a/packages/irc-client/irc-client.0.5.2/opam
+++ b/packages/irc-client/irc-client.0.5.2/opam
@@ -29,7 +29,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.00.1"}
-  "oasis" {build & >= "0.4.11"}
+  "oasis" {build & >= "0.4.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "result"

--- a/packages/irc-client/irc-client.0.5.4/opam
+++ b/packages/irc-client/irc-client.0.5.4/opam
@@ -29,7 +29,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.00.1"}
-  "oasis" {build & >= "0.4.11"}
+  "oasis" {build & >= "0.4.2"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "result"


### PR DESCRIPTION
`irc-client-lwt` fails on building `irc-client` 0.4.0 which fails because building the latter fails on an OASIS error.

This PR attempts to fix the build by using a newer version of OASIS, but it is unclear whether that will fix the build or the constraint will have to be raised.