### PR TITLE
[new release] chamelon and chamelon-unix (0.0.10)

### DIFF
--- a/packages/chamelon-unix/chamelon-unix.0.0.10/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.0.10/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Command-line Unix utilities for chamelon filesystems"
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bos" {>= "0.2.0"}
+  "chamelon" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock-unix" {>= "4.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.0.10/chamelon-v0.0.10.tbz"
+  checksum: [
+    "sha256=592a0becee61ecf45c283bed686afc4258c7d77c40d7d6f7ae062e67b4a0a89f"
+    "sha512=4ac8ab3ed004b9f8881ad116c292ad1bef845d79edcfd7c6058f8b9cb476cb2b7bbbf78a3fa10bd9cf1683ad988b7b4b75a51f238fc7b5b46e9a699cdff8b42a"
+  ]
+}
+x-commit-hash: "6cb1037bb7cba779603ee67d8f983363863a7b65"

--- a/packages/chamelon/chamelon.0.0.10/opam
+++ b/packages/chamelon/chamelon.0.0.10/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Subset of littlefs filesystem fulfilling MirageOS KV"
+description: """
+Chamelon implements a subset of the littlefs filesystem,
+which was originally designed for microcontroller use.  It exposes
+an interface matching the Mirage_kv.RW module type and operates
+on top of a block device matching Mirage_block.S .
+
+It is extremely not POSIX."""
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "chamelon-unix" {= version & with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-unix" {>= "2.13.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bechamel" {>= "0.2.0" & with-test}
+  "bechamel-js" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.2"}
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "ptime" {>= "0.8.6"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+  "optint" {>= "0.0.4"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.0.10/chamelon-v0.0.10.tbz"
+  checksum: [
+    "sha256=592a0becee61ecf45c283bed686afc4258c7d77c40d7d6f7ae062e67b4a0a89f"
+    "sha512=4ac8ab3ed004b9f8881ad116c292ad1bef845d79edcfd7c6058f8b9cb476cb2b7bbbf78a3fa10bd9cf1683ad988b7b4b75a51f238fc7b5b46e9a699cdff8b42a"
+  ]
+}
+x-commit-hash: "6cb1037bb7cba779603ee67d8f983363863a7b65"


### PR DESCRIPTION
Subset of littlefs filesystem fulfilling MirageOS KV

- Project page: <a href="https://github.com/yomimono/chamelon">https://github.com/yomimono/chamelon</a>

##### CHANGES:

* detect simple cycles in the metadata tree at connect time (@yomimono)
* check block size in the superblock at connect time, and fail if it doesn't match block device (@yomimono)
