### PR TITLE
3 packages from c-cube/ocaml-containers at 3.8

### DIFF
--- a/packages/containers-data/containers-data.3.8/opam
+++ b/packages/containers-data/containers-data.3.8/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "containers" { = version }
+  "seq"
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.8.tar.gz"
+  checksum: [
+    "md5=f1c717c9a1015e81253f226ae594f547"
+    "sha512=7640b6af5a61e53e52eac51f237a06c5c21597374481af218cf0601c2b9059b96254058b92adb73ce20b1dece4ccaffb99d1b29b235c4dc954619738d8d0de40"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.8/opam
+++ b/packages/containers-thread/containers-thread.3.8/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  "qtest" { with-test }
+  "qcheck" { with-test }
+  "ounit" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.8.tar.gz"
+  checksum: [
+    "md5=f1c717c9a1015e81253f226ae594f547"
+    "sha512=7640b6af5a61e53e52eac51f237a06c5c21597374481af218cf0601c2b9059b96254058b92adb73ce20b1dece4ccaffb99d1b29b235c4dc954619738d8d0de40"
+  ]
+}

--- a/packages/containers/containers.3.8/opam
+++ b/packages/containers/containers.3.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "dune-configurator"
+  "seq" # compat
+  "either" # compat
+  "qtest" { with-test }
+  "qcheck" { >= "0.14" & with-test }
+  "ounit2" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "csexp" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.8.tar.gz"
+  checksum: [
+    "md5=f1c717c9a1015e81253f226ae594f547"
+    "sha512=7640b6af5a61e53e52eac51f237a06c5c21597374481af218cf0601c2b9059b96254058b92adb73ce20b1dece4ccaffb99d1b29b235c4dc954619738d8d0de40"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.8`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.8`: A set of advanced datatypes for containers
-`containers-thread.3.8`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0