### PR TITLE
ocamlformat.0.23.0 is incompatible with odoc-parser.2.0.0

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.23.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.23.0/opam
@@ -23,7 +23,7 @@ depends: [
   "ocaml-version" {>= "3.3.0"}
   "ocamlformat-rpc-lib" {with-test & post & = version}
   "ocp-indent"
-  "odoc-parser" {>= "1.0.0"}
+  "odoc-parser" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}
   "stdio"
   "uuseg" {>= "10.0.0"}


### PR DESCRIPTION
opam files of previous ocamlformat releases were modified in #21746, but 0.23.0 is also incompatible.

Compatible release coming soon.