### PR TITLE
inquire is not compatible with lambda-term 3.3.0

### DIFF
--- a/packages/inquire/inquire.0.1.0/opam
+++ b/packages/inquire/inquire.0.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "alcotest" {with-test}
   "base"
   "lwt"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/inquire/inquire.0.2.0/opam
+++ b/packages/inquire/inquire.0.2.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
   "lwt"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" {>= "2.0"}
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling inquire.0.2.0 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/inquire.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p inquire -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/inquire-31-16efe4.env
# output-file          ~/.opam/log/inquire-31-16efe4.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -open StdLabels -g -bin-annot -I lib/.inquire.objs/byte -I /home/opam/.opam/4.14/lib/lambda-term -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/lwt_react -I /home/opam/.opam/4.14/lib/mew -I /home/opam/.opam/4.14/lib/mew_vi -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/react -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/trie -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uucp -I /home/opam/.opam/4.14/lib/uuseg -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zed -no-alias-deps -open Inquire__ -o lib/.inquire.objs/byte/inquire__Confirm.cmo -c -impl lib/prompts/confirm.ml)
# File "lib/prompts/confirm.ml", line 4, characters 11-42:
# 4 |   let open CamomileLibraryDefault.Camomile in
#                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module CamomileLibraryDefault
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -open StdLabels -g -bin-annot -I lib/.inquire.objs/byte -I /home/opam/.opam/4.14/lib/lambda-term -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/lwt_react -I /home/opam/.opam/4.14/lib/mew -I /home/opam/.opam/4.14/lib/mew_vi -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/react -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/trie -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uucp -I /home/opam/.opam/4.14/lib/uuseg -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zed -no-alias-deps -open Inquire__ -o lib/.inquire.objs/byte/inquire__Select.cmo -c -impl lib/prompts/select.ml)
# File "lib/prompts/select.ml", line 11, characters 11-42:
# 11 |   let open CamomileLibraryDefault.Camomile in
#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module CamomileLibraryDefault
```