### PR TITLE
[new release] graphql_parser, graphql, graphql-lwt, graphql-cohttp and graphql-async (0.14.0)

### DIFF
--- a/packages/graphql-async/graphql-async.0.13.0/opam
+++ b/packages/graphql-async/graphql-async.0.13.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1"}
-  "graphql" {>= "0.13.0"}
+  "graphql" {>= "0.13.0" & < "0.14.0"}
   "async_kernel" {>= "v0.9.0" & < "v0.15"}
   "alcotest" {with-test}
   "async_unix" {with-test & >= "v0.9.0" & < "v0.15"}

--- a/packages/graphql-async/graphql-async.0.14.0/opam
+++ b/packages/graphql-async/graphql-async.0.14.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/graphql-async/graphql-async.0.14.0/opam
+++ b/packages/graphql-async/graphql-async.0.14.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1"}
+  "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "async_kernel" {>= "v0.9.0"}
   "alcotest" {with-test}

--- a/packages/graphql-async/graphql-async.0.14.0/opam
+++ b/packages/graphql-async/graphql-async.0.14.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "async_kernel" {>= "v0.9.0"}

--- a/packages/graphql-async/graphql-async.0.14.0/opam
+++ b/packages/graphql-async/graphql-async.0.14.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "graphql" {>= "0.13.0"}
+  "async_kernel" {>= "v0.9.0"}
+  "alcotest" {with-test}
+  "async_unix" {with-test & >= "v0.9.0"}
+  "yojson" {with-test & >= "1.6.0"}
+]
+
+synopsis: "Build GraphQL schemas with Async support"
+
+description: """
+`graphql-async` adds support for Async to `graphql`, so you can use Async in your GraphQL schema resolver functions."""
+url {
+  src:
+    "https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz"
+  checksum: [
+    "sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06"
+    "sha512=1d303d9ab67faecea8081f007b3696e36033aa65eba0854f50067b4d667d9a9ad185ad949371790a03509cb31bf6356b75c58f3066da9c35d82e620df5780185"
+  ]
+}
+x-commit-hash: "79e01a09d08b0de3b3fff8195e19f7d8ab566498"

--- a/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1"}
+  "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "cohttp" {>= "2.0.0"}
   "crunch"

--- a/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "cohttp" {>= "2.0.0"}
-  "crunch"
+  "crunch" {>= "2.0.0"}
   "astring" {>= "0.8.3"}
   "base64" {>= "3.0.0"}
   "ocplib-endian" {>= "1.0"}

--- a/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "cohttp" {>= "2.0.0"}

--- a/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "graphql" {>= "0.13.0"}
+  "cohttp" {>= "2.0.0"}
+  "crunch"
+  "astring" {>= "0.8.3"}
+  "base64" {>= "3.0.0"}
+  "ocplib-endian" {>= "1.0"}
+  "digestif" {>= "0.7.0"}
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "graphql-lwt" {with-test}
+]
+
+synopsis: "Run GraphQL servers with `cohttp`"
+
+description: """
+This package allows you to execute Cohttp HTTP requests against GraphQL schemas build with `graphql`. The package is agnostic to Lwt/Async."""
+url {
+  src:
+    "https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz"
+  checksum: [
+    "sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06"
+    "sha512=1d303d9ab67faecea8081f007b3696e36033aa65eba0854f50067b4d667d9a9ad185ad949371790a03509cb31bf6356b75c58f3066da9c35d82e620df5780185"
+  ]
+}
+x-commit-hash: "79e01a09d08b0de3b3fff8195e19f7d8ab566498"

--- a/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
+++ b/packages/graphql-cohttp/graphql-cohttp.0.14.0/opam
@@ -22,6 +22,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "ocplib-endian" {>= "1.0"}
   "digestif" {>= "0.7.0"}
+  "yojson" {>= "1.6.0"}
   "alcotest" {with-test}
   "cohttp-lwt-unix" {with-test}
   "graphql-lwt" {with-test}

--- a/packages/graphql-lwt/graphql-lwt.0.13.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.13.0/opam
@@ -14,7 +14,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1"}
-  "graphql" {>= "0.13.0"}
+  "graphql" {>= "0.13.0" & < "0.14.0"}
   "alcotest" {with-test}
   "lwt"
 ]

--- a/packages/graphql-lwt/graphql-lwt.0.14.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.14.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/graphql-lwt/graphql-lwt.0.14.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.14.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1"}
+  "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "alcotest" {with-test}
   "yojson" {with-test & >= "1.6.0"}

