### PR TITLE
gufo is not compatible with lambda-term 3.3.0 (expects to use camomile)

### DIFF
--- a/packages/gufo/gufo.0.1.2/opam
+++ b/packages/gufo/gufo.0.1.2/opam
@@ -24,7 +24,7 @@ depends: [
   "camomile"
   "react"
   "lwt"
-  "lambda-term" {>= "2.0.2"}
+  "lambda-term" {>= "2.0.2" & < "3.3.0"}
   "base-unix"
   "sedlex" {>= "2.0.0" & < "3.0"}
   "oasis" 


### PR DESCRIPTION
```
#=== ERROR while compiling gufo.0.1.2 =========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/gufo.0.1.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/gufo-6944-2a8388.env
# output-file          ~/.opam/log/gufo-6944-2a8388.out
### output ###
# ocaml setup.ml -build 
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/4.14/lib/ocamlbuild /home/opam/.opam/4.14/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/4.14/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/guforun.ml > src/guforun.ml.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/genUtils.mli > src/genUtils.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufo.mli > src/gufo.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/genUtils.cmi src/genUtils.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoParsed.mli > src/gufoParsed.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoUtils.mli > src/gufoUtils.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoParsed.cmi src/gufoParsed.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoUtils.cmi src/gufoUtils.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoConfig.mli > src/gufoConfig.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoConsole.ml > src/gufoConsole.ml.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufo.cmi src/gufo.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoCompletion.ml > src/gufoCompletion.ml.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoExpression.mli > src/gufoExpression.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoExpression.cmi src/gufoExpression.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoEngine.mli > src/gufoEngine.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoParsedToOpt.mli > src/gufoParsedToOpt.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoStart.mli > src/gufoStart.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/sedlex_menhir.ml > src/sedlex_menhir.ml.depends
# menhir --dump --explain --raw-depend --ocamldep '/home/opam/.opam/4.14/bin/ocamlfind ocamldep -modules' src/gufo_parser.mly > src/gufo_parser.mly.depends
# + menhir --dump --explain --raw-depend --ocamldep '/home/opam/.opam/4.14/bin/ocamlfind ocamldep -modules' src/gufo_parser.mly > src/gufo_parser.mly.depends
# File "src/gufo_parser.mly", line 149, characters 6-13:
# Warning: the token WITHOUT is unused.
# menhir --dump --explain --ocamlc '/home/opam/.opam/4.14/bin/ocamlfind ocamlc -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src' --infer src/gufo_parser.mly
# + menhir --dump --explain --ocamlc '/home/opam/.opam/4.14/bin/ocamlfind ocamlc -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src' --infer src/gufo_parser.mly
# File "src/gufo_parser.mly", line 149, characters 6-13:
# Warning: the token WITHOUT is unused.
# File "src/gufo_parser.mly", line 171, characters 0-5:
# Warning: the precedence level assigned to TILDE is never useful.
# File "src/gufo_parser.mly", line 149, characters 0-5:
# Warning: the precedence level assigned to WITHOUT is never useful.
# Warning: 26 states have shift/reduce conflicts.
# Warning: one state has reduce/reduce conflicts.
# Warning: 363 shift/reduce conflicts were arbitrarily resolved.
# Warning: 57 reduce/reduce conflicts were arbitrarily resolved.
# File "src/gufo_parser.mly", line 741, characters 4-7:
# Warning: production cmd_arg -> DOT is never reduced.
# Warning: in total, 1 production is never reduced.
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufo_parser.mli > src/gufo_parser.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufo_parser.cmi src/gufo_parser.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoCompletion.cmo src/gufoCompletion.ml
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoEngine.cmi src/gufoEngine.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoParsedToOpt.cmi src/gufoParsedToOpt.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoStart.cmi src/gufoStart.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/sedlex_menhir.cmo src/sedlex_menhir.ml
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufoModuleUtils.mli > src/gufoModuleUtils.mli.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufo_lexer.ml > src/gufo_lexer.ml.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamldep -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -modules src/gufo_lexing.ml > src/gufo_lexing.ml.depends
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoConfig.cmi src/gufoConfig.mli
# /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoConsole.cmo src/gufoConsole.ml
# + /home/opam/.opam/4.14/bin/ocamlfind ocamlc -c -g -g -annot -bin-annot -thread -package camomile -package lambda-term -package lwt -package menhir -package menhirLib -package react -package sedlex.ppx -package str -package unix -package zed -I src -o src/gufoConsole.cmo src/gufoConsole.ml
# File "src/gufoConsole.ml", line 465, characters 18-26:
# 465 |     Zed_utf8.fold colorize (ctx_to_string expr) ([], "",false,false) (*list to print,curword, and a boolean to know if we are in quote*)
#                         ^^^^^^^^
# Error: This expression has type
#          CamomileLibrary.UChar.t ->
#          LTerm_text.item list * CamomileLibrary.UTF8.t * bool * bool ->
#          LTerm_text.item list * string * bool * bool
#        but an expression was expected of type Uchar.t -> 'weak10 -> 'weak10
#        Type CamomileLibrary.UChar.t is not compatible with type Uchar.t 
# Command exited with code 2.
```