### PR TITLE
owl.1.0.2: release owl 1.0.2-1 with patch to fix systems providing liblapacke separately

### DIFF
--- a/packages/owl-top/owl-top.1.0.2/opam
+++ b/packages/owl-top/owl-top.1.0.2/opam
@@ -18,8 +18,8 @@ depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.0.0"}
   "ocaml-compiler-libs"
-  "owl" {= version}
-  "owl-zoo" {= version}
+  "owl" {= version | = "1.0.2-1"}
+  "owl-zoo" {= version | = "1.0.2-1"}
 ]
 x-commit-hash: "dc77f1d3b7a4b81beba5bcfc4366317e044bce6d"
 url {

--- a/packages/owl-zoo/owl-zoo.1.0.2/opam
+++ b/packages/owl-zoo/owl-zoo.1.0.2/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml" {>= "4.10.0" & < "4.14.0"}
   "dune" {>= "2.0.0"}
   "ocaml-compiler-libs"
-  "owl" {= version}
+  "owl" {= version | = "1.0.2-1"}
 ]
 x-commit-hash: "dc77f1d3b7a4b81beba5bcfc4366317e044bce6d"
 url {

--- a/packages/owl/owl.1.0.2-1/files/0001-Revert-update-config-file-for-publication.patch
+++ b/packages/owl/owl.1.0.2-1/files/0001-Revert-update-config-file-for-publication.patch
@@ -1,0 +1,29 @@
+From 98e01498dd1318fc7d812ca7067fd4728384fdaa Mon Sep 17 00:00:00 2001
+From: Marcello Seri <marcello.seri@gmail.com>
+Date: Mon, 16 May 2022 20:21:32 +0200
+Subject: [PATCH] Revert "update config file for publication"
+
+This reverts commit 93e706d6c0e2c4dc2fbef66208c4024b49c2d9dd.
+
+Signed-off-by: Marcello Seri <marcello.seri@gmail.com>
+---
+ src/owl/config/configure.ml | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/owl/config/configure.ml b/src/owl/config/configure.ml
+index 190926d7..1f9e3444 100644
+--- a/src/owl/config/configure.ml
++++ b/src/owl/config/configure.ml
+@@ -235,8 +235,7 @@ some details on how your openblas has been installed and the output of
+               ~link_flags:(openblas_conf.libs @ [ "-lm" ])
+             |> not
+         in
+-        (* if needs_lapacke_flag then [ "-llapacke" ] else [] *)
+-        if needs_lapacke_flag then [ ] else []
++        if needs_lapacke_flag then [ "-llapacke" ] else []
+       in
+       let openmp_config = get_openmp_config c in
+       (* configure link options *)
+-- 
+2.30.1 (Apple Git-130)
+

--- a/packages/owl/owl.1.0.2-1/opam
+++ b/packages/owl/owl.1.0.2-1/opam
@@ -37,7 +37,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "dune-configurator"
   "eigen" {>= "0.3.0"}
-  "owl-base" {= version}
+  "owl-base" {= "1.0.2"}
   "stdio" {build}
   "npy"
 ]

--- a/packages/owl/owl.1.0.2-1/opam
+++ b/packages/owl/owl.1.0.2-1/opam
@@ -18,13 +18,28 @@ Recently, Owl has implemented algorithmic differentiation which essentially make
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+patches: "0001-Revert-update-config-file-for-publication.patch"
+
+extra-files: [
+  ["0001-Revert-update-config-file-for-publication.patch" "sha256=333c7a2ee46380faee42b419acdd236953b8d5e081f2e945807b12c430345949"]
 ]
 
 depends: [
   "ocaml" {>= "4.10.0"}
+  "alcotest" {with-test}
+  "base" {build}
+  "base-bigarray"
+  "conf-openblas" {>= "0.2.1"}
+  "ctypes" {>= "0.16.0"}
   "dune" {>= "2.0.0"}
-  "owl" {= version | = "1.0.2-1"}
-  "plplot"
+  "dune-configurator"
+  "eigen" {>= "0.3.0"}
+  "owl-base" {= version}
+  "stdio" {build}
+  "npy"
 ]
 x-commit-hash: "dc77f1d3b7a4b81beba5bcfc4366317e044bce6d"
 url {


### PR DESCRIPTION
The patch reverts a spurious commits that break all systems providing liblapacke separately. This should fix the build on debian and recent ubuntus, while we wait for the support to M1 and the new build configuration to land

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>