### PR TITLE
Restrict maximum ocamlformat version for OCanren

### DIFF
--- a/packages/OCanren/OCanren.0.3.0/opam
+++ b/packages/OCanren/OCanren.0.3.0/opam
@@ -30,7 +30,7 @@ depends: [
   "GT" {>= "0.5"}
   "OCanren-ppx" { >= "0.3.0" }
   "benchmark" { with-test }
-  "ocamlformat" { with-test }
+  "ocamlformat" { with-test & < "0.22" }
   "ppx_inline_test"
   "mtime" { >= "1.1" }
   "odoc" {with-doc}


### PR DESCRIPTION
The error message looks like this:

```
ocamlformat: option '--profile': value `compact` has been removed in version
             0.22.
```

So this makes sure that OCanren will pick a version that has `compact`.