### PR TITLE
Update ppx_seq to 0.3.2

### DIFF
--- a/packages/ppx_seq/ppx_seq.0.3.2/opam
+++ b/packages/ppx_seq/ppx_seq.0.3.2/opam
@@ -39,9 +39,9 @@ dev-repo: "git+https://git.sr.ht/~hyphen/ppx_seq"
 url {
   src: "https://github.com/hyphenrf/ppx_seq/archive/refs/tags/0.3.2.tar.gz"
   checksum: [
-    "md5=d41d8cd98f00b204e9800998ecf8427e"
-    "sha256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    "sha512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+    "md5=dca5b027638ecaecf5229174b8492757"
+    "sha256=a3687a6b1491eb8e23ccb104d4864b2e4c13eeb44cb8848e60cba990dba1081e"
+    "sha512=0b165dd5450a157cdb950b5bf14c1f33c795efcfc4c145f552a4a07965a7239edd41a0647c2c33193e919145ad17035ad7ca166655a92c3c4f3ac846b11fe172"
   ]
   mirrors: "https://git.sr.ht/~hyphen/ppx_seq/archive/0.3.2.tar.gz"
 }

--- a/packages/ppx_seq/ppx_seq.0.3.2/opam
+++ b/packages/ppx_seq/ppx_seq.0.3.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Seq literals ppx for OCaml"
+description: """
+Simple unintrusive ppx rewriter that offers Seq literals.
+It offers List-like syntax in the form of [%seq a; b; c...],
+among other features like a compact ranges syntax.
+"""
+maintainer: "hyphens@pm.me"
+authors: "Hazem Elmasry"
+license: "ISC"
+tags: "syntax"
+homepage: "https://sr.ht/~hyphen/ppx_seq"
+doc: "https://git.sr.ht/~hyphen/ppx_seq/tree/master/item/README"
+bug-reports: "https://lists.sr.ht/~hyphen/ppx_seq"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "2.9"}
+  "ppxlib" {>= "0.23"}
+  "seq" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.sr.ht/~hyphen/ppx_seq"
+url {
+  src: "https://github.com/hyphenrf/ppx_seq/archive/refs/tags/0.3.2.tar.gz"
+  checksum: [
+    "md5=d41d8cd98f00b204e9800998ecf8427e"
+    "sha256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    "sha512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+  ]
+  mirrors: "https://git.sr.ht/~hyphen/ppx_seq/archive/0.3.2.tar.gz"
+}


### PR DESCRIPTION
upstream urls changed, should i change them retroactively in the older versions?