### PR TITLE
ndbm is already present in the base system on Macs

### DIFF
--- a/packages/conf-dbm/conf-dbm.1.0.0/opam
+++ b/packages/conf-dbm/conf-dbm.1.0.0/opam
@@ -15,13 +15,12 @@ depexts: [
   ["gdbm-devel"] {os-distribution = "fedora"}
   ["gdbm-devel"] {os-distribution = "ol"}
   ["gdbm-dev"] {os-distribution = "alpine"}
-  ["gdbm"] {os-distribution = "homebrew"}
   ["gdbm"] {os-distribution = "arch"}
   ["sys-libs/gdbm"] {os-distribution = "gentoo"}
 ]
 synopsis: "Virtual package relying on gdbm"
 description:
-  "This package can only install if the gdbm library is installed on the system."
+  "This package can only install if the gdbm or ndbm library is installed on the system."
 extra-files: [
   ["test_gdbm.c" "md5=bb6869c63ffe5f767d859fb364fcecc8"]
   ["test_ndbm.c" "md5=f5f74ae297a6a7ced42843372156af85"]


### PR DESCRIPTION
No need to install gdbm.
Tested on a Mac M1.