### PR TITLE
ocamlgraph < 2.0.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/ocamlgraph/ocamlgraph.1.8.8/opam
+++ b/packages/ocamlgraph/ocamlgraph.1.8.8/opam
@@ -29,7 +29,7 @@ build: [
 install: [make "install-findlib"]
 remove: [["ocamlfind" "remove" "ocamlgraph"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
 ]
 depopts: [


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlgraph.1.8.8 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamlgraph.1.8.8
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ocamlgraph-8-2c51b3.env
# output-file          ~/.opam/log/ocamlgraph-8-2c51b3.out
### output ###
# sed -e s/VERSION/1.8.8/ -e s/CMA/graph.cma/ -e s/CMXA/graph.cmxa/ -e s/CMXS/graph.cmxs/ \
# 	META.in > META
# rm -f src/version.ml
# echo "let version = \""1.8.8"\"" > src/version.ml
# echo 'let date = "'"Sat Jul  9 13:34:21 BST 2022"'"' >> src/version.ml
# rm -f .depend
# ocamldep -slash -I src -I lib -I editor -I view_graph -I dgraph\
# 	lib/*.ml lib/*.mli \
# 	src/*.ml src/*.mli \
# 	editor/*.mli editor/*.ml \
# 	view_graph/*.mli view_graph/*.ml \
# 	dgraph/*.mli dgraph/*.ml > .depend
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/sig.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/sig_pack.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/dot_ast.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/unionfind.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/unionfind.ml
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/heap.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/heap.ml
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/bitv.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/bitv.ml
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/persistentQueue.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 lib/persistentQueue.ml
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/version.ml
# File "src/version.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/util.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/util.ml
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/blocks.ml
# File "src/blocks.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# File "src/blocks.ml", line 390, characters 7-46:
# 390 |        val unsafe_add_vertex: t -> vertex -> t
#              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Warning 32 [unused-value-declaration]: unused value unsafe_add_vertex.
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/persistent.mli
# ocamlc.opt -c -I src -I lib -g -dtypes -w +a -w -4 -w -44 -w -50 -w -48 -w -29 src/persistent.ml
# File "src/persistent.ml", line 51, characters 20-38:
# 51 |   let compare x y = Pervasives.compare x.tag y.tag
#                          ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:575: src/persistent.cmo] Error 2
```