### PR TITLE
removes a spurious dependency on `str` from the bap-x86 package

### DIFF
--- a/packages/bap-x86/bap-x86.2.5.0/opam
+++ b/packages/bap-x86/bap-x86.2.5.0/opam
@@ -38,7 +38,6 @@ depends: [
   "bap-primus" {= "2.5.0"}
   "bap-main" {= "2.5.0"}
   "bap-std" {= "2.5.0"}
-  "str"
 ]
 synopsis: "BAP x86 lifter"
 


### PR DESCRIPTION
There is no such package as `str`, not sure how it managed to slip in and pass through the CI, probably some release script error on our side. Obviously, it prevents us from installing bap.2.5.0 with
```
$ opam install bap.2.5.0
[ERROR] Package conflict!
  * Missing dependency:
    - str
    unknown package
```