### PR TITLE
cairo2.0.6.2: incompatible with dune-configurator 1.0.0

### DIFF
--- a/packages/cairo2/cairo2.0.6.2/opam
+++ b/packages/cairo2/cairo2.0.6.2/opam
@@ -18,7 +18,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "base-bigarray"
   "dune"
-  "dune-configurator"
+  "dune-configurator" {>= "1.11.4"}
   "conf-cairo"
 ]
 depopts: [


### PR DESCRIPTION
The library changed name from `dune.configurator` to `dune-configurator` in 1.11.4