### PR TITLE
Package epictetus.3.1.1

### DIFF
--- a/packages/epictetus/epictetus.3.1.1/opam
+++ b/packages/epictetus/epictetus.3.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Elegant Printer of Insanely Complex Tables Expressing Trees with Uneven Shapes"
+maintainer: "Marc Chevalier <github@marc-chevalier.com>"
+authors: "Marc Chevalier <github@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.6.3"}
+  "ounit2" {with-test & >= "2.0.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+homepage: "https://github.com/marc-chevalier/epictetus"
+bug-reports: "https://github.com/marc-chevalier/epictetus/issues"
+dev-repo: "git+https://github.com/marc-chevalier/epictetus.git"
+license: "MIT"
+description: """
+Align nicely tables in which each line may not have the same subdivision of subcolumns.
+"""
+url {
+  src: "https://github.com/marc-chevalier/epictetus/archive/3.1.0.tar.gz"
+  checksum: [
+    "md5=2b364e398946d9babace2db178c4d865"
+    "sha512=058fb6551fed906829c00f2c55a2946fc05b1941a59a6770226912d3052207fdd88864302df980312a9d03d4d2100a5e9c77448b799c878c6782a943d5b40557"
+  ]
+}


### PR DESCRIPTION
### `epictetus.3.1.1`
Elegant Printer of Insanely Complex Tables Expressing Trees with Uneven Shapes
Align nicely tables in which each line may not have the same subdivision of subcolumns.



---
* Homepage: https://github.com/marc-chevalier/epictetus
* Source repo: git+https://github.com/marc-chevalier/epictetus.git
* Bug tracker: https://github.com/marc-chevalier/epictetus/issues

---
:camel: Pull-request generated by opam-publish v2.1.0