### PR TITLE
mirage 4.1: tighter opam-monorepo bounds for testing

### DIFF
--- a/packages/mirage/mirage.4.1.0/opam
+++ b/packages/mirage/mirage.4.1.0/opam
@@ -27,6 +27,7 @@ depends: [
   "logs"
   "mirage-runtime" {= version}
   "opam-monorepo" {>= "0.3.0"}
+  "opam-monorepo" {= "0.3.0" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
 ]

--- a/packages/mirage/mirage.4.1.1/opam
+++ b/packages/mirage/mirage.4.1.1/opam
@@ -27,6 +27,7 @@ depends: [
   "logs"
   "mirage-runtime" {= version}
   "opam-monorepo" {>= "0.3.0"}
+  "opam-monorepo" {= "0.3.0" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
 ]


### PR DESCRIPTION
discovered in #21888:
```
#=== ERROR while compiling mirage.4.1.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/mirage.4.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p mirage -j 31
# exit-code            1
# env-file             ~/.opam/log/mirage-480-637a44.env
# output-file          ~/.opam/log/mirage-480-637a44.out
### output ###
# File "test/opam-monorepo/lock.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/d13b1fb625efc8551bb8569ebca1a87b/default/test/opam-monorepo/lock.t _build/.sandbox/d13b1fb625efc8551bb8569ebca1a87b/default/test/opam-monorepo/lock.t.corrected
# diff --git a/_build/.sandbox/d13b1fb625efc8551bb8569ebca1a87b/default/test/opam-monorepo/lock.t b/_build/.sandbox/d13b1fb625efc8551bb8569ebca1a87b/default/test/opam-monorepo/lock.t.corrected
# index dc9f4c9..aa08149 100644
# --- a/_build/.sandbox/d13b1fb625efc8551bb8569ebca1a87b/default/test/opam-monorepo/lock.t
# +++ b/_build/.sandbox/d13b1fb625efc8551bb8569ebca1a87b/default/test/opam-monorepo/lock.t.corrected
# @@ -3,7 +3,7 @@
#    ==> Found 8 opam dependencies for the target package.
#    ==> Querying opam database for their metadata and Dune compatibility.
#    ==> Calculating exact pins for each of them.
# -  ==> Wrote lockfile with 6 entries to $TESTCASE_ROOT/unikernel.opam.locked. You can now run opam monorepo pull to fetch their sources.
# +  ==> Wrote lockfile with 4 entries to $TESTCASE_ROOT/unikernel.opam.locked. You can now run opam monorepo pull to fetch their sources.
#  
#    $ cat unikernel.opam.locked
#    opam-version: "2.0"
# @@ -23,17 +23,14 @@
#      ["fmt.0.9.0+dune" "https://fmt.src"]
#      ["gmp.6.2.9+dune" "https://gmp.src"]
#      ["mirage-runtime.4.0.0" "https://mirage.src"]
# -    ["ocaml-solo5.0.8.0" "https://ocaml-solo5.src"]
# -    ["solo5.0.7.1" "https://solo5.src"]
#      ["zarith.1.12+dune+mirage" "https://github.com/ocaml/zarith.git"]
#    ]
# +  x-opam-monorepo-cli-args: ["--require-cross-compile"]
#    x-opam-monorepo-duniverse-dirs: [
#      ["https://fmt.src" "fmt"]
#      ["https://github.com/ocaml/zarith.git" "zarith"]
#      ["https://gmp.src" "gmp"]
#      ["https://mirage.src" "mirage"]
# -    ["https://ocaml-solo5.src" "ocaml-solo5"]
# -    ["https://solo5.src" "solo5"]
#    ]
#    x-opam-monorepo-opam-provided: ["ocaml-solo5"]
#    x-opam-monorepo-opam-repositories: [
# (cd _build/default/test/mirage && ./test.exe)
# Testing `mirage'.
# This run has ID `IKHXSEIL'.
# 
#   [OK]          basic          0   pp.
# 
# Full test results in `~/.opam/4.14/.opam-switch/build/mirage.4.1.0/_build/default/test/mirage/_build/_tests/mirage'.
# Test Successful in 0.000s. 1 test run.
```