### PR TITLE
Package secp256k1.0.4.4

### DIFF
--- a/packages/secp256k1/secp256k1.0.4.4/opam
+++ b/packages/secp256k1/secp256k1.0.4.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elliptic curve library secp256k1 wrapper for Ocaml"
+description: """\
+This library wrap the secp256k1 EC(DSA) library into an OCaml library. At the moment only a subset of functionalities are available:
+- Context: create, clone, destroy, randomize
+- Elliptic curve: public key creation
+- ECDSA: verify, sign, recover
+
+All exchanged data (pubkey, signature, seckey) are represented as hex strings."""
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Yoichi Hirai <i@yoichihirai.com>"
+  "Anton Trunov"
+]
+license: "MIT"
+homepage: "https://github.com/dakk/secp256k1-ml"
+bug-reports: "https://github.com/dakk/secp256k1-ml/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "base" {build & >= "v0.9.2"}
+  "stdio" {build & >= "v0.9.0"}
+  "dune-configurator" {build & >= "1.0"}
+  "hex" {with-test & >= "1.1.1"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "odoc" {with-test & >= "1.3.0"}
+  "base-bigarray"
+  "conf-secp256k1"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dakk/secp256k1-ml"
+url {
+  src: "https://github.com/dakk/secp256k1-ml/archive/refs/tags/0.4.4.zip"
+  checksum: [
+    "md5=ca8faedd0ed878652f212874e1b263fb"
+    "sha512=73f1649cde4aa3afd75d1c14e97271851c6e9b1d3797fcef0ba015cb99f2854f727dcd6166c5d62d909b805da08530135468e80fddae5d21c6a54a3fc2a7ce69"
+  ]
+}


### PR DESCRIPTION
### `secp256k1.0.4.4`
Elliptic curve library secp256k1 wrapper for Ocaml
This library wrap the secp256k1 EC(DSA) library into an OCaml library. At the moment only a subset of functionalities are available:
- Context: create, clone, destroy, randomize
- Elliptic curve: public key creation
- ECDSA: verify, sign, recover

All exchanged data (pubkey, signature, seckey) are represented as hex strings.



---
* Homepage: https://github.com/dakk/secp256k1-ml
* Source repo: git+https://github.com/dakk/secp256k1-ml
* Bug tracker: https://github.com/dakk/secp256k1-ml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0