### PR TITLE
zarith.1.3 is not compatible with OCaml 5.0 (uses the (.[]<-) notation)

### DIFF
--- a/packages/zarith/zarith.1.3/opam
+++ b/packages/zarith/zarith.1.3/opam
@@ -15,7 +15,7 @@ build: [
 ]
 remove:  ["ocamlfind" "remove" "zarith"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "conf-gmp"
   "conf-perl" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling zarith.1.3 =========================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/zarith.1.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/zarith-21-d065ff.env
# output-file          ~/.opam/log/zarith-21-d065ff.out
### output ###
# ./z_pp.pl x86_64
# found assembly file caml_z_x86_64.S
#   found abs
#   found add
#   found div
#   found logand
#   found lognot
#   found logor
#   found logxor
#   found mul
#   found neg
#   found pred
#   found rem
#   found shift_left
#   found shift_right
#   found sub
#   found succ
# ocamldep -native  *.ml *.mli > depend
# File "bitest.ml", line 52, characters 4-42:
# 52 |     s.[i] <- Char.chr (48 + Random.int 10)
#          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Syntax error: strings are immutable, there is no assignment syntax for them.
# Hint: Mutable sequences of bytes are available in the Bytes module.
# Hint: Did you mean to use 'Bytes.set'?
# project.mak:150: depend: No such file or directory
# make: *** [project.mak:148: depend] Error 2
```