### PR TITLE
cryptokit < 1.16 is not compatible with OCaml 5.0 (uses oasis/Stream)

### DIFF
--- a/packages/cryptokit/cryptokit.1.11/opam
+++ b/packages/cryptokit/cryptokit.1.11/opam
@@ -5,7 +5,7 @@ bug-reports: "https://forge.ocamlcore.org/tracker/?group_id=133"
 homepage: "https://forge.ocamlcore.org/projects/cryptokit/"
 remove: [["ocamlfind" "remove" "cryptokit"]]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & != "0.9.0"}
   "conf-zlib"

--- a/packages/cryptokit/cryptokit.1.12/opam
+++ b/packages/cryptokit/cryptokit.1.12/opam
@@ -4,7 +4,7 @@ authors: ["Xavier Leroy"]
 bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
 homepage: "https://github.com/xavierleroy/cryptokit"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build & != "0.9.0"}
   "conf-zlib"

--- a/packages/cryptokit/cryptokit.1.13/opam
+++ b/packages/cryptokit/cryptokit.1.13/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
 homepage: "https://github.com/xavierleroy/cryptokit"
 dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build & != "0.9.0"}
   "conf-zlib"

--- a/packages/cryptokit/cryptokit.1.14/opam
+++ b/packages/cryptokit/cryptokit.1.14/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/xavierleroy/cryptokit/issues"
 homepage: "https://github.com/xavierleroy/cryptokit"
 dev-repo: "git+https://github.com/xavierleroy/cryptokit.git"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build & != "0.9.0"}
   "conf-zlib"


### PR DESCRIPTION
```
#=== ERROR while compiling cryptokit.1.14 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/cryptokit.1.14
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/cryptokit-10-305fa1.env
# output-file          ~/.opam/log/cryptokit-10-305fa1.out
### output ###
# ocaml setup.ml -configure 
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
# make: *** [Makefile:34: setup.data] Error 2
```