### PR TITLE
Package lwt.5.6.1

### DIFF
--- a/packages/lwt/lwt.5.6.1/opam
+++ b/packages/lwt/lwt.5.6.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Raphaël Proust <code@bnwr.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.8.0"}
+  "dune-configurator"
+  "ocaml" {>= "4.08"}
+  "ocplib-endian"
+
+  # Until https://github.com/aantron/bisect_ppx/pull/327.
+  # "bisect_ppx" {dev & >= "2.0.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+build: [
+  ["dune" "exec" "-p" name "src/unix/config/discover.exe" "--" "--save"
+    "--use-libev" "%{conf-libev:installed}%"]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.6.1.tar.gz"
+  checksum: [
+    "md5=279024789a0ec84a9d97d98bad847f97"
+    "sha512=698875bd3bfcd5baa47eb48e412f442d289f9972421321541860ebe110b9af1949c3fbc253768495726ec547fe4ba25483cd97ff39bc668496fba95b2ed9edd8"
+  ]
+}


### PR DESCRIPTION
### `lwt.5.6.1`
Promises and event-driven I/O
A promise is a value that may become determined in the future.

Lwt provides typed, composable promises. Promises that are resolved by I/O are
resolved by Lwt in parallel.

Meanwhile, OCaml code, including code creating and waiting on promises, runs in
a single thread by default. This reduces the need for locks or other
synchronization primitives. Code can be run in parallel on an opt-in basis.



---
* Homepage: https://github.com/ocsigen/lwt
* Source repo: git+https://github.com/ocsigen/lwt.git
* Bug tracker: https://github.com/ocsigen/lwt/issues

---
:camel: Pull-request generated by opam-publish v2.1.0