### PR TITLE
sexplib is not compatible with OCaml 5.0

### DIFF
--- a/packages/sexplib/sexplib.v0.15.0/opam
+++ b/packages/sexplib/sexplib.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"    {>= "4.08.0"}
+  "ocaml"    {>= "4.08.0" & < "5.0"}
   "parsexp"  {>= "v0.15" & < "v0.16"}
   "sexplib0" {>= "v0.15" & < "v0.16"}
   "dune"     {>= "2.0.0"}


### PR DESCRIPTION
cc @tov @aalekseyev 
```
#=== ERROR while compiling sexplib.v0.15.0 ====================================#
# context              2.0.10 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/sexplib.v0.15.0
# command              ~/.opam/5.0/bin/dune build -p sexplib -j 72
# exit-code            1
# env-file             ~/.opam/log/sexplib-72-a95916.env
# output-file          ~/.opam/log/sexplib-72-a95916.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.sexplib.objs/byte -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Sexplib -o src/.sexplib.objs/byte/sexplib__Exn_magic.cmo -c -impl src/exn_magic.ml)
# File "src/exn_magic.ml", line 4, characters 15-40:
# 4 |   let of_val = Obj.extension_constructor
#                    ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Obj.extension_constructor
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.sexplib.objs/byte -I src/.sexplib.objs/native -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Sexplib -o src/.sexplib.objs/native/sexplib__Exn_magic.cmx -c -impl src/exn_magic.ml)
# File "src/exn_magic.ml", line 4, characters 15-40:
# 4 |   let of_val = Obj.extension_constructor
#                    ^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Obj.extension_constructor
```