### PR TITLE
[new release] merlin, merlin-lib and dot-merlin-reader (4.6-414)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.6-414/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.6-414/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "5.0.0"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.6"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-414/merlin-4.6-414.tbz"
+  checksum: [
+    "sha256=02ebd70a3c77d8940163dbe4c40774a448ed145ea84e0ad3d5ff5324410393ce"
+    "sha512=7373fadf05c692c9f054c7fe6a7d4bdfeefe237b9df432024ef9923782ee72e09021c0c3fba869da8347728105cb2d3ff0aa94b0c5eb09811bb25aa8da9fb520"
+  ]
+}
+x-commit-hash: "be753d9412387aedcf32aba88a1be9bcd33d97ba"

--- a/packages/merlin-lib/merlin-lib.4.6-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.6-414/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-414/merlin-4.6-414.tbz"
+  checksum: [
+    "sha256=02ebd70a3c77d8940163dbe4c40774a448ed145ea84e0ad3d5ff5324410393ce"
+    "sha512=7373fadf05c692c9f054c7fe6a7d4bdfeefe237b9df432024ef9923782ee72e09021c0c3fba869da8347728105cb2d3ff0aa94b0c5eb09811bb25aa8da9fb520"
+  ]
+}
+x-commit-hash: "be753d9412387aedcf32aba88a1be9bcd33d97ba"

--- a/packages/merlin/merlin.4.6-414/opam
+++ b/packages/merlin/merlin.4.6-414/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.6"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-414/merlin-4.6-414.tbz"
+  checksum: [
+    "sha256=02ebd70a3c77d8940163dbe4c40774a448ed145ea84e0ad3d5ff5324410393ce"
+    "sha512=7373fadf05c692c9f054c7fe6a7d4bdfeefe237b9df432024ef9923782ee72e09021c0c3fba869da8347728105cb2d3ff0aa94b0c5eb09811bb25aa8da9fb520"
+  ]
+}
+x-commit-hash: "be753d9412387aedcf32aba88a1be9bcd33d97ba"


### PR DESCRIPTION
CHANGES:

Thu Jun 30 14:51:42 CEST 2022

  + merlin binary
    - make most library public and split merlin in two packages: the
      `merlin-lib` package that exposes merlin's internals and the `merlin`
      package with the frontend. (ocaml/merlin#1448, ocaml/merlin#1455, ocaml/merlin#1457, ocaml/merlin#1497, @rgrinberg,
      @tmattio, @kit-ty-kate)
    - Type printing: use best_module_path for paths from Mty_alias (ocaml/merlin#1470)
    - Attempt at finding the 'real' capitalization of files on windows (ocaml/merlin#1462 by
      @mlasson)
    - Use newer `Seq`-based API of Yojson 2.0, avoiding the need for the
      deprecated `Stream` module (ocaml/merlin#1475 by @Leonidas-from-XIV)
    - unify parsing of `MERLIN_LOG` (ocaml/merlin#1480 by @ulugbekna)
    - Fix type deduplication in `type-enclosing` results (ocaml/merlin#1483, fixes ocaml/merlin#1477)
    - Only weakly reduce the shapes to speed up the new Merlin locate
      implementation. (ocaml/merlin#1488)
    - Ignore unknown configuration tags from dune configuration provider but not
      from dot-merlin-reader (ocaml/merlin#1486)
    - typing recovery: recover at the granularity of `core_type` (ocaml/merlin#1484)
  + editor modes
    - add method imenu items for emacs (ocaml/merlin#1481, @mndrix)
    - emacs: Make the prefix argument to `merlin-locate` optional, both for
      consistency with Emacs convention and for backwards compatibility. (ocaml/merlin#1476,
      @antalsz)
    - emacs: fix duplicated prefix path in imenu entries (ocaml/merlin#1495, @bcc32)