### PR TITLE
Package dkml-package-console.0.2.0

### DIFF
--- a/packages/dkml-package-console/dkml-package-console.0.2.0/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Console setup and uninstall executables for Diskuv OCaml (DKML) installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DKML runners."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "diskuvbox" {>= "0.1.0"}
+  "crunch" {>= "3.2.0"}
+  "dkml-component-xx-console" {>= "0.1.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=d65935d6a9a790fec09cfc50f6b04c43"
+    "sha512=08aeffeffa41b10ca54c9329bf9f6ec9219060c2e62c3a389d08b096513fe3dc048782e28d5006cae6a35e124cfd09441eb41a063c6a3f12fc6e60fa9d2acef7"
+  ]
+}


### PR DESCRIPTION
### `dkml-package-console.0.2.0`
Console setup and uninstall executables for Diskuv OCaml (DKML) installation
The setup and uninstall executables are responsible for launching the DKML runners.



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0