### PR TITLE
Package dkml-component-staging-ocamlrun.4.12.1~v1.0.0

### DIFF
--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.0/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.0/opam
@@ -1,0 +1,232 @@
+opam-version: "2.0"
+synopsis: "DKML component for ocamlrun"
+description:
+  "Standalone distribution of OCaml in <share>/staging-files containing just ocamlrun, the OCaml Stdlib and the other OCaml libraries (str, unix, bigarray, etc.)"
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-component-ocamlcompiler"
+bug-reports: "https://github.com/diskuv/dkml-component-ocamlcompiler/issues"
+depends: [
+  "dkml-install"            {>= "0.2.0"}
+  "dune"                    {>= "2.9"}
+]
+available: [ os = "macos" | (os = "linux" & (arch = "x86_32" | arch = "x86_64")) | os = "win32" ]
+build: [
+  # Homebrew's bundle tap, needed for reproducible build auditing in drc's crossplatform-functions.sh.
+  #
+  # The Opam sandbox will stop Homebrew from auto-installing its own tap. In particular 'brew bundle ...'
+  # is automatically installed per https://github.com/Homebrew/homebrew-bundle/tree/4756e4c4cf95485c5ea4da27375946c1dac2c71d#installation,
+  # and it is an "official" tap per
+  # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/official_taps.rb#L11-L18 .
+  #
+  # So our solution is to:
+  # a) Use extra-source:[] to download a Git tarball without tripping over the sandbox firewall
+  # b) Recreate a local file git repository
+  # c) Use the next build:[] steps to let Homebrew know about the bundle tap
+  #
+  # Test with: brew untap homebrew/bundle
+  ["install" "-d" "dl/homebrew-bundle"] {os = "macos"}
+  ["tar" "xCfz" "dl/homebrew-bundle" "dl/homebrew-bundle.tar.gz" "--strip-components=1"] {os = "macos"}
+  ["sh" "-c" """#!/bin/sh
+    set -eufx
+    if command -v brew; then
+      eval $(brew shellenv)
+      HOMEBREW_BREW_FILE="$(command -v brew)"
+      HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
+      HOMEBREW_PATH="$PATH"
+      HOMEBREW_CACHE="$PWD/dl/homebrew-cache"
+      export HOMEBREW_BREW_FILE HOMEBREW_PATH HOMEBREW_CACHE
+
+      # Clone the Library which contains the Taps/
+      # (and also Homebrew/ which is all the core scripts).
+      # * [-a] will copy and continue even if there are errors (like dangling symlinks).
+      install -d dl/homebrew
+      cp -a "$HOMEBREW_LIBRARY" dl/homebrew/ || true
+      HOMEBREW_LIBRARY="$PWD/dl/homebrew/Library"
+      export HOMEBREW_LIBRARY
+
+      # Install the tap manually by copying it. If we had used
+      # 'brew tap homebrew/bundle [URL]' or more specifically
+      # '/bin/bash "${HOMEBREW_LIBRARY}/Homebrew/brew.sh" tap homebrew/bundle [URL]'
+      # then brew would try to update its own configuration repository to say the tap was installed.
+      # It would fail with 'error: could not lock config file .git/config: Operation not permitted'
+      # because we are in a sandbox. We would have to ignore that error even though the tap was installed.
+      # too many sandbox permissions, even with a file:// URL).
+      install -d "${HOMEBREW_LIBRARY}/Taps/homebrew"
+      cp -rp dl/homebrew-bundle "${HOMEBREW_LIBRARY}/Taps/homebrew/"
+
+      /bin/bash "${HOMEBREW_LIBRARY}/Homebrew/brew.sh" bundle dump
+      test -e Brewfile
+    fi
+   """] {os = "macos"}
+
+  # OCaml source code
+  ["install" "-d" "dl/ocaml/flexdll"]
+  ["tar" "xCfz" "dl/ocaml"          "dl/ocaml.tar.gz"   "--strip-components=1"]
+  ["tar" "xCfz" "dl/ocaml/flexdll"  "dl/flexdll.tar.gz" "--strip-components=1"]
+
+  # Create a DKMLDIR. Its structure mimics a git submodule setup.
+  #   <dkmldir>/vendor/drc/
+  ["install" "-d" "dkmldir/vendor/drc"]
+  ["tar" "xCfz" "dkmldir/vendor/drc" "dl/dkml-runtime-common.tar.gz" "--strip-components=1"]
+  #   <dkmldir>/.dkmlroot
+  ["install" "dkmldir/vendor/drc/.template.dkmlroot" "dkmldir/.dkmlroot"]
+
+  #   <dkmldir>/vendor/dkml-compiler/
+  ["install" "-d" "dkmldir/vendor/dkml-compiler/src"]
+  ["tar" "xCfz" "dkmldir/vendor/dkml-compiler" "dl/dkml-compiler.tar.gz" "--strip-components=1"]
+
+  # Developers:
+  #   Uncomment to test your own scripts
+  #[ "diskuvbox" "copy-file" "r-c-ocaml-1-setup.sh" "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh" ]
+
+  # --------------
+  # Build component and .api library
+  # --------------
+
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+install: [
+  # --------------
+  # First pass
+  # --------------
+
+  # [1] Run r-c-ocaml-1-setup.sh
+  [
+    "env" "TOPDIR=dkmldir/vendor/drc/all/emptytop"
+      "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+      "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+      "-d" "dkmldir"
+      "-f" "src/ocaml-1"
+      "-k" "vendor/dkml-compiler/src/standard-compiler-env-to-ocaml-configure-env.sh"
+      "-v" "dl/ocaml"
+      #   Host-compile into staging-files/<host-abi>
+      "-t" "%{_:share}%/staging-files"
+      "-pwindows_x86_64"  { os = "win32" }
+      "-plinux_x86"       { os = "linux" & arch = "x86_32" }
+      "-plinux_x86_64"    { os = "linux" & arch = "x86_64" }
+      "-pdarwin_x86_64"   { os = "macos" }
+      #   ABIs
+      "-ewindows_x86_64"  { os = "win32" }
+      "-elinux_x86"       { os = "linux" & arch = "x86_32" }
+      "-elinux_x86_64"    { os = "linux" & arch = "x86_64" }
+      "-edarwin_x86_64"   { os = "macos" }
+      #   Cross-compile into staging-files/<cross-abi>
+      "-g" "."
+      #   Target architectures (if cross-compiling)
+      "-adarwin_arm64=vendor/dkml-compiler/src/standard-compiler-env-to-ocaml-configure-env.sh" { os = "macos" }
+      #     For any non cross-compiling platforms we save time and space by
+      #     only building the runtime.
+      "-r"                                        { os = "win32" | (os = "linux" & (arch = "x86_32" | arch = "x86_64")) }
+  ]
+
+  # [1] Run r-c-ocaml-2-build_host-noargs.sh
+  [
+    "sh" "-eufc"
+    "cd '%{_:share}%/staging-files' && echo 1 - host && share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-2-build_host-noargs.sh"
+  ]
+
+  # [1] Run r-c-ocaml-3-build_cross-noargs.sh if cross-compiling,
+  # which will place its output into staging-files/<cross-abi>
+  # (confer: "-g" "%{_:share}%/staging-files")
+  [
+    "sh" "-eufc"
+    "cd '%{_:share}%/staging-files' && echo 1 - cross && share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-3-build_cross-noargs.sh"
+  ] { os = "macos" }
+
+  # --------------
+  # Second pass
+  #   For platforms that can do multiple _host_ ABIs _without_ cross-compiling.
+  #   * MSVC can trivially do 32-bit and 64-bit without cross-compiling.
+  #   * Most often Linux can as well as long as `gcc -m32` is configured.
+  #     However for ease of use in GitHub Actions we expect Linux 32-bit and
+  #     Linux 64-bit to be done with different Opam switches.
+  # --------------
+
+  # [2] Run r-c-ocaml-1-setup.sh
+  [
+    "env" "TOPDIR=dkmldir/vendor/drc/all/emptytop"
+      "DKML_REPRODUCIBLE_SYSTEM_BREWFILE=%{_:build}%/Brewfile"
+      "dkmldir/vendor/dkml-compiler/src/r-c-ocaml-1-setup.sh"
+      "-d" "dkmldir"
+      "-f" "src/ocaml-2"
+      "-r" # Build runtime only
+      "-k" "vendor/dkml-compiler/src/standard-compiler-env-to-ocaml-configure-env.sh"
+      "-v" "dl/ocaml"
+      #   Host-compile into staging-files/<host-abi>
+      "-t" "%{_:share}%/staging-files"
+      "-pwindows_x86"     { os = "win32" }
+      #   ABIs
+      "-ewindows_x86"     { os = "win32" }
+  ] { !(os = "macos") & !(os = "linux") }
+
+  # [2] Run r-c-ocaml-2-build_host-noargs.sh
+  [
+    "sh" "-eufc"
+    "cd '%{_:share}%/staging-files' && echo 2 - host && share/dkml/repro/100co/vendor/dkml-compiler/src/r-c-ocaml-2-build_host-noargs.sh"
+  ] { !(os = "macos") & !(os = "linux") }
+
+  # --------------
+  # Clean build files
+  # --------------
+
+  [ "rm" "-rf" "%{_:share}%/staging-files/share" ]
+  [ "rm" "-rf" "%{_:share}%/staging-files/src" ]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlcompiler.git"
+extra-source "dl/ocaml.tar.gz" {
+  src: "https://github.com/ocaml/ocaml/archive/4.12.1.tar.gz"
+  checksum: "sha256=f5a48a90557cb47ace7b1590fcab1362a1af38629a218350f69c225c57e96a41"
+}
+extra-source "dl/flexdll.tar.gz" {
+  src: "https://github.com/alainfrisch/flexdll/archive/0.39.tar.gz"
+  checksum: "sha256=51a6ef2e67ff475c33a76b3dc86401a0f286c9a3339ee8145053ea02d2fb5974"
+}
+extra-source "dl/homebrew-bundle.tar.gz" {
+  src: "https://github.com/Homebrew/homebrew-bundle/archive/4756e4c4cf95485c5ea4da27375946c1dac2c71d.tar.gz"
+  checksum: [
+    "sha256=10c024ca7871cea36b4c27b2601971d3fa6cba6f37855613baf0026d0f555e76"
+  ]
+}
+extra-source "dl/dkml-compiler.tar.gz" {
+  src: "https://github.com/diskuv/dkml-compiler/archive/refs/tags/4.12.1-v1.0.0.tar.gz"
+  checksum: [
+    "sha256=b4850314ea64d357ce814faebc1f1ef54052e76ea048602401f481cf6bf40455"
+  ]
+}
+extra-source "dl/dkml-runtime-common.tar.gz" {
+  # This violates the v1.0.0 versioning, but this future patch is needed to allow the 'bundle'
+  # brew tap to be used on macOS in the Opam sandbox.
+  src: "https://github.com/diskuv/dkml-runtime-common/archive/refs/tags/v1.0.1-prerel0b.tar.gz"
+  checksum: [
+    "sha256=563b89382f07a4ce56917a8eb7034c5fa6993572f087ad909e58229e78748056"
+  ]
+}
+extra-source "dl/dkml-runtime-distribution.tar.gz" {
+  src: "https://github.com/diskuv/dkml-runtime-distribution/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: [
+    "sha256=bface5c975172f3d07636e5207806e8c0e43928ada1643ee3a2d4044c6fe6beb"
+  ]
+}
+url {
+  src:
+    "https://github.com/diskuv/dkml-component-ocamlrun/archive/4.12.1-v1.0.0.tar.gz"
+  checksum: [
+    "md5=9621ea195048f2ae0a01940e4f628d17"
+    "sha512=5c872c48456cf4699f1c57304f97a35512bf5fa0d079a5d8315dbeea6253ee65b4f4ae012475f584815245a9e5e195140fd225d6189fd03253ab52cc8f9b3ec8"
+  ]
+}

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.0/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.0/opam
@@ -205,7 +205,7 @@ extra-source "dl/homebrew-bundle.tar.gz" {
 extra-source "dl/dkml-compiler.tar.gz" {
   src: "https://github.com/diskuv/dkml-compiler/archive/refs/tags/4.12.1-v1.0.0.tar.gz"
   checksum: [
-    "sha256=b4850314ea64d357ce814faebc1f1ef54052e76ea048602401f481cf6bf40455"
+    "sha256=8beda92f97cde6d4a55a836ca6dc9f860bb5f1a6b765b80be4594943288571cf"
   ]
 }
 extra-source "dl/dkml-runtime-common.tar.gz" {


### PR DESCRIPTION
### `dkml-component-staging-ocamlrun.4.12.1~v1.0.0`
DKML component for ocamlrun
Standalone distribution of OCaml in <share>/staging-files containing just ocamlrun, the OCaml Stdlib and the other OCaml libraries (str, unix, bigarray, etc.)



---
* Homepage: https://github.com/diskuv/dkml-component-ocamlrun
* Source repo: git+https://github.com/diskuv/dkml-component-ocamlrun.git
* Bug tracker: https://github.com/diskuv/dkml-component-ocamlrun/issues

---
:camel: Pull-request generated by opam-publish v2.1.0