### PR TITLE
[new release] runtime_events_tools (0.2)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.2/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/sadiqj/runtime_events_tools/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "5.0.0~"}
-  "ocamlfind" # Required until https://github.com/ocaml/ocaml/pull/11007 goes through (alpha1?) or runtime_events is added to the list of builtin libraries in dune
+  "ocamlfind" # TODO: Required until https://github.com/ocaml/ocaml/pull/11007 goes through (alpha1?) or runtime_events is added to the list of builtin libraries in dune
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/runtime_events_tools/runtime_events_tools.0.2/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/sadiqj/runtime_events_tools"
+bug-reports: "https://github.com/sadiqj/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "ocamlfind"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sadiqj/runtime_events_tools.git"
+url {
+  src:
+    "https://github.com/sadiqj/runtime_events_tools/releases/download/0.2/runtime_events_tools-0.2.tbz"
+  checksum: [
+    "sha256=badd66ccf50b591f8de7957fffedfd94d8eab1204d7447c954c6c06f6f5ff026"
+    "sha512=b9ce5ecc19eae8196a0f6ad10d06c98f78581402fd7b9f0bb6d46a8bf5ea1885a15a235dbaede7aa1196c1c39b307818fdca004189ede8f1a93800eb17c82c49"
+  ]
+}
+x-commit-hash: "f5d35c5ae7d5f7847b3b1c70ce1f687a6010f08e"

--- a/packages/runtime_events_tools/runtime_events_tools.0.2/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/sadiqj/runtime_events_tools/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "5.0.0~"}
-  "ocamlfind"
+  "ocamlfind" # Required until https://github.com/ocaml/ocaml/pull/11007 goes through (alpha1?) or runtime_events is added to the list of builtin libraries in dune
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/sadiqj/runtime_events_tools">https://github.com/sadiqj/runtime_events_tools</a>

##### CHANGES:

0.1:
 * Initial opam release
