### PR TITLE
docteur-unix < 0.0.5 is not compatible with lwt 5.6.0

### DIFF
--- a/packages/docteur-unix/docteur-unix.0.0.2/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.2/opam
@@ -18,7 +18,7 @@ depends: [
   "digestif" {>= "1.0.0"}
   "git" {>= "3.4.0"}
   "logs" {>= "0.7.0"}
-  "lwt" {>= "5.4.0"}
+  "lwt" {>= "5.4.0" & < "5.6.0"}
   "mirage-kv" {>= "3.0.1"}
   "mirage" {with-test & < "4.0"}
   "mirage-unix" {with-test}

--- a/packages/docteur-unix/docteur-unix.0.0.3/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.3/opam
@@ -18,7 +18,7 @@ depends: [
   "digestif" {>= "1.0.0"}
   "git" {>= "3.7.0"}
   "logs" {>= "0.7.0"}
-  "lwt" {>= "5.4.0"}
+  "lwt" {>= "5.4.0" & < "5.6.0"}
   "mirage-kv" {>= "3.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/docteur-unix/docteur-unix.0.0.4/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.4/opam
@@ -18,7 +18,7 @@ depends: [
   "digestif" {>= "1.0.0"}
   "git" {>= "3.7.0"}
   "logs" {>= "0.7.0"}
-  "lwt" {>= "5.4.0"}
+  "lwt" {>= "5.4.0" & < "5.6.0"}
   "mirage-kv" {>= "3.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
```
#=== ERROR while compiling docteur-unix.0.0.4 =================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/docteur-unix.0.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p docteur-unix -j 31
# exit-code            1
# env-file             ~/.opam/log/docteur-unix-12823-e72bc2.env
# output-file          ~/.opam/log/docteur-unix-12823-e72bc2.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I unix/.docteur_unix.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/art -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/carton -I /home/opam/.opam/4.14/lib/carton-git -I /home/opam/.opam/4.14/lib/carton-lwt -I /home/opam/.opam/4.14/lib/carton/thin -I /home/opam/.opam/4.14/lib/checkseum -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/decompress/de -I /home/opam/.opam/4.14/lib/decompress/zl -I /home/opam/.opam/4.14/lib/digestif -I /home/opam/.opam/4.14/lib/docteur/analyze -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duff -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/emile -I /home/opam/.opam/4.14/lib/encore -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/functoria-runtime -I /home/opam/.opam/4.14/lib/git -I /home/opam/.opam/4.14/lib/git/loose -I /home/opam/.opam/4.14/lib/git/loose-git -I /home/opam/.opam/4.14/lib/git/nss -I /home/opam/.opam/4.14/lib/git/nss/git -I /home/opam/.opam/4.14/lib/git/nss/hkt -I /home/opam/.opam/4.14/lib/git/nss/neg -I /home/opam/.opam/4.14/lib/git/nss/pck -I /home/opam/.opam/4.14/lib/git/nss/pkt-line -I /home/opam/.opam/4.14/lib/git/nss/sigs -I /home/opam/.opam/4.14/lib/git/nss/smart -I /home/opam/.opam/4.14/lib/git/nss/smart-flow -I /home/opam/.opam/4.14/lib/git/nss/unixiz -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/hxd/string -I /home/opam/.opam/4.14/lib/io-page -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-runtime -I /home/opam/.opam/4.14/lib/mirage-unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uutf -intf-suffix .ml -no-alias-deps -open Docteur_unix__ -o unix/.docteur_unix.objs/byte/docteur_unix__Fast.cmo -c -impl unix/fast.ml)
# File "unix/fast.ml", line 21, characters 4-20:
# 21 |     Mmap.V1.map_file fd
#          ^^^^^^^^^^^^^^^^
# Error: Unbound module Mmap
# Hint: Did you mean Map?
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I unix/.docteur_unix.objs/byte -I unix/.docteur_unix.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/art -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/carton -I /home/opam/.opam/4.14/lib/carton-git -I /home/opam/.opam/4.14/lib/carton-lwt -I /home/opam/.opam/4.14/lib/carton/thin -I /home/opam/.opam/4.14/lib/checkseum -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/decompress/de -I /home/opam/.opam/4.14/lib/decompress/zl -I /home/opam/.opam/4.14/lib/digestif -I /home/opam/.opam/4.14/lib/docteur/analyze -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duff -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/emile -I /home/opam/.opam/4.14/lib/encore -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/functoria-runtime -I /home/opam/.opam/4.14/lib/git -I /home/opam/.opam/4.14/lib/git/loose -I /home/opam/.opam/4.14/lib/git/loose-git -I /home/opam/.opam/4.14/lib/git/nss -I /home/opam/.opam/4.14/lib/git/nss/git -I /home/opam/.opam/4.14/lib/git/nss/hkt -I /home/opam/.opam/4.14/lib/git/nss/neg -I /home/opam/.opam/4.14/lib/git/nss/pck -I /home/opam/.opam/4.14/lib/git/nss/pkt-line -I /home/opam/.opam/4.14/lib/git/nss/sigs -I /home/opam/.opam/4.14/lib/git/nss/smart -I /home/opam/.opam/4.14/lib/git/nss/smart-flow -I /home/opam/.opam/4.14/lib/git/nss/unixiz -I /home/opam/.opam/4.14/lib/hxd/core -I /home/opam/.opam/4.14/lib/hxd/string -I /home/opam/.opam/4.14/lib/io-page -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-runtime -I /home/opam/.opam/4.14/lib/mirage-unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocamlgraph -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uutf -intf-suffix .ml -no-alias-deps -open Docteur_unix__ -o unix/.docteur_unix.objs/native/docteur_unix__Fast.cmx -c -impl unix/fast.ml)
# File "unix/fast.ml", line 21, characters 4-20:
# 21 |     Mmap.V1.map_file fd
#          ^^^^^^^^^^^^^^^^
# Error: Unbound module Mmap
# Hint: Did you mean Map?
```