### PR TITLE
5 packages from diskuv/dkml-install-api at 0.1.0

### DIFF
--- a/packages/dkml-component-xx-console/dkml-component-xx-console.0.1.0/opam
+++ b/packages/dkml-component-xx-console/dkml-component-xx-console.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Internal component used by dkml-package-console"
+description:
+  "Executables for launching console based installers"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+install: [
+  ["install" "-d"
+    "%{_:share}%/staging-files/windows_x86/bin"
+    "%{_:share}%/staging-files/windows_x86_64/bin"]
+
+  # gsudo
+  [
+    "unzip" "-o" "-d" "%{_:share}%/staging-files/windows_x86/bin"
+    "dl/gsudo.v1.3.0.zip"
+    "gsudo.exe"
+  ]
+  [
+    "unzip" "-o" "-d" "%{_:share}%/staging-files/windows_x86_64/bin"
+    "dl/gsudo.v1.3.0.zip"
+    "gsudo.exe"
+  ]
+]
+extra-source "dl/gsudo.v1.3.0.zip" {
+  src: "https://github.com/gerardog/gsudo/releases/download/v1.3.0/gsudo.v1.3.0.zip"
+  checksum: [
+    "sha256=cfd28467bbedf85bb05dc35f59c2e16ba8f19bd7aa555abb37cb2693a9b97855"
+  ]
+}
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=946a6c2f04cc071b005bf91d0d0e4638"
+    "sha512=c4368e426c97fc6029f5dd4e95435201b126bdabf4bcba96d9d7a95b65939dc2e25f5dbb3b5037e91480f06c2c503f00e1ca1645387e423cc3a0cf9dc5722aca"
+  ]
+}

--- a/packages/dkml-install-installer/dkml-install-installer.0.1.0/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Build tools for DKML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=946a6c2f04cc071b005bf91d0d0e4638"
+    "sha512=c4368e426c97fc6029f5dd4e95435201b126bdabf4bcba96d9d7a95b65939dc2e25f5dbb3b5037e91480f06c2c503f00e1ca1645387e423cc3a0cf9dc5722aca"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Runner executable for Diskuv OCaml (DKML) installation"
+description:
+  "The runner executable is responsible for loading and running all DKML installation components."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dune" {>= "2.9" & >= "2.9"}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=946a6c2f04cc071b005bf91d0d0e4638"
+    "sha512=c4368e426c97fc6029f5dd4e95435201b126bdabf4bcba96d9d7a95b65939dc2e25f5dbb3b5037e91480f06c2c503f00e1ca1645387e423cc3a0cf9dc5722aca"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.1.0/opam
+++ b/packages/dkml-install/dkml-install.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "API and registry for Diskuv OCaml (DKML) installation components"
+description:
+  "All DKML installation components implement the interfaces exposed in this API."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dune" {>= "2.9" & >= "2.9"}
+  "ppx_deriving" {>= "5.2.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=946a6c2f04cc071b005bf91d0d0e4638"
+    "sha512=c4368e426c97fc6029f5dd4e95435201b126bdabf4bcba96d9d7a95b65939dc2e25f5dbb3b5037e91480f06c2c503f00e1ca1645387e423cc3a0cf9dc5722aca"
+  ]
+}

--- a/packages/dkml-package-console/dkml-package-console.0.1.0/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Console setup and uninstall executables for Diskuv OCaml (DKML) installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DKML runners."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9" & >= "2.9"}
+  "diskuvbox" {>= "0.1.0"}
+  "crunch" {>= "3.2.0"}
+  "dkml-component-xx-console" {>= "0.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=946a6c2f04cc071b005bf91d0d0e4638"
+    "sha512=c4368e426c97fc6029f5dd4e95435201b126bdabf4bcba96d9d7a95b65939dc2e25f5dbb3b5037e91480f06c2c503f00e1ca1645387e423cc3a0cf9dc5722aca"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-component-xx-console.0.1.0`: Internal component used by dkml-package-console
-`dkml-install.0.1.0`: API and registry for Diskuv OCaml (DKML) installation components
-`dkml-install-installer.0.1.0`: Build tools for DKML installers
-`dkml-install-runner.0.1.0`: Runner executable for Diskuv OCaml (DKML) installation
-`dkml-package-console.0.1.0`: Console setup and uninstall executables for Diskuv OCaml (DKML) installation



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0