### PR TITLE
mimic < 0.0.5 is not compatible with OCaml 5.0 (uses Obj.extension_id)

### DIFF
--- a/packages/mimic/mimic.0.0.1/opam
+++ b/packages/mimic/mimic.0.0.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.6.0"}
   "hmap"
   "fmt" {>= "0.8.9"}

--- a/packages/mimic/mimic.0.0.2/opam
+++ b/packages/mimic/mimic.0.0.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mirage/ocaml-git"
 doc: "https://mirage.github.io/ocaml-git/"
 bug-reports: "https://github.com/mirage/ocaml-git/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.8"}
   "fmt" {>= "0.8.9"}
   "lwt" {>= "5.3.0"}

--- a/packages/mimic/mimic.0.0.3/opam
+++ b/packages/mimic/mimic.0.0.3/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/dinosaure/mimic"
 doc: "https://dinosaure.github.io/mimic/"
 bug-reports: "https://github.com/dinosaure/mimic/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.8"}
   "fmt" {>= "0.8.9"}
   "lwt" {>= "5.3.0"}

--- a/packages/mimic/mimic.0.0.4/opam
+++ b/packages/mimic/mimic.0.0.4/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/dinosaure/mimic"
 doc: "https://dinosaure.github.io/mimic/"
 bug-reports: "https://github.com/dinosaure/mimic/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.8"}
   "fmt" {>= "0.8.9"}
   "lwt" {>= "5.3.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling mimic.0.0.4 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mimic.0.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mimic -j 255
# exit-code            1
# env-file             ~/.opam/log/mimic-8-0c20c6.env
# output-file          ~/.opam/log/mimic-8-0c20c6.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.mimic.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/logs -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/mirage-flow -intf-suffix .ml -no-alias-deps -open Mimic__ -o lib/.mimic.objs/byte/mimic__Implicit.cmo -c -impl lib/implicit.ml)
# File "lib/implicit.ml", line 113, characters 8-31:
# 113 |         Stdlib.Obj.extension_id [%extension_constructor T]
#               ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Stdlib.Obj.extension_id
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I lib/.mimic.objs/byte -I lib/.mimic.objs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/logs -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/mirage-flow -intf-suffix .ml -no-alias-deps -open Mimic__ -o lib/.mimic.objs/native/mimic__Implicit.cmx -c -impl lib/implicit.ml)
# File "lib/implicit.ml", line 113, characters 8-31:
# 113 |         Stdlib.Obj.extension_id [%extension_constructor T]
#               ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Stdlib.Obj.extension_id
```