### PR TITLE
[new release] pgx_value_ptime, pgx_value_core, pgx_unix, pgx_lwt_unix, pgx_lwt_mirage, pgx_lwt, pgx_async and pgx (2.1)

### DIFF
--- a/packages/pgx/pgx.2.1/opam
+++ b/packages/pgx/pgx.2.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Pure-OCaml PostgreSQL client library"
+description:
+  "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "alcotest" {with-test & >= "1.0.0"}
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "dune" {>= "1.11"}
+  "hex"
+  "ipaddr"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "ppx_compare" {>= "v0.13.0"}
+  "ppx_custom_printf" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "re" {>= "1.5.0"}
+  "sexplib0" {>= "v0.13.0"}
+  "uuidm"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_async/pgx_async.2.1/opam
+++ b/packages/pgx_async/pgx_async.2.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Pgx using Async for IO"
+description: "Pgx using Async for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest-async" {with-test & >= "1.0.0"}
+  "async_kernel" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0"}
+  "async_ssl"
+  "base64" {with-test & >= "3.0.0"}
+  "conduit-async" {>= "1.5.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_value_core" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_lwt/pgx_lwt.2.1/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt for IO"
+description: "Pgx using Lwt for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "lwt"
+  "logs"
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.1/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt on Mirage for IO"
+description: "Pgx using Lwt on Mirage for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "lwt"
+  "ocaml" {>= "4.08"}
+  "logs"
+  "mirage-channel"
+  "conduit-mirage" {>= "2.3.0"}
+  "dns-client" {>= "6.0.0"}
+  "mirage-random"
+  "mirage-time"
+  "mirage-clock"
+  "tcpip" {>= "7.0.0"}
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.1/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt and Unix libraries for IO"
+description: "Pgx using Lwt and Unix libraries for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_unix/pgx_unix.2.1/opam
+++ b/packages/pgx_unix/pgx_unix.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PGX using the standard library's Unix module for IO (synchronous)"
+description:
+  "PGX using the standard library's Unix module for IO (synchronous)"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_value_core/pgx_value_core.2.1/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Pgx_value converters for Core types like Date and Time"
+description: "Pgx_value converters for Core types like Date and Time"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "core_kernel" {>= "v0.13.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"

--- a/packages/pgx_value_ptime/pgx_value_ptime.2.1/opam
+++ b/packages/pgx_value_ptime/pgx_value_ptime.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Pgx_value converters for Ptime types"
+description: "Pgx_value converters for Ptime types"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "ptime" {>= "0.8.3"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.1/pgx-2.1.tbz"
+  checksum: [
+    "sha256=3c53140b3b7082835927604f2511c77329406edcea5f378fed60f9fe9cb7da5d"
+    "sha512=cc95e07625c195675f01700e31906488bbe40f3db887b2564c9d19f250900b165174ba595acdb35adb5f7db6bcaf5f9fb1d784efd1c5f7d5202d61641ac55a12"
+  ]
+}
+x-commit-hash: "78fde75fb70735c1514e3716db59ab839a50d5eb"


### PR DESCRIPTION
Pgx_value converters for Ptime types

- Project page: <a href="https://github.com/arenadotio/pgx">https://github.com/arenadotio/pgx</a>
- Documentation: <a href="https://arenadotio.github.io/pgx">https://arenadotio.github.io/pgx</a>

##### CHANGES:

### Breaking changes

* Missing SASL authentication impl provides an error instead of hanging (https://github.com/arenadotio/pgx/pull/122).
* pgx_lwt_mirage now requires conduit 2.3 instead of 2.2 (https://github.com/arenadotio/pgx/pull/117).
