### PR TITLE
mirage-flow-lwt 1.3.0 and 1.4.0 are not compatible with lwt 5.6.0

### DIFF
--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta7"}
   "fmt"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "cstruct" {>= "2.0.0" & < "6.0.1"}
   "mirage-clock" {>= "1.2.0" & < "3.0.0"}
   "mirage-flow" {>= "1.3.0" & < "2.0.0"}

--- a/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
+++ b/packages/mirage-flow-lwt/mirage-flow-lwt.1.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta7"}
   "fmt"
-  "lwt"
+  "lwt" {< "5.6.0"}
   "logs"
   "cstruct" {>= "2.0.0" & < "6.1.0"}
   "mirage-clock" {>= "1.2.0" & < "3.0.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling mirage-flow-lwt.1.4.0 ==============================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/mirage-flow-lwt.1.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p mirage-flow-lwt -j 31
# exit-code            1
# env-file             ~/.opam/log/mirage-flow-lwt-2211-0224da.env
# output-file          ~/.opam/log/mirage-flow-lwt-2211-0224da.out
### output ###
#     ocamlopt lwt/.mirage_flow_lwt.objs/mirage_flow_lwt.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lwt/.mirage_flow_lwt.objs -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-device -I /home/opam/.opam/4.14/lib/mirage-flow -no-alias-deps -o lwt/.mirage_flow_lwt.objs/mirage_flow_lwt.cmx -c -impl lwt/mirage_flow_lwt.ml)
# File "lwt/mirage_flow_lwt.ml", line 53, characters 16-29:
# 53 |   t: (unit, 'a) Result.result Lwt.t;
#                      ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
#       ocamlc lwt/.mirage_flow_lwt.objs/mirage_flow_lwt.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lwt/.mirage_flow_lwt.objs -I /home/opam/.opam/4.14/lib/bigarray-compat -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-device -I /home/opam/.opam/4.14/lib/mirage-flow -no-alias-deps -o lwt/.mirage_flow_lwt.objs/mirage_flow_lwt.cmo -c -impl lwt/mirage_flow_lwt.ml)
# File "lwt/mirage_flow_lwt.ml", line 53, characters 16-29:
# 53 |   t: (unit, 'a) Result.result Lwt.t;
#                      ^^^^^^^^^^^^^
# Error: Unbound type constructor Result.result
```