### PR TITLE
[new release] ocamlformat and ocamlformat-rpc-lib (0.24.0)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.24.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.24.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.24.0/ocamlformat-0.24.0.tbz"
+  checksum: [
+    "sha256=662974c1c79e5e6ab6c72d0e54bc5afd48e5e03b6c99ce023b2bfa268eeb55a3"
+    "sha512=36f08e072676a8c6a39053712f783798245f5aa0006bd00af052af526a97872abace6d1665410eb4e993f0df1afc223f9c080b966d4aab66f0279186da1a7862"
+  ]
+}
+x-commit-hash: "fd908d7b21a88c0f1cd6e9acdd50e83076b3fd17"

--- a/packages/ocamlformat/ocamlformat.0.24.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune" {with-test & < "3.0"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocamlformat-rpc-lib" {with-test & post & = version}
+  "ocp-indent"
+  "odoc-parser" {>= "2.0.0" & < "3.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.24.0/ocamlformat-0.24.0.tbz"
+  checksum: [
+    "sha256=662974c1c79e5e6ab6c72d0e54bc5afd48e5e03b6c99ce023b2bfa268eeb55a3"
+    "sha512=36f08e072676a8c6a39053712f783798245f5aa0006bd00af052af526a97872abace6d1665410eb4e993f0df1afc223f9c080b966d4aab66f0279186da1a7862"
+  ]
+}
+x-commit-hash: "fd908d7b21a88c0f1cd6e9acdd50e83076b3fd17" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.24.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.0/opam
@@ -12,7 +12,6 @@ depends: [
   "base" {>= "v0.12.0"}
   "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.8"}
-  "dune" {with-test & < "3.0"}
   "dune-build-info"
   "either"
   "fix"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### New features

- Support `odoc-parser.2.0.0` (ocaml-ppx/ocamlformat#2123, @gpetiot)
  * Breaking change: incompatible with earlier versions of `odoc-parser`
  * New inline math elements `{m ...}` available in doc-comments
  * New block math elements `{math ...}` available in doc-comments
