### PR TITLE
benchmark.1.4 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/benchmark/benchmark.1.4/opam
+++ b/packages/benchmark/benchmark.1.4/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "benchmark"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "5.0"}
   "base-unix"
   "ocamlfind"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling benchmark.1.4 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/benchmark.1.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/benchmark-9-d53904.env
# output-file          ~/.opam/log/benchmark-9-d53904.out
### output ###
# File "./setup.ml", line 320, characters 20-36:
# 320 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```