### PR TITLE
ringo >= 0.4 is not available with OCaml 5.0 (uses Ephemeron.iter)

### DIFF
--- a/packages/ringo/ringo.0.4/opam
+++ b/packages/ringo/ringo.0.4/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [

--- a/packages/ringo/ringo.0.5/opam
+++ b/packages/ringo/ringo.0.5/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [

--- a/packages/ringo/ringo.0.6/opam
+++ b/packages/ringo/ringo.0.6/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [

--- a/packages/ringo/ringo.0.7/opam
+++ b/packages/ringo/ringo.0.7/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [

--- a/packages/ringo/ringo.0.8/opam
+++ b/packages/ringo/ringo.0.8/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [

--- a/packages/ringo/ringo.0.9/opam
+++ b/packages/ringo/ringo.0.9/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/nomadic-labs/ringo/issues"
 dev-repo: "git+https://gitlab.com/nomadic-labs/ringo.git"
 license: "MIT"
 depends: [
-  "ocaml" { >= "4.05" }
+  "ocaml" {>= "4.05" & < "5.0"}
   "dune" { >= "1.7" }
 ]
 build: [


### PR DESCRIPTION
```

#=== ERROR while compiling ringo.0.9 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ringo.0.9
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ringo -j 127
# exit-code            1
# env-file             ~/.opam/log/ringo-8-39fed5.env
# output-file          ~/.opam/log/ringo-8-39fed5.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.ringo.objs/byte -intf-suffix .ml -no-alias-deps -open Ringo__ -o src/.ringo.objs/byte/ringo__Weak_tabler.cmo -c -impl src/weak_tabler.ml)
# File "src/weak_tabler.ml", line 50, characters 17-27:
# 50 |   let iter f t = Table.iter (fun _ v -> f v) t
#                       ^^^^^^^^^^
# Error: Unbound value Table.iter
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.ringo.objs/byte -I src/.ringo.objs/native -intf-suffix .ml -no-alias-deps -open Ringo__ -o src/.ringo.objs/native/ringo__Weak_tabler.cmx -c -impl src/weak_tabler.ml)
# File "src/weak_tabler.ml", line 50, characters 17-27:
# 50 |   let iter f t = Table.iter (fun _ v -> f v) t
#                       ^^^^^^^^^^
# Error: Unbound value Table.iter
```