### PR TITLE
Fix build of OCaml 4.09.1 with GCC 12.1

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
@@ -16,6 +16,7 @@ conflict-class: "ocaml-core-compiler"
 flags: compiler
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
+  ["sed" "-ib" "s/+dev1-2020-03-13//" "configure"]
   [
     "./configure"
     "--prefix=%{prefix}%"


### PR DESCRIPTION
OCaml 4.09.1 was released without the `configure` script being regenerated. This is entirely innocuous except that it enables `-Werror` for OCaml's C code, which obviously causes problems when new warnings are added the C compiler (as has happened with GCC 12.1).

We've been seeing this for a while in the [base image builder](https://images.ci.ocaml.org) as the 4.09.1 image has been failing to build on Arch. I'd guessed it was something to do with a bleeding-edge GCC, but it was https://github.com/ocaml/ocaml/issues/11358 which finally made me investigate.

Note that the `sed` command achieves _exactly_ the same effect as re-running `./autogen`.