### PR TITLE
osc-lwt is not compatible with lwt 5.6.0

### DIFF
--- a/packages/osc-lwt/osc-lwt.0.2.0/opam
+++ b/packages/osc-lwt/osc-lwt.0.2.0/opam
@@ -12,13 +12,10 @@ build: [
 
 depends: [
   "dune" {>= "2.9"}
-  "lwt"
+  "lwt" {>= "2.7.0" & < "5.6.0"}
   "ocaml" {>= "4.08"}
   "osc" {= version}
   "ounit" {with-test}
-]
-conflicts: [
-  "lwt" {< "2.7.0"}
 ]
 synopsis: "OpenSoundControl Lwt library"
 description: """


### PR DESCRIPTION
cc @johnelse 
```
#=== ERROR while compiling osc-lwt.0.2.0 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/osc-lwt.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p osc-lwt -j 31
# exit-code            1
# env-file             ~/.opam/log/osc-lwt-89-01d8ff.env
# output-file          ~/.opam/log/osc-lwt-89-01d8ff.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lwt/.osc_lwt.objs/byte -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/osc -no-alias-deps -o src/lwt/.osc_lwt.objs/byte/osc_lwt.cmi -c -intf src/lwt/osc_lwt.mli)
# File "src/lwt/osc_lwt.mli", line 24, characters 9-22:
# 24 |       ]) Result.result) Lwt.t
#               ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```