### PR TITLE
2 packages from c-cube/calculon at 0.8

### DIFF
--- a/packages/calculon-web/calculon-web.0.8/opam
+++ b/packages/calculon-web/calculon-web.0.8/opam
@@ -5,7 +5,7 @@ authors: ["Armael" "Enjolras" "c-cube"]
 maintainer: "c-cube"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [

--- a/packages/calculon-web/calculon-web.0.8/opam
+++ b/packages/calculon-web/calculon-web.0.8/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+license: "MIT"
+synopsis: "A collection of web plugins for Calculon"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "calculon" { = version }
+  "re" { >= "1.7.2" }
+  "uri"
+  "curly"
+  "atdgen"
+  "lambdasoup"
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.8.tar.gz"
+  checksum: [
+    "md5=4d34a4d99816effb06954ea283be0e5b"
+    "sha512=b9ec29bc0fc40774075b528524bd191b4dde013465805499b6f49b9dd070b404b34364c77ef994f0bc01c9213f1f7c0a4aa749f84f8de55de810088499b29cfc"
+  ]
+}

--- a/packages/calculon/calculon.0.8/opam
+++ b/packages/calculon/calculon.0.8/opam
@@ -5,7 +5,7 @@ authors: ["Armael" "Enjolras" "c-cube"]
 maintainer: "c-cube"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
@@ -15,7 +15,7 @@ depends: [
   "irc-client" { >= "0.7.0"}
   "irc-client-lwt"
   "irc-client-lwt-ssl"
-  "sqlite3"
+  "sqlite3" {>= "5.0.0"}
   "logs" {>= "0.5.0"}
   "yojson" { >= "1.7" }
   "containers" { >= "3.0" & < "4.0" }

--- a/packages/calculon/calculon.0.8/opam
+++ b/packages/calculon/calculon.0.8/opam
@@ -18,7 +18,7 @@ depends: [
   "sqlite3" {>= "5.0.0"}
   "logs" {>= "0.5.0"}
   "yojson" { >= "1.7" }
-  "containers" { >= "3.0" & < "4.0" }
+  "containers" { >= "3.6" & < "4.0" }
   "ptime"
   "stringext"
   "re" { >= "1.7.2" & < "2.0" }
@@ -27,6 +27,9 @@ depends: [
 ]
 depopts: [
   "iter"
+]
+conflicts: [
+  "result" {< "1.5"}
 ]
 tags: [ "irc" "bot" "factoids" ]
 homepage: "https://github.com/c-cube/calculon"

--- a/packages/calculon/calculon.0.8/opam
+++ b/packages/calculon/calculon.0.8/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+license: "MIT"
+synopsis: "Library for writing IRC bots in OCaml and a collection of plugins"
+authors: ["Armael" "Enjolras" "c-cube"]
+maintainer: "c-cube"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "base-unix"
+  "lwt"
+  "irc-client" { >= "0.7.0"}
+  "irc-client-lwt"
+  "irc-client-lwt-ssl"
+  "sqlite3"
+  "logs" {>= "0.5.0"}
+  "yojson" { >= "1.7" }
+  "containers" { >= "3.0" & < "4.0" }
+  "ptime"
+  "stringext"
+  "re" { >= "1.7.2" & < "2.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.08.0" }
+]
+depopts: [
+  "iter"
+]
+tags: [ "irc" "bot" "factoids" ]
+homepage: "https://github.com/c-cube/calculon"
+bug-reports: "https://github.com/c-cube/calculon/issues"
+dev-repo: "git+https://github.com/c-cube/calculon.git"
+url {
+  src: "https://github.com/c-cube/calculon/archive/v0.8.tar.gz"
+  checksum: [
+    "md5=4d34a4d99816effb06954ea283be0e5b"
+    "sha512=b9ec29bc0fc40774075b528524bd191b4dde013465805499b6f49b9dd070b404b34364c77ef994f0bc01c9213f1f7c0a4aa749f84f8de55de810088499b29cfc"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`calculon.0.8`: Library for writing IRC bots in OCaml and a collection of plugins
-`calculon-web.0.8`: A collection of web plugins for Calculon



---
* Homepage: https://github.com/c-cube/calculon
* Source repo: git+https://github.com/c-cube/calculon.git
* Bug tracker: https://github.com/c-cube/calculon/issues

---
:camel: Pull-request generated by opam-publish v2.1.0