### PR TITLE
Remove dependency on `base-bytes` on stringext versions using dune/jbuilder

### DIFF
--- a/packages/stringext/stringext.1.5.0/opam
+++ b/packages/stringext/stringext.1.5.0/opam
@@ -15,7 +15,6 @@ depends: [
   "jbuilder" {>= "1.0+beta10"}
   "ounit" {with-test}
   "qtest" {with-test & >= "2.2"}
-  "base-bytes"
 ]
 synopsis: "Extra string functions for OCaml"
 description: """

--- a/packages/stringext/stringext.1.6.0/opam
+++ b/packages/stringext/stringext.1.6.0/opam
@@ -9,7 +9,6 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "qtest" {with-test & >= "2.2"}
-  "base-bytes"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
They do not use the `bytes` package in the codebase itself.

Upstream PR: https://github.com/rgrinberg/stringext/pull/12