### PR TITLE
Package seq.0.3

### DIFF
--- a/packages/seq/seq.0.3/opam
+++ b/packages/seq/seq.0.3/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis:
+  "Compatibility package for OCaml's standard iterator type starting from 4.07"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "LGPL2.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml"
+]
+tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+dev-repo: "git+https://github.com/c-cube/seq.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/seq/archive/v0.3.tar.gz"
+  checksum: [
+    "md5=68bc79bdb9108fd862cb6372f9c6ed19"
+    "sha512=3cbca9e771bc05350b5c6ffd41237fa12c6909a077f1090e28c4d0403711c137c96fccd670f074b1ea1a47bdcfd7a7618247bdad6ee71e52e9af75894e8cd974"
+  ]
+}

--- a/packages/seq/seq.0.3/opam
+++ b/packages/seq/seq.0.3/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis:
   "Compatibility package for OCaml's standard iterator type starting from 4.07"
 maintainer: "simon.cruanes.2007@m4x.org"
-license: "LGPL2.1"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]


### PR DESCRIPTION
### `seq.0.3`
Compatibility package for OCaml's standard iterator type starting from 4.07



---
* Homepage: https://github.com/c-cube/seq/
* Source repo: git+https://github.com/c-cube/seq.git
* Bug tracker: https://github.com/c-cube/seq/issues

---
:camel: Pull-request generated by opam-publish v2.1.0