### PR TITLE
re < 1.7.2 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/re/re.1.3.0/opam
+++ b/packages/re/re.1.3.0/opam
@@ -17,7 +17,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/re/re.1.3.1/opam
+++ b/packages/re/re.1.3.1/opam
@@ -17,7 +17,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/re/re.1.3.2/opam
+++ b/packages/re/re.1.3.2/opam
@@ -17,7 +17,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/re/re.1.4.0/opam
+++ b/packages/re/re.1.4.0/opam
@@ -17,7 +17,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/re/re.1.4.1/opam
+++ b/packages/re/re.1.4.1/opam
@@ -17,7 +17,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/re/re.1.5.0/opam
+++ b/packages/re/re.1.5.0/opam
@@ -13,7 +13,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/re/re.1.6.0/opam
+++ b/packages/re/re.1.6.0/opam
@@ -13,7 +13,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/re/re.1.6.1/opam
+++ b/packages/re/re.1.6.1/opam
@@ -13,7 +13,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/re/re.1.7.0/opam
+++ b/packages/re/re.1.7.0/opam
@@ -13,7 +13,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/re/re.1.7.1/opam
+++ b/packages/re/re.1.7.1/opam
@@ -13,7 +13,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "re"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"


### PR DESCRIPTION
```
#=== ERROR while compiling re.1.7.1 ===========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/re.1.7.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/re-10-0e5261.env
# output-file          ~/.opam/log/re-10-0e5261.out
### output ###
# File "./setup.ml", line 581, characters 4-15:
# 581 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```