### PR TITLE
rankers requires cpm >= 10.0.0 (uses MakeROC.pr_auc)

### DIFF
--- a/packages/rankers/rankers.1.0.0/opam
+++ b/packages/rankers/rankers.1.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "batteries"
   "bst"
   "conf-gnuplot"
-  "cpm"
+  "cpm" {>= "10.0.0"}
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.6"}
   "minicli"

--- a/packages/rankers/rankers.2.0.1/opam
+++ b/packages/rankers/rankers.2.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "batteries"
   "bst"
   "conf-gnuplot"
-  "cpm"
+  "cpm" {>= "10.0.0"}
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.6"}
   "minicli"

--- a/packages/rankers/rankers.2.0.7/opam
+++ b/packages/rankers/rankers.2.0.7/opam
@@ -11,7 +11,7 @@ depends: [
   "batteries"
   "bst"
   "conf-gnuplot"
-  "cpm"
+  "cpm" {>= "10.0.0"}
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.6"}
   "minicli" {>= "5.0.0"}


### PR DESCRIPTION
cc @UnixJunkie 
```
#=== ERROR while compiling rankers.2.0.1 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/rankers.2.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p rankers -j 31
# exit-code            1
# env-file             ~/.opam/log/rankers-15313-223cb1.env
# output-file          ~/.opam/log/rankers-15313-223cb1.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -g -bin-annot -I src/.bwmine.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/equeue -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/molenc -I /home/opam/.opam/4.14/lib/netcamlbox -I /home/opam/.opam/4.14/lib/netmulticore -I /home/opam/.opam/4.14/lib/netplex -I /home/opam/.opam/4.14/lib/netstring -I /home/opam/.opam/4.14/lib/netsys -I /home/opam/.opam/4.14/lib/nlopt -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parany -I /home/opam/.opam/4.14/lib/parmap -I /home/opam/.opam/4.14/lib/rpc -no-alias-deps -o src/.bwmine.eobjs/byte/perf.cmo -c -impl src/perf.ml)
# File "src/perf.ml", line 68, characters 13-23:
# 68 |     let pr = ROC.pr_auc for_auc in
#                   ^^^^^^^^^^
# Error: Unbound value ROC.pr_auc
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -g -bin-annot -I src/.bwmine.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/equeue -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/molenc -I /home/opam/.opam/4.14/lib/netcamlbox -I /home/opam/.opam/4.14/lib/netmulticore -I /home/opam/.opam/4.14/lib/netplex -I /home/opam/.opam/4.14/lib/netstring -I /home/opam/.opam/4.14/lib/netsys -I /home/opam/.opam/4.14/lib/nlopt -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parany -I /home/opam/.opam/4.14/lib/parmap -I /home/opam/.opam/4.14/lib/rpc -no-alias-deps -o src/.bwmine.eobjs/byte/common.cmo -c -impl src/common.ml)
# File "src/common.ml", line 94, characters 17-27:
# 94 |      | PR_AUC -> ROC.pr_auc
#                       ^^^^^^^^^^
# Error: Unbound value ROC.pr_auc

- (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -g -bin-annot -I src/.bwmine.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/equeue -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/molenc -I /home/opam/.opam/4.14/lib/netcamlbox -I /home/opam/.opam/4.14/lib/netmulticore -I /home/opam/.opam/4.14/lib/netplex -I /home/opam/.opam/4.14/lib/netstring -I /home/opam/.opam/4.14/lib/netsys -I /home/opam/.opam/4.14/lib/nlopt -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parany -I /home/opam/.opam/4.14/lib/parmap -I /home/opam/.opam/4.14/lib/rpc -no-alias-deps -o src/.bwmine.eobjs/byte/perf.cmo -c -impl src/perf.ml)
- File "src/perf.ml", line 68, characters 13-23:
- 68 |     let pr = ROC.pr_auc for_auc in
-                   ^^^^^^^^^^
- Error: Unbound value ROC.pr_auc
- (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -g -bin-annot -I src/.bwmine.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/equeue -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/molenc -I /home/opam/.opam/4.14/lib/netcamlbox -I /home/opam/.opam/4.14/lib/netmulticore -I /home/opam/.opam/4.14/lib/netplex -I /home/opam/.opam/4.14/lib/netstring -I /home/opam/.opam/4.14/lib/netsys -I /home/opam/.opam/4.14/lib/nlopt -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parany -I /home/opam/.opam/4.14/lib/parmap -I /home/opam/.opam/4.14/lib/rpc -no-alias-deps -o src/.bwmine.eobjs/byte/common.cmo -c -impl src/common.ml)
- File "src/common.ml", line 94, characters 17-27:
- 94 |      | PR_AUC -> ROC.pr_auc
-                       ^^^^^^^^^^
- Error: Unbound value ROC.pr_auc
```