### PR TITLE
base64 < 2.1.2 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/base64/base64.1.1.0/opam
+++ b/packages/base64/base64.1.1.0/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "base64"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/base64/base64.2.0.0/opam
+++ b/packages/base64/base64.2.0.0/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "base64"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling base64.2.0.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/base64.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/base64-8-261483.env
# output-file          ~/.opam/log/base64-8-261483.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```