### PR TITLE
Prevent jbuilder from reading config files

### DIFF
--- a/packages/crowbar/crowbar.0.1/opam
+++ b/packages/crowbar/crowbar.0.1/opam
@@ -11,6 +11,7 @@ build: [
     "build"
     "--only-packages"
     name
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"
@@ -22,6 +23,7 @@ build: [
     "build"
     "--only-packages"
     name
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"

--- a/packages/decompress/decompress.0.8/opam
+++ b/packages/decompress/decompress.0.8/opam
@@ -13,6 +13,7 @@ build: [
     "build"
     "--only-packages"
     name
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"
@@ -24,6 +25,7 @@ build: [
     "build"
     "--only-packages"
     name
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"

--- a/packages/fieldslib/fieldslib.v0.9.0/opam
+++ b/packages/fieldslib/fieldslib.v0.9.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/janestreet/fieldslib/issues"
 dev-repo: "git+https://github.com/janestreet/fieldslib.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "fieldslib" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--only-packages" "fieldslib" "--no-config" {jbuilder:version >= "1.0+beta18"} "--root" "." "-j" jobs "@install"]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/malfunction/malfunction.0.2.1/opam
+++ b/packages/malfunction/malfunction.0.2.1/opam
@@ -11,6 +11,7 @@ build: [
     "build"
     "--only-packages"
     "%{name}%"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"
@@ -22,6 +23,7 @@ build: [
     "build"
     "--only-packages"
     "%{name}%"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"

--- a/packages/malfunction/malfunction.0.2/opam
+++ b/packages/malfunction/malfunction.0.2/opam
@@ -11,6 +11,7 @@ build: [
     "build"
     "--only-packages"
     "%{name}%"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"
@@ -22,6 +23,7 @@ build: [
     "build"
     "--only-packages"
     "%{name}%"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "--root"
     "."
     "-j"

--- a/packages/mirage-net-macosx/mirage-net-macosx.1.4.0/opam
+++ b/packages/mirage-net-macosx/mirage-net-macosx.1.4.0/opam
@@ -8,7 +8,10 @@ doc:         "https://mirage.github.io/mirage-net-macosx/"
 
 license: "ISC"
 build: [
-  [ "jbuilder" "build" "--only-packages=mirage-net-macosx" ]
+  [
+    "jbuilder" "build" "--only-packages=mirage-net-macosx"
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
 ]
 
 depends: [

--- a/packages/nonstd/nonstd.0.0.3/opam
+++ b/packages/nonstd/nonstd.0.0.3/opam
@@ -7,7 +7,9 @@ homepage: "https://bitbucket.org/smondet/nonstd"
 bug-reports: "https://bitbucket.org/smondet/nonstd"
 dev-repo: "git+https://bitbucket.org/smondet/nonstd.git"
 build: [
-  "jbuilder" "build" "--only" "nonstd" "--root" "." "-j" jobs "@install"
+  "jbuilder" "build" "--only" "nonstd" "--root" "." "-j" jobs
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+    "@install"
 ]
 depends: [
   "ocaml" {>= "4.02.0"}

--- a/packages/npy/npy.0.0.5/opam
+++ b/packages/npy/npy.0.0.5/opam
@@ -11,6 +11,7 @@ build: [
   "npy"
   "--root"
   "."
+  "--no-config" {jbuilder:version >= "1.0+beta18"}
   "-j"
   jobs
   "@install"

--- a/packages/npy/npy.0.0.7/opam
+++ b/packages/npy/npy.0.0.7/opam
@@ -11,6 +11,7 @@ build: [
   "npy"
   "--root"
   "."
+  "--no-config" {jbuilder:version >= "1.0+beta18"}
   "-j"
   jobs
   "@install"

--- a/packages/nullable-array/nullable-array.0.1/opam
+++ b/packages/nullable-array/nullable-array.0.1/opam
@@ -13,6 +13,7 @@ build: [
     "nullable-array"
     "--root"
     "."
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "-j"
     jobs
     "@install"

--- a/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.9.0/opam
+++ b/packages/ocaml-compiler-libs/ocaml-compiler-libs.v0.9.0/opam
@@ -6,7 +6,10 @@ bug-reports: "https://github.com/janestreet/ocaml-compiler-libs/issues"
 dev-repo: "git+https://github.com/janestreet/ocaml-compiler-libs.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ocaml-compiler-libs" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--only-packages" "ocaml-compiler-libs" "--root" "." "-j" jobs
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+    "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.6/opam
@@ -16,6 +16,7 @@ build: [
   "ocaml-migrate-parsetree"
   "--root"
   "."
+  "--no-config" {jbuilder:version >= "1.0+beta18"}
   "-j"
   jobs
   "@install"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.0.7/opam
@@ -16,6 +16,7 @@ build: [
   "ocaml-migrate-parsetree"
   "--root"
   "."
+  "--no-config" {jbuilder:version >= "1.0+beta18"}
   "-j"
   jobs
   "@install"

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.1.0/opam
@@ -16,6 +16,7 @@ build: [
   "ocaml-migrate-parsetree"
   "--root"
   "."
+  "--no-config" {jbuilder:version >= "1.0+beta18"}
   "-j"
   jobs
   "@install"

--- a/packages/osbx/osbx.1.0.0/opam
+++ b/packages/osbx/osbx.1.0.0/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: [
+  "jbuilder" "build"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+      "@install"
+]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/osbx/osbx.1.0.1/opam
+++ b/packages/osbx/osbx.1.0.1/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/darrenldl/ocaml-SeqBox"
 bug-reports: "https://github.com/darrenldl/ocaml-SeqBox/issues"
 license: "BSD-3-Clause"
 dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
-build: ["jbuilder" "build" "@install"]
+build: [
+    "jbuilder" "build"
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+        "@install"
+]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}

--- a/packages/ppx_assert/ppx_assert.v0.9.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_assert/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_assert.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_assert" "--root" "." "-j" jobs "@install"]
+  [
+    "jbuilder" "build" "--only-packages" "ppx_assert" "--root" "." "-j" jobs
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+        "@install"
+    ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_ast/ppx_ast.v0.9.0/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}

--- a/packages/ppx_ast/ppx_ast.v0.9.1/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.1/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}

--- a/packages/ppx_ast/ppx_ast.v0.9.2/opam
+++ b/packages/ppx_ast/ppx_ast.v0.9.2/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_ast/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_ast.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_ast" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.06.0" & < "4.08.0"}

--- a/packages/ppx_base/ppx_base.v0.9.0/opam
+++ b/packages/ppx_base/ppx_base.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_base/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_base.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_base" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_base" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.9.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_bin_prot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_bin_prot.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_bin_prot" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_bin_prot" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_compare/ppx_compare.v0.9.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_compare/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_compare.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_compare" "--root" "." "-j" jobs "@install"]
+    [
+        "jbuilder" "build" "--only-packages" "ppx_compare" "--root" "." "-j" jobs
+            "--no-config" {jbuilder:version >= "1.0+beta18"}
+            "@install"
+    ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_conv_func/ppx_conv_func.v0.9.0/opam
+++ b/packages/ppx_conv_func/ppx_conv_func.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_conv_func/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_conv_func.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_conv_func" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_conv_func" "--root" "." "-j" jobs
+            "--no-config" {jbuilder:version >= "1.0+beta18"}
+            "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_core/ppx_core.v0.9.0/opam
+++ b/packages/ppx_core/ppx_core.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_core" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_core" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}

--- a/packages/ppx_core/ppx_core.v0.9.2/opam
+++ b/packages/ppx_core/ppx_core.v0.9.2/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_core/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_core.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_core" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_core" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.9.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_custom_printf/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_custom_printf.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_custom_printf" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_custom_printf" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_enumerate/ppx_enumerate.v0.9.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_enumerate/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_enumerate.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_enumerate" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" "ppx_enumerate" "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_expect/ppx_expect.v0.9.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_expect/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_expect.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_expect" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_fail/ppx_fail.v0.9.0/opam
+++ b/packages/ppx_fail/ppx_fail.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_fail/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fail.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_fail" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.9.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_fields_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_fields_conv.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_fields_conv" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_hash/ppx_hash.v0.9.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_hash/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_hash.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_hash" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_jane/ppx_jane.v0.9.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_jane/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_jane.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_jane" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_js_style/ppx_js_style.v0.9.0/opam
+++ b/packages/ppx_js_style/ppx_js_style.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_js_style/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_js_style.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_js_style" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_let/ppx_let.v0.9.0/opam
+++ b/packages/ppx_let/ppx_let.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_let/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_let.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_let" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_metaquot/ppx_metaquot.v0.9.0/opam
+++ b/packages/ppx_metaquot/ppx_metaquot.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_metaquot/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_metaquot.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_metaquot" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_optcomp/ppx_optcomp.v0.9.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_optcomp/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optcomp.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_optcomp" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_optional/ppx_optional.v0.9.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_optional/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_optional.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_optional" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_pipebang/ppx_pipebang.v0.9.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_pipebang/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_pipebang.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_pipebang" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_regexp/ppx_regexp.0.3.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.0/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/paurkedal/ppx_regexp"
 bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
-build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+build: [
+  "jbuilder" "build" "--root" "." "-j" jobs
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+      "@install"
+]
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder"

--- a/packages/ppx_regexp/ppx_regexp.0.3.1/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.1/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/paurkedal/ppx_regexp"
 bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
-build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+build: [
+  "jbuilder" "build" "--root" "." "-j" jobs
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+      "@install"
+]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder"

--- a/packages/ppx_regexp/ppx_regexp.0.3.2/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.3.2/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/paurkedal/ppx_regexp"
 bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
 dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
-build: ["jbuilder" "build" "--root" "." "-j" jobs "@install"]
+build: [
+  "jbuilder" "build" "--root" "." "-j" jobs
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+      "@install"
+]
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder"

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.9.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_sexp_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_conv.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_sexp_conv" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.9.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_sexp_message/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_message.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_sexp_message" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.9.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_sexp_value/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_sexp_value.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_sexp_value" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_traverse/ppx_traverse.v0.9.0/opam
+++ b/packages/ppx_traverse/ppx_traverse.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_traverse/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_traverse" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.9.0/opam
+++ b/packages/ppx_traverse_builtins/ppx_traverse_builtins.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_traverse_builtins/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_traverse_builtins.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_traverse_builtins" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
+++ b/packages/ppx_type_conv/ppx_type_conv.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_type_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_type_conv.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_type_conv" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.9.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_typerep_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_typerep_conv.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_typerep_conv" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.9.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/ppx_variants_conv/issues"
 dev-repo: "git+https://github.com/janestreet/ppx_variants_conv.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "ppx_variants_conv" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/prometheus-app/prometheus-app.0.2/opam
+++ b/packages/prometheus-app/prometheus-app.0.2/opam
@@ -8,8 +8,12 @@ dev-repo: "git+https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  ["jbuilder" "build" "--only-packages=prometheus,prometheus-app"]
-  ["jbuilder" "runtest"] {with-test}
+  ["jbuilder" "build" "--only-packages=prometheus,prometheus-app"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
+  ["jbuilder" "runtest"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.02.3"}

--- a/packages/prometheus/prometheus.0.2/opam
+++ b/packages/prometheus/prometheus.0.2/opam
@@ -8,7 +8,9 @@ dev-repo: "git+https://github.com/mirage/prometheus.git"
 doc:          "https://mirage.github.io/prometheus/"
 
 build: [
-  [ "jbuilder" "build" "--only-packages=prometheus" ]
+  [ "jbuilder" "build" "--only-packages=prometheus"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
 ]
 
 depends: [

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.10.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.10.0/opam
@@ -8,7 +8,9 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  [ "jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p,protocol-9p-tool" ]
+  [ "jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p,protocol-9p-tool"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
 ]
 
 depends: [

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.0/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.0/opam
@@ -8,7 +8,9 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  [ "jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p,protocol-9p-tool" ]
+  [ "jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p,protocol-9p-tool"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
 ]
 
 depends: [

--- a/packages/protocol-9p-tool/protocol-9p-tool.0.11.1/opam
+++ b/packages/protocol-9p-tool/protocol-9p-tool.0.11.1/opam
@@ -8,7 +8,9 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  [ "jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p,protocol-9p-tool" ]
+  [ "jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p,protocol-9p-tool"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
 ]
 
 depends: [

--- a/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
+++ b/packages/protocol-9p-unix/protocol-9p-unix.0.10.0/opam
@@ -8,8 +8,12 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p"]
-  ["jbuilder" "runtest"] {with-test}
+  ["jbuilder" "build" "--only-packages=protocol-9p-unix,protocol-9p"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
+  ["jbuilder" "runtest"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/protocol-9p/protocol-9p.0.10.0/opam
+++ b/packages/protocol-9p/protocol-9p.0.10.0/opam
@@ -8,8 +8,12 @@ bug-reports:  "https://github.com/mirage/ocaml-9p/issues"
 doc:          "https://mirage.github.io/ocaml-9p/"
 
 build: [
-  ["jbuilder" "build" "--only-packages=protocol-9p"]
-  ["jbuilder" "runtest"] {with-test}
+  ["jbuilder" "build" "--only-packages=protocol-9p"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
+  ["jbuilder" "runtest"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/pumping/pumping.0.1.0/opam
+++ b/packages/pumping/pumping.0.1.0/opam
@@ -7,7 +7,10 @@ dev-repo: "git+https://github.com/Drup/pumping.git"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 tags: [ "regex" "types" ]
 build: [
-  ["jbuilder" "build" "--only-packages" "pumping" "--root" "." "-j" jobs "@install"]
+  ["jbuilder" "build" "--only-packages" "pumping" "--root" "." "-j" jobs
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+      "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/qcow/qcow.0.10.0/opam
+++ b/packages/qcow/qcow.0.10.0/opam
@@ -34,7 +34,9 @@ depends: [
   "ppx_type_conv" {build}
 ]
 build: [
-  ["jbuilder" "build" "--only-packages=qcow"]
+  ["jbuilder" "build" "--only-packages=qcow"
+      "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
 ]
 synopsis: "Support for Qcow2 images"
 description: """

--- a/packages/rfc1951/rfc1951.0.1/opam
+++ b/packages/rfc1951/rfc1951.0.1/opam
@@ -17,6 +17,7 @@ build: [
     "."
     "-j"
     jobs
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "@install"
   ]
   [
@@ -28,6 +29,7 @@ build: [
     "."
     "-j"
     jobs
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
     "@runtest"
   ] {with-test}
 ]

--- a/packages/sanddb/sanddb.0.1/opam
+++ b/packages/sanddb/sanddb.0.1/opam
@@ -6,7 +6,9 @@ bug-reports: "https://github.com/StrykerKKD/SandDB/issues"
 license: "MIT"
 dev-repo: "git+http://github.com/StrykerKKD/SandDB.git"
 build: [
-  "jbuilder" "build" "--only" "sanddb" "--root" "." "-j" jobs "@install"
+  "jbuilder" "build" "--only" "sanddb" "--root" "." "-j" jobs
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+    "@install"
 ]
 depends: [
   "ocaml" {>= "4.04.2"}

--- a/packages/stdio/stdio.v0.9.0/opam
+++ b/packages/stdio/stdio.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "stdio" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}

--- a/packages/stdio/stdio.v0.9.1/opam
+++ b/packages/stdio/stdio.v0.9.1/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/stdio/issues"
 dev-repo: "git+https://github.com/janestreet/stdio.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "stdio" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/tar-mirage/tar-mirage.0.8.0/opam
+++ b/packages/tar-mirage/tar-mirage.0.8.0/opam
@@ -8,8 +8,12 @@ dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
 doc:          "https://mirage.github.io/ocaml-tar/"
 
 build: [
-  ["jbuilder" "build" "--only-packages=tar,tar-unix,tar-mirage"]
-  ["jbuilder" "runtest"] {with-test}
+  ["jbuilder" "build" "--only-packages=tar,tar-unix,tar-mirage"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
+  ["jbuilder" "runtest"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}

--- a/packages/tar-unix/tar-unix.0.8.0/opam
+++ b/packages/tar-unix/tar-unix.0.8.0/opam
@@ -8,8 +8,12 @@ dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
 doc:          "https://mirage.github.io/ocaml-tar/"
 
 build: [
-  ["jbuilder" "build" "--only-packages=tar,tar-unix"]
-  ["jbuilder" "runtest"] {with-test}
+  ["jbuilder" "build" "--only-packages=tar,tar-unix"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ]
+  ["jbuilder" "runtest"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+  ] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}

--- a/packages/tar/tar.0.8.0/opam
+++ b/packages/tar/tar.0.8.0/opam
@@ -8,7 +8,10 @@ dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
 doc:          "https://mirage.github.io/ocaml-tar/"
 
 build: [
-  ["jbuilder" "build" "--only-packages=tar"]
+  ["jbuilder" "build" "--only-packages=tar"
+    "--no-config" {jbuilder:version >= "1.0+beta18"}
+    "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}

--- a/packages/tensorflow/tensorflow.0.0.10/opam
+++ b/packages/tensorflow/tensorflow.0.0.10/opam
@@ -13,6 +13,7 @@ build: [
   "."
   "-j"
   jobs
+  "--no-config" {jbuilder:version >= "1.0+beta18"}
   "@install"
 ]
 depends: [

--- a/packages/tube/tube.3.1/opam
+++ b/packages/tube/tube.3.1/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/alinpopa/tube"
 bug-reports: "https://github.com/alinpopa/tube/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/alinpopa/tube.git"
-build: ["jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs "@install"]
+build: [
+    "jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs
+        "@install"
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder"

--- a/packages/tube/tube.4.0/opam
+++ b/packages/tube/tube.4.0/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/alinpopa/tube"
 bug-reports: "https://github.com/alinpopa/tube/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/alinpopa/tube.git"
-build: ["jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs "@install"]
+build: [
+    "jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+        "@install"
+]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder"

--- a/packages/tube/tube.4.1.1/opam
+++ b/packages/tube/tube.4.1.1/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/alinpopa/tube"
 bug-reports: "https://github.com/alinpopa/tube/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/alinpopa/tube.git"
-build: ["jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs "@install"]
+build: [
+    "jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+        "@install"
+]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {>= "1.0+beta10"}

--- a/packages/tube/tube.4.1/opam
+++ b/packages/tube/tube.4.1/opam
@@ -5,7 +5,11 @@ homepage: "https://github.com/alinpopa/tube"
 bug-reports: "https://github.com/alinpopa/tube/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/alinpopa/tube.git"
-build: ["jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs "@install"]
+build: [
+    "jbuilder" "build" "--only" "tube" "--root" "." "-j" jobs
+        "--no-config" {jbuilder:version >= "1.0+beta18"}
+        "@install"
+]
 depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {>= "1.0+beta10"}

--- a/packages/typerep/typerep.v0.9.0/opam
+++ b/packages/typerep/typerep.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/typerep/issues"
 dev-repo: "git+https://github.com/janestreet/typerep.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "typerep" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/variantslib/variantslib.v0.9.0/opam
+++ b/packages/variantslib/variantslib.v0.9.0/opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/janestreet/variantslib/issues"
 dev-repo: "git+https://github.com/janestreet/variantslib.git"
 license: "Apache-2.0"
 build: [
-  ["jbuilder" "build" "--only-packages" "variantslib" "--root" "." "-j" jobs "@install"]
+  [
+      "jbuilder" "build" "--only-packages" name "--root" "." "-j" jobs
+          "--no-config" {jbuilder:version >= "1.0+beta18"}
+          "@install"
+  ]
 ]
 depends: [
   "ocaml" {>= "4.03.0"}

--- a/packages/zipperposition/zipperposition.1.5/opam
+++ b/packages/zipperposition/zipperposition.1.5/opam
@@ -6,8 +6,14 @@ bug-reports: "https://github.com/c-cube/zipperposition/issues"
 tags: ["logic" "unification" "term" "superposition" "prover"]
 dev-repo: "git+https://github.com/c-cube/zipperposition.git"
 build: [
-  ["jbuilder" "build" "@install"]
-  ["jbuilder" "build" "@doc"] {with-doc}
+  ["jbuilder" "build"
+       "--no-config" {jbuilder:version >= "1.0+beta18"}
+       "@install"
+  ]
+  ["jbuilder" "build"
+       "--no-config" {jbuilder:version >= "1.0+beta18"}
+       "@doc"
+  ] {with-doc}
 ]
 depends: [
   "ocaml" {>= "4.03.0"}


### PR DESCRIPTION
## The issue

The issue we're trying to fix is that `jbuilder` tries to read dune's configuration file. The symptom is an error message like:

    File "/path/to/.config/dune/config", line 1, characters 0-16:
    Error: S-expression of the form (_ _) expected

(tracked as #15943 and dune#3232)

## A bit of history

When introduced, `jbuilder` did not have any configuration file. Instructions in opam files were not very precise, basically just `jbuild build`.
In `1.0+beta7`, the `-p` option got added, with the same semantics that `dune` has today: something to attach various options to release packages.
In `1.0+beta18`, a config file was added, and with it the option `--no-config` (implied by `-p`). The path to that config file is `~/.config/dune/config`.

So we're seeing opam files that use not precise instructions (no `-p`, no `--no-config` - because these were not supported, or because instructions were not generated by `jbuilder`).

## What can we do about this?

The precise fix is to pass `--no-config` whenever it is supported by `jbuilder`. That means adding `"--no-config" {jbuilder:version >= "1.0+beta18"}` to all affected build instructions. This works before `1.0+beta18` (no config reading so nothing to fix) and after (`jbuilder` might read the config file, but the option will prevent it).

Let's explore the alternatives:
- we could add a lower bound `"jbuilder" {>= "1.0+beta18"}` and add `--no-config`. This would work is upgrading `jbuilder` was always an option (like it is for `dune`) but unfortunately some packages only build with old versions of `jbuilder` (see #10479 for an example). So this would make these uninstallable.
- we could add an upper bound `"jbuilder" {< "1.0+beta18"}` to prevent config reading. But that's problematic because that restricts the build plans a lot (for example it prevents using them with `dune` `1.x` through `jbuilder.transition`).
- we could add `-p` to the affected packages and add a bound `"jbuilder" {>= "1.0+beta7"}` - this will automatically pass `--no-config` after `1.0+beta18`. But this change is a bit more invasive as it will change what is being built.

## Finding affected packages

To find the affected packages, I ran the following program to check for packages that depend on `jbuilder` but whose build instructions do not contain `-p` or `--no-config`.

<details>
<summary>find.ml</summary>

```ocaml
let depends_on package (formula : OpamTypes.filtered_formula) =
  OpamFormula.fold_left
    (fun acc (name, _) -> acc || OpamPackage.Name.compare package name = 0)
    false formula

let commands_to_list commands =
  List.concat_map
    (fun (args, _) ->
      List.map
        (fun (arg, _) ->
          match arg with OpamTypes.CString s -> s | CIdent s -> s)
        args)
    commands

let main str =
  let root = OpamFilename.Dir.of_string str in
  let packages = OpamRepository.packages root in
  OpamPackage.Set.iter
    (fun pkg ->
      let prefix = Some (OpamPackage.name_to_string pkg) in
      let path = OpamRepositoryPath.opam root prefix pkg in
      let opam = OpamFile.OPAM.read path in
      let depends = OpamFile.OPAM.depends opam in
      let depends_on_jbuilder =
        depends_on (OpamPackage.Name.of_string "jbuilder") depends
      in
      if depends_on_jbuilder then
        let build = OpamFile.OPAM.build opam in
        let build_list = commands_to_list build in
        let fixed =
          List.exists
            (fun fragment -> List.mem fragment build_list)
            [ "-p"; "--no-config" ]
        in
        if not fixed then Printf.printf "%s\n" (OpamPackage.to_string pkg))
    packages

let info = Cmdliner.Cmd.info "find"

let repo =
  let open Cmdliner.Arg in
  required & pos 0 (some string) None & info []

let term =
  let open Cmdliner.Term in
  const main $ repo

let () = Cmdliner.Cmd.v info term |> Cmdliner.Cmd.eval |> Stdlib.exit
```
</details>

I then went through the list of results to triage. There are 3 possible outcomes:

- :heavy_minus_sign: no-overlap: this package is not affected because it does not build with `jbuilder` versions that can read config files
- :heavy_plus_sign: patch: this package needs to be patched and that can be done in the `opam` file.
- :x: patch-upstream: this package needs to be patched, but doing so in the `opam` file is not possible. For example, the build instruction is `make` and the default target in `Makefile` is `jbuilder build`.

Here are the results:

<details>

<summary>:heavy_minus_sign: no-overlap: X packages, :heavy_plus_sign: patch: 74 patches, :x: patch-upstream: 53 packages</summary>

- :heavy_minus_sign: base.v0.9.0
- :heavy_minus_sign: base.v0.9.1
- :heavy_minus_sign: bin_prot.v0.9.0
- :heavy_plus_sign: crowbar.0.1
- :heavy_plus_sign: decompress.0.8
- :heavy_plus_sign: fieldslib.v0.9.0
- :x: jupyter-kernel.0.1
- :x: jupyter-kernel.0.2
- :x: jupyter-kernel.0.3
- :heavy_plus_sign: malfunction.0.2
- :heavy_plus_sign: malfunction.0.2.1
- :heavy_plus_sign: mirage-net-macosx.1.4.0
- :heavy_plus_sign: nonstd.0.0.3
- :heavy_plus_sign: npy.0.0.5
- :heavy_plus_sign: npy.0.0.7
- :heavy_plus_sign: nullable-array.0.1
- :heavy_plus_sign: ocaml-compiler-libs.v0.9.0
- :heavy_plus_sign: ocaml-migrate-parsetree.0.6
- :heavy_plus_sign: ocaml-migrate-parsetree.0.7
- :heavy_plus_sign: ocaml-migrate-parsetree.1.0
- :x: ocaml-topexpect.0.3
- :x: ocamlformat_support.0.1
- :x: opam-client.2.0.0~beta5
- :x: opam-client.2.0.0~rc
- :x: opam-client.2.0.0~rc2
- :x: opam-client.2.0.0~rc3
- :x: opam-client.2.0.0
- :x: opam-client.2.0.1
- :x: opam-core.2.0.0~beta5
- :x: opam-core.2.0.0~rc
- :x: opam-core.2.0.0~rc2
- :x: opam-core.2.0.0~rc3
- :x: opam-core.2.0.0
- :x: opam-core.2.0.1
- :x: opam-devel.2.0.0~beta5
- :x: opam-devel.2.0.0~rc
- :x: opam-devel.2.0.0~rc2
- :x: opam-devel.2.0.0~rc3
- :x: opam-devel.2.0.0
- :x: opam-devel.2.0.1
- :x: opam-format.2.0.0~beta5
- :x: opam-format.2.0.0~rc
- :x: opam-format.2.0.0~rc2
- :x: opam-format.2.0.0~rc3
- :x: opam-format.2.0.0
- :x: opam-format.2.0.1
- :x: opam-installer.2.0.0~beta5
- :x: opam-installer.2.0.0~rc
- :x: opam-installer.2.0.0~rc2
- :x: opam-installer.2.0.0~rc3
- :x: opam-installer.2.0.0
- :x: opam-installer.2.0.1
- :x: opam-repository.2.0.0~beta5
- :x: opam-repository.2.0.0~rc
- :x: opam-repository.2.0.0~rc2
- :x: opam-repository.2.0.0~rc3
- :x: opam-repository.2.0.0
- :x: opam-repository.2.0.1
- :x: opam-solver.2.0.0~beta5
- :x: opam-solver.2.0.0~rc
- :x: opam-solver.2.0.0~rc2
- :x: opam-solver.2.0.0~rc3
- :x: opam-solver.2.0.0
- :x: opam-solver.2.0.1
- :x: opam-state.2.0.0~beta5
- :x: opam-state.2.0.0~rc
- :x: opam-state.2.0.0~rc2
- :x: opam-state.2.0.0~rc3
- :x: opam-state.2.0.0
- :x: opam-state.2.0.1
- :heavy_plus_sign: osbx.1.0.0
- :heavy_plus_sign: osbx.1.0.1
- :heavy_plus_sign: ppx_assert.v0.9.0
- :heavy_plus_sign: ppx_ast.v0.9.0
- :heavy_plus_sign: ppx_ast.v0.9.1
- :heavy_plus_sign: ppx_ast.v0.9.2
- :heavy_plus_sign: ppx_base.v0.9.0
- :heavy_minus_sign: ppx_bench.v0.9.0
- :heavy_plus_sign: ppx_bin_prot.v0.9.0
- :heavy_plus_sign: ppx_compare.v0.9.0
- :heavy_plus_sign: ppx_conv_func.v0.9.0
- :heavy_plus_sign: ppx_core.v0.9.0
- :heavy_plus_sign: ppx_core.v0.9.2
- :heavy_plus_sign: ppx_custom_printf.v0.9.0
- :heavy_minus_sign: ppx_driver.v0.9.0
- :heavy_plus_sign: ppx_enumerate.v0.9.0
- :heavy_plus_sign: ppx_expect.v0.9.0
- :heavy_plus_sign: ppx_fail.v0.9.0
- :heavy_plus_sign: ppx_fields_conv.v0.9.0
- :heavy_plus_sign: ppx_hash.v0.9.0
- :heavy_minus_sign: ppx_here.v0.9.0
- :heavy_minus_sign: ppx_inline_test.v0.9.0
- :heavy_plus_sign: ppx_jane.v0.9.0
- :heavy_plus_sign: ppx_js_style.v0.9.0
- :heavy_plus_sign: ppx_let.v0.9.0
- :heavy_plus_sign: ppx_metaquot.v0.9.0
- :heavy_plus_sign: ppx_optcomp.v0.9.0
- :heavy_plus_sign: ppx_optional.v0.9.0
- :heavy_plus_sign: ppx_pipebang.v0.9.0
- :heavy_plus_sign: ppx_regexp.0.3.0
- :heavy_plus_sign: ppx_regexp.0.3.1
- :heavy_plus_sign: ppx_regexp.0.3.2
- :heavy_plus_sign: ppx_sexp_conv.v0.9.0
- :heavy_plus_sign: ppx_sexp_message.v0.9.0
- :heavy_plus_sign: ppx_sexp_value.v0.9.0
- :heavy_plus_sign: ppx_traverse.v0.9.0
- :heavy_plus_sign: ppx_traverse_builtins.v0.9.0
- :heavy_plus_sign: ppx_type_conv.v0.9.0
- :heavy_plus_sign: ppx_typerep_conv.v0.9.0
- :heavy_plus_sign: ppx_variants_conv.v0.9.0
- :heavy_plus_sign: prometheus.0.2
- :heavy_plus_sign: prometheus-app.0.2
- :heavy_plus_sign: protocol-9p.0.10.0
- :heavy_plus_sign: protocol-9p-tool.0.10.0
- :heavy_plus_sign: protocol-9p-tool.0.11.0
- :heavy_plus_sign: protocol-9p-tool.0.11.1
- :heavy_plus_sign: protocol-9p-unix.0.10.0
- :heavy_plus_sign: pumping.0.1.0
- :heavy_plus_sign: qcow.0.10.0
- :heavy_plus_sign: rfc1951.0.1
- :heavy_plus_sign: sanddb.0.1
- :heavy_minus_sign: sexplib.v0.9.0
- :heavy_minus_sign: sexplib.v0.9.1
- :heavy_plus_sign: stdio.v0.9.0
- :heavy_plus_sign: stdio.v0.9.1
- :heavy_plus_sign: tar.0.8.0
- :heavy_plus_sign: tar-mirage.0.8.0
- :heavy_plus_sign: tar-unix.0.8.0
- :heavy_plus_sign: tensorflow.0.0.10
- :heavy_plus_sign: tube.3.1
- :heavy_plus_sign: tube.4.0
- :heavy_plus_sign: tube.4.1
- :heavy_plus_sign: tube.4.1.1
- :heavy_plus_sign: typerep.v0.9.0
- :heavy_plus_sign: variantslib.v0.9.0
- :heavy_plus_sign: zipperposition.1.5
</details>