### PR TITLE
Package ometrics.0.2.1

### DIFF
--- a/packages/ometrics/ometrics.0.2.1/opam
+++ b/packages/ometrics/ometrics.0.2.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+license: "MIT"
+maintainer: "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+homepage: "https://gitlab.com/nomadic-labs/ometrics"
+dev-repo: "git+https://gitlab.com/nomadic-labs/ometrics.git"
+bug-reports: "https://gitlab.com/nomadic-labs/ometrics/-/issues"
+synopsis: "OCaml analysis in a merge request changes"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.9.1"}
+  "ppxlib" {>= "0.24.0" & < "0.26.0"}
+  "cmdliner" {>= "1.0.0"}
+  "digestif" {>= "0.7.2"}
+  "qcheck-alcotest" {with-test & >= "0.18"}
+  "bisect_ppx" {dev & >= "2.6.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+authors: [
+  "Thomas Letan <lthms@nomadic-labs.com>"
+  "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
+]
+url {
+  src: "https://github.com/vch9/ometrics/archive/0.2.1.tar.gz"
+  checksum: [
+    "md5=723b7123a7468e116e83b034e1d59f60"
+    "sha512=b785e1f878c9432dabdc437e5c9c96724f097b79d1c8aaf1f465fbf6b6ae35f240d77a2294f31a10ba39a56065056a5befd3641adf93aee56cf5d519ce2a955f"
+  ]
+}


### PR DESCRIPTION
### `ometrics.0.2.1`
OCaml analysis in a merge request changes



---
* Homepage: https://gitlab.com/nomadic-labs/ometrics
* Source repo: git+https://gitlab.com/nomadic-labs/ometrics.git
* Bug tracker: https://gitlab.com/nomadic-labs/ometrics/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0