### PR TITLE
Package carray.0.0.2

### DIFF
--- a/packages/carray/carray.0.0.2/opam
+++ b/packages/carray/carray.0.0.2/opam
@@ -8,7 +8,7 @@ bug-reports: "https://gitlab.com/dannywillems/ocaml-carray/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
-  "bls12-381" {>= "3.0.0" & with-test}
+  "bls12-381" {>= "3.0.0" & < "4.0.0" & with-test}
   "alcotest" {with-test}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]

--- a/packages/carray/carray.0.0.2/opam
+++ b/packages/carray/carray.0.0.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Contiguous arrays in OCaml"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-carray"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-carray/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "3.0.0" & with-test}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-carray.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-carray/-/archive/0.0.2/ocaml-carray-0.0.2.tar.bz2"
+  checksum: [
+    "md5=28991f1b5a3f1c2ba18b085e7e8da5a3"
+    "sha512=497ee34ec4108bbe3c8c5531b940c7a2b19c628adbd9d2af6d97f5a25a6ea80999cc20e885a9a9ddfb39993eda91eb66e05fb65fd7b4e1d9bd19bdd4ba5982ec"
+  ]
+}


### PR DESCRIPTION
### `carray.0.0.2`
Contiguous arrays in OCaml



---
* Homepage: https://gitlab.com/dannywillems/ocaml-carray
* Source repo: git+https://gitlab.com/dannywillems/ocaml-carray.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-carray/issues

---
:camel: Pull-request generated by opam-publish v2.1.0