### PR TITLE
[new release] odoc-parser (1.0.1)

### DIFF
--- a/packages/odoc-parser/odoc-parser.1.0.1/opam
+++ b/packages/odoc-parser/odoc-parser.1.0.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-doc/odoc-parser"
+bug-reports: "https://github.com/ocaml-doc/odoc-parser/issues"
+dev-repo: "git+https://github.com/ocaml-doc/odoc-parser.git"
+# This template exists because without it dune pop is dependencies and build rules
+# involving odoc. Since odoc depends on this package, this doesn't work.
+doc: "https://ocaml-doc.github.io/odoc-parser/"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.02.0"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml-doc/odoc-parser/releases/download/1.0.1/odoc-parser-1.0.1.tbz"
+  checksum: [
+    "sha256=a2bbe8e4201b60e980bab01e96e41f2ba0b05ba3f50b44f75837e8a2fb907d2c"
+    "sha512=c3339aae880ce72df866746d9ed9e7d38a752bf994ba24e948c086349604007e39602a1c31cf2ddb61ac8f8dc9dceccca43fe185850b83e3a02d75121f9ddfe2"
+  ]
+}
+x-commit-hash: "216e3234b57bf194e65e14200e43607cc4e47da6"
+


### PR DESCRIPTION
Parser for ocaml documentation comments

- Project page: <a href="https://github.com/ocaml-doc/odoc-parser">https://github.com/ocaml-doc/odoc-parser</a>
- Documentation: <a href="https://ocaml-doc.github.io/odoc-parser/">https://ocaml-doc.github.io/odoc-parser/</a>

##### CHANGES:

- OCaml 5.0 support (@talex5, ocaml-doc/odoc-parser#6)
