### PR TITLE
obuild is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/obuild/obuild.0.1.10/opam
+++ b/packages/obuild/obuild.0.1.10/opam
@@ -19,7 +19,7 @@ build it.
 
 The design is based on Haskell's Cabal and borrows most of the layout
 and way of working, adapting parts where necessary to fully support OCaml."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "5.0"}]
 url {
   src: "https://github.com/ocaml-obuild/obuild/archive/obuild-v0.1.10.tar.gz"
   checksum: "md5=4bd50db236a0ecdaf5f4d9495565f5cc"

--- a/packages/obuild/obuild.0.1.9/opam
+++ b/packages/obuild/obuild.0.1.9/opam
@@ -19,7 +19,7 @@ build it.
 
 The design is based on Haskell's Cabal and borrows most of the layout
 and way of working, adapting parts where necessary to fully support OCaml."""
-depends: ["ocaml"]
+depends: ["ocaml" {< "5.0"}]
 conflicts: [
   "ocamlfind" {>= "1.8.0"} # does not support warning(..) = "..." in META files
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling obuild.0.1.10 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/obuild.0.1.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./bootstrap
# exit-code            2
# env-file             ~/.opam/log/obuild-8-ab64b7.env
# output-file          ~/.opam/log/obuild-8-ab64b7.out
### output ###
# 5.0.0+dev4-2022-06-14
# Using compat402.ml
# COMPILING compat
# COMPILING fugue
# File "fugue.ml", line 215, characters 18-36:
# 215 |     let compare = Pervasives.compare
#                         ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```