### PR TITLE
bap-std >= 2.1.0 explicitly requires mmap

### DIFF
--- a/packages/bap-std/bap-std.2.1.0/opam
+++ b/packages/bap-std/bap-std.2.1.0/opam
@@ -51,6 +51,7 @@ depends: [
   "ogre"
   "monads"
   "result"
+  "mmap"
 ]
 depexts: [
   ["libgmp-dev" "libzip-dev" "clang"] {os-distribution = "ubuntu"}

--- a/packages/bap-std/bap-std.2.2.0/opam
+++ b/packages/bap-std/bap-std.2.2.0/opam
@@ -53,6 +53,7 @@ depends: [
   "ogre" {= "2.2.0"}
   "monads" {= "2.2.0"}
   "result"
+  "mmap"
 ]
 depexts: [
   ["libgmp-dev" "libzip-dev" "clang"] {os-distribution = "ubuntu"}

--- a/packages/bap-std/bap-std.2.3.0/opam
+++ b/packages/bap-std/bap-std.2.3.0/opam
@@ -53,6 +53,7 @@ depends: [
   "ogre" {= "2.3.0"}
   "monads" {= "2.3.0"}
   "result"
+  "mmap"
   "conf-gmp" {build}
   "conf-zlib" {build}
   "conf-clang" {build}

--- a/packages/bap-std/bap-std.2.4.0/opam
+++ b/packages/bap-std/bap-std.2.4.0/opam
@@ -53,6 +53,7 @@ depends: [
   "ogre" {= "2.4.0"}
   "monads" {= "2.4.0"}
   "result"
+  "mmap"
   "conf-gmp"
   "conf-clang"
   "conf-perl"


### PR DESCRIPTION
cc @ivg 
```
#=== ERROR while compiling bap-std.2.4.0 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/bap-std.2.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/4.14 --with-cxx=`which clang++` --mandir=/home/opam/.opam/4.14/man --enable-bap-std
# exit-code            1
# env-file             ~/.opam/log/bap-std-38696-3cb64f.env
# output-file          ~/.opam/log/bap-std-38696-3cb64f.out
### output ###
# File "oasis/common.setup.ml.in", line 573, characters 4-15:
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 601, characters 19-36:
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 608, characters 37-48:
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 611, characters 17-31:
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1429, characters 16-33:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1431, characters 22-38:
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1432, characters 14-26:
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1433, characters 11-23:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1433, characters 28-40:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1434, characters 11-23:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1434, characters 28-41:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1435, characters 11-24:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "oasis/common.setup.ml.in", line 1436, characters 11-23:
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3176, characters 8-19:
# 3176 |         Stream.from
#                ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3179, characters 21-32:
# 3179 |                match Stream.next st with
#                             ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3182, characters 18-32:
# 3182 |              with Stream.Failure -> None)
#                          ^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3184, characters 6-23:
# 3184 |       Genlex.make_lexer ["="] st_line
#              ^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3187, characters 12-24:
# 3187 |       match Stream.npeek 3 lxr with
#                    ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3188, characters 9-21:
# 3188 |       | [Genlex.Ident nm; Genlex.Kwd "="; Genlex.String value] ->
#                 ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3188, characters 26-36:
# 3188 |       | [Genlex.Ident nm; Genlex.Kwd "="; Genlex.String value] ->
#                                  ^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3188, characters 42-55:
# 3188 |       | [Genlex.Ident nm; Genlex.Kwd "="; Genlex.String value] ->
#                                                  ^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3189, characters 8-19:
# 3189 |         Stream.junk lxr; Stream.junk lxr; Stream.junk lxr;
#                ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3189, characters 25-36:
# 3189 |         Stream.junk lxr; Stream.junk lxr; Stream.junk lxr;
#                                 ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3189, characters 42-53:
# 3189 |         Stream.junk lxr; Stream.junk lxr; Stream.junk lxr;
#                                                  ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3201, characters 17-34:
# 3201 |         let st = Stream.of_channel chn in
#                         ^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3326, characters 16-33:
# 3326 |   let var_lxr = Genlex.make_lexer []
#                        ^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3345, characters 22-38:
# 3345 |              var_lxr (Stream.of_string var)
#                              ^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3347, characters 17-29:
# 3347 |            match Stream.npeek 3 st with
#                         ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 3348, characters 16-28:
# 3348 |              | [Genlex.Ident "utoh"; Genlex.Ident nm] ->
#                        ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3348, characters 37-49:
# 3348 |              | [Genlex.Ident "utoh"; Genlex.Ident nm] ->
#                                             ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3350, characters 16-28:
# 3350 |              | [Genlex.Ident "utoh"; Genlex.String s] ->
#                        ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3350, characters 37-50:
# 3350 |              | [Genlex.Ident "utoh"; Genlex.String s] ->
#                                             ^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3352, characters 16-28:
# 3352 |              | [Genlex.Ident "ocaml_escaped"; Genlex.Ident nm] ->
#                        ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3352, characters 46-58:
# 3352 |              | [Genlex.Ident "ocaml_escaped"; Genlex.Ident nm] ->
#                                                      ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3354, characters 16-28:
# 3354 |              | [Genlex.Ident "ocaml_escaped"; Genlex.String s] ->
#                        ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3354, characters 46-59:
# 3354 |              | [Genlex.Ident "ocaml_escaped"; Genlex.String s] ->
#                                                      ^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3356, characters 16-28:
# 3356 |              | [Genlex.Ident nm] ->
#                        ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 3369, characters 13-25:
# 3369 |            | Stream.Error e ->
#                     ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 4518, characters 21-38:
# 4518 |            let lxr = Genlex.make_lexer [] (stream_of_reader rdr) in
#                             ^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 4520, characters 19-31:
# 4520 |              match Stream.npeek 2 lxr with
#                           ^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 4521, characters 16-29:
# 4521 |              | [Genlex.String e; Genlex.String d] ->
#                        ^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 4521, characters 33-46:
# 4521 |              | [Genlex.String e; Genlex.String d] ->
#                                         ^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Genlex
# Use the camlp-streams library instead.
# File "setup.ml", line 4523, characters 15-26:
# 4523 |                Stream.junk lxr; Stream.junk lxr;
#                       ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# File "setup.ml", line 4523, characters 32-43:
# 4523 |                Stream.junk lxr; Stream.junk lxr;
#                                        ^^^^^^^^^^^
# Alert deprecated: module Stdlib.Stream
# Use the camlp-streams library instead.
# ocamlfind: Package `mmap' not found
```