### PR TITLE
ocamlbuild < 0.14.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.0/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.0/opam
@@ -28,7 +28,7 @@ conflicts: [
 synopsis:
   "OCamlbuild is a build system with builtin rules to easily build most OCaml projects."
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
 ]
 url {
   src: "https://github.com/ocaml/ocamlbuild/archive/0.14.0.tar.gz"


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlbuild.0.14.0 ==================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamlbuild.0.14.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make check-if-preinstalled all opam-install
# exit-code            2
# env-file             ~/.opam/log/ocamlbuild-23-ae9d11.env
# output-file          ~/.opam/log/ocamlbuild-23-ae9d11.out
### output ###
# if test -d /home/opam/.opam/5.0/lib/ocaml/ocamlbuild; then\
#   >&2 echo "ERROR: Preinstalled ocamlbuild detected at"\
#        "/home/opam/.opam/5.0/lib/ocaml/ocamlbuild";\
#   >&2 echo "Installation aborted; if you want to bypass this"\
#         "safety check, pass CHECK_IF_PREINSTALLED=false to make";\
#   exit 2;\
# fi
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/const.ml
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/loc.mli
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/loc.ml
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/discard_printf.mli
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/discard_printf.ml
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/signatures.mli
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/my_std.mli
# ocamlc.opt -w L -w R -w Z -I src -I +unix -safe-string -bin-annot -strict-sequence -c src/my_std.ml
# File "src/my_std.ml", line 127, characters 20-38:
# 127 |       let compare = Pervasives.compare
#                           ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:422: src/my_std.cmo] Error 2
```