### PR TITLE
jbuilder: -p requires >= 1.0+beta7

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
 ]

--- a/packages/DrawGrammar/DrawGrammar.0.2.1/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir"
   "JsOfOCairo" {>= "1.0.1" & < "2"}
   "cairo2" {>= "0.5" & < "0.6"}

--- a/packages/General/General.0.4.0/opam
+++ b/packages/General/General.0.4.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build & >= "1.3.0"}
   "num"
 ]

--- a/packages/General/General.0.5.0/opam
+++ b/packages/General/General.0.5.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "js_of_ocaml-compiler" {with-test}
   "cppo" {build & >= "1.3.0"}
   "num"

--- a/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
+++ b/packages/JsOfOCairo/JsOfOCairo.1.0.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "js_of_ocaml-compiler" {build & >= "3.0" & < "3.4"}
   "js_of_ocaml-ppx" {>= "3.0" & < "3.4"}
   "js_of_ocaml" {>= "3.0" & < "3.4"}

--- a/packages/acgtk/acgtk.1.3.2/opam
+++ b/packages/acgtk/acgtk.1.3.2/opam
@@ -8,7 +8,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "dypgen"
   "camlp4"
   "bolt"

--- a/packages/acgtk/acgtk.1.3.3/opam
+++ b/packages/acgtk/acgtk.1.3.3/opam
@@ -8,7 +8,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "dypgen"
   "camlp4"
   "bolt"

--- a/packages/amqp-client-async/amqp-client-async.2.0.0/opam
+++ b/packages/amqp-client-async/amqp-client-async.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "amqp-client" {= "2.0.0"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client-async/amqp-client-async.2.0.1/opam
+++ b/packages/amqp-client-async/amqp-client-async.2.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "amqp-client" {= "2.0.1"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client-async/amqp-client-async.2.0.2/opam
+++ b/packages/amqp-client-async/amqp-client-async.2.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "amqp-client" {= "2.0.2"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client-lwt/amqp-client-lwt.2.0.0/opam
+++ b/packages/amqp-client-lwt/amqp-client-lwt.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "amqp-client" {= "2.0.0"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client-lwt/amqp-client-lwt.2.0.1/opam
+++ b/packages/amqp-client-lwt/amqp-client-lwt.2.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "amqp-client" {= "2.0.1"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client-lwt/amqp-client-lwt.2.0.2/opam
+++ b/packages/amqp-client-lwt/amqp-client-lwt.2.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "amqp-client" {= "2.0.2"}
   "ocplib-endian" {>= "0.6"}

--- a/packages/amqp-client/amqp-client.1.1.0/opam
+++ b/packages/amqp-client/amqp-client.1.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.1.1.1/opam
+++ b/packages/amqp-client/amqp-client.1.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder" {<= "1.0+beta17"}
+  "jbuilder" {>= "1.0+beta7" & <= "1.0+beta17"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.1.1.2/opam
+++ b/packages/amqp-client/amqp-client.1.1.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.1.1.3/opam
+++ b/packages/amqp-client/amqp-client.1.1.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.1.1.4/opam
+++ b/packages/amqp-client/amqp-client.1.1.4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.2.0.0/opam
+++ b/packages/amqp-client/amqp-client.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.2.0.1/opam
+++ b/packages/amqp-client/amqp-client.2.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/amqp-client/amqp-client.2.0.2/opam
+++ b/packages/amqp-client/amqp-client.2.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xml-light" {build}
   "ocplib-endian" {>= "0.6"}
   "async" {with-test}

--- a/packages/ascii85/ascii85.0.4/opam
+++ b/packages/ascii85/ascii85.0.4/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "ascii85 - Adobe's Ascii85 encoding as a module and a command line tool"

--- a/packages/async_js/async_js.v0.9.1/opam
+++ b/packages/async_js/async_js.v0.9.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "async_kernel" {>= "v0.9" & < "v0.10"}
   "async_rpc_kernel" {>= "v0.9" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "js_of_ocaml" {>= "3.0" & < "3.4"}

--- a/packages/async_parallel/async_parallel.v0.9.1/opam
+++ b/packages/async_parallel/async_parallel.v0.9.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "async" {>= "v0.9" & < "v0.10"}
   "core" {>= "v0.9.2" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "sexplib" {>= "v0.9.3" & < "v0.10"}

--- a/packages/async_shell/async_shell.v0.9.1/opam
+++ b/packages/async_shell/async_shell.v0.9.1/opam
@@ -13,7 +13,7 @@ depends: [
   "async" {>= "v0.9" & < "v0.10"}
   "core" {>= "v0.9.2" & < "v0.10"}
   "core_extended" {>= "v0.9.1" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}

--- a/packages/async_unix/async_unix.v0.9.1/opam
+++ b/packages/async_unix/async_unix.v0.9.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.11.0"}
   "async_kernel" {>= "v0.9" & < "v0.10"}
   "core" {>= "v0.9.2" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "ocaml-migrate-parsetree" {>= "0.4" & < "2.0.0"}

--- a/packages/atd/atd.2.0.0/opam
+++ b/packages/atd/atd.2.0.0/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & < "20211215"}
   "easy-format"
 ]

--- a/packages/atdgen-runtime/atdgen-runtime.1.13.0/opam
+++ b/packages/atdgen-runtime/atdgen-runtime.1.13.0/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1"}
 ]

--- a/packages/atdgen-runtime/atdgen-runtime.2.0.0/opam
+++ b/packages/atdgen-runtime/atdgen-runtime.2.0.0/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1"}
 ]

--- a/packages/atdgen/atdgen.1.10.2/opam
+++ b/packages/atdgen/atdgen.1.10.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "1.2.0" & < "1.13.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1"}

--- a/packages/atdgen/atdgen.1.12.0/opam
+++ b/packages/atdgen/atdgen.1.12.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "1.2.0" & < "1.13.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1"}

--- a/packages/atdgen/atdgen.1.13.0/opam
+++ b/packages/atdgen/atdgen.1.13.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "1.13.0" & < "2.0.0"}
   "atdgen-runtime"
   "biniou" {>= "1.0.6"}

--- a/packages/atdgen/atdgen.2.0.0/opam
+++ b/packages/atdgen/atdgen.2.0.0/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "2.0.0" & < "2.3.0"}
   "atdgen-runtime" {>= "2.0.0"}
   "biniou" {>= "1.0.6"}

--- a/packages/atdj/atdj.1.13.0/opam
+++ b/packages/atdj/atdj.1.13.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "1.13.0" & < "2.0.0"}
   "atdgen" {>= "1.13.0"}
   "conf-openjdk" {with-test}

--- a/packages/atdj/atdj.2.0.0/opam
+++ b/packages/atdj/atdj.2.0.0/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "2.0.0" & < "2.1.0"}
 ]
 synopsis: "Java code generation for ATD."

--- a/packages/aws-s3-async/aws-s3-async.2.0.0/opam
+++ b/packages/aws-s3-async/aws-s3-async.2.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "aws-s3" {= "2.0.0"}
   "async" {>= "v0.9.0" & < "v0.15"}
   "cohttp-async"

--- a/packages/aws-s3-async/aws-s3-async.3.0.0/opam
+++ b/packages/aws-s3-async/aws-s3-async.3.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "aws-s3" {= "3.0.0"}
   "async_kernel" {>= "v0.9.0" & < "v0.15"}
   "core_kernel" {>= "v0.9.0" & < "v0.15"}

--- a/packages/aws-s3-lwt/aws-s3-lwt.2.0.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.2.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "aws-s3" {= "2.0.0"}
   "tls" | "ssl"
   "lwt"

--- a/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.3.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "aws-s3" {= "3.0.0"}
   "lwt"
   "cohttp-lwt-unix"

--- a/packages/aws-s3/aws-s3.1.1.0/opam
+++ b/packages/aws-s3/aws-s3.1.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core" {>= "v0.9" & < "v0.10"}
   "async"
   "async_extended"

--- a/packages/aws-s3/aws-s3.1.1.1/opam
+++ b/packages/aws-s3/aws-s3.1.1.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/andersfugmann/aws-s3/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core" {>= "v0.9" & < "v0.10"}
   "async"
   "async_extended"

--- a/packages/aws-s3/aws-s3.2.0.0/opam
+++ b/packages/aws-s3/aws-s3.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core" {>= "v0.9.0"}
   "ounit"
   "cohttp"

--- a/packages/aws-s3/aws-s3.3.0.0/opam
+++ b/packages/aws-s3/aws-s3.3.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core" {>= "v0.9.0"}
   "ounit"
   "base64" {<"3.0.0"}

--- a/packages/balancer/balancer.1.0/opam
+++ b/packages/balancer/balancer.1.0/opam
@@ -15,7 +15,7 @@ build: [
   
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "fmt"
   "cstruct" {< "6.1.0"}
   "lwt"

--- a/packages/benchmark/benchmark.1.5/opam
+++ b/packages/benchmark/benchmark.1.5/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "3.12.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-unix"
   "base-bigarray" {with-test}
   "pcre" {with-test}

--- a/packages/biniou/biniou.1.1.0/opam
+++ b/packages/biniou/biniou.1.1.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "conf-which" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "easy-format"
   "base-bytes"
 ]

--- a/packages/bitmasks/bitmasks.1.1.0/opam
+++ b/packages/bitmasks/bitmasks.1.1.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.07"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "odoc" {with-doc}
 ]
 patches: ["82eb7ee561c3e660dc33a6938346abf7354a23d4.patch"]

--- a/packages/bitstring/bitstring.3.0.0/opam
+++ b/packages/bitstring/bitstring.3.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {>= "1.0.5" & < "2.0.0"}
   "ounit" {with-test}

--- a/packages/bitstring/bitstring.3.1.0/opam
+++ b/packages/bitstring/bitstring.3.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned" {build}
   "ocaml-migrate-parsetree" {>= "1.0.5" & < "2.0.0"}
   "ounit" {with-test}

--- a/packages/brotli/brotli.2.0.3/opam
+++ b/packages/brotli/brotli.2.0.3/opam
@@ -14,7 +14,7 @@ install: ["jbuilder" "install"]
 remove: ["jbuilder" "uninstall"]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "odoc" {build}
   "opam-installer" {build}
   "conf-brotli"

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 available: opam-version >= "1.2"
 synopsis:

--- a/packages/bun/bun.0.3.1/opam
+++ b/packages/bun/bun.0.3.1/opam
@@ -8,7 +8,7 @@ license: "MIT"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.05"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "bos" {>= "0.2.0"}
   "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "fpath"

--- a/packages/bun/bun.0.3.2/opam
+++ b/packages/bun/bun.0.3.2/opam
@@ -8,7 +8,7 @@ license: "MIT"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.05"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "bos" {>= "0.2.0"}
   "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "fpath"

--- a/packages/bun/bun.0.3/opam
+++ b/packages/bun/bun.0.3/opam
@@ -8,7 +8,7 @@ license: "MIT"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.04"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "bos" {>= "0.2.0"}
   "cmdliner" {>= "1.0.0" & < "1.1.0"}
   "fpath"

--- a/packages/calculon-web/calculon-web.0.2/opam
+++ b/packages/calculon-web/calculon-web.0.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "calculon" { < "0.4" }
   "re"
   "uri"

--- a/packages/calculon-web/calculon-web.0.3/opam
+++ b/packages/calculon-web/calculon-web.0.3/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "calculon" { < "0.4" }
   "re" {>= "1.7.2"}
   "uri"

--- a/packages/calculon/calculon.0.2/opam
+++ b/packages/calculon/calculon.0.2/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
   "result"

--- a/packages/camlimages/camlimages.5.0.0/opam
+++ b/packages/camlimages/camlimages.5.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "cppo" {build}
   "configurator" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-unix"
 ]
 depopts: ["lablgtk" "graphics"]

--- a/packages/camlimages/camlimages.5.0.1/opam
+++ b/packages/camlimages/camlimages.5.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlfind" {build}
   "cppo" {build}
   "configurator" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-unix"
 ]
 depopts: ["lablgtk" "graphics"]

--- a/packages/camlon/camlon.2.0.2/opam
+++ b/packages/camlon/camlon.2.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/camlon"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "Caml Object Notion, parsing and printing OCaml like data expressions"

--- a/packages/capnp/capnp.3.0.0/opam
+++ b/packages/capnp/capnp.3.0.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core_kernel" {>= "112.24.00"}
   "extunix"
   "ocplib-endian" {>= "0.7"}

--- a/packages/capnp/capnp.3.1.0/opam
+++ b/packages/capnp/capnp.3.1.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "result"
   "core_kernel" {>= "112.24.00"}
   "extunix"

