### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.0.8-1)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.0.8-1/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.8-1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.8-1/paf-0.0.8-1.tbz"
+  checksum: [
+    "sha256=320406348df093126842abc2d68324ce7091736b7fb8cb3645968168de3ae642"
+    "sha512=c067e933bc67a9e658e4e64897911d2118fa4b73a2ae73749108b6fc2fe6cb927ef158c48d86e5d076cf1f2e0e83959fc82ca79a412f672cd62e03a3a6f5271d"
+  ]
+}
+x-commit-hash: "a19f43fe09ea51eae9d216418841185c867f2875"

--- a/packages/paf-le/paf-le.0.0.8-1/opam
+++ b/packages/paf-le/paf-le.0.0.8-1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.8-1/paf-0.0.8-1.tbz"
+  checksum: [
+    "sha256=320406348df093126842abc2d68324ce7091736b7fb8cb3645968168de3ae642"
+    "sha512=c067e933bc67a9e658e4e64897911d2118fa4b73a2ae73749108b6fc2fe6cb927ef158c48d86e5d076cf1f2e0e83959fc82ca79a412f672cd62e03a3a6f5271d"
+  ]
+}
+x-commit-hash: "a19f43fe09ea51eae9d216418841185c867f2875"

--- a/packages/paf/paf.0.0.8-1/opam
+++ b/packages/paf/paf.0.0.8-1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic"
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.7.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.0.8-1/paf-0.0.8-1.tbz"
+  checksum: [
+    "sha256=320406348df093126842abc2d68324ce7091736b7fb8cb3645968168de3ae642"
+    "sha512=c067e933bc67a9e658e4e64897911d2118fa4b73a2ae73749108b6fc2fe6cb927ef158c48d86e5d076cf1f2e0e83959fc82ca79a412f672cd62e03a3a6f5271d"
+  ]
+}
+x-commit-hash: "a19f43fe09ea51eae9d216418841185c867f2875"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Do the TLS handshake in an asynchronous task (@TheLortex, @hannesm, dinosaure/paf-le-chien#64)
