### PR TITLE
Maximum constraint on Yojson for Merlin 4.5-413

### DIFF
--- a/packages/merlin/merlin.4.5-413/opam
+++ b/packages/merlin/merlin.4.5-413/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.5.1"}
   "menhir" {dev}


### PR DESCRIPTION
As discussed in the comments at https://github.com/ocaml/opam-repository/commit/63cbf66956bbd16de6ff7ad951d4f06aa64758d4