### PR TITLE
3 packages from 0xffea/ocaml-redis at 0.6

### DIFF
--- a/packages/redis-lwt/redis-lwt.0.6/opam
+++ b/packages/redis-lwt/redis-lwt.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD-3-Clause"
+tags: ["redis" "lwt"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client (lwt interface)"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  # ["dune" "runtest" "-p" name "-j" jobs] {with-test}  # need network
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "lwt" {>= "2.4.7"}
+  "ocaml" { >= "4.03.0" }
+  "ounit2" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=be1850ecdb92400e548e7ada346f1acd"
+    "sha512=77aace7d537606f252f37397c3368bb3a66cf6ca66d52d6cbe2524b0218a7991ca643e6ec00d70bf20b0715c412d5e290b9a06d07bd9575bcfba32b59f17bc26"
+  ]
+}

--- a/packages/redis-sync/redis-sync.0.6/opam
+++ b/packages/redis-sync/redis-sync.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD-3-Clause"
+tags: ["redis" "unix"]
+synopsis: "Redis client (blocking)"
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  # ["dune" "runtest" "-p" name "-j" jobs] {with-test} # need network
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" {>= "1.0"}
+  "redis" { = version }
+  "ocaml" { >= "4.03.0" }
+  "camlp-streams"
+  "ounit2" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=be1850ecdb92400e548e7ada346f1acd"
+    "sha512=77aace7d537606f252f37397c3368bb3a66cf6ca66d52d6cbe2524b0218a7991ca643e6ec00d70bf20b0715c412d5e290b9a06d07bd9575bcfba32b59f17bc26"
+  ]
+}

--- a/packages/redis/redis.0.6/opam
+++ b/packages/redis/redis.0.6/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Simon Cruanes"
+authors: [
+  "Mike Wells"
+  "David Höppner"
+  "Aleksandr Dinu"
+]
+homepage: "https://github.com/0xffea/ocaml-redis"
+bug-reports: "https://github.com/0xffea/ocaml-redis/issues"
+license: "BSD-3-Clause"
+tags: ["redis"]
+dev-repo: "git+https://github.com/0xffea/ocaml-redis.git"
+synopsis: "Redis client"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  # ["dune" "runtest" "-p" name "-j" jobs] {with-test} # need network
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "base-unix"
+  "uuidm"
+  "stdlib-shims"
+  "re" {>= "1.7.2"}
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/0xffea/ocaml-redis/archive/v0.6.tar.gz"
+  checksum: [
+    "md5=be1850ecdb92400e548e7ada346f1acd"
+    "sha512=77aace7d537606f252f37397c3368bb3a66cf6ca66d52d6cbe2524b0218a7991ca643e6ec00d70bf20b0715c412d5e290b9a06d07bd9575bcfba32b59f17bc26"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`redis.0.6`: Redis client
-`redis-lwt.0.6`: Redis client (lwt interface)
-`redis-sync.0.6`: Redis client (blocking)



---
* Homepage: https://github.com/0xffea/ocaml-redis
* Source repo: git+https://github.com/0xffea/ocaml-redis.git
* Bug tracker: https://github.com/0xffea/ocaml-redis/issues

---
:camel: Pull-request generated by opam-publish v2.1.0