### PR TITLE
[new release] cairo2, cairo2-pango and cairo2-gtk (0.6.3)

### DIFF
--- a/packages/cairo2-gtk/cairo2-gtk.0.6.3/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
 doc: "https://Chris00.github.io/ocaml-cairo/doc"
 tags: ["Cairo" "stroke" "drawing" "tutorial"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc"] {with-doc}
 ]

--- a/packages/cairo2-gtk/cairo2-gtk.0.6.3/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {>= "2.0.0"}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2" {= version}
+  "lablgtk"
+]
+synopsis: "Rendering Cairo on Gtk2 canvas"
+description: """
+This provides the link between Cairo and Lablgtk.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.3/cairo2-0.6.3.tbz"
+  checksum: [
+    "sha256=366273303b351e2bcd781d44a01c961729f6451f9917d75cd038465370481822"
+    "sha512=49dbd0a4dcb51f9847c9adc7c45125114ea0a83d3179c1785b28221a1d289a8d6a1db34a926386709844fed69ce12a7bf271bd76505580425b2a11794febe375"
+  ]
+}
+x-commit-hash: "cd80c793e3c6406fdc50376201fc1b0a3b4cc5c5"

--- a/packages/cairo2-pango/cairo2-pango.0.6.3/opam
+++ b/packages/cairo2-pango/cairo2-pango.0.6.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
 doc: "https://Chris00.github.io/ocaml-cairo/doc"
 tags: ["Cairo" "stroke" "drawing" "tutorial"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc"] {with-doc}
 ]

--- a/packages/cairo2-pango/cairo2-pango.0.6.3/opam
+++ b/packages/cairo2-pango/cairo2-pango.0.6.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {>= "2.7.0"}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2" {= version}
+  "lablgtk"
+]
+synopsis: "Interface between Cairo and Pango (for Gtk2)"
+description: """
+This package provides a way to use Pango (lablgtk, Gtk2) with Cairo.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.3/cairo2-0.6.3.tbz"
+  checksum: [
+    "sha256=366273303b351e2bcd781d44a01c961729f6451f9917d75cd038465370481822"
+    "sha512=49dbd0a4dcb51f9847c9adc7c45125114ea0a83d3179c1785b28221a1d289a8d6a1db34a926386709844fed69ce12a7bf271bd76505580425b2a11794febe375"
+  ]
+}
+x-commit-hash: "cd80c793e3c6406fdc50376201fc1b0a3b4cc5c5"

--- a/packages/cairo2/cairo2.0.6.3/opam
+++ b/packages/cairo2/cairo2.0.6.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
 doc: "https://Chris00.github.io/ocaml-cairo/doc"
 tags: ["Cairo" "stroke" "drawing" "tutorial"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc"] {with-doc}

--- a/packages/cairo2/cairo2.0.6.3/opam
+++ b/packages/cairo2/cairo2.0.6.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {>= "2.7.0"}
+  "dune-configurator" {>= "2.7.0"}
+  "conf-cairo"
+]
+depopts: [
+  "conf-freetype"
+]
+conflicts: [
+  "cairo" {= "0.4.1"}
+  "cairo" {= "0.4.2"}
+]
+post-messages: [
+  "Try to re-run the install command with PKG_CONFIG_PATH pointing a pkg-config path including libffi, e.g. if you use homebrew you can try PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig" {failure & os = "macos"}
+]
+synopsis: "Binding to Cairo, a 2D Vector Graphics Library"
+description: """
+This is a binding to Cairo, a 2D graphics library with support for
+multiple output devices. Currently supported output targets include
+the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
+and SVG file output."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.3/cairo2-0.6.3.tbz"
+  checksum: [
+    "sha256=366273303b351e2bcd781d44a01c961729f6451f9917d75cd038465370481822"
+    "sha512=49dbd0a4dcb51f9847c9adc7c45125114ea0a83d3179c1785b28221a1d289a8d6a1db34a926386709844fed69ce12a7bf271bd76505580425b2a11794febe375"
+  ]
+}
+x-commit-hash: "cd80c793e3c6406fdc50376201fc1b0a3b4cc5c5"


### PR DESCRIPTION
Binding to Cairo, a 2D Vector Graphics Library

- Project page: <a href="https://github.com/Chris00/ocaml-cairo">https://github.com/Chris00/ocaml-cairo</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-cairo/doc">https://Chris00.github.io/ocaml-cairo/doc</a>

##### CHANGES:

- Fix bug in `Path.fold`.
- Extend `Image.get_data*` to bigarrays with externally managed payload.
