### PR TITLE
Package libbinaryen.108.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.108.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.108.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {with-test & >= "3.10.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v108.0.0/libbinaryen-v108.0.0.tar.gz"
+  checksum: [
+    "md5=cb9031112295364fd898ec478fd8f853"
+    "sha512=305195eba075a79f1064d51f8ab416ee74690927689390aecbb75042646962d56917041cb65ff0b1a1c5ce27cf96c70238cf540da3830b4a8e44ab5046299c06"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.108.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [108.0.0](https://github.com/grain-lang/libbinaryen/compare/v107.0.1...v108.0.0) (2022-06-25)


### ⚠ BREAKING CHANGES

* Change js_of_ocaml binding to Binaryen
* Avoid building tools
* Update binaryen to version_108 (#62)

### Features

* Update binaryen to version_108 ([#62](https://github.com/grain-lang/libbinaryen/issues/62)) ([1e69a07](https://github.com/grain-lang/libbinaryen/commit/1e69a071c6cb905dd8d8e1b86957222f29243ed0))


### Miscellaneous Chores

* Avoid building tools ([1e69a07](https://github.com/grain-lang/libbinaryen/commit/1e69a071c6cb905dd8d8e1b86957222f29243ed0))
* Change js_of_ocaml binding to Binaryen ([1e69a07](https://github.com/grain-lang/libbinaryen/commit/1e69a071c6cb905dd8d8e1b86957222f29243ed0))

---
:camel: Pull-request generated by opam-publish v2.0.3