### PR TITLE
resto-cohttp-server >= 0.6 is not compatible with lwt 5.6.0

### DIFF
--- a/packages/resto-cohttp-server/resto-cohttp-server.0.6.1/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "resto-acl" {= version }
   "cohttp-lwt-unix" { >= "2.0.0" }
   "conduit-lwt-unix" { >= "2.0.0" }
-  "lwt" { >= "3.0.0" & < "6.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
 ]
 url {
   src:

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.6/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "resto-acl" {= version }
   "cohttp-lwt-unix" { >= "2.0.0"}
   "conduit-lwt-unix" { >= "2.0.0" & < "3.0.0" }
-  "lwt" { >= "3.0.0" & < "6.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
 ]
 url {
   src:

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.7/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.7/opam
@@ -19,7 +19,7 @@ depends: [
   "resto-acl" {= version }
   "cohttp-lwt-unix" { >= "2.0.0" }
   "conduit-lwt-unix" { >= "2.0.0" }
-  "lwt" { >= "3.0.0" & < "6.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
 ]
 url {
   src:

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.8/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.8/opam
@@ -19,7 +19,7 @@ depends: [
   "resto-acl" {= version }
   "cohttp-lwt-unix" { >= "2.0.0" }
   "conduit-lwt-unix" { >= "2.0.0" }
-  "lwt" { >= "3.0.0" & < "6.0.0" }
+  "lwt" { >= "3.0.0" & < "5.6.0" }
 ]
 url {
   src:


### PR DESCRIPTION
```
#=== ERROR while compiling resto-cohttp-server.0.6.1 ==========================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/resto-cohttp-server.0.6.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p resto-cohttp-server -j 31
# exit-code            1
# env-file             ~/.opam/log/resto-cohttp-server-19-eac5f0.env
# output-file          ~/.opam/log/resto-cohttp-server-19-eac5f0.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -open Resto_cohttp -open Resto_acl -g -bin-annot -I src/.resto_cohttp_server.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/resto -I /home/opam/.opam/4.14/lib/resto-acl -I /home/opam/.opam/4.14/lib/resto-cohttp -I /home/opam/.opam/4.14/lib/resto-directory -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -no-alias-deps -open Resto_cohttp_server -o src/.resto_cohttp_server.objs/byte/resto_cohttp_server__Server.cmi -c -intf src/server.mli)
# File "src/server.mli", line 109, characters 51-64:
# 109 |       (string * Media_type.t, [> `Not_acceptable]) Result.result
#                                                          ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```