### PR TITLE
Release ppx_regexp 0.5.0.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.5.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.5.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.11"}
   "ppxlib" {>= "0.9.0"}
-  "re" {>= "1.7.1"}
+  "re" {>= "1.7.2"}
   "qcheck" {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ppx_regexp/ppx_regexp.0.5.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Gabriel Radanne <drupyog@zoho.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11"}
+  "ppxlib" {>= "0.9.0"}
+  "re" {>= "1.7.1"}
+  "qcheck" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
+synopsis: "Matching Regular Expressions with OCaml Patterns"
+description: """
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ppx_regexp/releases/download/v0.5.0/ppx_regexp-v0.5.0.tbz"
+  checksum: [
+    "sha256=5c80bee02ae3fd4eb1109267bc790d6b8c719f5be0e4973a96f8d92e5e07d8d0"
+    "sha512=620929b214756a57179e587fd9f5f01ec3ee7facc3510c254978aa9c65e0b12c96d3c8302d53e561ea1fb3a35f3b9949debf51562fc7c1ea7d05db151c6c1d81"
+  ]
+}
+x-commit-hash: "9604bc0c6883a481d8962acf4ad5d15c34df7c96"


### PR DESCRIPTION
This release migrates `ppx_regexp` to ppxlib and replaces the linking exception with the LGPL-3.0 Linking
  Exception.