### PR TITLE
[new release] rtop and reason (3.8.1)

### DIFF
--- a/packages/reason/reason.3.8.1/opam
+++ b/packages/reason/reason.3.8.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/reasonml/reason"
+doc: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+dev-repo: "git+https://github.com/reasonml/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"         {>= "4.03" & < "4.15"}
+  "dune"          {>= "1.4"}
+  "ocamlfind"     {build}
+  "menhir"        {>= "20180523"}
+  "merlin-extend" {>= "0.6"}
+  "fix"
+  "result"
+  "ppx_derivers"
+]
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.8.1/reason-3.8.1.tbz"
+  checksum: [
+    "sha256=7e9f2ac9de46619b9dcfeb067cb7e6fd794c342fb766dafef34ad66c507c7c24"
+    "sha512=f5e833205aee6d59007ef13314e0a5fdecb5c8bce1d747d6ebefbfab809beb1e46dd8a2179db7329d59481eacb154904d9829f6be60141d9e63db4e89fcfd7ee"
+  ]
+}
+x-commit-hash: "02fa372146d113e9e19b63373ab60f3f0995e40c"

--- a/packages/reason/reason.3.8.1/opam
+++ b/packages/reason/reason.3.8.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"         {>= "4.03" & < "5.1"}
-  "dune"          {>= "1.4"}
+  "dune"          {>= "2.3"}
   "ocamlfind"     {build}
   "menhir"        {>= "20180523"}
   "merlin-extend" {>= "0.6"}

--- a/packages/reason/reason.3.8.1/opam
+++ b/packages/reason/reason.3.8.1/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "4.03" & < "4.15"}
+  "ocaml"         {>= "4.03" & < "5.1"}
   "dune"          {>= "1.4"}
   "ocamlfind"     {build}
   "menhir"        {>= "20180523"}

--- a/packages/rtop/rtop.3.8.1/opam
+++ b/packages/rtop/rtop.3.8.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Jordan Walke <jordojw@gmail.com>"
+authors: [ "Jordan Walke <jordojw@gmail.com>" ]
+license: "MIT"
+homepage: "https://github.com/reasonml/reason"
+doc: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+dev-repo: "git+https://github.com/reasonml/reason.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"  {>= "4.02" & < "4.15"}
+  "dune"   {>= "1.4"}
+  "reason" {=version}
+  "utop"   {>= "2.0"}
+]
+synopsis: "Reason toplevel"
+description:
+  "rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/diml/utop)."
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.8.1/reason-3.8.1.tbz"
+  checksum: [
+    "sha256=7e9f2ac9de46619b9dcfeb067cb7e6fd794c342fb766dafef34ad66c507c7c24"
+    "sha512=f5e833205aee6d59007ef13314e0a5fdecb5c8bce1d747d6ebefbfab809beb1e46dd8a2179db7329d59481eacb154904d9829f6be60141d9e63db4e89fcfd7ee"
+  ]
+}
+x-commit-hash: "02fa372146d113e9e19b63373ab60f3f0995e40c"
+

--- a/packages/rtop/rtop.3.8.1/opam
+++ b/packages/rtop/rtop.3.8.1/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"  {>= "4.02" & < "4.15"}
+  "ocaml"  {>= "4.02" & < "5.1"}
   "dune"   {>= "1.4"}
   "reason" {=version}
   "utop"   {>= "2.0"}

--- a/packages/rtop/rtop.3.8.1/opam
+++ b/packages/rtop/rtop.3.8.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 depends: [
   "ocaml"  {>= "4.02" & < "5.1"}
-  "dune"   {>= "1.4"}
+  "dune"   {>= "2.3"}
   "reason" {=version}
   "utop"   {>= "2.0"}
 ]


### PR DESCRIPTION
Reason toplevel

- Project page: <a href="https://github.com/reasonml/reason">https://github.com/reasonml/reason</a>
- Documentation: <a href="https://reasonml.github.io/">https://reasonml.github.io/</a>

##### CHANGES:

- (Internal) Rename: Reason_migrate_parsetree -> Reason_omp (@ManasJayanth) [reasonml/reason#2666](https://github.com/reasonml/reason/pull/2666)
- Add support for OCaml 5.0 (@EduardoRFS and @anmonteiro) [reasonml/reason#2667](https://github.com/reasonml/reason/pull/2667)
