### PR TITLE
[new release] albatross (1.5.0)

### DIFF
--- a/packages/albatross/albatross.1.5.0/opam
+++ b/packages/albatross/albatross.1.5.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.0.4"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+available: os != "macos"
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.5.0/albatross-1.5.0.tbz"
+  checksum: [
+    "sha256=adaca5b25498a607aa68c371eb7ab1105a9360174d8fe8634487bc87ed3173e5"
+    "sha512=7dba5aa68c40f2646fe03114424b9bc4bb14da2f905009b628bfaa05f63a7a70e8d3ca04161ce02455d915d4a599bc5d12b27ad0622a33d33f529ea1d4b6bac3"
+  ]
+}
+x-commit-hash: "7a68addb43ef92fd6cc6ee9f555fdfed6d0b861d"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- Revise Name.t to use ':' as path separation, and allow '.' in labels.
  Previously the path was built by the common name in the X.509 certificate
  chain and the leaf certificate was appended (i.e. chain certificate "foo",
  chain certificate "bar", leaf certificate "my.unikernel" lead to the name
  "foo.bar.my.unikernel" -- and chain certificate "foo", leaf "bar.my.unikernel"
  lead to the identical name). Since the holder of the certificate and private
  key "foo" could issue at any point another intermediate certificate for "bar",
  this is not security critical -- but for resource management this was
  confusing and lead to some issues (policy could be violated).
  Now, the path separator is ':' (i.e. "foo:bar:my.unikernel" and
  "foo:bar.my.unikernel").
  In addition, various test cases have been added, for vmm_trie, vmm_resources
  and also for old and new wire versions (albatross daemon state, command
  execution) to ensure that old clients continue to work with new server
  components. The wire version has been bumped to WV5, since the Name.t encoding
  was changed. (roburio/albatross#111, @hannesm @reynir)
- systemd: fifo are created by albatross_daemon (not albatross_console) (roburio/albatross#106,
  @reynir)
- systemd: cleanup, use group albatross, (roburio/albatross#108, fixes roburio/albatross#105, @reynir)
- documentation: remove solo5-elftool requirement -- since 1.4.0
  ocaml-solo5-elftool is used (roburio/albatross#109 @hannesm)
- CI execute tests (roburio/albatross#112, @hannesm)
- fix URL to builder-web (https://builds.robur.coop) which dropped the
  opam-switch postfix in the URL (roburio/albatross#113 @hannesm)
- albatross-client-local, albatross-client-bistro: support remote (socket/host)
  '-' to output the command as hexdump (PEM file) on standard output (@hannesm)
