### PR TITLE
[new release] bechamel, bechamel-js, bechamel-notty and bechamel-perf (0.3.0)

### DIFF
--- a/packages/bechamel-js/bechamel-js.0.3.0/opam
+++ b/packages/bechamel-js/bechamel-js.0.3.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "HTML generator for bechamel's output"
+description: """A simple tool to generate a standalone HTML
+page which shows results from bechamel's benchmarks."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "bechamel"   {= version}
+  "rresult"
+  "json-data-encoding"
+  "jsonm"
+  "fmt"        {>= "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.3.0/bechamel-0.3.0.tbz"
+  checksum: [
+    "sha256=d719040841a1a3be6f93699ae9bf1f8cb2c5d294f0218c0bc0a735386c2d71a0"
+    "sha512=dc1233d4dcf01a997a3fcbafc116df0aae22ea5a6c98c09e200e4aa984c558976c8290b3e14b1156519ad12a6cc4b1b9fa4adf3dc2458d373d77a07fb9f7acff"
+  ]
+}
+x-commit-hash: "adf2b19fe09be6f405f11a69e15845529a5d80b7"

--- a/packages/bechamel-notty/bechamel-notty.0.3.0/opam
+++ b/packages/bechamel-notty/bechamel-notty.0.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "CLI generator for bechamel's output"
+description: """A simple tool to generate a CLI output with notty
+which shows results from bechamel's benchmarks (as core_bench)."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "bechamel"   {= version}
+  "notty"
+  "fmt"        {>= "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.3.0/bechamel-0.3.0.tbz"
+  checksum: [
+    "sha256=d719040841a1a3be6f93699ae9bf1f8cb2c5d294f0218c0bc0a735386c2d71a0"
+    "sha512=dc1233d4dcf01a997a3fcbafc116df0aae22ea5a6c98c09e200e4aa984c558976c8290b3e14b1156519ad12a6cc4b1b9fa4adf3dc2458d373d77a07fb9f7acff"
+  ]
+}
+x-commit-hash: "adf2b19fe09be6f405f11a69e15845529a5d80b7"

--- a/packages/bechamel-perf/bechamel-perf.0.3.0/opam
+++ b/packages/bechamel-perf/bechamel-perf.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "Linux perf's metrics for bechamel"
+description: """A simple layer on Linux perf's metrics for
+bechamel to record and analyze them."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "mperf"
+  "bechamel"   {= version}
+  "fmt"        {>= "0.9.0"}
+  "base-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.3.0/bechamel-0.3.0.tbz"
+  checksum: [
+    "sha256=d719040841a1a3be6f93699ae9bf1f8cb2c5d294f0218c0bc0a735386c2d71a0"
+    "sha512=dc1233d4dcf01a997a3fcbafc116df0aae22ea5a6c98c09e200e4aa984c558976c8290b3e14b1156519ad12a6cc4b1b9fa4adf3dc2458d373d77a07fb9f7acff"
+  ]
+}
+x-commit-hash: "adf2b19fe09be6f405f11a69e15845529a5d80b7"

--- a/packages/bechamel/bechamel.0.3.0/opam
+++ b/packages/bechamel/bechamel.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "Yet Another Benchmark in OCaml"
+description: """BEnchmark for a CHAMEL/camel/caml which
+is agnostic to the system. It's a micro-benchmark tool
+which lets the user to re-analyzes and prints samples."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "fmt"        {>= "0.9.0"}
+  "base-bytes"
+  "stdlib-shims"
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.3.0/bechamel-0.3.0.tbz"
+  checksum: [
+    "sha256=d719040841a1a3be6f93699ae9bf1f8cb2c5d294f0218c0bc0a735386c2d71a0"
+    "sha512=dc1233d4dcf01a997a3fcbafc116df0aae22ea5a6c98c09e200e4aa984c558976c8290b3e14b1156519ad12a6cc4b1b9fa4adf3dc2458d373d77a07fb9f7acff"
+  ]
+}
+x-commit-hash: "adf2b19fe09be6f405f11a69e15845529a5d80b7"


### PR DESCRIPTION
Yet Another Benchmark in OCaml

- Project page: <a href="https://github.com/mirage/bechamel">https://github.com/mirage/bechamel</a>
- Documentation: <a href="https://mirage.github.io/bechamel/">https://mirage.github.io/bechamel/</a>

##### CHANGES:

- Improve the entry point documentation (@yomimono, mirage/bechamel#28)
- Fix deprecated `Obj` function (@OlivierNicole, mirage/bechamel#29)
- Use json-data-encoding instead of ocplib-json-typed (@samoht, mirage/bechamel#34)
- Improve the documentation (@edwintorok, mirage/bechamel#32)
- Add hardware perf measures (@OlivierNicole, mirage/bechamel#30)
