### PR TITLE
Update ocaml-config.3 for Windows readiness and compatibility with latest OCaml trunk

### DIFF
--- a/packages/ocaml-config/ocaml-config.3/files/gen_ocaml_config.ml.in
+++ b/packages/ocaml-config/ocaml-config.3/files/gen_ocaml_config.ml.in
@@ -40,6 +40,12 @@ let () =
     let sep = if Sys.os_type = "Win32" then ";" else ":" in
     String.concat sep lines
   in
+  let has_native_dynlink =
+    let check_dir libdir =
+      Sys.file_exists (Filename.concat libdir "dynlink.cmxa")
+    in
+    List.exists check_dir [Filename.concat libdir "dynlink"; libdir]
+  in
   let p fmt = Printf.fprintf oc (fmt ^^ "\n") in
   p "opam-version: \"2.0\"";
   p "variables {";
@@ -50,7 +56,7 @@ let () =
        (ex. '...\bin\ocamlc.exe') so we use [ocaml] to check *)
     (Sys.file_exists (ocaml^"c.opt"^suffix));
   p "  native-dynlink: %%b"
-    (Sys.file_exists (Filename.concat libdir "dynlink.cmxa"));
+    has_native_dynlink;
   p "  stubsdir: %%S"
     stubsdir;
   p "  preinstalled: %{ocaml-system:installed}%";

--- a/packages/ocaml-config/ocaml-config.3/opam
+++ b/packages/ocaml-config/ocaml-config.3/opam
@@ -18,6 +18,6 @@ depends: [
 ]
 substs: "gen_ocaml_config.ml"
 extra-files: [
-  ["gen_ocaml_config.ml.in" "md5=1b6c14b465e104ca6641c6899e097143"]
+  ["gen_ocaml_config.ml.in" "md5=c0a50fb1f6ffe7a48bf8600e83ae6d38"]
   ["ocaml-config.install"   "md5=8e50c5e2517d3463b3aad649748cafd7"]
 ]

--- a/packages/ocaml-config/ocaml-config.3/opam
+++ b/packages/ocaml-config/ocaml-config.3/opam
@@ -11,9 +11,9 @@ license: "ISC"
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml-base-compiler" {>= "5.0.0~"} |
-  "ocaml-variants" {>= "5.0.0~"} |
-  "ocaml-system" {>= "5.0.0~"} |
+  "ocaml-base-compiler" {>= "5.0.0~" | os = "win32"} |
+  "ocaml-variants" {>= "5.0.0~" | os = "win32"} |
+  "ocaml-system" {>= "5.0.0~" | os = "win32"} |
   "dkml-base-compiler" {>= "4.12.0~"}
 ]
 substs: "gen_ocaml_config.ml"


### PR DESCRIPTION
Trunk OCaml changed the installation layout of the Unix, Dynlink and Str libraries yesterday evening. As this only affects the test ocaml-variants.5.0.0+trunk, ocaml-config.3 is updated directly, as we we can't constrain it.

While it's being updated, I widened the constraint for `ocaml-config.3` ready for the Windows version of ocaml-base-compiler - Windows requires ocaml-config.3. Technically, ocaml-config.1 and ocaml-config.2 should be updated to constrain away Windows, but this will trigger mass switch rebuilds, so I suggest leaving it be for now.