### PR TITLE
[new release] runtime_events_tools (0.1)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.1/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/sadiqj/runtime_events_tools"
+bug-reports: "https://github.com/sadiqj/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sadiqj/runtime_events_tools.git"
+url {
+  src:
+    "https://github.com/sadiqj/runtime_events_tools/releases/download/0.1/runtime_events_tools-0.1.tbz"
+  checksum: [
+    "sha256=a3074ab50665f81e2dd29cb7df84c30d841855c50759814d88c8d446f406d823"
+    "sha512=d8c45566657d6f5e6572c7bdc6491111f774b2ca93e05ee357485b942f0d97151f09027422472bd9b8060bd06f1171c8b37b8588fef65ce7c9cda8a505193297"
+  ]
+}
+x-commit-hash: "e0f3b6453622bb1867044b9abe10d366295c6ab6"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/sadiqj/runtime_events_tools">https://github.com/sadiqj/runtime_events_tools</a>

##### CHANGES:

0.1:
 * Initial opam release
