### PR TITLE
[new release] chamelon and chamelon-unix (0.0.9)

### DIFF
--- a/packages/chamelon-unix/chamelon-unix.0.0.9/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.0.9/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Command-line Unix utilities for chamelon filesystems"
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "bos" {>= "0.2.0"}
+  "chamelon" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock-unix" {>= "4.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.0.9/chamelon-0.0.9.tbz"
+  checksum: [
+    "sha256=7f40c06a67f228ee513bc00f06c72cd11cf9aea5c18cb9dbe8c50208bdb2f44e"
+    "sha512=fda6278572829ec7bb5907182577185649f45666f8d6e74ea07634d5133eb809b43f7295d408c9b28e827bbb34d10efeb37bb14262650173f0defc0cef85133b"
+  ]
+}
+x-commit-hash: "457056d4cdd0b1da22e568d9fca1814ee7cc2dca"

--- a/packages/chamelon/chamelon.0.0.9/opam
+++ b/packages/chamelon/chamelon.0.0.9/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Subset of littlefs filesystem fulfilling MirageOS KV"
+description: """
+Chamelon implements a subset of the littlefs filesystem,
+which was originally designed for microcontroller use.  It exposes
+an interface matching the Mirage_kv.RW module type and operates
+on top of a block device matching Mirage_block.S .
+
+It is extremely not POSIX."""
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "chamelon-unix" {= version & with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-unix" {>= "2.13.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.4" & with-test}
+  "bechamel" {>= "0.2.0" & with-test}
+  "bechamel-js" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.2"}
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "ptime" {>= "0.8.6"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+  "optint" {>= "0.0.4"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.0.9/chamelon-0.0.9.tbz"
+  checksum: [
+    "sha256=7f40c06a67f228ee513bc00f06c72cd11cf9aea5c18cb9dbe8c50208bdb2f44e"
+    "sha512=fda6278572829ec7bb5907182577185649f45666f8d6e74ea07634d5133eb809b43f7295d408c9b28e827bbb34d10efeb37bb14262650173f0defc0cef85133b"
+  ]
+}
+x-commit-hash: "457056d4cdd0b1da22e568d9fca1814ee7cc2dca"


### PR DESCRIPTION
Subset of littlefs filesystem fulfilling MirageOS KV

- Project page: <a href="https://github.com/yomimono/chamelon">https://github.com/yomimono/chamelon</a>

##### CHANGES:

* be consistent in the use of Logs vs Log module (@palainp)
* implement a lookahead block allocator more similar to the littlefs one (@yomimono)
* bring back fuzz tests and improve them (@yomimono)
* test for correct block index detection in CTZ files, and fix an edge case (@yomimono)
* remove literals that break compilation on 32-bit systems (@yomimono)
