### PR TITLE
Add a new release of mlmpfr.4.1.0 renaming the main module

### DIFF
--- a/packages/mlmpfr/mlmpfr.4.1.0+bugfix2/files/mlmpfr_compatibility_test.c
+++ b/packages/mlmpfr/mlmpfr.4.1.0+bugfix2/files/mlmpfr_compatibility_test.c
@@ -1,0 +1,16 @@
+#include <string.h>
+#include <stdio.h>
+#include <mpfr.h>
+
+int main(int argc, char **argv)
+{
+  const char *version = mpfr_get_version();
+  char subversion[6];
+  memcpy(subversion, version, 5);
+  subversion[5] = '\0';
+
+  if(strcmp(subversion, "4.1.0") == 0)
+    return 0;
+
+  return 1;
+}

--- a/packages/mlmpfr/mlmpfr.4.1.0+bugfix2/opam
+++ b/packages/mlmpfr/mlmpfr.4.1.0+bugfix2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Laurent Thévenoux <lrnt@thvnx.com>"
+authors:      "Laurent Thévenoux <lrnt@thvnx.com>"
+homepage:     "https://github.com/thvnx/mlmpfr"
+bug-reports:  "https://github.com/thvnx/mlmpfr/issues"
+license:      "LGPL-3.0-only"
+dev-repo:     "git+https://github.com/thvnx/mlmpfr.git"
+build: [
+  ["cc" "mlmpfr_compatibility_test.c" "-lmpfr" "-o" "mlmpfr_compatibility_test"]
+  ["./mlmpfr_compatibility_test"]
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.04"}
+  "dune" {>= "2.9"}
+  "conf-mpfr"
+]
+x-ci-accept-failures: ["debian-unstable"]
+post-messages: [
+  "Make sure you had MPFR version 4.1.0 installed on your system." {failure}
+]
+synopsis: "OCaml C bindings for MPFR-4.1.0"
+url {
+  src: "https://github.com/thvnx/mlmpfr/archive/refs/tags/mlmpfr.4.1.0-bugfix2.tar.gz"
+  checksum: "md5=20de14505f17e1c59841dab71261e9f5"
+}
+description: """
+The package provides bindings for MPFR-4.1.0.
+
+Warning: this bugfix2 version breaks backward compatibility since it renames the
+Mpfr module into Mlmpfr. See thvnx#21 for more details.
+
+You need to have MPFR-4.1.0 installed on your system. See opam info mlmpfr for
+all available versions."""
+extra-files: ["mlmpfr_compatibility_test.c"
+              "md5=34cf77d2aa08092d4bd94582594a26f2"]

--- a/packages/why3/why3.1.5.0/opam
+++ b/packages/why3/why3.1.5.0/opam
@@ -61,7 +61,7 @@ depopts: [
 conflicts: [
   "why3-base"
   "ocamlgraph" {< "1.8.2"}
-  "mlmpfr" {< "4.0.0"}
+  "mlmpfr" {< "4.0.0" | > "4.1.0+bugfix1"}
   "base-effects"
 ]
 


### PR DESCRIPTION
This patch remanes the main mlmpfr module from Mpfr to Mlmpfr to avoid
name clashes with the mlgmpidl's mpfr module.

Warning: it breaks the backward compatibility.

See also https://github.com/thvnx/mlmpfr/issues/21.