### PR TITLE
typerep < v0.9.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/typerep/typerep.109.55.00/opam
+++ b/packages/typerep/typerep.109.55.00/opam
@@ -13,7 +13,7 @@ remove: [
   ["ocamlfind" "remove" "typerep_kernel"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {= "109.53.00"}

--- a/packages/typerep/typerep.109.55.02/opam
+++ b/packages/typerep/typerep.109.55.02/opam
@@ -13,7 +13,7 @@ remove: [
   ["ocamlfind" "remove" "typerep_kernel"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {>= "109.53.00" & <= "111.03.00"}

--- a/packages/typerep/typerep.111.06.00/opam
+++ b/packages/typerep/typerep.111.06.00/opam
@@ -12,7 +12,7 @@ remove: [
   ["ocamlfind" "remove" "typerep_generics_sexprep"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {>= "109.53.00" & <= "111.03.00"}

--- a/packages/typerep/typerep.111.17.00/opam
+++ b/packages/typerep/typerep.111.17.00/opam
@@ -12,7 +12,7 @@ remove: [
   ["ocamlfind" "remove" "typerep_generics_sexprep"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {>= "109.53.00" & < "112.02.00"}

--- a/packages/typerep/typerep.112.06.00/opam
+++ b/packages/typerep/typerep.112.06.00/opam
@@ -12,7 +12,7 @@ remove: [
   ["ocamlfind" "remove" "typerep_generics_sexprep"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {>= "112.06.00" & < "112.07.00"}

--- a/packages/typerep/typerep.112.17.00/opam
+++ b/packages/typerep/typerep.112.17.00/opam
@@ -8,7 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "typerep_lib"]]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {>= "112.17.00" & < "112.18.00"}

--- a/packages/typerep/typerep.112.24.00/opam
+++ b/packages/typerep/typerep.112.24.00/opam
@@ -8,7 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "typerep_lib"]]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "camlp4"
   "ocamlfind" {>= "1.3.2"}
   "bin_prot" {>= "112.24.00" & < "112.25.00"}

--- a/packages/typerep/typerep.113.24.00/opam
+++ b/packages/typerep/typerep.113.24.00/opam
@@ -10,7 +10,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.2"}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling typerep.113.24.00 ==================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/typerep.113.24.00
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/typerep-8-a89863.env
# output-file          ~/.opam/log/typerep-8-a89863.out
### output ###
# File "./setup.ml", line 316, characters 20-36:
# 316 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```