### PR TITLE
[new release] crunch (3.3.0)

### DIFF
--- a/packages/crunch/crunch.3.3.0/opam
+++ b/packages/crunch/crunch.3.3.0/opam
@@ -22,7 +22,7 @@ conflicts: [
   "mirage-kv" {< "3.0.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/crunch/crunch.3.3.0/opam
+++ b/packages/crunch/crunch.3.3.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer:   "MirageOS team"
+authors:      ["Anil Madhavapeddy" "Thomas Gazagnaire" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/ocaml-crunch"
+bug-reports:  "https://github.com/mirage/ocaml-crunch/issues"
+doc:          "https://mirage.github.io/ocaml-crunch/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/ocaml-crunch.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "cmdliner" {>= "1.1"}
+  "ptime"
+  "dune" {>= "2.5"}
+  "lwt" {with-test}
+  "mirage-kv" {with-test & >= "3.0.0"}
+  "mirage-kv-mem" {with-test & >= "3.0.0"}
+  "fmt" {with-test}
+]
+conflicts: [
+  "mirage-kv" {< "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+     name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+synopsis: "Convert a filesystem into a static OCaml module"
+description: """
+`ocaml-crunch` takes a directory of files and compiles them into a standalone
+OCaml module which serves the contents directly from memory.  This can be
+convenient for libraries that need a few embedded files (such as a web server)
+and do not want to deal with all the trouble of file configuration.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-crunch/releases/download/v3.3.0/crunch-3.3.0.tbz"
+  checksum: [
+    "sha256=5884e1e071e7e17beffe86856b2ddea58b31bd38df670632b050466a4bc6d52c"
+    "sha512=ad05a1212af62bf8270801d8fce7c3fdf3408825399fd96940e0a9f3a30ef5852ab658e7c58b64bd349de869418dae20efe2b229a915436d038c0f4b66f444ea"
+  ]
+}
+x-commit-hash: "1952e78fa8d9902f579db3724510220cea6682fe"


### PR DESCRIPTION
Convert a filesystem into a static OCaml module

- Project page: <a href="https://github.com/mirage/ocaml-crunch">https://github.com/mirage/ocaml-crunch</a>
- Documentation: <a href="https://mirage.github.io/ocaml-crunch/">https://mirage.github.io/ocaml-crunch/</a>

##### CHANGES:

* Open files in binary mode so buffers don't underread on Windows.
  (mirage/ocaml-crunch#54, @jonahbeckford)
* Always use Unix-style paths for path keys (mirage/ocaml-crunch#58, @MisterDA)
* Add -s and --silent flags (mirage/ocaml-crunch#52, mirage/ocaml-crunch#60, @MisterDA)
* Add `hash` and `size` functions to the plain module (mirage/ocaml-crunch#53, mirage/ocaml-crunch#60, @MisterDA)
* Update to cmdliner 1.1 (mirage/ocaml-crunch#55, @MisterDA)
