### PR TITLE
camlzip < 1.11 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/camlzip/camlzip.1.06/opam
+++ b/packages/camlzip/camlzip.1.06/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "camlzip"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
 ]
 depexts: [

--- a/packages/camlzip/camlzip.1.07/opam
+++ b/packages/camlzip/camlzip.1.07/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "camlzip"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
 ]
 depexts: [

--- a/packages/camlzip/camlzip.1.08/opam
+++ b/packages/camlzip/camlzip.1.08/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install-findlib"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-zlib"
 ]

--- a/packages/camlzip/camlzip.1.09/opam
+++ b/packages/camlzip/camlzip.1.09/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install-findlib"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-zlib"
 ]

--- a/packages/camlzip/camlzip.1.10/opam
+++ b/packages/camlzip/camlzip.1.10/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install-findlib"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-zlib"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling camlzip.1.10 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/camlzip.1.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/camlzip-9-aeed37.env
# output-file          ~/.opam/log/camlzip-9-aeed37.out
### output ###
# ocamlfind ocamlc -g -safe-string -c -ccopt -g  zlibstubs.c
# ocamlfind ocamlmklib -oc camlzip zlibstubs.o \
#              -lz
# ocamlfind ocamlc -g -safe-string -c zlib.mli
# ocamlfind ocamlc -g -safe-string -c zlib.ml
# ocamlfind ocamlc -g -safe-string -c zip.mli
# ocamlfind ocamlc -g -safe-string -c zip.ml
# File "zip.ml", line 62, characters 16-37:
# 62 |     if_channel: Pervasives.in_channel;
#                      ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:59: zip.cmo] Error 2

- ocamlfind ocamlc -g -safe-string -c zip.ml
- File "zip.ml", line 62, characters 16-37:
- 62 |     if_channel: Pervasives.in_channel;
-                      ^^^^^^^^^^^^^^^^^^^^^
- Error: Unbound module Pervasives
- make: *** [Makefile:59: zip.cmo] Error 2
```