### PR TITLE
base64.3.5.0: Fix compilation on OCaml 5.0 without ocamlfind installed

### DIFF
--- a/packages/base64/base64.3.5.0/opam
+++ b/packages/base64/base64.3.5.0/opam
@@ -20,6 +20,7 @@ depends: [
   "bos" {with-test}
   "rresult" {with-test}
   "alcotest" {with-test}
+  "base-bytes"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
```
#=== ERROR while compiling base64.3.5.0 =======================================#
# context              2.1.2 | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/base64.3.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p base64 -j 31
# exit-code            1
# env-file             ~/.opam/log/base64-19-b34c70.env
# output-file          ~/.opam/log/base64-19-b34c70.out
### output ###
# File "src/dune", line 5, characters 12-17:
# 5 |  (libraries bytes))
#                 ^^^^^
# Error: Library "bytes" not found.
# -> required by library "base64" in _build/default/src
# -> required by _build/default/META.base64
# -> required by _build/install/default/lib/base64/META
# -> required by _build/default/base64.install
# -> required by alias install
# File "src/dune", line 14, characters 12-17:
# 14 |  (libraries bytes))
#                  ^^^^^
# Error: Library "bytes" not found.
# -> required by library "base64.rfc2045" in _build/default/src
# -> required by _build/default/META.base64
# -> required by _build/install/default/lib/base64/META
# -> required by _build/default/base64.install
# -> required by alias install
```
Fixed upstream in https://github.com/mirage/ocaml-base64/pull/52