### PR TITLE
5 packages from ocsigen/lwt

### DIFF
--- a/packages/lwt/lwt.5.6.0/opam
+++ b/packages/lwt/lwt.5.6.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.8.0"}
+  "dune-configurator"
+  "ocaml" {>= "4.08"}
+  "ocplib-endian"
+
+  # Until https://github.com/aantron/bisect_ppx/pull/327.
+  # "bisect_ppx" {dev & >= "2.0.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+build: [
+  ["dune" "exec" "-p" name "src/unix/config/discover.exe" "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
+  checksum: [
+    "md5=e63979ee40a80d5b9e9e5545f33323b4"
+    "sha512=d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
+  ]
+}

--- a/packages/lwt/lwt.5.6.0/opam
+++ b/packages/lwt/lwt.5.6.0/opam
@@ -40,14 +40,16 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 
-description: "A promise is a value that may become determined in the future.
+description: """
+A promise is a value that may become determined in the future.
 
 Lwt provides typed, composable promises. Promises that are resolved by I/O are
 resolved by Lwt in parallel.
 
 Meanwhile, OCaml code, including code creating and waiting on promises, runs in
 a single thread by default. This reduces the need for locks or other
-synchronization primitives. Code can be run in parallel on an opt-in basis."
+synchronization primitives. Code can be run in parallel on an opt-in basis.
+"""
 url {
   src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
   checksum: [

--- a/packages/lwt_domain/lwt_domain.0.2.0/opam
+++ b/packages/lwt_domain/lwt_domain.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using Domainslib with Lwt"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Lwt_domain"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Sudha Parimala"
+]
+maintainer: [
+  "Sudha Parimala"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt" {>= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "domainslib" {>= "0.3.2"}
+  "base-domains"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
+  checksum: [
+    "md5=e63979ee40a80d5b9e9e5545f33323b4"
+    "sha512=d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
+  ]
+}

--- a/packages/lwt_ppx/lwt_ppx.2.1.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.1.0/opam
@@ -19,7 +19,6 @@ depends: [
   "lwt"
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.16.0"}
-  "ocaml" {>= "4.08"}
 ]
 
 build: [

--- a/packages/lwt_ppx/lwt_ppx.2.1.0/opam
+++ b/packages/lwt_ppx/lwt_ppx.2.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "PPX syntax for Lwt, providing something similar to async/await from JavaScript"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Ppx_lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Gabriel Radanne"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt"
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.16.0"}
+  "ocaml" {>= "4.08"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
+  checksum: [
+    "md5=e63979ee40a80d5b9e9e5545f33323b4"
+    "sha512=d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
+  ]
+}

--- a/packages/lwt_ppx_let/lwt_ppx_let.5.6.0/opam
+++ b/packages/lwt_ppx_let/lwt_ppx_let.5.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "Dummy package context for ppx_let tests"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt"
+  "ppx_let" {with-test}
+  "ocaml" {>= "4.08"}
+]
+
+description: "Internal package used to partition ppx_let tests."
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
+  checksum: [
+    "md5=e63979ee40a80d5b9e9e5545f33323b4"
+    "sha512=d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
+  ]
+}

--- a/packages/lwt_react/lwt_react.1.2.0/opam
+++ b/packages/lwt_react/lwt_react.1.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using React with Lwt"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/dev/api/Lwt_react"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt" {>= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.6.0.tar.gz"
+  checksum: [
+    "md5=e63979ee40a80d5b9e9e5545f33323b4"
+    "sha512=d616389bc9e0da11f25843ab7541ac2d40c9543700a89455f14115b339bbe58cef2b8acf0ae97fd54e15a4cb93149cfe1ebfda301aa93933045f76b7d9344160"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`lwt.5.6.0`: Promises and event-driven I/O
-`lwt_domain.0.2.0`: Helpers for using Domainslib with Lwt
-`lwt_ppx.2.1.0`: PPX syntax for Lwt, providing something similar to async/await from JavaScript
-`lwt_ppx_let.5.6.0`: Dummy package context for ppx_let tests
-`lwt_react.1.2.0`: Helpers for using React with Lwt



---
* Homepage: https://github.com/ocsigen/lwt
* Source repo: git+https://github.com/ocsigen/lwt.git
* Bug tracker: https://github.com/ocsigen/lwt/issues

---
:camel: Pull-request generated by opam-publish v2.1.0