### PR TITLE
Remove base-bytes from PCRE versions using jbuilder/dune

### DIFF
--- a/packages/pcre/pcre.7.3.0/opam
+++ b/packages/pcre/pcre.7.3.0/opam
@@ -15,7 +15,6 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "conf-libpcre"
-  "base-bytes"
   "base" {build}
   "stdio" {build}
   "configurator" {build}

--- a/packages/pcre/pcre.7.3.2/opam
+++ b/packages/pcre/pcre.7.3.2/opam
@@ -14,7 +14,6 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04"}
-  "base-bytes"
   "conf-libpcre" {build}
   "base" {build}
   "stdio" {build}

--- a/packages/pcre/pcre.7.3.3/opam
+++ b/packages/pcre/pcre.7.3.3/opam
@@ -14,7 +14,6 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04"}
-  "base-bytes"
   "conf-libpcre" {build}
   "base" {build}
   "stdio" {build}

--- a/packages/pcre/pcre.7.3.4/opam
+++ b/packages/pcre/pcre.7.3.4/opam
@@ -14,7 +14,6 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04"}
-  "base-bytes"
   "conf-libpcre" {build}
   "base" {build}
   "stdio" {build}

--- a/packages/pcre/pcre.7.3.5/opam
+++ b/packages/pcre/pcre.7.3.5/opam
@@ -18,7 +18,6 @@ depends: [
   "dune-configurator"
   "conf-libpcre" {build}
   "base" {build}
-  "base-bytes"
 ]
 
 synopsis: "Bindings to the Perl Compatibility Regular Expressions library"

--- a/packages/pcre/pcre.7.4.0/opam
+++ b/packages/pcre/pcre.7.4.0/opam
@@ -18,7 +18,6 @@ depends: [
   "dune-configurator"
   "conf-libpcre" {build}
   "base" {build}
-  "base-bytes"
 ]
 
 synopsis: "Bindings to the Perl Compatibility Regular Expressions library"

--- a/packages/pcre/pcre.7.4.1/opam
+++ b/packages/pcre/pcre.7.4.1/opam
@@ -18,7 +18,6 @@ depends: [
   "dune-configurator"
   "conf-libpcre" {build}
   "base" {build}
-  "base-bytes"
 ]
 
 synopsis: "Bindings to the Perl Compatibility Regular Expressions library"

--- a/packages/pcre/pcre.7.4.2/opam
+++ b/packages/pcre/pcre.7.4.2/opam
@@ -17,7 +17,6 @@ depends: [
   "dune" {>= "1.8.0"}
   "conf-libpcre" {build}
   "base" {build}
-  "base-bytes"
 ]
 
 synopsis: "Bindings to the Perl Compatibility Regular Expressions library"

--- a/packages/pcre/pcre.7.4.3/opam
+++ b/packages/pcre/pcre.7.4.3/opam
@@ -21,7 +21,6 @@ depends: [
   "dune" {>= "1.10"}
   "conf-libpcre" {build}
   "base" {build}
-  "base-bytes"
 ]
 url {
   src:

--- a/packages/pcre/pcre.7.4.4/opam
+++ b/packages/pcre/pcre.7.4.4/opam
@@ -22,7 +22,6 @@ depends: [
   "dune-configurator"
   "conf-libpcre" {build}
   "base" {build}
-  "base-bytes"
 ]
 url {
   src:

--- a/packages/pcre/pcre.7.4.6/opam
+++ b/packages/pcre/pcre.7.4.6/opam
@@ -21,7 +21,6 @@ depends: [
   "dune" {>= "1.10"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base-bytes"
 ]
 url {
   src:

--- a/packages/pcre/pcre.7.5.0/opam
+++ b/packages/pcre/pcre.7.5.0/opam
@@ -15,7 +15,6 @@ depends: [
   "ocaml" {>= "4.12"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base-bytes"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
I looked through the history of PCRE all the way to when 7.3.0 started to use jbuilder and they do not need `base-bytes` nor do they reference `bytes` that might need Dune 1.4+. Might as well remove that dependency retrospectively.

Upstream PR to resolve this for the future: https://github.com/mmottl/pcre-ocaml/pull/27