### PR TITLE
[new release] alcotest, alcotest-mirage, alcotest-lwt, alcotest-js and alcotest-async (1.6.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.6.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.6.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "base"
+  "async_kernel"
+  "ocaml" {>= "4.11.0"}
+  "alcotest" {= version}
+  "async" {>= "v0.15.0"}
+  "async_unix" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.6.0/alcotest-1.6.0.tbz"
+  checksum: [
+    "sha256=fd00f9668395874ff3b1d7ef566d14efc02fa7dd34123eb25d59355be94b2329"
+    "sha512=69a7ef300ba10a9ccb1e25b1cfdb0a0abf9ca976864a52a22f0e1fae1e5d1cbeb99498c086230b839ee9da4d0fd71e63686e126ca42221537f3fdb6f6c5aae95"
+  ]
+}
+x-commit-hash: "6be328d73513db7f32173f86a997a59904fb1ee6"

--- a/packages/alcotest-js/alcotest-js.1.6.0/opam
+++ b/packages/alcotest-js/alcotest-js.1.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+description:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest" {= version}
+  "js_of_ocaml-compiler" {>= "3.11.0"}
+  "fmt" {with-test & >= "0.8.7"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.6.0/alcotest-1.6.0.tbz"
+  checksum: [
+    "sha256=fd00f9668395874ff3b1d7ef566d14efc02fa7dd34123eb25d59355be94b2329"
+    "sha512=69a7ef300ba10a9ccb1e25b1cfdb0a0abf9ca976864a52a22f0e1fae1e5d1cbeb99498c086230b839ee9da4d0fd71e63686e126ca42221537f3fdb6f6c5aae95"
+  ]
+}
+x-commit-hash: "6be328d73513db7f32173f86a997a59904fb1ee6"

--- a/packages/alcotest-lwt/alcotest-lwt.1.6.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt"
+  "ocaml" {>= "4.05.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.6.0/alcotest-1.6.0.tbz"
+  checksum: [
+    "sha256=fd00f9668395874ff3b1d7ef566d14efc02fa7dd34123eb25d59355be94b2329"
+    "sha512=69a7ef300ba10a9ccb1e25b1cfdb0a0abf9ca976864a52a22f0e1fae1e5d1cbeb99498c086230b839ee9da4d0fd71e63686e126ca42221537f3fdb6f6c5aae95"
+  ]
+}
+x-commit-hash: "6be328d73513db7f32173f86a997a59904fb1ee6"

--- a/packages/alcotest-mirage/alcotest-mirage.1.6.0/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt"
+  "ocaml" {>= "4.05.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.6.0/alcotest-1.6.0.tbz"
+  checksum: [
+    "sha256=fd00f9668395874ff3b1d7ef566d14efc02fa7dd34123eb25d59355be94b2329"
+    "sha512=69a7ef300ba10a9ccb1e25b1cfdb0a0abf9ca976864a52a22f0e1fae1e5d1cbeb99498c086230b839ee9da4d0fd71e63686e126ca42221537f3fdb6f6c5aae95"
+  ]
+}
+x-commit-hash: "6be328d73513db7f32173f86a997a59904fb1ee6"

--- a/packages/alcotest/alcotest.1.6.0/opam
+++ b/packages/alcotest/alcotest.1.6.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.05.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "stdlib-shims"
+  "uutf" {>= "1.0.1"}
+  "ocaml-syntax-shims"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.6.0/alcotest-1.6.0.tbz"
+  checksum: [
+    "sha256=fd00f9668395874ff3b1d7ef566d14efc02fa7dd34123eb25d59355be94b2329"
+    "sha512=69a7ef300ba10a9ccb1e25b1cfdb0a0abf9ca976864a52a22f0e1fae1e5d1cbeb99498c086230b839ee9da4d0fd71e63686e126ca42221537f3fdb6f6c5aae95"
+  ]
+}
+x-commit-hash: "6be328d73513db7f32173f86a997a59904fb1ee6"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- Fix a bug when running test concurently. Alcotest could fail to
  output the content of the log file. (#353, @hhugo)

- Require Cmdliner.1.1.0. (#339, @MisterDA)

- Upgrade to `async>=v0.15.0` (#352, @crackcomm)