### PR TITLE
datakit-server is not compatible with lwt 5.6.0

### DIFF
--- a/packages/datakit-server/datakit-server.0.10.0/opam
+++ b/packages/datakit-server/datakit-server.0.10.0/opam
@@ -25,6 +25,7 @@ depends: [
   "sexplib"
   "prometheus"
   "cmdliner"
+  "lwt" {< "5.6.0"}
 ]
 synopsis: "A library to write Datakit servers"
 description: """

--- a/packages/datakit-server/datakit-server.0.10.1/opam
+++ b/packages/datakit-server/datakit-server.0.10.1/opam
@@ -25,6 +25,7 @@ depends: [
   "sexplib"
   "prometheus"
   "cmdliner"
+  "lwt" {< "5.6.0"}
 ]
 synopsis: "A library to write Datakit servers"
 description: """

--- a/packages/datakit-server/datakit-server.0.11.0/opam
+++ b/packages/datakit-server/datakit-server.0.11.0/opam
@@ -17,7 +17,7 @@ depends: [
   "logs"
   "rresult"
   "fmt"
-  "lwt" {>= "3.0.0"}
+  "lwt" {>= "3.0.0" & < "5.6.0"}
   "cstruct" {>= "2.2.0"}
 ]
 synopsis: "A library to write Datakit servers"

--- a/packages/datakit-server/datakit-server.0.12.0/opam
+++ b/packages/datakit-server/datakit-server.0.12.0/opam
@@ -17,7 +17,7 @@ depends: [
   "logs"
   "rresult"
   "fmt"
-  "lwt" {>= "3.0.0"}
+  "lwt" {>= "3.0.0" & < "5.6.0"}
   "cstruct" {>= "2.2.0" & < "6.1.0"}
 ]
 synopsis: "A library to write Datakit servers"

--- a/packages/datakit-server/datakit-server.0.12.2/opam
+++ b/packages/datakit-server/datakit-server.0.12.2/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "rresult"
   "fmt"
-  "lwt" {>= "3.0.0"}
+  "lwt" {>= "3.0.0" & < "5.6.0"}
   "cstruct" {>= "2.2.0" & < "6.1.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-server/datakit-server.0.12.3/opam
+++ b/packages/datakit-server/datakit-server.0.12.3/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "rresult"
   "fmt"
-  "lwt" {>= "3.0.0"}
+  "lwt" {>= "3.0.0" & < "5.6.0"}
   "cstruct" {>= "2.2.0" & < "6.1.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-server/datakit-server.0.6.0/opam
+++ b/packages/datakit-server/datakit-server.0.6.0/opam
@@ -26,6 +26,7 @@ depends: [
   "protocol-9p" {>= "0.7.0" & < "0.9.0"}
   "sexplib" {< "v0.11.0"}
   "mirage-types-lwt" {>= "2.6.0" & < "3.0.0"}
+  "lwt" {< "5.6.0"}
 ]
 synopsis: "A library to write Datakit servers"
 description: """

--- a/packages/datakit-server/datakit-server.0.7.0/opam
+++ b/packages/datakit-server/datakit-server.0.7.0/opam
@@ -26,6 +26,7 @@ depends: [
   "protocol-9p" {>= "0.7.4" & < "0.9.0"}
   "sexplib" {< "v0.11.0"}
   "mirage-types-lwt" {>= "2.6.0" & < "3.0.0"}
+  "lwt" {< "5.6.0"}
 ]
 synopsis: "A library to write Datakit servers"
 description: """

--- a/packages/datakit-server/datakit-server.0.8.0/opam
+++ b/packages/datakit-server/datakit-server.0.8.0/opam
@@ -27,6 +27,7 @@ depends: [
   "protocol-9p" {>= "0.7.4" & < "0.9.0"}
   "sexplib" {< "v0.11.0"}
   "mirage-types-lwt" {>= "2.6.0" & < "3.0.0"}
+  "lwt" {< "5.6.0"}
 ]
 synopsis: "A library to write Datakit servers"
 description: """

--- a/packages/datakit-server/datakit-server.0.9.0/opam
+++ b/packages/datakit-server/datakit-server.0.9.0/opam
@@ -27,6 +27,7 @@ depends: [
   "protocol-9p" {>= "0.7.4" & < "0.9.0"}
   "sexplib" {< "v0.11.0"}
   "mirage-types-lwt" {>= "2.6.0" & < "3.0.0"}
+  "lwt" {< "5.6.0"}
 ]
 synopsis: "A library to write Datakit servers"
 description: """

--- a/packages/datakit-server/datakit-server.1.0.0/opam
+++ b/packages/datakit-server/datakit-server.1.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "rresult"
   "fmt"
-  "lwt" {>= "3.0.0"}
+  "lwt" {>= "3.0.0" & < "5.6.0"}
   "cstruct" {>= "2.2.0" & < "6.1.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
```
#=== ERROR while compiling datakit-server.1.0.0 ===============================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/datakit-server.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p datakit-server -j 31
# exit-code            1
# env-file             ~/.opam/log/datakit-server-1451-319052.env
# output-file          ~/.opam/log/datakit-server-1451-319052.out
### output ###
# File "dune-project", line 4, characters 11-14:
# 4 | (using fmt 1.1)
#                ^^^
# Warning: Version 1.1 of integration with automatic formatters is not
# supported until version 1.7 of the dune language.
# There are no supported versions of this extension in version 1.0 of the dune
# language.
# 
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/datakit-server/.datakit_server.objs/byte -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/rresult -no-alias-deps -o src/datakit-server/.datakit_server.objs/byte/vfs.cmi -c -intf src/datakit-server/vfs.mli)
# File "src/datakit-server/vfs.mli", line 61, characters 31-44:
# 61 | type 'a or_err = ('a, Error.t) Result.result Lwt.t
#                                     ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```