### PR TITLE
testing conf-dbm change for Macs [do not merge]

### DIFF
--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -15,7 +15,6 @@ depexts: [
   ["gdbm-devel"] {os-distribution = "fedora"}
   ["gdbm-devel"] {os-distribution = "ol"}
   ["gdbm-dev"] {os-distribution = "alpine"}
-  ["gdbm"] {os-distribution = "homebrew"}
   ["gdbm"] {os-distribution = "arch"}
   ["sys-libs/gdbm"] {os-distribution = "gentoo"}
 ]


### PR DESCRIPTION
Xavier says "gdbm is not required since ndbm is part of the standard C library" in https://github.com/ocaml/dbm/issues/15
I wonder if the CI tests of opam-repository can check that