### PR TITLE
[new release] ppx_cstruct, cstruct, cstruct-unix, cstruct-sexp, cstruct-lwt and cstruct-async (6.1.1)

### DIFF
--- a/packages/cstruct-async/cstruct-async.6.1.1/opam
+++ b/packages/cstruct-async/cstruct-async.6.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+tags: [ "org:mirage" "org:ocamllabs" ]
+doc: "https://mirage.github.io/ocaml-cstruct/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "async" {>= "v0.9.0"}
+  "async_unix" {>= "v0.9.0"}
+  "core" {>= "v0.9.0"}
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.1.1/cstruct-6.1.1.tbz"
+  checksum: [
+    "sha256=1b74f9870f6a7ee6008924590716dd533a728a3ca10bb18da9fea8be467f518d"
+    "sha512=6fdd4517436c501ff0f39088eb0c3ea18e93370e020fa4d10dbf7aad29f1ee9cef881d52499f02c738e8aa0d78b568622a793c68f50ef51f282ee03160171317"
+  ]
+}
+x-commit-hash: "b14e6a336a8dff2a37ebda56d075feda5956593d"

--- a/packages/cstruct-lwt/cstruct-lwt.6.1.1/opam
+++ b/packages/cstruct-lwt/cstruct-lwt.6.1.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dune" {>= "2.0.0"}
+  "lwt"
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.1.1/cstruct-6.1.1.tbz"
+  checksum: [
+    "sha256=1b74f9870f6a7ee6008924590716dd533a728a3ca10bb18da9fea8be467f518d"
+    "sha512=6fdd4517436c501ff0f39088eb0c3ea18e93370e020fa4d10dbf7aad29f1ee9cef881d52499f02c738e8aa0d78b568622a793c68f50ef51f282ee03160171317"
+  ]
+}
+x-commit-hash: "b14e6a336a8dff2a37ebda56d075feda5956593d"

--- a/packages/cstruct-sexp/cstruct-sexp.6.1.1/opam
+++ b/packages/cstruct-sexp/cstruct-sexp.6.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "sexplib"
+  "cstruct" {=version}
+  "alcotest" {with-test}
+]
+synopsis: "S-expression serialisers for C-like structures"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+
+This library provides Sexplib serialisers for the Cstruct.t values."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.1.1/cstruct-6.1.1.tbz"
+  checksum: [
+    "sha256=1b74f9870f6a7ee6008924590716dd533a728a3ca10bb18da9fea8be467f518d"
+    "sha512=6fdd4517436c501ff0f39088eb0c3ea18e93370e020fa4d10dbf7aad29f1ee9cef881d52499f02c738e8aa0d78b568622a793c68f50ef51f282ee03160171317"
+  ]
+}
+x-commit-hash: "b14e6a336a8dff2a37ebda56d075feda5956593d"

--- a/packages/cstruct-unix/cstruct-unix.6.1.1/opam
+++ b/packages/cstruct-unix/cstruct-unix.6.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "2.0.0"}
+  "base-unix"
+  "cstruct" {=version}
+]
+synopsis: "Access C-like structures directly from OCaml"
+
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml. It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.1.1/cstruct-6.1.1.tbz"
+  checksum: [
+    "sha256=1b74f9870f6a7ee6008924590716dd533a728a3ca10bb18da9fea8be467f518d"
+    "sha512=6fdd4517436c501ff0f39088eb0c3ea18e93370e020fa4d10dbf7aad29f1ee9cef881d52499f02c738e8aa0d78b568622a793c68f50ef51f282ee03160171317"
+  ]
+}
+x-commit-hash: "b14e6a336a8dff2a37ebda56d075feda5956593d"

--- a/packages/cstruct/cstruct.6.1.1/opam
+++ b/packages/cstruct/cstruct.6.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Anton Kochkov" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "alcotest" {with-test}
+  "fmt" {>= "0.8.9"}
+  "crowbar" {with-test}
+]
+conflicts: [ "js_of_ocaml" {<"3.5.0"} ]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.1.1/cstruct-6.1.1.tbz"
+  checksum: [
+    "sha256=1b74f9870f6a7ee6008924590716dd533a728a3ca10bb18da9fea8be467f518d"
+    "sha512=6fdd4517436c501ff0f39088eb0c3ea18e93370e020fa4d10dbf7aad29f1ee9cef881d52499f02c738e8aa0d78b568622a793c68f50ef51f282ee03160171317"
+  ]
+}
+x-commit-hash: "b14e6a336a8dff2a37ebda56d075feda5956593d"

--- a/packages/ppx_cstruct/ppx_cstruct.6.1.1/opam
+++ b/packages/ppx_cstruct/ppx_cstruct.6.1.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      ["Anil Madhavapeddy" "Richard Mortier" "Thomas Gazagnaire"
+               "Pierre Chambart" "David Kaloper" "Jeremy Yallop" "David Scott"
+               "Mindy Preston" "Thomas Leonard" "Etienne Millon" ]
+homepage:     "https://github.com/mirage/ocaml-cstruct"
+license:      "ISC"
+dev-repo: "git+https://github.com/mirage/ocaml-cstruct.git"
+bug-reports:  "https://github.com/mirage/ocaml-cstruct/issues"
+doc: "https://mirage.github.io/ocaml-cstruct/"
+
+tags: [ "org:mirage" "org:ocamllabs" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cstruct" {=version}
+  "ounit" {with-test}
+  "ppxlib" {>= "0.16.0"}
+  "ppx_sexp_conv" {with-test}
+  "sexplib" {>="v0.9.0"}
+  "cstruct-sexp" {with-test}
+  "cppo" {with-test}
+  "cstruct-unix" {with-test & =version}
+  "ocaml-migrate-parsetree" {>= "2.1.0" & with-test}
+  "lwt_ppx" {>= "2.0.2" & with-test}
+]
+synopsis: "Access C-like structures directly from OCaml"
+description: """
+Cstruct is a library and syntax extension to make it easier to access C-like
+structures directly from OCaml.  It supports both reading and writing to these
+structures, and they are accessed via the `Bigarray` module."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-cstruct/releases/download/v6.1.1/cstruct-6.1.1.tbz"
+  checksum: [
+    "sha256=1b74f9870f6a7ee6008924590716dd533a728a3ca10bb18da9fea8be467f518d"
+    "sha512=6fdd4517436c501ff0f39088eb0c3ea18e93370e020fa4d10dbf7aad29f1ee9cef881d52499f02c738e8aa0d78b568622a793c68f50ef51f282ee03160171317"
+  ]
+}
+x-commit-hash: "b14e6a336a8dff2a37ebda56d075feda5956593d"


### PR DESCRIPTION
Access C-like structures directly from OCaml

- Project page: <a href="https://github.com/mirage/ocaml-cstruct">https://github.com/mirage/ocaml-cstruct</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cstruct/">https://mirage.github.io/ocaml-cstruct/</a>

##### CHANGES:

- ppx_cstruct: remove superfluous stdlib-shims dependency (@hannesm mirage/ocaml-cstruct#300)
