### PR TITLE
[new release] runtime_events_tools (0.3)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.3/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/sadiqj/runtime_events_tools"
+bug-reports: "https://github.com/sadiqj/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "ocamlfind"
+  "hdr_histogram"
+  "cmdliner"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sadiqj/runtime_events_tools.git"
+url {
+  src:
+    "https://github.com/sadiqj/runtime_events_tools/releases/download/0.3/runtime_events_tools-0.3.tbz"
+  checksum: [
+    "sha256=f71ce130b23acac77cbc873a2df1f3acd6be07e5ad110077bc374e7a20b2567f"
+    "sha512=0a083bb455bb810ba33a48708259a843ae61a70a3e834d356d63568c4f558b6f010bc24d5b84f00eae409845b5b51a709e5ba1efd83d60a1b234755ea2fdc9d5"
+  ]
+}
+x-commit-hash: "341739b057f69a9141d60f60be0c70778cb6d6e6"

--- a/packages/runtime_events_tools/runtime_events_tools.0.3/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "5.0.0~"}
   "ocamlfind"
   "hdr_histogram"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/sadiqj/runtime_events_tools">https://github.com/sadiqj/runtime_events_tools</a>

##### CHANGES:

0.1:
 * Initial opam release
