### PR TITLE
bastet_async's tests is not compatible with alcotest-async >= 1.6.0

### DIFF
--- a/packages/bastet_async/bastet_async.0.1.0/opam
+++ b/packages/bastet_async/bastet_async.0.1.0/opam
@@ -13,8 +13,8 @@ depends: [
   "async_kernel" {>= "v0.12.0"}
   "async_unix" {with-test & >= "v0.12.0"}
   "core" {with-test & >= "v0.12.0"}
-  "alcotest" {>= "1.0.1" & with-test}
-  "alcotest-async" {>= "1.0.1" & with-test}
+  "alcotest" {>= "1.0.1" & < "1.6.0" & with-test}
+  "alcotest-async" {>= "1.0.1" & < "1.6.0" & with-test}
   "mdx" {>= "1.6.0" & with-test}
   "odoc" {>= "1.5.0" & with-doc}
   "dune" {>= "2.4.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling bastet_async.0.1.0 =================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/bastet_async.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bastet_async -j 31 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/bastet_async-3312-67fb33.env
# output-file          ~/.opam/log/bastet_async-3312-67fb33.out
### output ###
# File "dune-project", line 1, characters 11-16:
# 1 | (lang dune 2.4.0)
#                ^^^^^
# Warning: The ".0" part is ignored here.
# This version is parsed as just 2.4.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test_bastet_async.eobjs/byte -I /home/opam/.opam/4.14/lib/alcotest -I /home/opam/.opam/4.14/lib/alcotest-async -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_unix -I /home/opam/.opam/4.14/lib/bastet -I /home/opam/.opam/4.14/lib/core -I src/.bastet_async.objs/byte -no-alias-deps -o test/.test_bastet_async.eobjs/byte/dune__exe__Test_bastet_async.cmo -c -impl test/Test_bastet_async.ml)
# File "test/Test_bastet_async.ml", line 92, characters 47-63:
# 92 |             Alcotest_async.test_case "" `Quick Functor.identity;
#                                                     ^^^^^^^^^^^^^^^^
# Error: This expression has type unit -> unit Async_kernel.Deferred.t
#        but an expression was expected of type unit -> unit Async.Deferred.t
#        Type
#          unit Async_kernel.Deferred.t = unit Async_kernel__Types.Deferred.t
#        is not compatible with type unit Async.Deferred.t 
```