### PR TITLE
swhid.0.2

### DIFF
--- a/packages/swhid/swhid.0.2/opam
+++ b/packages/swhid/swhid.0.2/opam
@@ -34,6 +34,9 @@ depends: [
   "bisect_ppx" {with-test & >= "2.6" & dev}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/swhid/swhid.0.2/opam
+++ b/packages/swhid/swhid.0.2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "OCaml library to work with Software Heritage identifiers"
+description:
+  "swhid is an OCaml library to work with persistent identifiers found in Software Heritage"
+maintainer: [
+  "Léo Andrès <contact@ndrs.fr>"
+  "Dario Pinto <dario.pinto@ocamlpro.com>"
+]
+authors: [
+  "Léo Andrès <contact@ndrs.fr>"
+  "Dario Pinto <dario.pinto@ocamlpro.com>"
+]
+license: "ISC"
+tags: [
+  "swh"
+  "software"
+  "heritage"
+  "archive"
+  "swhid"
+  "persistent"
+  "identifier"
+]
+homepage: "https://github.com/ocamlpro/swhid"
+bug-reports: "https://github.com/ocamlpro/swhid/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "digestif" {>= "1.0.0"}
+  "jsonm" {>= "1.0.1"}
+  "ezcurl" {>= "0.1"}
+  "bos" {>= "0.2.0"}
+  "fpath"
+  "swhid_core"
+  "bisect_ppx" {with-test & >= "2.6" & dev}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocamlpro/swhid.git"
+url {
+  src: "https://github.com/OCamlPro/swhid/archive/refs/tags/0.2.tar.gz"
+  checksum: [
+    "sha256=c766eabb38217946195f506ff570aa19fd0e3b81a5c210d7c15b3df4cd39d1f7"
+    "sha512=77dd69bded58920963dcbbde7d3e61b68e05e7a12e2a5eaf821ba1e5fe8d076dfe2695303d5bed182b075f333dffa9f6e8638bd89ede3db2bdeaf7098d613479"
+  ]
+}


### PR DESCRIPTION
Hi,

I updated `swhid` to use the latest `swhid_core`.

Now, both `swhid_compute` and `swhid_types` are deprecated. The policy is still the same (not removing anything) ? I believe they've never been used by anyone so it would be simpler to delete them. But if you prefer I can mark them as deprecated.