### PR TITLE
[new release] current_web, current_slack, current_rpc, current_gitlab, current_github, current_git, current_examples, current_docker and current (0.6.2)

### DIFF
--- a/packages/current/current.0.6.2/opam
+++ b/packages/current/current.0.6.2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "current_incr" {>= "0.5"}
+  "fmt" {>= "0.8.9"}
+  "bos"
+  "ppx_deriving"
+  "lwt" {>= "4.3.0"}
+  "cmdliner" {>= "1.1.0"}
+  "sqlite3"
+  "duration"
+  "prometheus"
+  "dune" {>= "2.9"}
+  "re" {>= "1.9.0"}
+  "lwt-dllist"
+  "alcotest" {>= "1.2.0" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "prometheus-app" {with-test & >= "1.2"}
+  "conf-libev" {os != "win32"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_docker/current_docker.0.6.2/opam
+++ b/packages/current_docker/current_docker.0.6.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "ppx_deriving"
+  "lwt"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_examples/current_examples.0.6.2/opam
+++ b/packages/current_examples/current_examples.0.6.2/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt"
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_gitlab" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.5"}
+  "dune" {>= "2.9"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0"}
+  "dockerfile" {>= "7.0.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "routes" {>= "0.8.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "prometheus-app" {>= "1.2"}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_git/current_git.0.6.2/opam
+++ b/packages/current_git/current_git.0.6.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "conf-git"
+  "fmt" {>= "0.8.9"}
+  "ppx_deriving"
+  "lwt"
+  "irmin-watcher"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_github/current_github.0.6.2/opam
+++ b/packages/current_github/current_github.0.6.2/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt"
+  "duration"
+  "ptime"
+  "yojson"
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "hex" {>= "1.4.0"}
+  "x509" {>= "0.10.0"}
+  "tls" {>= "0.11.0"}
+  "dune" {>= "2.9"}
+  "github-unix" {>= "4.4.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_gitlab/current_gitlab.0.6.2/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "GitLab plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitLab.
+It can monitor and clone remote GitLab repositories, and can
+push GitLab status messages to show the results of testing
+PRs and branches."""
+maintainer: "timmcgil@gmail.com"
+authors: "timmcgil@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt"
+  "yojson"
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "dune" {>= "2.9"}
+  "gitlab-unix" {>= "0.1.4"}
+  "cmdliner" {>= "1.1.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_rpc/current_rpc.0.6.2/opam
+++ b/packages/current_rpc/current_rpc.0.6.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.4"}
+  "fpath"
+  "dune" {>= "2.9"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.3.0"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_slack/current_slack.0.6.2/opam
+++ b/packages/current_slack/current_slack.0.6.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "yojson"
+  "lwt"
+  "tls" {>= "0.12.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "dune" {>= "2.9"}
+  "logs" {>= "0.7.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"

--- a/packages/current_web/current_web.0.6.2/opam
+++ b/packages/current_web/current_web.0.6.2/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "crunch" {>= "3.2.0" & build}
+  "current" {= version}
+  "ansi" {>= "0.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "base64"
+  "session"
+  "session-cohttp-lwt"
+  "mirage-crypto" {>= "0.8.7"}
+  "mirage-crypto-rng"
+  "fmt" {>= "0.8.9"}
+  "bos"
+  "lwt"
+  "multipart_form-lwt" {>= "0.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "prometheus" {>= "0.7"}
+  "prometheus-app" {>= "1.2"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "tyxml" {>= "4.4.0"}
+  "csv" {>= "2.4"}
+  "routes" {>= "0.8.0"}
+  "dune" {>= "2.9"}
+  "conf-graphviz"
+  "astring" {>= "0.8.5"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "cstruct" {>= "5.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.2/current-0.6.2.tbz"
+  checksum: [
+    "sha256=ed312cab4ce8d13b9547ee2f935a6954f1d5211de1c22d44d85baaeb9f5fca9d"
+    "sha512=c2981a2c7f05bd6f235662b74ee3a679cc395be3d2cca808fac3dc562d6307e8bfe05efff40f42fa4738443cc2fe13929bab9d815c43d741950e5e0e1e6da7a6"
+  ]
+}
+x-commit-hash: "64a208a9021803ddbe443f86d7cf84692450d710"


### PR DESCRIPTION
Test web UI for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>

##### CHANGES:

Web UI:

- Update prometheus-app to support version 1.2.

Plugins:

- GitLab plugin depend on ocaml-gitlab >= "0.1.4" to include bugfixes.
