### PR TITLE
[new release] dolmen_type, dolmen_lsp, dolmen_loop, dolmen_bin and dolmen (0.7)

### DIFF
--- a/packages/dolmen/dolmen.0.7/opam
+++ b/packages/dolmen/dolmen.0.7/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "menhir" {>= "20211230" }
+  "dune" { >= "2.7" }
+  "fmt" { >= "0.8.7" }
+  "seq"
+  "odoc" { with-doc }
+  "qcheck" { with-test }
+]
+
+tags: [ "parser" "logic" "tptp" "smtlib" "dimacs" ]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A parser library for automated deduction"
+description:
+"Dolmen is a parser library. It currently targets languages used in automated theorem provers,
+but may be extended to other domains.
+
+Dolmen provides functors that takes as arguments a representation of terms and statements,
+and returns a module that can parse files (or streams of tokens) into the provided representation
+of terms or statements. This is meant so that Dolmen can be used as a drop-in replacement of existing
+parser, in order to factorize parsers among projects.
+
+Additionally, Dolmen also provides a standard implementation of terms and statements that cna be
+used ot instantiate its parsers."
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.7/dolmen-0.7.tbz"
+  checksum: [
+    "sha256=ff2889fa9d467d5b4d87ae4f819a64358715f457cc6226b455463c2fcd4ab2af"
+    "sha512=d6ba56945aabcf0886e83fcf44c45f2f8afcf68e48d2f0b25f9cd8e60d18106fae3976fee49d3e291b2e0ab3266837ad5eff800dc51fe2b3aab15ad81ea58cbb"
+  ]
+}
+x-commit-hash: "fcfc9d93308dde9e48c82849be9ba56878ed3e56"

--- a/packages/dolmen_bin/dolmen_bin.0.7/opam
+++ b/packages/dolmen_bin/dolmen_bin.0.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dolmen_type" {= version }
+  "dolmen_loop" {= version }
+  "dune" { >= "2.7" }
+  "fmt"
+  "cmdliner" { >= "1.1.0" }
+  "odoc" { with-doc }
+]
+depopts: [
+  "memtrace"
+]
+tags: [ "logic" "computation" "automated theorem prover" "logic" "smtlib" "tptp"]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A linter for logic languages"
+description:
+"The dolmen binary is an instantiation of the Dolmen library
+to provide a binary to easily parse and type files used in
+automated deduction. "
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.7/dolmen-0.7.tbz"
+  checksum: [
+    "sha256=ff2889fa9d467d5b4d87ae4f819a64358715f457cc6226b455463c2fcd4ab2af"
+    "sha512=d6ba56945aabcf0886e83fcf44c45f2f8afcf68e48d2f0b25f9cd8e60d18106fae3976fee49d3e291b2e0ab3266837ad5eff800dc51fe2b3aab15ad81ea58cbb"
+  ]
+}
+x-commit-hash: "fcfc9d93308dde9e48c82849be9ba56878ed3e56"

--- a/packages/dolmen_loop/dolmen_loop.0.7/opam
+++ b/packages/dolmen_loop/dolmen_loop.0.7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dolmen_type" {= version }
+  "dune" { >= "2.7" }
+  "gen"
+  "odoc" { with-doc }
+  "pp_loc" { >= "2.0.0" }
+]
+tags: [ "logic" "computation" "automated theorem prover" ]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A tool library for automated deduction tools"
+description:
+"Dolmen Loop is a library of useful helpers to parse
+and loop over statements found in automated deduction files."
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.7/dolmen-0.7.tbz"
+  checksum: [
+    "sha256=ff2889fa9d467d5b4d87ae4f819a64358715f457cc6226b455463c2fcd4ab2af"
+    "sha512=d6ba56945aabcf0886e83fcf44c45f2f8afcf68e48d2f0b25f9cd8e60d18106fae3976fee49d3e291b2e0ab3266837ad5eff800dc51fe2b3aab15ad81ea58cbb"
+  ]
+}
+x-commit-hash: "fcfc9d93308dde9e48c82849be9ba56878ed3e56"
+

