### PR TITLE
pgx_*.2.1: fix use of dune subst

### DIFF
--- a/packages/pgx/pgx.2.1/opam
+++ b/packages/pgx/pgx.2.1/opam
@@ -24,7 +24,7 @@ depends: [
   "uuidm"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_async/pgx_async.2.1/opam
+++ b/packages/pgx_async/pgx_async.2.1/opam
@@ -20,7 +20,7 @@ depends: [
   "pgx_value_core" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt/pgx_lwt.2.1/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.1/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "pgx_lwt" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.1/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "pgx_lwt" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_unix/pgx_unix.2.1/opam
+++ b/packages/pgx_unix/pgx_unix.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_value_core/pgx_value_core.2.1/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/pgx_value_ptime/pgx_value_ptime.2.1/opam
+++ b/packages/pgx_value_ptime/pgx_value_ptime.2.1/opam
@@ -15,7 +15,7 @@ depends: [
   "pgx" {= version}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Ping @gtrak 

This is a bug in dune, it is fixed in `dune language` >= 2.7. It is fine to fix it when releasing just in the opam repository

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>