### PR TITLE
4 packages from diskuv/dkml-install-api at 0.1.0

### DIFF
--- a/packages/dkml-install-installer/dkml-install-installer.0.1.0/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Build tools for DKML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "crunch" {>= "3.2.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=758b8f4a4cb870ef8e41f4b3856aa3eb"
+    "sha512=08c59e148f025ce468e94be52ef5f8ba4995b8017e993968206f135b8f7431e08ae48dbba91ce5ae83b7b118d09ec968013cccbd5fa15b1e3e81f60894e90c11"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Runner executable for Diskuv OCaml (DKML) installation"
+description:
+  "The runner executable is responsible for loading and running all DKML installation components."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dune" {>= "2.9" & >= "2.9"}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=758b8f4a4cb870ef8e41f4b3856aa3eb"
+    "sha512=08c59e148f025ce468e94be52ef5f8ba4995b8017e993968206f135b8f7431e08ae48dbba91ce5ae83b7b118d09ec968013cccbd5fa15b1e3e81f60894e90c11"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.1.0/opam
+++ b/packages/dkml-install/dkml-install.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "API and registry for Diskuv OCaml (DKML) installation components"
+description:
+  "All DKML installation components implement the interfaces exposed in this API."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dune" {>= "2.9" & >= "2.9"}
+  "ppx_deriving" {>= "5.2.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=758b8f4a4cb870ef8e41f4b3856aa3eb"
+    "sha512=08c59e148f025ce468e94be52ef5f8ba4995b8017e993968206f135b8f7431e08ae48dbba91ce5ae83b7b118d09ec968013cccbd5fa15b1e3e81f60894e90c11"
+  ]
+}

--- a/packages/dkml-package-console/dkml-package-console.0.1.0/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Console setup and uninstall executables for Diskuv OCaml (DKML) installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DKML runners."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9" & >= "2.9"}
+  "diskuvbox" {>= "0.1.0"}
+  "crunch" {>= "3.2.0"}
+  "dkml-component-xx-console" {>= "0.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=758b8f4a4cb870ef8e41f4b3856aa3eb"
+    "sha512=08c59e148f025ce468e94be52ef5f8ba4995b8017e993968206f135b8f7431e08ae48dbba91ce5ae83b7b118d09ec968013cccbd5fa15b1e3e81f60894e90c11"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-install.0.1.0`: API and registry for Diskuv OCaml (DKML) installation components
-`dkml-install-installer.0.1.0`: Build tools for DKML installers
-`dkml-install-runner.0.1.0`: Runner executable for Diskuv OCaml (DKML) installation
-`dkml-package-console.0.1.0`: Console setup and uninstall executables for Diskuv OCaml (DKML) installation



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0