### PR TITLE
utop is not compatible with lambda-term 3.3.0 (expects to use camomile)

### DIFF
--- a/packages/utop/utop.2.5.0/opam
+++ b/packages/utop/utop.2.5.0/opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.0.0" & < "4.0"}
+  "lambda-term" {>= "3.0.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.6.0/opam
+++ b/packages/utop/utop.2.6.0/opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.7.0/opam
+++ b/packages/utop/utop.2.7.0/opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.8.0/opam
+++ b/packages/utop/utop.2.8.0/opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.9.0/opam
+++ b/packages/utop/utop.2.9.0/opam
@@ -10,7 +10,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.9.1/opam
+++ b/packages/utop/utop.2.9.1/opam
@@ -16,7 +16,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"

--- a/packages/utop/utop.2.9.2/opam
+++ b/packages/utop/utop.2.9.2/opam
@@ -16,7 +16,7 @@ depends: [
   "base-unix"
   "base-threads"
   "ocamlfind" {>= "1.7.2"}
-  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "lambda-term" {>= "3.1.0" & < "3.3.0"}
   "lwt"
   "lwt_react"
   "camomile"


### PR DESCRIPTION
```

#=== ERROR while compiling utop.2.9.2 =========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/utop.2.9.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p utop -j 31
# exit-code            1
# env-file             ~/.opam/log/utop-19-fa3c7c.env
# output-file          ~/.opam/log/utop-19-fa3c7c.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I src/lib/.uTop.objs/byte -I /home/opam/.opam/4.14/lib/findlib -I /home/opam/.opam/4.14/lib/lambda-term -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/lwt_react -I /home/opam/.opam/4.14/lib/mew -I /home/opam/.opam/4.14/lib/mew_vi -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/react -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/trie -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uucp -I /home/opam/.opam/4.14/lib/uuseg -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zed -intf-suffix .ml -no-alias-deps -o src/lib/.uTop.objs/byte/uTop.cmo -c -impl src/lib/uTop.pp.ml)
# File "src/lib/uTop.ml", line 12, characters 5-36:
# Error: Unbound module CamomileLibraryDefault
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I src/lib/.uTop.objs/byte -I /home/opam/.opam/4.14/lib/findlib -I /home/opam/.opam/4.14/lib/lambda-term -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/lwt_react -I /home/opam/.opam/4.14/lib/mew -I /home/opam/.opam/4.14/lib/mew_vi -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/react -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/trie -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uucp -I /home/opam/.opam/4.14/lib/uuseg -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zed -intf-suffix .ml -no-alias-deps -o src/lib/.uTop.objs/byte/uTop_main.cmo -c -impl src/lib/uTop_main.pp.ml)
# File "src/lib/uTop_main.ml", line 12, characters 5-36:
# Error: Unbound module CamomileLibraryDefault
```