### PR TITLE
Package class_group_vdf.0.0.2

### DIFF
--- a/packages/class_group_vdf/class_group_vdf.0.0.2/opam
+++ b/packages/class_group_vdf/class_group_vdf.0.0.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Verifiable Delay Functions bindings to Chia's VDF"
+maintainer: "Nomadic Labs <contact@nomadic-labs.com>"
+authors: "Nomadic Labs <contact@nomadic-labs.com>"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/tezos"
+bug-reports: "https://gitlab.com/nomadic-labs/tezos/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+  "conf-gmp"
+  "conf-g++"
+  "integers"
+]
+available: arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/tezos"
+url {
+  src:
+    "https://gitlab.com/rrtoledo/ocaml-chia-vdf/-/archive/v0.0.2/ocaml-chia-vdf-v0.0.2.tar.gz"
+  checksum: [
+    "md5=2b20dfd020ad9a287f23c9435e5749ed"
+    "sha512=bdf7dfa2b0a1c489949388eeba4fef10bffca972b7329765c2739458cae63cc575095a576b59cdd2b4acae25d6647f6dcdb47b53dc54e603a3406990d51163cf"
+  ]
+}


### PR DESCRIPTION
### `class_group_vdf.0.0.2`
Verifiable Delay Functions bindings to Chia's VDF



---
* Homepage: https://gitlab.com/nomadic-labs/tezos
* Source repo: git+https://gitlab.com/nomadic-labs/tezos
* Bug tracker: https://gitlab.com/nomadic-labs/tezos/issues

---
:camel: Pull-request generated by opam-publish v2.1.0