### PR TITLE
[new release] stdcompat.19

### DIFF
--- a/packages/metapp/metapp.0.4.0/opam
+++ b/packages/metapp/metapp.0.4.0/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12"}
+  "stdcompat" {>= "12" & < "19"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/metapp/metapp.0.4.1/opam
+++ b/packages/metapp/metapp.0.4.1/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12"}
+  "stdcompat" {>= "12" & < "19"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/metapp/metapp.0.4.2/opam
+++ b/packages/metapp/metapp.0.4.2/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12"}
+  "stdcompat" {>= "12" & < "19"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/metapp/metapp.0.4.3/opam
+++ b/packages/metapp/metapp.0.4.3/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12"}
+  "stdcompat" {>= "12" & < "19"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/override/override.0.4.0/opam
+++ b/packages/override/override.0.4.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
   "ppxlib" {>= "0.23.0"}
-  "stdcompat" {>= "9"}
+  "stdcompat" {>= "9" & < "15"}
   "metapp" {>= "0.4.2"}
   "metaquot" {>= "0.4.0"}
   "refl" {>= "0.1.0"}

--- a/packages/stdcompat/stdcompat.15/opam
+++ b/packages/stdcompat/stdcompat.15/opam
@@ -8,7 +8,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
-  "ocaml" {>= "3.08"}
+  "ocaml" {>= "3.08" & < "5.0"}
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [

--- a/packages/stdcompat/stdcompat.16/opam
+++ b/packages/stdcompat/stdcompat.16/opam
@@ -8,7 +8,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
-  "ocaml" {>= "3.08"}
+  "ocaml" {>= "3.08" & < "5.0"}
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [

--- a/packages/stdcompat/stdcompat.17/opam
+++ b/packages/stdcompat/stdcompat.17/opam
@@ -8,7 +8,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
-  "ocaml" {>= "3.08"}
+  "ocaml" {>= "3.08" & < "5.0"}
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [

--- a/packages/stdcompat/stdcompat.18/opam
+++ b/packages/stdcompat/stdcompat.18/opam
@@ -8,7 +8,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
-  "ocaml" {>= "3.08"}
+  "ocaml" {>= "3.08" & < "5.0"}
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Compatibility module for OCaml standard library"
+description:
+  "Compatibility module for OCaml standard library allowing programs to use some recent additions to the OCaml standard library while preserving the ability to be compiled on former versions of OCaml."
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/stdcompat"
+bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
+depends: [
+  "ocaml" {>= "3.07"}
+]
+depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
+url {
+  src:
+    "https://github.com/thierry-martinez/stdcompat/releases/download/v19/stdcompat-19.tar.gz"
+  checksum: [
+    "sha512=ceae2dc2cb26ec1b6250e6f144baa8e1cb738edb0c5d71c9100452e4b19f15d20e34f07b4f7cab7cc64e70ef43102132a9e0936bedb0f88e19992d62e1daa8ff"
+  ]
+}

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -10,6 +10,8 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.07"}
   "dune" {>= "2.0"}
+  "conf-autoconf"
+  "conf-automake"
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -23,6 +23,6 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/v19/stdcompat-19.tar.gz"
   checksum: [
-    "sha512=ceae2dc2cb26ec1b6250e6f144baa8e1cb738edb0c5d71c9100452e4b19f15d20e34f07b4f7cab7cc64e70ef43102132a9e0936bedb0f88e19992d62e1daa8ff"
+    "sha512=22559ba34665d05f6821166bf0f6d4ffd9f680c3f022d4b98f11b591c310a56268b4a45f2271d9b512d80af2383d56026cfd93d152a0c80c498e14265b1767e8"
   ]
 }

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -21,8 +21,8 @@ install: [make "install"]
 dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
 url {
   src:
-    "https://github.com/thierry-martinez/stdcompat/releases/download/v19/stdcompat-19.tar.gz"
+    "https://github.com/thierry-martinez/stdcompat/releases/download/v19/stdcompat-19-dune.tar.gz"
   checksum: [
-    "sha512=66fec74a90e1133a8a174b233c0c5969b44831cc2555b6028e53478cd24646b68d363b60ffd4b4fbb1310ef7f481f2ff3b3fa5e20b0aec90e7d8dba819cdc718"
+    "sha512=1c55f71e9b64336a4e2fce3e4987bb156028d12ae82e0e85a29e3a39908b26556a4ea53748fd6eb0ee73ccc0832d32d5721a7b8025da46485d2581264c454a7a"
   ]
 }

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -23,6 +23,6 @@ url {
   src:
     "https://github.com/thierry-martinez/stdcompat/releases/download/v19/stdcompat-19.tar.gz"
   checksum: [
-    "sha512=22559ba34665d05f6821166bf0f6d4ffd9f680c3f022d4b98f11b591c310a56268b4a45f2271d9b512d80af2383d56026cfd93d152a0c80c498e14265b1767e8"
+    "sha512=66fec74a90e1133a8a174b233c0c5969b44831cc2555b6028e53478cd24646b68d363b60ffd4b4fbb1310ef7f481f2ff3b3fa5e20b0aec90e7d8dba819cdc718"
   ]
 }

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/thierry-martinez/stdcompat"
 bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.07"}
+  "dune" {>= "2.0"}
 ]
 depopts: [ "result" "seq" "uchar" "ocamlfind" ]
 build: [

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -19,7 +19,6 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-install: [make "install"]
 dev-repo: "git+https://github.com/thierry-martinez/stdcompat.git"
 url {
   src:


### PR DESCRIPTION
This PR publishes the new release stdcompat.19, compatible with OCaml 5.0, and mark older versions of stdcompat incompatible with OCaml 5.0. Here is stdcompat.19 change log:


- Compatibility with OCaml 5.0

- Add String.`{hash, seeded_hash}`

- Restore compatibility with OCaml 3.07, and fix order execution for
  `Set` and `Map.{iter, fold, filter_map}` on OCaml 3.07

- Updated port to `dune`
  (Marek Kubica, https://github.com/thierry-martinez/stdcompat/pull/16,
   https://github.com/thierry-martinez/stdcompat/pull/19)

- Add support for `flambda2`
  (Guillaume Bury, https://github.com/thierry-martinez/stdcompat/pull/14)

- Prevent replacing `/dev/null/ by a regular file when `./configure` is
  run as root
  (reported by Marc Chevalier, https://github.com/ocaml/ocaml/issues/11302)
