### PR TITLE
kmt v0.1; initial add to the repo

### DIFF
--- a/packages/kmt/kmt.0.1/opam
+++ b/packages/kmt/kmt.0.1/opam
@@ -1,10 +1,8 @@
 opam-version: "2.0"
-name: "kmt"
-version: "0.1"
 synopsis: "Framework for deriving Kleene Algebras with Tests (KAT)"
 maintainer: "Michael Greenberg <michael@greenberg.science>"
 authors: "Michael Greenberg <michael@greenberg.science>"
-license: "BSD"
+license: "MIT"
 homepage: "https://github.com/mgree/kmt"
 bug-reports: "https://github.com/mgree/kmt/issues"
 depends: [
@@ -17,11 +15,12 @@ depends: [
   "logs" {>= "0.7"}
   "cmdliner" {>= "1.0.4"}
   "ppx_deriving" {>= "5.2"}
+  "dune" {>= "2.9"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https:///github.com/mgree/kmt"
 url {
   src: "https://github.com/mgree/kmt/archive/refs/tags/0.1.tar.gz"
-  checksum: "md5=9dec0e043b4dc1e9b8ee29ae4ff78db6"
+  checksum: "md5=51bb11c18b43cc76b50e67c4933ecef7"
 }
 

--- a/packages/kmt/kmt.0.1/opam
+++ b/packages/kmt/kmt.0.1/opam
@@ -15,12 +15,12 @@ depends: [
   "logs" {>= "0.7"}
   "cmdliner" {>= "1.0.4"}
   "ppx_deriving" {>= "5.2"}
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https:///github.com/mgree/kmt"
 url {
   src: "https://github.com/mgree/kmt/archive/refs/tags/0.1.tar.gz"
-  checksum: "md5=51bb11c18b43cc76b50e67c4933ecef7"
+  checksum: "md5=d459c09e7045837074588e962a064c97"
 }
 

--- a/packages/kmt/kmt.0.1/opam
+++ b/packages/kmt/kmt.0.1/opam
@@ -11,9 +11,9 @@ depends: [
   "batteries" {>= "3.5"}
   "ANSITerminal" {>= "0.8"}
   "fmt" {>= "0.9"}
-  "alcotest" {>= "1.4"}
+  "alcotest" {>= "1.5"}
   "logs" {>= "0.7"}
-  "cmdliner" {>= "1.0.4"}
+  "cmdliner" {>= "1.1"}
   "ppx_deriving" {>= "5.2"}
   "dune" {>= "3.0"}
 ]
@@ -21,6 +21,5 @@ build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https:///github.com/mgree/kmt"
 url {
   src: "https://github.com/mgree/kmt/archive/refs/tags/0.1.tar.gz"
-  checksum: "md5=d459c09e7045837074588e962a064c97"
+  checksum: "md5=55d4e5443ae5f8ebf6d539ea6ca564d8"
 }
-

--- a/packages/kmt/kmt.0.1/opam
+++ b/packages/kmt/kmt.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "kmt"
+version: "0.1"
+synopsis: "Framework for deriving Kleene Algebras with Tests (KAT)"
+maintainer: "Michael Greenberg <michael@greenberg.science>"
+authors: "Michael Greenberg <michael@greenberg.science>"
+license: "BSD"
+homepage: "https://github.com/mgree/kmt"
+bug-reports: "https://github.com/mgree/kmt/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "z3" {>= "4.8"}
+  "batteries" {>= "3.5"}
+  "ANSITerminal" {>= "0.8"}
+  "fmt" {>= "0.9"}
+  "alcotest" {>= "1.4"}
+  "logs" {>= "0.7"}
+  "cmdliner" {>= "1.0.4"}
+  "ppx_deriving" {>= "5.2"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https:///github.com/mgree/kmt"
+url {
+  src: "https://github.com/mgree/kmt/archive/refs/tags/0.1.tar.gz"
+  checksum: "md5=9dec0e043b4dc1e9b8ee29ae4ff78db6"
+}
+


### PR DESCRIPTION
This is the initial add of KMT to OPAM. 😁 

Tests are green on our end: https://github.com/mgree/kmt/actions/runs/2543196473.

