### PR TITLE
sexplib0 < v0.15.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/sexplib0/sexplib0.v0.11.0/opam
+++ b/packages/sexplib0/sexplib0.v0.11.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0"}
   "jbuilder" {>= "1.0+beta18.1"}
 ]
 conflicts: [

--- a/packages/sexplib0/sexplib0.v0.12.0/opam
+++ b/packages/sexplib0/sexplib0.v0.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.0"}
   "dune"  {>= "1.5.1"}
 ]
 synopsis: "Library containing the definition of S-expressions and some base converters"

--- a/packages/sexplib0/sexplib0.v0.13.0/opam
+++ b/packages/sexplib0/sexplib0.v0.13.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.0"}
   "dune"  {>= "1.5.1"}
 ]
 synopsis: "Library containing the definition of S-expressions and some base converters"

--- a/packages/sexplib0/sexplib0.v0.14.0/opam
+++ b/packages/sexplib0/sexplib0.v0.14.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.0"}
   "dune"  {>= "2.0.0"}
 ]
 synopsis: "Library containing the definition of S-expressions and some base converters"

--- a/packages/sexplib0/sexplib0.v0.15.0/opam
+++ b/packages/sexplib0/sexplib0.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.0"}
   "dune"  {>= "2.0.0"}
 ]
 synopsis: "Library containing the definition of S-expressions and some base converters"


### PR DESCRIPTION
```
#=== ERROR while compiling sexplib0.v0.15.0 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/sexplib0.v0.15.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sexplib0 -j 47
# exit-code            1
# env-file             ~/.opam/log/sexplib0-10-cd2234.env
# output-file          ~/.opam/log/sexplib0-10-cd2234.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.sexplib0.objs/byte -intf-suffix .ml -no-alias-deps -open Sexplib0__ -o src/.sexplib0.objs/byte/sexplib0__Sexp_conv.cmo -c -impl src/sexp_conv.ml)
# File "src/sexp_conv.ml", line 99, characters 15-31:
# 99 |       let id = Obj.extension_id
#                     ^^^^^^^^^^^^^^^^
# Error: Unbound value Obj.extension_id
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.sexplib0.objs/byte -I src/.sexplib0.objs/native -intf-suffix .ml -no-alias-deps -open Sexplib0__ -o src/.sexplib0.objs/native/sexplib0__Sexp_conv.cmx -c -impl src/sexp_conv.ml)
# File "src/sexp_conv.ml", line 99, characters 15-31:
# 99 |       let id = Obj.extension_id
#                     ^^^^^^^^^^^^^^^^
# Error: Unbound value Obj.extension_id
```