### PR TITLE
lambdapi: remove un-required conflict

### DIFF
--- a/packages/lambdapi/lambdapi.2.0.0/opam
+++ b/packages/lambdapi/lambdapi.2.0.0/opam
@@ -56,7 +56,6 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
-conflicts: [ "camlp-streams" ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/lambdapi/lambdapi.2.0.0/opam
+++ b/packages/lambdapi/lambdapi.2.0.0/opam
@@ -33,7 +33,8 @@ interactive modes for proving both unification goals
 and typing goals, and tactics for solving them step by step.
 In particular, a rewrite tactic like in SSReflect, and
 a why3 tactic for calling external automated provers through
-the Why3 platform."""
+the Why3 platform.
+"""
 maintainer: ["dedukti-dev@inria.fr"]
 authors: ["Deducteam"]
 license: "CECILL-2.1"

--- a/packages/lambdapi/lambdapi.2.1.0/opam
+++ b/packages/lambdapi/lambdapi.2.1.0/opam
@@ -57,7 +57,6 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
-conflicts: [ "camlp-streams" ]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/lambdapi/lambdapi.2.2.0/opam
+++ b/packages/lambdapi/lambdapi.2.2.0/opam
@@ -60,7 +60,6 @@ depends: [
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
 ]
-conflicts: [ "camlp-streams" ]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
camlp-streams is now compatible with Stdlib.Stream (see #21656)