### PR TITLE
[new release] xapi-stdext-zerocheck, xapi-stdext-unix, xapi-stdext-threads, xapi-stdext-std, xapi-stdext-pervasives, xapi-stdext-encodings and xapi-stdext-date (4.19.0)

### DIFF
--- a/packages/xapi-inventory/xapi-inventory.1.2.1/opam
+++ b/packages/xapi-inventory/xapi-inventory.1.2.1/opam
@@ -4,6 +4,7 @@ authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xcp-inventory"
 bug-reports: "https://github.com/xapi-project/xcp-inventory/issues"
 dev-repo: "git+http://github.com/xapi-project/xcp-inventory.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 tags: [ "org:xapi-project" ]
 build: [
   ["ocamlfind" "ocamlc" "-linkpkg" "-package" "findlib,cmdliner" "-o" "configure" "configure.ml"]
@@ -18,7 +19,7 @@ depends: [
   "base-threads"
   "astring"
   "xapi-stdext-unix"
-  "xapi-stdext-threads"
+  "xapi-stdext-threads" {< "4.19.0"}
   "cmdliner"
   "uuidm"
 ]

--- a/packages/xapi-stdext-date/xapi-stdext-date.4.19.0/opam
+++ b/packages/xapi-stdext-date/xapi-stdext-date.4.19.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Dates"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.11"}
+  "alcotest" {with-test}
+  "astring"
+  "base-unix"
+  "ptime"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.19.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.19.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Encodings"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"

--- a/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.19.0/opam
+++ b/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.19.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Pervasives"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.11"}
+  "logs"
+  "odoc" {with-doc}
+  "xapi-backtrace"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.19.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.19.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Stdlib"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.11"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.19.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.19.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Threads"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "base-threads"
+  "base-unix"
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Unix"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.11"}
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"

--- a/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.19.0/opam
+++ b/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.19.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Zerocheck"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.19.0/xapi-stdext-4.19.0.tbz"
+  checksum: [
+    "sha256=1b02f6ddcfa0553c8ae1cf0c4e1ed09550219ffbb25a6983043e7e909f0c6b5d"
+    "sha512=f978c6984e6497725c97b5bcf037f7493d781616e9204b1d010e9c39171683abed81f3161005271885f1a99b41c384beffc28a682d1cf3cbd4ae2170d5733efc"
+  ]
+}
+x-commit-hash: "690d233cf37c4e523e17e9b5ed74a118804bc9f5"


### PR DESCRIPTION
Xapi's standard library extension

- Project page: <a href="https://github.com/xapi-project/stdext">https://github.com/xapi-project/stdext</a>

##### CHANGES:

 - maintenance: give a name to the project
 - threads: Remove all the modules except Mutex
 - Add license to opam metadata, remove unused opam files
