### PR TITLE
[new release] frama-c (25.0)

### DIFF
--- a/packages/frama-c/frama-c.25.0/opam
+++ b/packages/frama-c/frama-c.25.0/opam
@@ -1,0 +1,157 @@
+opam-version: "2.0"
+synopsis: "Platform dedicated to the analysis of source code written in C"
+description:"""
+Frama-C gathers several analysis techniques in a single collaborative
+framework, based on analyzers (called "plug-ins") that can build upon the
+results computed by other analyzers in the framework.
+Thanks to this approach, Frama-C provides sophisticated tools, including:
+- an analyzer based on abstract interpretation (Eva plug-in);
+- a program proof framework based on weakest precondition calculus (WP plug-in);
+- a program slicer (Slicing plug-in);
+- a tool for verification of temporal (LTL) properties (Aoraï plug-in);
+- a runtime verification tool (E-ACSL plug-in);
+- several tools for code base exploration and dependency analysis
+  (plug-ins From, Impact, Metrics, Occurrence, Scope, etc.).
+These plug-ins communicate between each other via the Frama-C API
+and via ACSL (ANSI/ISO C Specification Language) properties.
+"""
+maintainer: "francois.bobot@cea.fr"
+authors: [
+  "Michele Alberti"
+  "Thibaud Antignac"
+  "Gergö Barany"
+  "Patrick Baudin"
+  "Thibaut Benjamin"
+  "Allan Blanchard"
+  "Lionel Blatter"
+  "François Bobot"
+  "Richard Bonichon"
+  "Quentin Bouillaguet"
+  "David Bühler"
+  "Zakaria Chihani"
+  "Loïc Correnson"
+  "Julien Crétin"
+  "Pascal Cuoq"
+  "Zaynah Dargaye"
+  "Basile Desloges"
+  "Jean-Christophe Filliâtre"
+  "Philippe Herrmann"
+  "Maxime Jacquemin"
+  "Florent Kirchner"
+  "Tristan Le Gall"
+  "Jean-Christophe Léchenet"
+  "Matthieu Lemerre"
+  "Dara Ly"
+  "David Maison"
+  "Claude Marché"
+  "André Maroneze"
+  "Thibault Martin"
+  "Fonenantsoa Maurica"
+  "Melody Méaulle"
+  "Benjamin Monate"
+  "Yannick Moy"
+  "Anne Pacalet"
+  "Valentin Perrelle"
+  "Guillaume Petiot"
+  "Dario Pinto"
+  "Virgile Prevosto"
+  "Armand Puccetti"
+  "Félix Ridoux"
+  "Virgile Robles"
+  "Muriel Roger"
+  "Julien Signoles"
+  "Kostyantyn Vorobyov"
+  "Boris Yakobowski"
+]
+homepage: "https://frama-c.com/"
+license: "LGPL-2.1-only"
+dev-repo: "git+https://git.frama-c.com/pub/frama-c.git"
+doc: "http://frama-c.com/download/user-manual-25.0-Manganese.pdf"
+bug-reports: "https://git.frama-c.com/pub/frama-c/issues"
+tags: [
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "interactive theorem prover"
+  "C"
+  "plugins"
+  "abstract interpretation"
+  "slicing"
+  "weakest precondition"
+  "ACSL"
+  "dataflow analysis"
+  "runtime verification"
+]
+
+build: [
+  ["autoconf"] {dev}
+  ["./configure" "--prefix" prefix
+                 "--mandir=%{man}%"
+  ]
+  [make "-j%{jobs}%"]
+  [make "-C" "doc" "download"] {with-doc}
+]
+
+install: [
+  [make "install"]
+  [make "-C" "doc" "install"] {with-doc}
+]
+
+run-test: [
+  [make "-j%{jobs}%" "PTESTS_OPTS=-error-code" "tests"] { arch != "ppc64" & arch != "x86_32" & arch != "arm32" }
+  # tests are disabled on PPC64 due to floating-point oracle differences
+  # (some ULPs in libc trigonometric functions) and due to the lack of
+  # available hardware to test them locally
+]
+
+# Please keep depends and depopts sorted by package name
+depends: [
+  "conf-autoconf" { build }
+  ( ( "lablgtk" { >= "2.18.8" } & "conf-gnomecanvas" & "conf-gtksourceview"
+      & ("ocamlgraph" { < "2.0" } | "ocamlgraph_gtk" ))
+    | ( "lablgtk3" { >= "3.1.0" & os!="macos" }
+        & "lablgtk3-sourceview3" & "conf-gtksourceview3" ) )
+  ( "alt-ergo-free" | "alt-ergo" )
+  "conf-graphviz" { post }
+  "conf-time" { with-test }
+  "ocaml" { >= "4.08.1" }
+  "ocamlfind" # needed beyond build stage, used by -load-module
+  "ocamlgraph" { >= "1.8.8" }
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_import" {>= "1.8.0"}
+  "why3" { >= "1.5.0" }
+  "yojson" {>= "1.6.0" & ( < "2.0.0" | ! with-test) }
+  "zarith" {>= "1.5"}
+]
+
+conflicts: [
+  "result" {< "1.5"}
+  "cairo2" { < "0.6.2" }
+]
+
+depopts: [
+  # cannot use {build}: Frama-C must be recompiled when Coq and libraries
+  # change.
+  # Coq: because .vo would would not be loadable by another version of Coq
+  # libraries: because we use dynamic linking
+  "apron"
+  "coq"
+  "mlgmpidl"
+  "zmq"
+]
+
+x-ci-accept-failures: [
+  "nnp" "nnpchecker"
+  "centos-7"  # Too old version of make
+]
+
+post-messages: [
+  "Why3 provers setup: rm -f ~/.why3.conf ; why3 config detect"
+]
+
+url {
+  src: "https://www.frama-c.com/download/frama-c-25.0-Manganese.tar.gz"
+  checksum: "sha256=222dcefcd272053540bf5b6cff369efc47b81c28f360eb616669c3f30a8bc29f"
+}


### PR DESCRIPTION
Replaces https://github.com/ocaml/opam-repository/pull/21710, by being created from a team repository for easier management.