### PR TITLE
[new release] ocaml-version (3.5.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.5.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml
+compiler, and enumerates the various official OCaml releases and configuration
+variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the
+`patch` and `extra` fields are optional.  This library offers the following
+functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under
+  the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.5.0/ocaml-version-3.5.0.tbz"
+  checksum: [
+    "sha256=d63ca1c3970d6b14057f7176bfdae623e6c0176287c6a6e8b78cf50e2f7f635b"
+    "sha512=7b5f475897b1c560c81d322ca77b80099025102ec4163b410518e32dce0d6decf7c2ef671f795932bc173741b20bb442e07b182583423d2c990c632c921be5df"
+  ]
+}
+x-commit-hash: "ee6c14c52e1995d69a134b23df2c1c721ea7a994"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

 * Add 4.14 entry (@dra27 ocurrent/ocaml-version#45)
 * Add 5.0 entry (@dra27 @kit-ty-kate ocurrent/ocaml-version#44)
 * Add oldest versions of OCaml that support arm64, ppc64le and s390x (@tmcgilchrist ocurrent/ocaml-version#47)
 * Add 5.1.0 trunk development version (@dra27 ocurrent/ocaml-version#48)
 * Add riscv64 for 4.11 onwards (@mtelvers @dra27 ocurrent/ocaml-version#49)
