### PR TITLE
odoc < 2.1.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/odoc/odoc.1.0.0/opam
+++ b/packages/odoc/odoc.1.0.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml-doc/odoc/issues"
 tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.7.5"}

--- a/packages/odoc/odoc.1.1.0/opam
+++ b/packages/odoc/odoc.1.1.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml-doc/odoc/issues"
 tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta7"}
   "doc-ock"

--- a/packages/odoc/odoc.1.1.1/opam
+++ b/packages/odoc/odoc.1.1.1/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml-doc/odoc/issues"
 tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta7"}
   "doc-ock"

--- a/packages/odoc/odoc.1.2.0/opam
+++ b/packages/odoc/odoc.1.2.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/ocaml-doc/odoc/issues"
 tags: ["doc" "html" "ocaml" "org:ocaml-doc"]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta10"}
   "doc-ock" {>= "1.2.0"}

--- a/packages/odoc/odoc.2.0.2/opam
+++ b/packages/odoc/odoc.2.0.2/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"

--- a/packages/odoc/odoc.2.1.0/opam
+++ b/packages/odoc/odoc.2.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"


### PR DESCRIPTION
```
#=== ERROR while compiling odoc.2.1.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/odoc.2.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p odoc -j 71
# exit-code            1
# env-file             ~/.opam/log/odoc-8-7cea12.env
# output-file          ~/.opam/log/odoc-8-7cea12.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/document/.odoc_document.objs/byte -I /home/opam/.opam/5.0/lib/astring -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/fpath -I /home/opam/.opam/5.0/lib/ocaml/compiler-libs -I /home/opam/.opam/5.0/lib/odoc-parser -I /home/opam/.opam/5.0/lib/result -I src/model/.odoc_model.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_document -o src/document/.odoc_document.objs/byte/odoc_document__Codefmt.cmo -c -impl src/document/codefmt.ml)
# File "src/document/codefmt.ml", line 130, characters 8-29:
# 130 |         Format.print_open_tag = (fun _ -> ());
#               ^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound record field Format.print_open_tag
# Hint: Did you mean print_open_stag?
```