### PR TITLE
[new release] ppx_irmin, libirmin, irmin, irmin-unix, irmin-tezos, irmin-test, irmin-pack, irmin-mirage, irmin-mirage-graphql, irmin-mirage-git, irmin-http, irmin-graphql, irmin-git, irmin-fs, irmin-containers, irmin-chunk and irmin-bench (3.3.0)

### DIFF
--- a/packages/irmin-bench/irmin-bench.3.3.0/opam
+++ b/packages/irmin-bench/irmin-bench.3.3.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.9.0"}
+  "irmin-pack"   {= version}
+  "irmin-test"   {= version}
+  "irmin-tezos"  {= version}
+  "cmdliner"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "repr"         {>= "0.3.0"}
+  "ppx_repr"
+  "re"           {>= "1.9.0"}
+  "fmt"
+  "uuidm"
+  "progress"     {>="0.2.1"}
+  "fpath"        {with-test}
+  "bentov"
+  "mtime"
+  "ppx_deriving"
+  "alcotest"     {with-test}
+  "rusage"
+  "uutf"
+  "uucp"
+  "printbox"     {>= "0.6"}
+  "printbox-text"
+]
+
+available: [
+   # Disabled on 32-bit platforms due to an overly-large int literal in the source
+   arch != "arm32" & arch != "x86_32"
+]
+
+synopsis: "Irmin benchmarking suite"
+description: """
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-chunk/irmin-chunk.3.3.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.3.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "fmt"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-containers/irmin-containers.3.3.0/opam
+++ b/packages/irmin-containers/irmin-containers.3.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "irmin-unix" {= version}
+  "irmin-git"  {= version}
+  "ppx_irmin"  {= version}
+  "lwt"        {>= "5.3.0"}
+  "mtime"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Mergeable Irmin data structures"
+description: """
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-fs/irmin-fs.3.3.0/opam
+++ b/packages/irmin-fs/irmin-fs.3.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "astring"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-git/irmin-git.3.3.0/opam
+++ b/packages/irmin-git/irmin-git.3.3.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ # Tests disabled on 32-bit platforms as the Dune build fails in CI:
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "git"        {>= "3.7.0"}
+  "digestif"   {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "fpath"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "uri"
+  "mimic"
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test & >= "3.7.0"}
+  "mtime"      {with-test & >= "1.0.0"}
+  "alcotest"   {with-test}
+]
+available: [ arch != "s390x" ] # temporary disable until ocaml-git works properly
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-graphql/irmin-graphql.3.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.9.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.13.0"}
+  "graphql-lwt"    {>= "0.13.0"}
+  "graphql-cohttp" {>= "0.13.0"}
+  "graphql_parser" {>= "0.13.0"}
+  "cohttp-lwt"
+  "cohttp"
+  "fmt"
+  "lwt"            {>= "5.3.0"}
+  "alcotest-lwt"    {with-test & >= "1.1.0"}
+  "yojson"          {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "alcotest"        {with-test & >= "1.2.3"}
+  "logs"            {with-test}
+]
+
+
+synopsis: "GraphQL server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-http/irmin-http.3.3.0/opam
+++ b/packages/irmin-http/irmin-http.3.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.9.0"}
+  "crunch"     {>= "2.2.0"}
+  "webmachine" {>= "0.6.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "uri"
+  "irmin-git"  {with-test & = version}
+  "irmin-test" {with-test & = version}
+  "git-unix"   {with-test & >= "3.5.0"}
+  "digestif"   {with-test & >= "0.9.0"}
+  "cohttp-lwt-unix" {with-test}
+]
+
+synopsis: "HTTP client and server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.3.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.9.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"    {= version}
+  "mirage-kv"    {>= "3.0.0"}
+  "fmt"
+  "git"          {>= "3.7.0"}
+  "lwt"          {>= "5.3.0"}
+  "mirage-clock"
+  "uri"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.3.3.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.3.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"          {>= "2.9.0"}
+  "irmin-mirage"  {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt"           {>= "5.3.0"}
+  "uri"
+  "git"           {>= "3.4.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-mirage/irmin-mirage.3.3.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.3.3.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-pack/irmin-pack.3.3.0/opam
+++ b/packages/irmin-pack/irmin-pack.3.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.08.0"}
+  "dune"         {>= "2.9.0"}
+  "irmin"        {= version}
+  "ppx_irmin"    {= version}
+  "index"        {>= "1.6.0"}
+  "fmt"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "mtime"
+  "cmdliner"
+  "optint"       {>= "0.1.0"}
+  "irmin-test"   {with-test & = version}
+  "alcotest-lwt" {with-test}
+  "astring"      {with-test}
+  "alcotest"     {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-test/irmin-test.3.3.0/opam
+++ b/packages/irmin-test/irmin-test.3.3.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "irmin"        {= version}
+  "ppx_irmin"    {= version}
+  "ocaml"        {>= "4.02.3"}
+  "dune"         {>= "2.9.0"}
+  "alcotest"     {>= "1.5.0"}
+  "mtime"        {>= "1.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "metrics-unix"
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "metrics" {>= "0.2.0"}
+  "hex" {with-test & >= "1.4.0"}
+  "vector" {with-test & >= "1.0.0"}
+  "alcotest-lwt" {with-test & >= "1.5.0"}
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-tezos/irmin-tezos.3.3.0/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Irmin implementation of the Tezos context hash specification"
+description: "Irmin implementation of the Tezos context hash specification"
+maintainer: "Tarides <contact@tarides.com>"
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "MIT"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "2.9.0"}
+  "irmin" {>= version}
+  "irmin-pack" {= version}
+  "ppx_irmin" {= version}
+  "tezos-base58"
+  "digestif" {>= "0.7"}
+  "cmdliner"
+  "fmt"
+  "yojson"
+  "alcotest" {with-test}
+  "hex" {with-test & >= "1.4.0"}
+  "fpath" {with-test}
+  "irmin-test" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin-unix/irmin-unix.3.3.0/opam
+++ b/packages/irmin-unix/irmin-unix.3.3.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+available: arch != "arm32" & arch != "x86_32"
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "2.9.0"}
+  "irmin"         {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-tezos"   {= version}
+  "git-unix"      {>= "3.7.0"}
+  "digestif"      {>= "0.9.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "3.0.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix"
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git"           {>= "3.7.0"}
+  "happy-eyeballs-lwt"
+  "lwt"           {>= "5.3.0"}
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+  "mdx" {>= "2.0.0" & with-test}
+]
+
+synopsis: "Unix backends for Irmin"
+description: """
+`Irmin_unix` defines Unix backends (including Git and HTTP) for Irmin, as well
+as a very simple CLI tool (called `irmin`) to manipulate and inspect Irmin
+stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/irmin/irmin.3.3.0/opam
+++ b/packages/irmin/irmin.3.3.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.9.0"}
+  "repr"    {>= "0.6.0"}
+  "fmt"     {>= "0.8.0"}
+  "uri"     {>= "1.3.12"}
+  "uutf"
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "5.3.0"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "mtime" {>= "1.0.0"}
+  "bigstringaf" { >= "0.2.0" }
+  "ppx_irmin" {= version}
+  "hex"      {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {with-test}
+  "vector" {with-test}
+  "odoc" {(< "2.0.1" | > "2.0.2") & with-doc} # See https://github.com/ocaml/odoc/issues/793
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+
+conflicts: [
+  "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+]
+
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"

--- a/packages/libirmin/libirmin.3.3.0/opam
+++ b/packages/libirmin/libirmin.3.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "C bindings for irmin"
+description: "C bindings for irmin using Ctypes inverted stubs"
+maintainer: ["zachshipko@gmail.com"]
+authors: ["Zach Shipko"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ctypes" {>= "0.19"}
+  "ctypes-foreign" {>= "0.18"}
+  "irmin-unix" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+available: [ arch != "arm64" ]
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504" # disabled because of SEGFAULT

--- a/packages/ppx_irmin/ppx_irmin.3.3.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "ppx_repr" {>= "0.2.0"}
+  "ppxlib" {>= "0.12.0"}
+  "logs" {>= "0.5.0"}
+  "fmt" {with-test & >= "0.8.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+
+synopsis: "PPX deriver for Irmin type representations"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.3.0/irmin-3.3.0.tbz"
+  checksum: [
+    "sha256=38f90d1dcada0a691e45ac9f26e1e0ea3e6967e9660c7b694fdd2423fbc92ea8"
+    "sha512=aac01211fb70c10727bdd8457f403f784d63f3be4d7b513577694448088006b6f39063d07a212f5b6f56639d0937231bef47c53cb56801460d6177824f6cbb81"
+  ]
+}
+x-commit-hash: "3820bcae4da017ebd8ecb42e570369d8cd2d3504"


### PR DESCRIPTION
PPX deriver for Irmin type representations

- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>

##### CHANGES:

### Added

- **irmin**
  - Add `Metrics` module to describe metric gathering in irmin.
    (mirage/irmin#1817, @maiste)
  - Add `Repo.config` to access config used to create repo
    (mirage/irmin#1886, @zshipko)

- **irmin-unix**
  - Add `--plugin` flag to load Dynlink plugins that can register new
    contents, hash and store types (mirage/irmin#1808, @zshipko)

- **irmin-pack**
  - Add `use_fsync`, `dict_auto_flush_threshold` and
  - `suffix_auto_flush_threshold` in store configuration. (mirage/irmin#1865, @Ngoguey42)
  - Add `no_migrate` in store configuration. (mirage/irmin#1893, @zshipko)

### Changed

- **irmin-pack**
  - Move `Irmin_pack.Pack_store.Indexing_strategy` to
    `Irmin_pack.Indexing_strategy` and the rest of `Pack_store`
    to `Irmin_pack_unix` (mirage/irmin#1833, @Ngoguey42)
  - Different repos opened using the same store module no longer share caches
    and file descriptors (mirage/irmin#1852, @Ngoguey42)
  - `Snapshot.Import.close` requires a repo as additional argument (mirage/irmin#1872,
    @icristescu)
  - Upgraded on-disk format to version 3 to support better synchronisation
    mechanism between readwrite and readonly instances. This change is *not*
    backwards-compatible with existing stores using `irmin-pack.x.x < 3.3.0`
    versions. A migration done by the readwrite instance is necessary to open
    older stores with `irmin-pack.3.3.0`. It is not forwards compatible. (mirage/irmin#1865)
  - Rename `Store.sync` to `Store.reload` (mirage/irmin#1900, @Ngoguey42).
  - Add `Pack_error` exception that centralizes many error cases alongside
    `RO_not_allowed` and `Unix.Unix_error` (mirage/irmin#1899, @Ngoguey42)

### Fixed

- **irmin-pack**
  - Allow snapshot export to work on indexed root nodes (mirage/irmin#1845, @icristescu)

- **irmin**
  - Fix Tree.export for nodes exported twice using different repos. (mirage/irmin#1795,
    @Ngoguey42)
