### PR TITLE
ocp-browser is not compatible with lambda-term 3.3.0 

### DIFF
--- a/packages/ocp-browser/ocp-browser.1.2.1/opam
+++ b/packages/ocp-browser/ocp-browser.1.2.1/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" { >= "2.0.0" }
 ]
 url {

--- a/packages/ocp-browser/ocp-browser.1.2.2/opam
+++ b/packages/ocp-browser/ocp-browser.1.2.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" { >= "2.0.0" }
   "odoc" {with-test}
 ]

--- a/packages/ocp-browser/ocp-browser.1.3.0/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" { >= "2.0.0" }
   "odoc" {with-test}
 ]

--- a/packages/ocp-browser/ocp-browser.1.3.1/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.1/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" {>= "2.0.0"}
   "odoc" {with-test}
 ]

--- a/packages/ocp-browser/ocp-browser.1.3.2/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.2/opam
@@ -21,7 +21,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" {>= "2.0.0"}
   "odoc" {with-test}
 ]

--- a/packages/ocp-browser/ocp-browser.1.3.3/opam
+++ b/packages/ocp-browser/ocp-browser.1.3.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-index" {= version}
   "cmdliner"
-  "lambda-term"
+  "lambda-term" {< "3.3.0"}
   "zed" {>= "2.0.0"}
   "odoc" {with-test}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling ocp-browser.1.3.3 ==================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ocp-browser.1.3.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocp-browser -j 31
# exit-code            1
# env-file             ~/.opam/log/ocp-browser-2074-871c50.env
# output-file          ~/.opam/log/ocp-browser-2074-871c50.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -9-3 -g -bin-annot -I src/.browserMain.eobjs/byte -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/lambda-term -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/lwt_react -I /home/opam/.opam/4.14/lib/mew -I /home/opam/.opam/4.14/lib/mew_vi -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -I /home/opam/.opam/4.14/lib/ocp-index/lib -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/react -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/trie -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uucp -I /home/opam/.opam/4.14/lib/uuseg -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zed -I src/.indexOptions.objs/byte -no-alias-deps -o src/.browserMain.eobjs/byte/browserMain.cmo -c -impl src/browserMain.pp.ml)
# File "src/browserMain.ml", line 3, characters 5-36:
# Error: Unbound module CamomileLibraryDefault
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -w -9 -g -I src/.indexOptions.objs/byte -I src/.indexOptions.objs/native -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocp-indent/lexer -I /home/opam/.opam/4.14/lib/ocp-indent/utils -I /home/opam/.opam/4.14/lib/ocp-index/lib -intf-suffix .ml -no-alias-deps -o src/.indexOptions.objs/native/indexOptions.cmx -c -impl src/indexOptions.pp.ml)
# File "src/indexOptions.ml", line 101, characters 10-14:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexOptions.ml", line 121, characters 10-14:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexOptions.ml", line 145, characters 10-14:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexOptions.ml", line 179, characters 6-10:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexOptions.ml", line 209, characters 10-14:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "src/indexOptions.ml", line 323, characters 4-8:
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
```