### PR TITLE
[new release] coq-serapi (8.15.0+0.15.2)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
@@ -31,7 +31,7 @@ depends: [
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3"               }
   "ppx_deriving"        {           >= "4.2.1"               }
-  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.16" }
+  "ppx_sexp_conv"       {           >= "v0.13.0" }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }
 ]

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.07.0"              }
+  "coq"                 {           >= "8.15" & < "8.16"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.16" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.15.0%2B0.15.2/coq-serapi-8.15.0.0.15.2.tbz"
+  checksum: [
+    "sha256=e252d05b41e920c1df4343c437be4018804971ecfd00291ddb4d31ce72281853"
+    "sha512=1f936181265346d0cd17ec292b98f201382ea84440b415b77664430044ba599072e653366f080d8b63ee5f8fe5bfc0d2cd2a38cc759532500d8c60a483fe36b7"
+  ]
+}
+x-commit-hash: "20f868bbf1a387852c3973f0afd60cab885d39b4"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [deps]   Support Jane Street libraries v0.15.0 (@ejgallego)
 - [deps]   Require cmdliner >= 1.1.0 (@ejgallego)
