### PR TITLE
[new release] links, links-postgresql, links-sqlite3 and links-mysql (0.9.7)

### DIFF
--- a/packages/links-mysql/links-mysql.0.9.7/opam
+++ b/packages/links-mysql/links-mysql.0.9.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "James Cheney <jcheney@inf.ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "MySQL database driver for the Links Programming Language"
+description: "MySQL database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "conf-mysql"
+  "mysql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.7/links-0.9.7.tbz"
+  checksum: [
+    "sha256=8030ef41d05e88b8c9d987816d362c87019d740ee75f2df9e30545e8f26547fc"
+    "sha512=a2ddfc0f9b606ac8c9b91ef3a368682c845915bd2943bbdda402288dbfe3e397317b08094cf328eb201c4c7ced744aad9825ca22a835a677687ef8b33d5c95d9"
+  ]
+}
+x-commit-hash: "ef4dacf2f5ddf23e1103090112873cdb9db724cc"

--- a/packages/links-postgresql/links-postgresql.0.9.7/opam
+++ b/packages/links-postgresql/links-postgresql.0.9.7/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "Postgresql database driver for the Links Programming Language"
+description: "Postgresql database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "postgresql"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.7/links-0.9.7.tbz"
+  checksum: [
+    "sha256=8030ef41d05e88b8c9d987816d362c87019d740ee75f2df9e30545e8f26547fc"
+    "sha512=a2ddfc0f9b606ac8c9b91ef3a368682c845915bd2943bbdda402288dbfe3e397317b08094cf328eb201c4c7ced744aad9825ca22a835a677687ef8b33d5c95d9"
+  ]
+}
+x-commit-hash: "ef4dacf2f5ddf23e1103090112873cdb9db724cc"

--- a/packages/links-sqlite3/links-sqlite3.0.9.7/opam
+++ b/packages/links-sqlite3/links-sqlite3.0.9.7/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "SQLite database driver for the Links Programming Language"
+description: "SQLite database driver for the Links Programming Language"
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "sqlite3"
+  "links" {= version}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.7/links-0.9.7.tbz"
+  checksum: [
+    "sha256=8030ef41d05e88b8c9d987816d362c87019d740ee75f2df9e30545e8f26547fc"
+    "sha512=a2ddfc0f9b606ac8c9b91ef3a368682c845915bd2943bbdda402288dbfe3e397317b08094cf328eb201c4c7ced744aad9825ca22a835a677687ef8b33d5c95d9"
+  ]
+}
+x-commit-hash: "ef4dacf2f5ddf23e1103090112873cdb9db724cc"

--- a/packages/links/links.0.9.7/opam
+++ b/packages/links/links.0.9.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "The Links Team <links-dev@inf.ed.ac.uk>"
+synopsis: "The Links Programming Language"
+description: "Links is a functional programming language designed to make web programming easier."
+homepage: "https://github.com/links-lang/links"
+dev-repo: "git+https://github.com/links-lang/links.git"
+bug-reports: "https://github.com/links-lang/links/issues"
+license: "GPL-3.0-only"
+
+
+build: [
+  [ "dune" "exec" "preinstall/preinstall.exe" "--" "-libdir" _:lib ]
+  [ make "opam-build-links.opam" ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.3"}
+  "base64"
+  "linenoise"
+  "ANSITerminal"
+  "lwt" {>= "5.0.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit-lwt-unix"
+  "uri"
+  "tls"
+  "websocket"
+  "websocket-lwt-unix"
+  "safepass"
+  "result"
+  "ocamlfind"
+  "menhir" {>= "20210419"}
+  "ppx_sexp_conv"
+  "calendar" {>= "2.0.4"}
+]
+url {
+  src:
+    "https://github.com/links-lang/links/releases/download/0.9.7/links-0.9.7.tbz"
+  checksum: [
+    "sha256=8030ef41d05e88b8c9d987816d362c87019d740ee75f2df9e30545e8f26547fc"
+    "sha512=a2ddfc0f9b606ac8c9b91ef3a368682c845915bd2943bbdda402288dbfe3e397317b08094cf328eb201c4c7ced744aad9825ca22a835a677687ef8b33d5c95d9"
+  ]
+}
+x-commit-hash: "ef4dacf2f5ddf23e1103090112873cdb9db724cc"


### PR DESCRIPTION
The Links Programming Language

- Project page: <a href="https://github.com/links-lang/links">https://github.com/links-lang/links</a>

##### CHANGES:

This release includes minor bug fixes, improvements, and a breaking
change.

* **Breaking change**: The Links standard library has adopted `Maybe`
  as it optional type. Previously, the standard library made
  inconsistent use of both `Option` and `Maybe` types. As a
  consequence of this change, every instance of `Option` has been
  turned into a `Maybe` type.
* Uniform paths: The file paths used by Links internally are now
  uniformly computed at compile time from the base of the current OPAM
  switch.
* Support for record extension in the presence of temporal projections.
* It is now to use `default` as a setting value in the REPL.
* Fixed an assertion failure in the relational lens code base.
* Effect aliases: It is now possible to define aliases for effect
  signatures, e.g.

```links
effectname State(s, e::Eff) = {Get:s, Put:(s) -> () |e};
```

defines an alias named `State` for an effect row with two operations
`Get`, and `Put`. This alias is analogous to aliases introduced via
`typename`, except that `effectname` aliases may be used in places
where an effect row is expected, e.g.

```links
sig f : () ~State(Int, {})~> ()
```

is equivalent to

```links
sig f : () {Get:Int, Put:(Int) -> ()}~> ()
```

* Client/server annotations are now permitted on local and anonymous
  functions.
* Fixed a bug where remote calls involving a client closure would
  cause the server side to crash.
