### PR TITLE
Add patch to ocamlfind 1.9.5 for installation without coreutils

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.5/files/0001-Fix-bug-when-installing-with-a-system-compiler.patch
+++ b/packages/ocamlfind/ocamlfind.1.9.5/files/0001-Fix-bug-when-installing-with-a-system-compiler.patch
@@ -1,0 +1,26 @@
+From f53247f546375972789b96c3f612cd7f524bf2aa Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Mon, 11 Jul 2022 18:12:18 +0200
+Subject: [PATCH] Fix bug when installing with a system compiler
+
+See https://discuss.ocaml.org/t/problem-installing-ocamlfind-on-latest-ocamlpro-alpine-docker-image/10147
+---
+ src/findlib/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/findlib/Makefile b/src/findlib/Makefile
+index 84514b6f22..ea23f4a10c 100644
+--- a/src/findlib/Makefile
++++ b/src/findlib/Makefile
+@@ -123,7 +123,7 @@ clean:
+ install: all
+ 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_SITELIB)/$(NAME)"
+ 	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAMLFIND_BIN)"
+-	$(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)"
++	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLDIR) "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)"
+ 	test $(INSTALL_TOPFIND) -eq 0 || $(INSTALLFILE) topfind "$(DESTDIR)$(prefix)$(OCAML_CORE_STDLIB)/"
+ 	files=`$(SH) $(TOP)/tools/collect_files $(TOP)/Makefile.config \
+ 	findlib.cmi findlib.mli findlib.cma findlib.cmxa findlib$(LIB_SUFFIX) findlib.cmxs \
+-- 
+2.35.1
+

--- a/packages/ocamlfind/ocamlfind.1.9.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.5/opam
@@ -34,6 +34,8 @@ install: [
   [make "install"]
   ["install" "-m" "0755" "ocaml-stub" "%{bin}%/ocaml"] {ocaml:preinstalled}
 ]
+extra-files: ["0001-Fix-bug-when-installing-with-a-system-compiler.patch" "md5=130d3d6fe399948ed7991b7756f50dc3"]
+patches: ["0001-Fix-bug-when-installing-with-a-system-compiler.patch"]
 dev-repo: "git+https://github.com/ocaml/ocamlfind.git"
 url {
   src: "http://download.camlcity.org/download/findlib-1.9.5.tar.gz"


### PR DESCRIPTION
Not sure if we want to patch it this way or wait for a proper release, but although the failure is on a corner case it does block the whole ecosystem.
So I thought I would propose this PR anyway.
Sad to have to trigger so many recompilations while this only patches the install without changing the code, though, but well.