### PR TITLE
cudf < 0.10 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/cudf/cudf.0.6.3/opam
+++ b/packages/cudf/cudf.0.6.3/opam
@@ -6,7 +6,7 @@ build: [
   ["ocp-build" "-scan" "cudf" "-v" "0"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocp-build"
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}

--- a/packages/cudf/cudf.0.7/opam
+++ b/packages/cudf/cudf.0.7/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "roberto@dicosmo.org"
 build: [make "all" "opt" "DOC="]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   ("extlib" | "extlib-compat")
   "ocamlfind" {build}

--- a/packages/cudf/cudf.0.8/opam
+++ b/packages/cudf/cudf.0.8/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/irill/cudf/-/issues"
 dev-repo: "git+https://gitlab.com/irill/cudf.git"
 build: [make "all" "opt" "DOC="]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   ("extlib" | "extlib-compat")
   "ocamlfind" {build}

--- a/packages/cudf/cudf.0.9-1/opam
+++ b/packages/cudf/cudf.0.9-1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/irill/cudf/-/issues"
 dev-repo: "git+https://gitlab.com/irill/cudf.git"
 build: [make "all" "opt" "DOC="]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/cudf/cudf.0.9/opam
+++ b/packages/cudf/cudf.0.9/opam
@@ -6,7 +6,7 @@ bug-reports: "https://gitlab.com/irill/cudf/-/issues"
 dev-repo: "git+https://gitlab.com/irill/cudf.git"
 build: [make "all" "opt" "DOC="]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   ("extlib" | "extlib-compat")
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling cudf.0.9-1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/cudf.0.9-1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all opt DOC=
# exit-code            2
# env-file             ~/.opam/log/cudf-8-cc54b1.env
# output-file          ~/.opam/log/cudf-8-cc54b1.out
### output ###
# ocamlbuild  cudf.cma
# /home/opam/.opam/5.0/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "examples/_tags", line 1, characters 25-33:
# Warning: the tag "pkg_cudf" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# File "_tags", line 1, characters 26-35:
# Warning: the tag "pkg_oUnit" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# File "_tags", line 2, characters 31-40:
# Warning: the tag "pkg_oUnit" is not used in any flag or dependency declaration, so it will have no effect; it may be a typo. Otherwise you can use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
# ocamlfind ocamldep -package extlib -modules cudf_types.mli > cudf_types.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_types.cmi cudf_types.mli
# ocamlfind ocamldep -package extlib -modules cudf_types.ml > cudf_types.ml.depends
# ocamlfind ocamldep -package extlib -modules cudf_conf.mli > cudf_conf.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_conf.cmi cudf_conf.mli
# ocamlfind ocamldep -package extlib -modules cudf_conf.ml > cudf_conf.ml.depends
# /home/opam/.opam/5.0/bin/ocamlyacc cudf_822_parser.mly
# ocamlfind ocamldep -package extlib -modules cudf_822_parser.mli > cudf_822_parser.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_822_parser.cmi cudf_822_parser.mli
# ocamlfind ocamldep -package extlib -modules cudf_822_parser.ml > cudf_822_parser.ml.depends
# /home/opam/.opam/5.0/bin/ocamlyacc cudf_type_parser.mly
# ocamlfind ocamldep -package extlib -modules cudf_type_parser.mli > cudf_type_parser.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_type_parser.cmi cudf_type_parser.mli
# ocamlfind ocamldep -package extlib -modules cudf_type_parser.ml > cudf_type_parser.ml.depends
# ocamlfind ocamldep -package extlib -modules cudf_types_pp.mli > cudf_types_pp.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_types_pp.cmi cudf_types_pp.mli
# ocamlfind ocamldep -package extlib -modules cudf_types_pp.ml > cudf_types_pp.ml.depends
# /home/opam/.opam/5.0/bin/ocamllex.opt -q cudf_type_lexer.mll
# ocamlfind ocamldep -package extlib -modules cudf_type_lexer.ml > cudf_type_lexer.ml.depends
# ocamlfind ocamlc -c -package extlib -o cudf_type_lexer.cmo cudf_type_lexer.ml
# /home/opam/.opam/5.0/bin/ocamllex.opt -q cudf_822_lexer.mll
# ocamlfind ocamldep -package extlib -modules cudf_822_lexer.ml > cudf_822_lexer.ml.depends
# ocamlfind ocamldep -package extlib -modules cudf.mli > cudf.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf.cmi cudf.mli
# ocamlfind ocamldep -package extlib -modules cudf.ml > cudf.ml.depends
# ocamlfind ocamldep -package extlib -modules cudf_parser.mli > cudf_parser.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_parser.cmi cudf_parser.mli
# ocamlfind ocamldep -package extlib -modules cudf_parser.ml > cudf_parser.ml.depends
# ocamlfind ocamlc -c -package extlib -o cudf_822_lexer.cmo cudf_822_lexer.ml
# ocamlfind ocamldep -package extlib -modules cudf_checker.mli > cudf_checker.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_checker.cmi cudf_checker.mli
# ocamlfind ocamldep -package extlib -modules cudf_checker.ml > cudf_checker.ml.depends
# ocamlfind ocamldep -package extlib -modules cudf_printer.mli > cudf_printer.mli.depends
# ocamlfind ocamlc -c -package extlib -o cudf_printer.cmi cudf_printer.mli
# ocamlfind ocamldep -package extlib -modules cudf_printer.ml > cudf_printer.ml.depends
# ocamlfind ocamlc -c -package extlib -o cudf_types.cmo cudf_types.ml
# ocamlfind ocamlc -c -package extlib -o cudf_conf.cmo cudf_conf.ml
# ocamlfind ocamlc -c -package extlib -o cudf_822_parser.cmo cudf_822_parser.ml
# ocamlfind ocamlc -c -package extlib -o cudf_type_parser.cmo cudf_type_parser.ml
# ocamlfind ocamlc -c -package extlib -o cudf_types_pp.cmo cudf_types_pp.ml
# + ocamlfind ocamlc -c -package extlib -o cudf_types_pp.cmo cudf_types_pp.ml
# File "cudf_types_pp.ml", line 92, characters 27-37:
# 92 |     | `Enum l -> `Enum (l, parse_enum l s)
#                                 ^^^^^^^^^^
# Warning 6 [labels-omitted]: label enums was omitted in the application of this function.
# File "cudf_types_pp.ml", line 104, characters 20-44:
# 104 | let string_of_int = Pervasives.string_of_int
#                           ^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# + /home/opam/.opam/5.0/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# make: *** [Makefile:61: _build/cudf.cma] Error 10
```