### PR TITLE
3 packages from diskuv/dkml-install-api at 0.2.0

### DIFF
--- a/packages/dkml-install-installer/dkml-install-installer.0.2.0/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.2.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Build tools for DKML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "dune-build-info"
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "crunch" {>= "3.2.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=d65935d6a9a790fec09cfc50f6b04c43"
+    "sha512=08aeffeffa41b10ca54c9329bf9f6ec9219060c2e62c3a389d08b096513fe3dc048782e28d5006cae6a35e124cfd09441eb41a063c6a3f12fc6e60fa9d2acef7"
+  ]
+}

--- a/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Runner executable for Diskuv OCaml (DKML) installation"
+description:
+  "The runner executable is responsible for loading and running all DKML installation components."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dune" {>= "2.9"}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=d65935d6a9a790fec09cfc50f6b04c43"
+    "sha512=08aeffeffa41b10ca54c9329bf9f6ec9219060c2e62c3a389d08b096513fe3dc048782e28d5006cae6a35e124cfd09441eb41a063c6a3f12fc6e60fa9d2acef7"
+  ]
+}

--- a/packages/dkml-install/dkml-install.0.2.0/opam
+++ b/packages/dkml-install/dkml-install.0.2.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "API and registry for Diskuv OCaml (DKML) installation components"
+description:
+  "All DKML installation components implement the interfaces exposed in this API."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dune" {>= "2.9"}
+  "ppx_deriving" {>= "5.2.1"}
+  "result" {>= "1.5"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+  "diskuvbox" {>= "0.1.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src: "https://github.com/diskuv/dkml-install-api/archive/v0.2.0.tar.gz"
+  checksum: [
+    "md5=d65935d6a9a790fec09cfc50f6b04c43"
+    "sha512=08aeffeffa41b10ca54c9329bf9f6ec9219060c2e62c3a389d08b096513fe3dc048782e28d5006cae6a35e124cfd09441eb41a063c6a3f12fc6e60fa9d2acef7"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`dkml-install.0.2.0`: API and registry for Diskuv OCaml (DKML) installation components
-`dkml-install-installer.0.2.0`: Build tools for DKML installers
-`dkml-install-runner.0.2.0`: Runner executable for Diskuv OCaml (DKML) installation



---
* Homepage: https://github.com/diskuv/dkml-install-api
* Source repo: git+https://github.com/diskuv/dkml-install-api.git
* Bug tracker: https://github.com/diskuv/dkml-install-api/issues

---
:camel: Pull-request generated by opam-publish v2.1.0