### PR TITLE
opam-monorepo is not compatible with ocaml 5 (Obj.extension_id)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.2.3/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.3/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "conf-pkg-config" {build}
 ]
 conflicts: [

--- a/packages/opam-monorepo/opam-monorepo.0.2.4/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.4/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "conf-pkg-config" {build}
 ]
 conflicts: [

--- a/packages/opam-monorepo/opam-monorepo.0.2.5/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.5/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "conf-pkg-config" {build}
 ]
 conflicts: [

--- a/packages/opam-monorepo/opam-monorepo.0.2.6/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.6/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "conf-pkg-config" {build}
 ]
 conflicts: [

--- a/packages/opam-monorepo/opam-monorepo.0.2.7/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.2.7/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/ocamllabs/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "conf-pkg-config" {build}
 ]
 conflicts: [

--- a/packages/opam-monorepo/opam-monorepo.0.3.0/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.0/opam
@@ -14,7 +14,7 @@ doc: "https://ocamllabs.github.io/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "odoc" {with-doc}
   "conf-pkg-config"
 ]

--- a/packages/opam-monorepo/opam-monorepo.0.3.1/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.1/opam
@@ -14,7 +14,7 @@ doc: "https://ocamllabs.github.io/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "odoc" {with-doc}
   "conf-pkg-config"
 ]

--- a/packages/opam-monorepo/opam-monorepo.0.3.2/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.2/opam
@@ -14,7 +14,7 @@ doc: "https://ocamllabs.github.io/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "3.1"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "odoc" {with-doc}
   "conf-pkg-config"
 ]

--- a/packages/opam-monorepo/opam-monorepo.0.3.3/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.3/opam
@@ -14,7 +14,7 @@ doc: "https://ocamllabs.github.io/opam-monorepo"
 bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
 depends: [
   "dune" {>= "3.2"}
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "odoc" {with-doc}
   "conf-pkg-config"
 ]


### PR DESCRIPTION
as it occured in https://github.com/ocaml/opam-repository/pull/21887

//cc @NathanReb @Leonidas-from-XIV 

```
#=== ERROR while compiling opam-monorepo.0.3.3 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/opam-monorepo.0.3.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p opam-monorepo -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/opam-monorepo-8-712ea7.env
# output-file          ~/.opam/log/opam-monorepo-8-712ea7.out
### output ###
# (cd duniverse/0install/src/gui_gtk && /home/opam/.opam/5.0/bin/ocaml -I +compiler-libs /home/opam/.opam/5.0/.opam-switch/build/opam-monorepo.0.3.3/_build/.dune/default/duniverse/0install/src/gui_gtk/dune.ml)
# ocamlfind: Package `lablgtk3' not found
# (will skip building the GTK plugin)
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w -a -alert -all -g -I duniverse/sexplib0/src/.sexplib0.objs/byte -I duniverse/sexplib0/src/.sexplib0.objs/native -intf-suffix .ml -no-alias-deps -open Sexplib0__ -o duniverse/sexplib0/src/.sexplib0.objs/native/sexplib0__Sexp_conv.cmx -c -impl duniverse/sexplib0/src/sexp_conv.ml)
# File "duniverse/sexplib0/src/sexp_conv.ml", line 99, characters 15-31:
# 99 |       let id = Obj.extension_id
#                     ^^^^^^^^^^^^^^^^
# Error: Unbound value Obj.extension_id
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -a -alert -all -g -bin-annot -I duniverse/base/shadow-stdlib/gen/.gen.eobjs/byte -I /home/opam/.opam/5.0/lib/ocaml/compiler-libs -I /home/opam/.opam/5.0/lib/ocaml/str -I duniverse/base/compiler-stdlib/src/.caml.objs/byte -no-alias-deps -o duniverse/base/shadow-stdlib/gen/.gen.eobjs/byte/mapper.cmo -c -impl duniverse/base/shadow-stdlib/gen/mapper.ml)
# File "duniverse/base/shadow-stdlib/gen/mapper.mll", line 7, characters 27-44:
# Error: Unbound value String.capitalize
```