### PR TITLE
[new release] awa, awa-mirage and awa-lwt (0.1.1)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.1.1/opam
+++ b/packages/awa-lwt/awa-lwt.0.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.1/awa-0.1.1.tbz"
+  checksum: [
+    "sha256=69ed604f1dc49a69287ffd869e1ab47794727e4171db58479151158323dd5eea"
+    "sha512=1e0a904298c67bde98db970ca36e93341e1781beb28bb444b64e1e8f954f69f184ae4b9eb169fee231e140223867ede81ffbf0045c3cb90e4a93067b406dc275"
+  ]
+}
+x-commit-hash: "8f4b12da523ba62471d6a45e9d247e763441b9ec"

--- a/packages/awa-mirage/awa-mirage.0.1.1/opam
+++ b/packages/awa-mirage/awa-mirage.0.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "mirage-time" {>= "2.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.1/awa-0.1.1.tbz"
+  checksum: [
+    "sha256=69ed604f1dc49a69287ffd869e1ab47794727e4171db58479151158323dd5eea"
+    "sha512=1e0a904298c67bde98db970ca36e93341e1781beb28bb444b64e1e8f954f69f184ae4b9eb169fee231e140223867ede81ffbf0045c3cb90e4a93067b406dc275"
+  ]
+}
+x-commit-hash: "8f4b12da523ba62471d6a45e9d247e763441b9ec"

--- a/packages/awa/awa.0.1.1/opam
+++ b/packages/awa/awa.0.1.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.15.2"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "cstruct-sexp"
+  "sexplib"
+  "mtime"
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.1/awa-0.1.1.tbz"
+  checksum: [
+    "sha256=69ed604f1dc49a69287ffd869e1ab47794727e4171db58479151158323dd5eea"
+    "sha512=1e0a904298c67bde98db970ca36e93341e1781beb28bb444b64e1e8f954f69f184ae4b9eb169fee231e140223867ede81ffbf0045c3cb90e4a93067b406dc275"
+  ]
+}
+x-commit-hash: "8f4b12da523ba62471d6a45e9d247e763441b9ec"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* awa_gen_key: output ed25519 private key instead of the seed (@hannesm, mirage/awa-ssh#46)
