### PR TITLE
[new release] qmp (0.19.0)

### DIFF
--- a/packages/qmp/qmp.0.19.0/opam
+++ b/packages/qmp/qmp.0.19.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: [ "Dave Scott" ]
+homepage: "https://github.com/xapi-project/ocaml-qmp"
+bug-reports: "https://github.com/xapi-project/ocaml-qmp/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+depends: [
+  "ocaml"
+  "base-unix"
+  "dune" {>= "1.4"}
+  "yojson" {>= "1.6.0"}
+  "cmdliner"
+  "ounit2" {with-test}
+]
+dev-repo: "git+https://github.com/xapi-project/ocaml-qmp"
+synopsis: "OCaml implementation of a Qemu Message Protocol (QMP) client"
+url {
+  src:
+    "https://github.com/xapi-project/ocaml-qmp/releases/download/v0.19.0/qmp-0.19.0.tbz"
+  checksum: [
+    "sha256=5456d4ada457eb88155d16aa44cb9158c31fbd7e7ee7bc7fe251fbd973f1453a"
+    "sha512=9f65b45b863fbe2e73b7240f3526b3ec4398cd69eacc7de4f6b5c7b022dfc4e2c4db674d5e663b7138d512928129fbd150feb7ed50869b52bf0ac7d5689305c6"
+  ]
+}
+x-commit-hash: "adaa2e9d566593c3faeb776bf18b7c4578199210"


### PR DESCRIPTION
OCaml implementation of a Qemu Message Protocol (QMP) client

- Project page: <a href="https://github.com/xapi-project/ocaml-qmp">https://github.com/xapi-project/ocaml-qmp</a>

##### CHANGES:

* Add license to opam metadata
* use ounit2
* Bump minimal dependency version of Yojson
* opam: change dev-repo protocol
