### PR TITLE
cconv-0.2: use tarball from opam source archives

### DIFF
--- a/packages/cconv/cconv.0.2/opam
+++ b/packages/cconv/cconv.0.2/opam
@@ -44,6 +44,6 @@ deserializing the values into several formats. The library ships with
 conversion to Json (yojson), S-expressions (sexplib) and B-encode."""
 flags: light-uninstall
 url {
-  src: "https://github.com/c-cube/cconv/archive/0.2.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/cconv-0.2.tar.gz"
   checksum: "md5=ac8384a679cec49f2dda98fe3f5ba59b"
 }


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/21475