### PR TITLE
[new release] merlin (3.8.0)

### DIFF
--- a/packages/merlin/merlin.3.8.0/opam
+++ b/packages/merlin/merlin.3.8.0/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test & ocaml:version >= "4.03"}
+]
+depends: [
+  "ocaml" {>= "4.02.3" & < "4.12"}
+  "dune" {>= "1.8.0"}
+  "dot-merlin-reader" {>= "3.4.2"}
+  "yojson" {>= "2.0.0"}
+  "mdx" {with-test & >= "1.3.0" & < "2.0.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "result" {>= "1.5"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+conflicts: "seq" {!= "base"}
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v3.8.0/merlin-3.8.0.tbz"
+  checksum: [
+    "sha256=c260463705cbdc176e178a35b145ed00e507278c6632fb1603197f41d363ff6f"
+    "sha512=6595624fb9346c8f0563e187885a8f821173057a10f50c43615c6ec694f44025d02a955acbe50b8e1b9c540ed0444dc4303140b435169973d16de6ef78defa27"
+  ]
+}
+x-commit-hash: "5d123b4b80e9b2af0e4ce95198e633d28496eb94"


### PR DESCRIPTION
CHANGES:

Thu Jun 30 16:51:42 CEST 2022

  + merlin binary
    - Use newer `Seq`-based API of Yojson 2.0, avoiding the need for the
      deprecated `Stream` module (ocaml/merlin#1475 by @Leonidas-from-XIV)