### PR TITLE
[new release] prometheus and prometheus-app (1.2)

### DIFF
--- a/packages/current/current.0.1/opam
+++ b/packages/current/current.0.1/opam
@@ -23,16 +23,16 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "bos"
   "ppx_deriving"
-  "lwt"
+  "lwt" {>= "4.3.0"}
   "cmdliner"
   "sqlite3"
   "duration"
   "prometheus"
   "dune" {>= "1.9"}
-  "re"
+  "re" {>= "1.9.0"}
   "lwt-dllist"
   "alcotest-lwt" {with-test & < "1.0.0"}
 ]

--- a/packages/current/current.0.2/opam
+++ b/packages/current/current.0.2/opam
@@ -24,16 +24,16 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "current_incr" {= version}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "bos"
   "ppx_deriving"
-  "lwt"
+  "lwt" {>= "4.3.0"}
   "cmdliner"
   "sqlite3"
   "duration"
   "prometheus"
   "dune" {>= "1.9"}
-  "re"
+  "re" {>= "1.9.0"}
   "lwt-dllist"
   "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]

--- a/packages/current/current.0.3/opam
+++ b/packages/current/current.0.3/opam
@@ -24,16 +24,16 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "current_incr" {= version}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "bos"
   "ppx_deriving"
-  "lwt"
+  "lwt" {>= "4.3.0"}
   "cmdliner"
   "sqlite3"
   "duration"
   "prometheus"
   "dune" {>= "2.0"}
-  "re"
+  "re" {>= "1.9.0"}
   "lwt-dllist"
   "alcotest-lwt" {>= "1.0.1" & < "1.2.0" & with-test}
 ]

--- a/packages/current/current.0.4/opam
+++ b/packages/current/current.0.4/opam
@@ -19,16 +19,16 @@ bug-reports: "https://github.com/ocurrent/ocurrent/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "current_incr" {= version}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "bos"
   "ppx_deriving"
-  "lwt"
+  "lwt" {>= "4.3.0"}
   "cmdliner"
   "sqlite3"
   "duration"
   "prometheus"
   "dune" {>= "2.0"}
-  "re"
+  "re" {>= "1.9.0"}
   "lwt-dllist"
   "alcotest" {>= "1.2.0" & with-test}
   "alcotest-lwt" {>= "1.2.0" & with-test}
@@ -36,7 +36,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}
   "result" {>= "1.5"}
-  "prometheus-app" {>= "0.7" & with-test}
+  "prometheus-app" {with-test & >= "0.7" & < "1.2"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/current/current.0.5/opam
+++ b/packages/current/current.0.5/opam
@@ -36,7 +36,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}
   "result" {>= "1.5"}
-  "prometheus-app" {>= "0.7" & with-test}
+  "prometheus-app" {with-test & >= "0.7" & < "1.2"}
 ]
 conflicts: [
   "seq" {< "base"}

--- a/packages/current/current.0.6.1/opam
+++ b/packages/current/current.0.6.1/opam
@@ -36,7 +36,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}
   "result" {>= "1.5"}
