### PR TITLE
docteur.0.0.5 has a missing dependency on mmap

### DIFF
--- a/packages/docteur/docteur.0.0.5/opam
+++ b/packages/docteur/docteur.0.0.5/opam
@@ -25,6 +25,7 @@ depends: [
   "rresult" {>= "0.6.0"}
   "carton" {>= "0.4.0"}
   "art" {>= "0.1.1"}
+  "mmap"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]


### PR DESCRIPTION
cc @dinosaure 
```
#=== ERROR while compiling docteur.0.0.5 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/docteur.0.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p docteur -j 31
# exit-code            1
# env-file             ~/.opam/log/docteur-19-152ef7.env
# output-file          ~/.opam/log/docteur-19-152ef7.out
### output ###
# File "bin/dune", line 24, characters 2-6:
# 24 |   mmap
#        ^^^^
# Error: Library "mmap" not found.
# -> required by _build/default/bin/make.exe
# -> required by _build/install/default/bin/docteur.make
# -> required by _build/default/docteur.install
# -> required by alias install
# File "bin/dune", line 51, characters 2-6:
# 51 |   mmap
#        ^^^^
# Error: Library "mmap" not found.
# -> required by _build/default/bin/verify.exe
# -> required by _build/install/default/bin/docteur.verify
# -> required by _build/default/docteur.install
# -> required by alias install
```