### PR TITLE
Remove unused dependency on `base-bytes` in gettext

### DIFF
--- a/packages/gettext-camomile/gettext-camomile.0.4.1/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.4.1/opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
   "camomile"
-  "base-bytes"
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/packages/gettext-camomile/gettext-camomile.0.4.2/opam
+++ b/packages/gettext-camomile/gettext-camomile.0.4.2/opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
   "camomile"
-  "base-bytes"
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/packages/gettext-stub/gettext-stub.0.4.1/opam
+++ b/packages/gettext-stub/gettext-stub.0.4.1/opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
   "dune-configurator"
-  "base-bytes"
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/packages/gettext-stub/gettext-stub.0.4.2/opam
+++ b/packages/gettext-stub/gettext-stub.0.4.2/opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.11.0"}
   "dune-configurator"  
-  "base-bytes"
   "gettext" {= version}
   "ounit" {with-test & > "2.0.8"}
   "fileutils" {with-test}

--- a/packages/gettext-stub/gettext-stub.0.4.2/opam
+++ b/packages/gettext-stub/gettext-stub.0.4.2/opam
@@ -16,7 +16,7 @@ build: [
    "@runtest" {with-test} ]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.11.0"}
   "dune-configurator"  
   "gettext" {= version}

--- a/packages/gettext/gettext.0.4.1/opam
+++ b/packages/gettext/gettext.0.4.1/opam
@@ -19,7 +19,6 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.11"}
   "dune" {>= "1.11.0"}
   "fileutils"
-  "base-bytes"
   "ounit" {with-test & > "2.0.8"}
 ]
 synopsis: "Internationalization library (i18n)"

--- a/packages/gettext/gettext.0.4.1/opam
+++ b/packages/gettext/gettext.0.4.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.11"}
   "dune" {>= "1.11.0"}
   "fileutils"
-  "ounit" {with-test & > "2.0.8"}
+  "ounit" {with-test & > "2.0.8" & < "2.2.6"}
 ]
 synopsis: "Internationalization library (i18n)"
 description:"""

--- a/packages/gettext/gettext.0.4.2/opam
+++ b/packages/gettext/gettext.0.4.2/opam
@@ -20,7 +20,6 @@ depends: [
   "dune" {>= "1.11.0"}
   "cppo" {build}
   "fileutils"
-  "base-bytes"
   "ounit" {with-test & > "2.0.8" & < "2.2.6"}
 ]
 synopsis: "Internationalization library (i18n)"

--- a/packages/gettext/gettext.0.4.2/opam
+++ b/packages/gettext/gettext.0.4.2/opam
@@ -16,7 +16,7 @@ build: [
    "@runtest" {with-test} ]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.11.0"}
   "cppo" {build}
   "fileutils"

--- a/packages/gettext/gettext.0.4.2/opam
+++ b/packages/gettext/gettext.0.4.2/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.11.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
   "fileutils"
   "ounit" {with-test & > "2.0.8" & < "2.2.6"}
 ]


### PR DESCRIPTION
It is not used in the code base of gettext since at least the first release that uses dune.

Upstream PR to have it fixed for future releases: https://github.com/gildor478/ocaml-gettext/pull/23