### PR TITLE
[new release] ocamlformat and ocamlformat-rpc-lib (0.23.0)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.23.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.23.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.23.0/ocamlformat-0.23.0.tbz"
+  checksum: [
+    "sha256=9bd3e3cfb0da1b2f75eccd468f27ea1b92e6e677bb6129491764957031dedfed"
+    "sha512=6da6f56cb4c605a87020dd7511c99b0114d844d7e26c727ffef521390265bc8f1e8a86e0e4ac916d27df56734941957468aa3462ae01991b522e75c42b392597"
+  ]
+}
+x-commit-hash: "66f4b82b31c4a91819658aca688e307587ecfa17"

--- a/packages/ocamlformat/ocamlformat.0.23.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.23.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune" {with-test & < "3.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocamlformat-rpc-lib" {with-test & post & = version}
+  "ocp-indent"
+  "odoc-parser" {>= "1.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.23.0/ocamlformat-0.23.0.tbz"
+  checksum: [
+    "sha256=9bd3e3cfb0da1b2f75eccd468f27ea1b92e6e677bb6129491764957031dedfed"
+    "sha512=6da6f56cb4c605a87020dd7511c99b0114d844d7e26c727ffef521390265bc8f1e8a86e0e4ac916d27df56734941957468aa3462ae01991b522e75c42b392597"
+  ]
+}
+x-commit-hash: "66f4b82b31c4a91819658aca688e307587ecfa17" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### Removed

- `bench` binary is not distributed anymore to avoid name collisions (ocaml-ppx/ocamlformat#2104, @gpetiot)

### Deprecated

### Bug fixes

- Preserve comments around object open/close flag (ocaml-ppx/ocamlformat#2097, @trefis, @gpetiot)
- Preserve comments around private/mutable/virtual keywords (ocaml-ppx/ocamlformat#2098, @trefis, @gpetiot)
- Closing parentheses of local open now comply with `indicate-multiline-delimiters` (ocaml-ppx/ocamlformat#2116, @gpetiot)
- emacs: fix byte-compile warnings (ocaml-ppx/ocamlformat#2119, @syohex)

### Changes

- Use the API of ocp-indent to parse the `.ocp-indent` files (ocaml-ppx/ocamlformat#2103, @gpetiot)
- JaneStreet profile: set `max-indent = 2` (ocaml-ppx/ocamlformat#2099, @gpetiot)
- JaneStreet profile: align pattern-matching bar `|` under keyword instead of parenthesis (ocaml-ppx/ocamlformat#2102, @gpetiot)

### New features
