### PR TITLE
8 packages from gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz

### DIFF
--- a/packages/resto-acl/resto-acl.0.10/opam
+++ b/packages/resto-acl/resto-acl.0.10/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Access Control Lists for Resto"
+maintainer: "contact@nomadic-labs.com"
+authors: "Nomadic Labs"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "resto" {= version}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.0.10/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.0.10/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "resto-cohttp" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.10/opam
+++ b/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.0.10/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: "Nomadic Labs"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "resto-cohttp-client" {= version}
+  "resto-cohttp-server" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.10/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.10/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto-directory" {= version}
+  "resto-cohttp" {= version}
+  "resto-acl" {= version}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conduit-lwt-unix" {>= "2.0.0"}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.0.10/opam
+++ b/packages/resto-cohttp/resto-cohttp.0.10/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto-directory" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto-directory/resto-directory.0.10/opam
+++ b/packages/resto-directory/resto-directory.0.10/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto" {= version}
+  "resto-json" {= version & with-test}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto-json/resto-json.0.10/opam
+++ b/packages/resto-json/resto-json.0.10/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto" {= version}
+  "json-data-encoding" {= "0.9.1"}
+  "json-data-encoding-bson" {= "0.9.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}

--- a/packages/resto/resto.0.10/opam
+++ b/packages/resto/resto.0.10/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "json-data-encoding" {= "0.9.1" & with-test}
+  "json-data-encoding-bson" {= "0.9.1" & with-test}
+  "ezjsonm" {with-test}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "ocamlformat" {= "0.20.1" & with-doc}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v0.10/resto-v0.10.tar.gz"
+  checksum: [
+    "md5=c2da6431298aa1cdda43fb703f8c72a4"
+    "sha512=5ad6b0c65f8d19e2605e7b743d65a968ddb2b4f0d667b76c7efb73872bae9ba8638f6a78208b90a19c323869ef5815538e145b9e98297f79ea861ca19897ac97"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`resto.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-acl.0.10`: Access Control Lists for Resto
-`resto-cohttp.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-client.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-self-serving-client.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-server.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
-`resto-directory.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-json.0.10`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.1.0