### PR TITLE
Package data-encoding.0.6

### DIFF
--- a/packages/data-encoding/data-encoding.0.6/opam
+++ b/packages/data-encoding/data-encoding.0.6/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+homepage: "https://gitlab.com/nomadic-labs/data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/data-encoding/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/data-encoding.git"
+license: "MIT"
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "2.0" }
+  "ezjsonm"
+  "zarith" {>= "1.4"}
+  "zarith_stubs_js"
+  "hex" {>= "1.3.0"}
+  "json-data-encoding" { = "0.11" }
+  "json-data-encoding-bson" { = "0.11" }
+  "alcotest" { with-test }
+  "crowbar" { >= "0.2" & with-test }
+  "ppx_expect" { with-test }
+  "either"
+  "ppx_hash"
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+  "md2mld" { with-test } # not technically a test dep; modify when https://github.com/ocurrent/ocaml-ci/issues/264 is fixed
+  "js_of_ocaml-compiler" { with-test }
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Library of JSON and binary encoding combinators"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/data-encoding/-/archive/v0.6/data-encoding-v0.6.tar.gz"
+  checksum: [
+    "md5=c0c288d30b791a83a2c6fde0e2282cc0"
+    "sha512=443f3e4e53c26b87ba519affc43692385f413112aeac04ddc3ff39ef555a6218439eefe1d3d0e472f3fba20f19b79b3b0ca0794f2716b663b795eff6b1de938b"
+  ]
+}

--- a/packages/data-encoding/data-encoding.0.6/opam
+++ b/packages/data-encoding/data-encoding.0.6/opam
@@ -19,9 +19,7 @@ depends: [
   "ppx_expect" { with-test }
   "either"
   "ppx_hash"
-  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
   "odoc" { with-doc }
-  "md2mld" { with-test } # not technically a test dep; modify when https://github.com/ocurrent/ocaml-ci/issues/264 is fixed
   "js_of_ocaml-compiler" { with-test }
 ]
 build: [


### PR DESCRIPTION
### `data-encoding.0.6`
Library of JSON and binary encoding combinators



---
* Homepage: https://gitlab.com/nomadic-labs/data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/data-encoding.git
* Bug tracker: https://gitlab.com/nomadic-labs/data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0