### PR TITLE
Release ppx_regexp 0.5.1 (bugfix).

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.5.1/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.5.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Gabriel Radanne <drupyog@zoho.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ppx_regexp"
+bug-reports: "https://github.com/paurkedal/ppx_regexp/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.11"}
+  "ppxlib" {>= "0.9.0"}
+  "re" {>= "1.7.2"}
+  "qcheck" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
+synopsis: "Matching Regular Expressions with OCaml Patterns"
+description: """
+This syntax extension turns
+
+    match%pcre x with
+    | {|re1|} -> e1
+    ...
+    | {|reN|} -> eN
+    | _ -> e0
+
+into suitable invocations to the ocaml-re library.  The patterns are plain
+strings of the form accepted by `Re_pcre`, except groups can be bound to
+variables using the syntax `(?<var>...)`.  The type of `var` will be
+`string` if a match is of the groups is guaranteed given a match of the
+whole pattern, and `string option` if the variable is bound to or nested
+below an optionally matched group.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ppx_regexp/releases/download/v0.5.1/ppx_regexp-v0.5.1.tbz"
+  checksum: [
+    "sha256=25083bc47c6ca224b52d958e3272c938c1115895446ed526ca330f03a2d50ca8"
+    "sha512=e9e8888b8f4cf4f7b2aab38af8e835f716a5b973b7a48ae329daafcc80b705bc8f839f6f76364699804903cc7f9ae6d5d69d9cf0f257c007558ff9f0fbf6d357"
+  ]
+}
+x-commit-hash: "6d583527146f117d0ba06a0fd3e070bcc8b83fe3"


### PR DESCRIPTION
There was an unfortunate bug in the latest version released a few days ago (which prevents preprocessing files which do not actually use the extension). [Change log](https://github.com/paurkedal/ppx_regexp/releases/tag/v0.5.1):

- Fix invalid AST due to empty binding list in `ppx_regexp`.
