### PR TITLE
Package liquidsoap.2.1.0-1

### DIFF
--- a/packages/liquidsoap/liquidsoap.2.1.0-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.1.0-1/opam
@@ -1,4 +1,3 @@
-available: false
 opam-version: "2.0"
 synopsis: "Swiss-army knife for multimedia streaming"
 description: """\
@@ -16,7 +15,7 @@ bug-reports: "https://github.com/savonet/liquidsoap/issues"
 depends: [
   "conf-autoconf" {dev}
   "conf-automake" {dev}
-  "ocaml" {>= "4.12.0" & < "5.0.0"}
+  "ocaml" {>= "4.12.0" & <= "5.0.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.4"}
   "duppy" {>= "0.9.1"}
@@ -179,9 +178,9 @@ depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
 dev-repo: "git+https://github.com/savonet/liquidsoap.git"
 url {
   src:
-    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.1.0/liquidsoap-2.1.0.tar.bz2"
+    "https://github.com/savonet/liquidsoap-release-assets/releases/download/v2.1.0/liquidsoap-2.1.0-1.tar.bz2"
   checksum: [
-    "md5=966a5318127afbff1c050785f19ac138"
-    "sha512=20576c69fccadd96eb0fcb32ceb4f71fadf5b4b6ae85940915a35dd4b236c362918f7183bc64084ce00d6ae1929d031240102ca89ff2acf438219aceeef17535"
+    "md5=94feba4a29321b03216e51d1c3580ced"
+    "sha512=d2f2b9e426059672efa3aa37187c9a07293aa0d5558950420ebef67f4fde999a5909c47cf89926049aeb1ed658aab6c3c724ec4019873d45ed90ce7ce2e5d8f4"
   ]
 }

--- a/packages/liquidsoap/liquidsoap.2.1.0-1/opam
+++ b/packages/liquidsoap/liquidsoap.2.1.0-1/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/savonet/liquidsoap/issues"
 depends: [
   "conf-autoconf" {dev}
   "conf-automake" {dev}
-  "ocaml" {>= "4.12.0" & <= "5.0.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
   "camomile" {>= "1.0.0"}
   "dtools" {>= "0.4.4"}
   "duppy" {>= "0.9.1"}


### PR DESCRIPTION
We have encountered minor issues with the original release:
* Build would fail in some situations when `pandoc` binary is in the `PATH` as this triggered a broken doc build
* `mem_usage` optional features were not being compiled.

This release fixes both. Since the `2.1.0` release is not installable in some instance, it is also marked as not available.