### PR TITLE
[new release] ocaml-migrate-parsetree (2.4.0)

### DIFF
--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
@@ -14,7 +14,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.02.3" & < "5.2"}
+  "ocaml" {>= "4.02.3" & < "5.1"}
   "cinaps" {with-test & >= "v0.13.0"}
 ]
 conflicts: [

--- a/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
+++ b/packages/ocaml-migrate-parsetree/ocaml-migrate-parsetree.2.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "frederic.bour@lakaban.net"
+authors: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+  "Jérémie Dimino <jeremie@dimino.org>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree"
+bug-reports: "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+doc: "https://ocaml-ppx.github.io/ocaml-migrate-parsetree/"
+tags: [ "syntax" "org:ocamllabs" ]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.02.3" & < "5.2"}
+  "cinaps" {with-test & >= "v0.13.0"}
+]
+conflicts: [
+  "base-effects"
+]
+synopsis: "Convert OCaml parsetrees between different versions"
+description: """
+Convert OCaml parsetrees between different versions
+
+This library converts parsetrees, outcometree and ast mappers between
+different OCaml versions.  High-level functions help making PPX
+rewriters independent of a compiler version.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocaml-migrate-parsetree/releases/download/2.4.0/ocaml-migrate-parsetree-2.4.0.tbz"
+  checksum: [
+    "sha256=ec49c452dc337a620556ab682bf0198bf50182550b502d8fb230a591260aa6a4"
+    "sha512=9478b9e5a969040400ee8fd7402bc4034f0f398d84e619254c43d5b7928463242629a2ccea35427f9747fbcedefa7ffc12edd1955ef8de866ba632e77f173219"
+  ]
+}
+x-commit-hash: "4b05692f45f7a8456725ddc4d50b970e271c4278"


### PR DESCRIPTION
Convert OCaml parsetrees between different versions

- Project page: <a href="https://github.com/ocaml-ppx/ocaml-migrate-parsetree">https://github.com/ocaml-ppx/ocaml-migrate-parsetree</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ocaml-migrate-parsetree/">https://ocaml-ppx.github.io/ocaml-migrate-parsetree/</a>

##### CHANGES:

- Add support for 5.0 (ocaml-ppx/ocaml-migrate-parsetree#122, @pitag-ha)
