### PR TITLE
fieldslib < v0.9.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/fieldslib/fieldslib.108.00.02/opam
+++ b/packages/fieldslib/fieldslib.108.00.02/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "108.00.02"}

--- a/packages/fieldslib/fieldslib.108.07.00/opam
+++ b/packages/fieldslib/fieldslib.108.07.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "108.07.00"}

--- a/packages/fieldslib/fieldslib.108.07.01/opam
+++ b/packages/fieldslib/fieldslib.108.07.01/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "108.07.01"}

--- a/packages/fieldslib/fieldslib.108.08.00/opam
+++ b/packages/fieldslib/fieldslib.108.08.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "108.08.00"}

--- a/packages/fieldslib/fieldslib.109.07.00/opam
+++ b/packages/fieldslib/fieldslib.109.07.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.07.00"}

--- a/packages/fieldslib/fieldslib.109.08.00/opam
+++ b/packages/fieldslib/fieldslib.109.08.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.08.00"}

--- a/packages/fieldslib/fieldslib.109.09.00/opam
+++ b/packages/fieldslib/fieldslib.109.09.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.09.00"}

--- a/packages/fieldslib/fieldslib.109.10.00/opam
+++ b/packages/fieldslib/fieldslib.109.10.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.10.00"}

--- a/packages/fieldslib/fieldslib.109.11.00/opam
+++ b/packages/fieldslib/fieldslib.109.11.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.11.00"}

--- a/packages/fieldslib/fieldslib.109.12.00/opam
+++ b/packages/fieldslib/fieldslib.109.12.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "type_conv" {= "109.12.00"}
   "ocamlbuild" {build}

--- a/packages/fieldslib/fieldslib.109.13.00/opam
+++ b/packages/fieldslib/fieldslib.109.13.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.13.00"}

--- a/packages/fieldslib/fieldslib.109.14.00/opam
+++ b/packages/fieldslib/fieldslib.109.14.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.14.00"}

--- a/packages/fieldslib/fieldslib.109.15.00/opam
+++ b/packages/fieldslib/fieldslib.109.15.00/opam
@@ -3,7 +3,7 @@ maintainer: "Jane Street developers"
 build: make
 remove: [["ocamlfind" "remove" "fieldslib"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "ocamlfind"
   "type_conv" {= "109.15.00"}

--- a/packages/fieldslib/fieldslib.113.24.00/opam
+++ b/packages/fieldslib/fieldslib.113.24.00/opam
@@ -10,7 +10,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling fieldslib.113.24.00 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/fieldslib.113.24.00
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/fieldslib-8-ad9ae2.env
# output-file          ~/.opam/log/fieldslib-8-ad9ae2.out
### output ###
# File "./setup.ml", line 316, characters 20-36:
# 316 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```