### PR TITLE
[new release] memtrace-mirage (0.2.1.2.2)

### DIFF
--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.2/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.2/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt" {>= "5.5.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.2/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Streaming client for Memprof using MirageOS API"
+description: "Generates compact traces of a program's memory use."
+maintainer: ["hannes@mehnert.org"]
+authors: [
+  "Jane Street Group, LLC <opensource@janestreet.com>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "MIT"
+homepage: "https://github.com/hannesm/memtrace-mirage"
+bug-reports: "https://github.com/hannesm/memtrace-mirage/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "mirage-flow" {>= "3.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "ptime" {>= "1.0.0"}
+  "lwt" {>= "5.5.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hannesm/memtrace-mirage.git"
+url {
+  src:
+    "https://github.com/hannesm/memtrace-mirage/releases/download/v0.2.1.2.2/memtrace-mirage-0.2.1.2.2.tbz"
+  checksum: [
+    "sha256=34b0464af8399bc8b1c9a1de907d6fcc4bab135879e1f650c63bf658cd300f8e"
+    "sha512=e9a61c4519050b7bc3f35ed9075755b1ad33cf1ac87d08293915a6b4677d8b2502f8b00d8a5b5207e6b5c92cab92c5c14c9c05b95cbbfb23b1a36f5befd43c58"
+  ]
+}
+x-commit-hash: "a33d488aa5c5eab9248c7ea9f6ba94b1c870842b"


### PR DESCRIPTION
Streaming client for Memprof using MirageOS API

- Project page: <a href="https://github.com/hannesm/memtrace-mirage">https://github.com/hannesm/memtrace-mirage</a>

##### CHANGES:

Improve failure behaviour on write error: avoid raising an exception
