### PR TITLE
key-parsers: add conflict with yojson 2

### DIFF
--- a/packages/key-parsers/key-parsers.0.10.1/opam
+++ b/packages/key-parsers/key-parsers.0.10.1/opam
@@ -26,6 +26,7 @@ depends: [
 ]
 conflicts: [
   "ppx_driver" {= "v0.9.1"}
+  "yojson" {>= "2.0.0"}
 ]
 synopsis: "Parsers for multiple key formats"
 description: """


### PR DESCRIPTION
It otherwise fails with
```
#=== ERROR while compiling key-parsers.0.10.1 =================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/key-parsers.0.10.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p key-parsers -j 31
# exit-code            1
# env-file             ~/.opam/log/key-parsers-3557-3a1e3c.env
# output-file          ~/.opam/log/key-parsers-3557-3a1e3c.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -39 -g -bin-annot -I lib/.key_parsers.objs/byte -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -open Key_parsers -o lib/.key_parsers.objs/byte/key_parsers__Cvc.cmi -c -intf lib/cvc.pp.mli)
# File "lib/cvc.mli", line 28, characters 25-41:
# 28 |     val to_yojson : t -> Yojson.Safe.json
#                               ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -39 -g -bin-annot -I lib/.key_parsers.objs/byte -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -open Key_parsers -o lib/.key_parsers.objs/byte/key_parsers__Ltpa.cmi -c -intf lib/ltpa.pp.mli)
# File "lib/ltpa.mli", line 44, characters 25-41:
# 44 |     val to_yojson : t -> Yojson.Safe.json
#                               ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -39 -g -bin-annot -I lib/.key_parsers.objs/byte -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -open Key_parsers -o lib/.key_parsers.objs/byte/key_parsers__Derivable.cmi -c -intf lib/derivable.pp.mli)
# File "lib/derivable.mli", line 15, characters 23-39:
# 15 |   val to_yojson : t -> Yojson.Safe.json
#                             ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -39 -g -bin-annot -I lib/.key_parsers.objs/byte -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/yojson -I /home/opam/.opam/4.14/lib/zarith -no-alias-deps -open Key_parsers -o lib/.key_parsers.objs/byte/key_parsers__Asn1.cmi -c -intf lib/asn1.pp.mli)
# File "lib/asn1.mli", line 34, characters 25-41:
# 34 |     val to_yojson : t -> Yojson.Safe.json
#                               ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
```
Seen on #21523 