### PR TITLE
[new release] ocamlformat and ocamlformat-rpc-lib (0.22.2)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.22.2/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.22.2/opam
@@ -30,7 +30,7 @@ build: [
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.2/ocamlformat-rpc-lib-0.22.2.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.2/ocamlformat-0.22.2.tbz"
   checksum: [
     "sha256=6820e6fce875d8975472b86765b26c3135edb3901d4cb90432953981e3450c3f"
     "sha512=e079ee7399e26ee181f4100dc1fd72b88bc2580c693338f053bb6765b5bb2b82c7e580b087c8d1326fa7a50161b0a4e2c08395c6beb0c2901b9df55302aa6bf2"

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.22.2/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.22.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.2/ocamlformat-rpc-lib-0.22.2.tbz"
+  checksum: [
+    "sha256=6820e6fce875d8975472b86765b26c3135edb3901d4cb90432953981e3450c3f"
+    "sha512=e079ee7399e26ee181f4100dc1fd72b88bc2580c693338f053bb6765b5bb2b82c7e580b087c8d1326fa7a50161b0a4e2c08395c6beb0c2901b9df55302aa6bf2"
+  ]
+}
+x-commit-hash: "97750965fc61ef27ed18d04c1627138c491ad902"

--- a/packages/ocamlformat/ocamlformat.0.22.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.22.2/opam
@@ -48,7 +48,7 @@ dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 url {
   src:
-    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.2/ocamlformat-rpc-lib-0.22.2.tbz"
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.2/ocamlformat-0.22.2.tbz"
   checksum: [
     "sha256=6820e6fce875d8975472b86765b26c3135edb3901d4cb90432953981e3450c3f"
     "sha512=e079ee7399e26ee181f4100dc1fd72b88bc2580c693338f053bb6765b5bb2b82c7e580b087c8d1326fa7a50161b0a4e2c08395c6beb0c2901b9df55302aa6bf2"

--- a/packages/ocamlformat/ocamlformat.0.22.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.22.2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune" {with-test & < "3.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocp-indent"
+  "odoc-parser" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.22.2/ocamlformat-rpc-lib-0.22.2.tbz"
+  checksum: [
+    "sha256=6820e6fce875d8975472b86765b26c3135edb3901d4cb90432953981e3450c3f"
+    "sha512=e079ee7399e26ee181f4100dc1fd72b88bc2580c693338f053bb6765b5bb2b82c7e580b087c8d1326fa7a50161b0a4e2c08395c6beb0c2901b9df55302aa6bf2"
+  ]
+}
+x-commit-hash: "97750965fc61ef27ed18d04c1627138c491ad902" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.22.2/opam
+++ b/packages/ocamlformat/ocamlformat.0.22.2/opam
@@ -29,6 +29,7 @@ depends: [
   "uutf" {>= "1.0.1"}
   "csexp" {>= "1.4.0"}
   "odoc" {with-doc}
+  "ocamlformat-rpc-lib" {=version & with-test & post}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### Removed

- Profiles `compact` and `sparse` are now removed (ocaml-ppx/ocamlformat#2075, @gpetiot)
- Options `align-cases`, `align-constructors-decl` and `align-variants-decl` are now removed (ocaml-ppx/ocamlformat#2076, @gpetiot)
- Option `disable-outside-detected-project` is now removed (ocaml-ppx/ocamlformat#2077, @gpetiot)

### Deprecated

- Cancel the deprecations of options that are not set by the preset profiles (ocaml-ppx/ocamlformat#2074, @gpetiot)

### Bug fixes

- emacs: Remove temp files in the event of an error (ocaml-ppx/ocamlformat#2003, @gpetiot)
- Fix unstable comment formatting around prefix op (ocaml-ppx/ocamlformat#2046, @gpetiot)

### Changes

- Qtest comments are not re-formatted (ocaml-ppx/ocamlformat#2034, @gpetiot)
- ocamlformat-rpc is now distributed through the ocamlformat package (ocaml-ppx/ocamlformat#2035, @Julow)
- Doc-comments code blocks with a language other than 'ocaml' (set in metadata) are not parsed as OCaml (ocaml-ppx/ocamlformat#2037, @gpetiot)
- More comprehensible error message in case of version mismatch (ocaml-ppx/ocamlformat#2042, @gpetiot)
- The global configuration file (`$XDG_CONFIG_HOME` or `$HOME/.config`) is only applied when no project is detected, `--enable-outside-detected-project` is set, and no applicable `.ocamlformat` file has been found. Global and local configurations are no longer used at the same time. (ocaml-ppx/ocamlformat#2039, @gpetiot)
- Set `ocaml-version` to a fixed version (4.04.0) by default to avoid reproducibility issues and surprising behaviours (ocaml-ppx/ocamlformat#2064, @kit-ty-kate)
- Split option `--numeric=X-Y` into `--range=X-Y` and `--numeric` (flag). For now `--range` can only be used with `--numeric`. (ocaml-ppx/ocamlformat#2073, ocaml-ppx/ocamlformat#2082, @gpetiot)

### New features

- New syntax `(*= ... *)` for verbatim comments (ocaml-ppx/ocamlformat#2028, @gpetiot)
- Preserve the begin-end construction in the AST (ocaml-ppx/ocamlformat#1785, @hhugo, @gpetiot)
- Preserve position of comments located after the semi-colon of the last element of lists/arrays/records (ocaml-ppx/ocamlformat#2032, @gpetiot)
- Option `--print-config` displays a warning when an .ocamlformat file defines redundant options (already defined by a profile) (ocaml-ppx/ocamlformat#2084, @gpetiot)