--- a/packages/dolmen_lsp/dolmen_lsp.0.7/opam
+++ b/packages/dolmen_lsp/dolmen_lsp.0.7/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dolmen_type" {= version }
+  "dolmen_loop" { = version }
+  "dune" { >= "2.7" }
+  "ocaml-syntax-shims"
+  "odoc" { with-doc }
+  "logs"
+  "lsp"
+  "linol" { >= "0.4" & < "0.5" }
+  "linol-lwt" { >= "0.4" & < "0.5" }
+]
+tags: [ "logic" "computation" "automated theorem prover" "lsp" "language server protocol"]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A LSP server for automated deduction languages"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.7/dolmen-0.7.tbz"
+  checksum: [
+    "sha256=ff2889fa9d467d5b4d87ae4f819a64358715f457cc6226b455463c2fcd4ab2af"
+    "sha512=d6ba56945aabcf0886e83fcf44c45f2f8afcf68e48d2f0b25f9cd8e60d18106fae3976fee49d3e291b2e0ab3266837ad5eff800dc51fe2b3aab15ad81ea58cbb"
+  ]
+}
+x-commit-hash: "fcfc9d93308dde9e48c82849be9ba56878ed3e56"

--- a/packages/dolmen_type/dolmen_type.0.7/opam
+++ b/packages/dolmen_type/dolmen_type.0.7/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Guillaume Bury <guillaume.bury@gmail.com>"
+authors: "Guillaume Bury <guillaume.bury@gmail.com>"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dolmen" {= version }
+  "dune" { >= "2.7" }
+  "spelll"
+  "uutf"
+  "odoc" { with-doc }
+]
+tags: [ "logic" "type" "typechecking" "first order" "polymorphism" ]
+homepage: "https://github.com/Gbury/dolmen"
+dev-repo: "git+https://github.com/Gbury/dolmen.git"
+bug-reports: "https://github.com/Gbury/dolmen/issues"
+
+doc: "http://gbury.github.io/dolmen"
+synopsis: "A typechecker for automated deduction languages"
+url {
+  src:
+    "https://github.com/Gbury/dolmen/releases/download/v0.7/dolmen-0.7.tbz"
+  checksum: [
+    "sha256=ff2889fa9d467d5b4d87ae4f819a64358715f457cc6226b455463c2fcd4ab2af"
+    "sha512=d6ba56945aabcf0886e83fcf44c45f2f8afcf68e48d2f0b25f9cd8e60d18106fae3976fee49d3e291b2e0ab3266837ad5eff800dc51fe2b3aab15ad81ea58cbb"
+  ]
+}
+x-commit-hash: "fcfc9d93308dde9e48c82849be9ba56878ed3e56"


### PR DESCRIPTION
A typechecker for automated deduction languages

- Project page: <a href="https://github.com/Gbury/dolmen">https://github.com/Gbury/dolmen</a>
- Documentation: <a href="http://gbury.github.io/dolmen">http://gbury.github.io/dolmen</a>

##### CHANGES:

### UI

- Added source input snippet printing for errors and warnings
- Fix a bug affecting warning options (e.g.
  `dolmen --warn=+all` triggered an uncaught exception that is
  now fixed)

### Parsing

* Fix bug in SMTLIB syntax (v2.6 and poly), where the
  define-funs-rec syntax construction expected an open
  paren at the end instead of a closing paren

### Typing

- Complete the typing of alt-ergo's builtins
  PR#89
- Added exhaustivity and redundant pattern matching analysis
  (redundant patterns trigger a warning, whereas inexhaustive
  pattern matching trigger a typing error)
  part of PR#89
- Removed the typing of real and extended bitvector literals
  from the Float theory. These are not part of the FP
  specification, so it's better for Dolmen to be strict.
  Additionally, dependengin on the order of theories, they
  could shadow the proper typing of such literals and
  result in bogus warnings/errors
  PR#79 (see also Issue#43 Issue#74)
- Fixed the handling of the `reset` and `reset-assertions`
  commands of smtlibv2.6. Previsously reset was ignored,
  and reset-assertions was treated as reset (meaning that
  any set-logic were erased). These two commands should
  now be correctly implemented in the typing loop.
  PR#80
- Added a warning for multiple set-logics
  PR#82
- Added a hint to suggest a missing theory when a literal
  is unbound.
  PR#81


### API

- Added proper abstractions for names and paths.
  Names are used instead of strings for parsed
  identifiers (Id.t), while Paths are used instead of
  strings for typed identifiers (Expr.id).
  This results in a speedup on some smtlib problems
  because indexed identifiers no longer need to be
  encoded and then split.
- Added to Dolmen a custom implementation of Radix tries
  for a better indexation of strings. This results
  in signifcant speedup on large problem.
- Added some convenience modules for testing and profiling
  (Timer and Stats)
- The pipeline now delegates the task of printing backtraces
  for excpetions to the caller/finally argument of the run
  function
- the `Dolmen_loop` library now has an added dependency on
  `pp_loc` (used for the source input printing)
- updated version bounds on `cmdliner` and `pp_locs`
