### PR TITLE
[new release] archi, archi-lwt and archi-async (0.2.0)

### DIFF
--- a/packages/archi-async/archi-async.0.2.0/opam
+++ b/packages/archi-async/archi-async.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/archi"
+bug-reports: "https://github.com/anmonteiro/archi/issues"
+dev-repo: "git+https://github.com/anmonteiro/archi.git"
+doc: "https://anmonteiro.github.io/archi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "2.5"}
+  "archi" {= version}
+  "async"
+]
+synopsis:
+  "Async runtime for Archi, a library for managing the lifecycle of stateful components in OCaml"
+url {
+  src:
+    "https://github.com/anmonteiro/archi/releases/download/0.2.0/archi-0.2.0.tbz"
+  checksum: [
+    "sha256=5b33fc94a73d211f6d7ccebe750ac52b03962029fc90e35bb47329de611799c0"
+    "sha512=f5fb600a19cd6d0022ae0f6519ee7473c773c32fb6cb15638b26a9a08c320ddfafd1a12e8ed3207727a7e8c893ef0ac6eadd57a0f8a935da40e79cabf86b11be"
+  ]
+}
+x-commit-hash: "57dcef55e07affca53684e7f0fa9e2f388a73770"

--- a/packages/archi-lwt/archi-lwt.0.2.0/opam
+++ b/packages/archi-lwt/archi-lwt.0.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/archi"
+bug-reports: "https://github.com/anmonteiro/archi/issues"
+dev-repo: "git+https://github.com/anmonteiro/archi.git"
+doc: "https://anmonteiro.github.io/archi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "2.5"}
+  "archi" {= version}
+  "lwt"
+]
+synopsis:
+  "Lwt runtime for Archi, a library for managing the lifecycle of stateful components in OCaml"
+url {
+  src:
+    "https://github.com/anmonteiro/archi/releases/download/0.2.0/archi-0.2.0.tbz"
+  checksum: [
+    "sha256=5b33fc94a73d211f6d7ccebe750ac52b03962029fc90e35bb47329de611799c0"
+    "sha512=f5fb600a19cd6d0022ae0f6519ee7473c773c32fb6cb15638b26a9a08c320ddfafd1a12e8ed3207727a7e8c893ef0ac6eadd57a0f8a935da40e79cabf86b11be"
+  ]
+}
+x-commit-hash: "57dcef55e07affca53684e7f0fa9e2f388a73770"

--- a/packages/archi/archi.0.2.0/opam
+++ b/packages/archi/archi.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/archi"
+bug-reports: "https://github.com/anmonteiro/archi/issues"
+dev-repo: "git+https://github.com/anmonteiro/archi.git"
+doc: "https://anmonteiro.github.io/archi/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "2.5"}
+  "hmap"
+  "alcotest" {with-test}
+]
+synopsis:
+  "A library for managing the lifecycle of stateful components in OCaml"
+description:
+"""
+Archi is an OCaml library for managing the lifecycle of stateful components and
+their dependencies.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/archi/releases/download/0.2.0/archi-0.2.0.tbz"
+  checksum: [
+    "sha256=5b33fc94a73d211f6d7ccebe750ac52b03962029fc90e35bb47329de611799c0"
+    "sha512=f5fb600a19cd6d0022ae0f6519ee7473c773c32fb6cb15638b26a9a08c320ddfafd1a12e8ed3207727a7e8c893ef0ac6eadd57a0f8a935da40e79cabf86b11be"
+  ]
+}
+x-commit-hash: "57dcef55e07affca53684e7f0fa9e2f388a73770"


### PR DESCRIPTION
A library for managing the lifecycle of stateful components in OCaml

- Project page: <a href="https://github.com/anmonteiro/archi">https://github.com/anmonteiro/archi</a>
- Documentation: <a href="https://anmonteiro.github.io/archi/">https://anmonteiro.github.io/archi/</a>

##### CHANGES:

- archi: add `Component.identity`which creates a component whose value is its
  argument ([anmonteiro/archi#12](https://github.com/anmonteiro/archi/pull/12))
- archi: Expose `Cycle_found` errors instead of throwing
  ([anmonteiro/archi#13](https://github.com/anmonteiro/archi/pull/13))
