### PR TITLE
base: Add a preview package for OCaml 5.0

### DIFF
--- a/packages/base/base.v0.15.1~5.0preview/opam
+++ b/packages/base/base.v0.15.1~5.0preview/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+flags: avoid-version
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "sexplib0"          {>= "v0.15" & < "v0.16"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "git+https://github.com/kit-ty-kate/base#500-015"
+}


### PR DESCRIPTION
The `base` package is a dependency of some of the platform package and not having it is slowing the adoption rate of OCaml 5.0.

As with previous preview packages (e.g. #20900), this preview package is only available on OCaml 5.0 and will be disabled whenever `base.v0.15.1` is released.

cc @tov