### PR TITLE
Package lz4.1.2

### DIFF
--- a/packages/lz4/lz4.1.2/opam
+++ b/packages/lz4/lz4.1.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Bindings to the LZ4 compression algorithm"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/whitequark/ocaml-lz4"
+doc: "http://whitequark.github.io/ocaml-lz4"
+bug-reports: "https://github.com/whitequark/ocaml-lz4/issues"
+dev-repo: "git://github.com/whitequark/ocaml-lz4.git"
+tags: [ "lz4" "compression" "decompression" ]
+build: [
+  ["dune" "build" "@install" "-j" jobs "-p" name]
+  ["dune" "runtest" "-j" jobs "-p" name] {with-test}
+  ["dune" "build" "@doc" "-j" jobs "-p" name] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "conf-liblz4"
+  "dune" { >= "2.0" }
+  "ctypes" {>= "0.4.1"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/whitequark/ocaml-lz4/archive/v1.2.0.tar.gz"
+  checksum: [
+    "md5=da4db685501fe0b408f7faee81f39ea2"
+    "sha512=c3425cbd3ceb03ef11e711ad01c8b97868e0a7ac5b540c4045681c002db14fa4ebd5c3ad62771c65208de877bd0f6309e982fcc7fc35c78ba320802b50350908"
+  ]
+}


### PR DESCRIPTION
### `lz4.1.2`
Bindings to the LZ4 compression algorithm



---
* Homepage: https://github.com/whitequark/ocaml-lz4
* Source repo: git://github.com/whitequark/ocaml-lz4.git
* Bug tracker: https://github.com/whitequark/ocaml-lz4/issues

---
:camel: Pull-request generated by opam-publish v2.1.0