### PR TITLE
integers < 0.6.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/integers/integers.0.1.0/opam
+++ b/packages/integers/integers.0.1.0/opam
@@ -12,7 +12,7 @@ build:
 [[ "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/integers/integers.0.2.0/opam
+++ b/packages/integers/integers.0.2.0/opam
@@ -12,7 +12,7 @@ build:
 [[ "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/integers/integers.0.2.1/opam
+++ b/packages/integers/integers.0.2.1/opam
@@ -12,7 +12,7 @@ build:
 [[ "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/integers/integers.0.2.2/opam
+++ b/packages/integers/integers.0.2.2/opam
@@ -12,7 +12,7 @@ build:
 [[ "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build & != "0.9.0"}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/integers/integers.0.3.0/opam
+++ b/packages/integers/integers.0.3.0/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "dune"
 ]
 doc: "http://ocamllabs.github.io/ocaml-integers/api.docdir/"

--- a/packages/integers/integers.0.4.0/opam
+++ b/packages/integers/integers.0.4.0/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "dune"
 ]
 doc: "http://ocamllabs.github.io/ocaml-integers/api.docdir/"

--- a/packages/integers/integers.0.5.0/opam
+++ b/packages/integers/integers.0.5.0/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune"
 ]
 doc: "http://ocamllabs.github.io/ocaml-integers/api.docdir/"

--- a/packages/integers/integers.0.5.1/opam
+++ b/packages/integers/integers.0.5.1/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "dune"
 ]
 doc: "http://ocamllabs.github.io/ocaml-integers/api.docdir/"


### PR DESCRIPTION
```
#=== ERROR while compiling integers.0.5.1 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/integers.0.5.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p integers -j 31
# exit-code            1
# env-file             ~/.opam/log/integers-10-cd37ab.env
# output-file          ~/.opam/log/integers-10-cd37ab.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.integers.objs/byte -intf-suffix .ml -no-alias-deps -o src/.integers.objs/byte/unsigned.cmo -c -impl src/unsigned.ml)
# File "src/unsigned.ml", line 104, characters 32-50:
# 104 |   let compare (x : t) (y : t) = Pervasives.compare x y
#                                       ^^^^^^^^^^^^^^^^^^
# Error: The module Pervasives is an alias for module Pervasives, which is missing
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.integers.objs/byte -I src/.integers.objs/native -intf-suffix .ml -no-alias-deps -o src/.integers.objs/native/unsigned.cmx -c -impl src/unsigned.ml)
# File "src/unsigned.ml", line 104, characters 32-50:
# 104 |   let compare (x : t) (y : t) = Pervasives.compare x y
#                                       ^^^^^^^^^^^^^^^^^^
# Error: The module Pervasives is an alias for module Pervasives, which is missing
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.integers.objs/byte -intf-suffix .ml -no-alias-deps -o src/.integers.objs/byte/signed.cmo -c -impl src/signed.ml)
# File "src/signed.ml", line 79, characters 18-36:
# 79 |     let max_int = Pervasives.max_int
#                        ^^^^^^^^^^^^^^^^^^
# Error: The module Pervasives is an alias for module Pervasives, which is missing
```