### PR TITLE
Release of Solo5.0.7.2

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.2/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.2/solo5-v0.7.2.tar.gz"
+  checksum: "sha512=376d5d6caebf824928949a2e8be9b879dd924a6ce30128e183ebdfb99d812a42f528196315d85b0bee4ddec87ea92264ed763f74548cf3f9519c94fd13abb4b9"
+}

--- a/packages/solo5/solo5.0.7.2/opam
+++ b/packages/solo5/solo5.0.7.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.2/solo5-v0.7.2.tar.gz"
+  checksum: "sha512=376d5d6caebf824928949a2e8be9b879dd924a6ce30128e183ebdfb99d812a42f528196315d85b0bee4ddec87ea92264ed763f74548cf3f9519c94fd13abb4b9"
+}


### PR DESCRIPTION
# v0.7.2 (2022-05-27)

* Suppress gcc array bounds warning in `test_zeropage` (@felixmoebius, #515)
* Xen: retrieve `mem_size` uniformly via `XENMEM_memory_map` hypercall.
  Previously, the memory map was extracted from the HVM start info (if
  available and booting directly via PVH), or multiboot info (if booting via
  multiboot). The fallback for direct PVH booting was the `XENMEM_memory_map`
  hypercall (which retrieves an E820 memory map). This lead to three distinct
  paths, with no fallback for the memory map not being present in the multiboot
  info. With QubesOS 4.1 (Xen 4.14), this didn't work anymore (it worked with
  QubesOS 4.0 (Xen 4.8)).
  Now, there is a single path of the code, which uses the hypercall. Since this
  is only executed once at startup, the overhead is negligible (@hannesm, #516,
  review and discussions with @marmarek @xaki23 @palainp)
* Xen: do not skip first token of command line when booted via multiboot.
  This code originated from the virtio binding, but when booting on xen via
  multiboot there is no additional token.
  (@hannesm, #517, review and testing with @palainp @xaki23)