### PR TITLE
stdint < 0.5.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/stdint/stdint.0.3.0-0/opam
+++ b/packages/stdint/stdint.0.3.0-0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "stdint"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}

--- a/packages/stdint/stdint.0.4.0/opam
+++ b/packages/stdint/stdint.0.4.0/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "project"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/stdint/stdint.0.4.1/opam
+++ b/packages/stdint/stdint.0.4.1/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "project"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/stdint/stdint.0.4.2/opam
+++ b/packages/stdint/stdint.0.4.2/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "stdint"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}

--- a/packages/stdint/stdint.0.5.0/opam
+++ b/packages/stdint/stdint.0.5.0/opam
@@ -19,7 +19,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "stdint"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling stdint.0.4.2 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/stdint.0.4.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/stdint-23-1248b6.env
# output-file          ~/.opam/log/stdint-23-1248b6.out
### output ###
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```