### PR TITLE
mirage-bootvar-solo5: drop upper bound of mirage-solo5

### DIFF
--- a/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
+++ b/packages/mirage-bootvar-solo5/mirage-bootvar-solo5.0.6.0/opam
@@ -20,7 +20,7 @@ build: [
 depends: [
   "ocaml" {>= "4.04.2"}
   "dune" {>= "1.0"}
-  "mirage-solo5" {>= "0.6.0" & < "0.9.0"}
+  "mirage-solo5" {>= "0.6.0"}
   "lwt"
   "parse-argv"
 ]


### PR DESCRIPTION
discovered in e.g. https://github.com/mirage/mirage/pull/1338 //cc @TheLortex 