### PR TITLE
unix-errno < 0.6: don't use ocamlbuild 0.9.0

### DIFF
--- a/packages/unix-errno/unix-errno.0.2.0/opam
+++ b/packages/unix-errno/unix-errno.0.2.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocamlfind" {build}
   "ctypes" {>= "0.4.0" & < "0.6.0"}
   "rresult"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 synopsis: "Unix errno types, maps, and support"
 description: """

--- a/packages/unix-errno/unix-errno.0.3.0/opam
+++ b/packages/unix-errno/unix-errno.0.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "alcotest" {with-test}
   "base-bytes"
   "result"
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
 ]
 depopts: ["base-unix" "ctypes"]
 conflicts: [

--- a/packages/unix-errno/unix-errno.0.4.0/opam
+++ b/packages/unix-errno/unix-errno.0.4.0/opam
@@ -11,7 +11,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "alcotest" {with-test}
   "base-bytes"
   "result"

--- a/packages/unix-errno/unix-errno.0.4.1/opam
+++ b/packages/unix-errno/unix-errno.0.4.1/opam
@@ -15,7 +15,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "alcotest" {with-test}
   "base-bytes"
   "result"

--- a/packages/unix-errno/unix-errno.0.4.2/opam
+++ b/packages/unix-errno/unix-errno.0.4.2/opam
@@ -15,7 +15,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "alcotest" {with-test}
   "base-bytes"
   "result"

--- a/packages/unix-errno/unix-errno.0.5.0/opam
+++ b/packages/unix-errno/unix-errno.0.5.0/opam
@@ -15,7 +15,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "alcotest" {with-test}
   "base-bytes"
   "result"

--- a/packages/unix-errno/unix-errno.0.5.1/opam
+++ b/packages/unix-errno/unix-errno.0.5.1/opam
@@ -15,7 +15,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "alcotest" {with-test}
   "base-bytes"
   "result"

--- a/packages/unix-errno/unix-errno.0.5.2/opam
+++ b/packages/unix-errno/unix-errno.0.5.2/opam
@@ -15,7 +15,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.01.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "alcotest" {with-test}
   "base-bytes"
   "result"


### PR DESCRIPTION
It has issues with stubs. The error was seen in the lower bound tests of #21544 
The error is
```
+ ocamlfind ocamlmklib -o unix/unix_errno_stubs -L/usr/local/lib unix/unix_errno_util.o unix/unix_errno_stubs.o
# gcc: error: unix/unix_errno_util.o: No such file or directory
# gcc: error: unix/unix_errno_stubs.o: No such file or directory
```
but is not very informative, the problem has been seen in other instances of packages with stubs when compiling using ocamlbuild 0.9.0

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>