### PR TITLE
Package epictetus.3.1.1

### DIFF
--- a/packages/epictetus/epictetus.3.1.1/opam
+++ b/packages/epictetus/epictetus.3.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Elegant Printer of Insanely Complex Tables Expressing Trees with Uneven Shapes"
+maintainer: "Marc Chevalier <github@marc-chevalier.com>"
+authors: "Marc Chevalier <github@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.6.3"}
+  "ounit2" {with-test & >= "2.0.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+homepage: "https://github.com/marc-chevalier/epictetus"
+bug-reports: "https://github.com/marc-chevalier/epictetus/issues"
+dev-repo: "git+https://github.com/marc-chevalier/epictetus.git"
+license: "MIT"
+description: """
+Align nicely tables in which each line may not have the same subdivision of subcolumns.
+"""
+url {
+  src: "https://github.com/marc-chevalier/epictetus/archive/3.1.1.tar.gz"
+  checksum: [
+    "md5=bfd5f390e134d209dab7ed269389e75a"
+    "sha512=8de3f69ed0c8a622f66d930a7def4ff022b7747b4bf8ccf884ce7b4b43e0fc99a27f1a00f2515bd3f97d26a386d887bcc3f67dc77fbbfa46bdf0d9a4af0f9f30"
+  ]
+}


### PR DESCRIPTION
### `epictetus.3.1.1`
Elegant Printer of Insanely Complex Tables Expressing Trees with Uneven Shapes
Align nicely tables in which each line may not have the same subdivision of subcolumns.



---
* Homepage: https://github.com/marc-chevalier/epictetus
* Source repo: git+https://github.com/marc-chevalier/epictetus.git
* Bug tracker: https://github.com/marc-chevalier/epictetus/issues

---
:camel: Pull-request generated by opam-publish v2.1.0