### PR TITLE
molenc >= 5.0.2 requires cpm >= 9.0.0 (type of TopKeeper.add changed)

### DIFF
--- a/packages/molenc/molenc.11.4.0/opam
+++ b/packages/molenc/molenc.11.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-graphviz"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "9.0.0"}
   "dokeysto_camltc"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}

--- a/packages/molenc/molenc.15.4.0/opam
+++ b/packages/molenc/molenc.15.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "conf-graphviz"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "9.0.0"}
   "dokeysto_camltc"
   "dolog" {>= "5.0.0"}
   "dune" {>= "1.11"}

--- a/packages/molenc/molenc.7.0.1/opam
+++ b/packages/molenc/molenc.7.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "bst"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "9.0.0"}
   "dokeysto"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}

--- a/packages/molenc/molenc.8.0.2/opam
+++ b/packages/molenc/molenc.8.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "bst"
   "conf-python-3"
   "conf-rdkit"
-  "cpm"
+  "cpm" {>= "9.0.0"}
   "dokeysto"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}


### PR DESCRIPTION
```
#=== ERROR while compiling molenc.8.0.2 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/molenc.8.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p molenc -j 31
# exit-code            1
# env-file             ~/.opam/log/molenc-19-1055d8.env
# output-file          ~/.opam/log/molenc-19-1055d8.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.encoder.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dokeysto -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/equeue -I /home/opam/.opam/4.14/lib/extunix -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/netcamlbox -I /home/opam/.opam/4.14/lib/netmulticore -I /home/opam/.opam/4.14/lib/netplex -I /home/opam/.opam/4.14/lib/netstring -I /home/opam/.opam/4.14/lib/netsys -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parany -I /home/opam/.opam/4.14/lib/rpc -I src/.molenc.objs/byte -no-alias-deps -o src/.encoder.eobjs/byte/filter.cmo -c -impl src/filter.ml)
# File "src/filter.ml", line 216, characters 28-33:
# 216 |               TopKeeper.add top_k score mol;
#                                   ^^^^^
# Error: This expression has type TopKeeper.t = Cpm.TopKeeper.t
#        but an expression was expected of type string
```