--- a/packages/capnp/capnp.3.2.0/opam
+++ b/packages/capnp/capnp.3.2.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "result"
   "core_kernel" {>= "v0.10.0" & < "v0.11"}
   "extunix"

--- a/packages/capnp/capnp.3.2.1/opam
+++ b/packages/capnp/capnp.3.2.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "result"
   "core_kernel" {>= "v0.11.0" & < "v0.13"}
   "extunix"

--- a/packages/caqti-async/caqti-async.0.10.0/opam
+++ b/packages/caqti-async/caqti-async.0.10.0/opam
@@ -13,7 +13,7 @@ depends: [
   "async" {>= "v0.10.0" & < "v0.13"}
   "core" {< "v0.13"}
   "caqti" {= "0.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Async support for Caqti"
 url {

--- a/packages/caqti-async/caqti-async.0.10.1/opam
+++ b/packages/caqti-async/caqti-async.0.10.1/opam
@@ -13,7 +13,7 @@ depends: [
   "async" {>= "v0.10.0" & < "v0.13"}
   "core" {< "v0.13"}
   "caqti" {= "0.10.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Async support for Caqti"
 url {

--- a/packages/caqti-async/caqti-async.0.9.0/opam
+++ b/packages/caqti-async/caqti-async.0.9.0/opam
@@ -13,7 +13,7 @@ depends: [
   "async" {>= "v0.10.0" & < "v0.13"}
   "core" {< "v0.13"}
   "caqti" {= "0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Async support for Caqti"
 url {

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mariadb" {>= "0.10" & < "1.1.0"}
 ]
 synopsis: "MariaDB driver for Caqti using C bindings"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.10.1/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mariadb" {>= "0.10" & < "1.1.0"}
 ]
 synopsis: "MariaDB driver for Caqti using C bindings"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.0.9.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mariadb" {>= "0.10" & < "1.1.0"}
 ]
 synopsis: "MariaDB driver for Caqti using C bindings"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "postgresql"
 ]
 synopsis: "PostgreSQL driver for Caqti based on C bindings"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.10.1/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "postgresql"
 ]
 synopsis: "PostgreSQL driver for Caqti based on C bindings"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.9.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.0.9.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "postgresql"
 ]
 synopsis: "PostgrSQL driver for Caqti based on C bindings"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "sqlite3"
 ]
 synopsis: "Sqlite3 driver for Caqti using C bindings"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.1/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.10.1/opam
@@ -14,7 +14,7 @@ depends: [
   "caqti-async" {with-test & = "0.10.1"}
   "caqti-dynload" {with-test & = "0.10.1"}
   "caqti-lwt" {with-test & = "0.10.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "sqlite3"
 ]
 synopsis: "Sqlite3 driver for Caqti using C bindings"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.9.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.0.9.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "sqlite3"
 ]
 synopsis: "Sqlite3 driver for Caqti using C bindings"

--- a/packages/caqti-dynload/caqti-dynload.0.10.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind"
   "ppx_optcomp" {>= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"

--- a/packages/caqti-dynload/caqti-dynload.0.10.1/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.10.1/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind"
   "ppx_optcomp" {>= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"

--- a/packages/caqti-dynload/caqti-dynload.0.9.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.0.9.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind"
   "ppx_optcomp" {>= "v0.9.0" & < "v0.11.0"}
   "ppx_driver"

--- a/packages/caqti-lwt/caqti-lwt.0.10.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.10.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt" {< "4.0.0"}
 ]
 synopsis: "Lwt support for Caqti"

--- a/packages/caqti-lwt/caqti-lwt.0.10.1/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.10.1/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.10.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt" {< "4.0.0"}
 ]
 synopsis: "Lwt support for Caqti"

--- a/packages/caqti-lwt/caqti-lwt.0.9.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.0.9.0/opam
@@ -11,7 +11,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt" {< "4.0.0"}
 ]
 synopsis: "Lwt support for Caqti"

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "caqti" {= "0.10.0"}
   "calendar" {>= "2.00"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Date and time field types using the calendar library."
 url {

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.10.1/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.10.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "caqti" {= "0.10.1"}
   "calendar" {>= "2.00"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Date and time field types using the calendar library."
 url {

--- a/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.0.9.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "caqti" {= "0.9.0"}
   "calendar" {>= "2.00"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Date and time field types using the calendar library."
 url {

--- a/packages/caqti/caqti.0.10.0/opam
+++ b/packages/caqti/caqti.0.10.0/opam
@@ -10,7 +10,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"

--- a/packages/caqti/caqti.0.10.1/opam
+++ b/packages/caqti/caqti.0.10.1/opam
@@ -10,7 +10,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"

--- a/packages/caqti/caqti.0.9.0/opam
+++ b/packages/caqti/caqti.0.9.0/opam
@@ -10,7 +10,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "calendar" {>= "2.00"}
   "ocamlfind" {build}
   "ptime"

--- a/packages/cfstream/cfstream.1.2.3/opam
+++ b/packages/cfstream/cfstream.1.2.3/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/biocaml/cfstream.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core_kernel" {>= "v0.9.0" & < "v0.11"}
   "ounit"
   "conf-m4" {build}

--- a/packages/checkseum/checkseum.0.0.1/opam
+++ b/packages/checkseum/checkseum.0.0.1/opam
@@ -11,7 +11,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "optint" {< "0.0.5"}
   "base-bytes"
 ]

--- a/packages/checkseum/checkseum.0.0.2/opam
+++ b/packages/checkseum/checkseum.0.0.2/opam
@@ -11,7 +11,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "optint" {< "0.0.5"}
   "base-bytes"
   "base-bigarray"

--- a/packages/clarity/clarity.0.3.1/opam
+++ b/packages/clarity/clarity.0.3.1/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/IndiscriminateCoding/clarity.git"
 license: "BSD-3-Clause"
 depends: [
   "ocaml" {>= "4.04.0" & < "4.08.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind" {build}
 ]
 build: [

--- a/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
+++ b/packages/cmdtui-lambda-term/cmdtui-lambda-term.0.4.3/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/edwintorok/cmdtui.git"
 bug-reports: "https://gitlab.com/edwintorok/cmdtui/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "astring" {>= "0.8.3"}
   "fmt" {>= "0.8.0"}
   "lambda-term" {< "2.0"}

--- a/packages/cmdtui/cmdtui.0.4.3/opam
+++ b/packages/cmdtui/cmdtui.0.4.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://gitlab.com/edwintorok/cmdtui/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "astring" {>= "0.8.3"}
 ]
 build: [

--- a/packages/coin/coin.0.1.0/opam
+++ b/packages/coin/coin.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "re" {>= "1.7.2"}
   "fmt"
   "bos"

--- a/packages/core/core.v0.9.1/opam
+++ b/packages/core/core.v0.9.1/opam
@@ -13,7 +13,7 @@ depends: [
   "base" {>= "v0.9" & < "v0.10"}
   "configurator" {>= "v0.9" & < "v0.10"}
   "core_kernel" {>= "v0.9" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_assert" {>= "v0.9" & < "v0.10"}
   "ppx_driver" {>= "v0.9" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}

--- a/packages/core/core.v0.9.2/opam
+++ b/packages/core/core.v0.9.2/opam
@@ -13,7 +13,7 @@ depends: [
   "base" {>= "v0.9.4" & < "v0.10"}
   "configurator" {>= "v0.9" & < "v0.10"}
   "core_kernel" {>= "v0.9.1" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_assert" {>= "v0.9" & < "v0.10"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}

--- a/packages/core_extended/core_extended.v0.9.1/opam
+++ b/packages/core_extended/core_extended.v0.9.1/opam
@@ -14,7 +14,7 @@ depends: [
   "core" {>= "v0.9.2" & < "v0.10"}
   "core_kernel" {>= "v0.9.1" & < "v0.10"}
   "fieldslib" {>= "v0.9" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "re2" {>= "v0.9.1" & < "v0.10"}

--- a/packages/core_kernel/core_kernel.v0.9.1/opam
+++ b/packages/core_kernel/core_kernel.v0.9.1/opam
@@ -15,7 +15,7 @@ depends: [
   "configurator" {>= "v0.9" & < "v0.10"}
   "fieldslib" {>= "v0.9" & < "v0.10"}
   "jane-street-headers" {>= "v0.9" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_assert" {>= "v0.9" & < "v0.10"}
   "ppx_base" {>= "v0.9" & < "v0.10"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}

--- a/packages/cowabloga/cowabloga.0.3.0/opam
+++ b/packages/cowabloga/cowabloga.0.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "re" {< "1.7.2"}
   "magic-mime"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Simple static blogging support."
 description: "ALPHA. It will likely be in flux for a little while."

--- a/packages/cowabloga/cowabloga.0.4.0/opam
+++ b/packages/cowabloga/cowabloga.0.4.0/opam
@@ -20,7 +20,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "magic-mime"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cohttp" {with-test & >= "0.5.0"}
   "cohttp-lwt-unix" {with-test}
 ]

--- a/packages/cpm/cpm.4.0.0/opam
+++ b/packages/cpm/cpm.4.0.0/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.0-or-later"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries"
 ]
 synopsis:

--- a/packages/craml/craml.1.0.0/opam
+++ b/packages/craml/craml.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "fmt" {>= "0.8.5"}
   "astring"
   "logs"

--- a/packages/crlibm/crlibm.0.1/opam
+++ b/packages/crlibm/crlibm.0.1/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base" {build}
   "stdio" {build}
   "configurator" {build}

--- a/packages/crlibm/crlibm.0.2/opam
+++ b/packages/crlibm/crlibm.0.2/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base" {build}
   "stdio" {build}
   "configurator" {build}

--- a/packages/csv-lwt/csv-lwt.2.0/opam
+++ b/packages/csv-lwt/csv-lwt.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "csv" {= "2.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
   "lwt" {>= "2.4.7"}

--- a/packages/csvfields/csvfields.v0.9.1/opam
+++ b/packages/csvfields/csvfields.v0.9.1/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "core" {>= "v0.9.2" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "sexplib" {>= "v0.9.3" & < "v0.10"}

--- a/packages/cuid/cuid.0.1/opam
+++ b/packages/cuid/cuid.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "alcotest" {with-test}
   "re" {with-test}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core" {>= "v0.9.0"}
 ]
 synopsis: "CUID generator for OCaml."

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "2.7.1"}
   "datakit-github" {>= "0.10.0" & < "0.11.0"}

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.10.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "3.0.0"}
   "datakit-github" {>= "0.10.0" & < "0.11.0"}

--- a/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
+++ b/packages/datakit-bridge-github/datakit-bridge-github.0.11.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "3.0.0"}
   "datakit-github" {>= "0.11.0" & < "0.12.0"}

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.10.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.10.0/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "irmin-watcher"
   "irmin" {>= "1.1.0" & < "2.0.0"}

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.10.1/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.10.1/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "irmin-watcher"
   "irmin" {>= "1.1.0" & < "2.0.0"}

--- a/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
+++ b/packages/datakit-bridge-local-git/datakit-bridge-local-git.0.11.0/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "irmin-watcher"
   "irmin" {>= "1.2.0" & < "2.0.0"}

--- a/packages/datakit-ci/datakit-ci.0.10.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.10.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "multipart-form-data" {< "0.3.0"}
   "datakit-client" {>= "0.10.0" & < "0.11.0"}
   "datakit-github" {>= "0.10.0" & < "0.11.0"}

--- a/packages/datakit-ci/datakit-ci.0.10.1/opam
+++ b/packages/datakit-ci/datakit-ci.0.10.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "multipart-form-data" {< "0.3.0"}
   "datakit-client" {>= "0.10.0" & < "0.11.0"}
   "datakit-github" {>= "0.10.0" & < "0.11.0"}

--- a/packages/datakit-ci/datakit-ci.0.11.0/opam
+++ b/packages/datakit-ci/datakit-ci.0.11.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "multipart-form-data" {< "0.3.0"}
   "datakit-client" {>= "0.11.0"}
   "datakit-client-9p" {>= "0.11.0"}

--- a/packages/datakit-client-9p/datakit-client-9p.0.11.0/opam
+++ b/packages/datakit-client-9p/datakit-client-9p.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "astring"
   "logs"
   "fmt"

--- a/packages/datakit-client-git/datakit-client-git.0.11.0/opam
+++ b/packages/datakit-client-git/datakit-client-git.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "datakit-client" {>= "0.11.0"}
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "irmin" {< "1.4.0"}

--- a/packages/datakit-client/datakit-client.0.10.0/opam
+++ b/packages/datakit-client/datakit-client.0.10.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "base-bytes"
   "astring"
   "logs"

--- a/packages/datakit-client/datakit-client.0.10.1/opam
+++ b/packages/datakit-client/datakit-client.0.10.1/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "base-bytes"
   "astring"
   "logs"

--- a/packages/datakit-client/datakit-client.0.11.0/opam
+++ b/packages/datakit-client/datakit-client.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "astring"
   "result"
   "fmt"

--- a/packages/datakit-github/datakit-github.0.10.0/opam
+++ b/packages/datakit-github/datakit-github.0.10.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "2.7.1"}
   "uri" {>= "1.8.0"}

--- a/packages/datakit-github/datakit-github.0.10.1/opam
+++ b/packages/datakit-github/datakit-github.0.10.1/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.8.0"}

--- a/packages/datakit-github/datakit-github.0.11.0/opam
+++ b/packages/datakit-github/datakit-github.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "lwt" {>= "3.0.0"}
   "uri" {>= "1.8.0"}

--- a/packages/datakit-server-9p/datakit-server-9p.0.11.0/opam
+++ b/packages/datakit-server-9p/datakit-server-9p.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "datakit-server" {>= "0.11.0"}
   "mirage-flow-lwt"
   "protocol-9p" {>= "0.11.0"}

--- a/packages/datakit-server/datakit-server.0.10.0/opam
+++ b/packages/datakit-server/datakit-server.0.10.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "base-bytes"
   "astring"
   "logs"

--- a/packages/datakit-server/datakit-server.0.10.1/opam
+++ b/packages/datakit-server/datakit-server.0.10.1/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "base-bytes"
   "astring"
   "logs"

--- a/packages/datakit-server/datakit-server.0.11.0/opam
+++ b/packages/datakit-server/datakit-server.0.11.0/opam
@@ -12,7 +12,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "astring"
   "logs"
   "rresult"

--- a/packages/datakit/datakit.0.10.0/opam
+++ b/packages/datakit/datakit.0.10.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "rresult"
   "astring"

--- a/packages/datakit/datakit.0.10.1/opam
+++ b/packages/datakit/datakit.0.10.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "rresult"
   "astring"

--- a/packages/datakit/datakit.0.11.0/opam
+++ b/packages/datakit/datakit.0.11.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder" {< "1.0+beta12"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta12"}
   "cmdliner"
   "rresult"
   "astring"

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.1.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.1.0/opam
@@ -164,7 +164,7 @@ doc: "https://mattjbray.github.io/ocaml-decoders/decoders-ezjsonm"
 bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "decoders" {< "0.3.0"}
   "ezjsonm" {>= "0.4.0"}

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.1.1/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.1.1/opam
@@ -255,7 +255,7 @@ doc: "https://mattjbray.github.io/ocaml-decoders/decoders-ezjsonm"
 bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "decoders" {< "0.3.0"}
   "ezjsonm" {>= "0.4.0"}

--- a/packages/decoders-yojson/decoders-yojson.0.1.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.1.0/opam
@@ -164,7 +164,7 @@ doc: "https://mattjbray.github.io/ocaml-decoders/decoders-yojson"
 bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "decoders" {< "0.3.0"}
   "yojson"

--- a/packages/decoders-yojson/decoders-yojson.0.1.1/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.1.1/opam
@@ -255,7 +255,7 @@ doc: "https://mattjbray.github.io/ocaml-decoders/decoders-yojson"
 bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "decoders" {< "0.3.0"}
   "yojson"

--- a/packages/decoders/decoders.0.1.0/opam
+++ b/packages/decoders/decoders.0.1.0/opam
@@ -164,7 +164,7 @@ doc: "https://mattjbray.github.io/ocaml-decoders/decoders"
 bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "containers"
 ]

--- a/packages/decoders/decoders.0.1.1/opam
+++ b/packages/decoders/decoders.0.1.1/opam
@@ -255,7 +255,7 @@ doc: "https://mattjbray.github.io/ocaml-decoders/decoders"
 bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "containers"
 ]

--- a/packages/digestif/digestif.0.6.1/opam
+++ b/packages/digestif/digestif.0.6.1/opam
@@ -13,7 +13,7 @@ build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-bigarray"
 ]

--- a/packages/dns-async/dns-async.1.0.0/opam
+++ b/packages/dns-async/dns-async.1.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dns" {>= "1.0.0" & < "2.0.0"}
   "async" {>= "v0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "DNS client and server implementation in pure OCaml"
 description: """

--- a/packages/dns-async/dns-async.1.0.1/opam
+++ b/packages/dns-async/dns-async.1.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dns" {>= "1.0.0" & < "2.0.0"}
   "async" {>= "v0.9.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "DNS client and server implementation in pure OCaml"
 description: """

--- a/packages/doc-ock-html/doc-ock-html.1.1.0/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.1.0/opam
@@ -10,7 +10,7 @@ tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "doc-ock" {>= "1.1.0" & < "1.2.0"}
   "tyxml" {>= "4.0.0"}
   "xmlm"

--- a/packages/doc-ock-html/doc-ock-html.1.1.1/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.1.1/opam
@@ -10,7 +10,7 @@ tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "doc-ock" {>= "1.1.0" & < "1.2.0"}
   "tyxml" {>= "4.0.0"}
   "xmlm"

--- a/packages/doc-ock-html/doc-ock-html.1.2.0/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.2.0/opam
@@ -10,7 +10,7 @@ tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "doc-ock" {>= "1.2.0" & < "1.2.1"}
   "tyxml" {>= "4.0.0"}
   "xmlm"

--- a/packages/doc-ock-html/doc-ock-html.1.2.1/opam
+++ b/packages/doc-ock-html/doc-ock-html.1.2.1/opam
@@ -10,7 +10,7 @@ tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "doc-ock" {>= "1.2.1"}
   "tyxml" {>= "4.0.0"}
   "xmlm"

--- a/packages/doc-ock-xml/doc-ock-xml.1.1.0/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.1.0/opam
@@ -13,7 +13,7 @@ tags: ["doc" "xml" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xmlm"
   "menhir"
   "doc-ock" {>= "1.1.0" & < "1.2.0"}

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.0/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.0/opam
@@ -13,7 +13,7 @@ tags: ["doc" "xml" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xmlm"
   "menhir"
   "doc-ock" {>= "1.2.0" & < "1.2.1"}

--- a/packages/doc-ock-xml/doc-ock-xml.1.2.1/opam
+++ b/packages/doc-ock-xml/doc-ock-xml.1.2.1/opam
@@ -13,7 +13,7 @@ tags: ["doc" "xml" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "xmlm"
   "menhir"
   "doc-ock" {>= "1.2.1"}

--- a/packages/doc-ock/doc-ock.1.1.0/opam
+++ b/packages/doc-ock/doc-ock.1.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06"}
   "cppo" {build}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "octavius"
 ]
 build: [

--- a/packages/doc-ock/doc-ock.1.1.1/opam
+++ b/packages/doc-ock/doc-ock.1.1.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06"}
   "cppo" {build}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "octavius"
 ]
 build: [

--- a/packages/doc-ock/doc-ock.1.2.0/opam
+++ b/packages/doc-ock/doc-ock.1.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "cppo" {build}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "octavius"
 ]
 build: [

--- a/packages/doc-ock/doc-ock.1.2.1/opam
+++ b/packages/doc-ock/doc-ock.1.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
   "cppo" {build}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "octavius"
 ]
 build: [

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "dokeysto"
   "lz4"
 ]

--- a/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/opam
+++ b/packages/dokeysto_lz4/dokeysto_lz4.2.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "dokeysto"
   "lz4"
 ]

--- a/packages/dryunit/dryunit.0.3.1/opam
+++ b/packages/dryunit/dryunit.0.3.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_dryunit"
   "cmdliner" {>= "1.0.2"}
 ]

--- a/packages/dryunit/dryunit.0.4.0/opam
+++ b/packages/dryunit/dryunit.0.4.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "cmdliner" {>= "1.0.2"}
 ]

--- a/packages/dryunit/dryunit.0.4.1/opam
+++ b/packages/dryunit/dryunit.0.4.1/opam
@@ -11,7 +11,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "cmdliner" {>= "1.0.2"}
 ]

--- a/packages/dryunit/dryunit.0.5.0/opam
+++ b/packages/dryunit/dryunit.0.5.0/opam
@@ -11,7 +11,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "cmdliner" {>= "1.0.2"}
 ]

--- a/packages/dune-release/dune-release.0.1.0/opam
+++ b/packages/dune-release/dune-release.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "fmt" {< "0.8.7"}
   "bos"
   "cmdliner" {< "1.1.0"}

--- a/packages/dune-release/dune-release.0.2.0/opam
+++ b/packages/dune-release/dune-release.0.2.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "fmt" {< "0.8.7"}
   "bos"
   "cmdliner" {< "1.1.0"}

--- a/packages/dune-release/dune-release.0.3.0/opam
+++ b/packages/dune-release/dune-release.0.3.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "fmt" {< "0.8.7"}
   "bos"
   "cmdliner" {< "1.1.0"}

--- a/packages/dune_watch/dune_watch.0.0.1/opam
+++ b/packages/dune_watch/dune_watch.0.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/dune_watch"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt"
   "ppx_monadic"
 ]

--- a/packages/dune_watch/dune_watch.0.1.0/opam
+++ b/packages/dune_watch/dune_watch.0.1.0/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/dune_watch"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt"
   "ppx_monadic" {>= "2.3.0"}
   "ppx_meta_conv" {>= "4.0.0"}

--- a/packages/dune_watch/dune_watch.0.2.0/opam
+++ b/packages/dune_watch/dune_watch.0.2.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/dune_watch"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt"
   "ppx_monadic" {>= "2.3.0"}
   "ppx_meta_conv" {>= "4.0.0"}

--- a/packages/easy-format/easy-format.1.3.0/opam
+++ b/packages/easy-format/easy-format.1.3.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "High-level and functional interface to the Format module of the OCaml standard library"

--- a/packages/easy-format/easy-format.1.3.1/opam
+++ b/packages/easy-format/easy-format.1.3.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "High-level and functional interface to the Format module of the OCaml standard library"

--- a/packages/email_message/email_message.v0.9.1/opam
+++ b/packages/email_message/email_message.v0.9.1/opam
@@ -13,7 +13,7 @@ depends: [
   "async" {>= "v0.9" & < "v0.10"}
   "core" {>= "v0.9.2" & < "v0.10"}
   "core_extended" {>= "v0.9.1" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "re2" {>= "v0.9.1" & < "v0.10"}

--- a/packages/exenum/exenum.0.82.0/opam
+++ b/packages/exenum/exenum.0.82.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/lebotlan/ocaml-exenum/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/lebotlan/ocaml-exenum.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
-depends: ["ocaml" "ocamlfind" "jbuilder" "num"]
+depends: ["ocaml" "ocamlfind" "jbuilder" {>= "1.0+beta7"} "num"]
 depopts: "lwt"
 conflicts: [
   "lwt" {>= "4.0.0"}

--- a/packages/exenum/exenum.0.84/opam
+++ b/packages/exenum/exenum.0.84/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/lebotlan/ocaml-exenum/issues"
 license: "MIT"
 dev-repo: "git+https://github.com/lebotlan/ocaml-exenum.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
-depends: ["ocaml" "ocamlfind" "jbuilder" "zarith"]
+depends: ["ocaml" "ocamlfind" "jbuilder" {>= "1.0+beta7"} "zarith"]
 depopts: "lwt"
 conflicts: [
   "lwt" {>= "4.0.0"}

--- a/packages/fftw3/fftw3.0.8.1/opam
+++ b/packages/fftw3/fftw3.0.8.1/opam
@@ -24,7 +24,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.10"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "configurator" {build}
   "base" {build}

--- a/packages/fftw3/fftw3.0.8/opam
+++ b/packages/fftw3/fftw3.0.8/opam
@@ -24,7 +24,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.10"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "configurator" {build}
   "base" {build}

--- a/packages/gapi-ocaml/gapi-ocaml.0.3.6/opam
+++ b/packages/gapi-ocaml/gapi-ocaml.0.3.6/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "cryptokit"
   ("extlib" | "extlib-compat")
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlnet" {>= "4.1.4"}
   "ocurl"
   "xmlm"

--- a/packages/gdbprofiler/gdbprofiler.0.2/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir" {build}
   "lwt" {>= "2.4.6" & < "4.0.0"}
   "containers" {>= "0.20" & < "3.0"}

--- a/packages/gdbprofiler/gdbprofiler.0.3/opam
+++ b/packages/gdbprofiler/gdbprofiler.0.3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir" {build}
   "lwt" {>= "3.2.0"}
   "lwt_ppx"

--- a/packages/gen/gen.0.5.1/opam
+++ b/packages/gen/gen.0.5.1/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.11"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "odoc" {with-doc}
   "qtest" {with-test}

--- a/packages/get_line/get_line.4.0.0/opam
+++ b/packages/get_line/get_line.4.0.0/opam
@@ -8,7 +8,7 @@ license: "GPL-1.0-or-later"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries" {>= "2.6.0"}
 ]
 synopsis:

--- a/packages/git-http/git-http.1.11.0/opam
+++ b/packages/git-http/git-http.1.11.0/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "git" {>= "1.11.0" & < "2.0.0"}
   "cohttp" {>= "0.19.1" & < "0.99"}
 ]

--- a/packages/git-http/git-http.1.11.2/opam
+++ b/packages/git-http/git-http.1.11.2/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "git" {>= "1.11.0" & < "2.0.0"}
   "cohttp-lwt" {>= "0.99.0" & < "1.0"}
 ]

--- a/packages/git-http/git-http.1.11.4/opam
+++ b/packages/git-http/git-http.1.11.4/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "sexplib"
   "git" {>= "1.11.0" & < "2.0.0"}
   "cohttp-lwt" {>= "1.0.0" & < "2.2.0"}

--- a/packages/git-mirage/git-mirage.1.11.0/opam
+++ b/packages/git-mirage/git-mirage.1.11.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mirage-http"
   "mirage-flow-lwt"
   "mirage-channel-lwt"

--- a/packages/git-mirage/git-mirage.1.11.2/opam
+++ b/packages/git-mirage/git-mirage.1.11.2/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mirage-http"
   "mirage-flow-lwt"
   "mirage-channel-lwt"

--- a/packages/git-mirage/git-mirage.1.11.4/opam
+++ b/packages/git-mirage/git-mirage.1.11.4/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cohttp-mirage" {>= "1.0.1"}
   "mirage-flow-lwt"
   "mirage-channel-lwt"

--- a/packages/git-unix/git-unix.1.11.1/opam
+++ b/packages/git-unix/git-unix.1.11.1/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner" {< "1.1.0"}
   "logs"
   "git-http" {>= "1.11.0"}

--- a/packages/git-unix/git-unix.1.11.2/opam
+++ b/packages/git-unix/git-unix.1.11.2/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner" {< "1.1.0"}
   "logs"
   "git-http" {>= "1.11.0"}

--- a/packages/git-unix/git-unix.1.11.4/opam
+++ b/packages/git-unix/git-unix.1.11.4/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner" {< "1.1.0"}
   "logs"
   "git-http" {>= "1.11.0" & < "2.0.0"}

--- a/packages/git-unix/git-unix.1.11.5/opam
+++ b/packages/git-unix/git-unix.1.11.5/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner" {< "1.1.0"}
   "logs"
   "git-http" {>= "1.11.0" & < "2.0.0"}

--- a/packages/git/git.1.11.0/opam
+++ b/packages/git/git.1.11.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mstruct" {>= "1.3.1"}
   "ocamlgraph"
   "uri" {>= "1.3.12"}

--- a/packages/git/git.1.11.2/opam
+++ b/packages/git/git.1.11.2/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mstruct" {>= "1.3.1"}
   "ocamlgraph"
   "uri" {>= "1.3.12"}

--- a/packages/git/git.1.11.3/opam
+++ b/packages/git/git.1.11.3/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mstruct" {>= "1.3.1"}
   "ocamlgraph"
   "uri" {>= "1.3.12"}

--- a/packages/git/git.1.11.5/opam
+++ b/packages/git/git.1.11.5/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mstruct" {>= "1.3.1"}
   "ocamlgraph"
   "uri" {>= "1.3.12"}

--- a/packages/gnuplot/gnuplot.0.5.3/opam
+++ b/packages/gnuplot/gnuplot.0.5.3/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "core" {< "v0.13"}
   "conf-gnuplot"
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Simple interface to Gnuplot"
 description: """

--- a/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.23/opam
+++ b/packages/google-drive-ocamlfuse/google-drive-ocamlfuse.0.6.23/opam
@@ -15,7 +15,7 @@ depends: [
   "base-threads" {build}
   "camlidl" {build}
   "gapi-ocaml" {>= "0.3.6" & < "0.4.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfuse" {< "2.7.1-cvs6"}
   "cryptokit"
   "extlib" {< "1.7.8"}

--- a/packages/graphql-async/graphql-async.0.1.0/opam
+++ b/packages/graphql-async/graphql-async.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql" {< "0.7.0"}
   "async_kernel" {>= "v0.9.0" & < "v0.15"}
   "alcotest" {with-test}

--- a/packages/graphql-cohttp/graphql-cohttp.0.8.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.8.0/opam
@@ -13,7 +13,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql" {>= "0.8.0"}
   "cohttp" {>= "1.0.0"}
   "crunch"

--- a/packages/graphql-lwt/graphql-lwt.0.1.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql" {< "0.7.0"}
   "alcotest" {with-test}
   "lwt"

--- a/packages/graphql-lwt/graphql-lwt.0.3.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.3.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql" {< "0.7.0"}
   "alcotest" {with-test}
   "lwt"

--- a/packages/graphql-lwt/graphql-lwt.0.6.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql" {< "0.7.0"}
   "alcotest" {with-test}
   "lwt"

--- a/packages/graphql-lwt/graphql-lwt.0.7.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.7.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql" {>= "0.7.0" & < "0.8.0"}
   "alcotest" {with-test}
   "lwt"

--- a/packages/graphql/graphql.0.1.0/opam
+++ b/packages/graphql/graphql.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "angstrom" {>= "0.4.0" & < "0.7.0"}
   "sexplib"
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/packages/graphql/graphql.0.2.0/opam
+++ b/packages/graphql/graphql.0.2.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "angstrom" {>= "0.4.0" & < "0.7.0"}
   "sexplib"
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/packages/graphql/graphql.0.4.0/opam
+++ b/packages/graphql/graphql.0.4.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql_parser" {< "0.9.0"}
   "yojson"
   "rresult"

--- a/packages/graphql/graphql.0.5.0/opam
+++ b/packages/graphql/graphql.0.5.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql_parser" {< "0.9.0"}
   "yojson"
   "rresult"

--- a/packages/graphql/graphql.0.6.0/opam
+++ b/packages/graphql/graphql.0.6.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql_parser" {< "0.9.0"}
   "yojson"
   "rresult"

--- a/packages/graphql/graphql.0.7.0/opam
+++ b/packages/graphql/graphql.0.7.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql_parser" {< "0.9.0"}
   "yojson"
   "rresult"

--- a/packages/graphql_parser/graphql_parser.0.4.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.4.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "angstrom" {>= "0.4.0" & < "0.7.0"}
   "sexplib"
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/packages/graphql_parser/graphql_parser.0.5.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.5.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "angstrom" {>= "0.7.0" & < "0.14.0"}
   "sexplib"
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/packages/graphql_parser/graphql_parser.0.7.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.7.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "angstrom" {>= "0.7.0" & < "0.14.0"}
   "sexplib"
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/packages/grenier/grenier.0.7/opam
+++ b/packages/grenier/grenier.0.7/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.10"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "A collection of various algorithms in OCaml."
 description: """

--- a/packages/hashids/hashids.1.0.0/opam
+++ b/packages/hashids/hashids.1.0.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "General" {>= "0.4.0"}
 ]
 synopsis:

--- a/packages/hiredis-value/hiredis-value.0.8/opam
+++ b/packages/hiredis-value/hiredis-value.0.8/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Hiredis Value type"
 description:

--- a/packages/hiredis/hiredis.0.8/opam
+++ b/packages/hiredis/hiredis.0.8/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt" {>= "3.3.0"}
   "hiredis-value" {>= "0.8"}
   "conduit-lwt-unix" {<"2.0.0"}

--- a/packages/integration1d/integration1d.0.5/opam
+++ b/packages/integration1d/integration1d.0.5/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "camlp4" {build}
 ]
 synopsis: "Integration of functions of one variable"

--- a/packages/interval/interval.1.4/opam
+++ b/packages/interval/interval.1.4/opam
@@ -16,7 +16,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "An interval library for OCaml"
 description: """

--- a/packages/inuit/inuit.0.4.1/opam
+++ b/packages/inuit/inuit.0.4.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/let-def/inuit.git"
 bug-reports: "https://github.com/let-def/inuit/issues"
 depends: [
   "ocaml" {>= "4.01.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "grenier" {>= "0.4"}
 ]
 build: [

--- a/packages/irmin-fs/irmin-fs.1.2.0/opam
+++ b/packages/irmin-fs/irmin-fs.1.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "irmin" {>= "1.2.0" & < "1.3.0"}
   "alcotest" {with-test}
   "mtime" {with-test & >= "1.0.0"}

--- a/packages/irmin-git/irmin-git.1.2.0/opam
+++ b/packages/irmin-git/irmin-git.1.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "irmin" {>= "1.2.0" & < "1.3.0"}
   "git" {>= "1.11.0" & < "1.12.0"}
   "alcotest" {with-test}

--- a/packages/irmin-http/irmin-http.1.2.0/opam
+++ b/packages/irmin-http/irmin-http.1.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "crunch"
   "webmachine" {>= "0.3.2" & < "0.6.0"}
   "irmin" {>= "1.2.0" & < "2.0.0"}

--- a/packages/irmin-mem/irmin-mem.1.2.0/opam
+++ b/packages/irmin-mem/irmin-mem.1.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "irmin" {>= "1.2.0" & < "1.3.0"}
   "alcotest" {with-test}
   "mtime" {with-test & >= "1.0.0"}

--- a/packages/irmin-mirage/irmin-mirage.1.2.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.1.2.0/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "irmin" {>= "1.2.0" & < "2.0.0"}
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "irmin-mem" {>= "1.2.0" & < "2.0.0"}

--- a/packages/irmin-unix/irmin-unix.1.2.0/opam
+++ b/packages/irmin-unix/irmin-unix.1.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "irmin" {>= "1.2.0" & < "1.3.0"}
   "irmin-git" {>= "1.2.0" & < "2.0.0"}
   "irmin-http" {>= "1.2.0" & < "2.0.0"}

--- a/packages/irmin/irmin.1.2.0/opam
+++ b/packages/irmin/irmin.1.2.0/opam
@@ -11,7 +11,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "result" {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}

--- a/packages/kafka/kafka.0.3/opam
+++ b/packages/kafka/kafka.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "base-unix"
   "lwt"
   "cmdliner"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 depexts: [
   ["zlib-dev" "librdkafka-dev"] {os-distribution = "alpine"}

--- a/packages/kafka/kafka.0.4/opam
+++ b/packages/kafka/kafka.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "base-unix"
   "lwt"
   "cmdliner"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 depexts: [
   ["librdkafka-dev" "zlib-dev"] {os-distribution = "alpine"}

--- a/packages/kicadsch/kicadsch.0.2.0/opam
+++ b/packages/kicadsch/kicadsch.0.2.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
 ]
 synopsis: "Schematic plotter"

--- a/packages/kicadsch/kicadsch.0.3.0/opam
+++ b/packages/kicadsch/kicadsch.0.3.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
 ]
 synopsis: "Schematic plotter"

--- a/packages/kubecaml/kubecaml.0.1.0/opam
+++ b/packages/kubecaml/kubecaml.0.1.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cohttp-lwt-unix" {>= "1.0.2"}
   "lwt" {>= "3.3.0"}
   "ppx_deriving_yojson" {>= "3.1"}

--- a/packages/kyotocabinet/kyotocabinet.0.1/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.1/opam
@@ -21,7 +21,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 depexts: [
   ["libkyotocabinet-dev"] {os-family = "debian"}

--- a/packages/kyotocabinet/kyotocabinet.0.2/opam
+++ b/packages/kyotocabinet/kyotocabinet.0.2/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 depexts: [
   ["libkyotocabinet-dev"] {os-family = "debian"}

--- a/packages/lens/lens.1.2.1/opam
+++ b/packages/lens/lens.1.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_deriving" {< "5.0"}
   "ppx_tools" {build}
   "ppxfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
 ]
 synopsis: "Functional lenses"

--- a/packages/lens/lens.1.2.2/opam
+++ b/packages/lens/lens.1.2.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_deriving" {< "5.0"}
   "ppx_tools" {build}
   "ppxfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
 ]
 synopsis: "Functional lenses"

--- a/packages/let-if/let-if.0.1.0/opam
+++ b/packages/let-if/let-if.0.1.0/opam
@@ -8,7 +8,7 @@ license: "BSD-2-clause"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppxlib" {< "0.9.0"}
 ]
 synopsis: "This ppx brings a `let%if` construct similar Rust's `if let`."

--- a/packages/levenshtein/levenshtein.1.1.3/opam
+++ b/packages/levenshtein/levenshtein.1.1.3/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/ocaml_levenshtein"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_test" {>= "1.6.0"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]

--- a/packages/libsvm/libsvm.0.9.4/opam
+++ b/packages/libsvm/libsvm.0.9.4/opam
@@ -18,7 +18,7 @@ depends: [
   "base"
   "stdio"
   "lacaml"
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "conf-g++"
 ]
 synopsis: "LIBSVM bindings for OCaml"

--- a/packages/links-postgresql/links-postgresql.0.7.2/opam
+++ b/packages/links-postgresql/links-postgresql.0.7.2/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "postgresql"
   "links" {= version}
 ]

--- a/packages/links-postgresql/links-postgresql.0.7.3/opam
+++ b/packages/links-postgresql/links-postgresql.0.7.3/opam
@@ -13,7 +13,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "postgresql"
   "links" {= version}
 ]

--- a/packages/links/links.0.7.2/opam
+++ b/packages/links/links.0.7.2/opam
@@ -51,7 +51,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.04.0" & < "4.06"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "deriving" {build}
   "cgi"
   "base64" {< "3.0.0"}

--- a/packages/links/links.0.7.3/opam
+++ b/packages/links/links.0.7.3/opam
@@ -51,7 +51,7 @@ remove: [
 
 depends: [
   "ocaml" {>= "4.06.0" & < "4.07"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "base64" {< "3.0.0"}

--- a/packages/llopt/llopt.1.0.0/opam
+++ b/packages/llopt/llopt.1.0.0/opam
@@ -9,7 +9,7 @@ tags: ["llvm" "optimization" "test" "testing" "compiler"]
 build: ["jbuilder" "build" "-p" "llopt" "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "llvm" {>= "3.5"}
   "cmdliner"
 ]

--- a/packages/lwt_camlp4/lwt_camlp4.1.0.0/opam
+++ b/packages/lwt_camlp4/lwt_camlp4.1.0.0/opam
@@ -14,7 +14,7 @@ license: "LGPL with OpenSSL linking exception"
 depends: [
   "ocaml"
   "camlp4"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt"
 ]
 build: [

--- a/packages/mastodon-archive-viewer/mastodon-archive-viewer.0.1/opam
+++ b/packages/mastodon-archive-viewer/mastodon-archive-viewer.0.1/opam
@@ -9,7 +9,7 @@ tags: ["mastodon" "ActivityPub"]
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "containers"
   "ezjsonm" {>= "0.4.0"}
   "ptime"

--- a/packages/mesh-display/mesh-display.0.8.9/opam
+++ b/packages/mesh-display/mesh-display.0.8.9/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"
   "ocamlfind" {build & >= "1.5"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "configurator" {build}
   "mesh" {= "0.8.9"}
   "graphics"

--- a/packages/mesh-graphics/mesh-graphics.0.9.0/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.5"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "configurator" {build}
   "mesh" {= "0.9.0"}
   "graphics"

--- a/packages/mesh-graphics/mesh-graphics.0.9.1/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.1/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.5"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "configurator" {build}
   "mesh" {= "0.9.1"}
   "graphics"

--- a/packages/mesh-graphics/mesh-graphics.0.9.2/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.2/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.5"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "configurator" {build}
   "mesh" {= "0.9.2"}
   "graphics"

--- a/packages/mesh-graphics/mesh-graphics.0.9.3/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.3/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mesh" {= "0.9.3"}
   "graphics"
 ]

--- a/packages/mesh-graphics/mesh-graphics.0.9.4/opam
+++ b/packages/mesh-graphics/mesh-graphics.0.9.4/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mesh" {= "0.9.4"}
   "graphics"
 ]

--- a/packages/milter/milter.1.0.4/opam
+++ b/packages/milter/milter.1.0.4/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/andrenth/ocaml-milter.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {< "4.09.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 depexts: [
   ["libmilter-dev"] {os-distribution = "alpine"}

--- a/packages/minimal/minimal.1.0.0/opam
+++ b/packages/minimal/minimal.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & >= "20170418" & < "20211215"}
 ]
 synopsis: "Minima.l, a minimal Lisp"

--- a/packages/minimal/minimal.1.1.0/opam
+++ b/packages/minimal/minimal.1.1.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & >= "20170418"}
   "sedlex" {build & >= "1.99.4" & < "2.0"}
   "yojson" {build & >= "1.4.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cstruct" {>= "1.3.0" & < "3.4.0"}
   "lwt" {>= "2.6.0"}
   "mirage-block-lwt" {>= "1.0.0"}

--- a/packages/mirage-nat/mirage-nat.1.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "logs"
   "lru" {< "0.3.0"}
   "ppx_deriving" {>= "4.2"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "tcpip" {>= "3.0.0" & <"3.6.0"}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
+++ b/packages/mirage-net-flow/mirage-net-flow.1.0.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mirage-net-lwt" {>= "1.0.0" & < "2.0.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "cstruct-lwt" {>= "3.0.0"}

--- a/packages/modular-arithmetic/modular-arithmetic.0.1/opam
+++ b/packages/modular-arithmetic/modular-arithmetic.0.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
 ]
 synopsis:

--- a/packages/monomorphic/monomorphic.1.5/opam
+++ b/packages/monomorphic/monomorphic.1.5/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/kit-ty-kate/ocaml-monomorphic/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 tags: [
   "polymorphic"

--- a/packages/moss/moss.0.1/opam
+++ b/packages/moss/moss.0.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-unix"
   "base-bytes"
   "uri"

--- a/packages/multipart-form-data/multipart-form-data.0.2.0/opam
+++ b/packages/multipart-form-data/multipart-form-data.0.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "alcotest" {with-test}
   "stringext"

--- a/packages/mustache/mustache.3.0.2/opam
+++ b/packages/mustache/mustache.3.0.2/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "menhir"
   "base-unsafe-string"
 ]

--- a/packages/mvar/mvar.1.0.0/opam
+++ b/packages/mvar/mvar.1.0.0/opam
@@ -16,7 +16,7 @@ remove: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "opam-installer" {build}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/nsq/nsq.0.1.1/opam
+++ b/packages/nsq/nsq.0.1.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "containers" {< "2.0"}
   "lwt" {< "4.0.0"}
   "ocplib-endian"

--- a/packages/nsq/nsq.0.1/opam
+++ b/packages/nsq/nsq.0.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "containers" {< "2.0"}
   "lwt" {< "4.0.0"}
   "ocplib-endian"

--- a/packages/nsq/nsq.0.2.4/opam
+++ b/packages/nsq/nsq.0.2.4/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "containers"
   "lwt" {>= "3.2.0" & <"4.0.0"}
   "ocplib-endian"

--- a/packages/nsq/nsq.0.2.5/opam
+++ b/packages/nsq/nsq.0.2.5/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base" {< "v0.15"}
   "lwt" {>= "3.2.0" & <"4.0.0"}
   "ocplib-endian"

--- a/packages/nsq/nsq.0.3.0/opam
+++ b/packages/nsq/nsq.0.3.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ryanslade/nsq-ocaml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base" {< "v0.15"}
   "lwt" {>= "3.2.0" & <"4.0.0"}
   "ocplib-endian"

--- a/packages/numalib/numalib.0.1.0/opam
+++ b/packages/numalib/numalib.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "core" {>= "v0.9"}
   "async" {>= "v0.9"}
   "conf-numa"

--- a/packages/nunchaku/nunchaku.0.5.1/opam
+++ b/packages/nunchaku/nunchaku.0.5.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "containers" {>= "1.0"}
   "menhir" {build & <= "20181026"}
   "sequence"

--- a/packages/nunchaku/nunchaku.0.6/opam
+++ b/packages/nunchaku/nunchaku.0.6/opam
@@ -6,7 +6,7 @@ authors: ["Simon Cruanes" "Jasmin Blanchette"]
 homepage: "https://github.com/nunchaku-inria/nunchaku/"
 bug-reports: "https://github.com/nunchaku-inria/nunchaku/issues"
 depends: [
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "containers" {>= "1.0"}
   "menhir" {build & <= "20181026"}
   "sequence" {>= "1.0"}

--- a/packages/oc45/oc45.1.0.0/opam
+++ b/packages/oc45/oc45.1.0.0/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.0-or-later"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Pure OCaml implementation of the C4.5 algorithm."
 description: """

--- a/packages/ocaml-r/ocaml-r.0.1.0/opam
+++ b/packages/ocaml-r/ocaml-r.0.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "configurator" {build}
   "conf-r" {build}
   "conf-r-mathlib" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "stdio" {build}
 ]
 synopsis: "Objective Caml bindings for the R interpreter"

--- a/packages/ocaml-top/ocaml-top.1.1.4/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.4/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/OCamlPro/ocaml-top.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {< "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocp-pp" {build}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}

--- a/packages/ocaml-top/ocaml-top.1.1.5/opam
+++ b/packages/ocaml-top/ocaml-top.1.1.5/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/OCamlPro/ocaml-top.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocp-pp" {build}
   "lablgtk" {>= "2.16.0"}
   "conf-gtksourceview" {= "2"}

--- a/packages/ocamlformat/ocamlformat.0.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "cmdliner"
   "cmdliner" {with-test & < "1.1.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {>= "1.0.5" & < "2.0.0"}
   "ocamlformat_support" {= "0.1"}
   "stdio" {< "v0.12"}

--- a/packages/ocamlformat/ocamlformat.0.3/opam
+++ b/packages/ocamlformat/ocamlformat.0.3/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "cmdliner"
   "cmdliner" {with-test & < "1.1.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {>= "1.0.6" & < "2.0.0"}
   "ocamlformat_support" {= "0.2"}
   "stdio" {< "v0.12"}

--- a/packages/ocamlformat/ocamlformat.0.4/opam
+++ b/packages/ocamlformat/ocamlformat.0.4/opam
@@ -15,7 +15,7 @@ depends: [
   "base-unix"
   "cmdliner"
   "cmdliner" {with-test & < "1.1.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {>= "1.0.6" & < "2.0.0"}
   "ocamlformat_support" {= "0.3"}
   "stdio" {< "v0.12"}

--- a/packages/ocamlspot/ocamlspot.4.07.0.2.3.2/opam
+++ b/packages/ocamlspot/ocamlspot.4.07.0.2.3.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/ocamlspot"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {= "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "OCamlSpotter - OCaml source browsing"
 description: """

--- a/packages/ocp-browser/ocp-browser.1.1.6/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.6/opam
@@ -10,7 +10,7 @@ build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocp-pp"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocp-index" {= "1.1.6"}
   "cmdliner"
   "lambda-term" {< "2.0"}

--- a/packages/ocp-browser/ocp-browser.1.1.7/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.7/opam
@@ -18,7 +18,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocp-pp" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocp-index" {= version}
   "cmdliner"
   "lambda-term" {< "2.0"}

--- a/packages/ocp-browser/ocp-browser.1.1.8/opam
+++ b/packages/ocp-browser/ocp-browser.1.1.8/opam
@@ -18,7 +18,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.0"}
   "ocp-pp" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocp-index" {= "1.1.7" | = version}
   "cmdliner"
   "lambda-term" {< "2.0"}

--- a/packages/ocp-index/ocp-index.1.1.7/opam
+++ b/packages/ocp-index/ocp-index.1.1.7/opam
@@ -23,7 +23,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.10"}
   "ocp-pp" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.7.2"}
   "cmdliner"

--- a/packages/odoc/odoc.1.1.0/opam
+++ b/packages/odoc/odoc.1.1.0/opam
@@ -10,7 +10,7 @@ tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "doc-ock"
   "doc-ock-html"
   "doc-ock-xml" {< "1.2.0"}

--- a/packages/odoc/odoc.1.1.1/opam
+++ b/packages/odoc/odoc.1.1.1/opam
@@ -10,7 +10,7 @@ tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "doc-ock"
   "doc-ock-html"
   "doc-ock-xml" {< "1.2.0"}

--- a/packages/opam-lock/opam-lock.0.1/opam
+++ b/packages/opam-lock/opam-lock.0.1/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/AltGr/opam-lock/issues"
 dev-repo: "git+https://github.com/AltGr/opam-lock.git"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner" {>= "1.0"}
   "opam-solver" {>= "2.0.0~beta5"}
   "opam-state" {>= "2.0.0~beta5" & < "2.1"}

--- a/packages/opam-lock/opam-lock.0.2/opam
+++ b/packages/opam-lock/opam-lock.0.2/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/AltGr/opam-lock/issues"
 dev-repo: "git+https://github.com/AltGr/opam-lock.git"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner" {>= "1.0"}
   "opam-solver" {>= "2.0.0~beta5"}
   "opam-state" {>= "2.0.0~beta5" & < "2.1"}

--- a/packages/opam-package-upgrade/opam-package-upgrade.0.1/opam
+++ b/packages/opam-package-upgrade/opam-package-upgrade.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "opam-client" {>= "2.0.0~beta3.1" & < "2.1"}
   "cmdliner"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Upgrades opam package definition files to the latest format"
 description: """

--- a/packages/open/open.0.1.0/opam
+++ b/packages/open/open.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {>= "1.0+beta6"}
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "Conveniently open files such as PDFs in their default applications."

--- a/packages/open/open.0.2.0/opam
+++ b/packages/open/open.0.2.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {>= "1.0+beta6"}
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "Conveniently open files such as PDFs in their default applications."

--- a/packages/open/open.0.2.1/opam
+++ b/packages/open/open.0.2.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {>= "1.0+beta6"}
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:
   "Conveniently open files such as PDFs in their default applications."

--- a/packages/opium/opium.0.16.0/opam
+++ b/packages/opium/opium.0.16.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "opium_kernel"
   "cohttp-lwt-unix" {>= "0.99.0"}
   "base-unix"

--- a/packages/opium_kernel/opium_kernel.0.16.0/opam
+++ b/packages/opium_kernel/opium_kernel.0.16.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "hmap"
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt" {>= "0.99.0"}

--- a/packages/optimization1d/optimization1d.0.6/opam
+++ b/packages/optimization1d/optimization1d.0.6/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Find extrema of 1D functions"
 description: """

--- a/packages/orandforest/orandforest.1.0.0/opam
+++ b/packages/orandforest/orandforest.1.0.0/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.0-or-later"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "oc45"
   "parmap"
 ]

--- a/packages/oranger/oranger.0.9.11/opam
+++ b/packages/oranger/oranger.0.9.11/opam
@@ -15,7 +15,7 @@ remove: [
   ["rm" "-f" "%{prefix}%/bin/ml_rf_ranger"]
 ]
 depends: [
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "conf-cmake" {build}
   "conf-wget" {build}
 # "conf-c++" {build}

--- a/packages/orec/orec.1.0/opam
+++ b/packages/orec/orec.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "dynamic open records"
 description: """

--- a/packages/orsvm_e1071/orsvm_e1071.2.0.0/opam
+++ b/packages/orsvm_e1071/orsvm_e1071.2.0.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "conf-r"
   "dolog" {< "4.0.0" & with-test}
   "batteries" {with-test}

--- a/packages/orsvm_e1071/orsvm_e1071.3.0.0/opam
+++ b/packages/orsvm_e1071/orsvm_e1071.3.0.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "conf-r"
   "dolog" {< "4.0.0" & with-test}
   "batteries" {with-test}

--- a/packages/orsvm_e1071/orsvm_e1071.3.0.1/opam
+++ b/packages/orsvm_e1071/orsvm_e1071.3.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml"
   "conf-r"
   "dolog" {< "4.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries" {with-test}
   "cpm" {with-test}
   "minicli" {with-test}

--- a/packages/orxgboost/orxgboost.1.0.1/opam
+++ b/packages/orxgboost/orxgboost.1.0.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "conf-r"
   "dolog" {< "4.0.0" & with-test}
   "batteries" {with-test}

--- a/packages/osbx/osbx.1.1.1/opam
+++ b/packages/osbx/osbx.1.1.1/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "stdint" {build}
   "nocrypto" {build}
   "digestif" {build & = "0.5"}

--- a/packages/osbx/osbx.1.2.1/opam
+++ b/packages/osbx/osbx.1.2.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "stdint" {build}
   "nocrypto" {build}
   "digestif" {build & = "0.5"}

--- a/packages/osbx/osbx.1.2.2/opam
+++ b/packages/osbx/osbx.1.2.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "stdint" {build}
   "nocrypto" {build}
   "digestif" {build & = "0.5"}

--- a/packages/osbx/osbx.1.2.3/opam
+++ b/packages/osbx/osbx.1.2.3/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "stdint"
   "nocrypto"
   "digestif" {= "0.5"}

--- a/packages/osbx/osbx.1.2.4/opam
+++ b/packages/osbx/osbx.1.2.4/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/darrenldl/ocaml-SeqBox.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "stdint"
   "nocrypto"
   "digestif" {= "0.5"}

--- a/packages/otetris/otetris.1.0/opam
+++ b/packages/otetris/otetris.1.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/vzaliva/otetris.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries"
   "lwt" {>= "3.1.0" & < "4.0.0"}
   "lambda-term" {< "2.0"}

--- a/packages/otetris/otetris.1.1/opam
+++ b/packages/otetris/otetris.1.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/vzaliva/otetris.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries"
   "lwt" {>= "3.1.0" & < "4.0.0"}
   "lambda-term" {< "2.0"}

--- a/packages/owl-base/owl-base.0.3.7/opam
+++ b/packages/owl-base/owl-base.0.3.7/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "alcotest" {with-test}
   "base-bigarray"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "An OCaml Numerical Library"
 description: """

--- a/packages/owl-base/owl-base.0.3.8/opam
+++ b/packages/owl-base/owl-base.0.3.8/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "alcotest" {with-test}
   "base-bigarray"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "An OCaml Numerical Library"
 description: """

--- a/packages/owl-top/owl-top.0.3.7/opam
+++ b/packages/owl-top/owl-top.0.3.7/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-compiler-libs"
   "owl"
   "owl-zoo"

--- a/packages/owl-top/owl-top.0.3.8/opam
+++ b/packages/owl-top/owl-top.0.3.8/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-compiler-libs"
   "owl" {>= "0.3.8"}
   "owl-zoo" {>= "0.3.8"}

--- a/packages/owl-zoo/owl-zoo.0.3.7/opam
+++ b/packages/owl-zoo/owl-zoo.0.3.7/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0" & < "4.14.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-compiler-libs"
   "owl" {= version}
 ]

--- a/packages/owl-zoo/owl-zoo.0.3.8/opam
+++ b/packages/owl-zoo/owl-zoo.0.3.8/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.06.0" & < "4.14.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-compiler-libs"
   "owl" {= version}
 ]

--- a/packages/owl/owl.0.3.0/opam
+++ b/packages/owl/owl.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dolog" {>= "3.0" & < "4.0.0"}
   "gsl" {>= "1.20.0"}
   "conf-gsl"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "plplot"
   "eigen" {>= "0.0.3" & < "0.1.0"}
   "conf-openblas"

--- a/packages/owl/owl.0.3.7/opam
+++ b/packages/owl/owl.0.3.7/opam
@@ -21,7 +21,7 @@ depends: [
   "configurator" {build}
   "ctypes" {< "0.17.0"}
   "eigen" {>= "0.0.3" & < "0.1.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "owl-base" {= version}
   "plplot"
   "stdio" {build}

--- a/packages/owl/owl.0.3.8/opam
+++ b/packages/owl/owl.0.3.8/opam
@@ -21,7 +21,7 @@ depends: [
   "configurator" {build}
   "ctypes" {< "0.17.0"}
   "eigen" {>= "0.0.3" & < "0.1.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "owl-base" {>= "0.3.8" & < "0.4.0"}
   "plplot"
   "stdio" {build}

--- a/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/opam
+++ b/packages/pa_sqlexpr/pa_sqlexpr.0.9.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "sqlexpr"
   "estring"
   "camlp4"

--- a/packages/parsexp/parsexp.v0.9.1/opam
+++ b/packages/parsexp/parsexp.v0.9.1/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "base" {>= "v0.9.4" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_compare" {>= "v0.9" & < "v0.10"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_fields_conv" {>= "v0.9" & < "v0.10"}

--- a/packages/parsexp_io/parsexp_io.v0.9.1/opam
+++ b/packages/parsexp_io/parsexp_io.v0.9.1/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "base" {>= "v0.9.4" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "parsexp" {>= "v0.9.1" & < "v0.10"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_js_style" {>= "v0.9" & < "v0.10"}

--- a/packages/phantom-algebra/phantom-algebra.1.0/opam
+++ b/packages/phantom-algebra/phantom-algebra.1.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
 ]
 synopsis: "A strongly-typed tensor library à la GLSL"

--- a/packages/phashtbl/phashtbl.1.0.0/opam
+++ b/packages/phashtbl/phashtbl.1.0.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "dbm"
 ]
 synopsis: "Persistent hash table library using dbm under the carpet."

--- a/packages/pla/pla.1.2/opam
+++ b/packages/pla/pla.1.2/opam
@@ -8,7 +8,7 @@ build: [["jbuilder" "build" "-p" name]]
 
 depends: [
   "ocaml" {>= "4.02.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 available: opam-version >= "1.2"

--- a/packages/plotkicadsch/plotkicadsch.0.1.4/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.1.4/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "pcre"
   "tyxml" {>= "4.0.0"}
   "lwt" {< "4.0.0"}

--- a/packages/plotkicadsch/plotkicadsch.0.2.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.2.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "kicadsch" {= "0.2.0"}
   "tyxml" {>= "4.0.0"}
   "lwt" {>= "3.1.0" & < "4.0.0"}

--- a/packages/plotkicadsch/plotkicadsch.0.3.0/opam
+++ b/packages/plotkicadsch/plotkicadsch.0.3.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "kicadsch" {= "0.3.0"}
   "tyxml" {>= "4.0.0"}
   "lwt" {>= "3.1.0" & < "4.0.0"}

--- a/packages/posixat/posixat.v0.9.1/opam
+++ b/packages/posixat/posixat.v0.9.1/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "4.05.0"}
   "base" {>= "v0.9.4" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "sexplib" {>= "v0.9.3" & < "v0.10"}
 ]
 synopsis: "Bindings to the posix *at functions"

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.0/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.0/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
   "bitstring" {>= "2.1.0" & < "3.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
 ]

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.1/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.1/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
   "bitstring" {>= "2.1.0" & < "3.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
 ]

--- a/packages/ppx_bitstring/ppx_bitstring.2.0.2/opam
+++ b/packages/ppx_bitstring/ppx_bitstring.2.0.2/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
   "bitstring" {>= "2.1.0" & < "3.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned"
   "ocaml-migrate-parsetree" {build & >= "1.0.5" & < "2.0.0"}
 ]

--- a/packages/ppx_blob/ppx_blob.0.3.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.3.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "alcotest" {with-test}
 ]

--- a/packages/ppx_blob/ppx_blob.0.4.0/opam
+++ b/packages/ppx_blob/ppx_blob.0.4.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "alcotest" {with-test}
 ]

--- a/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
+++ b/packages/ppx_deriving_madcast/ppx_deriving_madcast.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_deriving" {< "5.0"}
   "ppx_tools"
   "ppxfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind" {with-test}
 ]
 synopsis: "Library deriving cast functions based on their types."

--- a/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
+++ b/packages/ppx_deriving_protocol/ppx_deriving_protocol.0.8/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_core" {build}
   "ppx_type_conv" {build}
   "ppx_driver" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_metaquot" {build}
 ]
 synopsis:

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.5.9.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.5.9.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "rpclib" {= version}
   "rresult"

--- a/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.0.0/opam
+++ b/packages/ppx_deriving_rpc/ppx_deriving_rpc.6.0.0/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.10.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "rpclib" {= version}
   "rresult"
   "ppxlib" {< "0.9.0"}

--- a/packages/ppx_dryunit/ppx_dryunit.0.3.1/opam
+++ b/packages/ppx_dryunit/ppx_dryunit.0.3.1/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/gersonmoraes/dryunit.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "ppx_tools_versioned"

--- a/packages/ppx_dryunit/ppx_dryunit.0.4.0/opam
+++ b/packages/ppx_dryunit/ppx_dryunit.0.4.0/opam
@@ -8,7 +8,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "ppx_tools_versioned"

--- a/packages/ppx_graphql/ppx_graphql.0.1.0/opam
+++ b/packages/ppx_graphql/ppx_graphql.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql"
   "yojson"
   "ppx_metaquot"

--- a/packages/ppx_graphql/ppx_graphql.0.2.0/opam
+++ b/packages/ppx_graphql/ppx_graphql.0.2.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "graphql"
   "yojson"
   "ppx_metaquot"

--- a/packages/ppx_hardcaml/ppx_hardcaml.1.3.0/opam
+++ b/packages/ppx_hardcaml/ppx_hardcaml.1.3.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03"}
   "ppx_tools_versioned"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "hardcaml" {>= "1.2.0" & < "2.0.0"}
 ]

--- a/packages/ppx_integer/ppx_integer.0.1.0/opam
+++ b/packages/ppx_integer/ppx_integer.0.1.0/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_integer"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned" {>= "5.0"}
   "ppxx" {>= "2.3.0" & < "2.4.0"}
 ]

--- a/packages/ppx_meta_conv/ppx_meta_conv.4.0.0/opam
+++ b/packages/ppx_meta_conv/ppx_meta_conv.4.0.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/ppx_meta_conv"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "spotlib" {>= "4.0.0"}
   "ppxx" {>= "2.3.0" & < "2.4.0"}

--- a/packages/ppx_monadic/ppx_monadic.2.3.0/opam
+++ b/packages/ppx_monadic/ppx_monadic.2.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_monadic"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned" {>= "5.0"}
   "ppxx" {>= "2.3.0" & < "2.4.0"}
 ]

--- a/packages/ppx_nanocaml/ppx_nanocaml.0.1/opam
+++ b/packages/ppx_nanocaml/ppx_nanocaml.0.1/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
   "batteries"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Framework for writing nanopass-style compilers"

--- a/packages/ppx_orakuda/ppx_orakuda.3.3.0/opam
+++ b/packages/ppx_orakuda/ppx_orakuda.3.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/orakuda"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "spotlib" {>= "4.0.0" & < "4.1.0"}
   "pcre"
   "ppx_tools_versioned" {>= "5.0"}

--- a/packages/ppx_poly_record/ppx_poly_record.1.3.0/opam
+++ b/packages/ppx_poly_record/ppx_poly_record.1.3.0/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/ppx_poly_record"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppxx" {>= "2.3.0" & < "2.4.0"}
 ]
 synopsis: "ppx for polymorphic records"

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.0.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_type_conv"
   "ppx_driver"
   "ppx_core"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_metaquot" {build}
 ]
 synopsis:

--- a/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
+++ b/packages/ppx_protocol_conv/ppx_protocol_conv.1.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_type_conv"
   "ppx_driver" {>= "v0.10.1"}
   "ppx_core"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_metaquot" {build}
 ]
 synopsis:

--- a/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.2.0.0/opam
+++ b/packages/ppx_protocol_conv_json/ppx_protocol_conv_json.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base"
   "yojson" {< "1.6.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"
 description: """

--- a/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.2.0.0/opam
+++ b/packages/ppx_protocol_conv_msgpack/ppx_protocol_conv_msgpack.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base"
   "msgpck" {>= "1.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "MessagePack driver for Ppx_protocol_conv"
 description: """

--- a/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.2.0.0/opam
+++ b/packages/ppx_protocol_conv_xml_light/ppx_protocol_conv_xml_light.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base"
   "xml-light"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Xml driver for Ppx_protocol_conv"
 description: """

--- a/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.2.0.0/opam
+++ b/packages/ppx_protocol_conv_yaml/ppx_protocol_conv_yaml.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ppx_protocol_conv" {>= "2.0.0" & <= "3.1.1"}
   "base"
   "yaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Json driver for Ppx_protocol_conv"
 description: """

--- a/packages/ppx_regexp/ppx_regexp.0.2.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.2.0/opam
@@ -8,7 +8,7 @@ license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "re" {< "1.7.2~"}
   "ppx_tools"

--- a/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/opam
+++ b/packages/ppx_sqlexpr/ppx_sqlexpr.0.9.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned"
   "ppx_core"
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/ppx_test/ppx_test.1.6.0/opam
+++ b/packages/ppx_test/ppx_test.1.6.0/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build & >= "1.5.6"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "re"
   "ppxx" {>= "2.3.0" & < "2.4.0"}
 ]

--- a/packages/ppxx/ppxx.2.3.1/opam
+++ b/packages/ppxx/ppxx.2.3.1/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.07.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned" {>= "5.0"}
   "ocaml-compiler-libs"
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/ppxx/ppxx.2.3.2/opam
+++ b/packages/ppxx/ppxx.2.3.2/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.07.0" & < "4.08.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools_versioned" {>= "5.0"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]

--- a/packages/qcheck/qcheck.0.8/opam
+++ b/packages/qcheck/qcheck.0.8/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
   "ounit"

--- a/packages/qcow-tool/qcow-tool.0.10.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.0/opam
@@ -30,7 +30,7 @@ depends: [
   "astring"
   "io-page"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-tool/qcow-tool.0.10.2/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.2/opam
@@ -35,7 +35,7 @@ depends: [
   "astring"
   "io-page"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-tool/qcow-tool.0.10.3/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.3/opam
@@ -35,7 +35,7 @@ depends: [
   "astring"
   "io-page"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-tool/qcow-tool.0.10.4/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.4/opam
@@ -35,7 +35,7 @@ depends: [
   "astring"
   "io-page"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow-tool/qcow-tool.0.10.5/opam
+++ b/packages/qcow-tool/qcow-tool.0.10.5/opam
@@ -35,7 +35,7 @@ depends: [
   "astring"
   "io-page"
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
   "mirage-block-ramdisk" {with-test}
   "ezjsonm" {with-test}

--- a/packages/qcow/qcow.0.10.2/opam
+++ b/packages/qcow/qcow.0.10.2/opam
@@ -31,7 +31,7 @@ depends: [
   "logs"
   "fmt" {>= "0.8.2"}
   "io-page-unix" {>= "2.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_tools"
   "ppx_sexp_conv"
   "ppx_type_conv" {build}

--- a/packages/radare2/radare2.0.0.2/opam
+++ b/packages/radare2/radare2.0.0.2/opam
@@ -18,7 +18,7 @@ depexts: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "base-unix"

--- a/packages/reason/reason.3.0.4/opam
+++ b/packages/reason/reason.3.0.4/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.07"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20171013"}
   "utop" {>= "1.17"}

--- a/packages/reason/reason.3.2.0/opam
+++ b/packages/reason/reason.3.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.07"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind" {build}
   "menhir" {>= "20170418" & <= "20171013"}
   "merlin-extend" {>= "0.3" & < "0.4"}

--- a/packages/redis-lwt/redis-lwt.0.3.4/opam
+++ b/packages/redis-lwt/redis-lwt.0.3.4/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "redis" {= version}
   "base-unix"
   "lwt"

--- a/packages/redis-lwt/redis-lwt.0.3.5/opam
+++ b/packages/redis-lwt/redis-lwt.0.3.5/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "redis" {= version}
   "base-unix"
   "lwt"

--- a/packages/redis-lwt/redis-lwt.0.3.6/opam
+++ b/packages/redis-lwt/redis-lwt.0.3.6/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "redis" {= version}
   "lwt"
 ]

--- a/packages/redis-sync/redis-sync.0.3.4/opam
+++ b/packages/redis-sync/redis-sync.0.3.4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "redis" {= version}
   "base-unix"
 ]

--- a/packages/redis-sync/redis-sync.0.3.5/opam
+++ b/packages/redis-sync/redis-sync.0.3.5/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "redis" {= version}
   "base-unix"
 ]

--- a/packages/redis-sync/redis-sync.0.3.6/opam
+++ b/packages/redis-sync/redis-sync.0.3.6/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "redis" {= version}
 ]
 synopsis: "Synchronous client for Redis"

--- a/packages/redis/redis.0.3.4/opam
+++ b/packages/redis/redis.0.3.4/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "uuidm"
   "re"

--- a/packages/redis/redis.0.3.5/opam
+++ b/packages/redis/redis.0.3.5/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "uuidm"
   "re"

--- a/packages/redis/redis.0.3.6/opam
+++ b/packages/redis/redis.0.3.6/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-unix"
   "uuidm"

--- a/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
+++ b/packages/reed-solomon-erasure/reed-solomon-erasure.1.0.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/darrenldl/ocaml-reed-solomon-erasure.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.06"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "bisect_ppx" {build & < "2.6.0"}
   "core_kernel"

--- a/packages/regenerate/regenerate.0.1/opam
+++ b/packages/regenerate/regenerate.0.1/opam
@@ -9,7 +9,7 @@ doc: "https://drup.github.io/regenerate/doc/0.1/"
 
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cmdliner"
   "fmt"
   "containers" {< "3.0"}

--- a/packages/resp-server/resp-server.0.2/opam
+++ b/packages/resp-server/resp-server.0.2/opam
@@ -10,7 +10,7 @@ tags: ["redis"]
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "hiredis" {<= "0.7"}
   "conduit-lwt-unix" {>= "1.0" & <"2.0.0"}
 ]

--- a/packages/resp-server/resp-server.0.3/opam
+++ b/packages/resp-server/resp-server.0.3/opam
@@ -10,7 +10,7 @@ tags: ["redis"]
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "hiredis-value" {>= "0.8"}
   "conduit-lwt-unix" {>= "1.0" & <"2.0.0"}
 ]

--- a/packages/rpc/rpc.5.9.0/opam
+++ b/packages/rpc/rpc.5.9.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "rpclib" {= version}
   "rpclib-async" {= version}
   "rpclib-lwt" {= version}

--- a/packages/rpc/rpc.6.0.0/opam
+++ b/packages/rpc/rpc.6.0.0/opam
@@ -12,7 +12,7 @@ tags: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "rpclib" {= version}
   "rpclib-async" {= version}
   "rpclib-lwt" {= version}

--- a/packages/rpclib-async/rpclib-async.5.9.0/opam
+++ b/packages/rpclib-async/rpclib-async.5.9.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"
   "alcotest" {with-test}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "rpclib" {= version}
   "async"
 ]

