### PR TITLE
[new release] icalendar (0.1.6)

### DIFF
--- a/packages/icalendar/icalendar.0.1.6/opam
+++ b/packages/icalendar/icalendar.0.1.6/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/v0.1.6/icalendar-0.1.6.tbz"
+  checksum: [
+    "sha256=85448916a57deb375a2206c73d060c040e79411294810b5311dee384564d3f2e"
+    "sha512=4c0ae4a7f676eb73f36d5e00f26a686fa420f97a38e3724c194b9538ef411b87f76aaf4430ed78c39b6f973c2f39f84c3c674d0af95e740549be60d6449a6cdf"
+  ]
+}
+x-commit-hash: "bf880378ab7b276b6eb37229cfe069c3ca06381f"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/roburio/icalendar">https://github.com/roburio/icalendar</a>
- Documentation: <a href="https://roburio.github.io/icalendar/">https://roburio.github.io/icalendar/</a>

##### CHANGES:

* Improve performance by 40x when computing occurrences of timezones and other
  recurrences (investigated by @rand00 roburio/icalendar#7)
