### PR TITLE
linwrap.5.1.1 requires cpm >= 5.0.0 (uses MakeROC.mcc)

### DIFF
--- a/packages/linwrap/linwrap.5.1.1/opam
+++ b/packages/linwrap/linwrap.5.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "conf-liblinear-tools"
   "conf-python-3"
   "conf-rdkit"
-  "cpm" {>= "4.0.0"}
+  "cpm" {>= "5.0.0"}
   "dokeysto_camltc"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.10"}


### PR DESCRIPTION
```
#=== ERROR while compiling linwrap.5.1.1 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/linwrap.5.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p linwrap -j 31
# exit-code            1
# env-file             ~/.opam/log/linwrap-7885-402a12.env
# output-file          ~/.opam/log/linwrap-7885-402a12.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.linwrap.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/camltc -I /home/opam/.opam/4.14/lib/camltc/tc -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dokeysto -I /home/opam/.opam/4.14/lib/dokeysto_camltc -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/extunix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parany -no-alias-deps -o src/.linwrap.eobjs/byte/linwrap.cmo -c -impl src/linwrap.ml)
# File "src/linwrap.ml", line 270, characters 18-25:
# 270 |         let mcc = ROC.mcc t score_labels in
#                         ^^^^^^^
# Error: Unbound value ROC.mcc

- (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.linwrap.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/camltc -I /home/opam/.opam/4.14/lib/camltc/tc -I /home/opam/.opam/4.14/lib/cpm -I /home/opam/.opam/4.14/lib/cpu -I /home/opam/.opam/4.14/lib/dokeysto -I /home/opam/.opam/4.14/lib/dokeysto_camltc -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/extunix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parany -no-alias-deps -o src/.linwrap.eobjs/byte/linwrap.cmo -c -impl src/linwrap.ml)
- File "src/linwrap.ml", line 270, characters 18-25:
- 270 |         let mcc = ROC.mcc t score_labels in
-                         ^^^^^^^
- Error: Unbound value ROC.mcc
```