### PR TITLE
Update `dot-merlin-reader`'s ocaml upper bounds

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.1/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.06.1" }
+  "ocaml" {>= "4.06.1" & < "5.0.0"}
   "dune" {>= "2.7.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.2/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "dune" {>= "2.9.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}


### PR DESCRIPTION
The package does not build with OCaml 5 since it uses the now-removed `String.capitalize` function.
See #21629 