### PR TITLE
Package smtlib-utils.0.4

### DIFF
--- a/packages/smtlib-utils/smtlib-utils.0.4/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.4/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Parser for SMTLIB2"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "menhir" {build}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.08.0" }
+  "catapult" { with-test }
+  "catapult-file" { with-test }
+]
+tags: [ "SMTLIB" "smt2" "parse" "logic" ]
+homepage: "https://github.com/c-cube/smtlib-utils/"
+bug-reports: "https://github.com/c-cube/smtlib-utils/issues"
+dev-repo: "git+https://github.com/c-cube/smtlib-utils.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/smtlib-utils/archive/v0.4.tar.gz"
+  checksum: [
+    "md5=ab7e8e99a3b977941e6900c531f126af"
+    "sha512=23e5d2b8274186f49a43ef23b8e64d76d4098e9b8f50b65958d16ec0afde745d0ce12cc6c6beec29abf91596c32cae05404a80aa21afacde5b8c15fd9711ba62"
+  ]
+}
+

--- a/packages/smtlib-utils/smtlib-utils.0.4/opam
+++ b/packages/smtlib-utils/smtlib-utils.0.4/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "dune" { >= "2.0" }
-  "menhir" {build}
+  "menhir" {build & >= "20180523"}
   "odoc" {with-doc}
   "ocaml" { >= "4.08.0" }
   "catapult" { with-test }


### PR DESCRIPTION
### `smtlib-utils.0.4`
Parser for SMTLIB2



---
* Homepage: https://github.com/c-cube/smtlib-utils/
* Source repo: git+https://github.com/c-cube/smtlib-utils.git
* Bug tracker: https://github.com/c-cube/smtlib-utils/issues

---
:camel: Pull-request generated by opam-publish v2.1.0