### PR TITLE
Make ppx_regexp 0.5.0 unavailable due to severe bug.

### DIFF
--- a/packages/ppx_regexp/ppx_regexp.0.5.0/opam
+++ b/packages/ppx_regexp/ppx_regexp.0.5.0/opam
@@ -14,6 +14,7 @@ depends: [
   "re" {>= "1.7.2"}
   "qcheck" {with-test}
 ]
+available: false
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/paurkedal/ppx_regexp.git"
 synopsis: "Matching Regular Expressions with OCaml Patterns"


### PR DESCRIPTION
As suggested in #21499.
