### PR TITLE
res.4.0.7 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/res/res.4.0.7/opam
+++ b/packages/res/res.4.0.7/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "res"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "base-bytes"
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling res.4.0.7 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/res.4.0.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/res-9-5489f5.env
# output-file          ~/.opam/log/res-9-5489f5.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```