### PR TITLE
ppx_expect is not compatible with OCaml 5.0

### DIFF
--- a/packages/ppx_expect/ppx_expect.v0.15.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"           {>= "4.08.0"}
+  "ocaml"           {>= "4.08.0" & < "5.0"}
   "base"            {>= "v0.15" & < "v0.16"}
   "ppx_here"        {>= "v0.15" & < "v0.16"}
   "ppx_inline_test" {>= "v0.15" & < "v0.16"}


### PR DESCRIPTION
```
#=== ERROR while compiling ppx_expect.v0.15.0 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ppx_expect.v0.15.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_expect -j 31
# exit-code            1
# env-file             ~/.opam/log/ppx_expect-23-c3ca09.env
# output-file          ~/.opam/log/ppx_expect-23-c3ca09.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I evaluator/.ppx_expect_evaluator.objs/byte -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/jane-street-headers -I /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_inline_test/config -I /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/ppxlib/print_diff -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdio -I /home/opam/.opam/5.0/lib/time_now -I collector/.expect_test_collector.objs/byte -I common/.expect_test_common.objs/byte -I config/types/.expect_test_config_types.objs/byte -I matcher/.expect_test_matcher.objs/byte -intf-suffix .ml -no-alias-deps -o evaluator/.ppx_expect_evaluator.objs/byte/ppx_expect_evaluator.cmo -c -impl evaluator/ppx_expect_evaluator.ml)
# File "evaluator/ppx_expect_evaluator.ml", line 12, characters 17-49:
# 12 |     let of_val = Stdlib.Obj.extension_constructor
#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Stdlib.Obj.extension_constructor
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I evaluator/.ppx_expect_evaluator.objs/byte -I evaluator/.ppx_expect_evaluator.objs/native -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/jane-street-headers -I /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_inline_test/config -I /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/ppxlib/print_diff -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdio -I /home/opam/.opam/5.0/lib/time_now -I collector/.expect_test_collector.objs/byte -I collector/.expect_test_collector.objs/native -I common/.expect_test_common.objs/byte -I common/.expect_test_common.objs/native -I config/types/.expect_test_config_types.objs/byte -I config/types/.expect_test_config_types.objs/native -I matcher/.expect_test_matcher.objs/byte -I matcher/.expect_test_matcher.objs/native -intf-suffix .ml -no-alias-deps -o evaluator/.ppx_expect_evaluator.objs/native/ppx_expect_evaluator.cmx -c -impl evaluator/ppx_expect_evaluator.ml)
# File "evaluator/ppx_expect_evaluator.ml", line 12, characters 17-49:
# 12 |     let of_val = Stdlib.Obj.extension_constructor
#                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Stdlib.Obj.extension_constructor
```