### PR TITLE
Package ssl.0.5.11

### DIFF
--- a/packages/ssl/ssl.0.5.11/opam
+++ b/packages/ssl/ssl.0.5.11/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Bindings for OpenSSL"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/savonet/ocaml-ssl"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+  "base-unix"
+  "conf-libssl"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+url {
+  src: "https://github.com/savonet/ocaml-ssl/archive/refs/tags/0.5.11.tar.gz"
+  checksum: [
+    "md5=7552adb0e0c6ab720cfd7da573e5b438"
+    "sha512=4a766fc600797d3607b40c7fccde624d2debb5274bb6219eab52fffacde3f5c634565a57ec12f49e0658c4189a1197542d9a0f1e34ba88af67d48e724085a995"
+  ]
+}

--- a/packages/ssl/ssl.0.5.11/opam
+++ b/packages/ssl/ssl.0.5.11/opam
@@ -13,7 +13,7 @@ depends: [
   "conf-libssl"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"


### PR DESCRIPTION
### `ssl.0.5.11`
Bindings for OpenSSL



---
* Homepage: https://github.com/savonet/ocaml-ssl
* Source repo: git+https://github.com/savonet/ocaml-ssl.git
* Bug tracker: https://github.com/savonet/ocaml-ssl/issues

---
:camel: Pull-request generated by opam-publish v2.1.0