### PR TITLE
8 packages from gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz

### DIFF
--- a/packages/resto-acl/resto-acl.0.8/opam
+++ b/packages/resto-acl/resto-acl.0.8/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "Access Control Lists for Resto"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto" {= version }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.0.8/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.0.8/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.8/opam
+++ b/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.8/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp-client" {= version }
+  "resto-cohttp-server" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.8/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.8/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "resto-cohttp" {= version }
+  "resto-acl" {= version }
+  "cohttp-lwt-unix" { >= "2.0.0" }
+  "conduit-lwt-unix" { >= "2.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.0.8/opam
+++ b/packages/resto-cohttp/resto-cohttp.0.8/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto-directory/resto-directory.0.8/opam
+++ b/packages/resto-directory/resto-directory.0.8/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "resto-json" {= version & with-test }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto-json/resto-json.0.8/opam
+++ b/packages/resto-json/resto-json.0.8/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "json-data-encoding" {= "0.9.1" }
+  "json-data-encoding-bson" {= "0.9.1" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto/resto.0.8/opam
+++ b/packages/resto/resto.0.8/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "json-data-encoding" {= "0.9.1" & with-test }
+  "json-data-encoding-bson" {= "0.9.1" & with-test }
+  "ezjsonm" {with-test}
+  "lwt" {with-test}
+  "base-unix"{with-test}
+  "alcotest" { = "1.5.0" & with-test}
+  "alcotest-lwt" { = "1.5.0" & with-test}
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"
+  checksum: [
+    "md5=0f2a4c07a71d78b783eb69f2c720494b"
+    "sha512=6f2bb07f8546d86788f32372879ea6af5a18d9715f64a0e7ff5f28b5db6ddcb7fa691936af387a880a1dc9f320b7b9224670fbdcfe1841890b8144ff0f9e66a2"
+  ]
+}

--- a/packages/resto/resto.0.8/opam
+++ b/packages/resto/resto.0.8/opam
@@ -25,6 +25,7 @@ depends: [
   "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
   "odoc" { with-doc }
 ]
+conflicts: [ "result" {< "1.5"} ]
 url {
   src:
     "https://gitlab.com/nomadic-labs/resto/-/archive/v0.8/resto-v0.8.tar.gz"


### PR DESCRIPTION
This pull-request concerns:
-`resto.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-acl.0.8`: Access Control Lists for Resto
-`resto-cohttp.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-client.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-self-serving-client.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-server.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
-`resto-directory.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-json.0.8`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.1.0