### PR TITLE
[new release] odoc (2.1.1)

### DIFF
--- a/packages/odoc/odoc.2.1.1/opam
+++ b/packages/odoc/odoc.2.1.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "odoc-parser" {>= "0.9.0"}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "2.9.1"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {< "2.0.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+
+  "bisect_ppx" {dev & > "2.5.0"}
+  ("ocaml" {< "4.03.0" & dev} | "mdx" {dev})
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.1.1/odoc-2.1.1.tbz"
+  checksum: [
+    "sha256=f574dbd28cd0fc3a2b95525c4bb95ddf6d1f6408bb4fe12157fa537884f987fd"
+    "sha512=1c545c281a7022a167f028fff8cec6fb3f2f82da0881431be74e7a4281c5353ed83bfbdb4d9d9e08af6755dbe3505c052c5e5b58cdeb08c57aed5e89c0f15e91"
+  ]
+}
+x-commit-hash: "f556f10aa67f80e83d1e3e66c4b478e8efe4e18d"


### PR DESCRIPTION
OCaml documentation generator

- Project page: <a href="http://github.com/ocaml/odoc">http://github.com/ocaml/odoc</a>
- Documentation: <a href="https://ocaml.github.io/odoc/">https://ocaml.github.io/odoc/</a>

##### CHANGES:

- OCaml 5.0 compatibility (@dra27, ocaml/odoc#873)
