### PR TITLE
Package oseq.0.4.1

### DIFF
--- a/packages/oseq/oseq.0.4.1/opam
+++ b/packages/oseq/oseq.0.4.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "gen" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+  "seq"
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "sequence" "iterator" "seq" "pure" "list" ]
+homepage: "https://github.com/c-cube/oseq/"
+doc: "https://c-cube.github.io/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+dev-repo: "git+https://github.com/c-cube/oseq.git"
+synopsis: "Simple list of suspensions, as a composable lazy iterator that behaves like a value"
+description: "Extends the new standard library's `Seq` module with many useful combinators."
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/oseq/archive/v0.4.1.tar.gz"
+  checksum: [
+    "md5=1547a97040d4b8787ffda0e959e8cd95"
+    "sha512=3028849493e90a008d7a490e5d3abb955f5a36fa1be784e9895a60c630ed36dc6ea9663e6148d9dc996d9462b8cc5ac75de38233d06f4ecce75e896552e72d92"
+  ]
+}


### PR DESCRIPTION
### `oseq.0.4.1`
Simple list of suspensions, as a composable lazy iterator that behaves like a value
Extends the new standard library's `Seq` module with many useful combinators.



---
* Homepage: https://github.com/c-cube/oseq/
* Source repo: git+https://github.com/c-cube/oseq.git
* Bug tracker: https://github.com/c-cube/oseq/issues

---
:camel: Pull-request generated by opam-publish v2.1.0