### PR TITLE
pcre < 7.3.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/pcre/pcre.7.1.3/opam
+++ b/packages/pcre/pcre.7.1.3/opam
@@ -14,19 +14,10 @@ remove: [
   ["ocamlfind" "remove" "pcre"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlfind" {>= "1.5"}
   "conf-libpcre"
   "ocamlbuild" {build & != "0.9.0"}
-]
-conflicts: [
-  "pcre" {= "6.2.5"}
-  "pcre" {= "7.0.2"}
-  "pcre" {= "7.0.3"}
-  "pcre" {= "7.0.4"}
-  "pcre" {= "7.1.0"}
-  "pcre" {= "7.1.1"}
-  "pcre" {= "7.1.2"}
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis:

--- a/packages/pcre/pcre.7.1.5/opam
+++ b/packages/pcre/pcre.7.1.5/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "pcre"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "base-bytes"
   "ocamlfind" {>= "1.5"}
   "conf-libpcre"

--- a/packages/pcre/pcre.7.1.6/opam
+++ b/packages/pcre/pcre.7.1.6/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "pcre"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}

--- a/packages/pcre/pcre.7.2.2/opam
+++ b/packages/pcre/pcre.7.2.2/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "pcre"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build & != "0.9.0"}

--- a/packages/pcre/pcre.7.2.3/opam
+++ b/packages/pcre/pcre.7.2.3/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "pcre"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build & != "0.9.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling pcre.7.2.3 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/pcre.7.2.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/pcre-8-e70bec.env
# output-file          ~/.opam/log/pcre-8-e70bec.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```