--- a/packages/graphql-lwt/graphql-lwt.0.14.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.14.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "graphql" {>= "0.13.0"}
+  "alcotest" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "lwt"
+]
+
+synopsis: "Build GraphQL schemas with Lwt support"
+
+description: """
+`graphql-lwt` adds support for Lwt to `graphql`, so you can use Lwt in your GraphQL schema resolver functions."""
+url {
+  src:
+    "https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz"
+  checksum: [
+    "sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06"
+    "sha512=1d303d9ab67faecea8081f007b3696e36033aa65eba0854f50067b4d667d9a9ad185ad949371790a03509cb31bf6356b75c58f3066da9c35d82e620df5780185"
+  ]
+}
+x-commit-hash: "79e01a09d08b0de3b3fff8195e19f7d8ab566498"

--- a/packages/graphql-lwt/graphql-lwt.0.14.0/opam
+++ b/packages/graphql-lwt/graphql-lwt.0.14.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
   "graphql" {>= "0.13.0"}
   "alcotest" {with-test}

--- a/packages/graphql/graphql.0.14.0/opam
+++ b/packages/graphql/graphql.0.14.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/graphql/graphql.0.14.0/opam
+++ b/packages/graphql/graphql.0.14.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1"}
+  "dune" {>= "1.11"}
   "graphql_parser" {>= "0.9.0"}
   "yojson" {>= "1.6.0"}
   "rresult" {>= "0.3.0"}

--- a/packages/graphql/graphql.0.14.0/opam
+++ b/packages/graphql/graphql.0.14.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
   "graphql_parser" {>= "0.9.0"}
   "yojson" {>= "1.6.0"}

--- a/packages/graphql/graphql.0.14.0/opam
+++ b/packages/graphql/graphql.0.14.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "graphql_parser" {>= "0.9.0"}
+  "yojson" {>= "1.6.0"}
+  "rresult" {>= "0.3.0"}
+  "seq"
+  "alcotest" {with-test}
+]
+
+synopsis: "Build GraphQL schemas and execute queries against them"
+
+description: """
+`graphql` is a package for creating GraphQL servers. Current feature set includes:
+
+- Type-safe schema design
+- GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
+- Query execution
+- Introspection of schemas
+- Arguments for fields
+- Allows variables in queries
+- Subscriptions
+
+Supporting packages:
+
+- Use `graphql-lwt` for Lwt support.
+- Use `graphql-async` for Async support.
+- Use `graphql-cohttp` to run a GraphQL server with `cohttp`."""
+url {
+  src:
+    "https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz"
+  checksum: [
+    "sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06"
+    "sha512=1d303d9ab67faecea8081f007b3696e36033aa65eba0854f50067b4d667d9a9ad185ad949371790a03509cb31bf6356b75c58f3066da9c35d82e620df5780185"
+  ]
+}
+x-commit-hash: "79e01a09d08b0de3b3fff8195e19f7d8ab566498"

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -18,7 +18,7 @@ depends: [
   "menhir" {build & >= "20180523"}
   "alcotest" {with-test & >= "0.8.1"}
   "fmt" {>= "0.8.7"}
-  "re" {>= "1.5.0"}
+  "re" {>= "1.6.0"}
 ]
 
 synopsis: "Library for parsing GraphQL queries"

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "1.1"}
+  "dune" {>= "1.11"}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
   "fmt"

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors: "Andreas Garnaes <andreas.garnaes@gmail.com>"
+homepage: "https://github.com/andreas/ocaml-graphql-server"
+doc: "https://andreas.github.io/ocaml-graphql-server/"
+bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
+dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.1"}
+  "menhir" {build}
+  "alcotest" {with-test & >= "0.8.1"}
+  "fmt"
+  "re" {>= "1.5.0"}
+]
+
+synopsis: "Library for parsing GraphQL queries"
+url {
+  src:
+    "https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz"
+  checksum: [
+    "sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06"
+    "sha512=1d303d9ab67faecea8081f007b3696e36033aa65eba0854f50067b4d667d9a9ad185ad949371790a03509cb31bf6356b75c58f3066da9c35d82e620df5780185"
+  ]
+}
+x-commit-hash: "79e01a09d08b0de3b3fff8195e19f7d8ab566498"

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
-  "menhir" {build}
+  "menhir" {build & >= "20180523"}
   "alcotest" {with-test & >= "0.8.1"}
   "fmt" {>= "0.8.7"}
   "re" {>= "1.5.0"}

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.11"}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}

