### PR TITLE
Package libbinaryen.107.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.107.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.107.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {with-test & >= "3.10.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v107.0.1/libbinaryen-v107.0.1.tar.gz"
+  checksum: [
+    "md5=78c9782313d5d0056fa2dfce616c1387"
+    "sha512=32bddd8e34b670a579b477064a61fdabfb9cec100c2f1a00ba98785ce7b98236540b0a5928c813b87569b09f5d1e9f82832e4d82405dc6b21e3ec7378eb419ec"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.107.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
### [107.0.1](https://github.com/grain-lang/libbinaryen/compare/v107.0.0...v107.0.1) (2022-05-24)


### Bug Fixes

* Remove upper bounds on dependencies ([#60](https://github.com/grain-lang/libbinaryen/issues/60)) ([3a75c23](https://github.com/grain-lang/libbinaryen/commit/3a75c23941e1387d07a686dfa06266f517100c8f))

---
:camel: Pull-request generated by opam-publish v2.0.3