### PR TITLE
odoc-parser uses `Stream.t` which is gone in OCaml 5.0

### DIFF
--- a/packages/odoc-parser/odoc-parser.0.9.0/opam
+++ b/packages/odoc-parser/odoc-parser.0.9.0/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/ocaml-doc/odoc-parser.git"
 doc: "https://ocaml-doc.github.io/odoc-parser/"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "astring"
   "result"
   "ppx_expect" {with-test}

--- a/packages/odoc-parser/odoc-parser.1.0.0/opam
+++ b/packages/odoc-parser/odoc-parser.1.0.0/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/ocaml-doc/odoc-parser.git"
 doc: "https://ocaml-doc.github.io/odoc-parser/"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "astring"
   "result"
   "ppx_expect" {with-test}


### PR DESCRIPTION
Upstream has already merged a fix, this is just to prevent old releases from being picked up in OCaml 5.0.