--- a/packages/rpclib-async/rpclib-async.6.0.0/opam
+++ b/packages/rpclib-async/rpclib-async.6.0.0/opam
@@ -14,8 +14,8 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0" < "4.10.0"}
-  "jbuilder"
+  "ocaml" {>= "4.04.0" & < "4.10.0"}
+  "jbuilder" {>= "1.0+beta7"}
   "alcotest" {with-test}
   "rpclib" {= version}
   "async" {< "v0.13"}

--- a/packages/rpclib-lwt/rpclib-lwt.5.9.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.5.9.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"
   "alcotest" {with-test & < "1.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "rpclib" {= version}
   "lwt" {>= "3.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}

--- a/packages/rpclib-lwt/rpclib-lwt.6.0.0/opam
+++ b/packages/rpclib-lwt/rpclib-lwt.6.0.0/opam
@@ -14,8 +14,8 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0" < "4.10.0"}
-  "jbuilder"
+  "ocaml" {>= "4.04.0" & < "4.10.0"}
+  "jbuilder" {>= "1.0+beta7"}
   "alcotest" {with-test & < "1.0.0"}
   "alcotest-lwt" {with-test & < "1.0.0"}
   "rpclib" {= version}

--- a/packages/rtop/rtop.3.2.0/opam
+++ b/packages/rtop/rtop.3.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02" & < "4.07"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "reason" {= "3.2.0"}
   "utop" {>= "1.17"}
 ]

--- a/packages/safepass/safepass.3.0/opam
+++ b/packages/safepass/safepass.3.0/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Facilities for the safe storage of user passwords"
 url {

--- a/packages/sequence/sequence.1.1/opam
+++ b/packages/sequence/sequence.1.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {< "4.08.0"}
   "base-bytes"
   "result"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "qcheck" {with-test}
   "qtest" {with-test}
   "odoc" {with-doc}

--- a/packages/smbc/smbc.0.4.2/opam
+++ b/packages/smbc/smbc.0.4.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/c-cube/smbc.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder" {>= "1.0+beta6"}
+  "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "containers" {>= "1.0" & < "3.0"}
   "sequence" {>= "0.4"}

--- a/packages/spacetime_lib/spacetime_lib.0.2.0/opam
+++ b/packages/spacetime_lib/spacetime_lib.0.2.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.08.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlfind" {build}
   "owee"
   "raw_spacetime"

--- a/packages/spf/spf.2.0.2/opam
+++ b/packages/spf/spf.2.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/andrenth/ocaml-spf.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 depexts: [
   ["libspf2-dev"] {os-distribution = "alpine"}

--- a/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/opam
+++ b/packages/sphinxcontrib-ocaml/sphinxcontrib-ocaml.0.3.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml" {= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "General" {>= "0.4.0"}
   "yojson"
 ]

--- a/packages/spotlib/spotlib.4.0.3/opam
+++ b/packages/spotlib/spotlib.4.0.3/opam
@@ -9,7 +9,7 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.12.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_test" {>= "1.6.0"}
 ]
 synopsis: "Useful functions for OCaml programming used by @camlspotter"

--- a/packages/sqlexpr/sqlexpr.0.9.0/opam
+++ b/packages/sqlexpr/sqlexpr.0.9.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "csv"
   "lwt" {>= "2.2.0"}
   "lwt_ppx"

--- a/packages/srs/srs.2.0.0/opam
+++ b/packages/srs/srs.2.0.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/andrenth/ocaml-srs.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 x-ci-accept-failures: ["debian-unstable"]
 synopsis: "OCaml bindings for libsrs2"

--- a/packages/ssh-agent/ssh-agent.0.1.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.1.0/opam
@@ -7,7 +7,7 @@ license: "BSD-2-clause"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_cstruct" {build}
   "ppx_sexp_conv"
   "angstrom" {>= "0.10" & < "0.11"}

--- a/packages/sslconf/sslconf.0.8.3/opam
+++ b/packages/sslconf/sslconf.0.8.3/opam
@@ -10,7 +10,7 @@ authors: [
 license: "ISC"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_sexp_conv"
   "ocaml-migrate-parsetree" {< "2.0.0"}
   "sexplib"

--- a/packages/stdint/stdint.0.5.1/opam
+++ b/packages/stdint/stdint.0.5.1/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml"
   "base-bytes"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "signed and unsigned integer types having specified widths"
 description: """

--- a/packages/swagger/swagger.0.1.0/opam
+++ b/packages/swagger/swagger.0.1.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "atdgen" {>= "1.12.0" & < "2.3.0"}
   "re" {>= "1.7.3"}
   "yojson" {>= "1.4.1"}

--- a/packages/telegraml/telegraml.2.2.0/opam
+++ b/packages/telegraml/telegraml.2.2.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/nv-vn/telegraml.git"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "lwt" {>= "2.5.0"}
   "lwt_ssl"
   "cohttp" {>= "1.0.0"}

--- a/packages/tiny_json/tiny_json.1.1.5/opam
+++ b/packages/tiny_json/tiny_json.1.1.5/opam
@@ -9,7 +9,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.5.0"}
   "ocamlfind" {build}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "A small Json library from OCAMLTTER"
 description:

--- a/packages/tiny_json/tiny_json.1.1.6/opam
+++ b/packages/tiny_json/tiny_json.1.1.6/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/tiny_json"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.05.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "A small Json library from OCAMLTTER"
 description:

--- a/packages/traildb/traildb.0.1/opam
+++ b/packages/traildb/traildb.0.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml"
   "uuidm"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ounit" {with-test}
 ]
 depexts: [

--- a/packages/travis-opam/travis-opam.1.2.0/opam
+++ b/packages/travis-opam/travis-opam.1.2.0/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "jsonm" {build}
 ]
 synopsis: "Scripts for OCaml projects"

--- a/packages/travis-opam/travis-opam.1.3.0/opam
+++ b/packages/travis-opam/travis-opam.1.3.0/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "jsonm" {build}
 ]
 synopsis: "Scripts for OCaml projects"

--- a/packages/travis-opam/travis-opam.1.4.0/opam
+++ b/packages/travis-opam/travis-opam.1.4.0/opam
@@ -12,7 +12,7 @@ doc: "https://ocaml.github.io/ocaml-ci-scripts/"
 bug-reports: "https://github.com/ocaml/ocaml-ci-scripts/issues"
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "jsonm" {build}
 ]
 flags: light-uninstall

--- a/packages/trax/trax.0.3.0/opam
+++ b/packages/trax/trax.0.3.0/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.01.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "Stack-independent exception tracing"
 description:

--- a/packages/treeprint/treeprint.2.2.0/opam
+++ b/packages/treeprint/treeprint.2.2.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/treeprint"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02.1"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "spotlib" {>= "3.0.0"}
   "ppx_meta_conv" {>= "4.0.0"}
 ]

--- a/packages/typpx/typpx.1.4.3/opam
+++ b/packages/typpx/typpx.1.4.3/opam
@@ -8,7 +8,7 @@ dev-repo: "hg+https://bitbucket.org/camlspotter/typpx"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0" & < "4.07.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ppxx" {>= "2.3.0" & < "2.4.0"}
 ]
 synopsis: "a library for PPX with types"

--- a/packages/tyre/tyre.0.4.1/opam
+++ b/packages/tyre/tyre.0.4.1/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "re" {>= "1.8.0"}
   "alcotest" {with-test & >= "0.8.0"}
   "result"

--- a/packages/tyre/tyre.0.4/opam
+++ b/packages/tyre/tyre.0.4/opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "re" {>= "1.8.0"}
   "alcotest" {with-test & >= "0.8.0"}
   "result"

--- a/packages/unmagic/unmagic.1.0.4/opam
+++ b/packages/unmagic/unmagic.1.0.4/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://gitlab.com/camlspotter/unmagic"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "spotlib"
   "typerep" {>= "v0.10.0"}
   "ppx_typerep_conv"

--- a/packages/uuuu/uuuu.0.1.0/opam
+++ b/packages/uuuu/uuuu.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "re" {>= "1.7.2"}
   "fmt"
   "bos"

--- a/packages/varint/varint.1.0/opam
+++ b/packages/varint/varint.1.0/opam
@@ -17,7 +17,7 @@ build: [
   
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "mstruct"
 ]
 synopsis:

--- a/packages/vcardgen/vcardgen.1.1/opam
+++ b/packages/vcardgen/vcardgen.1.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/vzaliva/vcardgen.git"
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "ocaml"
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "batteries"
 ]
 synopsis: "Simple OCaml library for generating VCards per RFC-6350."

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.1/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cstruct" {< "6.0.0"}
   "lwt" {>= "2.4.3" & <= "3.1.0"}
   "mirage-block" {< "2.0.0"}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.9.2/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cstruct" {< "6.0.0"}
   "lwt" {>= "2.4.3" & <= "3.1.0"}
   "mirage-block" {< "2.0.0"}

--- a/packages/vhd-format/vhd-format.0.9.1/opam
+++ b/packages/vhd-format/vhd-format.0.9.1/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-vhd"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cstruct" {>= "1.9" & < "3.4.0"}
   "io-page"
   "rresult" {>= "0.2.0"}

--- a/packages/vhd-format/vhd-format.0.9.2/opam
+++ b/packages/vhd-format/vhd-format.0.9.2/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-vhd"
 build: [[ "jbuilder" "build" "-p" name "-j" jobs ]]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cstruct" {>= "1.9" & <"3.4.0"}
   "io-page"
   "rresult" {>= "0.2.0"}

--- a/packages/virtual_dom/virtual_dom.v0.9.1/opam
+++ b/packages/virtual_dom/virtual_dom.v0.9.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "async_js" {>= "v0.9.1" & < "v0.10"}
   "base" {>= "v0.9.4" & < "v0.10"}
-  "jbuilder" {>= "1.0+beta2"}
+  "jbuilder" {>= "1.0+beta7"}
   "ppx_driver" {>= "v0.9.2" & < "v0.10"}
   "ppx_jane" {>= "v0.9" & < "v0.10"}
   "js_of_ocaml"

--- a/packages/wall/wall.0.1/opam
+++ b/packages/wall/wall.0.1/opam
@@ -9,7 +9,7 @@ patches: ["fix-ocaml-beta.patch"]
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {< "4.10"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "gg"
   "result"
   "stb_image"

--- a/packages/wall/wall.0.2/opam
+++ b/packages/wall/wall.0.2/opam
@@ -9,7 +9,7 @@ patches: ["fix-ocaml-beta.patch"]
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {< "4.10"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "gg"
   "result"
   "stb_image"

--- a/packages/wall/wall.0.3/opam
+++ b/packages/wall/wall.0.3/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/let-def/wall"
 patches: ["fix-ocaml-beta.patch"]
 depends: [
   "ocaml" {< "4.10"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "gg"
   "result"
   "stb_image"

--- a/packages/wcs-api/wcs-api.2017-05-26.01/opam
+++ b/packages/wcs-api/wcs-api.2017-05-26.01/opam
@@ -20,7 +20,7 @@ depends: [
   "wcs-lib" {= "2017-05-26.01"}
   "lwt_ssl"
   "cohttp-lwt-unix" {>= "0.20.0" & < "1.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "SDK for Watson Conversation Service"
 description: """

--- a/packages/wcs-api/wcs-api.2017-05-26.02/opam
+++ b/packages/wcs-api/wcs-api.2017-05-26.02/opam
@@ -21,7 +21,7 @@ depends: [
   "wcs-lib" {= "2017-05-26.02"}
   "lwt_ssl" | "tls"
   "cohttp-lwt-unix" {< "1.0.0"}
-  "jbuilder" {<="1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & <= "1.0+beta20.2"}
 ]
 synopsis: "SDK for Watson Conversation Service"
 description: """

--- a/packages/wcs-api/wcs-api.2017-05-26.03/opam
+++ b/packages/wcs-api/wcs-api.2017-05-26.03/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "wcs-lib" {= "2017-05-26.03"}
   "cohttp-lwt-unix" {>= "1.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "SDK for Watson Conversation Service"
 description: """

--- a/packages/wcs-api/wcs-api.2017-05-26.04/opam
+++ b/packages/wcs-api/wcs-api.2017-05-26.04/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "wcs-lib" {= "2017-05-26.04"}
   "cohttp-lwt-unix" {>= "1.0.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis: "SDK for Watson Conversation Service"
 description: """

--- a/packages/wcs-lib/wcs-lib.2017-05-26.00/opam
+++ b/packages/wcs-lib/wcs-lib.2017-05-26.00/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}
-  "jbuilder" {<"1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta20.2"}
   "atdgen" {build & < "1.13.0"}
   "lwt_ssl"
   "cohttp-lwt-unix" {< "1.0.0"}

--- a/packages/wcs-lib/wcs-lib.2017-05-26.01/opam
+++ b/packages/wcs-lib/wcs-lib.2017-05-26.01/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "ocamlfind" {build}
-  "jbuilder" {<"1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta20.2"}
   "atdgen" {build & < "1.13.0"}
 ]
 synopsis: "SDK for Watson Conversation Service"

--- a/packages/wcs-lib/wcs-lib.2017-05-26.02/opam
+++ b/packages/wcs-lib/wcs-lib.2017-05-26.02/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {<"1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta20.2"}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "atdgen" {build & < "1.13.0"}
   "atd"

--- a/packages/wcs-lib/wcs-lib.2017-05-26.03/opam
+++ b/packages/wcs-lib/wcs-lib.2017-05-26.03/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {<"1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta20.2"}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "atdgen" {build & < "1.13.0"}
   "atd"

--- a/packages/wcs-lib/wcs-lib.2017-05-26.04/opam
+++ b/packages/wcs-lib/wcs-lib.2017-05-26.04/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder" {<"1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta20.2"}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "atdgen" {build & < "1.13.0"}
   "atd"

--- a/packages/wcs-lib/wcs-lib.2017-05-26.05/opam
+++ b/packages/wcs-lib/wcs-lib.2017-05-26.05/opam
@@ -18,7 +18,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder" {<"1.0+beta20.2"}
+  "jbuilder" {>= "1.0+beta7" & < "1.0+beta20.2"}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "atdgen" {build}
   "atd"

--- a/packages/weberizer/weberizer.0.7.8/opam
+++ b/packages/weberizer/weberizer.0.7.8/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocamlnet"
 ]
 synopsis: "Compile HTML templates into OCaml modules"

--- a/packages/yara/yara.0.1/opam
+++ b/packages/yara/yara.0.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {build & < "2.0.0"}
   "ppx_deriving" {>= "4.2.0"}
   "core" {>= "v0.9.0"}

--- a/packages/yojson/yojson.1.4.0/opam
+++ b/packages/yojson/yojson.1.4.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "easy-format"
   "biniou" {>= "1.2.0"}

--- a/packages/yojson/yojson.1.4.1/opam
+++ b/packages/yojson/yojson.1.4.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "cppo" {build}
   "easy-format"
   "biniou" {>= "1.2.0"}

--- a/packages/yuscii/yuscii.0.1.0/opam
+++ b/packages/yuscii/yuscii.0.1.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "jbuilder"
+  "jbuilder" {>= "1.0+beta7"}
   "fmt"
   "uutf"
   "rresult"


### PR DESCRIPTION
The -p option was only added in 1.0+beta7, so this adjusts the constraints of all the packages that use it.
