### PR TITLE
[new release] dockerfile, dockerfile-opam and dockerfile-cmd (8.0.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "dockerfile-opam" {= version}
   "cmdliner"
-  "fmt" {>= "0.8.4"}
+  "fmt" {>= "0.8.5"}
   "logs"
   "bos"
   "result"

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL - generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0.0"}
+  "dockerfile-opam" {= version}
+  "cmdliner"
+  "fmt"
+  "logs"
+  "bos"
+  "result"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.0.0/dockerfile-8.0.0.tbz"
+  checksum: [
+    "sha256=e97e49621489fde147dd5ebc9e8c7f742f2b9d9df766391063a2f65e5ade5d01"
+    "sha512=645abd32db85b7e1867b258cce0aa1702d0b78a08949040e3be2b9af50593591ddfd1fb09a7569746901d0b5534eac1d58130f9be5cbab001048f73605b8d0fc"
+  ]
+}
+x-commit-hash: "4acf3e60c3578b73a23277c10406a6e969f2081d"

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "dockerfile-opam" {= version}
   "cmdliner"
-  "fmt"
+  "fmt" {>= "0.8.4"}
   "logs"
   "bos"
   "result"

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "dockerfile-opam" {= version}
   "cmdliner"
-  "fmt" {>= "0.8.5"}
+  "fmt" {>= "0.8.7"}
   "logs"
   "bos"
   "result"

