### PR TITLE
[new release] ppxlib (0.27.0)

### DIFF
--- a/packages/ppx_jsonaf_conv/ppx_jsonaf_conv.v0.15.0/opam
+++ b/packages/ppx_jsonaf_conv/ppx_jsonaf_conv.v0.15.0/opam
@@ -15,7 +15,7 @@ depends: [
   "jsonaf"   {>= "v0.15" & < "v0.16"}
   "ppx_jane" {>= "v0.15" & < "v0.16"}
   "dune"     {>= "2.0.0"}
-  "ppxlib"   {>= "0.23.0"}
+  "ppxlib"   {>= "0.23.0" & < "0.27.0"}
 ]
 synopsis: "[@@deriving] plugin to generate Jsonaf conversion functions"
 description: "

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.13.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.13.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_jane"            {>= "v0.13" & < "v0.14"}
   "ppx_yojson_conv_lib" {>= "v0.13" & < "v0.14"}
   "dune"                {>= "1.5.1"}
-  "ppxlib"              {>= "0.9.0"}
+  "ppxlib"              {>= "0.9.0" & < "0.27.0"}
 ]
 synopsis: "[@@deriving] plugin to generate Yojson conversion functions"
 description: "

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.14.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.14.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_js_style"        {>= "v0.14" & < "v0.15"}
   "ppx_yojson_conv_lib" {>= "v0.14" & < "v0.15"}
   "dune"                {>= "2.0.0"}
-  "ppxlib"              {>= "0.11.0"}
+  "ppxlib"              {>= "0.11.0" & < "0.27.0"}
 ]
 synopsis: "[@@deriving] plugin to generate Yojson conversion functions"
 description: "

--- a/packages/ppx_yojson_conv/ppx_yojson_conv.v0.15.0/opam
+++ b/packages/ppx_yojson_conv/ppx_yojson_conv.v0.15.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_js_style"        {>= "v0.15" & < "v0.16"}
   "ppx_yojson_conv_lib" {>= "v0.15" & < "v0.16"}
   "dune"                {>= "2.0.0"}
-  "ppxlib"              {>= "0.23.0"}
+  "ppxlib"              {>= "0.23.0" & < "0.27.0"}
 ]
 synopsis: "[@@deriving] plugin to generate Yojson conversion functions"
 description: "

--- a/packages/ppxlib/ppxlib.0.27.0/opam
+++ b/packages/ppxlib/ppxlib.0.27.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Standard library for ppx rewriters"
+description: """
+Ppxlib is the standard library for ppx rewriters and other programs
+that manipulate the in-memory representation of OCaml programs, a.k.a
+the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & < "5.1.0"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & < "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.27.0/ppxlib-0.27.0.tbz"
+  checksum: [
+    "sha256=764b96121d6ffd6a73820e0ec5235176bfc42b94cf2ff97e32d068a5c4b28c62"
+    "sha512=2dcce0be6acdb3e185bfdad2785303a405c617f99949316abe6793f785d7227c10795ca49e79290bd385873da635191b44e8a5c211de114a168846d5d26f505c"
+  ]
+}
+x-commit-hash: "c33c48981a30359af5b4cddaeb633060c1784d62"


### PR DESCRIPTION
Standard library for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Update expansion context to leave out value name when multiple are
  defined at once. (ocaml-ppx/ppxlib#351, @ceastlund)

- Add support for OCaml 5.0 (ocaml-ppx/ppxlib#348, @pitag-ha)

- Add `Code_path.enclosing_value` (ocaml-ppx/ppxlib#349, @ceastlund)

- Add `Code_path.enclosing_module` (ocaml-ppx/ppxlib#346, @ceastlund)

- Expand code generated by `~enclose_intf` and `~enclose_impl` (ocaml-ppx/ppxlib#345, @ceastlund)

- Add type annotations to code generated by metaquot (ocaml-ppx/ppxlib#344, @ceastlund)

- Fix typo in description field of dune-project (ocaml-ppx/ppxlib#343, @ceastlund)

- Fix Ast_pattern.many (ocaml-ppx/ppxlib#333, @nojb)

- Fix quoter and optimize identifier quoting (ocaml-ppx/ppxlib#327, @sim642)

- Driver, when run with `--check`: Allow `toplevel_printer` attributes (ocaml-ppx/ppxlib#340, @pitag-ha)

- Documentation: Add a section on reporting errors by embedding extension nodes
  in the AST (ocaml-ppx/ppxlib#318, @panglesd)

- Driver: In the case of ppxlib internal errors, embed those errors instead of
  raising to return a meaningful AST (ocaml-ppx/ppxlib#329, @panglesd)

- API: For each function that could raise a located error, add a function that
  return a `result` instead (ocaml-ppx/ppxlib#329, @panglesd)
