### PR TITLE
lwt_react.1.0.1 is not compatible with OCaml 5.0 (uses Stream/oasis)

### DIFF
--- a/packages/lwt_react/lwt_react.1.0.1/opam
+++ b/packages/lwt_react/lwt_react.1.0.1/opam
@@ -21,7 +21,7 @@ remove: [
     ["ocamlfind" "remove" "lwt_react"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "lwt" {>= "3.0.0"}
   "react" {>= "1.0.0"}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling lwt_react.1.0.1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/lwt_react.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make configure
# exit-code            2
# env-file             ~/.opam/log/lwt_react-10-850b34.env
# output-file          ~/.opam/log/lwt_react-10-850b34.out
### output ###
# ocaml setup.ml -configure 
# File "./setup.ml", line 581, characters 4-15:
# 581 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
# make: *** [Makefile:37: configure] Error 2
```