### PR TITLE
mdx.0.8.{1,2}'s tests require mdx < 2.0

### DIFF
--- a/packages/msat/msat.0.8.1/opam
+++ b/packages/msat/msat.0.8.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
   "containers" {with-test & < "3.0"}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 tags: [ "sat" "smt" ]
 homepage: "https://github.com/Gbury/mSAT"

--- a/packages/msat/msat.0.8.2/opam
+++ b/packages/msat/msat.0.8.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" { >= "1.1" }
   "iter" { >= "1.2" }
   "containers" {with-test & < "3.0"}
-  "mdx" {with-test}
+  "mdx" {with-test & < "2.0"}
 ]
 tags: [ "sat" "smt" "cdcl" "functor" ]
 homepage: "https://github.com/Gbury/mSAT"


### PR DESCRIPTION
```
#=== ERROR while compiling msat.0.8.2 =========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/msat.0.8.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p msat
# exit-code            1
# env-file             ~/.opam/log/msat-775-241a26.env
# output-file          ~/.opam/log/msat-775-241a26.out
### output ###
# File "dune", line 8, characters 15-18:
# 8 |           (run mdx test README.md)
#                    ^^^
# Error: Program mdx not found in the tree or in PATH
#  (context: default)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -open Msat -g -bin-annot -I tests/.test_api.eobjs/byte -I /home/opam/.opam/4.14/lib/iter -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I src/core/.msat.objs/byte -I src/sat/.msat_sat.objs/byte -no-alias-deps -o tests/.test_api.eobjs/byte/test_api.cmo -c -impl tests/test_api.ml)
```