### PR TITLE
5 packages from benfaerber/liquid-ml at 0.1

### DIFF
--- a/packages/liquid_interpreter/liquid_interpreter.0.1/opam
+++ b/packages/liquid_interpreter/liquid_interpreter.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "The interpreter for Liquid"
+description: """
+The interpreter for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [ "base" "core" "stdio" "re2" "liquid_syntax" "liquid_parser" "liquid_std" ]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/benfaerber/liquid-ml/archive/0.1.tar.gz"
+  checksum: [
+    "md5=6615a9f8bbd3221bcd26556269fd3049"
+    "sha512=a3235c4ef96637256f5dd246fddc5f309aa7e725c30b802fb99163a2db83f0e5272c321f1798554dbcedce8d03f9edf2abd70d3f82100a2058305fc08c03df7a"
+  ]
+}

--- a/packages/liquid_ml/liquid_ml.0.1/opam
+++ b/packages/liquid_ml/liquid_ml.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "Shopify's Liquid templating language in OCaml"
+description: """
+Shopify's Liquid templating language for the OCaml!
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [ "base" "core" "stdio" "liquid_syntax" "liquid_parser" "liquid_interpreter" ]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/benfaerber/liquid-ml/archive/0.1.tar.gz"
+  checksum: [
+    "md5=6615a9f8bbd3221bcd26556269fd3049"
+    "sha512=a3235c4ef96637256f5dd246fddc5f309aa7e725c30b802fb99163a2db83f0e5272c321f1798554dbcedce8d03f9edf2abd70d3f82100a2058305fc08c03df7a"
+  ]
+}

--- a/packages/liquid_parser/liquid_parser.0.1/opam
+++ b/packages/liquid_parser/liquid_parser.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "The parser for Liquid"
+description: """
+The parser for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [ "base" "core" "stdio" "re2" "liquid_syntax" ]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/benfaerber/liquid-ml/archive/0.1.tar.gz"
+  checksum: [
+    "md5=6615a9f8bbd3221bcd26556269fd3049"
+    "sha512=a3235c4ef96637256f5dd246fddc5f309aa7e725c30b802fb99163a2db83f0e5272c321f1798554dbcedce8d03f9edf2abd70d3f82100a2058305fc08c03df7a"
+  ]
+}

--- a/packages/liquid_std/liquid_std.0.1/opam
+++ b/packages/liquid_std/liquid_std.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "The Standard Libarary for Liquid"
+description: """
+The Standard Libarary for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [ "base" "core" "stdio" "re2" "calendar" "base64" "sha" "liquid_syntax" "liquid_parser" ]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/benfaerber/liquid-ml/archive/0.1.tar.gz"
+  checksum: [
+    "md5=6615a9f8bbd3221bcd26556269fd3049"
+    "sha512=a3235c4ef96637256f5dd246fddc5f309aa7e725c30b802fb99163a2db83f0e5272c321f1798554dbcedce8d03f9edf2abd70d3f82100a2058305fc08c03df7a"
+  ]
+}

--- a/packages/liquid_syntax/liquid_syntax.0.1/opam
+++ b/packages/liquid_syntax/liquid_syntax.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+synopsis: "The Syntax Definitions for Liquid"
+description: """
+The Syntax Definitions for Liquid
+"""
+maintainer: "faerberbendev@protonmail.com"
+authors: ["Ben Faerber"]
+homepage: "https://github.com/benfaerber/liquid-ml"
+bug-reports: "https://github.com/benfaerber/liquid-ml/issues"
+dev-repo: "git+https://github.com/benfaerber/liquid-ml.git"
+license: "MIT"
+depends: [ "base" "core" "stdio" "batteries" "re2" "calendar" ]
+build: [
+    ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/benfaerber/liquid-ml/archive/0.1.tar.gz"
+  checksum: [
+    "md5=6615a9f8bbd3221bcd26556269fd3049"
+    "sha512=a3235c4ef96637256f5dd246fddc5f309aa7e725c30b802fb99163a2db83f0e5272c321f1798554dbcedce8d03f9edf2abd70d3f82100a2058305fc08c03df7a"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`liquid_interpreter.0.1`: The interpreter for Liquid
-`liquid_ml.0.1`: Shopify's Liquid templating language in OCaml
-`liquid_parser.0.1`: The parser for Liquid
-`liquid_std.0.1`: The Standard Libarary for Liquid
-`liquid_syntax.0.1`: The Syntax Definitions for Liquid



---
* Homepage: https://github.com/benfaerber/liquid-ml
* Source repo: git+https://github.com/benfaerber/liquid-ml.git
* Bug tracker: https://github.com/benfaerber/liquid-ml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0