--- a/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "fmt" {>= "0.8.4"}
+  "fmt" {>= "0.8.5"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "fmt"
+  "fmt" {>= "0.8.4"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "fmt" {>= "0.8.5"}
+  "fmt" {>= "0.8.7"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution
+support for generating dockerfiles."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0.0"}
+  "dockerfile" {= version}
+  "ocaml-version" {>= "3.5.0"}
+  "cmdliner"
+  "astring"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.0.0/dockerfile-8.0.0.tbz"
+  checksum: [
+    "sha256=e97e49621489fde147dd5ebc9e8c7f742f2b9d9df766391063a2f65e5ade5d01"
+    "sha512=645abd32db85b7e1867b258cce0aa1702d0b78a08949040e3be2b9af50593591ddfd1fb09a7569746901d0b5534eac1d58130f9be5cbab001048f73605b8d0fc"
+  ]
+}
+x-commit-hash: "4acf3e60c3578b73a23277c10406a6e969f2081d"

--- a/packages/dockerfile/dockerfile.8.0.0/opam
+++ b/packages/dockerfile/dockerfile.8.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "fmt" {>= "0.8.4"}
+  "fmt" {>= "0.8.5"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/dockerfile/dockerfile.8.0.0/opam
+++ b/packages/dockerfile/dockerfile.8.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "2.0.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "fmt"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.0.0/dockerfile-8.0.0.tbz"
+  checksum: [
+    "sha256=e97e49621489fde147dd5ebc9e8c7f742f2b9d9df766391063a2f65e5ade5d01"
+    "sha512=645abd32db85b7e1867b258cce0aa1702d0b78a08949040e3be2b9af50593591ddfd1fb09a7569746901d0b5534eac1d58130f9be5cbab001048f73605b8d0fc"
+  ]
+}
+x-commit-hash: "4acf3e60c3578b73a23277c10406a6e969f2081d"

--- a/packages/dockerfile/dockerfile.8.0.0/opam
+++ b/packages/dockerfile/dockerfile.8.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "fmt" {>= "0.8.5"}
+  "fmt" {>= "0.8.7"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/dockerfile/dockerfile.8.0.0/opam
+++ b/packages/dockerfile/dockerfile.8.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "fmt"
+  "fmt" {>= "0.8.4"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Dockerfile eDSL in OCaml

- Project page: <a href="https://github.com/ocurrent/ocaml-dockerfile">https://github.com/ocurrent/ocaml-dockerfile</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-dockerfile/doc">https://ocurrent.github.io/ocaml-dockerfile/doc</a>

##### CHANGES:

- Deprecate Ubuntu 21.10 (@tmcgilchrist ocurrent/ocaml-dockerfile#104)
- Various LCU Updates (@mtelvers ocurrent/ocaml-dockerfile#103 ocurrent/ocaml-dockerfile#98 ocurrent/ocaml-dockerfile#95 ocurrent/ocaml-dockerfile#93 ocurrent/ocaml-dockerfile#91 ocurrent/ocaml-dockerfile#89 ocurrent/ocaml-dockerfile#83)
- Add IBM-Z Docker images for Ubuntu (@mtelvers ocurrent/ocaml-dockerfile#102)
- Added RISCV64 (@mtelvers ocurrent/ocaml-dockerfile#100)
- Ubuntu LTS and current release is 22.04 (@dra27 ocurrent/ocaml-dockerfile#97)
- When compiling opam, build OCaml once using `make compiler` on the master
  branch of opam and then share this compiler with the release branches.
  Simultaneously circumvents the `sigaltstack` problems with OCaml < 4.13 on new
  releases, improves the build time of opam and reduces the carbon footprint of
  the base image builder! (@dra27 ocurrent/ocaml-dockerfile#85)
- Only compile bubblewrap from sources if the OS either doesn't distribute it or
  it's too old (@dra27 ocurrent/ocaml-dockerfile#85)
- Add `Dockerfile_distro.bubblewrap_version` to return the version of bubblewrap
  package in a given release (@dra27 ocurrent/ocaml-dockerfile#85)
- Change types for aliasing of distributions. The return type of
  `Dockerfile_distro.resolve_alias` is guaranteed not to include an alias but
  may require coercing back to `Dockerfile_distro.t` in some code. Similarly
  affects uses of some of the Windows functions in `Dockerfile_distro`
  (@dra27 ocurrent/ocaml-dockerfile#85)
- Move CentOS 8 to deprecated and change CentOS latest to V7! (@kit-ty-kate ocurrent/ocaml-dockerfile#88)
- Add OCaml 5.00 support (@dra27 ocurrent/ocaml-dockerfile#84)
- Add Alpine 3.15 (3.14 is now tier 2 and 3.13 is deprecated) (@talex5)
- Switch all GitHub access from git:// to https:// in advance of insecure protocol
  sunset (@kit-ty-kate ocurrent/ocaml-dockerfile#73)
- Fix dependencies of dockerfile-cmd: result now correctly used (@dra27 ocurrent/ocaml-dockerfile#72)
- Add Fedora 35 and make the latest (@dra27 ocurrent/ocaml-dockerfile#71)
- Move Ubuntu 21.04 to deprecated (@dra27 ocurrent/ocaml-dockerfile#71)
- Add Ubuntu 22.04 (@dra27 ocurrent/ocaml-dockerfile#71)
- Add Alpine 3.14 and Ubuntu 21.10 (@avsm)
- Move Fedora 33 and OpenSUSE 15.2 to deprecated and Alpine 3.13 to Tier 2. (@avsm)
- Latest Fedora is now Fedora 34 (@avsm)
- Asssume Windows x64 is an active distro even when it doesn't have the latest
  release (@dra27 ocurrent/ocaml-dockerfile#66; ocurrent/ocaml-dockerfile#68)
- Latest base distro is now Debian 11 (from Debian 10) (@kit-ty-kate ocurrent/ocaml-dockerfile#59)
- Ensure stray double-quotes don't end up in PATH on Windows images (@dra27 ocurrent/ocaml-dockerfile#62)
- Stop pinning binutils to 2.35 in Windows builds as that no longer works with
  GCC 11. (@dra27 ocurrent/ocaml-dockerfile#61)
- Introduce Windows 10 LTSC 2022 and Windows Server image (@MisterDA ocurrent/ocaml-dockerfile#63)
- Expose `Dockerfile_distro.win10_docker_base_image` and
  `Dockerfile_distro.win10_base_tag` to get the Windows container base
  image and tags. (@MisterDA ocurrent/ocaml-dockerfile#63)
