### PR TITLE
extlib is not compatible with OCaml 5.0

### DIFF
--- a/packages/extlib/extlib.1.7.7-1/opam
+++ b/packages/extlib/extlib.1.7.7-1/opam
@@ -30,7 +30,7 @@ build: [
 ]
 install: [ [make "minimal=1" "install"] ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}

--- a/packages/extlib/extlib.1.7.8/opam
+++ b/packages/extlib/extlib.1.7.8/opam
@@ -26,7 +26,7 @@ build: [
 ]
 install: [ [make "minimal=1" "install"] ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "base-bytes" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling extlib.1.7.8 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/extlib.1.7.8
# command              ~/.opam/opam-init/hooks/sandbox.sh build make minimal=1 build
# exit-code            2
# env-file             ~/.opam/log/extlib-10-2ffd30.env
# output-file          ~/.opam/log/extlib-10-2ffd30.out
### output ###
# fatal: not a git repository: '.git'
# make -C src build
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/extlib.1.7.8/src'
# ocamlfind ocamlc -pp "cppo -D \"OCAML 500\"  -D WITH_BYTES" -g -bin-annot -package bytes -i extBytes.ml > extBytes.mli
# ocamlfind ocamlc -pp "cppo -D \"OCAML 500\"  -D WITH_BYTES" -g -bin-annot -package bytes -c extBytes.mli extBytes.ml
# ocamlfind ocamlc -pp "cppo -D \"OCAML 500\"  -D WITH_BYTES" -g -bin-annot -package bytes -c enum.mli enum.ml
# ocamlfind ocamlc -pp "cppo -D \"OCAML 500\"  -D WITH_BYTES" -g -bin-annot -package bytes -c bitSet.mli bitSet.ml
# ocamlfind ocamlc -pp "cppo -D \"OCAML 500\"  -D WITH_BYTES" -g -bin-annot -package bytes -c dynArray.mli dynArray.ml
# ocamlfind ocamlc -pp "cppo -D \"OCAML 500\"  -D WITH_BYTES" -g -bin-annot -package bytes -c extArray.mli extArray.ml
# File "extArray.ml", line 1:
# Error: The implementation extArray.ml
#        does not match the interface extArray.cmi:  ...
#        The value `make_float' is required but not provided
#        File "extArray.mli", line 121, characters 2-37: Expected declaration
#        The value `create' is required but not provided
#        File "extArray.mli", line 153, characters 2-60: Expected declaration
#        In module Array:
#        The value `create_matrix' is required but not provided
#        File "extArray.mli", line 156, characters 2-56: Expected declaration
# make[1]: *** [Makefile:50: extArray.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/extlib.1.7.8/src'
# make: *** [Makefile:14: build] Error 2
```