### PR TITLE
[new release] memtrace-mirage (0.2.1.2.1)

### DIFF
--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.1/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.1/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt" {>= "5.5.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.1/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof using MirageOS API"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["hannes@mehnert.org"]
+authors: [
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "MIT"
+homepage: "https://github.com/hannesm/memtrace-mirage"
+bug-reports: "https://github.com/hannesm/memtrace-mirage/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "ptime" {>= "1.0.0"}
+  "lwt" {>= "5.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hannesm/memtrace-mirage.git"
+url {
+  src:
+    "https://github.com/hannesm/memtrace-mirage/releases/download/v0.2.1.2.1/memtrace-mirage-0.2.1.2.1.tbz"
+  checksum: [
+    "sha256=d233a1e9a3b8ceb22ee64d285e00b61bca3df620f75a0a28473ff66a7f43dc6c"
+    "sha512=ec31247a854b36e60f22f748a54958ae92796631de111e69aff6b2bd5c6f2bb74ef7e1fffc50949fea5b493c09423e00fc551060af45af3c587e66d02b896f6c"
+  ]
+}
+x-commit-hash: "a7be29e96a1c2ec3526115042fd4c9a44bcf8b4a"


### PR DESCRIPTION
Streaming client for Memprof using MirageOS API

- Project page: <a href="https://github.com/hannesm/memtrace-mirage">https://github.com/hannesm/memtrace-mirage</a>

##### CHANGES:

Initial release, based on memtrace 521627fb5ced5b49ff03f608fc5fbe20ae1ff24f
