### PR TITLE
conf-libsecp256k1: add more Linux distros

### DIFF
--- a/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
+++ b/packages/conf-secp256k1/conf-secp256k1.1.0.0/opam
@@ -11,6 +11,10 @@ depexts: [
   ["dev-libs/libsecp256k1"] {os-distribution = "gentoo"}
   ["domt4/crypto/secp256k1"] {os-distribution = "homebrew" & os = "macos"}
   ["libsecp256k1-git"] {os-distribution = "arch"}
+  ["libsecp256k1" "libsecp256k1-dev"] {os-distribution = "alpine"}
+  ["libsecp256k1" "libsecp256k1-devel"] {os-distribution = "fedora"}
+  ["libsecp256k1"] {os-family = "suse"}
+  ["libsecp256k1" "libsecp256k1-devel"] {os-distribution = "oraclelinux"}
 ]
 synopsis: "Virtual package relying on a secp256k1 lib system installation"
 description:


### PR DESCRIPTION
Namely, Alpine, Fedora, SUSE, Oracle Linux.

Hopefully, this will fix some CI failures for PR #21426.