### PR TITLE
ringo.0.1 is not available with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/ringo/ringo.0.1/opam
+++ b/packages/ringo/ringo.0.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling ringo.0.1 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ringo.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ringo -j 47
# exit-code            1
# env-file             ~/.opam/log/ringo-8-5c83a0.env
# output-file          ~/.opam/log/ringo-8-5c83a0.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.ringo.objs/byte -intf-suffix .ml -no-alias-deps -open Ringo -o src/.ringo.objs/byte/ringo__WeakRingTable.cmo -c -impl src/weakRingTable.ml)
# File "src/weakRingTable.ml", line 69, characters 18-36:
# 69 |     let compare = Pervasives.compare
#                        ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.ringo.objs/byte -I src/.ringo.objs/native -intf-suffix .ml -no-alias-deps -open Ringo -o src/.ringo.objs/native/ringo__WeakRingTable.cmx -c -impl src/weakRingTable.ml)
# File "src/weakRingTable.ml", line 69, characters 18-36:
# 69 |     let compare = Pervasives.compare
#                        ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```