### PR TITLE
[new release] yojson and yojson-bench (2.0.0)

### DIFF
--- a/packages/calculon/calculon.0.5/opam
+++ b/packages/calculon/calculon.0.5/opam
@@ -16,7 +16,7 @@ depends: [
   "irc-client" { >= "0.6.0" & < "0.7.0" }
   "irc-client-lwt"
   "irc-client-lwt-ssl"
-  "yojson" {>= "1.4.1"}
+  "yojson" {>= "1.4.1" & < "2.0.0"}
   "containers" { >= "1.2" & < "3.0" }
   "ISO8601"
   "stringext"

--- a/packages/merlin/merlin.4.5-414/opam
+++ b/packages/merlin/merlin.4.5-414/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.14" & < "4.15"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.5.1"}
   "menhir" {dev}

--- a/packages/yojson-bench/yojson-bench.2.0.0/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "core_unix" {>= "v0.14.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 synopsis: "Run Yojson benchmarks"

--- a/packages/yojson-bench/yojson-bench.2.0.0/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: ["paul-elliot@tarides.com" "nathan@tarides.com" "marek@tarides.com"]
+authors: ["Martin Jambon"]
+homepage: "https://github.com/ocaml-community/yojson"
+bug-reports: "https://github.com/ocaml-community/yojson/issues"
+dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+doc: "https://ocaml-community.github.io/yojson/"
+license: "BSD-3-Clause"
+depends: [
+  "ocaml" {>= "4.08"}
+  "yojson" {= version}
+  "dune"
+  "core_bench" {>= "v0.14.0"}
+  "core" {>= "v0.14.0"}
+  "core_unix" {>= "v0.14.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "Run Yojson benchmarks"
+description: """\
+Yojson benchmarks require `Core_bench` which is not a dependency of Yojson,
+because it is not part of the regular installation/testing flow. This is solely
+meant for developers that are worried about performance changes in Yojson."""
+url {
+  src:
+    "https://github.com/ocaml-community/yojson/releases/download/2.0.0/yojson-2.0.0.tbz"
+  checksum: [
+    "sha256=ab5d863f7f951a8f7fb4a708399ca2da2cf139a5e0af7818145c20295420cb1a"
+    "sha512=3ea982dbeef7ec8da54d29124ddb8b86f90583eb96ed3947851cedec9e3d2d47b981e3465d41f2c94943e6865ba6a9a51c6f0252efa6df2386d398b679aae8f2"
+  ]
+}
+x-commit-hash: "9c5cee131ae0ec79713e62397076d597486844ed"

--- a/packages/yojson/yojson.2.0.0/opam
+++ b/packages/yojson/yojson.2.0.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocaml-community/yojson.git"
 doc: "https://ocaml-community.github.io/yojson/"
 license: "BSD-3-Clause"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}

--- a/packages/yojson/yojson.2.0.0/opam
+++ b/packages/yojson/yojson.2.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: ["nathan@cryptosense.com" "marek@xivilization.net"]
+authors: ["Martin Jambon"]
+homepage: "https://github.com/ocaml-community/yojson"
+bug-reports: "https://github.com/ocaml-community/yojson/issues"
+dev-repo: "git+https://github.com/ocaml-community/yojson.git"
+doc: "https://ocaml-community.github.io/yojson/"
+license: "BSD-3-Clause"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune"
+  "cppo" {build}
+  "alcotest" {with-test & >= "0.8.5"}
+  "odoc" {with-doc}
+  "seq" {>= "0.2.2"}
+]
+synopsis:
+  "Yojson is an optimized parsing and printing library for the JSON format"
+description: """
+Yojson is an optimized parsing and printing library for the JSON format.
+
+ydump is a pretty-printing command-line program provided with the
+yojson package."""
+url {
+  src:
+    "https://github.com/ocaml-community/yojson/releases/download/2.0.0/yojson-2.0.0.tbz"
+  checksum: [
+    "sha256=ab5d863f7f951a8f7fb4a708399ca2da2cf139a5e0af7818145c20295420cb1a"
+    "sha512=3ea982dbeef7ec8da54d29124ddb8b86f90583eb96ed3947851cedec9e3d2d47b981e3465d41f2c94943e6865ba6a9a51c6f0252efa6df2386d398b679aae8f2"
+  ]
+}
+x-commit-hash: "9c5cee131ae0ec79713e62397076d597486844ed"


### PR DESCRIPTION
Yojson is an optimized parsing and printing library for the JSON format

- Project page: <a href="https://github.com/ocaml-community/yojson">https://github.com/ocaml-community/yojson</a>
- Documentation: <a href="https://ocaml-community.github.io/yojson/">https://ocaml-community.github.io/yojson/</a>

##### CHANGES:

### Removed

- Removed dependency on easy-format and removed `pretty_format` from
  `Yojson`, `Yojson.Basic`, `Yojson.Safe` and `Yojson.Raw`. (@c-cube, ocaml-community/yojson#90)
- Removed dependency on `biniou`, simplifying the chain of dependencies. This
  changes some APIs:
  * `Bi_outbuf.t` in signatures is replaced with `Buffer.t`
  * `to_outbuf` becomes `to_buffer` and `stream_to_outbuf` becomes
    `stream_to_buffer`
  (@Leonidas-from-XIV, ocaml-community/yojson#74, and @gasche, ocaml-community/yojson#132)
- Removed `yojson-biniou` library
- Removed deprecated `json` type aliasing type `t` which has been available
  since 1.6.0 (@Leonidas-from-XIV, ocaml-community/yojson#100).
- Removed `json_max` type (@Leonidas-from-XIV, ocaml-community/yojson#103)
- Removed constraint that the "root" value being rendered (via either
  `pretty_print` or `to_string`) must be an object or array. (@cemerick, ocaml-community/yojson#121)
- Removed `validate_json` as it only made sense if the type was called `json`.
  (@Leonidas-from-XIV, ocaml-community/yojson#137)

### Add

- Add an opam package `yojson-bench` to deal with benchmarks dependency
  (@tmcgilchrist, ocaml-community/yojson#117)
- Add a benchmark to judge the respective performance of providing a buffer vs
  letting Yojson create an internal (ocaml-community/yojson#134, @Leonidas-from-XIV)
- Add an optional `suf` keyword argument was added to functions that write
  serialized JSON, thus allowing NDJSON output. Most functions default to not
  adding any suffix except for `to_file` (ocaml-community/yojson#124, @panglesd) and functions
  writing sequences of values where the default is `\n` (ocaml-community/yojson#135,
  @Leonidas-from-XIV)

### Change

- The `stream_from_*` and `stream_to_*` functions now use a `Seq.t` instead of a
  `Stream.t`, and they are renamed into `seq_from_*` and `seq_to_*` (@gasche, ocaml-community/yojson#131).

### Fix

- Avoid copying unnecessarily large amounts of strings when parsing (ocaml-community/yojson#85, ocaml-community/yojson#108,
  @Leonidas-from-XIV)
- Fix `stream_to_file` (ocaml-community/yojson#133, @tcoopman and @gasche)
