### PR TITLE
OCaml 5.0: define SITELIB variable when installing 5.0.0+trunk

### DIFF
--- a/packages/base-bytes/base-bytes.compiler/opam
+++ b/packages/base-bytes/base-bytes.compiler/opam
@@ -3,7 +3,6 @@ maintainer: " "
 authors: " "
 homepage: " "
 depends: [
-  "ocaml" {>= "4.02.0" & < "5.0.0"}
-  "ocamlfind" {>= "1.5.3"}
+  "ocaml" {>= "5.0.0"}
 ]
 synopsis: "Bytes library distributed with the OCaml compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -22,6 +22,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "SITELIBDIR=%{lib}%"
     "--docdir=%{doc}%/ocaml"
     "-C"
     "--with-afl" {ocaml-option-afl:installed}


### PR DESCRIPTION
The compiler is considering the option to install its own META files directly in ocaml/ocaml#11007 .

To keep a maximal compatibility with ocamlfind, we are proposing to add a SITELIB configuration variable to the compiler.
The compiler will then install the META files for the compiler distributed libraries according to the ocamlfind's sitelib convention.

This draft PR updates the package for OCaml 5.0.0+trunk in order to define this variable in its first commit.
In the second commit, I propose to use the new compiler-distributed META files to remove the ocamlfind dependency of the `base-bytes` compatibility packages (since the META file will be directly distributed by the compiler itself). 