### PR TITLE
Remove unnecessary bound on cmdliner

### DIFF
--- a/packages/index/index.1.6.1/opam
+++ b/packages/index/index.1.6.1/opam
@@ -27,7 +27,7 @@ depends: [
   "fmt"     {>= "0.8.5"}
   "logs"    {>= "0.7.0"}
   "mtime"   {>= "1.1.0"}
-  "cmdliner" {< "1.1.0"}
+  "cmdliner"
   "progress" {>= "0.2.1"}
   "semaphore-compat" {>= "1.0.1"}
   "jsonm"


### PR DESCRIPTION
In a recent change to index, the maintainers made it compatible with both cmdliner.1.1.0 and older versions. This upper bound was a leftover and is not necessary anymore.