### PR TITLE
ocamlmod is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/ocamlmod/ocamlmod.0.0.8/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.8/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocaml" "%{etc}%/ocamlmod/_oasis_remove_.ml" "%{etc}%/ocamlmod"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
   "ocamlbuild" {build}

--- a/packages/ocamlmod/ocamlmod.0.0.9/opam
+++ b/packages/ocamlmod/ocamlmod.0.0.9/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocaml" "%{etc}%/ocamlmod/_oasis_remove_.ml" "%{etc}%/ocamlmod"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "2.0.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlmod.0.0.9 =====================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamlmod.0.0.9
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/ocamlmod-19-4b8a71.env
# output-file          ~/.opam/log/ocamlmod-19-4b8a71.out
### output ###
# File "./setup.ml", line 596, characters 4-15:
# 596 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```