### PR TITLE
carton < 0.4.4 is not compatible with OCaml 5.0

### DIFF
--- a/packages/carton/carton.0.1.0/opam
+++ b/packages/carton/carton.0.1.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.6.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}

--- a/packages/carton/carton.0.4.3/opam
+++ b/packages/carton/carton.0.4.3/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ke" {>= "0.4"}
   "duff" {>= "0.3"}


### PR DESCRIPTION
```
#=== ERROR while compiling carton.0.4.3 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/carton.0.4.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p carton -j 255
# exit-code            1
# env-file             ~/.opam/log/carton-8-28f575.env
# output-file          ~/.opam/log/carton-8-28f575.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I bin/carton/.hxd_cmdliner.objs/byte -I /home/opam/.opam/5.0/lib/cmdliner -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/hxd/core -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/rresult -no-alias-deps -o bin/carton/.hxd_cmdliner.objs/byte/hxd_cmdliner.cmo -c -impl bin/carton/hxd_cmdliner.ml)
# File "bin/carton/hxd_cmdliner.ml", line 124, characters 12-23:
# 124 |   let env = Arg.env_var "HXD_COLOR" in
#                   ^^^^^^^^^^^
# Alert deprecated: Cmdliner.Arg.env_var
# Use Cmd.Env.info instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I bin/carton/.hxd_cmdliner.objs/byte -I bin/carton/.hxd_cmdliner.objs/native -I /home/opam/.opam/5.0/lib/cmdliner -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/hxd/core -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/rresult -intf-suffix .ml -no-alias-deps -o bin/carton/.hxd_cmdliner.objs/native/hxd_cmdliner.cmx -c -impl bin/carton/hxd_cmdliner.ml)
# File "bin/carton/hxd_cmdliner.ml", line 124, characters 12-23:
# 124 |   let env = Arg.env_var "HXD_COLOR" in
#                   ^^^^^^^^^^^
# Alert deprecated: Cmdliner.Arg.env_var
# Use Cmd.Env.info instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/carton/.carton.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/checkseum -I /home/opam/.opam/5.0/lib/decompress/de -I /home/opam/.opam/5.0/lib/decompress/zl -I /home/opam/.opam/5.0/lib/duff -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/ke -I /home/opam/.opam/5.0/lib/optint -I /home/opam/.opam/5.0/lib/psq -intf-suffix .ml -no-alias-deps -open Carton__ -o src/carton/.carton.objs/byte/carton__Idx.cmo -c -impl src/carton/idx.ml)
# File "src/carton/idx.ml", line 565, characters 18-37:
# 565 |   let device () = Ephemeron.K1.create ()
#                         ^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Ephemeron.K1.create
```