### PR TITLE
Package dkml-component-xx-console.0.1.0

### DIFF
--- a/packages/dkml-component-xx-console/dkml-component-xx-console.0.1.0/opam
+++ b/packages/dkml-component-xx-console/dkml-component-xx-console.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Component used by the dkml-package-console Console Packager"
+description:
+  "Executables for launching console based installers"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+install: [
+  ["install" "-d"
+    "%{_:share}%/staging-files/windows_x86/bin"
+    "%{_:share}%/staging-files/windows_x86_64/bin"]
+
+  # gsudo
+  [
+    "unzip" "-o" "-d" "%{_:share}%/staging-files/windows_x86/bin"
+    "dl/gsudo.v1.3.0.zip"
+    "gsudo.exe"
+  ]
+  [
+    "unzip" "-o" "-d" "%{_:share}%/staging-files/windows_x86_64/bin"
+    "dl/gsudo.v1.3.0.zip"
+    "gsudo.exe"
+  ]
+]
+extra-source "dl/gsudo.v1.3.0.zip" {
+  src: "https://github.com/gerardog/gsudo/releases/download/v1.3.0/gsudo.v1.3.0.zip"
+  checksum: [
+    "sha256=cfd28467bbedf85bb05dc35f59c2e16ba8f19bd7aa555abb37cb2693a9b97855"
+  ]
+}
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-console/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=33163a6d1bf8cf5980a5382f00456933"
+    "sha512=5576735da071ce0e3cab693ef93754b0ae73739c8096916eb33cda7c06cc15dd1c4507ab5805caa08a07cc53a77015a3df90a70bd9e1bfbbfab3d9098bb903cd"
+  ]
+}


### PR DESCRIPTION
### `dkml-component-xx-console.0.1.0`
Component used by the dkml-package-console Console Packager
Executables for launching console based installers



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0