### PR TITLE
lablgl is not compatible with OCaml 5.0 (uses Genlex)

### DIFF
--- a/packages/lablgl/lablgl.1.04.20120306/opam
+++ b/packages/lablgl/lablgl.1.04.20120306/opam
@@ -7,7 +7,10 @@ build: [
   [make "glut"]
   [make "glutopt"]
 ]
-depends: ["ocaml" "camlp4"]
+depends: [
+  "ocaml" {< "5.0"}
+  "camlp4"
+]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
     {os-family = "debian"}

--- a/packages/lablgl/lablgl.1.05/opam
+++ b/packages/lablgl/lablgl.1.05/opam
@@ -20,7 +20,10 @@ remove: [
   ["rm" "-rf" "%{lib}%/lablgl"]
   ["rm" "-f" "%{bin}%/lablglut"]
 ]
-depends: ["ocaml" "camlp4"]
+depends: [
+  "ocaml" {< "5.0"}
+  "camlp4"
+]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
     {os-family = "debian"}

--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -20,7 +20,9 @@ remove: [
   ["rm" "-rf" "%{lib}%/lablgl"]
   ["rm" "-f" "%{bin}%/lablglut"]
 ]
-depends: ["ocaml" {>= "4.03"}]
+depends: [
+  "ocaml" {>= "4.03" & < "5.0"}
+]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]
     {os-family = "debian"}


### PR DESCRIPTION
```
#=== ERROR while compiling lablgl.1.06 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/lablgl.1.06
# command              ~/.opam/opam-init/hooks/sandbox.sh build make INSTALLDIR=/home/opam/.opam/5.0/lib/lablgl glut
# exit-code            2
# env-file             ~/.opam/log/lablgl-8-6e7bc5.env
# output-file          ~/.opam/log/lablgl-8-6e7bc5.out
### output ###
# cd src && make all LIBDIR="`ocamlc -where`"
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/lablgl.1.06/src'
# ocamlc -c -w s  -I +labltk var2def.ml
# File "var2def.ml", line 17, characters 5-11:
# 17 | open Genlex
#           ^^^^^^
# Error: Unbound module Genlex
# make[1]: *** [../Makefile.common:48: var2def.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/lablgl.1.06/src'
# make: *** [Makefile:12: lib] Error 2
```