--- a/packages/graphql_parser/graphql_parser.0.14.0/opam
+++ b/packages/graphql_parser/graphql_parser.0.14.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "1.11"}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "re" {>= "1.5.0"}
 ]
 

--- a/packages/irmin-graphql/irmin-graphql.2.0.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.1.0"}
   "irmin" {>= "2.0.0" & < "2.2.0"}
-  "graphql" {>= "0.13.0 & < "0.14.0"}
+  "graphql" {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"

--- a/packages/irmin-graphql/irmin-graphql.2.0.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.1.0"}
   "irmin" {>= "2.0.0" & < "2.2.0"}
-  "graphql" {>= "0.13.0"}
+  "graphql" {>= "0.13.0 & < "0.14.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"

--- a/packages/irmin-graphql/irmin-graphql.2.1.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.8.0"}
   "irmin" {>= "2.0.0" & < "2.2.0"}
-  "graphql" {>= "0.13.0 & < "0.14.0"}
+  "graphql" {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"

--- a/packages/irmin-graphql/irmin-graphql.2.1.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.8.0"}
   "irmin" {>= "2.0.0" & < "2.2.0"}
-  "graphql" {>= "0.13.0"}
+  "graphql" {>= "0.13.0 & < "0.14.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"

--- a/packages/irmin-graphql/irmin-graphql.2.10.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.10.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.10.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.10.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.10.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.10.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.10.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.2.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.8.0"}
   "irmin" {>= "2.2.0" & < "2.3.0"}
-  "graphql" {>= "0.13.0"}
+  "graphql" {>= "0.13.0 & < "0.14.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"

--- a/packages/irmin-graphql/irmin-graphql.2.2.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"   {>= "4.03.0"}
   "dune"    {>= "1.8.0"}
   "irmin" {>= "2.2.0" & < "2.3.0"}
-  "graphql" {>= "0.13.0 & < "0.14.0"}
+  "graphql" {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt" {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "cohttp-lwt"

--- a/packages/irmin-graphql/irmin-graphql.2.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.4.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.4.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.4.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.3/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.3/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.3/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.4/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.5.4/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.5.4/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.6.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.6.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.6.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.6.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.6.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.7.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
   "result"         {>= "1.5"}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.7.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.7.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
   "result"         {>= "1.5"}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.7.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.7.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.7.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.7.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.7.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.7.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.7.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.7.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.8.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.8.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.8.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.8.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.9.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.9.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.9.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.9.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.2.9.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.2.9.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.7.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.0.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.0.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.1.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.1.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.2.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.2.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.2.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.2.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.2.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.2.2/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.2.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.3.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.3.0/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.3.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0"}
+  "graphql"        {>= "0.13.0" & <= "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}

--- a/packages/irmin-graphql/irmin-graphql.3.3.1/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.3.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml"          {>= "4.03.0"}
   "dune"           {>= "2.9.0"}
   "irmin"          {= version}
-  "graphql"        {>= "0.13.0" & <= "0.14.0"}
+  "graphql"        {>= "0.13.0" & < "0.14.0"}
   "graphql-lwt"    {>= "0.13.0"}
   "graphql-cohttp" {>= "0.13.0"}
   "graphql_parser" {>= "0.13.0"}


### PR DESCRIPTION
Library for parsing GraphQL queries

- Project page: <a href="https://github.com/andreas/ocaml-graphql-server">https://github.com/andreas/ocaml-graphql-server</a>
- Documentation: <a href="https://andreas.github.io/ocaml-graphql-server/">https://andreas.github.io/ocaml-graphql-server/</a>

##### CHANGES:

- Support `__typename` on subscriptions (andreas/ocaml-graphql-server#178)
- Handle unknown fields for subscriptions (andreas/ocaml-graphql-server#178)
- Add ocamlformat (andreas/ocaml-graphql-server#177)
- Handle missing variables as null (andreas/ocaml-graphql-server#184)
- Show default value in introspection query (andreas/ocaml-graphql-server#194)
- Support block strings in the parser (andreas/ocaml-graphql-server#198)
- Handle skip/include directives on fragment spreads (andreas/ocaml-graphql-server#200)
- Improved handling of recursive arguments and objects (andreas/ocaml-graphql-server#199)
- Fix websocket conflict (andreas/ocaml-graphql-server#206)
- Update deprecated Fmt functions (andreas/ocaml-graphql-server#206)
- Use Yojson `t` types instead of deprecated `json` type (andreas/ocaml-graphql-server#208)
- Raise minimum `rresult` version (andreas/ocaml-graphql-server#209)
