### PR TITLE
Remove dependency on `base-bytes` from res which is unused

### DIFF
--- a/packages/res/res.5.0.0/opam
+++ b/packages/res/res.5.0.0/opam
@@ -14,7 +14,6 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04"}
-  "base-bytes"
   "jbuilder" {>= "1.0+beta10"}
 ]
 synopsis: "RES - Library for resizable, contiguous datastructures"

--- a/packages/res/res.5.0.1/opam
+++ b/packages/res/res.5.0.1/opam
@@ -15,7 +15,6 @@ build: [
 depends: [
   "ocaml" {>= "4.04"}
   "dune" {>= "1.4.0"}
-  "base-bytes"
 ]
 
 synopsis: "RES - Library for resizable, contiguous datastructures"


### PR DESCRIPTION
Upstream PR: https://github.com/mmottl/res/pull/5 As can be seen the `bytes` library is not used in the codebase.