### PR TITLE
[new release] mirage-solo5 (0.9.0)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.9.0/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.9.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.9.0/mirage-solo5-0.9.0.tbz"
+  checksum: [
+    "sha256=f868f813793d97597bdfb221ec21eeae32fc8079072dd5855fc45de0d1c0608f"
+    "sha512=66b09789e3895467ca54bc3b2bbd8237bf17f8ea043b787c0c65fd7eee693e60dae65ef8b3f09b9d9ed7502e5f35875bd798fbcebc1e9b92d4cb96f333299c8c"
+  ]
+}
+x-commit-hash: "8848047ad011ca294b42675be0bdb8cfb29708d0"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* provide Memory.stat (uses dlmalloc mallinfo - expensive), and Memory.trim
  (releases free memory), improve Memory.quick_stat accuracy using ocaml-solo5
  0.8.1 (@palainp mirage/mirage-solo5#91)
