### PR TITLE
Package algaeff.0.1.0

### DIFF
--- a/packages/algaeff/algaeff.0.1.0/opam
+++ b/packages/algaeff/algaeff.0.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Reusable Effects-Based Components"
+description: """
+This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/algaeff"
+bug-reports: "https://github.com/RedPRL/algaeff/issues"
+dev-repo: "git+https://github.com/RedPRL/algaeff.git"
+depends: [
+  "dune" {>= "2.0"}
+  "base-domains"
+  "alcotest" {>= "1.5" & with-test}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/algaeff/archive/0.1.0.tar.gz"
+  checksum: [
+    "md5=070071daf587ff50ba0f60266ab7c5d9"
+    "sha512=257762cb07c75d22f1ae3a0da3a37b2aa2ab8bca7a7dc036b940163fc238b64a7d92efa2535c3bb8185a1f39cc3841cdce5ad936fd2dd804eff25dd68dd21d39"
+  ]
+}


### PR DESCRIPTION
### `algaeff.0.1.0`
Reusable Effects-Based Components
This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.



---
* Homepage: https://github.com/RedPRL/algaeff
* Source repo: git+https://github.com/RedPRL/algaeff.git
* Bug tracker: https://github.com/RedPRL/algaeff/issues

---
:camel: Pull-request generated by opam-publish v2.1.0