### PR TITLE
functoria 4.0.0~beta*: restrict testing to dune < 3

### DIFF
--- a/packages/functoria/functoria.4.0.0~beta1/opam
+++ b/packages/functoria/functoria.4.0.0~beta1/opam
@@ -27,6 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
+  "dune" {< "3.0.0" & with-test}
   "base-unix"
   "cmdliner" {>= "0.9.8" & < "1.1.0"}
   "rresult" {>= "0.7.0"}

--- a/packages/functoria/functoria.4.0.0~beta2/opam
+++ b/packages/functoria/functoria.4.0.0~beta2/opam
@@ -27,6 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
+  "dune" {< "3.0.0" & with-test}
   "base-unix"
   "cmdliner" {>= "0.9.8" & < "1.1.0"}
   "rresult" {>= "0.7.0"}

--- a/packages/functoria/functoria.4.0.0~beta3/opam
+++ b/packages/functoria/functoria.4.0.0~beta3/opam
@@ -27,6 +27,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.8.0"}
+  "dune" {< "3.0.0" & with-test}
   "base-unix"
   "cmdliner" {>= "0.9.8" & < "1.1.0"}
   "rresult" {>= "0.7.0"}


### PR DESCRIPTION
observed in #21888

```
#=== ERROR while compiling functoria.4.0.0~beta3 ==============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/functoria.4.0.0~beta3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p functoria -j 31
# exit-code            1
# env-file             ~/.opam/log/functoria-515-ce99bc.env
# output-file          ~/.opam/log/functoria-515-ce99bc.out
### output ###
# (cd _build/default/test/functoria && ./test.exe)
# Testing `functoria'.
# This run has ID `90HFAH5X'.
# 
#   [OK]          cli              0   read_full_eval.
#   [OK]          cli              1   configure.
#   [OK]          cli              2   describe.
#   [OK]          cli              3   build.
#   [OK]          cli              4   clean.
#   [OK]          cli              5   help.
#   [OK]          cli              6   default.
#   [OK]          package          0   merge.
#   [OK]          package          1   pp.
#   [OK]          graph            0   var_name.
#   [OK]          graph            1   impl_name.
#   [OK]          graph            2   test_graph.
#   [OK]          action           0   bind.
#   [OK]          action           1   seq.
#   [OK]          action           2   rm.
#   [OK]          action           3   mkdir.
#   [OK]          action           4   rmdir.
#   [OK]          action           5   with_dir.
#   [OK]          action           6   pwd.
#   [OK]          action           7   is_file.
#   [OK]          action           8   is_dir.
#   [OK]          action           9   size_of.
#   [OK]          action          10   set_var.
#   [OK]          action          11   get_var.
#   [OK]          action          12   run_cmd.
#   [OK]          action          13   run_cmd_out.
#   [OK]          action          14   write_file.
#   [OK]          action          15   tmp_file.
#   [OK]          action          16   ls.
#   [OK]          action          17   with_output.
#   [OK]          key              0   equal.
#   [OK]          key              1   eval.
#   [OK]          key              2   get.
#   [OK]          key              3   find.
#   [OK]          key              4   merge.
#   [OK]          key              5   cmdliner.
# 
# Full test results in `~/.opam/4.14/.opam-switch/build/functoria.4.0.0~beta3/_build/default/test/functoria/_build/_tests/functoria'.
# Test Successful in 0.004s. 36 tests run.
# File "test/functoria/tool/run.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/d534ce5c172d07e4252475b924b7791c/default/test/functoria/tool/run.t _build/.sandbox/d534ce5c172d07e4252475b924b7791c/default/test/functoria/tool/run.t.corrected
# diff --git a/_build/.sandbox/d534ce5c172d07e4252475b924b7791c/default/test/functoria/tool/run.t b/_build/.sandbox/d534ce5c172d07e4252475b924b7791c/default/test/functoria/tool/run.t.corrected
# index d77e75a..cf8ae78 100644
# --- a/_build/.sandbox/d534ce5c172d07e4252475b924b7791c/default/test/functoria/tool/run.t
# +++ b/_build/.sandbox/d534ce5c172d07e4252475b924b7791c/default/test/functoria/tool/run.t.corrected
# @@ -63,7 +63,7 @@ Clean
#    * Run_cmd_cli '_build/default/./config.exe clean a b c --dry-run' (ok)
#    * Get_var INSIDE_FUNCTORIA_TESTS -> <not set>
#    * Run_cmd 'dune clean' (ok)
# -  * Ls ./ (12 entries)
# +  * Ls ./ (11 entries)
#    * Is_file? dune-project -> true
#    * Read dune-project (47 bytes)
#    * Rm dune-project (removed)
# File "test/functoria/e2e/clean.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/0ca1b9dfb748a0c036263976e7b600da/default/test/functoria/e2e/clean.t _build/.sandbox/0ca1b9dfb748a0c036263976e7b600da/default/test/functoria/e2e/clean.t.corrected
# diff --git a/_build/.sandbox/0ca1b9dfb748a0c036263976e7b600da/default/test/functoria/e2e/clean.t b/_build/.sandbox/0ca1b9dfb748a0c036263976e7b600da/default/test/functoria/e2e/clean.t.corrected
# index 2b904c3..bcc1f5c 100644
# --- a/_build/.sandbox/0ca1b9dfb748a0c036263976e7b600da/default/test/functoria/e2e/clean.t
# +++ b/_build/.sandbox/0ca1b9dfb748a0c036263976e7b600da/default/test/functoria/e2e/clean.t.corrected
# @@ -38,7 +38,6 @@ Make sure that clean remove everything:
#                         vote=cat (default),
#                         warn_error=false (default)
#    test.exe: [INFO] Skipped ./app
# -  test.exe: [INFO] Skipped ./clean.t
#    test.exe: [INFO] Skipped ./help.exe
#    test.exe: [INFO] Skipped ./lib
#    test.exe: [INFO] Skipped ./test.exe
# @@ -88,7 +87,6 @@ Check that clean works with `--output`:
#                         vote=cat (default),
#                         warn_error=false (default)Output     toto
#    test.exe: [INFO] Skipped ./app
# -  test.exe: [INFO] Skipped ./clean.t
#    test.exe: [INFO] Skipped ./help.exe
#    test.exe: [INFO] Skipped ./lib
#    test.exe: [INFO] Skipped ./test.exe
```