### PR TITLE
Package yuujinchou.3.1.0

### DIFF
--- a/packages/yuujinchou/yuujinchou.3.1.0/opam
+++ b/packages/yuujinchou/yuujinchou.3.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A domain-specific language for manipulating hierarchical names"
+description: """
+This package offers a domain-specific language for manipulating hierarchical names. It intends to facilitate the implementation of lexical scoping and import statements.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: [
+  "favonia <favonia@gmail.com>"
+  "Jon Sterling <jon@jonmsterling.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/yuujinchou"
+bug-reports: "https://github.com/RedPRL/yuujinchou/issues"
+dev-repo: "git+https://github.com/RedPRL/yuujinchou.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "5.0"}
+  "algaeff" {>= "0.2"}
+  "bwd" {>= "2.0"}
+  "alcotest" {>= "1.5" & with-test}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {>= "2.0" & with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/yuujinchou/archive/3.1.0.tar.gz"
+  checksum: [
+    "md5=2164fed8f82ed1a6b63547b5f2ed0a57"
+    "sha512=f4e574b450f3cbf1803d1591678ea6ed26bd9f7d86ff92f76a53a0f91a107ae065b109a609f13359a587d0abe1d10b15ee4f0284bd4488b4f7dcd1f1481cfc82"
+  ]
+}


### PR DESCRIPTION
### `yuujinchou.3.1.0`
A domain-specific language for manipulating hierarchical names
This package offers a domain-specific language for manipulating hierarchical names. It intends to facilitate the implementation of lexical scoping and import statements.



---
* Homepage: https://github.com/RedPRL/yuujinchou
* Source repo: git+https://github.com/RedPRL/yuujinchou.git
* Bug tracker: https://github.com/RedPRL/yuujinchou/issues

---
:camel: Pull-request generated by opam-publish v2.1.0