### PR TITLE
8 packages from gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz

### DIFF
--- a/packages/resto-acl/resto-acl.0.9/opam
+++ b/packages/resto-acl/resto-acl.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "Access Control Lists for Resto"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto" {= version }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.0.9/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.0.9/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.9/opam
+++ b/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.9/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp-client" {= version }
+  "resto-cohttp-server" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.9/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.9/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "resto-cohttp" {= version }
+  "resto-acl" {= version }
+  "cohttp-lwt-unix" { >= "2.0.0" }
+  "conduit-lwt-unix" { >= "2.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.0.9/opam
+++ b/packages/resto-cohttp/resto-cohttp.0.9/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto-directory/resto-directory.0.9/opam
+++ b/packages/resto-directory/resto-directory.0.9/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "resto-json" {= version & with-test }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto-json/resto-json.0.9/opam
+++ b/packages/resto-json/resto-json.0.9/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "json-data-encoding" {= "0.9.1" }
+  "json-data-encoding-bson" {= "0.9.1" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}

--- a/packages/resto/resto.0.9/opam
+++ b/packages/resto/resto.0.9/opam
@@ -20,8 +20,8 @@ depends: [
   "ezjsonm" {with-test}
   "lwt" {with-test}
   "base-unix"{with-test}
-  "alcotest" { = "1.5.0" & with-test}
-  "alcotest-lwt" { = "1.5.0" & with-test}
+  "alcotest" { >= "1.5.0" & with-test}
+  "alcotest-lwt" { >= "1.5.0" & with-test}
   "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
   "odoc" { with-doc }
 ]

--- a/packages/resto/resto.0.9/opam
+++ b/packages/resto/resto.0.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "json-data-encoding" {= "0.9.1" & with-test }
+  "json-data-encoding-bson" {= "0.9.1" & with-test }
+  "ezjsonm" {with-test}
+  "lwt" {with-test}
+  "base-unix"{with-test}
+  "alcotest" { = "1.5.0" & with-test}
+  "alcotest-lwt" { = "1.5.0" & with-test}
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+]
+
+conflicts: [ "result" {< "1.5"} ]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.9/resto-v0.9.tar.gz"
+  checksum: [
+    "md5=863a932f2e869589565eae3c6f11d3e0"
+    "sha512=edbd7c04d4f574af661c05e820109c5a9ab0a0b2ae47f8ae834175500603e17edb9d81c4ec59b2fc84e366327ea015ed5923befafff99b97e3a55803b04af2a2"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`resto.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-acl.0.9`: Access Control Lists for Resto
-`resto-cohttp.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-client.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-self-serving-client.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-server.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
-`resto-directory.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-json.0.9`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.1.0