### PR TITLE
[new release] mirage-xen (8.0.0)

### DIFF
--- a/packages/mirage-xen/mirage-xen.8.0.0/opam
+++ b/packages/mirage-xen/mirage-xen.8.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v8.0.0/mirage-xen-8.0.0.tbz"
+  checksum: [
+    "sha256=3d6f1b7ca7a258fd4f409ef1c2b67920e5921353feae0662d8a04efb3176a221"
+    "sha512=98ad88b9197e4552f179513c6ed930604c0316c818ed9e15dc032054c122f3c264d6812f4d0ba3b1a79c43c90cc921c2aa1615883dc4bc9075d8010c3fdd14a9"
+  ]
+}
+x-commit-hash: "bdc9d957d9bcb85584a97c6baebd70f6efb615c5"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* provide Memory.stat (uses dlmalloc mallinfo - expensive), and Memory.trim
  (releases free memory), improve Memory.quick_stat accuracy using ocaml-solo5
  0.8.1 (@palainp @winux138, mirage/mirage-xen#48)
