### PR TITLE
Mark stringext < 1.5.0 as not available with OCaml 5.0

### DIFF
--- a/packages/stringext/stringext.1.2.0/opam
+++ b/packages/stringext/stringext.1.2.0/opam
@@ -14,7 +14,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/stringext/stringext.1.3.0/opam
+++ b/packages/stringext/stringext.1.3.0/opam
@@ -16,7 +16,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/stringext/stringext.1.3.1/opam
+++ b/packages/stringext/stringext.1.3.1/opam
@@ -16,7 +16,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/stringext/stringext.1.4.0/opam
+++ b/packages/stringext/stringext.1.4.0/opam
@@ -18,7 +18,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ounit" {with-test}

--- a/packages/stringext/stringext.1.4.1/opam
+++ b/packages/stringext/stringext.1.4.1/opam
@@ -18,7 +18,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ounit" {with-test}

--- a/packages/stringext/stringext.1.4.2/opam
+++ b/packages/stringext/stringext.1.4.2/opam
@@ -18,7 +18,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ounit" {with-test}

--- a/packages/stringext/stringext.1.4.3/opam
+++ b/packages/stringext/stringext.1.4.3/opam
@@ -18,7 +18,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stringext"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ounit" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling stringext.1.4.0 ====================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/stringext.1.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure
# exit-code            2
# env-file             ~/.opam/log/stringext-23-0930b4.env
# output-file          ~/.opam/log/stringext-23-0930b4.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```