### PR TITLE
Revert "Add stdcompat upper bounds"

### DIFF
--- a/packages/metapp/metapp.0.4.0/opam
+++ b/packages/metapp/metapp.0.4.0/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12" & < "19"}
+  "stdcompat" {>= "12"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/metapp/metapp.0.4.1/opam
+++ b/packages/metapp/metapp.0.4.1/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12" & < "19"}
+  "stdcompat" {>= "12"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/metapp/metapp.0.4.2/opam
+++ b/packages/metapp/metapp.0.4.2/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12" & < "19"}
+  "stdcompat" {>= "12"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/metapp/metapp.0.4.3/opam
+++ b/packages/metapp/metapp.0.4.3/opam
@@ -13,7 +13,7 @@ doc: "https://github.com/thierry-martinez/metapp"
 bug-reports: "https://github.com/thierry-martinez/metapp"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdcompat" {>= "12" & < "19"}
+  "stdcompat" {>= "12"}
   "ppxlib" {>= "0.18.0" & < "0.26.0"}
   "ocamlfind" {>= "1.8.1"}
   "dune" {>= "1.11.0"}

--- a/packages/override/override.0.4.0/opam
+++ b/packages/override/override.0.4.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
   "ppxlib" {>= "0.23.0"}
-  "stdcompat" {>= "9" & < "15"}
+  "stdcompat" {>= "9"}
   "metapp" {>= "0.4.2"}
   "metaquot" {>= "0.4.0"}
   "refl" {>= "0.1.0"}


### PR DESCRIPTION
This reverts commit 567f637fcb2f5630df33a14f51a7bc39b5127fff.
First we need it to compare the errors and understand a few things.

