### PR TITLE
ocamlify is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/ocamlify/ocamlify.0.0.1/opam
+++ b/packages/ocamlify/ocamlify.0.0.1/opam
@@ -5,7 +5,7 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlify.0.0.1 =====================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamlify.0.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/ocamlify-19-b9432f.env
# output-file          ~/.opam/log/ocamlify-19-b9432f.out
### output ###
# File "/home/gildor/programmation/oasis/src/oasis/PropList.ml", line 93, characters 13-29:
# Error: Unbound value String.lowercase
```