### PR TITLE
[new release] ppx_import (1.10.0)

### DIFF
--- a/packages/ppx_import/ppx_import.1.10.0/opam
+++ b/packages/ppx_import/ppx_import.1.10.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A syntax extension for importing declarations from interface files"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+homepage: "https://github.com/ocaml-ppx/ppx_import"
+doc: "https://ocaml-ppx.github.io/ppx_import/"
+license: "MIT"
+bug-reports: "https://github.com/ocaml-ppx/ppx_import/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
+tags: [ "syntax" ]
+
+depends: [
+  (
+  "ocaml"                   {>= "4.05.0" &  < "4.10.0"  }
+  "dune"                    {              >= "1.11.0"  }
+  "ppxlib"                  {              >= "0.26.0"  }
+  "ounit"                   { with-test                 }
+  "ppx_deriving"            { with-test  & >= "4.2.1"   }
+  )
+  |
+  (
+  "ocaml"                   { >= "4.10.0"               }
+  "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }
+  "dune"                    {              >= "1.11.0"  }
+  "ppxlib"                  {              >= "0.26.0"  }
+  "ounit"                   { with-test                 }
+  "ppx_deriving"            { with-test  & >= "4.2.1"   }
+  )
+]
+
+build:      [["dune" "build"   "-p" name "-j" jobs]
+             ["dune" "runtest" "-p" name "-j" jobs] { with-test }
+            ]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_import/releases/download/1.10.0/ppx_import-1.10.0.tbz"
+  checksum: [
+    "sha256=300f2c7f417b0a1d702432fc13ce3bd2e90ac7b2a2796ca35899c942ca81556f"
+    "sha512=835d5abff0f1eba28313f5925beaeb8c27a4458c91cf395fdd28b984b0745aad8725b4a8a921517ad09ed567ff8586f48a4afa4127eab6c2f773efc5d50c40fb"
+  ]
+}
+x-commit-hash: "bba10ee113166982fda75687f31439d63271b560"

--- a/packages/ppx_import/ppx_import.1.10.0/opam
+++ b/packages/ppx_import/ppx_import.1.10.0/opam
@@ -10,22 +10,11 @@ dev-repo: "git+https://github.com/ocaml-ppx/ppx_import.git"
 tags: [ "syntax" ]
 
 depends: [
-  (
-  "ocaml"                   {>= "4.05.0" &  < "4.10.0"  }
+  "ocaml"                   {>= "4.05.0" &  < "4.10.0"  } | ("ocaml" {>= "4.10.0"} "ppx_sexp_conv" {with-test & >= "v0.13.0"})
   "dune"                    {              >= "1.11.0"  }
   "ppxlib"                  {              >= "0.26.0"  }
   "ounit"                   { with-test                 }
   "ppx_deriving"            { with-test  & >= "4.2.1"   }
-  )
-  |
-  (
-  "ocaml"                   { >= "4.10.0"               }
-  "ppx_sexp_conv"           { with-test  & >= "v0.13.0" }
-  "dune"                    {              >= "1.11.0"  }
-  "ppxlib"                  {              >= "0.26.0"  }
-  "ounit"                   { with-test                 }
-  "ppx_deriving"            { with-test  & >= "4.2.1"   }
-  )
 ]
 
 build:      [["dune" "build"   "-p" name "-j" jobs]


### PR DESCRIPTION
A syntax extension for importing declarations from interface files

- Project page: <a href="https://github.com/ocaml-ppx/ppx_import">https://github.com/ocaml-ppx/ppx_import</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_import/">https://ocaml-ppx.github.io/ppx_import/</a>

##### CHANGES:

  * Update ppxlib to 0.26.0 (ocaml-ppx/ppx_import#69, @pitag-ha)
