### PR TITLE
angstrom-lwt-unix < 0.11.0 is not compatible with lwt 5.6.0

### DIFF
--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.10.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.10.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "base-unix"
 ]
 synopsis: "Angstrom - Lwt- and Unix-specific support"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.6.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.6.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "base-unix"
 ]
 synopsis: "Angstrom - Lwt- and Unix-specific support"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.7.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.7.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.06.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "base-unix"
 ]
 synopsis: "Angstrom - Lwt- and Unix-specific support"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "base-unix"
 ]
 synopsis: "Angstrom - Lwt- and Unix-specific support"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.1/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.8.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "base-unix"
 ]
 synopsis: "Angstrom - Lwt- and Unix-specific support"

--- a/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.9.0/opam
+++ b/packages/angstrom-lwt-unix/angstrom-lwt-unix.0.9.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
   "angstrom"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "base-unix"
 ]
 synopsis: "Angstrom - Lwt- and Unix-specific support"


### PR DESCRIPTION
```
#=== ERROR while compiling angstrom-lwt-unix.0.9.0 ============================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/angstrom-lwt-unix.0.9.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p angstrom-lwt-unix -j 31
# exit-code            1
# env-file             ~/.opam/log/angstrom-lwt-unix-1254-c4ecff.env
# output-file          ~/.opam/log/angstrom-lwt-unix-1254-c4ecff.out
### output ###
#       ocamlc lwt/.angstrom_lwt_unix.objs/angstrom_lwt_unix.{cmi,cmti} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I lwt/.angstrom_lwt_unix.objs -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -no-alias-deps -o lwt/.angstrom_lwt_unix.objs/angstrom_lwt_unix.cmi -c -intf lwt/angstrom_lwt_unix.mli)
# File "lwt/angstrom_lwt_unix.mli", line 41, characters 41-54:
# 41 |   -> (Buffered.unconsumed * ('a, string) Result.result) Lwt.t
#                                               ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```