### PR TITLE
hockmd: fix doc url

### DIFF
--- a/packages/hockmd/hockmd.0.1.0/opam
+++ b/packages/hockmd/hockmd.0.1.0/opam
@@ -5,7 +5,7 @@ maintainer: ["Paul-Elliot Anglès d'Auriac <peada@free.fr>"]
 authors: ["Paul-Elliot Anglès d'Auriac <peada@free.fr>"]
 license: "MIT"
 homepage: "https://github.com/panglesd/hockmd"
-doc: "https://panglesd.github.io/hockmd-api/"
+doc: "https://panglesd.github.io/hockmd/"
 bug-reports: "https://github.com/panglesd/hockmd/issues"
 depends: [
   "ocaml" {>= "4.08.0"}


### PR DESCRIPTION
It was set to an old name of the repository...