### PR TITLE
[new release] knights_tour (0.0.2)

### DIFF
--- a/packages/knights_tour/knights_tour.0.0.2/opam
+++ b/packages/knights_tour/knights_tour.0.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Solves the Knight's tour puzzle; and others"
+description: "See https://en.wikipedia.org/wiki/Knight%27s_tour"
+maintainer: ["kris.de.volder@gmail.com"]
+authors: ["Kris De Volder"]
+license: "MIT"
+homepage: "https://github.com/kdvolder/knights_tour"
+bug-reports: "https://github.com/kdvolder/knights_tour/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.14.0"}
+  "graphics"
+  "stdio"
+  "ppx_inline_test"
+  "ppx_expect"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/kdvolder/knights_tour.git"
+url {
+  src:
+    "https://github.com/kdvolder/knights_tour/releases/download/v0.0.2/knights_tour-0.0.2.tbz"
+  checksum: [
+    "sha256=8362f846492183e83e1901f73933d772c193c08b8a375480c28d0f23f0d29e11"
+    "sha512=5fe79ac95a3e5a2e01d429665fa7a8bfef422d9843758b35db2c8efc299c762c1d22974266f5e8802ee6f81e09223aa90476824d1fd93540c473cc8a357d38a3"
+  ]
+}
+x-commit-hash: "7ed64f2ce5da549fb7a6904255c2a9f7b6bd74b1"


### PR DESCRIPTION
Solves the Knight's tour puzzle; and others

- Project page: <a href="https://github.com/kdvolder/knights_tour">https://github.com/kdvolder/knights_tour</a>

##### CHANGES:

Exploration of solving a different type of puzzle (i.e. Pentominos).
Added some extra convenience methods into the SearchEngine module.
Improved the docs.
