### PR TITLE
tcpip >= 4.1.0 < 6.0.0 has a missing dependency to result

### DIFF
--- a/packages/tcpip/tcpip.4.1.0/opam
+++ b/packages/tcpip/tcpip.4.1.0/opam
@@ -23,6 +23,7 @@ depends: [
   "dune"
   "dune-configurator"
   "ocaml" {>= "4.06.0"}
+  "result"
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "cstruct-lwt"

--- a/packages/tcpip/tcpip.5.0.0/opam
+++ b/packages/tcpip/tcpip.5.0.0/opam
@@ -23,6 +23,7 @@ depends: [
   "dune"
   "dune-configurator"
   "ocaml" {>= "4.06.0"}
+  "result"
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "cstruct-lwt"

--- a/packages/tcpip/tcpip.5.0.1/opam
+++ b/packages/tcpip/tcpip.5.0.1/opam
@@ -23,6 +23,7 @@ depends: [
   "dune"
   "dune-configurator"
   "ocaml" {>= "4.06.0"}
+  "result"
   "rresult" {>= "0.5.0"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "cstruct-lwt"


### PR DESCRIPTION

```
#=== ERROR while compiling tcpip.5.0.1 ========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/tcpip.5.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build env OPAM_PKG_CONFIG_PATH=/home/opam/.opam/4.14/lib/pkgconfig dune build -p tcpip -j 31
# exit-code            1
# env-file             ~/.opam/log/tcpip-4877-100a20.env
# output-file          ~/.opam/log/tcpip-4877-100a20.out
### output ###
# File "src/stack-direct/dune", line 4, characters 28-34:
# 4 |  (libraries logs ipaddr lwt result fmt mirage-time mirage-random
#                                 ^^^^^^
# Error: Library "result" not found.
```