### PR TITLE
[new release] knights_tour (0.0.3)

### DIFF
--- a/packages/knights_tour/knights_tour.0.0.3/opam
+++ b/packages/knights_tour/knights_tour.0.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Solves the Knight's tour puzzle; and others"
+description: "See https://en.wikipedia.org/wiki/Knight%27s_tour"
+maintainer: ["kris.de.volder@gmail.com"]
+authors: ["Kris De Volder"]
+license: "MIT"
+homepage: "https://github.com/kdvolder/knights_tour"
+bug-reports: "https://github.com/kdvolder/knights_tour/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.14.0"}
+  "graphics"
+  "stdio"
+  "ppx_inline_test"
+  "ppx_expect"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/kdvolder/knights_tour.git"
+doc: "https://kdvolder.github.io/knights_tour/"
+url {
+  src:
+    "https://github.com/kdvolder/knights_tour/releases/download/v0.0.3/knights_tour-0.0.3.tbz"
+  checksum: [
+    "sha256=4c693ffd5554cdbb064b0aa2ec104ec1831d3abd077ea2cec0a52922ebdc2212"
+    "sha512=f3cd71b81c7e44e7186e43c407ee679a2fede799a8aa07c495932a1a7469c5cc80a32f28eaa0b2868d195e64896802baf7959bae5b3466f777279fa1500f3e60"
+  ]
+}
+x-commit-hash: "971396646864a2aa4af0c2f483f6d08279485034"


### PR DESCRIPTION
Solves the Knight's tour puzzle; and others

- Project page: <a href="https://github.com/kdvolder/knights_tour">https://github.com/kdvolder/knights_tour</a>

##### CHANGES:

Add some randomization to the Hexo puzzle solver to make it more
interesting. It still does a 'complete' search however by
randomizing the order in which puzzle pieces and variants are
tried means it will find different solutions on each run.
Randomizations also more often than not find a solution much 
faster than the default ordering.

Remove the 'withUndo' operator from Searchspace because it
is hard to support properly and hard to use properly without
introducing bugs in a searchspace definition (hard to contain
side-effects).

Add a 'breadth_search' searchspace exploration algorithm that
gradually regresses back to dept-first search to limit memory
usage.

Add a human readable textual de/serialization format
for specifying polyomino puzzles. 

Make graphical drawing of polyomino board more pleasing to the eye:
- each piece has a different color.
- borders around the pieces to make them stand out more.

Add hexo_solve executable which solves an instance of Hexominos.

Add random_hexo_puzzle executable which generates and saves a
randomized hexo_puzzle to a text file.

Add a `solve_file` executable that reads a polyomino puzzle 
specification from a text file and starts solving it.

