### PR TITLE
Replace `mparser` tarballs with broken checksums by archived

### DIFF
--- a/packages/mparser/mparser.1.2.2/opam
+++ b/packages/mparser/mparser.1.2.2/opam
@@ -41,6 +41,6 @@ parser combinator library similar to the Parsec library for Haskell by Daan
 Leijen and the FParsec library for FSharp by Stephan Tolksdorf."""
 flags: light-uninstall
 url {
-  src: "https://github.com/cakeplus/mparser/archive/1.2.2.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mparser-1.2.2.tar.gz"
   checksum: "md5=80845a537bb4be0bbe41ffad8a2f09f3"
 }

--- a/packages/mparser/mparser.1.2.3/opam
+++ b/packages/mparser/mparser.1.2.3/opam
@@ -41,6 +41,6 @@ parser combinator library similar to the Parsec library for Haskell by Daan
 Leijen and the FParsec library for FSharp by Stephan Tolksdorf."""
 flags: light-uninstall
 url {
-  src: "https://github.com/cakeplus/mparser/archive/1.2.3.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/mparser-1.2.3.tar.gz"
   checksum: "md5=6e60c1fabb5d51482c664aa1bc8abc95"
 }


### PR DESCRIPTION
As seen in https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/23e1e77043642c6666128efe7e4b56e4cf7a7c8f `mparser.1.2.2` and `mparser.1.2.3` fail due to invalid checksums.

This PR replaces them by the versions from the archive.