### PR TITLE
unmagic: Add missing dependency

### DIFF
--- a/packages/unmagic/unmagic.1.0.3/opam
+++ b/packages/unmagic/unmagic.1.0.3/opam
@@ -14,6 +14,7 @@ depends: [
   "typerep" {>= "v0.10.0"}
   "ppx_typerep_conv"
   "ppx_deriving"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"
 description: """

--- a/packages/unmagic/unmagic.1.0.4/opam
+++ b/packages/unmagic/unmagic.1.0.4/opam
@@ -13,6 +13,7 @@ depends: [
   "typerep" {>= "v0.10.0"}
   "ppx_typerep_conv"
   "ppx_deriving"
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis: "Runtime tag-checking of marshaled ocaml data"
 description: """


### PR DESCRIPTION
```
#=== ERROR while compiling unmagic.1.0.4 ======================================#
# context              2.1.2 | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/unmagic.1.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p unmagic -j 31
# exit-code            1
# env-file             ~/.opam/log/unmagic-3001-2ae1f9.env
# output-file          ~/.opam/log/unmagic-3001-2ae1f9.out
### output ###
# Error: I couldn't find 'ocaml-migrate-parsetree.driver-main'.
# I need this library in order to use ppx rewriters.
# See the manual for details.
# Hint: opam install ocaml-migrate-parsetree
```