### PR TITLE
base is not compatible with OCaml 5.0 (uses String.uppercase)

### DIFF
--- a/packages/base/base.v0.15.0/opam
+++ b/packages/base/base.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"             {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "sexplib0"          {>= "v0.15" & < "v0.16"}
   "dune"              {>= "2.0.0"}
   "dune-configurator"


### PR DESCRIPTION
```
#=== ERROR while compiling base.v0.15.0 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/base.v0.15.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p base -j 31
# exit-code            1
# env-file             ~/.opam/log/base-19-115a43.env
# output-file          ~/.opam/log/base-19-115a43.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I shadow-stdlib/gen/.gen.eobjs/byte -I /home/opam/.opam/5.0/lib/ocaml/compiler-libs -I /home/opam/.opam/5.0/lib/ocaml/str -I compiler-stdlib/src/.caml.objs/byte -no-alias-deps -o shadow-stdlib/gen/.gen.eobjs/byte/mapper.cmo -c -impl shadow-stdlib/gen/mapper.ml)
# File "shadow-stdlib/gen/mapper.mll", line 7, characters 27-44:
# Error: Unbound value String.capitalize
```