### PR TITLE
3 packages from OCamlPro/alt-ergo at 2.3.3

### DIFF
--- a/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: "Alt-Ergo developers"
+maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
+license: "OCamlPro Non-Commercial Purpose License, version 1"
+build: [
+  ["./configure" name]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+install:
+[
+	[make "install" "MANDIR=%{man}%"]
+]
+depends: [
+  "ocaml" {>="4.04.0" & < "4.07.0"}
+  "dune" {>= "1.5" build & < "3.0.0"}
+  "alt-ergo-lib-free" { = version }
+  "alt-ergo-parsers-free" { = version }
+  "lablgtk"
+]
+conflicts: [
+  "alt-ergo"
+]
+homepage: "http://alt-ergo.ocamlpro.com/"
+dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
+bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
+
+synopsis: "The Alt-Ergo SMT prover"
+description:
+"Alt-Ergo is an automatic theorem prover of mathematical formulas. It was developed at LRI, and is now maintained at OCamlPro.
+
+See more details on http://alt-ergo.ocamlpro.com/"
+url {
+  src: "https://github.com/OCamlPro/alt-ergo/archive/2.3.3-free.tar.gz"
+  checksum: [
+    "md5=66131860e31abbcdaa29b721bef311fd"
+    "sha512=72fc1dabdf13615eb771574e4d2ffa9855e5ec832e34df2c5eb361fd5ad34ca2e2269ffb5ab41296e2123447cb2f81860a5fce822e7a40c7377ed966d7294940"
+  ]
+}

--- a/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
-license: "OCamlPro Non-Commercial Purpose License, version 1"
+license: "Apache-2.0"
 build: [
   ["./configure" name]
   ["dune" "subst"] {pinned}
@@ -31,9 +31,9 @@ description:
 
 See more details on http://alt-ergo.ocamlpro.com/"
 url {
-  src: "https://github.com/OCamlPro/alt-ergo/archive/2.3.3-free.tar.gz"
+  src:
+    "http://alt-ergo.ocamlpro.com/http/alt-ergo-free-2.3.3/alt-ergo-free-2.3.3.tar.gz"
   checksum: [
-    "md5=66131860e31abbcdaa29b721bef311fd"
-    "sha512=72fc1dabdf13615eb771574e4d2ffa9855e5ec832e34df2c5eb361fd5ad34ca2e2269ffb5ab41296e2123447cb2f81860a5fce822e7a40c7377ed966d7294940"
+    "md5=adaea0b3bc67b24df5d6eec800d249f7"
   ]
 }

--- a/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
@@ -18,6 +18,9 @@ depends: [
   "alt-ergo-parsers-free" { = version }
   "lablgtk"
 ]
+depexts: [
+  ["libgtksourceview2.0-dev"] {os-family = "debian"}
+]
 conflicts: [
   "alt-ergo"
 ]

--- a/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
+++ b/packages/alt-ergo-free/alt-ergo-free.2.3.3/opam
@@ -4,7 +4,7 @@ maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "Apache-2.0"
 build: [
   ["./configure" name]
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 install:
@@ -13,7 +13,7 @@ install:
 ]
 depends: [
   "ocaml" {>="4.04.0" & < "4.07.0"}
-  "dune" {>= "1.5" build & < "3.0.0"}
+  "dune" {>= "1.5" & < "3.0.0"}
   "alt-ergo-lib-free" { = version }
   "alt-ergo-parsers-free" { = version }
   "lablgtk"

--- a/packages/alt-ergo-lib-free/alt-ergo-lib-free.2.3.3/opam
+++ b/packages/alt-ergo-lib-free/alt-ergo-lib-free.2.3.3/opam
@@ -4,12 +4,12 @@ maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "Apache-2.0"
 build: [
   ["./configure" name]
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml" {>="4.04.0" & < "4.07.0"}
-  "dune" {>= "1.5" build & < "3.0.0"}
+  "dune" {>= "1.5" & < "3.0.0"}
   "num"
   "ocplib-simplex" {>= "0.4" }
   "zarith"

--- a/packages/alt-ergo-lib-free/alt-ergo-lib-free.2.3.3/opam
+++ b/packages/alt-ergo-lib-free/alt-ergo-lib-free.2.3.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+authors: "Alt-Ergo developers"
+maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
+license: "OCamlPro Non-Commercial Purpose License, version 1"
+build: [
+  ["./configure" name]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.04.0" & < "4.07.0"}
+  "dune" {>= "1.5" build & < "3.0.0"}
+  "num"
+  "ocplib-simplex" {>= "0.4" }
+  "zarith"
+  "seq"
+  "stdlib-shims"
+]
+conflicts: [
+  "alt-ergo"
+  "alt-ergo-lib"
+]
+homepage: "http://alt-ergo.ocamlpro.com/"
+dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
+bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
+
+synopsis: "The Alt-Ergo SMT prover library"
+description:
+"This is the core library used in the Alt-Ergo SMT solver.
+
+Alt-Ergo is an automatic theorem prover of mathematical formulas. It was developed at LRI, and is now maintained at OCamlPro.
+
+See more details on http://alt-ergo.ocamlpro.com/"
+url {
+  src: "https://github.com/OCamlPro/alt-ergo/archive/2.3.3-free.tar.gz"
+  checksum: [
+    "md5=66131860e31abbcdaa29b721bef311fd"
+    "sha512=72fc1dabdf13615eb771574e4d2ffa9855e5ec832e34df2c5eb361fd5ad34ca2e2269ffb5ab41296e2123447cb2f81860a5fce822e7a40c7377ed966d7294940"
+  ]
+}

--- a/packages/alt-ergo-lib-free/alt-ergo-lib-free.2.3.3/opam
+++ b/packages/alt-ergo-lib-free/alt-ergo-lib-free.2.3.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
-license: "OCamlPro Non-Commercial Purpose License, version 1"
+license: "Apache-2.0"
 build: [
   ["./configure" name]
   ["dune" "subst"] {pinned}
@@ -32,9 +32,9 @@ Alt-Ergo is an automatic theorem prover of mathematical formulas. It was develop
 
 See more details on http://alt-ergo.ocamlpro.com/"
 url {
-  src: "https://github.com/OCamlPro/alt-ergo/archive/2.3.3-free.tar.gz"
+  src:
+    "http://alt-ergo.ocamlpro.com/http/alt-ergo-free-2.3.3/alt-ergo-free-2.3.3.tar.gz"
   checksum: [
-    "md5=66131860e31abbcdaa29b721bef311fd"
-    "sha512=72fc1dabdf13615eb771574e4d2ffa9855e5ec832e34df2c5eb361fd5ad34ca2e2269ffb5ab41296e2123447cb2f81860a5fce822e7a40c7377ed966d7294940"
+    "md5=adaea0b3bc67b24df5d6eec800d249f7"
   ]
 }

--- a/packages/alt-ergo-parsers-free/alt-ergo-parsers-free.2.3.3/opam
+++ b/packages/alt-ergo-parsers-free/alt-ergo-parsers-free.2.3.3/opam
@@ -4,12 +4,12 @@ maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
 license: "Apache-2.0"
 build: [
   ["./configure" name]
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
   "ocaml" {>="4.04.0" & < "4.07.0"}
-  "dune" {>= "1.5" build }
+  "dune" {>= "1.5" }
   "alt-ergo-lib-free" { = version }
   "psmt2-frontend" { >= "0.2" & < "0.4" }
   "camlzip"

--- a/packages/alt-ergo-parsers-free/alt-ergo-parsers-free.2.3.3/opam
+++ b/packages/alt-ergo-parsers-free/alt-ergo-parsers-free.2.3.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+authors: "Alt-Ergo developers"
+maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
+license: "OCamlPro Non-Commercial Purpose License, version 1"
+build: [
+  ["./configure" name]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="4.04.0" & < "4.07.0"}
+  "dune" {>= "1.5" build }
+  "alt-ergo-lib-free" { = version }
+  "psmt2-frontend" { >= "0.2" & < "0.4" }
+  "camlzip"
+  "menhir" { < "20210310" }
+  "stdlib-shims"
+]
+conflicts: [
+  "alt-ergo-parsers"
+]
+homepage: "http://alt-ergo.ocamlpro.com/"
+dev-repo: "git+https://github.com/OCamlPro/alt-ergo.git"
+bug-reports: "https://github.com/OCamlPro/alt-ergo/issues"
+
+synopsis: "The Alt-Ergo SMT prover parser library"
+description:
+"This is the parser library used in the Alt-Ergo SMT solver.
+
+Alt-Ergo is an automatic theorem prover of mathematical formulas. It was developed at LRI, and is now maintained at OCamlPro.
+
+See more details on http://alt-ergo.ocamlpro.com/"
+url {
+  src: "https://github.com/OCamlPro/alt-ergo/archive/2.3.3-free.tar.gz"
+  checksum: [
+    "md5=66131860e31abbcdaa29b721bef311fd"
+    "sha512=72fc1dabdf13615eb771574e4d2ffa9855e5ec832e34df2c5eb361fd5ad34ca2e2269ffb5ab41296e2123447cb2f81860a5fce822e7a40c7377ed966d7294940"
+  ]
+}

--- a/packages/alt-ergo-parsers-free/alt-ergo-parsers-free.2.3.3/opam
+++ b/packages/alt-ergo-parsers-free/alt-ergo-parsers-free.2.3.3/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 authors: "Alt-Ergo developers"
 maintainer: "OCamlPro <alt-ergo@ocamlpro.com>"
-license: "OCamlPro Non-Commercial Purpose License, version 1"
+license: "Apache-2.0"
 build: [
   ["./configure" name]
   ["dune" "subst"] {pinned}
@@ -31,9 +31,9 @@ Alt-Ergo is an automatic theorem prover of mathematical formulas. It was develop
 
 See more details on http://alt-ergo.ocamlpro.com/"
 url {
-  src: "https://github.com/OCamlPro/alt-ergo/archive/2.3.3-free.tar.gz"
+  src:
+    "http://alt-ergo.ocamlpro.com/http/alt-ergo-free-2.3.3/alt-ergo-free-2.3.3.tar.gz"
   checksum: [
-    "md5=66131860e31abbcdaa29b721bef311fd"
-    "sha512=72fc1dabdf13615eb771574e4d2ffa9855e5ec832e34df2c5eb361fd5ad34ca2e2269ffb5ab41296e2123447cb2f81860a5fce822e7a40c7377ed966d7294940"
+    "md5=adaea0b3bc67b24df5d6eec800d249f7"
   ]
 }


### PR DESCRIPTION
This pull-request concerns:
-`alt-ergo-free.2.3.3`: The Alt-Ergo SMT prover
-`alt-ergo-lib-free.2.3.3`: The Alt-Ergo SMT prover library
-`alt-ergo-parsers-free.2.3.3`: The Alt-Ergo SMT prover parser library



---
* Homepage: http://alt-ergo.ocamlpro.com/
* Source repo: git+https://github.com/OCamlPro/alt-ergo.git
* Bug tracker: https://github.com/OCamlPro/alt-ergo/issues

---
:camel: Pull-request generated by opam-publish v2.0.3