### PR TITLE
Release of Solo5.0.7.3

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.3/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.3/solo5-v0.7.3.tar.gz"
+  checksum: "sha512=cafc590923b7bb53f27d46255914af620e47f14ce772c2e03afb0badf3c89abe06e625db290a8ccfaf280320ad4e63cf4876106f5d1d8a7801b13ccb5c033f2d"
+}

--- a/packages/solo5/solo5.0.7.3/opam
+++ b/packages/solo5/solo5.0.7.3/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.3/solo5-v0.7.3.tar.gz"
+  checksum: "sha512=cafc590923b7bb53f27d46255914af620e47f14ce772c2e03afb0badf3c89abe06e625db290a8ccfaf280320ad4e63cf4876106f5d1d8a7801b13ccb5c033f2d"
+}


### PR DESCRIPTION
* Fix broken API doc link in the README.md (@YuseiIto, solo5/solo5#521)
* Be more informative when `tap_attach` fails (@reynir, solo5/solo5#522)
* Ignore `up` variable to avoid compiler warning on FreeBSD (@hannesm, solo5/solo5#520)