### PR TITLE
Package spotlib.4.2.0

### DIFF
--- a/packages/spotlib/spotlib.4.2.0/opam
+++ b/packages/spotlib/spotlib.4.2.0/opam
@@ -9,7 +9,7 @@ homepage: "https://gitlab.com/camlspotter/spotlib"
 bug-reports: "https://gitlab.com/camlspotter/spotlib/-/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ppx_test" {>= "1.8.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/spotlib/spotlib.4.2.0/opam
+++ b/packages/spotlib/spotlib.4.2.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "Useful functions for OCaml programming used by @camlspotter"
+description: """\
+Spotlib is a small library package used for several softwares by Jun Furuse.
+It is almost a poor replication of Jane Street Core, but it is small."""
+maintainer: "jun.furuse@gmail.com"
+authors: "Jun Furuse"
+homepage: "https://gitlab.com/camlspotter/spotlib"
+bug-reports: "https://gitlab.com/camlspotter/spotlib/-/issues"
+depends: [
+  "dune" {build & >= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_test" {>= "1.8.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/camlspotter/spotlib"
+url {
+  src:
+    "https://gitlab.com/camlspotter/spotlib/-/archive/4.2.0/spotlib-4.2.0.tar.gz"
+  checksum: [
+    "md5=b5b115479074c30364c325179442cadb"
+    "sha512=3fc14b1d4dc39121ec87e90e53eff197446e07f3fb1cfdd26b715175b5e3cb9982f9206a30a35de8d715f9223617668bd5014ba13ee6a1fb0d185d9cba92f6df"
+  ]
+}

--- a/packages/spotlib/spotlib.4.2.0/opam
+++ b/packages/spotlib/spotlib.4.2.0/opam
@@ -8,7 +8,7 @@ authors: "Jun Furuse"
 homepage: "https://gitlab.com/camlspotter/spotlib"
 bug-reports: "https://gitlab.com/camlspotter/spotlib/-/issues"
 depends: [
-  "dune" {build & >= "2.0"}
+  "dune" {>= "2.0"}
   "ocaml" {>= "4.08.0"}
   "ppx_test" {>= "1.8.0"}
 ]

--- a/packages/spotlib/spotlib.4.2.0/opam
+++ b/packages/spotlib/spotlib.4.2.0/opam
@@ -7,6 +7,7 @@ maintainer: "jun.furuse@gmail.com"
 authors: "Jun Furuse"
 homepage: "https://gitlab.com/camlspotter/spotlib"
 bug-reports: "https://gitlab.com/camlspotter/spotlib/-/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08.0" & < "5.0"}


### PR DESCRIPTION
### `spotlib.4.2.0`
Useful functions for OCaml programming used by @camlspotter
Spotlib is a small library package used for several softwares by Jun Furuse.
It is almost a poor replication of Jane Street Core, but it is small.



---
* Homepage: https://gitlab.com/camlspotter/spotlib
* Source repo: git+https://gitlab.com/camlspotter/spotlib
* Bug tracker: https://gitlab.com/camlspotter/spotlib/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0