### PR TITLE
uuidm.0.9.7 is not compatible with cmdliner < 0.9.8 (uses Term.const)

### DIFF
--- a/packages/uuidm/uuidm.0.9.7/opam
+++ b/packages/uuidm/uuidm.0.9.7/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build} ]
 depopts: [ "cmdliner" ]
+conflicts: [
+  "cmdliner" {< "0.9.8"}
+]
 build:
 [  "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"


### PR DESCRIPTION
```
#=== ERROR while compiling uuidm.0.9.7 ========================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/uuidm.0.9.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --with-cmdliner true
# exit-code            1
# env-file             ~/.opam/log/uuidm-39-3a404a.env
# output-file          ~/.opam/log/uuidm-39-3a404a.out
### output ###
# ocamlfind ocamldep -package bytes -modules src/uuidm.ml > src/uuidm.ml.depends
# ocamlfind ocamldep -package bytes -modules src/uuidm.mli > src/uuidm.mli.depends
# ocamlfind ocamlc -c -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmi src/uuidm.mli
# ocamlfind ocamlopt -c -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmx src/uuidm.ml
# + ocamlfind ocamlopt -c -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmx src/uuidm.ml
# File "src/uuidm.ml", line 186, characters 40-58:
# 186 | let compare : string -> string -> int = Pervasives.compare
#                                               ^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
# ocamlfind ocamlopt -a -package bytes -I src src/uuidm.cmx -o src/uuidm.cmxa
# ocamlfind ocamlopt -shared -linkall -package bytes -I src src/uuidm.cmxa -o src/uuidm.cmxs
# ocamlfind ocamlc -c -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmo src/uuidm.ml
# + ocamlfind ocamlc -c -bin-annot -safe-string -package bytes -I src -I test -o src/uuidm.cmo src/uuidm.ml
# File "src/uuidm.ml", line 186, characters 40-58:
# 186 | let compare : string -> string -> int = Pervasives.compare
#                                               ^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
# ocamlfind ocamlc -a -package bytes -I src src/uuidm.cmo -o src/uuidm.cma
# ocamlfind ocamldep -package cmdliner -package bytes -modules test/uuidtrip.ml > test/uuidtrip.ml.depends
# ocamlfind ocamlc -c -bin-annot -safe-string -package cmdliner -package bytes -I test -I src -o test/uuidtrip.cmo test/uuidtrip.ml
# + ocamlfind ocamlc -c -bin-annot -safe-string -package cmdliner -package bytes -I test -I src -o test/uuidtrip.cmo test/uuidtrip.ml
# File "test/uuidtrip.ml", line 85, characters 8-13:
# 85 |   Term.(const gen $ version $ ns $ name_ $ upper $ binary),
#              ^^^^^
# Error: Unbound value const
# Hint: Did you mean cos or cosh?
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ["ocamlbuild"; "-use-ocamlfind"; "-classic-display"; "-build-dir";
#      "_build"; "opam"; "pkg/META"; "CHANGES.md"; "LICENSE.md"; "README.md";
#      "src/uuidm.a"; "src/uuidm.cmxs"; "src/uuidm.cmxa"; "src/uuidm.cma";
#      "src/uuidm.cmx"; "src/uuidm.cmi"; "src/uuidm.mli";
#      "test/uuidtrip.native"]: exited with 10
```