### PR TITLE
Fix lower-version `dokeysto` packaging issues

### DIFF
--- a/packages/camltc/camltc.0.9.8/opam
+++ b/packages/camltc/camltc.0.9.8/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {> "4.02.3"}
   "dune" {>= "1.1.0"}
   "lwt" {>= "3.2.0"}
-  "logs"
+  "logs" {>= "0.5.0"}
   "ounit" {with-test}
 ]
 patches: "osx.patch" {os = "macos"}

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -11,6 +11,7 @@ depexts: [
   ["lz4-devel"] {os-distribution = "centos"}
   ["lz4-devel"] {os-distribution = "rhel"}
   ["lz4-devel"] {os-distribution = "fedora"}
+  ["lz4-devel"] {os-distribution = "oraclelinux-8"}
   ["lz4-dev"] {os-distribution = "alpine"}
   ["liblz4-devel"] {os-family = "suse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -11,7 +11,7 @@ depexts: [
   ["lz4-devel"] {os-distribution = "centos"}
   ["lz4-devel"] {os-distribution = "rhel"}
   ["lz4-devel"] {os-distribution = "fedora"}
-  ["lz4-devel"] {os-distribution = "oraclelinux-8"}
+  ["lz4-devel"] {os-distribution = "ol"}
   ["lz4-dev"] {os-distribution = "alpine"}
   ["liblz4-devel"] {os-family = "suse"}
   ["lz4"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/dokeysto/dokeysto.2.0.0/opam
+++ b/packages/dokeysto/dokeysto.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta19"}
   "base-bytes"
   "base-unix"
-  "extunix"
+  "extunix" {>= "0.2.0"}
 ]
 synopsis: "the dumb OCaml key-value store"
 description: """

--- a/packages/dokeysto/dokeysto.2.0.0/opam
+++ b/packages/dokeysto/dokeysto.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta19"}
   "base-bytes"
   "base-unix"
-  "extunix" {>= "0.2.0"}
+  "extunix"
 ]
 synopsis: "the dumb OCaml key-value store"
 description: """

--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.0/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"
   "dune" {< "2.0"}
   "dokeysto"
-  "camltc"
+  "camltc" {>= "0.9.8"}
 ]
 synopsis: "the dumb OCaml key-value store w/ tokyocabinet backend"
 description: "dokeysto with tokyocabinet backend (camltc package in opam)"

--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.1/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.0" & < "3.0"}
   "dokeysto"
-  "camltc"
+  "camltc" {>= "0.9.8"}
 ]
 synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
 description: "dokeysto with tokyocabinet backend (camltc package in opam)"

--- a/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.3.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.11"}
   "dokeysto"
-  "camltc"
+  "camltc" {>= "0.9.8"}
 ]
 synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
 description: "dokeysto with tokyocabinet backend (camltc package in opam)"

--- a/packages/dokeysto_camltc/dokeysto_camltc.4.0.0/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.4.0.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "1.11"}
-  "dokeysto"
+  "dokeysto" {>= "4.0.0"}
   "camltc"
 ]
 synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"

--- a/packages/dokeysto_camltc/dokeysto_camltc.4.0.0/opam
+++ b/packages/dokeysto_camltc/dokeysto_camltc.4.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml"
   "dune" {>= "1.11"}
   "dokeysto" {>= "4.0.0"}
-  "camltc"
+  "camltc" {>= "0.9.8"}
 ]
 synopsis: "The dumb OCaml key-value store w/ tokyocabinet backend"
 description: "dokeysto with tokyocabinet backend (camltc package in opam)"

--- a/packages/dokeysto_lz4/dokeysto_lz4.4.0.0/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.4.0.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "1.11"}
-  "dokeysto"
+  "dokeysto" {>= "4.0.0"}
   "minicli" {>= "5.0.0"}
   "lz4"
 ]

