### PR TITLE
Allow Sedlex 2.x to be used with OCaml 4.14

### DIFF
--- a/packages/sedlex/sedlex.1.99.4/opam
+++ b/packages/sedlex/sedlex.1.99.4/opam
@@ -7,7 +7,7 @@ build: [ [make "all"]  [make "opt"] ]
 install: [make "install"]
 remove: [["ocamlfind" "remove" "sedlex"]]
 depends: [
-  "ocaml" {>= "4.03.0" & < "4.14.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ppx_tools_versioned" {< "5.2.1"}
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/sedlex/sedlex.2.0/opam
+++ b/packages/sedlex/sedlex.2.0/opam
@@ -23,7 +23,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {build & >= "4.02.3" & < "4.14.0"}
+  "ocaml" {build & >= "4.02.3" & < "5.0"}
   "dune" {>= "1.0"}
   "ppx_tools_versioned" {>= "5.2.2"}
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/sedlex/sedlex.2.1/opam
+++ b/packages/sedlex/sedlex.2.1/opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.02.3" & < "4.14.0"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.8"}
   "ppx_tools_versioned" {>= "5.2.2"}
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/sedlex/sedlex.2.2/opam
+++ b/packages/sedlex/sedlex.2.2/opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.02.3" & < "4.14.0"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "dune" {>= "1.8"}
   "ppx_tools_versioned" {>= "5.2.3"}
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/sedlex/sedlex.2.3/opam
+++ b/packages/sedlex/sedlex.2.3/opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.04" & < "4.14.0"}
+  "ocaml" {>= "4.04" & < "5.0"}
   "dune" {>= "1.8"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "gen"

--- a/packages/sedlex/sedlex.2.4/opam
+++ b/packages/sedlex/sedlex.2.4/opam
@@ -14,7 +14,7 @@ license: "MIT"
 homepage: "https://github.com/ocaml-community/sedlex"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 depends: [
-  "ocaml" {>= "4.04" & < "4.14.0"}
+  "ocaml" {>= "4.04" & < "5.0"}
   "dune" {>= "2.8"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "gen"

--- a/packages/sedlex/sedlex.2.5/opam
+++ b/packages/sedlex/sedlex.2.5/opam
@@ -15,7 +15,7 @@ license: "MIT"
 homepage: "https://github.com/ocaml-community/sedlex"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 depends: [
-  "ocaml" {>= "4.04" & < "4.14.0"}
+  "ocaml" {>= "4.04" & < "5.0"}
   "dune" {>= "2.8"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "gen"

--- a/packages/sedlex/sedlex.2.6/opam
+++ b/packages/sedlex/sedlex.2.6/opam
@@ -15,7 +15,7 @@ license: "MIT"
 homepage: "https://github.com/ocaml-community/sedlex"
 bug-reports: "https://github.com/ocaml-community/sedlex/issues"
 depends: [
-  "ocaml" {>= "4.08" & < "4.14.0"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "2.8"}
   "ppxlib" {>= "0.26.0"}
   "gen"


### PR DESCRIPTION
#21396 is a regression because it breaks existing Sedlex 2.x users on OCaml 4.14. This PR fixes the regression by setting the upper bound OCaml version to 5.0.

Note that OCaml 4.14 deprecated the `Stream` API, but didn't remove it, therefore OCaml 4.14 is still compatible with Sedlex 2.x. Setting the upper bound to 4.14.0 was a mistake in #21396 .