### PR TITLE
Remove dependency on `base-bytes` for packages that use jbuilder/dune

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8.1/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.1/opam
@@ -16,7 +16,6 @@ build: [
 depends: [
   "ocaml"
   "dune"
-  "base-bytes"
   "base-unix"
 ]
 synopsis: "Basic control of ANSI compliant terminals and the windows shell"

--- a/packages/ANSITerminal/ANSITerminal.0.8.2/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.2/opam
@@ -16,7 +16,6 @@ build: [
 depends: [
   "ocaml"
   "dune"
-  "base-bytes"
   "base-unix"
 ]
 synopsis: "Basic control of ANSI compliant terminals and the windows shell"

--- a/packages/ANSITerminal/ANSITerminal.0.8.3/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.3/opam
@@ -16,7 +16,6 @@ build: [
 depends: [
   "ocaml"
   "dune"
-  "base-bytes"
   "base-unix"
 ]
 synopsis: "Basic control of ANSI compliant terminals and the windows shell"

--- a/packages/ANSITerminal/ANSITerminal.0.8.4/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.4/opam
@@ -16,7 +16,6 @@ build: [
 depends: [
   "ocaml"
   "dune" {>= "2.0"}
-  "base-bytes"
   "base-unix"
 ]
 synopsis: "Basic control of ANSI compliant terminals and the windows shell"

--- a/packages/ANSITerminal/ANSITerminal.0.8/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8/opam
@@ -16,7 +16,6 @@ build: [
 depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta7"}
-  "base-bytes"
   "base-unix"
 ]
 synopsis: "Basic control of ANSI compliant terminals and the windows shell"


### PR DESCRIPTION
This package is never required since jbuilder/dune require OCaml 4.02 and 4.02 has Bytes out of the box.

This PR is an exploration of the explanation given by @dra27 in https://github.com/ocaml/opam-repository/pull/21333#issuecomment-1153276739 to see how much breakage will happen if these extraneous dependencies are removed.

For now a draft, will require a few more iterations to capture all affected packages and possibly add patches to them.