### PR TITLE
Camomile, lwt_log are not compatible with OCaml 5

### DIFF
--- a/packages/camomile/camomile.1.0.2/opam
+++ b/packages/camomile/camomile.1.0.2/opam
@@ -13,7 +13,7 @@ doc: "https://yoriyuki.github.io/Camomile/"
 bug-reports: "https://github.com/yoriyuki/Camomile/issues"
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
 ]
 dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
 build: [

--- a/packages/lwt_log/lwt_log.1.0.0/opam
+++ b/packages/lwt_log/lwt_log.1.0.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/ocsigen/lwt/issues"
 license: "LGPL-2.0-or-later"
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta14"}
   "lwt" {< "4.0.0"}
 ]

--- a/packages/lwt_log/lwt_log.1.1.0/opam
+++ b/packages/lwt_log/lwt_log.1.1.0/opam
@@ -11,7 +11,7 @@ authors: [
 maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/aantron/lwt_log.git"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "lwt" {>= "4.0.0"}
 ]

--- a/packages/lwt_log/lwt_log.1.1.1/opam
+++ b/packages/lwt_log/lwt_log.1.1.1/opam
@@ -15,6 +15,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/ocsigen/lwt_log.git"
 
 depends: [
+  "ocaml" {< "5.0"}
   "dune" {>= "1.0"}
   "lwt" {>= "4.0.0"}
 ]


### PR DESCRIPTION
I checked that all `lwt_log` versions contain `String.lowercase`. This is also the case of `camomile.1.0.2`. It's probable that older `camomile` releases are incompatible too, but they already depend on `jbuilder` so it is not necessary to add the bounds.
