### PR TITLE
blake3 is not available on s390x

### DIFF
--- a/packages/blake3/blake3.0.1/opam
+++ b/packages/blake3/blake3.0.1/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "conf-rust" {build}
 ]
+available: arch != "s390x"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/blake3/blake3.0.2/opam
+++ b/packages/blake3/blake3.0.2/opam
@@ -12,6 +12,7 @@ depends: [
   "conf-rust" {build}
   "hacl-star" {with-test}
 ]
+available: arch != "s390x"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
```
#=== ERROR while compiling blake3.0.2 =========================================#
# context              2.2.0~alpha~dev | linux/s390x | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/blake3.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p blake3 -j 3
# exit-code            1
# env-file             ~/.opam/log/blake3-8-2434d2.env
# output-file          ~/.opam/log/blake3-8-2434d2.out
### output ###
# File "src/dune", line 1, characters 0-644:
#  1 | (rule
#  2 |  (targets libocaml_blake3.a dllocaml_blake3.so)
#  3 |  (deps (glob_files *.rs) ../Cargo.toml ../Cargo.lock ../cargo-config
# ....
# 11 |      "mv %{project_root}/../../_build_rust/release/libocaml_blake3.so ./dllocaml_blake3.so 2> /dev/null || \
# 12 |       mv %{project_root}/../../_build_rust/release/libocaml_blake3.dylib ./dllocaml_blake3.so")
# 13 |    (run mv %{project_root}/../../_build_rust/release/libocaml_blake3.a libocaml_blake3.a))))
# (cd _build/default/src && /usr/bin/cargo build --target-dir ../../../_build_rust --release)
#    Compiling autocfg v1.0.1
#    Compiling const_fn v0.4.3
#    Compiling proc-macro2 v1.0.24
#    Compiling cfg-if v1.0.0
#    Compiling lazy_static v1.4.0
#    Compiling version_check v0.9.2
#    Compiling unicode-xid v0.2.1
#    Compiling typenum v1.12.0
#    Compiling libc v0.2.80
#    Compiling scopeguard v1.1.0
#    Compiling syn v1.0.48
#    Compiling rayon-core v1.9.0
#    Compiling cc v1.0.65
#    Compiling ocaml-sys v0.19.0
#    Compiling cty v0.2.1
#    Compiling subtle v2.3.0
#    Compiling either v1.6.1
#    Compiling cfg-if v0.1.10
#    Compiling constant_time_eq v0.1.5
#    Compiling arrayref v0.3.6
#    Compiling arrayvec v0.5.2
#    Compiling crossbeam-utils v0.8.0
#    Compiling memoffset v0.5.6
#    Compiling rayon v1.5.0
#    Compiling generic-array v0.14.4
# error: `ptr::const_ptr::<impl *const T>::offset` is not yet stable as a const fn
#   --> /home/opam/.opam/4.14/.opam-switch/build/blake3.0.2/_build/default/vendor/ocaml-sys/src/mlvalues.rs:50:6
#    |
# 50 |     *(val as *const u8).offset(-1)
#    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# 
# error[E0658]: dereferencing raw pointers in constant functions is unstable
#   --> /home/opam/.opam/4.14/.opam-switch/build/blake3.0.2/_build/default/vendor/ocaml-sys/src/mlvalues.rs:50:5
#    |
# 50 |     *(val as *const u8).offset(-1)
#    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#    |
#    = note: see issue #51911 <https://github.com/rust-lang/rust/issues/51911> for more information
# 
# error: aborting due to 2 previous errors
# 
# For more information about this error, try `rustc --explain E0658`.
# error: could not compile `ocaml-sys`.
# 
# To learn more, run the command again with --verbose.
# warning: build failed, waiting for other jobs to finish...
# error: build failed
```