### PR TITLE
Restore ocaml-option-bytecode-only as a depopt for 5.x packages

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -68,6 +68,7 @@ conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
   "ocaml-option-default-unsafe-string"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -68,6 +68,7 @@ conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
   "ocaml-option-default-unsafe-string"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"


### PR DESCRIPTION
I made a small mistake in https://github.com/ocaml/opam-repository/pull/21510 - `ocaml-option-bytecode-only` should have remained as a depopt for the two 5.x trunk packages (otherwise if you have a normal switch and then `opam install ocaml-option-bytecode-only` it doesn't rebuild the switch).