### PR TITLE
[new release] eqaf (0.9)

### DIFF
--- a/packages/eqaf/eqaf.0.9/opam
+++ b/packages/eqaf/eqaf.0.9/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/eqaf"
+bug-reports:  "https://github.com/mirage/eqaf/issues"
+dev-repo:     "git+https://github.com/mirage/eqaf.git"
+doc:          "https://mirage.github.io/eqaf/"
+license:      "MIT"
+synopsis:     "Constant-time equal function on string"
+description: """
+This package provides an equal function on string in constant-time to avoid timing-attack with crypto stuff.
+"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" "1" "--no-buffer" "--verbose" ] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.07.0"}
+  "dune"           {>= "2.0"}
+  "cstruct"        {>= "1.1.0"}
+  "base64"         {with-test}
+  "alcotest"       {with-test}
+  "crowbar"        {with-test}
+  "fmt"            {with-test & >= "0.8.7"}
+  "bechamel"       {with-test}
+]
+url {
+  src: "https://github.com/mirage/eqaf/releases/download/v0.9/eqaf-0.9.tbz"
+  checksum: [
+    "sha256=ec0e28a946ac6817f95d5854f05a9961ae3a8408bb610e79cfad01b9b255dfe0"
+    "sha512=4df7fd3ea35156953a172c1a021aab05b8b122ee8d3cfdb34f96edb1b5133d1fe2721b90cb64287841d770b16c2ffe70559c66e90f8d61a92b73857da22548c4"
+  ]
+}
+x-commit-hash: "e878ed56e40ca05c851a0e3297ab00ab76b10e0e"


### PR DESCRIPTION
Constant-time equal function on string

- Project page: <a href="https://github.com/mirage/eqaf">https://github.com/mirage/eqaf</a>
- Documentation: <a href="https://mirage.github.io/eqaf/">https://mirage.github.io/eqaf/</a>

##### CHANGES:

- Add support of OCaml 5.00 (@kit-ty-kate, mirage/eqaf#37)
- Add support for current-bench and fix bad r² for unequal strings (@Zined-Ada, @art-w, mirage/eqaf#38)
- Add benchmark with `bechamel` (@Zineb-Ada, @art-w, mirage/eqaf#38)
