### PR TITLE
Release merlin v4.6-413/412 and dot-merlin-reader 4.5

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.5/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.5/opam
@@ -11,11 +11,11 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.06.1" & < "5.0.0"}
-  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
+  "dune" {>= "2.9.0"}
   "yojson" {>= "1.6.0"}
   "ocamlfind" {>= "1.6.0"}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
 ]
 description:
   "Helper process: reads .merlin files and gives the normalized content to merlin"

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.5/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.1" & < "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "yojson" {>= "1.6.0"}
+  "ocamlfind" {>= "1.6.0"}
+  "csexp" {>= "1.2.3"}
+]
+description:
+  "Helper process: reads .merlin files and gives the normalized content to merlin"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-413/merlin-4.6-413.tbz"
+  checksum: [
+    "sha256=f3dd371f84c4e85fefd8ac355e97297571222c875bf6595882de36cd247d90ee"
+    "sha512=fe88a52c4c3c94505da142fbb7d400fce11bfafe6e47ec7cd39437308baa7122399a008bb6d0ef7b8f29636c2a51f4d49e3535136010fec198a1188293914a56"
+  ]
+}
+x-commit-hash: "2f422293d26b16ccf934d6d340c7a02f76e444c9"

--- a/packages/merlin/merlin.4.6-412/opam
+++ b/packages/merlin/merlin.4.6-412/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.6-412/opam
+++ b/packages/merlin/merlin.4.6-412/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+conflicts: "seq" {!= "base"}
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-412/merlin-4.6-412.tbz"
+  checksum: [
+    "sha256=8ac8aeacb7969a29c9410478a07a493c2cd593a7049ad41d5f8fa7dcf7646b97"
+    "sha512=4362482ecd7c8af1c4e740e3816100cd5408eba3aebc01b867b45bdd1dcc237819cb0640e0f618b6ecf00aa8d55e58e55ecfeb176ed7b358c404ea71302443b0"
+  ]
+}
+x-commit-hash: "014387709c659fd937476647a30387cd7a58c9a7"

--- a/packages/merlin/merlin.4.6-413/opam
+++ b/packages/merlin/merlin.4.6-413/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.6-413/opam
+++ b/packages/merlin/merlin.4.6-413/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.13" & < "4.14"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+conflicts: "seq" {!= "base"}
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.6-413/merlin-4.6-413.tbz"
+  checksum: [
+    "sha256=f3dd371f84c4e85fefd8ac355e97297571222c875bf6595882de36cd247d90ee"
+    "sha512=fe88a52c4c3c94505da142fbb7d400fce11bfafe6e47ec7cd39437308baa7122399a008bb6d0ef7b8f29636c2a51f4d49e3535136010fec198a1188293914a56"
+  ]
+}
+x-commit-hash: "2f422293d26b16ccf934d6d340c7a02f76e444c9"


### PR DESCRIPTION
    CHANGES:
    
    Fri Jul  1 12:51:42 CEST 2022
    
      + merlin binary
        - Type printing: use `best_module_path` for paths from `Mty_alias` (ocaml/merlin#1470)
        - Attempt at finding the 'real' capitalization of files on windows (ocaml/merlin#1462 by
          @mlasson)
        - Use newer `Seq`-based API of Yojson 2.0, avoiding the need for the
          deprecated `Stream` module (ocaml/merlin#1475 by @Leonidas-from-XIV)
        - unify parsing of `MERLIN_LOG` (ocaml/merlin#1480 by @ulugbekna)
        - Fix type deduplication in `type-enclosing` results (ocaml/merlin#1483, fixes ocaml/merlin#1477)
        - Ignore unknown configuration tags from dune configuration provider but not
          from dot-merlin-reader (ocaml/merlin#1486)
        - typing recovery: recover at the granularity of `core_type` (ocaml/merlin#1484)
      + editor modes
        - Fix `merlin-locate-in-new-window` is ignored (ocaml/merlin#1461 by @emturner,
          fixes ocaml/merlin#1460)
        - add method imenu items for emacs (ocaml/merlin#1481, @mndrix)
        - emacs: Make the prefix argument to `merlin-locate` optional, both for
          consistency with Emacs convention and for backwards compatibility. (ocaml/merlin#1476,
          @antalsz)
        - emacs: fix duplicated prefix path in imenu entries (ocaml/merlin#1495, @bcc32)