### PR TITLE
ocplib-endian < 1.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/ocplib-endian/ocplib-endian.0.2/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.2/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocplib-endian"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "optcomp" {>= "1.6"}
   "camlp4"

--- a/packages/ocplib-endian/ocplib-endian.0.3/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.3/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocplib-endian"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "optcomp" {>= "1.6"}
   "camlp4"

--- a/packages/ocplib-endian/ocplib-endian.0.4/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.4/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocplib-endian"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "optcomp" {>= "1.6"}
   "camlp4"

--- a/packages/ocplib-endian/ocplib-endian.0.6/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.6/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocplib-endian"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind"
   "optcomp" {>= "1.6"}

--- a/packages/ocplib-endian/ocplib-endian.0.7/opam
+++ b/packages/ocplib-endian/ocplib-endian.0.7/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ocplib-endian"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind"
   "optcomp" {>= "1.6"}

--- a/packages/ocplib-endian/ocplib-endian.1.0/opam
+++ b/packages/ocplib-endian/ocplib-endian.1.0/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "ocplib-endian"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind"
   "cppo" {>= "1.1.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling ocplib-endian.1.0 ==================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocplib-endian.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --disable-debug --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/ocplib-endian-23-ff2cb9.env
# output-file          ~/.opam/log/ocplib-endian-23-ff2cb9.out
### output ###
# File "./setup.ml", line 1404, characters 23-41:
# 1404 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```