### PR TITLE
[new release] coq-serapi (8.13.0+0.13.1)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.13.0+0.13.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.13.0+0.13.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.13.0" & < "8.14"   }
+  "cmdliner"            {           >= "1.0.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.13.0%2B0.13.1/coq-serapi-8.13.0.0.13.1.tbz"
+  checksum: [
+    "sha256=530991b3e029102367184b96d8bd8a347c7172265a5815176a533b1061f8c6cf"
+    "sha512=c6cc5afcad3546c3fbcd8512f20a5ebd748f17529805c1d296959092fde8f31b77f7c7a06254f68c30eb6c6ad520bfbf03388505186a600e75d65ae3acd02c77"
+  ]
+}
+x-commit-hash: "719550c3e986dae08270c036908f3ae0bfd394f9"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serapi] New query `(Query () (LogicalPath file))` which will
            return the logical path for a particular `.v` file
            (@ejgallego, see also
            https://github.com/cpitclaudel/alectryon/pull/25)
 - [serapi] new `(SaveDoc opts)` command supporting saving of .vo
            files even when from interactive mode; note that using
            `--topfile` is required (fixes ejgallego/coq-serapi#238, @ejgallego, reported
            by Jason Gross)
 - [sertop] we don't link the OCaml `num` library anymore, this could
            have some impact on plugins (@ejgallego)
 - [nix]    Added Nix support (ejgallego/coq-serapi#249, fixes ejgallego/coq-serapi#248, @Zimmi48, reported
            by @nyraghu)
 - [serapi] Fix COQPATH support: interpret paths as absolute (ejgallego/coq-serapi#249, @Zimmi48)
 - [serlib] Ignore `env` parameter in certain exceptions (ejgallego/coq-serapi#254, fixes ejgallego/coq-serapi#250,
            @ejgallego, reported by @cpitclaudel)
 - [sertop] New option `--omit_env` that will disable the serialization of
            Coq's super heavy global environments (ejgallego/coq-serapi#254 @ejgallego)
 - [build]  Test OCaml 4.12 (ejgallego/coq-serapi#257 @ejgallego)
 - [sertop] Async mode was not working due to passing `-no-glob` to workers
