### PR TITLE
[new release] macaddr, macaddr-sexp, macaddr-cstruct, ipaddr, ipaddr-sexp and ipaddr-cstruct (5.3.1)

### DIFF
--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.3.1/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.3.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.1/ipaddr-5.3.1.tbz"
+  checksum: [
+    "sha256=9820bcbccadb6e6d9e22fe26b2f9a044897c8f47c29d157f464b41a2f191e7d4"
+    "sha512=1d400f8344d1a8c2ac1c55e4a7167484034094e2227ce7c8f2f45843b0875a83030851400ceb96b5cdb756fa8798d83c77d839705fcb9e3f2bd5e46d337d63d0"
+  ]
+}
+x-commit-hash: "4fe91c7a7774d829a65e711be5d7df1501bc2e75"

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.3.1/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.3.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "ipaddr-cstruct" {with-test & = version}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.1/ipaddr-5.3.1.tbz"
+  checksum: [
+    "sha256=9820bcbccadb6e6d9e22fe26b2f9a044897c8f47c29d157f464b41a2f191e7d4"
+    "sha512=1d400f8344d1a8c2ac1c55e4a7167484034094e2227ce7c8f2f45843b0875a83030851400ceb96b5cdb756fa8798d83c77d839705fcb9e3f2bd5e46d337d63d0"
+  ]
+}
+x-commit-hash: "4fe91c7a7774d829a65e711be5d7df1501bc2e75"

--- a/packages/ipaddr/ipaddr.5.3.1/opam
+++ b/packages/ipaddr/ipaddr.5.3.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * ounit2-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "domain-name" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.1/ipaddr-5.3.1.tbz"
+  checksum: [
+    "sha256=9820bcbccadb6e6d9e22fe26b2f9a044897c8f47c29d157f464b41a2f191e7d4"
+    "sha512=1d400f8344d1a8c2ac1c55e4a7167484034094e2227ce7c8f2f45843b0875a83030851400ceb96b5cdb756fa8798d83c77d839705fcb9e3f2bd5e46d337d63d0"
+  ]
+}
+x-commit-hash: "4fe91c7a7774d829a65e711be5d7df1501bc2e75"

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.3.1/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.3.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.1/ipaddr-5.3.1.tbz"
+  checksum: [
+    "sha256=9820bcbccadb6e6d9e22fe26b2f9a044897c8f47c29d157f464b41a2f191e7d4"
+    "sha512=1d400f8344d1a8c2ac1c55e4a7167484034094e2227ce7c8f2f45843b0875a83030851400ceb96b5cdb756fa8798d83c77d839705fcb9e3f2bd5e46d337d63d0"
+  ]
+}
+x-commit-hash: "4fe91c7a7774d829a65e711be5d7df1501bc2e75"

--- a/packages/macaddr-sexp/macaddr-sexp.5.3.1/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.3.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using sexp"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "macaddr-cstruct" {with-test & = version}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Sexp convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.1/ipaddr-5.3.1.tbz"
+  checksum: [
+    "sha256=9820bcbccadb6e6d9e22fe26b2f9a044897c8f47c29d157f464b41a2f191e7d4"
+    "sha512=1d400f8344d1a8c2ac1c55e4a7167484034094e2227ce7c8f2f45843b0875a83030851400ceb96b5cdb756fa8798d83c77d839705fcb9e3f2bd5e46d337d63d0"
+  ]
+}
+x-commit-hash: "4fe91c7a7774d829a65e711be5d7df1501bc2e75"

--- a/packages/macaddr/macaddr.5.3.1/opam
+++ b/packages/macaddr/macaddr.5.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * ounit2-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
+ """
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.3.1/ipaddr-5.3.1.tbz"
+  checksum: [
+    "sha256=9820bcbccadb6e6d9e22fe26b2f9a044897c8f47c29d157f464b41a2f191e7d4"
+    "sha512=1d400f8344d1a8c2ac1c55e4a7167484034094e2227ce7c8f2f45843b0875a83030851400ceb96b5cdb756fa8798d83c77d839705fcb9e3f2bd5e46d337d63d0"
+  ]
+}
+x-commit-hash: "4fe91c7a7774d829a65e711be5d7df1501bc2e75"


### PR DESCRIPTION
A library for manipulation of MAC address representations

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Remove stdlib-shims dependency, require OCaml 4.08+ (@hannesm, mirage/ocaml-ipaddr#112)
* Switch to ounit2 (@Alessandro-Barbieri, mirage/ocaml-ipaddr#111)
