### PR TITLE
[new release] xenstore (2.2.0)

### DIFF
--- a/packages/xenstore/xenstore.2.2.0/opam
+++ b/packages/xenstore/xenstore.2.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Dave Scott"
+  "Anil Madhavapeddy"
+  "Vincent Bernardoff"
+]
+homepage: "https://github.com/mirage/ocaml-xenstore"
+doc: "https://mirage.github.io/ocaml-xenstore/"
+bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "3.2.0"}
+  "ppx_cstruct" {>= "3.2.0"}
+  "lwt"
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-xenstore.git"
+synopsis: "Xenstore protocol in pure OCaml"
+description: """
+This repo contains:
+1. a xenstore client library, a merge of the Mirage and XCP ones
+2. a xenstore server library
+3. a xenstore server instance which runs under Unix with libxc
+4. a xenstore server instance which runs on mirage.
+
+The client and the server libraries have sets of unit-tests.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-xenstore/releases/download/v2.2.0/xenstore-2.2.0.tbz"
+  checksum: [
+    "sha256=d4c9eab6de731de45d6091ef85d40d8cdf1de32c5410a0f6729c2da1cec3182d"
+    "sha512=79411344d5d4dfb49202bb9ca6e0e9d1343dcef60bc617dc24d5538b81f4e9265233870ab996a7043dd65cd9aff933b677a45371314a03ca35a79a00b1690e97"
+  ]
+}
+x-commit-hash: "ef2d94e4dc82c5ea87807d24f07b14db4e7be878"


### PR DESCRIPTION
Xenstore protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-xenstore">https://github.com/mirage/ocaml-xenstore</a>
- Documentation: <a href="https://mirage.github.io/ocaml-xenstore/">https://mirage.github.io/ocaml-xenstore/</a>

##### CHANGES:

* Fix crash if watch quto is exceeded (mirage/ocaml-xenstore#47 @talex5)
* Switch to ounit2 (mirage/ocaml-xenstore#49 @Alessandro-Barbieri)
* Add license to opam metadata (mirage/ocaml-xenstore#48 @psafont)
