### PR TITLE
ocamlfind < 1.9.5 is not compatible with OCaml 5.0

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.0/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.0/opam
@@ -11,7 +11,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://gitlab.camlcity.org/gerd/lib-findlib/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 depopts: ["graphics"]
 patches: ["fix-bsd.patch"]

--- a/packages/ocamlfind/ocamlfind.1.9.1/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.1/opam
@@ -13,7 +13,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 depopts: ["graphics"]
 build: [

--- a/packages/ocamlfind/ocamlfind.1.9.2/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.2/opam
@@ -13,7 +13,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 depopts: ["graphics"]
 build: [

--- a/packages/ocamlfind/ocamlfind.1.9.3/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.3/opam
@@ -13,7 +13,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 depopts: ["graphics"]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlfind.1.9.1 ====================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamlfind.1.9.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure -bindir /home/opam/.opam/5.0/bin -sitelib /home/opam/.opam/5.0/lib -mandir /home/opam/.opam/5.0/man -config /home/opam/.opam/5.0/lib/findlib.conf -no-custom -no-camlp4
# exit-code            1
# env-file             ~/.opam/log/ocamlfind-23-f1292d.env
# output-file          ~/.opam/log/ocamlfind-23-f1292d.out
### output ###
# Welcome to findlib version 1.9.1
# Configuring core...
# Checking for #remove_directory...
# Testing threading model...
# systhread_supported: true
# Testing DLLs...
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# Testing whether ppxopt can be supported...
# Checking for ocamlc -opaque...
# Querying installation: found list of findlib-generated META files
# Installation has: bytes,compiler-libs,dynlink,ocamldoc,runtime_events,stdlib,str,threads,unix
# Configuring libraries...
# unix: not present (possible since 4.08)
# configure: ocamlfind requires OCaml's Unix library
```