### PR TITLE
Fix minimum version of SSL dependency for Lwt_ssl

### DIFF
--- a/packages/lwt_ssl/lwt_ssl.1.1.1/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.1/opam
@@ -23,7 +23,7 @@ depends: [
   "base-unix"
   "jbuilder" {>= "1.0+beta10"}
   "lwt" {>= "3.0.0"}
-  "ssl" {>= "0.5.0"}
+  "ssl" {>= "0.5.3"}
 ]
 synopsis: "Lwt-friendly OpenSSL bindings"
 url {

--- a/packages/lwt_ssl/lwt_ssl.1.1.2/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.2/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "jbuilder" {>= "1.0+beta10"}
   "lwt" {>= "3.0.0"}
-  "ssl" {>= "0.5.0"}
+  "ssl" {>= "0.5.3"}
 ]
 build: [
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/lwt_ssl/lwt_ssl.1.1.3/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.1.3/opam
@@ -19,7 +19,7 @@ depends: [
   "dune"
   "lwt" {>= "3.0.0"}
   "ocaml"
-  "ssl" {>= "0.5.0"}
+  "ssl" {>= "0.5.3"}
 ]
 
 build: [


### PR DESCRIPTION
It currently fails to compile with `invalid use of incomplete typedef 'X509_STORE_CTX'` and `ssl.0.5.3` seems to solve this differently, so upgrading the dependency might solve the issue at hand.