### PR TITLE
[new release] vhd-format and vhd-format-lwt (0.12.3)

### DIFF
--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Jon Ludlam"]
+tags: ["org:mirage" "org:xapi-project"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/mirage/ocaml-vhd"
+doc: "https://mirage.github.io/ocaml-vhd/"
+bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "cstruct"
+  "lwt" {>= "3.2.0"}
+  "mirage-block" {>= "2.0.1"}
+  "ounit2" {with-test}
+  "vhd-format"
+  "io-page-unix" {with-test}
+  "dune" {>= "1.0"}
+  "io-page" {with-test & >= "2.4.0"}
+]
+available: os = "linux" | os = "macos"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+synopsis: "Lwt interface to read/write VHD format data"
+description: """
+A pure OCaml library to read and write
+[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
+simple command-line tool which allows vhd files to be interrogated,
+manipulated, format-converted and streamed to and from files and remote
+servers.
+
+This package provides an Lwt compatible interface to the library.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.3/vhd-format-0.12.3.tbz"
+  checksum: [
+    "sha256=e3da58f79172f7c55d8b07cea100358771248b435baf5fbe941e61e6d0840730"
+    "sha512=3af8d9f618266c5bd9c65e1b81c97c6e68c07ab84b8031dbef691ac7775fe7ea308be995dfdba8a785f404aeb44a3e094c78861f1e9f8d8321a1110c1da64fd5"
+  ]
+}
+x-commit-hash: "6f3f75bc881c6f22117e01aa8520fa70564fde42"

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.02.3"}
-  "cstruct"
+  "cstruct" {< "6.1.0"}
   "lwt" {>= "3.2.0"}
   "mirage-block" {>= "2.0.1"}
   "ounit2" {with-test}

--- a/packages/vhd-format/vhd-format.0.12.3/opam
+++ b/packages/vhd-format/vhd-format.0.12.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["Dave Scott" "Jon Ludlam"]
+tags: ["org:mirage" "org:xapi-project"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/mirage/ocaml-vhd"
+doc: "https://mirage.github.io/ocaml-vhd/"
+bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "cstruct" {>= "1.9" & < "6.0.0"}
+  "io-page"
+  "rresult" {>= "0.3.0"}
+  "uuidm" {>= "0.9.6"}
+  "stdlib-shims"
+  "dune" {>= "1.0"}
+  "ppx_cstruct" {build & >= "3.0.0"}
+]
+available: os = "linux" | os = "macos"
+build: ["dune" "build" "-p" name "-j" jobs]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
+dev-repo: "git+https://github.com/mirage/ocaml-vhd.git"
+synopsis: "Pure OCaml library to read/write VHD format data"
+description: """
+A pure OCaml library to read and write
+[vhd](http://en.wikipedia.org/wiki/VHD_(file_format)) format data, plus a
+simple command-line tool which allows vhd files to be interrogated,
+manipulated, format-converted and streamed to and from files and remote
+servers.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-vhd/releases/download/v0.12.3/vhd-format-0.12.3.tbz"
+  checksum: [
+    "sha256=e3da58f79172f7c55d8b07cea100358771248b435baf5fbe941e61e6d0840730"
+    "sha512=3af8d9f618266c5bd9c65e1b81c97c6e68c07ab84b8031dbef691ac7775fe7ea308be995dfdba8a785f404aeb44a3e094c78861f1e9f8d8321a1110c1da64fd5"
+  ]
+}
+x-commit-hash: "6f3f75bc881c6f22117e01aa8520fa70564fde42"


### PR DESCRIPTION
Pure OCaml library to read/write VHD format data

- Project page: <a href="https://github.com/mirage/ocaml-vhd">https://github.com/mirage/ocaml-vhd</a>
- Documentation: <a href="https://mirage.github.io/ocaml-vhd/">https://mirage.github.io/ocaml-vhd/</a>

##### CHANGES:

* Lint opam file (@kit-ty-kate, mirage/ocaml-vhd#72)
* Use ounit2 (@Alessandro-Barbieri, mirage/ocaml-vhd#73)
* Use unixsupport.h for OCaml 5.0 compat (@dra27, mirage/ocaml-vhd#74)
* Set upper bounds on cstruct (@djs55, mirage/ocaml-vhd#75)
* Set lower bound on uuidm (@djs55, mirage/ocaml-vhd#75)
