### PR TITLE
Remove ppx_deriving_yojson constraint on Yojson 2.0

### DIFF
--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.1/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.10.0"}
-  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.2" & < "5.0"}
   "ppx_tools"    {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.2/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.2/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.11.0"}
-  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.2" & < "5.0"}
   "ppx_tools"    {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.3/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5.3/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.5" & < "5.0"}
   "ppx_tools"

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.5/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0" & < "4.09.0"}
-  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.2" & < "5.0"}
   "ppx_tools"    {build}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.0/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.0"}
-  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "5.0"}
   "ppxlib" {>= "0.9.0" & < "0.14.0"}

--- a/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.1/opam
+++ b/packages/ppx_deriving_yojson/ppx_deriving_yojson.3.6.1/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.0"}
-  "yojson" {>= "1.6.0" & < "2.0.0"}
+  "yojson" {>= "1.6.0"}
   "result"
   "ppx_deriving" {>= "5.1"}
   "ppxlib" {>= "0.14.0" & < "0.26.0"}


### PR DESCRIPTION
The tests seem to run with Yojson 2.0 just fine, so to allow people to use Yojson when they use ppx_deriving removing this constraint might be sensible.

Opening as a draft first to see whether this works with the latest release and might be removing the constraints from more releases if it works.