### PR TITLE
[new release] preface (1.0.0)

### DIFF
--- a/packages/preface/preface.1.0.0/opam
+++ b/packages/preface/preface.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+maintainer: "xaviervdw@gmail.com"
+authors: [
+  "Didier Plaindoux <d.plaindoux@free.fr>"
+  "Pierre Ruyter <grimfw@gmail.com>"
+  "Xavier Van de Woestyne <xaviervdw@gmail.com>"
+]
+
+license: "MIT"
+tags: ["library" "standard" "monad"]
+homepage: "https://github.com/xvw/preface"
+dev-repo: "git+https://github.com/xvw/preface.git"
+bug-reports: "https://github.com/xvw/preface/issues"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+  [ "dune" "build" "@doc" "-p" name ] {with-doc}
+]
+
+depends: [
+  "ocaml" { >= "4.08.0" }
+  "dune" { >= "2.8.0" }
+  "either"
+  "alcotest" {with-test}
+  "qcheck-core" {with-test}
+  "qcheck-alcotest" {with-test}
+  "mdx" {with-test}
+  "odoc"{with-doc}
+]
+
+synopsis: "An opinionated library for function programming (à La Haskell)"
+description:"""
+Preface is an opinionated library designed to facilitate the
+handling of recurring functional programming idioms in OCaml.
+"""
+url {
+  src:
+    "https://github.com/xvw/preface/releases/download/v1.0.0/preface-1.0.0.tbz"
+  checksum: [
+    "sha256=4bf4f89ecee0cc0064394d2f27ab2378b696c85dfa1d940fbf5c5594e3c669b9"
+    "sha512=aa2fc7e23cec7086a954c27bfe8e0c6e71cc09e140e6ddab9e041f3336c1b6ee22d661a29a7fe409f580be34a47bdf6699e339dedfe5275b8ac9724768fa56a8"
+  ]
+}
+x-commit-hash: "b7f5210830b7916033c56ede6108c2c439c31cdf"


### PR DESCRIPTION
An opinionated library for function programming (à La Haskell)

- Project page: <a href="https://github.com/xvw/preface">https://github.com/xvw/preface</a>

##### CHANGES:

- Add selective to Either, Options, Result and Try [**@d-plaindoux**](https://github.com/d-plaindoux)
- Add specialized interpreters/handlers for `Free` and `Freer` monads [**@xhtmlboi**](https://github.com/xhtmlboi)
- Add right-associative operators for `Contravariant`, `Divisible` and `Decidable`  [**@xhtmlboi**](https://github.com/xhtmlboi)
- Add `Bind` [**@d-plaindoux**](https://github.com/d-plaindoux)
- Add `Apply` [**@d-plaindoux**](https://github.com/d-plaindoux)
- Add `('a, 'b) handle` to simplify handlers for `Freer_monad` [**@xvw**](https://github.com/xvw)
- Rename `times` to `times_to_nel` for _semigroup-ish_ and add `times` for _monoid-ish_ [**@xvw**](https://github.com/xvw)
- Add `Decidable` (Contravariant analogue for `Alternative`) and add some missing infixes operators for `Divisible` [**@gr-im**](https://github.com/gr-im)
- Removing early destructive substitution [**@xhtmlboi**](https://github.com/xhtmlboi)
- Add `Semigroupoid` [**@d-plaindoux**](https://github.com/d-plaindoux)
- Add `Freer Selective` [**@gr-im**](https://github.com/gr-im)
- Add `Invariant` (Functor) (and some instance) [**@gr-im**](https://github.com/gr-im)
- Add `Kleisli` and `Cokleisli` [**@gr-im**](https://github.com/gr-im)
- Add `Join`, `Joker` and `Clown` [**@gr-im**](https://github.com/gr-im)
- Relax constraint for definition of `Profunctor` and `Choice` using the Kleisli Arrow [**@gr-im**](https://github.com/gr-im)
- Make `List` and `Nonenmpty_list` `Traversable` implementations (for both `Applicative` and `Monad`) Tail-recursive [**@xvw**](https://github.com/xvw)
- Add `Seq` module in Stdlib (with `Functor`, `Applicative` (with `Traversable`), `Alternative`, `Monad` (with `Traversable`), `Monad_plus`, `Monoid` and `Foldable`) [**@xvw**](https://github.com/xvw)
- Add `mli` for stdlib's test and example's test (in order to track unused tests) [**@xvw**](https://github.com/xvw)
- Use absolute URLs for image in documentation (in order to fit with the new version of OCaml.org) [**@xvw**](https://github.com/xvw)
- Add `Selective` for `Free monad` and `Freer monad` [**@xvw**](https://github.com/xvw)
