### PR TITLE
post-messages for OCaml pre-release packages

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
@@ -36,3 +36,18 @@ url {
   checksum: "sha256=70f5353001ba95dff96f71680a435e1e7d3708eddb1fd8c74b9e18a292fe40ce"
 }
 extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "Thank you for testing OCaml 5.0!
+
+   During the release cycle, there can be a lag between packages being fixed for
+   compatibility with the latest release of OCaml and an actual package-release
+   being made to opam-repository. You may wish to add opam-alpha-repository to
+   your switch by issuing:
+
+   opam repo add alpha git+https://github.com/ocaml/opam-alpha-repository
+
+   This will enable patched, but unreleased, versions of some packages which are
+   used for automated testing and made available to aid development and testing of
+   the new release. These packages are automatically upgraded when a new upstream
+   release is made to the official opam-repository."
+]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
@@ -36,12 +36,3 @@ url {
   checksum: "sha256=70f5353001ba95dff96f71680a435e1e7d3708eddb1fd8c74b9e18a292fe40ce"
 }
 extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -55,15 +55,6 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/5.0.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
-]
 conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -55,6 +55,21 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/5.0.tar.gz"
 }
+post-messages: [
+  "Thank you for testing OCaml 5.0!
+
+   During the release cycle, there can be a lag between packages being fixed for
+   compatibility with the latest release of OCaml and an actual package-release
+   being made to opam-repository. You may wish to add opam-alpha-repository to
+   your switch by issuing:
+
+   opam repo add alpha git+https://github.com/ocaml/opam-alpha-repository
+
+   This will enable patched, but unreleased, versions of some packages which are
+   used for automated testing and made available to aid development and testing of
+   the new release. These packages are automatically upgraded when a new upstream
+   release is made to the official opam-repository."
+]
 conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
@@ -57,15 +57,6 @@ url {
   checksum: "sha256=70f5353001ba95dff96f71680a435e1e7d3708eddb1fd8c74b9e18a292fe40ce"
 }
 extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
-  {failure & jobs > 1}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & opam-version >= "2.0.5"}
-]
 conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
@@ -57,6 +57,21 @@ url {
   checksum: "sha256=70f5353001ba95dff96f71680a435e1e7d3708eddb1fd8c74b9e18a292fe40ce"
 }
 extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "Thank you for testing OCaml 5.0!
+
+   During the release cycle, there can be a lag between packages being fixed for
+   compatibility with the latest release of OCaml and an actual package-release
+   being made to opam-repository. You may wish to add opam-alpha-repository to
+   your switch by issuing:
+
+   opam repo add alpha git+https://github.com/ocaml/opam-alpha-repository
+
+   This will enable patched, but unreleased, versions of some packages which are
+   used for automated testing and made available to aid development and testing of
+   the new release. These packages are automatically upgraded when a new upstream
+   release is made to the official opam-repository."
+]
 conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -55,6 +55,23 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
+post-messages: [
+  "Thank you for testing OCaml's trunk branch!
+
+   Between OCaml releases, there are frequently incompatibilities between parts
+   of the package ecosystem in opam-repository and the latest version of the
+   compiler. In particular, tools which rely on the parsetree or type checker
+   may be out-of-date.
+
+   You may wish to add opam-alpha-repository to your switch by issuing:
+
+   opam repo add alpha git+https://github.com/ocaml/opam-alpha-repository
+
+   This will enable patched, but unreleased, versions of some packages which are
+   used for automated testing and made available to aid development and testing of
+   the next release. These packages are automatically upgraded when a new upstream
+   release is made to the official opam-repository."
+]
 conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -55,15 +55,6 @@ install: [make "install"]
 url {
   src: "https://github.com/ocaml/ocaml/archive/trunk.tar.gz"
 }
-post-messages: [
-  "A failure in the middle of the build may be caused by build parallelism
-   (enabled by default).
-   See https://github.com/ocaml/opam-repository/pull/14257 for more info."
-  {failure & jobs > 1 & os != "cygwin"}
-  "You can try installing again including --jobs=1
-   to force a sequential build instead."
-  {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
-]
 conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"


### PR DESCRIPTION
This PR seeks both to thank users for trying out OCaml pre-releases and also to advertise more loudly that alpha releases may require the addition of a testing repository.

The intention is that the message about the alpha repository would disappear either with the beta or rc release. At the actual release, the message for the trunk package would change to reflect the fact it's no longer a pre-release.

It is possible to include a package in opam-alpha-repository to customise the message based on whether the repository has been enabled or not (using exactly the same mechanism as we do for ocaml-beta). This adds a small bit of complexity (one extra package appears in the switch) but it does have the benefit that we could _warn_ users to **remove** opam-alpha-repository when they test beta and rc releases, etc. We could even go further and _prevent_ the use of opam-alpha-repository with a released compiler (if we wanted).

This PR also proposes removing the parallelism failure message, at least from pre-releases, where that should be reported as a bug and arguably from all new releases, as it's a bug which should be reported and fixed.

Note that changing post-messages doesn't trigger a switch rebuild.