### PR TITLE
[new release] tcpip (7.1.1)

### DIFF
--- a/packages/tcpip/tcpip.7.1.1/opam
+++ b/packages/tcpip/tcpip.7.1.1/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding" {< "0.4.1"}
+  "result" {< "1.5"}
+]
+depends: [
+  "conf-pkg-config" {build}
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "ppx_cstruct"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "mirage-profile" {>= "0.5"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="0.7.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "ipaddr-cstruct" {with-test}
+  "lru" {>= "0.3.0"}
+  "metrics"
+]
+depopts: [
+  "ocaml-freestanding"
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v7.1.1/tcpip-7.1.1.tbz"
+  checksum: [
+    "sha256=5dda5d53610187e426fc659e35515d01e54e9cce41e6ead3f32f162867b2c1d0"
+    "sha512=a1d98ef57b0ffb3fc4a1b18e7e24cd8c3cb39a16798506e87afe8a906261e8526ed373bd1421697ca60595a05bd936ed337048f9d07b1ac5c4d50156b7832d8a"
+  ]
+}
+x-commit-hash: "76033e871e0f0228b2417d9b1c1a93a9e8f51a74"


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* Ndpv6: demote more logs to debug level (mirage/mirage-tcpip#480 @reynir)
* Ndpv6: set RS opt header (mirage/mirage-tcpip#482 @reynir)
* Icmpv6: add redirect parsing (mirage/mirage-tcpip#481 @reynir)
* Improve log messages of connect and disconnect of various layers and stacks:
  separate IP addresses with ", " (mirage/mirage-tcpip#485 @hannesm)
* TCP log sources: prefix "tcp" to distinguish them (mirage/mirage-tcpip#484 @reynir)
