### PR TITLE
[new release] bimage, bimage-unix, bimage-io and bimage-display (0.6.0)

### DIFF
--- a/packages/bimage-display/bimage-display.0.6.0/opam
+++ b/packages/bimage-display/bimage-display.0.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "glfw-ocaml" {>= "3.3.0"}
+    "conf-glew"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Window system for Bimage
+"""
+
+description: """
+Allows for Bimage Images to be displayed using OpenGL
+"""
+
+available: os = "linux"
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.6.0/bimage-0.6.0.tbz"
+  checksum: [
+    "sha256=7d4019a7783f20e5d9f1af72d0b5b14ef56cbfad9ed440da752cfc24d0f8d083"
+    "sha512=4abfcfcde072b8bae76ca24dd25b31e0695c08a7b2d43fa5a433ade3202527af4d24fbed9b3b90fe3888b837acaa8c6718e39c8a6014d61ee7faa390818a1133"
+  ]
+}
+x-commit-hash: "67b5cdd9b1b3a72b53e90ac4ecb285aa4f06a28e"

--- a/packages/bimage-io/bimage-io.0.6.0/opam
+++ b/packages/bimage-io/bimage-io.0.6.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "conf-openimageio"
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+Input/output for Bimage using OpenImageIO
+"""
+
+description: """
+Input/output for Bimage using OpenImageIO
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.6.0/bimage-0.6.0.tbz"
+  checksum: [
+    "sha256=7d4019a7783f20e5d9f1af72d0b5b14ef56cbfad9ed440da752cfc24d0f8d083"
+    "sha512=4abfcfcde072b8bae76ca24dd25b31e0695c08a7b2d43fa5a433ade3202527af4d24fbed9b3b90fe3888b837acaa8c6718e39c8a6014d61ee7faa390818a1133"
+  ]
+}
+x-commit-hash: "67b5cdd9b1b3a72b53e90ac4ecb285aa4f06a28e"
+

--- a/packages/bimage-unix/bimage-unix.0.6.0/opam
+++ b/packages/bimage-unix/bimage-unix.0.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+    "bimage" {= version}
+    "ctypes" {>= "0.14"}
+    "ctypes-foreign" {>= "0.4"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+    ["dune" "runtest" "-p" name] {with-test}
+]
+
+synopsis: """
+Bimage_unix provides methods for encoding/decoding images in many formats using ImageMagick/stb_image
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.6.0/bimage-0.6.0.tbz"
+  checksum: [
+    "sha256=7d4019a7783f20e5d9f1af72d0b5b14ef56cbfad9ed440da752cfc24d0f8d083"
+    "sha512=4abfcfcde072b8bae76ca24dd25b31e0695c08a7b2d43fa5a433ade3202527af4d24fbed9b3b90fe3888b837acaa8c6718e39c8a6014d61ee7faa390818a1133"
+  ]
+}
+x-commit-hash: "67b5cdd9b1b3a72b53e90ac4ecb285aa4f06a28e"

--- a/packages/bimage/bimage.0.6.0/opam
+++ b/packages/bimage/bimage.0.6.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Zach Shipko <zachshipko@gmail.com>"
+authors: ["Zach Shipko <zachshipko@gmail.com>"]
+homepage: "https://github.com/zshipko/ocaml-bimage"
+doc: "https://zshipko.github.io/ocaml-bimage/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/zshipko/ocaml-bimage.git"
+bug-reports: "https://github.com/zshipko/ocaml-bimage/issues"
+tags: ["image processing"]
+
+depends:
+[
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "2.0"}
+]
+
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: """
+A simple, efficient image-processing library
+"""
+
+description: """
+An image processing library for OCaml providing efficient, composable operations.
+Additionally, bimage supports most types supported by Bigarray.
+"""
+url {
+  src:
+    "https://github.com/zshipko/ocaml-bimage/releases/download/v0.6.0/bimage-0.6.0.tbz"
+  checksum: [
+    "sha256=7d4019a7783f20e5d9f1af72d0b5b14ef56cbfad9ed440da752cfc24d0f8d083"
+    "sha512=4abfcfcde072b8bae76ca24dd25b31e0695c08a7b2d43fa5a433ade3202527af4d24fbed9b3b90fe3888b837acaa8c6718e39c8a6014d61ee7faa390818a1133"
+  ]
+}
+x-commit-hash: "67b5cdd9b1b3a72b53e90ac4ecb285aa4f06a28e"


### PR DESCRIPTION
A simple, efficient image-processing library

- Project page: <a href="https://github.com/zshipko/ocaml-bimage">https://github.com/zshipko/ocaml-bimage</a>
- Documentation: <a href="https://zshipko.github.io/ocaml-bimage/doc">https://zshipko.github.io/ocaml-bimage/doc</a>

##### CHANGES:

- Fixed `Bimage_display.Window.mouse_position`
- Link against `libOpenImageIO_Util`
- Added `Expr.prepare`
