### PR TITLE
[new release] pyml.20220615

### DIFF
--- a/packages/pyml/pyml.20220615/opam
+++ b/packages/pyml/pyml.20220615/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "dune" {>= "2.8.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "18"}
+  "conf-python-3-dev" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/releases/download/20220615/pyml-20220615.tar.gz"
+  checksum: "sha512=8ad6b6c92ca1c2cdaae4a0fbc0baca75e80c95239731e56537b7c78c613ce0e0f2e13aa7a976631a324d4faf8291bc5f2f48cc8956e7c5623fb858d8a483e0b5"
+}


### PR DESCRIPTION
This PR publishes a new release of pyml.20220615. Change log:
- `Numpy.to_bigarray_k` is continuation-passing-style version of `Numpy.to_bigarray`,
  allowing caller to convert Numpy arrays to bigarrays without having to know
  the kind and the layout of the array
  (suggested by Lindsay Errington and Andie Sigler,
  https://github.com/thierry-martinez/pyml/issues/81)