### PR TITLE
Update metadata from CI failures

### DIFF
--- a/packages/linwrap/linwrap.4.0.0/opam
+++ b/packages/linwrap/linwrap.4.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-liblinear-tools"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "4.0.0"}
   "dokeysto_camltc"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.10"}

--- a/packages/linwrap/linwrap.5.0.0/opam
+++ b/packages/linwrap/linwrap.5.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "conf-liblinear-tools"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "4.0.0"}
   "dokeysto_camltc"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.10"}

--- a/packages/linwrap/linwrap.5.1.1/opam
+++ b/packages/linwrap/linwrap.5.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "conf-liblinear-tools"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "4.0.0"}
   "dokeysto_camltc"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.10"}

--- a/packages/ometrics/ometrics.0.2.0/opam
+++ b/packages/ometrics/ometrics.0.2.0/opam
@@ -24,7 +24,7 @@ authors: [
   "Valentin Chaboche <valentin.chaboche@lambda-coins.com>"
 ]
 url {
-  src: "https://github.com/vch9/ometrics/archive/0.2.0.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ometrics-0.2.0.tar.gz"
   checksum: [
     "md5=f0655344f0313f7d8ed06dcb16819fc0"
     "sha512=a1663599fc773b07a927adefdfb934348a5130547fadd8329b19a7123251b4b624068256cbf750b115d773cf6d8edf37bd3ca73e208d6eef6b99250d99464dbf"


### PR DESCRIPTION
These failures were seen on: https://github.com/ocaml/opam-repository/pull/21450