### PR TITLE
Remove useless bigarray-compat dependency on carton-lwt.0.4.4

### DIFF
--- a/packages/carton-lwt/carton-lwt.0.4.4/opam
+++ b/packages/carton-lwt/carton-lwt.0.4.4/opam
@@ -18,7 +18,6 @@ depends: [
   "decompress" {>= "1.4.3"}
   "optint" {>= "0.0.4"}
   "bigstringaf" {>= "0.9.0"}
-  "bigarray-compat" {with-test}
   "alcotest" {>= "1.2.3" & with-test}
   "alcotest-lwt" {>= "1.2.3" & with-test}
   "cstruct" {>= "6.1.0" & with-test}


### PR DESCRIPTION
Reported by @hannesm.