### PR TITLE
Apply Yojson 2.0 constraint on all Merlin versions

### DIFF
--- a/packages/merlin/merlin.1.3.1-trunk/opam
+++ b/packages/merlin/merlin.1.3.1-trunk/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {> "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.3.1/opam
+++ b/packages/merlin/merlin.1.3.1/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {= "4.00.1"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.3/opam
+++ b/packages/merlin/merlin.1.3/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {> "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.4.1/opam
+++ b/packages/merlin/merlin.1.4.1/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {>= "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.4/opam
+++ b/packages/merlin/merlin.1.4/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {>= "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.5/opam
+++ b/packages/merlin/merlin.1.5/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {>= "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.6/opam
+++ b/packages/merlin/merlin.1.6/opam
@@ -8,7 +8,7 @@ remove: [[make "uninstall"]]
 depends: [
   "ocaml" {>= "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.7.1/opam
+++ b/packages/merlin/merlin.1.7.1/opam
@@ -8,7 +8,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.1.7/opam
+++ b/packages/merlin/merlin.1.7/opam
@@ -8,7 +8,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.02.0"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "menhir"
   "ocamlbuild" {build}
 ]

--- a/packages/merlin/merlin.2.0.0/opam
+++ b/packages/merlin/merlin.2.0.0/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.03"}
   "ocamlfind"
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "merlin installed.

--- a/packages/merlin/merlin.2.1.0/opam
+++ b/packages/merlin/merlin.2.1.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.03"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "merlin installed.

--- a/packages/merlin/merlin.2.1.1/opam
+++ b/packages/merlin/merlin.2.1.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.03"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "merlin installed.

--- a/packages/merlin/merlin.2.1.2/opam
+++ b/packages/merlin/merlin.2.1.2/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.03"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "merlin installed.

--- a/packages/merlin/merlin.2.2/opam
+++ b/packages/merlin/merlin.2.2/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.1" & < "4.03"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "merlin installed.

--- a/packages/merlin/merlin.2.3.1/opam
+++ b/packages/merlin/merlin.2.3.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.0" & < "4.03"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.3/opam
+++ b/packages/merlin/merlin.2.3/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.00.0" & < "4.03"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.5.0/opam
+++ b/packages/merlin/merlin.2.5.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.04"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.5.1/opam
+++ b/packages/merlin/merlin.2.5.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.04"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.5.2/opam
+++ b/packages/merlin/merlin.2.5.2/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.05"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.5.3/opam
+++ b/packages/merlin/merlin.2.5.3/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.05"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.5.4/opam
+++ b/packages/merlin/merlin.2.5.4/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.05"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.2.5.5/opam
+++ b/packages/merlin/merlin.2.5.5/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.05"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.0.0/opam
+++ b/packages/merlin/merlin.3.0.0/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.06"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.0.1/opam
+++ b/packages/merlin/merlin.3.0.1/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.06"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.0.2/opam
+++ b/packages/merlin/merlin.3.0.2/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.06"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.0.4/opam
+++ b/packages/merlin/merlin.3.0.4/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.07"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.0.5/opam
+++ b/packages/merlin/merlin.3.0.5/opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.07"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.1.0/opam
+++ b/packages/merlin/merlin.3.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.02.1" & < "4.07"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 post-messages: [
   "

--- a/packages/merlin/merlin.3.2.1/opam
+++ b/packages/merlin/merlin.3.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.08"}
   "dune"
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "craml" {with-test}
 ]
 build: [

--- a/packages/merlin/merlin.3.2.2/opam
+++ b/packages/merlin/merlin.3.2.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.08"}
   "dune"
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "craml" {with-test}
 ]
 build: [

--- a/packages/merlin/merlin.3.3.0/opam
+++ b/packages/merlin/merlin.3.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
 ]
 synopsis:

--- a/packages/merlin/merlin.3.3.1/opam
+++ b/packages/merlin/merlin.3.3.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
 ]
 synopsis:

--- a/packages/merlin/merlin.3.3.2/opam
+++ b/packages/merlin/merlin.3.3.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.09"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
 ]
 synopsis:

--- a/packages/merlin/merlin.3.3.3/opam
+++ b/packages/merlin/merlin.3.3.3/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.1" & < "4.10"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.4/opam
+++ b/packages/merlin/merlin.3.3.4/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.11"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.4~4.10preview1/opam
+++ b/packages/merlin/merlin.3.3.4~4.10preview1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {= "4.10.0"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
 ]
 synopsis:
   "Editor helper, provides completion, typing and source browsing in Vim and Emacs"

--- a/packages/merlin/merlin.3.3.5/opam
+++ b/packages/merlin/merlin.3.3.5/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.11"}
   "dune" {>= "2.5.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.6/opam
+++ b/packages/merlin/merlin.3.3.6/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.11"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.7/opam
+++ b/packages/merlin/merlin.3.3.7/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.7~4.11preview1/opam
+++ b/packages/merlin/merlin.3.3.7~4.11preview1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {= "4.11.0"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.8/opam
+++ b/packages/merlin/merlin.3.3.8/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.3.9/opam
+++ b/packages/merlin/merlin.3.3.9/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "ocamlfind" {>= "1.5.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/merlin/merlin.3.4.0/opam
+++ b/packages/merlin/merlin.3.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "dot-merlin-reader" {= "3.4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}

--- a/packages/merlin/merlin.3.4.1/opam
+++ b/packages/merlin/merlin.3.4.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "dot-merlin-reader" {= version}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}

--- a/packages/merlin/merlin.3.4.2/opam
+++ b/packages/merlin/merlin.3.4.2/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "dot-merlin-reader" {= version}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}

--- a/packages/merlin/merlin.3.5.0/opam
+++ b/packages/merlin/merlin.3.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "dot-merlin-reader" {>= "3.4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}

--- a/packages/merlin/merlin.3.6.1/opam
+++ b/packages/merlin/merlin.3.6.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "dot-merlin-reader" {>= "3.4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}

--- a/packages/merlin/merlin.3.7.0/opam
+++ b/packages/merlin/merlin.3.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.12"}
   "dune" {>= "1.8.0"}
   "dot-merlin-reader" {>= "3.4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "mdx" {with-test & >= "1.3.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}

--- a/packages/merlin/merlin.4.1-411/opam
+++ b/packages/merlin/merlin.4.1-411/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.11" & < "4.12"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.1-412/opam
+++ b/packages/merlin/merlin.4.1-412/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.2-411/opam
+++ b/packages/merlin/merlin.4.2-411/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.2-412/opam
+++ b/packages/merlin/merlin.4.2-412/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.7.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.3.1-411/opam
+++ b/packages/merlin/merlin.4.3.1-411/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.3.1-412/opam
+++ b/packages/merlin/merlin.4.3.1-412/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.3.2~4.13preview/opam
+++ b/packages/merlin/merlin.4.3.2~4.13preview/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.4-411/opam
+++ b/packages/merlin/merlin.4.4-411/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.4-412/opam
+++ b/packages/merlin/merlin.4.4-412/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.4-413/opam
+++ b/packages/merlin/merlin.4.4-413/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.4.1~4.14preview/opam
+++ b/packages/merlin/merlin.4.4.1~4.14preview/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.14" & < "4.15"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.4.1~5.0preview/opam
+++ b/packages/merlin/merlin.4.4.1~5.0preview/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "5.0" & < "5.1"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.0"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.2.3"}
   "result" {>= "1.5"}

--- a/packages/merlin/merlin.4.5-411/opam
+++ b/packages/merlin/merlin.4.5-411/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.11.0" & < "4.12"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.5.1"}
   "menhir" {dev}

--- a/packages/merlin/merlin.4.5-412/opam
+++ b/packages/merlin/merlin.4.5-412/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.9.0"}
   "dot-merlin-reader" {>= "4.2"}
-  "yojson" {>= "1.6.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
   "csexp" {>= "1.5.1"}
   "menhir" {dev}


### PR DESCRIPTION
They probably all use the removed `Stream` API so unless inspecting them all individually, a general Yojson 2.0 constraint is probably the best course of action.

Related to #21514.