### PR TITLE
text is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/text/text.0.8.0/opam
+++ b/packages/text/text.0.8.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "text"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/text/text.0.8.1/opam
+++ b/packages/text/text.0.8.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
+ /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "make" "setup.exe" (CWD=/home/opam/.opam/5.0/.opam-switch/build/text.0.8.1)
- ocamlfind ocamlopt -o setup.exe setup.ml || ocamlfind ocamlc -o setup.exe setup.ml || true
- File "setup.ml", line 325, characters 20-36:
- 325 |     String.compare (String.lowercase s1) (String.lowercase s2)
-                           ^^^^^^^^^^^^^^^^
- Error: Unbound value String.lowercase
- File "setup.ml", line 325, characters 20-36:
- 325 |     String.compare (String.lowercase s1) (String.lowercase s2)
-                           ^^^^^^^^^^^^^^^^
- Error: Unbound value String.lowercase
- rm -f setup.cmi setup.cmo setup.cmx setup.o
Processing 11/12: [text: ./setup.exe]
+ /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "./setup.exe" "-configure" "--disable-pcre" "--disable-camlp4" (CWD=/home/opam/.opam/5.0/.opam-switch/build/text.0.8.1)
- [ERROR] Command not found: ./setup.exe
[ERROR] The compilation of text.0.8.1 failed at "./setup.exe -configure --disable-pcre --disable-camlp4".

#=== ERROR while compiling text.0.8.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/text.0.8.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./setup.exe -configure --disable-pcre --disable-camlp4
# exit-code            10
# env-file             ~/.opam/log/text-9-8a21d4.env
# output-file          ~/.opam/log/text-9-8a21d4.out
### output ###
# [ERROR] Command not found: ./setup.exe
```