### PR TITLE
fileutils is not compatible with OCaml 5.0 (uses oasis or Stream)

### DIFF
--- a/packages/fileutils/fileutils.0.5.3/opam
+++ b/packages/fileutils/fileutils.0.5.3/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "fileutils"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-unix"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/fileutils/fileutils.0.6.0/opam
+++ b/packages/fileutils/fileutils.0.6.0/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "http://ocaml-fileutils.forge.ocamlcore.org/"
 bug-reports: "https://github.com/gildor478/ocaml-fileutils/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-unix"
   "base-bytes"
   "stdlib-shims"

--- a/packages/fileutils/fileutils.0.6.1/opam
+++ b/packages/fileutils/fileutils.0.6.1/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "base-unix"
   "base-bytes"
   "stdlib-shims"

--- a/packages/fileutils/fileutils.0.6.2/opam
+++ b/packages/fileutils/fileutils.0.6.2/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "base-unix"
   "base-bytes"
   "stdlib-shims"

--- a/packages/fileutils/fileutils.0.6.3/opam
+++ b/packages/fileutils/fileutils.0.6.3/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "base-unix"
   "base-bytes"
   "stdlib-shims"


### PR DESCRIPTION
```
#=== ERROR while compiling fileutils.0.6.3 ====================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/fileutils.0.6.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p fileutils -j 31
# exit-code            1
# env-file             ~/.opam/log/fileutils-19-c2c666.env
# output-file          ~/.opam/log/fileutils-19-c2c666.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/fileutils/.fileutils.objs/byte -I src/lib/fileutils/.fileutils.objs/public_cmi -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/stdlib-shims -no-alias-deps -o src/lib/fileutils/.fileutils.objs/byte/fileUtilCMP.cmo -c -impl src/lib/fileutils/FileUtilCMP.ml)
# File "src/lib/fileutils/FileUtilCMP.ml", line 42, characters 8-20:
# 42 |         Stream.empty st;
#              ^^^^^^^^^^^^
# Error: Unbound module Stream
```