### PR TITLE
Package seq.0.3.1

### DIFF
--- a/packages/seq/seq.0.3.1/opam
+++ b/packages/seq/seq.0.3.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis:
+  "Compatibility package for OCaml's standard iterator type starting from 4.07"
+maintainer: "simon.cruanes.2007@m4x.org"
+license:  "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml"
+]
+tags: [ "iterator" "seq" "pure" "list" "compatibility" "cascade" ]
+homepage: "https://github.com/c-cube/seq/"
+bug-reports: "https://github.com/c-cube/seq/issues"
+dev-repo: "git+https://github.com/c-cube/seq.git"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/seq/archive/v0.3.1.tar.gz"
+  checksum: [
+    "md5=de05d9dedd492fa4e3c0c87bc2792475"
+    "sha512=06ce767d3ec1532f8a2421d033f4d9dc5c08c9a27574754d456c31a71ecb9a3c33857591b7d24f85492dce679cd0da8c8985c9fb1a5b5a7f8588d90056b663b8"
+  ]
+}


### PR DESCRIPTION
### `seq.0.3.1`
Compatibility package for OCaml's standard iterator type starting from 4.07



---
* Homepage: https://github.com/c-cube/seq/
* Source repo: git+https://github.com/c-cube/seq.git
* Bug tracker: https://github.com/c-cube/seq/issues

---
:camel: Pull-request generated by opam-publish v2.1.0