### PR TITLE
Package carray.0.0.1

### DIFF
--- a/packages/carray/carray.0.0.1/opam
+++ b/packages/carray/carray.0.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Contiguous arrays in OCaml"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-carray"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-carray/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "3.0.0" & with-test}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-carray.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-carray/-/archive/0.0.1/ocaml-carray-0.0.1.tar.bz2"
+  checksum: [
+    "md5=0e9d3d5214f50cc0adb331c26583c802"
+    "sha512=82dce500470e269f8052fa79b5c1fb27c5adc76981dd85451ddb1c8c58dd10f22b18ae73dd6ba466900f9a3a1ac03c3305094657cf7504c222ce14e7e29c54cb"
+  ]
+}


### PR DESCRIPTION
### `carray.0.0.1`
Contiguous arrays in OCaml



---
* Homepage: https://gitlab.com/dannywillems/ocaml-carray
* Source repo: git+https://gitlab.com/dannywillems/ocaml-carray.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-carray/issues

---
:camel: Pull-request generated by opam-publish v2.1.0