### PR TITLE
oseq 0.4.0: add upper bound on ocaml 4.14

### DIFF
--- a/packages/oseq/oseq.0.4/opam
+++ b/packages/oseq/oseq.0.4/opam
@@ -14,7 +14,7 @@ depends: [
   "containers" {with-test}
   "odoc" {with-doc}
   "seq"
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "4.14" }
 ]
 tags: [ "sequence" "iterator" "seq" "pure" "list" ]
 homepage: "https://github.com/c-cube/oseq/"


### PR DESCRIPTION
The api is no longer compatible

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>