### PR TITLE
[new release] xdg, stdune, ordering, ocamlc-loc, fiber, dyn, dune, dune-site, dune-rpc, dune-rpc-lwt, dune-private-libs, dune-glob, dune-configurator, dune-build-info, dune-action-plugin and chrome-trace (3.3.0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.3.0/opam
+++ b/packages/chrome-trace/chrome-trace.3.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-action-plugin/dune-action-plugin.3.3.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.3.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-build-info/dune-build-info.3.3.0/opam
+++ b/packages/dune-build-info/dune-build-info.3.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Embed build informations inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-configurator/dune-configurator.3.3.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.04.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-glob/dune-glob.3.3.0/opam
+++ b/packages/dune-glob/dune-glob.3.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-private-libs/dune-private-libs.3.3.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.3.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.3.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "dune-rpc" {= version}
+  "result" {>= "1.5"}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.3.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-rpc/dune-rpc.3.3.0/opam
+++ b/packages/dune-rpc/dune-rpc.3.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune-site/dune-site.3.3.0/opam
+++ b/packages/dune-site/dune-site.3.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Embed locations informations inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dune/dune.3.3.0/opam
+++ b/packages/dune/dune.3.3.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "bootstrap.ml" "-j" jobs]
+  ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/dyn/dyn.3.3.0/opam
+++ b/packages/dyn/dyn.3.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/fiber/fiber.3.3.0/opam
+++ b/packages/fiber/fiber.3.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Structured concurrency library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "stdune" {= version}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/ocamlc-loc/ocamlc-loc.3.3.0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "dune-private-libs" {= version}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/ordering/ordering.3.3.0/opam
+++ b/packages/ordering/ordering.3.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/stdune/stdune.3.3.0/opam
+++ b/packages/stdune/stdune.3.3.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"

--- a/packages/xdg/xdg.3.3.0/opam
+++ b/packages/xdg/xdg.3.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/ocaml/dune/releases/download/3.3.0/dune-3.3.0.tbz"
+  checksum: [
+    "sha256=1a08c708eb3f4346caa1ee814027484900d0e1518582f5c4d53fff6190d5504f"
+    "sha512=15cddad51ad6e9d1b71756da9e898a42846c2f320268342a18b8df79fc33383ffdc775c199fbe2a114affb480e0558a8f27492c9c274e6bc6cc86084ecdd543e"
+  ]
+}
+x-commit-hash: "f5ed6a495947c0e0cc8fa4fc0eac9ffcccdbdbd9"


### PR DESCRIPTION
XDG Base Directory Specification

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Sandbox preprocessing, lint, and dialect rules by default. All these rules
  now require precise dependency specifications (ocaml/dune#5807, @rgrinberg)

- Allow list expansion in the `pps` specification for preprocessing (ocaml/dune#5820,
  @Firobe)

- Add warnings 67-69 to dune's default set of warnings. These are warnings of
  the form "unused X.." (ocaml/dune#5844, @rgrinbreg)

- Introduce project "composition" for coq theories. Coq theories in separate
  projects can now refer to each other when in the same workspace (ocaml/dune#5784,
  @Alitzer, @rgrinberg)

- Fix hint message for ``data_only_dirs`` that wrongly mentions the unknown
  constructor ``data_only`` (ocaml/dune#5803, @lambdaxdotx)

- Fix creating sandbox directory trees by getting rid of buggy memoization
  (@5794, @rgrinberg, @snowleopard)

- Handle directory dependencies in sandboxed rules. Previously, the parents of
  these directory dependencies weren't created. (ocaml/dune#5754, @rgrinberg)

- Set the exit code to 130 when dune is terminated with a signal (ocaml/dune#5769, fixes
  ocaml/dune#5757)

- Support new locations of unix, str, dynlink in OCaml >= 5.0 (ocaml/dune#5582, @dra27)

- The ``coq.theory`` stanza now produces rules for running ``coqdoc``. Given a
  theory named ``mytheory``, the directory targets ``mytheory.html/`` and
  ``mytheory.tex/`` or additionally the aliases `@doc` and `@doc-latex` will
  build the HTML and LaTeX documentation repsectively. (ocaml/dune#5695, fixes ocaml/dune#3760,
  @Alizter)

- Coq theories marked as `(boot)` cannot depend on other theories
  (ocaml/dune#5867, @ejgallego)

- Ignore `bigarray` in `(libraries)` with OCaml >= 5.0. (ocaml/dune#5526, fixes ocaml/dune#5494,
  @moyodiallo)

- Start with :standard when building the ctypes generated foreign stubs so that
  we include important compiler flags, such as -fPIC (ocaml/dune#5816, fixes ocaml/dune#5809).
