### PR TITLE
OCaml 5.0.0~alpha1 package

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "First alpha release of OCaml 5.0.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.0"
+depends: [
+  "ocaml" {= "5.0.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.0.0-alpha1.tar.gz"
+  checksum: "sha256=e96d3079d9faec39ff64b390d5bf5b02d567f9841d217b4f2d93479c477e2612"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha1+options/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First alpha release of OCaml 5.0.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
+depends: [
+  "ocaml" {= "5.0.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.0.0-alpha1.tar.gz"
+  checksum: "sha256=e96d3079d9faec39ff64b390d5bf5b02d567f9841d217b4f2d93479c477e2612"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [ "ocaml-option-fp" ]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+]


### PR DESCRIPTION
The two usual package for the first (normal) alpha release for OCaml 5.0.
Compared to the zeroth alpha, the debugger is here, and there are some important refinement in the FFI API that should probably be tested in the wild as soon as possible. We also have the new META files distributed by the compiler.
And many more fixes:

----------

### Runtime system

- 11400: Runtime events counters fixes
  Fixes mismatch between OCaml and C APIs, removes events from 4.x that
  are not present in the 5.0 GC and adds some missing probes.
  (Sadiq Jaffer, review by Gabriel Scherer, Florian Angeletti)

- 11368: Runtime events buffer size OCAMLRUNPARAMS fix
  The runtime events buffer size can now be set via the 'e' OCAMLRUNPARAM.
  This is previously mistakenly enabled/disabled tracing instead.
  (Sadiq Jaffer, review by KC Sivaramakrishnan, David Allsopp, Damien Doligez)


- 11304: Fix data race on Windows file descriptors
  (Olivier Nicole and Xavier Leroy, review by Xavier Leroy, David Allsopp,
   and Sadiq Jaffer)

* 11337: pass 'flags' metadata to root scanners, to optimize stack
  scanning in the bytecode interpreter.
  Changes the interface of user-provided root-scanning hooks.
  (Gabriel Scherer, review by Xavier Leroy,
   Guillaume Munch-Maccagnoni, Sadiq Jaffer and Tom Kelly)

- 11144: Restore frame-pointers support for amd64
  (Fabrice Buoro, review by Frederic Bour and KC Sivaramakrishnan)

* 11255: in the C interface, `&Field(v, i)` now has type `volatile value *`
  instead of `value *` in OCaml 4.  This makes the memory model
  for mixed OCaml/C code better defined, but can cause warnings or type
  errors in user C code.
  (KC Sivaramakrishnan, review by Xavier Leroy, Gabriel Scherer and
  Guillaume Munch-Maccagnoni, additional discussions with Stephen
  Dolan and Luc Maranget)

### Standard library:

* 10867, 11345: Remove deprecated values: Array.create, Array.make_float,
  Array.create_matrix, Bytes.uppercase, Bytes.lowercase, Bytes.capitalize,
  Bytes.uncapitalize, Char.lowercase, Char.uppercase, Filename.temp_dir_name,
  Int32.format, Int64.format, Nativeint.format, Format.bprintf, Format.kprintf,
  Format.set_all_formatter_output_functions,
  Format.get_all_formatter_output_functions,
  Format.pp_set_all_formatter_output_functions,
  Format.pp_get_all_formatter_output_functions, Format.pp_open_tag,
  Format.pp_close_tag, Format.open_tag, Format.close_tag,
  Format.formatter_tag_functions, Format.pp_set_formatter_tag_functions,
  Format.pp_get_formatter_tag_functions, Format.set_formatter_tag_functions,
  Format.get_formatter_tag_functions, Gc (mutability of the fields of type
  Gc.control), Lazy.lazy_from_fun, Lazy.lazy_from_val, Lazy.lazy_is_val,
  Obj.set_tag, Obj.truncate, Obj.final_tag, Obj.extension_constructor,
  Obj.extension_name, Obj.extension_id, Scanf.stdib, Scanf.fscanf,
  Scanf.kfscanf, Stdlib.( & ), Stdlib.( or ), String.set, String.copy,
  String.fill, String.unsafe_set, String.unsafe_fill, String.uppercase,
  String.lowercase, String.capitalize, String.uncapitalize, Thread.kill,
  Thread.wait_write, Thread.wait_read, the whole ThreadUnix module, the
  infix operator (.[]<-).
  (Nicolás Ojeda Bär, review by Damien Doligez)

- 11309, 11424, 11427: Add Domain.recommended_domain_count.
  (Christiano Haesbaert, Konstantin Belousov, review by David Allsopp,
  KC Sivaramakrishnan, Gabriel Scherer, Nicolas Ojeda Bar)

 ### Tools:
- 11065: Port the bytecode debugger to 5.0, adding support for effect handlers.
  (Damien Doligez and @fabbing, review by @fabbing and Xavier Leroy)

- 11382: OCamlmktop use a new initialization module "OCamlmktop_init" to
  preserve backward-compatibility with user-module provided modules that install
  toplevel printers.
  (Florian Angeletti, review by Gabriel Scherer and David Allsopp)

 ### Installation

- 11007, 11399: META files for the stdlib, compiler-libs and other libraries
  (unix, dynlink, str, runtime_events, threads, ocamldoc) are now installed
  along with the compiler.
  (David Allsopp, Florian Angeletti, Nicolás Ojeda Bär and Sébastien Hinderer,
   review by Daniel Bünzli, Kate Deplaix, Anil Madhavapeddy and Gabriel Scherer)

### Bug fixes:
 
- 10768, 11340: Fix typechecking regression when combining first class
  modules and GADTs.
  (Jacques Garrigue, report by François Thiré, review by Matthew Ryan)

- 10790: don't drop variance and injectivity annotations when pretty printing
  `with` constraints (for example, `with type +!'a t = ...`).
  (Florian Angeletti, report by Luke Maurer, review by Matthew Ryan and
   Gabriel Scherer)

- 11289, 11405: fix some leaks on systhread termination
  (Fabrice Buoro, Enguerrand Decorne, Gabriel Scherer,
   review by Xavier Leroy and Florian Angeletti, report by Romain Beauxis)

- 11314, 11416: fix non-informative error message for module inclusion
  (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)

- 11358, 11379: Refactor the initialization of bytecode threading,
  This avoids a "dangling pointer" warning of GCC 12.1.
  (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)

- 11387, module type with constraints no longer crash the compiler in presence
  of both shadowing warnings and the `-bin-annot` compiler flag.
  (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)
