### PR TITLE
Package epictetus.3.1.1

### DIFF
--- a/packages/epictetus/epictetus.3.1.1/opam
+++ b/packages/epictetus/epictetus.3.1.1/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 run-test: [
-  ["dune" "runtest"]
+  ["dune" "runtest" "-p" name "-j" jobs]
 ]
 homepage: "https://github.com/marc-chevalier/epictetus"
 bug-reports: "https://github.com/marc-chevalier/epictetus/issues"

--- a/packages/epictetus/epictetus.3.1.1/opam
+++ b/packages/epictetus/epictetus.3.1.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Elegant Printer of Insanely Complex Tables Expressing Trees with Uneven Shapes"
+maintainer: "Marc Chevalier <github@marc-chevalier.com>"
+authors: "Marc Chevalier <github@marc-chevalier.com>"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.6.3"}
+  "ounit2" {with-test & >= "2.0.8"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest"]
+]
+homepage: "https://github.com/marc-chevalier/epictetus"
+bug-reports: "https://github.com/marc-chevalier/epictetus/issues"
+dev-repo: "git+https://github.com/marc-chevalier/epictetus.git"
+license: "MIT"
+description: """
+Align nicely tables in which each line may not have the same subdivision of subcolumns.
+"""
+url {
+  src: "https://github.com/marc-chevalier/epictetus/archive/3.1.1.tar.gz"
+  checksum: [
+    "md5=c1ce9f27de9fc173e72e64ee7c80eded"
+    "sha512=f4e5cffa90d578cc970fcb2588789bcde8f075693a03af1ec69831775fed5ef87b2c771ad720c0c8ebcf5eda7e711056098c4d50bb55f60787b342e4508f3395"
+  ]
+}


### PR DESCRIPTION
### `epictetus.3.1.1`
Elegant Printer of Insanely Complex Tables Expressing Trees with Uneven Shapes
Align nicely tables in which each line may not have the same subdivision of subcolumns.



---
* Homepage: https://github.com/marc-chevalier/epictetus
* Source repo: git+https://github.com/marc-chevalier/epictetus.git
* Bug tracker: https://github.com/marc-chevalier/epictetus/issues

---
:camel: Pull-request generated by opam-publish v2.1.0