### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.12.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.12.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.12.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.12.0/lsp-1.12.0.tbz"
+  checksum: [
+    "sha256=bb6905bc2b93baac5017a2b3cabae73bb0089ef4df7e33e7b2aa78be9060c240"
+    "sha512=7abb7c7fdf89d308a559b4789cd04ea41dcf2d10862422a227f2baf884c582cacc65cc47ce8452ae7cb1286ce8ea320cfb75916230b289d1509884c1f40c4f40"
+  ]
+}
+x-commit-hash: "5f3f4f5c4fb20c8471535fc8470073081bdc4144"

--- a/packages/lsp/lsp.1.12.0/opam
+++ b/packages/lsp/lsp.1.12.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "jsonrpc" {= version}
+  "dyn"
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "menhir" {"20211230" >= with-test}
+  "ppx_expect" {"v0.15.0" >= with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.12.0/lsp-1.12.0.tbz"
+  checksum: [
+    "sha256=bb6905bc2b93baac5017a2b3cabae73bb0089ef4df7e33e7b2aa78be9060c240"
+    "sha512=7abb7c7fdf89d308a559b4789cd04ea41dcf2d10862422a227f2baf884c582cacc65cc47ce8452ae7cb1286ce8ea320cfb75916230b289d1509884c1f40c4f40"
+  ]
+}
+x-commit-hash: "5f3f4f5c4fb20c8471535fc8470073081bdc4144"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.12.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.12.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc"
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "omd" {<= "1.3.1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14" & < "4.15"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.12.0/lsp-1.12.0.tbz"
+  checksum: [
+    "sha256=bb6905bc2b93baac5017a2b3cabae73bb0089ef4df7e33e7b2aa78be9060c240"
+    "sha512=7abb7c7fdf89d308a559b4789cd04ea41dcf2d10862422a227f2baf884c582cacc65cc47ce8452ae7cb1286ce8ea320cfb75916230b289d1509884c1f40c4f40"
+  ]
+}
+x-commit-hash: "5f3f4f5c4fb20c8471535fc8470073081bdc4144"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Fix cancellation mechanism for all requests (ocaml/ocaml-lsp#707)

- Allow cancellation of formatting requests (ocaml/ocaml-lsp#707)

- Add `--fallback-read-dot-merlin` to the LSP Server (ocaml/ocaml-lsp#705). If `ocamllsp` is
  started with this new flag, it will fall back to looking for Merlin
  configuration in `.merlin` files rather than calling `dune ocaml-merlin`.
  (ocaml/ocaml-lsp#705)

- Support folding more ranges (ocaml/ocaml-lsp#692)
