### PR TITLE
ez_api is not compatible with lwt 5.6.0

### DIFF
--- a/packages/ez_api/ez_api.0.1.0/opam
+++ b/packages/ez_api/ez_api.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.6"}
   "json-data-encoding" {>= "0.7.0"}
-  "lwt" {>= "4.0.0"}
+  "lwt" {>= "4.0.0" & < "5.6.0"}
   "ezjsonm" {>= "1.1.0"}
   "uuidm"
 ]

--- a/packages/ez_api/ez_api.1.0.0/opam
+++ b/packages/ez_api/ez_api.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
   "json-data-encoding" {>= "0.9"}
-  "lwt" {>= "4.0.0"}
+  "lwt" {>= "4.0.0" & < "5.6.0"}
   "ezjsonm" {>= "1.1.0"}
   "uuidm"
 ]

--- a/packages/ez_api/ez_api.1.1.1/opam
+++ b/packages/ez_api/ez_api.1.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
   "json-data-encoding" {>= "0.9"}
-  "lwt" {>= "4.0.0"}
+  "lwt" {>= "4.0.0" & < "5.6.0"}
   "ezjsonm" {>= "1.1.0"}
   "uuidm"
 ]


### PR DESCRIPTION
Uses Result.result without requiring the result library explicitly
```
#=== ERROR while compiling ez_api.1.1.1 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ez_api.1.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ez_api -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/ez_api-1761-db2940.env
# output-file          ~/.opam/log/ez_api-1761-db2940.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w +a-4-41-44-45-48-70 -warn-error -a -g -bin-annot -I src/request/.ezRequest.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/json-data-encoding -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/uutf -I src/common/.ezAPI.objs/byte -I src/common/virtual/.ezDebug.objs/byte -I src/common/virtual/.ezLwtSys.objs/byte -I src/encoding/.ezEncoding.objs/byte -I src/encoding/virtual/.ezjsonm_interface.objs/byte -I src/request/virtual/s/.ezReq_S.objs/byte -intf-suffix .ml -no-alias-deps -o src/request/.ezRequest.objs/byte/ezRequest.cmo -c -impl src/request/ezRequest.ml)
# File "src/request/ezRequest.ml", line 98, characters 25-38:
# 98 |       (('output, 'error) Result.result -> unit) ->
#                               ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -w +a-4-41-44-45-48-70 -warn-error -a -g -I src/request/.ezRequest.objs/byte -I src/request/.ezRequest.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/json-data-encoding -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/uutf -I src/common/.ezAPI.objs/byte -I src/common/.ezAPI.objs/native -I src/common/virtual/.ezDebug.objs/byte -I src/common/virtual/.ezDebug.objs/native -I src/common/virtual/.ezLwtSys.objs/byte -I src/common/virtual/.ezLwtSys.objs/native -I src/encoding/.ezEncoding.objs/byte -I src/encoding/.ezEncoding.objs/native -I src/encoding/virtual/.ezjsonm_interface.objs/byte -I src/encoding/virtual/.ezjsonm_interface.objs/native -I src/request/virtual/s/.ezReq_S.objs/byte -I src/request/virtual/s/.ezReq_S.objs/native -intf-suffix .ml -no-alias-deps -o src/request/.ezRequest.objs/native/ezRequest.cmx -c -impl src/request/ezRequest.ml)
# File "src/request/ezRequest.ml", line 98, characters 25-38:
# 98 |       (('output, 'error) Result.result -> unit) ->
#                               ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```
cc @maxtori 