### PR TITLE
[new release] xapi-inventory (1.2.3)

### DIFF
--- a/packages/xapi-inventory/xapi-inventory.1.2.3/opam
+++ b/packages/xapi-inventory/xapi-inventory.1.2.3/opam
@@ -12,8 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "ocamlfind" {build}
-  "dune" {build}
+  "dune" {>= "1.4.0"}
   "base-threads"
   "astring"
   "xapi-stdext-unix"

--- a/packages/xapi-inventory/xapi-inventory.1.2.3/opam
+++ b/packages/xapi-inventory/xapi-inventory.1.2.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: "xen-api@lists.xen.org"
+homepage: "https://github.com/xapi-project/xcp-inventory"
+bug-reports: "https://github.com/xapi-project/xcp-inventory/issues"
+dev-repo: "git+http://github.com/xapi-project/xcp-inventory.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: [ "org:xapi-project" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml"
+  "ocamlfind" {build}
+  "dune" {build}
+  "base-threads"
+  "astring"
+  "xapi-stdext-unix"
+  "xapi-stdext-threads"
+  "cmdliner"
+  "uuidm"
+]
+synopsis: "Library for accessing the xapi toolstack inventory file"
+description: """
+The inventory file provides global host identify information
+needed by multiple services."""
+url {
+  src:
+    "https://github.com/xapi-project/xcp-inventory/releases/download/v1.2.3/xapi-inventory-1.2.3.tbz"
+  checksum: [
+    "sha256=4e5c700bd228c8f1ba86b8a730f3aa27e7897abf2a289746c4bfab8b787aa3e9"
+    "sha512=d5d96e52bed1905cd3cfc4eba4467ba7f40587cef4a82d423dd1b4748d594da968e95ff7eb5cece5e6ea420694541977c3b06155578629831154cd6d7bbc9b31"
+  ]
+}
+x-commit-hash: "26e78d63c9462d86bc79865d91dc8e6c0ef96f99"


### PR DESCRIPTION
Library for accessing the xapi toolstack inventory file

- Project page: <a href="https://github.com/xapi-project/xcp-inventory">https://github.com/xapi-project/xcp-inventory</a>

##### CHANGES:

* maintenance: Decrease direct usages of Threadext
* Add license to opam metadata
