### PR TITLE
[new release] ANSITerminal (0.8.5)

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8.5/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler"
+           "Vincent Hugot" ]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/Chris00/ANSITerminal"
+dev-repo: "git+https://github.com/Chris00/ANSITerminal.git"
+bug-reports: "https://github.com/Chris00/ANSITerminal/issues"
+doc: "https://Chris00.github.io/ANSITerminal/doc"
+tags: [ "terminal"  ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {os != "win32" | >= "4.04"}
+  "dune" {>= "2.0"}
+  "base-bytes"
+  "base-unix"
+]
+synopsis: "Basic control of ANSI compliant terminals and the windows shell"
+description: """
+ANSITerminal is a module allowing to use the colors and cursor
+movements on ANSI terminals. It also works on the windows shell (but
+this part is currently work in progress)."""
+url {
+  src:
+    "https://github.com/Chris00/ANSITerminal/releases/download/0.8.5/ANSITerminal-0.8.5.tbz"
+  checksum: [
+    "sha256=ab73b218b6a30267d2bbc43312dcf313981b8b0bec555d92b06b87664b2dd30e"
+    "sha512=8ddd766c007bf66d6a6d1ce0f68ad55e18e82f439fdec6c0387f18f6a5e8c87bb2d7b595cbdab5acf9a5cf76efa73b8e8921481a5028774dcd9d2d9fe544603e"
+  ]
+}
+x-commit-hash: "27f912521b631312e8ff14831d5e7c00c69df76e"


### PR DESCRIPTION
Basic control of ANSI compliant terminals and the windows shell

- Project page: <a href="https://github.com/Chris00/ANSITerminal">https://github.com/Chris00/ANSITerminal</a>
- Documentation: <a href="https://Chris00.github.io/ANSITerminal/doc">https://Chris00.github.io/ANSITerminal/doc</a>

##### CHANGES:

- Do not vendor `io.h` now that OCaml exports it (@dra27).
