### PR TITLE
Package algaeff.0.2.0

### DIFF
--- a/packages/algaeff/algaeff.0.2.0/opam
+++ b/packages/algaeff/algaeff.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Reusable Effects-Based Components"
+description: """
+This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/algaeff"
+bug-reports: "https://github.com/RedPRL/algaeff/issues"
+dev-repo: "git+https://github.com/RedPRL/algaeff.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "5.0"}
+  "alcotest" {>= "1.5" & with-test}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/algaeff/archive/0.2.0.tar.gz"
+  checksum: [
+    "md5=433b1583d4ffd0d2cb5310f1918935e4"
+    "sha512=9e003e4916d579d063e5ae72302c71ca640e0b568378db25c6dc90becbcd6508f23dc29211a2849f745c54871f6611be0a37ea8526a08ecc203147838975ae70"
+  ]
+}


### PR DESCRIPTION
### `algaeff.0.2.0`
Reusable Effects-Based Components
This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.



---
* Homepage: https://github.com/RedPRL/algaeff
* Source repo: git+https://github.com/RedPRL/algaeff.git
* Bug tracker: https://github.com/RedPRL/algaeff/issues

---
:camel: Pull-request generated by opam-publish v2.1.0