### PR TITLE
ocaml-protoc is not compatible with OCaml 5.0

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.0.1.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.1/opam
@@ -20,7 +20,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.0.1.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.2/opam
@@ -19,7 +19,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.0.1.3.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.3.2/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.0.1.3/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.0.1.3/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.1.0.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.0.1/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.1.0.3/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.0.3/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.1.0.4/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.0.4/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.1.2.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.2.0/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [make "uninstall" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.1.2.6/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.2.6/opam
@@ -19,7 +19,7 @@ install: [
   [make "bin.install" "PREFIX=%{prefix}%" "BINDIR=%{bin}%"]
 ]
 depends: [
-  "ocaml" {>="4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "ocamlfind"  {build}
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"

--- a/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.1/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>="4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "dune"  {>= "1.11"}
   "stdlib-shims"
 ]

--- a/packages/ocaml-protoc/ocaml-protoc.2.0.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.0.2/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>="4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "dune"  {>="1.11"}
   "stdlib-shims"
 ]

--- a/packages/ocaml-protoc/ocaml-protoc.2.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.1/opam
@@ -16,7 +16,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"  {>= "1.11"}
   "stdlib-shims"
   "odoc" {with-doc}

--- a/packages/ocaml-protoc/ocaml-protoc.2.2/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.2/opam
@@ -19,7 +19,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>="4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"  {>="2.0"}
   "stdlib-shims"
   "pbrt" {= version}


### PR DESCRIPTION
cc @c-cube 
```
#=== ERROR while compiling ocaml-protoc.2.2 ===================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocaml-protoc.2.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p ocaml-protoc -j 31
# exit-code            1
# env-file             ~/.opam/log/ocaml-protoc-19-120f1a.env
# output-file          ~/.opam/log/ocaml-protoc-19-120f1a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -bin-annot -annot -safe-string -strict-sequence -keep-locs -no-alias-deps -w A-4-42-41-48-70 -g -I src/compilerlib/.compiler_lib.objs/byte -I src/compilerlib/.compiler_lib.objs/native -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/compilerlib/.compiler_lib.objs/native/pb_codegen_util.cmx -c -impl src/compilerlib/pb_codegen_util.ml)
# File "src/compilerlib/pb_codegen_util.ml", line 103, characters 15-32:
# 103 |   | Some () -> String.capitalize s [@@ocaml.warning "-3"]
#                      ^^^^^^^^^^^^^^^^^
# Error: Unbound value String.capitalize
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -bin-annot -annot -safe-string -strict-sequence -keep-locs -no-alias-deps -w A-4-42-41-48-70 -g -I src/compilerlib/.compiler_lib.objs/byte -I src/compilerlib/.compiler_lib.objs/native -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/compilerlib/.compiler_lib.objs/native/pb_codegen_backend.cmx -c -impl src/compilerlib/pb_codegen_backend.ml)
# File "src/compilerlib/pb_codegen_backend.ml", line 131, characters 5-22:
# 131 |   |> String.capitalize [@@ocaml.warning "-3"]
#            ^^^^^^^^^^^^^^^^^
# Error: Unbound value String.capitalize
```