--- a/packages/extunix/extunix.0.1.1/opam
+++ b/packages/extunix/extunix.0.1.1/opam
@@ -44,7 +44,7 @@ depends: [
   "ocamlfind" {build}
   "camlp4" {build}
   "ounit" {with-test}
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.1/opam
+++ b/packages/extunix/extunix.0.1.1/opam
@@ -44,7 +44,7 @@ depends: [
   "ocamlfind" {build}
   "camlp4" {build}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.2/opam
+++ b/packages/extunix/extunix.0.1.2/opam
@@ -48,7 +48,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.2/opam
+++ b/packages/extunix/extunix.0.1.2/opam
@@ -48,7 +48,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.3/opam
+++ b/packages/extunix/extunix.0.1.3/opam
@@ -48,7 +48,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.3/opam
+++ b/packages/extunix/extunix.0.1.3/opam
@@ -48,7 +48,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.4/opam
+++ b/packages/extunix/extunix.0.1.4/opam
@@ -49,7 +49,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.4/opam
+++ b/packages/extunix/extunix.0.1.4/opam
@@ -49,7 +49,7 @@ depends: [
   "ounit" {with-test & >= "1.0.3"}
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.5/opam
+++ b/packages/extunix/extunix.0.1.5/opam
@@ -49,7 +49,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.5/opam
+++ b/packages/extunix/extunix.0.1.5/opam
@@ -49,7 +49,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.6/opam
+++ b/packages/extunix/extunix.0.1.6/opam
@@ -51,7 +51,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.1.6/opam
+++ b/packages/extunix/extunix.0.1.6/opam
@@ -51,7 +51,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.2.0/opam
+++ b/packages/extunix/extunix.0.2.0/opam
@@ -47,7 +47,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.2.0/opam
+++ b/packages/extunix/extunix.0.2.0/opam
@@ -47,7 +47,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "base-unix"
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Collection of thin bindings to various low-level system API"
 description: """

--- a/packages/extunix/extunix.0.2.0/opam
+++ b/packages/extunix/extunix.0.2.0/opam
@@ -42,7 +42,7 @@ install: [
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "ocaml-migrate-parsetree" {build & < "2.0.0"}
+  "ocaml-migrate-parsetree" {build & >= "1.8.0" & < "2.0.0"}
   "ounit" {with-test & >= "1.0.3"}
   "base-bytes"
   "base-bigarray"

--- a/packages/lz4/lz4.1.0.0/opam
+++ b/packages/lz4/lz4.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
   "base-bytes"
   "ocamlfind" {build}
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
   "ctypes" {>= "0.3.2" & < "0.4.0"}
   "conf-liblz4"
 ]

--- a/packages/lz4/lz4.1.0.0/opam
+++ b/packages/lz4/lz4.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
   "base-bytes"
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
   "ctypes" {>= "0.3.2" & < "0.4.0"}
   "conf-liblz4"
 ]

--- a/packages/lz4/lz4.1.0.1/opam
+++ b/packages/lz4/lz4.1.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "ctypes" {>= "0.4.0" & < "0.6.0"}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
   "conf-liblz4"
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/lz4/lz4.1.0.1/opam
+++ b/packages/lz4/lz4.1.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "base-bytes"
   "ocamlfind" {build}
   "ctypes" {>= "0.4.0" & < "0.6.0"}
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
   "conf-liblz4"
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/lz4/lz4.1.1.0/opam
+++ b/packages/lz4/lz4.1.1.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes" {>= "0.4.1" & < "0.6.0"}
   "ounit" {with-test}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
   "conf-liblz4"
 ]
 install: ["ocaml" "setup.ml" "-install"]

--- a/packages/lz4/lz4.1.1.1/opam
+++ b/packages/lz4/lz4.1.1.1/opam
@@ -30,7 +30,7 @@ depends: [
   "base-bytes"
   "base-bigarray"
   "ocamlfind" {build}
-  "ocamlbuild" {build & >= "0.9.1"}
+  "ocamlbuild" {build & != "0.9.0"}
   "ctypes" {>= "0.4.1"}
   "ounit" {with-test}
   "conf-liblz4"

--- a/packages/lz4/lz4.1.1.1/opam
+++ b/packages/lz4/lz4.1.1.1/opam
@@ -28,6 +28,7 @@ remove: ["ocamlfind" "remove" "lz4"]
 depends: [
   "ocaml"
   "base-bytes"
+  "base-bigarray"
   "ocamlfind" {build}
   "ocamlbuild" {build & >= "0.9.1"}
   "ctypes" {>= "0.4.1"}

--- a/packages/lz4/lz4.1.1.1/opam
+++ b/packages/lz4/lz4.1.1.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocaml"
   "base-bytes"
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & >= "0.9.1"}
   "ctypes" {>= "0.4.1"}
   "ounit" {with-test}
   "conf-liblz4"


### PR DESCRIPTION
With extunix.0.1.1 if fails with dozens of messages like

```
gcc: error: src/eventfd.o: No such file or directory
```