### PR TITLE
mirage-types >= 1.1.0 < 3.0.0 is not compatible with OCaml 5.0

### DIFF
--- a/packages/mirage-types/mirage-types.1.1.0/opam
+++ b/packages/mirage-types/mirage-types.1.1.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.1.1.1/opam
+++ b/packages/mirage-types/mirage-types.1.1.1/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.1.1.2/opam
+++ b/packages/mirage-types/mirage-types.1.1.2/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.1.1.3/opam
+++ b/packages/mirage-types/mirage-types.1.1.3/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.1.2.0/opam
+++ b/packages/mirage-types/mirage-types.1.2.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.2.0.0/opam
+++ b/packages/mirage-types/mirage-types.2.0.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}

--- a/packages/mirage-types/mirage-types.2.0.1/opam
+++ b/packages/mirage-types/mirage-types.2.0.1/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}

--- a/packages/mirage-types/mirage-types.2.1.0/opam
+++ b/packages/mirage-types/mirage-types.2.1.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}

--- a/packages/mirage-types/mirage-types.2.1.1/opam
+++ b/packages/mirage-types/mirage-types.2.1.1/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}

--- a/packages/mirage-types/mirage-types.2.2.0/opam
+++ b/packages/mirage-types/mirage-types.2.2.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 remove: ["ocamlfind" "remove" "mirage-types"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "sexplib" {< "113.01.00"}
   "ocamlbuild" {build}

--- a/packages/mirage-types/mirage-types.2.3.0/opam
+++ b/packages/mirage-types/mirage-types.2.3.0/opam
@@ -11,7 +11,7 @@ install: [make "install-types"]
 remove:  ["ocamlfind" "remove" "mirage-types"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.2.5.1/opam
+++ b/packages/mirage-types/mirage-types.2.5.1/opam
@@ -11,7 +11,7 @@ install: [make "install-types"]
 remove:  ["ocamlfind" "remove" "mirage-types"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.2.6.0/opam
+++ b/packages/mirage-types/mirage-types.2.6.0/opam
@@ -11,7 +11,7 @@ install: [make "install-types"]
 remove:  ["ocamlfind" "remove" "mirage-types"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-types/mirage-types.2.8.0/opam
+++ b/packages/mirage-types/mirage-types.2.8.0/opam
@@ -11,7 +11,7 @@ install: [make "install-types"]
 remove:  ["ocamlfind" "remove" "mirage-types"]
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling mirage-types.2.8.0 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mirage-types.2.8.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make build-types
# exit-code            2
# env-file             ~/.opam/log/mirage-types-8-8d4746.env
# output-file          ~/.opam/log/mirage-types-8-8d4746.out
### output ###
# ./build
# + ocamlfind query lwt cstruct ipaddr io-page
# + echo 
# + WITH_LWT=
# + ocamlbuild -tag bin_annot types/V1.cmi
# /home/opam/.opam/5.0/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# + /home/opam/.opam/5.0/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "myocamlbuild.ml", line 155, characters 10-27:
# 155 |           Stream.of_channel chn
#                 ^^^^^^^^^^^^^^^^^
# Error: Unbound module Stream
# Command exited with code 2.
# make: *** [Makefile:19: build-types] Error 10
```