### PR TITLE
Package binaryen.0.18.0

### DIFF
--- a/packages/binaryen/binaryen.0.18.0/opam
+++ b/packages/binaryen/binaryen.0.18.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "108.0.0" & < "109.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.18.0/binaryen-archive-v0.18.0.tar.gz"
+  checksum: [
+    "md5=f1797a5c3c73ab320f470afe7d7da5c9"
+    "sha512=f85f7954a24a4f507173b831499ae2fa9fab7730b70a61499bcbd5fd1a7241907eba011f44dea953efebbcd47da75b35aa2b07113cc0fb8ce3a99ea0f8d9e048"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.18.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.18.0](https://github.com/grain-lang/binaryen.ml/compare/v0.17.1...v0.18.0) (2022-07-05)


### ⚠ BREAKING CHANGES

* Remove externref type
* Update to libbinaryen v108 (#163)
* Support passive memory segments (#158)

### Features

* Add anyref type as replacement for externref type ([f0c7d7e](https://github.com/grain-lang/binaryen.ml/commit/f0c7d7e5aaad93eb75ad850387730a245db3a545))
* Add eqref, i31ref, and dataref types ([#162](https://github.com/grain-lang/binaryen.ml/issues/162)) ([b6808ee](https://github.com/grain-lang/binaryen.ml/commit/b6808ee4422a68aa27114573e642b2467df9cc3c))
* Remove externref type ([f0c7d7e](https://github.com/grain-lang/binaryen.ml/commit/f0c7d7e5aaad93eb75ad850387730a245db3a545))
* Support passive memory segments ([#158](https://github.com/grain-lang/binaryen.ml/issues/158)) ([21857f7](https://github.com/grain-lang/binaryen.ml/commit/21857f7cf653a52e558fb7ffaa5a1e6042e895a0))
* Update to libbinaryen v108 ([#163](https://github.com/grain-lang/binaryen.ml/issues/163)) ([f0c7d7e](https://github.com/grain-lang/binaryen.ml/commit/f0c7d7e5aaad93eb75ad850387730a245db3a545))


### Bug Fixes

* Convert JSOO lists to JS arrays before working with them ([#161](https://github.com/grain-lang/binaryen.ml/issues/161)) ([e4931f0](https://github.com/grain-lang/binaryen.ml/commit/e4931f00cffccefd5918b94b17b18883e120e444))

---
:camel: Pull-request generated by opam-publish v2.0.3