### PR TITLE
Package lz4.1.2.0

### DIFF
--- a/packages/lz4/lz4.1.2.0/opam
+++ b/packages/lz4/lz4.1.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Bindings to the LZ4 compression algorithm"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/whitequark/ocaml-lz4"
+doc: "http://whitequark.github.io/ocaml-lz4"
+bug-reports: "https://github.com/whitequark/ocaml-lz4/issues"
+dev-repo: "git://github.com/whitequark/ocaml-lz4.git"
+tags: [ "lz4" "compression" "decompression" ]
+build: [
+  ["dune" "build" "@install" "-j" jobs "-p" name]
+  ["dune" "runtest" "-j" jobs "-p" name] {with-test}
+  ["dune" "build" "@doc" "-j" jobs "-p" name] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "conf-liblz4"
+  "dune" { >= "2.0" }
+  "ctypes" {>= "0.4.1"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/whitequark/ocaml-lz4/archive/v1.2.0.tar.gz"
+  checksum: [
+    "md5=d2e3d607dbc2961a94312164c309f0fa"
+    "sha512=9b817e5446c156abb00acdc3da2925bbe725600bfb2f0761079252d9aabd2abd36ea84b69bdb252cc26419009465bc629f8cc677fb68e0518a844f5c5deed00d"
+  ]
+}


### PR DESCRIPTION
### `lz4.1.2.0`
Bindings to the LZ4 compression algorithm



---
* Homepage: https://github.com/whitequark/ocaml-lz4
* Source repo: git://github.com/whitequark/ocaml-lz4.git
* Bug tracker: https://github.com/whitequark/ocaml-lz4/issues

---
:camel: Pull-request generated by opam-publish v2.1.0