### PR TITLE
2 packages from ocaml-community/cppo at 1.6.9

### DIFF
--- a/packages/cppo/cppo.1.6.9/opam
+++ b/packages/cppo/cppo.1.6.9/opam
@@ -24,7 +24,7 @@ depends: [
   "base-unix"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "-p" name "@doc"] {with-doc}

--- a/packages/cppo/cppo.1.6.9/opam
+++ b/packages/cppo/cppo.1.6.9/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Code preprocessor like cpp for OCaml"
+description: """\
+Cppo is an equivalent of the C preprocessor for OCaml programs.
+It allows the definition of simple macros and file inclusion.
+
+Cppo is:
+
+* more OCaml-friendly than cpp
+* easy to learn without consulting a manual
+* reasonably fast
+* simple to install and to maintain"""
+maintainer: [
+  "Martin Jambon <martin@mjambon.com>" "Yishuai Li <yishuai@upenn.edu>"
+]
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/cppo"
+doc: "https://ocaml-community.github.io/cppo"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.10"}
+  "base-unix"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+url {
+  src: "https://github.com/ocaml-community/cppo/archive/v1.6.9.tar.gz"
+  checksum: [
+    "md5=d23ffe85ac7dc8f0afd1ddf622770d09"
+    "sha512=26ff5a7b7f38c460661974b23ca190f0feae3a99f1974e0fd12ccf08745bd7d91b7bc168c70a5385b837bfff9530e0e4e41cf269f23dd8cf16ca658008244b44"
+  ]
+}

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.9/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.9/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlfind"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "-p" name "@doc"] {with-doc}

--- a/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.9/opam
+++ b/packages/cppo_ocamlbuild/cppo_ocamlbuild.1.6.9/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Plugin to use cppo with ocamlbuild"
+description: """\
+This ocamlbuild plugin lets you use cppo in ocamlbuild projects.
+
+To use it, you can call ocamlbuild with the argument `-plugin-tag
+package(cppo_ocamlbuild)` (only since ocaml 4.01 and cppo >= 0.9.4)."""
+maintainer: [
+  "Martin Jambon <martin@mjambon.com>" "Yishuai Li <yishuai@upenn.edu>"
+]
+authors: "Martin Jambon"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/cppo"
+doc: "https://ocaml-community.github.io/cppo"
+bug-reports: "https://github.com/ocaml-community/cppo/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.10"}
+  "ocamlbuild"
+  "ocamlfind"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "@doc"] {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml-community/cppo.git"
+url {
+  src: "https://github.com/ocaml-community/cppo/archive/v1.6.9.tar.gz"
+  checksum: [
+    "md5=d23ffe85ac7dc8f0afd1ddf622770d09"
+    "sha512=26ff5a7b7f38c460661974b23ca190f0feae3a99f1974e0fd12ccf08745bd7d91b7bc168c70a5385b837bfff9530e0e4e41cf269f23dd8cf16ca658008244b44"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`cppo.1.6.9`: Code preprocessor like cpp for OCaml
-`cppo_ocamlbuild.1.6.9`: Plugin to use cppo with ocamlbuild



---
* Homepage: https://github.com/ocaml-community/cppo
* Source repo: git+https://github.com/ocaml-community/cppo.git
* Bug tracker: https://github.com/ocaml-community/cppo/issues

---
:camel: Pull-request generated by opam-publish v2.1.0