### PR TITLE
[new release] easy-format (1.3.4)

### DIFF
--- a/packages/easy-format/easy-format.1.3.4/opam
+++ b/packages/easy-format/easy-format.1.3.4/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis:
+  "High-level and functional interface to the Format module of the OCaml standard library"
+description: """
+
+This module offers a high-level and functional interface to the Format module of
+the OCaml standard library. It is a pretty-printing facility, i.e. it takes as
+input some code represented as a tree and formats this code into the most
+visually satisfying result, breaking and indenting lines of code where
+appropriate.
+
+Input data must be first modelled and converted into a tree using 3 kinds of
+nodes:
+
+* atoms
+* lists
+* labelled nodes
+
+Atoms represent any text that is guaranteed to be printed as-is. Lists can model
+any sequence of items such as arrays of data or lists of definitions that are
+labelled with something like "int main", "let x =" or "x:"."""
+maintainer: ["martin@mjambon.com" "rudi.grinberg@gmail.com"]
+authors: ["Martin Jambon"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/easy-format"
+doc: "https://mjambon.github.io/easy-format/"
+bug-reports: "https://github.com/ocaml-community/easy-format/issues"
+depends: [
+  "dune" {>= "3.2" & >= "1.10"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/easy-format.git"
+url {
+  src:
+    "https://github.com/ocaml-community/easy-format/releases/download/1.3.4/easy-format-1.3.4.tbz"
+  checksum: [
+    "sha256=1dbf051e9f68574dde6e2e254a66b9c524ca425e80b36e99af96ed964ab610c3"
+    "sha512=90264864dde4cbf51f60fb5c21cf033e11bdeb662e76b62ce27b496c298ca9102174885ed7a6d29a6b8e43089e27d5bb5be247f88d9739c15cfd8470fec29d33"
+  ]
+}
+x-commit-hash: "ba4962884509ceec63905dd6e0ccb429be4f9f66"


### PR DESCRIPTION
High-level and functional interface to the Format module of the OCaml standard library

- Project page: <a href="https://github.com/ocaml-community/easy-format">https://github.com/ocaml-community/easy-format</a>
- Documentation: <a href="https://mjambon.github.io/easy-format/">https://mjambon.github.io/easy-format/</a>

##### CHANGES:

- Nix/Esy compatibility (ocaml-community/easy-format#29)
