### PR TITLE
ipaddr < 5.0.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/ipaddr/ipaddr.2.7.2/opam
+++ b/packages/ipaddr/ipaddr.2.7.2/opam
@@ -31,7 +31,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/ipaddr/ipaddr.2.8.0/opam
+++ b/packages/ipaddr/ipaddr.2.8.0/opam
@@ -22,7 +22,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "ocaml-migrate-parsetree" {< "2.0.0"}

--- a/packages/ipaddr/ipaddr.2.9.0/opam
+++ b/packages/ipaddr/ipaddr.2.9.0/opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.6.0"}
   "base-bytes"
   "ppx_sexp_conv" {>= "v0.9.0"}

--- a/packages/ipaddr/ipaddr.3.0.0/opam
+++ b/packages/ipaddr/ipaddr.3.0.0/opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune"
   "macaddr" {=version}
   "sexplib0"

--- a/packages/ipaddr/ipaddr.3.1.0/opam
+++ b/packages/ipaddr/ipaddr.3.1.0/opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune"
   "macaddr" {=version}
   "sexplib0"

--- a/packages/ipaddr/ipaddr.4.0.0/opam
+++ b/packages/ipaddr/ipaddr.4.0.0/opam
@@ -27,7 +27,7 @@ homepage: "https://github.com/mirage/ocaml-ipaddr"
 doc: "https://mirage.github.io/ocaml-ipaddr/"
 bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune" {>="1.9.0"}
   "macaddr" {=version}
   "sexplib0"


### PR DESCRIPTION
```
#=== ERROR while compiling ipaddr.4.0.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ipaddr.4.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ipaddr -j 47
# exit-code            1
# env-file             ~/.opam/log/ipaddr-8-deecfd.env
# output-file          ~/.opam/log/ipaddr-8-deecfd.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.ipaddr.objs/byte -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/macaddr -intf-suffix .ml -no-alias-deps -o lib/.ipaddr.objs/byte/ipaddr.cmo -c -impl lib/ipaddr.ml)
# File "lib/ipaddr.ml", line 71, characters 16-38:
# 71 |   | '0'..'9' -> Pervasives.int_of_char c - char_0
#                      ^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I lib/.ipaddr.objs/byte -I lib/.ipaddr.objs/native -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/macaddr -intf-suffix .ml -no-alias-deps -o lib/.ipaddr.objs/native/ipaddr.cmx -c -impl lib/ipaddr.ml)
# File "lib/ipaddr.ml", line 71, characters 16-38:
# 71 |   | '0'..'9' -> Pervasives.int_of_char c - char_0
#                      ^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```