### PR TITLE
adds to uuidm a lower bound constraint on the cmdliner version

### DIFF
--- a/packages/uuidm/uuidm.0.9.7/opam
+++ b/packages/uuidm/uuidm.0.9.7/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build} ]
 depopts: [ "cmdliner" ]
+conflicts: [
+  "cmdliner" {< "0.9.8"}
+]
 build:
 [  "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"


### PR DESCRIPTION
The uuidm.0.9.7 version is missing a conflict that defines the lower bound constraint on the cmdliner version, which results in the following error,

```
File "test/uuidtrip.ml", line 85, characters 8-13:
85 |   Term.(const gen $ version $ ns $ name_ $ upper $ binary),
```

when uuidm.0.9.7 [is built][1] with cmdliner.0.9.4.

Discovered in PR #21781, fixed in a separate PR for cleaner history.

CC Daniel @dbuenzli for the situational awareness.

[1]: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/bb37510c2bf1d1e78cfa6c25a14fe0c9627562f8/variant/opam-2.1,compilers,4.08,bap-core-theory.2.5.0,lower-bounds