### PR TITLE
biniou.1.2.1 is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/biniou/biniou.1.2.1/opam
+++ b/packages/biniou/biniou.1.2.1/opam
@@ -33,7 +33,7 @@ Biniou format specification: mjambon.github.io/atdgen-doc/biniou-format.txt"""
 depends: [
   "easy-format"
   "dune" {>= "1.10"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
 ]
 url {
   src:


### PR DESCRIPTION
Fixed in biniou 1.2.2 (#21554)
```
#=== ERROR while compiling biniou.1.2.1 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/biniou.1.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p biniou -j 31
# exit-code            1
# env-file             ~/.opam/log/biniou-23-6738d9.env
# output-file          ~/.opam/log/biniou-23-6738d9.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -safe-string -g -bin-annot -I src/.biniou.objs/byte -I /home/opam/.opam/5.0/lib/easy-format -no-alias-deps -o src/.biniou.objs/byte/bi_stream.cmi -c -intf src/bi_stream.mli)
# File "src/bi_stream.mli", line 20, characters 59-67:
# 20 | val read_stream : (string -> 'a array) -> in_channel -> 'a Stream.t
#                                                                 ^^^^^^^^
# Error: Unbound module Stream
```