### PR TITLE
Package binaryen.0.17.1

### DIFF
--- a/packages/binaryen/binaryen.0.17.1/opam
+++ b/packages/binaryen/binaryen.0.17.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "107.0.0" & < "108.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.17.1/binaryen-archive-v0.17.1.tar.gz"
+  checksum: [
+    "md5=c2e6aafd35ed243cd547c0b17c80ff47"
+    "sha512=311a8f4f116883c758880507cdd68b076c3a43780140bb87bfe5b36d27cb95a9a83b0ff9f0e6353be355020cbdf6822769c0d3fef53f477f4bdc0d8e3fcb399d"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.17.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
### [0.17.1](https://github.com/grain-lang/binaryen.ml/compare/v0.17.0...v0.17.1) (2022-06-11)

### Bug Fixes

- Remove upper bounds on dependencies ([#156](https://github.com/grain-lang/binaryen.ml/issues/156)) ([9ae4015](https://github.com/grain-lang/binaryen.ml/commit/9ae4015a4af6233e38d96a6f2ebabe55313fb8ea))


---
:camel: Pull-request generated by opam-publish v2.0.3