### PR TITLE
[new release] ocamlformat and ocamlformat-rpc-lib (0.24.1)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.24.1/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.24.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.24.1/ocamlformat-0.24.1.tbz"
+  checksum: [
+    "sha256=023425e9818f80ea50537b2371a4a766c149a9957d05807e88a004d2d5f441ce"
+    "sha512=753b6128be68042895202f99959b360ce954db6f82b19b83b4bb346761a8e9cfdfc2b4b25e2070e60601b555562e78f9ebb02760ff127464e0b66cedbddca304"
+  ]
+}
+x-commit-hash: "86938aa4435b251af1a3b081f7fbed90f982cf62"

--- a/packages/ocamlformat/ocamlformat.0.24.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.3.0"}
+  "ocamlformat-rpc-lib" {with-test & post & = version}
+  "ocp-indent"
+  "odoc-parser" {>= "2.0.0" & < "3.0.0"}
+  "re" {>= "1.7.2"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.24.1/ocamlformat-0.24.1.tbz"
+  checksum: [
+    "sha256=023425e9818f80ea50537b2371a4a766c149a9957d05807e88a004d2d5f441ce"
+    "sha512=753b6128be68042895202f99959b360ce954db6f82b19b83b4bb346761a8e9cfdfc2b4b25e2070e60601b555562e78f9ebb02760ff127464e0b66cedbddca304"
+  ]
+}
+x-commit-hash: "86938aa4435b251af1a3b081f7fbed90f982cf62" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.24.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.1/opam
@@ -20,7 +20,7 @@ depends: [
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
   "ocaml-version" {>= "3.3.0"}
-  "ocamlformat-rpc-lib" {with-test & post & = version}
+  "ocamlformat-rpc-lib" {with-test & = version}
   "ocp-indent"
   "odoc-parser" {>= "2.0.0" & < "3.0.0"}
   "re" {>= "1.7.2"}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### New features

- Support `odoc-parser.2.0.0` (ocaml-ppx/ocamlformat#2123, @gpetiot)
  * Breaking change: incompatible with earlier versions of `odoc-parser`
  * New inline math elements `{m ...}` available in doc-comments
  * New block math elements `{math ...}` available in doc-comments
