### PR TITLE
easy-format < 1.3.3 is not compatible with OCaml 5

### DIFF
--- a/packages/easy-format/easy-format.1.0.1/opam
+++ b/packages/easy-format/easy-format.1.0.1/opam
@@ -2,7 +2,10 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "easy-format"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+]
 patches: [
   "easy-format-make.diff"
   "meta-tpl.diff"

--- a/packages/easy-format/easy-format.1.0.2/opam
+++ b/packages/easy-format/easy-format.1.0.2/opam
@@ -2,7 +2,10 @@ opam-version: "2.0"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 build: make
 remove: [["ocamlfind" "remove" "easy-format"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+]
 install: [make "install"]
 synopsis:
   "High-level and functional interface to the Format module of the OCaml standard library"

--- a/packages/easy-format/easy-format.1.1.0/opam
+++ b/packages/easy-format/easy-format.1.1.0/opam
@@ -12,7 +12,10 @@ install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "easy-format"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+]
 synopsis:
   "High-level and functional interface to the Format module of the OCaml standard library"
 flags: light-uninstall

--- a/packages/easy-format/easy-format.1.2.0/opam
+++ b/packages/easy-format/easy-format.1.2.0/opam
@@ -12,7 +12,10 @@ install: [
   [make "install"]
 ]
 remove: [["ocamlfind" "remove" "easy-format"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+]
 synopsis:
   "High-level and functional interface to the Format module of the OCaml standard library"
 flags: light-uninstall

--- a/packages/easy-format/easy-format.1.3.0/opam
+++ b/packages/easy-format/easy-format.1.3.0/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:

--- a/packages/easy-format/easy-format.1.3.1/opam
+++ b/packages/easy-format/easy-format.1.3.1/opam
@@ -9,7 +9,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
 ]
 synopsis:

--- a/packages/easy-format/easy-format.1.3.2/opam
+++ b/packages/easy-format/easy-format.1.3.2/opam
@@ -34,7 +34,7 @@ any sequence of items such as arrays of data or lists of definitions that are
 labelled with something like "int main", "let x =" or "x:"."""
 depends: [
   "dune" {>= "1.10"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
 ]
 url {
   src:


### PR DESCRIPTION
The deprecated `Format.pp_get_formatter_tag_functions` was removed. Upstream easy-format is already fixed and has two versions that work on OCaml 5.0 so the migration shouldn't be overly painful.

Found this issue as part of the minimum-version build on #21523 where it picks an older version of easy-format on OCaml 5.0 and thus the build fails.