### PR TITLE
Make dkml-component-xx-console.0.1.0 installable only on Windows x86

### DIFF
--- a/packages/dkml-component-xx-console/dkml-component-xx-console.0.1.0/opam
+++ b/packages/dkml-component-xx-console/dkml-component-xx-console.0.1.0/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-install-api"
 bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
 dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+available: os = "win32" & (arch = "x86_32" | arch = "x86_64")
 install: [
   ["install" "-d"
     "%{_:share}%/staging-files/windows_x86/bin"


### PR DESCRIPTION
Installs windows binary

cc @jonahbeckford 