### PR TITLE
iter.1.4 is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/iter/iter.1.4/opam
+++ b/packages/iter/iter.1.4/opam
@@ -11,7 +11,7 @@ build: [
 depends: [
   "base-bytes"
   "result"
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "qcheck" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling iter.1.4 ===========================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/iter.1.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p iter -j 31
# exit-code            1
# env-file             ~/.opam/log/iter-23-e3a23c.env
# output-file          ~/.opam/log/iter-23-e3a23c.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -a+8 -safe-string -strict-sequence -nolabels -g -bin-annot -I src/.iter.objs/byte -I /home/opam/.opam/5.0/lib/result -no-alias-deps -o src/.iter.objs/byte/iterLabels.cmi -c -intf src/IterLabels.mli)
# File "src/IterLabels.mli", line 534, characters 19-27:
# 534 | val of_stream : 'a Stream.t -> 'a t
#                          ^^^^^^^^
# Error: Unbound module Stream
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -a+8 -safe-string -strict-sequence -nolabels -g -bin-annot -I src/.iter.objs/byte -I /home/opam/.opam/5.0/lib/result -no-alias-deps -o src/.iter.objs/byte/iter.cmi -c -intf src/Iter.mli)
# File "src/Iter.mli", line 570, characters 19-27:
# 570 | val of_stream : 'a Stream.t -> 'a t
#                          ^^^^^^^^
# Error: Unbound module Stream
```