### PR TITLE
[new release] jekyll-format (0.3.1)

### DIFF
--- a/packages/jekyll-format/jekyll-format.0.3.1/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "result"
   "astring"
   "omd"
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "rresult"
   "ptime"
   "fpath"

--- a/packages/jekyll-format/jekyll-format.0.3.1/opam
+++ b/packages/jekyll-format/jekyll-format.0.3.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Jekyll post parsing library"
+description: """
+This library provides an OCaml interface to parsing
+posts in the Jekyll format."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy" "Patrick Ferris"]
+license: "MIT"
+homepage: "https://github.com/avsm/jekyll-format"
+bug-reports: "https://github.com/avsm/jekyll-format/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.05.0"}
+  "yaml-sexp" {>= "3.0.0"}
+  "yaml" {>= "3.0.0"}
+  "sexplib"
+  "result"
+  "astring"
+  "omd"
+  "fmt"
+  "rresult"
+  "ptime"
+  "fpath"
+  "ezjsonm" {>= "1.1.0"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/avsm/jekyll-format.git"
+url {
+  src:
+    "https://github.com/avsm/jekyll-format/releases/download/v0.3.1/jekyll-format-0.3.1.tbz"
+  checksum: [
+    "sha256=1587cb9f32772e4f22dbc933be0cef9d5aa55e6f666967220b56081f576a1f43"
+    "sha512=d3f5991c664ef7729d20ab3ff2ace67da4d8093e90bc17dae33566b15b6711de4f17d26ea067c7de6f7547708ad79e7438b56d22745f44ac1d2828ba6ad9c838"
+  ]
+}
+x-commit-hash: "6533c6967d4dfb690cb3094b54a99c3dd2e475d4"


### PR DESCRIPTION
Jekyll post parsing library

- Project page: <a href="https://github.com/avsm/jekyll-format">https://github.com/avsm/jekyll-format</a>

##### CHANGES:

- Use non-deprecated Fmt interfaces (Fmt.any, Fmt.unit, Fmt.str)
- Update dune/opam builds to dune 2.9 format
