### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.3)

### DIFF
--- a/packages/eio/eio.0.3/opam
+++ b/packages/eio/eio.0.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "base-domains"
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "1.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.3/eio-0.3.tbz"
+  checksum: [
+    "sha256=1af8852025776d68eea24fd3baeffcb15b0db09805865fa3fa191f3139b689f9"
+    "sha512=12620fdeab7b444ce37226c34d4719560a8e2fa5dbfacf0c6d9480e0ee7d1759cd8293fc7fe451383c13fcc069ab33ad44d10b32d6dbc980d3163c209e1a03a6"
+  ]
+}
+x-commit-hash: "0b56cec54f3c9e0b9c4382e33b7594eef13af3d0"

--- a/packages/eio_linux/eio_linux.0.3/opam
+++ b/packages/eio_linux/eio_linux.0.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "base-domains"
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.3/eio-0.3.tbz"
+  checksum: [
+    "sha256=1af8852025776d68eea24fd3baeffcb15b0db09805865fa3fa191f3139b689f9"
+    "sha512=12620fdeab7b444ce37226c34d4719560a8e2fa5dbfacf0c6d9480e0ee7d1759cd8293fc7fe451383c13fcc069ab33ad44d10b32d6dbc980d3163c209e1a03a6"
+  ]
+}
+x-commit-hash: "0b56cec54f3c9e0b9c4382e33b7594eef13af3d0"

--- a/packages/eio_luv/eio_luv.0.3/opam
+++ b/packages/eio_luv/eio_luv.0.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "base-domains"
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.3/eio-0.3.tbz"
+  checksum: [
+    "sha256=1af8852025776d68eea24fd3baeffcb15b0db09805865fa3fa191f3139b689f9"
+    "sha512=12620fdeab7b444ce37226c34d4719560a8e2fa5dbfacf0c6d9480e0ee7d1759cd8293fc7fe451383c13fcc069ab33ad44d10b32d6dbc980d3163c209e1a03a6"
+  ]
+}
+x-commit-hash: "0b56cec54f3c9e0b9c4382e33b7594eef13af3d0"

--- a/packages/eio_main/eio_main.0.3/opam
+++ b/packages/eio_main/eio_main.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.3/eio-0.3.tbz"
+  checksum: [
+    "sha256=1af8852025776d68eea24fd3baeffcb15b0db09805865fa3fa191f3139b689f9"
+    "sha512=12620fdeab7b444ce37226c34d4719560a8e2fa5dbfacf0c6d9480e0ee7d1759cd8293fc7fe451383c13fcc069ab33ad44d10b32d6dbc980d3163c209e1a03a6"
+  ]
+}
+x-commit-hash: "0b56cec54f3c9e0b9c4382e33b7594eef13af3d0"


### PR DESCRIPTION
Effect-based direct-style IO mainloop for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

API changes:

- `Net.accept_sub` is deprecated in favour of `accept_fork` (@talex5 ocaml-multicore/eio#240).
  `Fiber.fork_on_accept`, which it used internally, has been removed.

- Allow short writes in `Read_source_buffer` (@talex5 ocaml-multicore/eio#239).
  The reader is no longer required to consume all the data in one go.
  Also, add `Linux_eio.Low_level.writev_single` to expose this behaviour directly.

- `Eio.Unix_perm` is now `Eio.Dir.Unix_perm`.

New features:

- Add `Eio.Mutex` (@TheLortex @talex5 ocaml-multicore/eio#223).

- Add `Eio.Buf_write` (@talex5 ocaml-multicore/eio#235).
  This is a buffered writer for Eio sinks, based on Faraday.

- Add `Eio_mock` library for testing (@talex5 ocaml-multicore/eio#228).
  At the moment it has mock flows and networks.

- Add `Eio_mock.Backend` (@talex5 ocaml-multicore/eio#237 ocaml-multicore/eio#238).
  Allows running tests without needing a dependency on eio_main.
  Also, as it is single-threaded, it can detect deadlocks in test code instead of just hanging.

- Add `Buf_read.{of_buffer, of_string, parse_string{,_exn}, return}` (@talex5 ocaml-multicore/eio#225).

- Add `<*>` combinator to `Buf_read.Syntax` (@talex5 ocaml-multicore/eio#227).

- Add `Eio.Dir.read_dir` (@patricoferris @talex5 ocaml-multicore/eio#207 ocaml-multicore/eio#218 ocaml-multicore/eio#219)

Performance:

- Add `Buf_read` benchmark and optimise it a bit (@talex5 ocaml-multicore/eio#230).

- Inline `Buf_read.consume` to improve performance (@talex5 ocaml-multicore/eio#232).

Bug fixes / minor changes:

- Allow IO to happen even if a fiber keeps yielding (@TheLortex @talex5 ocaml-multicore/eio#213).

- Fallback for `traceln` without an effect handler (@talex5 ocaml-multicore/eio#226).
  `traceln` now works outside of an event loop too.

- Check for cancellation when creating a non-protected child context (@talex5 ocaml-multicore/eio#222).

- eio_linux: handle EINTR when calling `getrandom` (@bikallem ocaml-multicore/eio#212).

- Update to cmdliner.1.1.0 (@talex5 ocaml-multicore/eio#190).
