### PR TITLE
stdint is not compatible with OCaml 5.0

### DIFF
--- a/packages/stdint/stdint.0.5.1/opam
+++ b/packages/stdint/stdint.0.5.1/opam
@@ -16,7 +16,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "jbuilder" {>= "1.0+beta7"}
 ]

--- a/packages/stdint/stdint.0.6.0/opam
+++ b/packages/stdint/stdint.0.6.0/opam
@@ -22,7 +22,7 @@ homepage: "https://github.com/andrenth/ocaml-stdint"
 doc: "https://andrenth.github.io/ocaml-stdint/"
 bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "dune" {>= "1.11"}
 ]
 build: [

--- a/packages/stdint/stdint.0.7.0/opam
+++ b/packages/stdint/stdint.0.7.0/opam
@@ -23,7 +23,7 @@ other integer type (including int, float and nativeint), parsing from and
 conversion to readable strings (binary, octal, decimal, hexademical), conversion
 to and from buffers in both big endian and little endian byte order."""
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "odoc" {with-doc}
   "dune" {>= "1.10"}
 ]


### PR DESCRIPTION
Makes packages using it fail at link time. e.g.
```
#=== ERROR while compiling catapult-daemon.0.1.1 ==============================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | pinned(https://github.com/AestheticIntegration/catapult/archive/v0.1.1.tar.gz)
# path                 ~/.opam/5.0/.opam-switch/build/catapult-daemon.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p catapult-daemon -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/catapult-daemon-4247-f7a71e.env
# output-file          ~/.opam/log/catapult-daemon-4247-f7a71e.out
### output ###
# File "src/daemon/dune", line 3, characters 8-23:
# 3 |   (name catapult_daemon)
#             ^^^^^^^^^^^^^^^
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -safe-string -warn-error -a+8 -g -inline 200 -o src/daemon/catapult_daemon.exe /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/5.0/lib/ocaml /home/opam/.opam/5.0/lib/catapult/catapult.cmxa /home/opam/.opam/5.0/lib/catapult/utils/catapult_utils.cmxa /home/opam/.opam/5.0/lib/sqlite3/sqlite3.cmxa -I /home/opam/.opam/5.0/lib/sqlite3 /home/opam/.opam/5.0/lib/directories/directories.cmxa /home/opam/.opam/5.0/lib/catapult-sqlite/catapult_sqlite.cmxa /home/opam/.opam/5.0/lib/stdint/stdint.cmxa -I /home/opam/.opam/5.0/lib/stdint /home/opam/.opam/5.0/lib/zmq/zmq.cmxa -I /home/opam/.opam/5.0/lib/zmq /home/opam/.opam/5.0/lib/logs/logs.cmxa src/daemon/.catapult_daemon.eobjs/native/dune__exe__Catapult_daemon.cmx)
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int32_conv.o): in function `int32_of_int':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int32_conv.c:33: undefined reference to `copy_int32'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int32_conv.o): in function `int32_of_nativeint':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int32_conv.c:40: undefined reference to `copy_int32'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int32_conv.o): in function `int32_of_float':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int32_conv.c:47: undefined reference to `copy_int32'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int32_conv.o): in function `int32_of_int8':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int32_conv.c:54: undefined reference to `copy_int32'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int32_conv.o): in function `int32_of_int16':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int32_conv.c:61: undefined reference to `copy_int32'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int32_conv.o):/home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int32_conv.c:68: more undefined references to `copy_int32' follow
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int40_conv.o): in function `int40_of_int':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int40_conv.c:33: undefined reference to `copy_int64'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int40_conv.o): in function `int40_of_nativeint':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int40_conv.c:40: undefined reference to `copy_int64'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int40_conv.o): in function `int40_of_float':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int40_conv.c:47: undefined reference to `copy_int64'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int40_conv.o): in function `int40_of_int8':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int40_conv.c:54: undefined reference to `copy_int64'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int40_conv.o): in function `int40_of_int16':
# /home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int40_conv.c:61: undefined reference to `copy_int64'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/stdint/libstdint_stubs.a(int40_conv.o):/home/opam/.opam/5.0/.opam-switch/build/stdint.0.7.0/_build/default/lib/int40_conv.c:68: more undefined references to `copy_int64' follow
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```
Upstream PR: https://github.com/andrenth/ocaml-stdint/pull/68