### PR TITLE
Set `--docdir` in ocaml-base-compiler.4.14.0

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
@@ -20,6 +20,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
     "-C"
     "CC=cc" {os = "openbsd" | os = "macos"}
     "ASPP=cc -c" {os = "openbsd" | os = "macos"}

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -5,7 +5,7 @@ maintainer: "platform@lists.ocaml.org"
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
 homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-dev-repo: "git+https://github.com/ocaml/ocaml.git#4.12"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
   "ocaml" {= "4.14.0" & post}
   "base-unix" {post}
@@ -19,6 +19,7 @@ build: [
   [
     "./configure"
     "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
     "-C"
     "--with-afl" {ocaml-option-afl:installed}
     "--disable-native-compiler" {ocaml-option-bytecode-only:installed}


### PR DESCRIPTION
Unintended difference between the rc2 and release packages. The 5.0.0 alpha packages are still setting `--docdir` correctly, so we'll just be careful that this doesn't happen with that release package too.