-  "prometheus-app" {>= "0.7" & with-test}
+  "prometheus-app" {with-test & >= "0.7" & < "1.2"}
   "conf-libev" {os != "win32"}
 ]
 build: [

--- a/packages/current/current.0.6/opam
+++ b/packages/current/current.0.6/opam
@@ -36,7 +36,7 @@ depends: [
   "fpath" {>= "0.7.3"}
   "logs" {>= "0.7.0"}
   "result" {>= "1.5"}
-  "prometheus-app" {>= "0.7" & with-test}
+  "prometheus-app" {with-test & >= "0.7" & < "1.2"}
   "conf-libev" {os != "win32"}
 ]
 build: [

--- a/packages/current_examples/current_examples.0.4/opam
+++ b/packages/current_examples/current_examples.0.4/opam
@@ -38,7 +38,7 @@ depends: [
   "routes" {>= "0.8.0"}
   "uri" {>= "4.0.0"}
   "yojson" {>= "1.7.0"}
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/current_examples/current_examples.0.5/opam
+++ b/packages/current_examples/current_examples.0.5/opam
@@ -38,7 +38,7 @@ depends: [
   "routes" {>= "0.8.0"}
   "uri" {>= "4.0.0"}
   "yojson" {>= "1.7.0"}
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/current_examples/current_examples.0.6.1/opam
+++ b/packages/current_examples/current_examples.0.6.1/opam
@@ -39,7 +39,7 @@ depends: [
   "routes" {>= "0.8.0"}
   "uri" {>= "4.0.0"}
   "yojson" {>= "1.7.0"}
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
   "mdx" {with-test}
 ]
 build: [

--- a/packages/current_examples/current_examples.0.6/opam
+++ b/packages/current_examples/current_examples.0.6/opam
@@ -39,7 +39,7 @@ depends: [
   "routes" {>= "0.8.0"}
   "uri" {>= "4.0.0"}
   "yojson" {>= "1.7.0"}
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
   "mdx" {with-test}
 ]
 build: [

--- a/packages/current_web/current_web.0.1/opam
+++ b/packages/current_web/current_web.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "bos"
   "lwt"
   "cmdliner"
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
   "dune" {>= "1.9"}

--- a/packages/current_web/current_web.0.2/opam
+++ b/packages/current_web/current_web.0.2/opam
@@ -23,7 +23,7 @@ depends: [
   "bos"
   "lwt"
   "cmdliner"
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
   "routes" {>= "0.7.0" & < "0.8.0"}

--- a/packages/current_web/current_web.0.3/opam
+++ b/packages/current_web/current_web.0.3/opam
@@ -28,7 +28,7 @@ depends: [
   "bos"
   "lwt"
   "cmdliner"
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
   "routes" {>= "0.8.0"}

--- a/packages/current_web/current_web.0.4/opam
+++ b/packages/current_web/current_web.0.4/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt"
   "cmdliner"
   "prometheus" {>= "0.7"}
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp" {>= "2.2.0"}
   "cohttp-lwt" {>= "2.2.0"}
   "cohttp-lwt-unix" {>= "2.2.0"}

--- a/packages/current_web/current_web.0.5/opam
+++ b/packages/current_web/current_web.0.5/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt"
   "cmdliner"
   "prometheus" {>= "0.7"}
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp" {>= "2.2.0"}
   "cohttp-lwt" {>= "2.2.0"}
   "cohttp-lwt-unix" {>= "2.2.0"}

--- a/packages/current_web/current_web.0.6.1/opam
+++ b/packages/current_web/current_web.0.6.1/opam
@@ -27,7 +27,7 @@ depends: [
   "multipart_form-lwt" {>= "0.4.0"}
   "cmdliner" {>= "1.1.0"}
   "prometheus" {>= "0.7"}
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0"}
   "csv" {>= "2.4"}

--- a/packages/current_web/current_web.0.6/opam
+++ b/packages/current_web/current_web.0.6/opam
@@ -25,7 +25,7 @@ depends: [
   "lwt"
   "cmdliner" {>= "1.1.0"}
   "prometheus" {>= "0.7"}
-  "prometheus-app"
+  "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0"}
   "routes" {>= "0.8.0"}

--- a/packages/ocluster/ocluster.0.1/opam
+++ b/packages/ocluster/ocluster.0.1/opam
@@ -30,7 +30,7 @@ depends: [
   "digestif" {>= "0.8"}
   "fpath"
   "lwt-dllist"
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
   "cohttp-lwt-unix"
   "sqlite3"
   "obuilder"

--- a/packages/prometheus-app/prometheus-app.0.2/opam
+++ b/packages/prometheus-app/prometheus-app.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "jbuilder"
   "prometheus" {= "0.2"}
   "fmt"
-  "re"
+  "re" {>= "1.8.0"}
   "cohttp" {>= "0.20.0" & < "0.99"}
   "lwt" {>= "2.5.0"}
   "alcotest" {with-test}

--- a/packages/prometheus-app/prometheus-app.0.3/opam
+++ b/packages/prometheus-app/prometheus-app.0.3/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "prometheus" {< "0.5"}
   "fmt"
-  "re"
+  "re" {>= "1.8.0"}
   "cohttp" {>= "0.20.0" & < "0.99"}
   "lwt" {>= "2.5.0"}
   "alcotest" {with-test}

--- a/packages/prometheus-app/prometheus-app.0.4/opam
+++ b/packages/prometheus-app/prometheus-app.0.4/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "prometheus" {< "0.5"}
   "fmt"
-  "re"
+  "re" {>= "1.8.0"}
   "cohttp" {>= "0.99.0" & < "1.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"

--- a/packages/prometheus-app/prometheus-app.0.5/opam
+++ b/packages/prometheus-app/prometheus-app.0.5/opam
@@ -15,9 +15,9 @@ build: [
 depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {>= "1.0+beta10"}
-  "prometheus" {>= "0.5"}
+  "prometheus" {= version}
   "fmt"
-  "re"
+  "re" {>= "1.8.0"}
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt" {< "3.0.0"}
   "cohttp-lwt-unix" {< "3.0.0"}

--- a/packages/prometheus-app/prometheus-app.0.6/opam
+++ b/packages/prometheus-app/prometheus-app.0.6/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "prometheus" {=version} 
   "fmt"
-  "re"
+  "re" {>= "1.8.0"}
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"

--- a/packages/prometheus-app/prometheus-app.0.7/opam
+++ b/packages/prometheus-app/prometheus-app.0.7/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "prometheus" {=version}
   "fmt"
-  "re"
+  "re" {>= "1.8.0"}
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"

--- a/packages/prometheus-app/prometheus-app.1.1/opam
+++ b/packages/prometheus-app/prometheus-app.1.1/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "prometheus" {= version}
   "fmt"
-  "re" {>= "1.5.0"}
+  "re" {>= "1.8.0"}
   "cohttp" {>= "1.0.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"

--- a/packages/prometheus-app/prometheus-app.1.2/opam
+++ b/packages/prometheus-app/prometheus-app.1.2/opam
@@ -20,37 +20,37 @@ Tick!
 Unikernels can use `Prometheus_app` instead of `Prometheus_unix` to avoid the `Unix` dependency."""
 maintainer: "talex5@gmail.com"
 authors: ["Thomas Leonard" "David Scott"]
-license: "Apache"
+license: "Apache-2.0"
 homepage: "https://github.com/mirage/prometheus"
 doc: "https://mirage.github.io/prometheus/"
 bug-reports: "https://github.com/mirage/prometheus/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
-  "dune" {>= "1.0"}
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.3"}
   "prometheus" {= version}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "re" {>= "1.8.0"}
-  "cohttp" {>= "1.0.0"}
-  "cohttp-lwt"
-  "cohttp-lwt-unix"
+  "cohttp-lwt" {>= "4.0.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
   "lwt" {>= "2.5.0"}
   "cmdliner"
   "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
   "asetmap"
   "astring"
-  "logs"
+  "logs" {>= "0.6.0"}
 ]
 build: [
-  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/mirage/prometheus.git"
 url {
   src:
-    "https://github.com/mirage/prometheus/releases/download/v1.0/prometheus-v1.0.tbz"
+    "https://github.com/mirage/prometheus/releases/download/v1.2/prometheus-1.2.tbz"
   checksum: [
-    "sha256=d17cec111516fa188d4a41add0c6c1f0dba1bc9ca4aa53c52cc9be21019aac26"
-    "sha512=be54f970d9397e2f338fe30bcd463ae1b11d9337027290ec272d7a9f8cceea8b8907d6d1ccb5708f0378810b7df13d598bbed461a8e37b145435a3e66f733956"
+    "sha256=83643a029a6b6de71d14034eee2e94feff1d08755c4a41d583dc1530ab555bcb"
+    "sha512=bbec7f0728b850b991ec50e76ef2c999341a9469ceaa11b68180f060150c4fe62f3dca87c13914ac331b3d7ef6e46256ae11466b607ecb60d00b8f284cab86b9"
   ]
 }
+x-commit-hash: "d1669d0e0d7e44b104755a0fd9700ae87e140f34"

--- a/packages/prometheus/prometheus.1.2/opam
+++ b/packages/prometheus/prometheus.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune" {>= "2.3"}
+  "astring"
+  "asetmap"
+  "re"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.2/prometheus-1.2.tbz"
+  checksum: [
+    "sha256=83643a029a6b6de71d14034eee2e94feff1d08755c4a41d583dc1530ab555bcb"
+    "sha512=bbec7f0728b850b991ec50e76ef2c999341a9469ceaa11b68180f060150c4fe62f3dca87c13914ac331b3d7ef6e46256ae11466b607ecb60d00b8f284cab86b9"
+  ]
+}
+x-commit-hash: "d1669d0e0d7e44b104755a0fd9700ae87e140f34"


### PR DESCRIPTION
Client library for Prometheus monitoring

- Project page: <a href="https://github.com/mirage/prometheus">https://github.com/mirage/prometheus</a>
- Documentation: <a href="https://mirage.github.io/prometheus/">https://mirage.github.io/prometheus/</a>

##### CHANGES:

- Add lwt collectors and pre-collectors (@killian-delarue, mirage/prometheus#43).
  Note that this is a temporary feature while we wait for OCaml 5 to be released,
  when this can be replaced by the use of effects.

- Fix deprecations in Fmt 0.8.10 (@MisterDA, mirage/prometheus#36).

- General build updates, upstream deprecations, etc (@talex5, mirage/prometheus#33 mirage/prometheus#34 mirage/prometheus#35 mirage/prometheus#40 mirage/prometheus#42).
