### PR TITLE
[new release] hvsock (3.0.1)

### DIFF
--- a/packages/hvsock/hvsock.3.0.1/opam
+++ b/packages/hvsock/hvsock.3.0.1/opam
@@ -33,12 +33,7 @@ depends: [
   "duration"
   "dune" {>= "1.2.0"}
   "alcotest" {with-test & >= "0.4.0"}
-]
-depexts: [
-  ["linux-headers"] {os-distribution = "alpine"}
-  ["linux-libc-dev"] {os-family = "debian"}
-  ["kernel-headers"] {os-distribution = "fedora"}
-  ["kernel-headers"] {os-distribution = "rhel"}
+  "conf-linux-libc-dev"
 ]
 synopsis: "Bindings for Hyper-V AF_VSOCK"
 description: """

--- a/packages/hvsock/hvsock.3.0.1/opam
+++ b/packages/hvsock/hvsock.3.0.1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [ "David Scott" "Rolf Neugebauer" "Anil Madhavapeddy" "Simon Ferquel"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-hvsock"
+dev-repo: "git+https://github.com/mirage/ocaml-hvsock.git"
+bug-reports: "https://github.com/mirage/ocaml-hvsock/issues"
+doc: "https://mirage.github.io/ocaml-hvsock"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "base-bytes"
+  "base-threads"
+  "base-unix"
+  "lwt" {>= "3.2.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1"}
+  "sha"
+  "uri"
+  "base64" {>= "3.0.0"}
+  "uuidm"
+  "uutf"
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "duration"
+  "dune" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.4.0"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+]
+synopsis: "Bindings for Hyper-V AF_VSOCK"
+description: """
+[![Build Status (Linux)](https://travis-ci.org/mirage/ocaml-hvsock.svg)](https://travis-ci.org/mirage/ocaml-hvsock)
+[![Build status (Windows)](https://ci.appveyor.com/api/projects/status/974tsg317b4k8xra?svg=true)](https://ci.appveyor.com/project/mirage/ocaml-hvsock/branch/master)
+
+These bindings allow Host <-> VM communication on Hyper-V systems on both Linux
+and Windows.
+
+*Warning*: the `AF_HYPERV` patches for Linux are not yet merged and hence the
+definition of `AF_HYPERV` is not yet stable. If other address families are merged
+before this one then the value of `AF_HYPERV` will change!
+
+Please read [the API documentation](https://djs55.github.io/ocaml-hvsock/index.html)."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-hvsock/releases/download/3.0.1/hvsock-3.0.1.tbz"
+  checksum: [
+    "sha256=41659fb404dd3c7b694e7e5ab450df7af4240f4592b5b7c356d1598dbd32cac4"
+    "sha512=4d355c58a86630dfe77ae084d93f23f2666bc46b0161128d99f51db286d0e49afc4f8130596b513b850c601fad8029e2e6dfc40d50cd854bf330c280a654e164"
+  ]
+}
+x-commit-hash: "6b90ba4ab43257e05e377672f4e07b2d1b643588"


### PR DESCRIPTION
Bindings for Hyper-V AF_VSOCK

- Project page: <a href="https://github.com/mirage/ocaml-hvsock">https://github.com/mirage/ocaml-hvsock</a>
- Documentation: <a href="https://mirage.github.io/ocaml-hvsock">https://mirage.github.io/ocaml-hvsock</a>

##### CHANGES:

- Update cmdliner dependency to 1.1
