### PR TITLE
Fix architecture support for OCaml 5.x

### DIFF
--- a/packages/ocaml-option-32bit/ocaml-option-32bit.1/opam
+++ b/packages/ocaml-option-32bit/ocaml-option-32bit.1/opam
@@ -4,7 +4,7 @@ depexts: [
   ["gcc-multilib" "g++-multilib"] {os-family = "debian"}
 ]
 depends: [
-  "ocaml-variants" {post & >= "4.12.0~"}
+  "ocaml-variants" {post & >= "4.12.0~" & < "5.0.0~~"} | ("ocaml-variants" {post & >= "5.0.0~~"} "ocaml-option-bytecode-only")
 ]
 available: [ arch = "x86_64" & (os = "linux" | os = "macos") ]
 maintainer: "platform@lists.ocaml.org"

--- a/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
+++ b/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
@@ -3,5 +3,6 @@ synopsis: "Compile OCaml without the native-code compiler"
 depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]
+conflicts: [ "ocaml-option-afl" "ocaml-option-fp" "ocaml-option-flambda" ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-option-fp/ocaml-option-fp.1/opam
+++ b/packages/ocaml-option-fp/ocaml-option-fp.1/opam
@@ -4,5 +4,6 @@ depends: [
   "ocaml-variants" {post & >= "4.12.0~"}
 ]
 conflicts: ["ocaml-option-musl"]
+available: os = "linux" & arch = "x86_64"
 maintainer: "platform@lists.ocaml.org"
 flags: compiler

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -63,6 +63,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
@@ -70,7 +71,6 @@ depopts: [
   "ocaml-option-default-unsafe-string"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
-  "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -13,6 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
@@ -67,7 +68,6 @@ conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
   "ocaml-option-default-unsafe-string"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -63,6 +63,7 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
+conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
@@ -70,7 +71,6 @@ depopts: [
   "ocaml-option-default-unsafe-string"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
-  "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-static"
 ]

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -13,6 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"
@@ -67,7 +68,6 @@ conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
   "ocaml-option-default-unsafe-string"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"

--- a/packages/opam-depext/opam-depext.1.2.1-1/opam
+++ b/packages/opam-depext/opam-depext.1.2.1-1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Install OS distribution packages"
+description: """\
+opam-depext is a simple program intended to facilitate the interaction between
+OPAM packages and the host package management system. It can query OPAM for the
+right external dependencies on a set of packages, depending on the host OS, and
+call the OS's package manager in the appropriate way to install them."""
+maintainer: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-depext"
+bug-reports: "https://github.com/ocaml/opam-depext/issues"
+depends: [
+  "ocaml" {>= "4.00"}
+  "base-unix"
+  "cmdliner" {>= "0.9.8" & dev}
+  "ocamlfind" {dev}
+]
+depopts: "ocaml-option-bytecode-only"
+available: opam-version >= "2.0.0~beta5"
+flags: plugin
+build: [
+  ["sed" "-ib" "-e" "/all:/s/ncl//" "src_ext/Makefile"]
+  [make "OCAMLOPT=%{ocaml-option-bytecode-only:installed?no:ocamlopt}%"] {!dev}
+  [
+    "ocamlfind"
+    "%{ocaml:native?ocamlopt:ocamlc}%"
+    "-package"
+    "unix,cmdliner"
+    "-linkpkg"
+    "-o"
+    "opam-depext"
+    "depext.ml"
+  ] {dev}
+]
+post-messages:
+  "opam-depext is unnecessary when used with opam >= 2.1. Please use opam install directly instead"
+    {opam-version >= "2.1"}
+dev-repo: "git+https://github.com/ocaml/opam-depext.git#2.0"
+url {
+  src:
+    "https://github.com/ocaml-opam/opam-depext/releases/download/v1.2.1/opam-depext-full-1.2.1.tbz"
+  checksum: [
+    "md5=7bda1fdbd88322e8f515919c82a37a2a"
+    "sha512=a031289ac4e2d4d28bf02b892313b2a0ee724c94f0b7a131b3d9bccc5fbaf2292834d53dd6a0b7134f43bab06ee70bd2c98562fb3a6a03f1a526981290cbf501"
+  ]
+}


### PR DESCRIPTION
OCaml 5.x is only available in native code for amd64 and arm64; all other configurations are bytecode-only.

- `ocaml-option-32bit` therefore pulls in `ocaml-option-bytecode-only` for 5.x
- `ocaml-option-afl`, `ocaml-option-fp` and `ocaml-option-flambda` are native compiler options, so they should always have conflicted `ocaml-option-bytecode-only`
- Frame pointers has only ever been available on linux amd64 which is now reflected in `ocaml-option-fp`
- Frame pointer support hasn't yet been restored to OCaml 5.x (the PR is under review), so for now the 5.x packages conflict `ocaml-option-fp`
- The 5.x packages depend on `ocaml-option-bytecode-only` if the architecture is not amd64 or arm64
- It turns out that `opam-depext` doesn't install correctly in a bytecode-only switch (ironically, as it _always_ build the bytecode version of the plugin, even in a full compiler switch). This is addressed in https://github.com/ocaml-opam/opam-depext/pull/149, but this PR also updates the build instructions for 1.2.1 (as a 1.2.1-1 package). There will be a 1.2.2 release with the upstream fix, at which point we can constrain the older packages away from 5.x, but this fix is critical for the CI base images.