### PR TITLE
[new release] mirage-monitoring (0.0.1)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.1/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-solo5" {>= "0.6.4"}
+  "mirage-solo5" {>= "0.6.4" & < "0.7.0"}
   "ocaml-freestanding" {>= "0.4.5"}
   "mirage-runtime"
   "memtrace-mirage" {>= "0.2.1.2.2"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.1/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/mirage-monitoring"
+doc: "https://roburio.github.io/mirage-monitoring"
+dev-repo: "git+https://github.com/roburio/mirage-monitoring.git"
+bug-reports: "https://github.com/roburio/mirage-monitoring/issues"
+license: "AGPL-3.0-only"
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune"
+  "logs" {>= "0.6.3"}
+  "metrics" {>= "0.4.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-solo5" {>= "0.6.4"}
+  "ocaml-freestanding" {>= "0.4.5"}
+  "mirage-runtime"
+  "memtrace-mirage" {>= "0.2.1.2.2"}
+  "mirage-clock" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Monitoring of MirageOS unikernels"
+description: """
+Reporting metrics to Influx, Telegraf. Dynamic adjusting log level and metrics
+sources, memprof profiling.
+"""
+url {
+  src:
+    "https://github.com/roburio/mirage-monitoring/releases/download/v0.0.1/mirage-monitoring-0.0.1.tbz"
+  checksum: [
+    "sha256=eeab5fdc332a97c361bc1c76ea7124a761ac8e2e88214129e2085b73cf02142b"
+    "sha512=d990da8398ae70ed5644bcff6eb995370798a5bb33a7b309e5ea15831959e93db20183d24c2a35b95e36bda870e8df6f4e584416f9dc5010c75a99bbf00ff504"
+  ]
+}
+x-commit-hash: "f949c87e4c741397b486f4470629a7ba9b7024af"


### PR DESCRIPTION
Monitoring of MirageOS unikernels

- Project page: <a href="https://github.com/roburio/mirage-monitoring">https://github.com/roburio/mirage-monitoring</a>
- Documentation: <a href="https://roburio.github.io/mirage-monitoring">https://roburio.github.io/mirage-monitoring</a>

##### CHANGES:

Initial public release
