### PR TITLE
reactiveData.0.2.2 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/reactiveData/reactiveData.0.2.2/opam
+++ b/packages/reactiveData/reactiveData.0.2.2/opam
@@ -13,9 +13,9 @@ tags: [ "reactive" "declarative" "signal" "event" "frp" ]
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.06.1" & < "5.0"}
   "ocamlfind"
-  "react" {>= "1.2.1" < "1.3"}
+  "react" {>= "1.2.1" & < "1.3"}
 ]
 build: [
   [


### PR DESCRIPTION
```
#=== ERROR while compiling reactiveData.0.2.2 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/reactiveData.0.2.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/build.ml native=true native-dynlink=true
# exit-code            10
# env-file             ~/.opam/log/reactiveData-8-3725f0.env
# output-file          ~/.opam/log/reactiveData-8-3725f0.out
### output ###
# ocamlfind ocamldep -package react -modules src/reactiveData.ml > src/reactiveData.ml.depends
# ocamlfind ocamldep -package react -modules src/reactiveData.mli > src/reactiveData.mli.depends
# ocamlfind ocamlc -c -bin-annot -safe-string -short-paths -strict-sequence -warn-error +1..49 -warn-error -45-3 -w A-4-40-42-44-48 -package react -I src -o src/reactiveData.cmi src/reactiveData.mli
# + ocamlfind ocamlc -c -bin-annot -safe-string -short-paths -strict-sequence -warn-error +1..49 -warn-error -45-3 -w A-4-40-42-44-48 -package react -I src -o src/reactiveData.cmi src/reactiveData.mli
# File "src/reactiveData.mli", lines 216-219, characters 0-46:
# 216 | (** Signature describing a raw data container (['a data]).
# 217 | 
# 218 |     Given an implementation of [DATA], an incremental version of the
# 219 |     container can be produced (via [Make]). *)
# Warning 50 [unexpected-docstring]: ambiguous documentation comment
# ocamlfind ocamlopt -c -bin-annot -safe-string -short-paths -strict-sequence -warn-error +1..49 -warn-error -45-3 -w A-4-40-42-44-48 -package react -I src -o src/reactiveData.cmx src/reactiveData.ml
# + ocamlfind ocamlopt -c -bin-annot -safe-string -short-paths -strict-sequence -warn-error +1..49 -warn-error -45-3 -w A-4-40-42-44-48 -package react -I src -o src/reactiveData.cmx src/reactiveData.ml
# File "src/reactiveData.ml", line 479, characters 44-62:
# 479 |                               let compare = Pervasives.compare
#                                                   ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
```