### PR TITLE
[new release] textwrap (0.2.1)

### DIFF
--- a/packages/textwrap/textwrap.0.2.1/opam
+++ b/packages/textwrap/textwrap.0.2.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Sergei Lebedev <superbobry@gmail.com>"
+authors: "Sergei Lebedev <superbobry@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/superbobry/ocaml-textwrap"
+bug-reports: "https://github.com/superbobry/ocaml-textwrap/issues"
+depends: ["ocaml" "dune"]
+dev-repo: "git+https://github.com/superbobry/ocaml-textwrap.git"
+synopsis: "Text wrapping and filling for OCaml"
+description: """
+An almost complete port of Python's textwrap library to OCaml.
+"""
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/superbobry/ocaml-textwrap/releases/download/0.2.1/textwrap-0.2.1.tbz"
+  checksum: [
+    "sha256=23c2b6963e8ae28d087b28960025e3d2aab9cc64bcca3b5a97c53038132404d9"
+    "sha512=0cba54075fc17c0dc3b60e9b9b241f7e85f2c6e372325e2a949ea251becd8a5c2d3ea843d2240ff005f3f9d76a1fbe20654405513cadc90c32f420bfc60af79b"
+  ]
+}
+x-commit-hash: "8c643886b087e5e0ba2cfeba9e810bc237956e3d"


### PR DESCRIPTION
Text wrapping and filling for OCaml

- Project page: <a href="https://github.com/superbobry/ocaml-textwrap">https://github.com/superbobry/ocaml-textwrap</a>

##### CHANGES:

Bugfix release, released on June 6th, 2022

- Port to build with dune (superbobry/ocaml-textwrap#2, @avsm)
