### PR TITLE
release ocaml-solo5 0.8.1

### DIFF
--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.0.8.1/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.0.8.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=aarch64-solo5-none-static"
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+   "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install" ]
+depends: [
+  "conf-which" {build}
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.15.0"}
+  "solo5" {>= "0.7.0"}
+  "solo5-cross-aarch64" {>= "0.7.0" }
+]
+conflicts: [
+  "ocaml-solo5"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v0.8.1.tar.gz"
+  checksum: [
+    "sha256=1645f143cd90d1ddff830894ea6206f9e38b46eb5feb1d38e760504b08c94c26"
+    "sha512=2fe64c034012d815fe7f8f6363c918b8f779a56e0d845785d2351ca3505ad5d2c2728ad40864be0ead3589c1b085ba66d83ec94247b29ff4af3d584a4718fc36"
+  ]
+}

--- a/packages/ocaml-solo5/ocaml-solo5.0.8.1/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.0.8.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+build: [
+  ["./configure.sh"
+   "--prefix=%{prefix}%"
+   "--target=x86_64-solo5-none-static" { arch = "x86_64" }
+   "--target=aarch64-solo5-none-static" { arch = "arm64" }
+   "--ocaml-configure-option=--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+   "--ocaml-configure-option=--enable-flambda" {ocaml-option-flambda:installed}
+   "--ocaml-configure-option=--disable-naked-pointers" {ocaml-option-nnp:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install" ]
+depends: [
+  "conf-which" {build}
+  "ocamlfind" {build} # needed by dune context (for tests)
+  "ocaml-src" {build}
+  "ocaml" {>= "4.12.1" & < "4.15.0"}
+  "solo5" {>= "0.7.0"}
+]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available: [
+  ((os = "linux" & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" & arch = "x86_64")
+  | (os = "openbsd" & arch = "x86_64"))
+]
+synopsis: "Freestanding OCaml compiler"
+description:
+  "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v0.8.1.tar.gz"
+  checksum: [
+    "sha256=1645f143cd90d1ddff830894ea6206f9e38b46eb5feb1d38e760504b08c94c26"
+    "sha512=2fe64c034012d815fe7f8f6363c918b8f779a56e0d845785d2351ca3505ad5d2c2728ad40864be0ead3589c1b085ba66d83ec94247b29ff4af3d584a4718fc36"
+  ]
+}


### PR DESCRIPTION
Keep track of memory allocation and releasing (fast than mallinfo, more accurate than footprint) https://github.com/mirage/ocaml-solo5/pull/120 @winux138 @palainp