### PR TITLE
Adapt ocaml-options-only-no-flat-float-array for 5.x bytecode

### DIFF
--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
@@ -2,12 +2,12 @@ opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with no-flat-float-array, and no other custom options"
 depends: [
   "ocaml-option-no-flat-float-array"
-  "ocaml-variants" {post & (< "5.00.0~~" | arch = "x86_64" | arch = "arm64")}
+  "ocaml-option-bytecode-only"
+  "ocaml-variants" {post & (>= "5.00.0~~" & arch != "x86_64" & arch != "arm64")}
 ]
 conflicts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
   "ocaml-option-default-unsafe-string"
   "ocaml-option-flambda"
   "ocaml-option-fp"


### PR DESCRIPTION
Follow-on from #21510, which is working well - the base image builder has identified an issue when building the `no-float-float-array` variant, which is fixed here.

`ocaml-options-only-no-flat-float-array`, like all the `ocaml-options-only-` packages conflicts all the other options. It's intended to be added to a switch to reject any packages which might conflict no-flat-float-array mode (rather than the default, which would be to rebuild the compiler).

The `conflicts` field is not able to express conjunctions, so this is expressed using a second package which is selected for i386, s390, ppc64, arm32, etc.