### PR TITLE
[new release] obuilder and obuilder-spec (0.4)

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.4/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.4/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+license: "Apache-2.0"
 synopsis: "Build specification format"
 description:
   "A library for constructing, reading and writing OBuilder build specification files."

--- a/packages/obuilder-spec/obuilder-spec.0.4/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "fmt" {>= "0.8.9"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.4/obuilder-0.4.tbz"
+  checksum: [
+    "sha256=b50d35dac6fe69cbb6a07bd82e922cb0fd842d7d70c60d74001491becdb18b13"
+    "sha512=1eb006a9bba83bf1f6006082cf313b03d1b9f6af6ee1faecdcb987731809e7e8f301f8373a02158c81017411f6d18f917b77b320ce78c7a9357175003c77d5d5"
+  ]
+}
+x-commit-hash: "ad84405ec45ed79a4b3a52051a2981068d992768"

--- a/packages/obuilder/obuilder.0.4/opam
+++ b/packages/obuilder/obuilder.0.4/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+license: "Apache-2.0"
 synopsis: "Run build scripts for CI"
 description:
   "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
@@ -15,7 +16,7 @@ depends: [
   "logs"
   "cmdliner" {>= "1.1.0"}
   "tar-unix" {>= "2.0.0"}
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "sexplib"
   "ppx_deriving"
   "ppx_sexp_conv"
@@ -26,6 +27,7 @@ depends: [
   "alcotest-lwt" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [ "result" {< "1.5"} ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/obuilder/obuilder.0.4/opam
+++ b/packages/obuilder/obuilder.0.4/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "lwt" {>= "5.5.0"}
+  "astring"
+  "fmt" {>= "0.8.9"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "tar-unix" {>= "2.0.0"}
+  "yojson"
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha"
+  "sqlite3"
+  "obuilder-spec" {= version}
+  "ocaml" {>= "4.10.0"}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.4/obuilder-0.4.tbz"
+  checksum: [
+    "sha256=b50d35dac6fe69cbb6a07bd82e922cb0fd842d7d70c60d74001491becdb18b13"
+    "sha512=1eb006a9bba83bf1f6006082cf313b03d1b9f6af6ee1faecdcb987731809e7e8f301f8373a02158c81017411f6d18f917b77b320ce78c7a9357175003c77d5d5"
+  ]
+}
+x-commit-hash: "ad84405ec45ed79a4b3a52051a2981068d992768"

--- a/packages/ocluster/ocluster.0.1/opam
+++ b/packages/ocluster/ocluster.0.1/opam
@@ -33,7 +33,7 @@ depends: [
   "prometheus-app" {>= "1.0" & < "1.2"}
   "cohttp-lwt-unix"
   "sqlite3"
-  "obuilder"
+  "obuilder" {< "0.4"}
   "psq"
   "mirage-crypto" {>= "0.8.5"}
   "ocaml" {>= "4.10.0"}


### PR DESCRIPTION
Run build scripts for CI

- Project page: <a href="https://github.com/ocurrent/obuilder">https://github.com/ocurrent/obuilder</a>
- Documentation: <a href="https://ocurrent.github.io/obuilder/">https://ocurrent.github.io/obuilder/</a>

##### CHANGES:

- Use GNU tar format instead of UStar for `copy` operations (@TheLortex ocurrent/obuilder#82, reviewed @dra27).
  This enables copying from sources containing long file names (>100 characters).

- Add support for secrets (@TheLortex ocurrent/obuilder#63, reviewed by @talex5).
  The obuilder spec's `run` command supports a new `secrets` fields, which allows to temporarily
  mount secret files in an user-specified location. The sandbox build context has an additional
  `secrets` parameter to provide values for the requested keys.

- Limit permissions on temporary directories (@talex5 ocurrent/obuilder#67)

- Check Linux kernel version support for btrfs (@kit-ty-kate ocurrent/obuilder#68)

- Generalise obuilder sandbox, removing runc/linux specifc pieces and
  making the S.SANDBOX interface more general
  (@patricoferris ocurrent/obuilder#58, reviewed by @talex5, @avsm, @MisterDA)

- Convert --fast-sync back to a flag (@talex5 ocurrent/obuilder#72)

- Support Fmt.cli and Logs.cli flags. (@MisterDA ocurrent/obuilder#74, reviewed by @talex5)
  For Fmt the new options are --color=always|never|auto
  For Log the new options are:
    -v, --verbose Increase verbosity
    --verbosity=LEVEL (absent=warning)
        Be more or less verbose. LEVEL must be one of quiet, error,
        warning, info or debug. Takes over -v.

- Minor cleanup changes (@talex5 ocurrent/obuilder#76)

- Fix deprecations in Fmt 0.8.10 (@tmcgilchrist ocurrent/obuilder#80)

- Remove travis-ci and replace with Github Actions (@MisterDA ocurrent/obuilder#84)

- Add RSync store backend for obuilder to support macOS builders (@patricoferris ocurrent/obuilder#88, reviewed @talex5)

- Fixes for ZFS tests in CI (@patricoferris ocurrent/obuilder#91)
