### PR TITLE
[new release] flint, calcium, arb and antic (0.1.5)

### DIFF
--- a/packages/antic/antic.0.1.5/opam
+++ b/packages/antic/antic.0.1.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Antic. Algebraic number"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "flint"
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "ocaml" {>= "4.10"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.1.5/flint-0.1.5.tbz"
+  checksum: [
+    "sha256=e2abf5828d9dee6a1118265430bb8bda3879d0e68b387e520bf74379058e3360"
+    "sha512=3247ca029f5fe27bbc616f419198a669a5b1d4aa3b860338050e0f7a701bb58c7fdae9d761b6fd7f7d317b7fe7fd071f6bbfeffe5aaccb7f438658f045f59d76"
+  ]
+}
+x-commit-hash: "881ef98e010ba3a2cfbfc04237b9b1c5e8ee5b3e"

--- a/packages/arb/arb.0.1.5/opam
+++ b/packages/arb/arb.0.1.5/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Arb. Ball approximation"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "flint"
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "ocaml" {>= "4.10"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.1.5/flint-0.1.5.tbz"
+  checksum: [
+    "sha256=e2abf5828d9dee6a1118265430bb8bda3879d0e68b387e520bf74379058e3360"
+    "sha512=3247ca029f5fe27bbc616f419198a669a5b1d4aa3b860338050e0f7a701bb58c7fdae9d761b6fd7f7d317b7fe7fd071f6bbfeffe5aaccb7f438658f045f59d76"
+  ]
+}
+x-commit-hash: "881ef98e010ba3a2cfbfc04237b9b1c5e8ee5b3e"

--- a/packages/calcium/calcium.0.1.5/opam
+++ b/packages/calcium/calcium.0.1.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Stub of the C library Antic. For exact computation with real and complex numbers, presently in early development"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "zarith" {>= "1.12"}
+  "flint"
+  "arb"
+  "antic"
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "dune-site" {with-test}
+  "ocaml" {>= "4.10"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.1.5/flint-0.1.5.tbz"
+  checksum: [
+    "sha256=e2abf5828d9dee6a1118265430bb8bda3879d0e68b387e520bf74379058e3360"
+    "sha512=3247ca029f5fe27bbc616f419198a669a5b1d4aa3b860338050e0f7a701bb58c7fdae9d761b6fd7f7d317b7fe7fd071f6bbfeffe5aaccb7f438658f045f59d76"
+  ]
+}
+x-commit-hash: "881ef98e010ba3a2cfbfc04237b9b1c5e8ee5b3e"

--- a/packages/flint/flint.0.1.5/opam
+++ b/packages/flint/flint.0.1.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Stub of the C library Flint2"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1"
+homepage: "https://github.com/bobot/ocaml-flint"
+bug-reports: "https://github.com/bobot/ocaml-flint/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "zarith" {>= "1.12"}
+  "ctypes" {>= "0.20.1"}
+  "conf-mpfr" {>= "3"}
+  "dune-site" {with-test}
+  "ocaml" {>= "4.10"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bobot/ocaml-flint.git"
+url {
+  src:
+    "https://github.com/bobot/ocaml-flint/releases/download/0.1.5/flint-0.1.5.tbz"
+  checksum: [
+    "sha256=e2abf5828d9dee6a1118265430bb8bda3879d0e68b387e520bf74379058e3360"
+    "sha512=3247ca029f5fe27bbc616f419198a669a5b1d4aa3b860338050e0f7a701bb58c7fdae9d761b6fd7f7d317b7fe7fd071f6bbfeffe5aaccb7f438658f045f59d76"
+  ]
+}
+x-commit-hash: "881ef98e010ba3a2cfbfc04237b9b1c5e8ee5b3e"


### PR DESCRIPTION
Stub of the C library Flint2, Arb, Antic, Calcium. Very preliminary mainly just to use functions from Calcium.

- Project page: <a href="https://github.com/bobot/ocaml-flint">https://github.com/bobot/ocaml-flint</a>

##### CHANGES:

  Initial Release
