### PR TITLE
[new release] libdash (v0.3)

### DIFF
--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -6,12 +6,11 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/mgree/libdash"
 bug-reports: "https://github.com/mgree/libdash/issues"
 depends: [
-  "ocaml" {>= "4.0.7"}
+  "ocaml" {>= "4.07"}
   "ocamlfind" {>= "1.8.0"}
   "ctypes" {>= "0.18.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "atdgen" {>= "2.3.2"}
-  "opam-installer" {>= "2.1.0"}
   "conf-autoconf" {build}
   "conf-aclocal" {build}
   "conf-libtool" {build}
@@ -32,9 +31,6 @@ build: [
   ["./mk_dot_install.sh"]
   ["./ldconfig.sh"] # fix up .so files if ldconfig didn't do it
   [make "-C" "ocaml" "test"] {with-test}
-]
-install: [
-  ["opam-installer" "--prefix=%{prefix}%" "libdash.install"]
 ]
 dev-repo: "git+https:///github.com/mgree/libdash"
 url {

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocamlfind" {>= "1.8.0"}
   "ctypes" {>= "0.18.0"}
   "ctypes-foreign" {>= "0.18.0"}
-  "atdgen" {>= "2.2.1"}
+  "atdgen" {>= "2.3.2"}
   "opam-installer" {>= "2.1.0"}
   "conf-autoconf" {build}
   "conf-aclocal" {build}

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "0.3"
 synopsis: "Bindings to the dash shell's parser"
 maintainer: "Michael Greenberg <michael.greenberg@pomona.edu>"
 authors: "Michael Greenberg <michael.greenberg@pomona.edu>"

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "ctypes" {>= "0.18.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "atdgen" {>= "2.2.1"}
-  "opam-installer" {>= "2.0.0"}
+  "opam-installer" {>= "2.1.0"}
   "conf-autoconf" {build}
   "conf-aclocal" {build}
   "conf-libtool" {build}

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -1,10 +1,9 @@
 opam-version: "2.0"
-name: "libdash"
 version: "0.3"
 synopsis: "Bindings to the dash shell's parser"
 maintainer: "Michael Greenberg <michael.greenberg@pomona.edu>"
 authors: "Michael Greenberg <michael.greenberg@pomona.edu>"
-license: "BSD"
+license: "BSD-3-Clause"
 homepage: "https://github.com/mgree/libdash"
 bug-reports: "https://github.com/mgree/libdash/issues"
 depends: [

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mgree/libdash/issues"
 depends: [
   "ocaml" {>= "4.0.7"}
   "ocamlfind" {>= "1.8.0"}
-  "ctypes" {>= "0.11.5"}
+  "ctypes" {>= "0.18.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "atdgen" {>= "2.2.1"}
   "opam-installer" {>= "2.0.0"}

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.0.7"}
   "ocamlfind" {>= "1.8.0"}
   "ctypes" {>= "0.11.5"}
-  "ctypes-foreign" {>= "0.4.0"}
+  "ctypes-foreign" {>= "0.18.0"}
   "atdgen" {>= "2.2.1"}
   "opam-installer" {>= "2.0.0"}
   "conf-autoconf" {build}

--- a/packages/libdash/libdash.0.3/opam
+++ b/packages/libdash/libdash.0.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+name: "libdash"
+version: "0.3"
+synopsis: "Bindings to the dash shell's parser"
+maintainer: "Michael Greenberg <michael.greenberg@pomona.edu>"
+authors: "Michael Greenberg <michael.greenberg@pomona.edu>"
+license: "BSD"
+homepage: "https://github.com/mgree/libdash"
+bug-reports: "https://github.com/mgree/libdash/issues"
+depends: [
+  "ocaml" {>= "4.0.7"}
+  "ocamlfind" {>= "1.8.0"}
+  "ctypes" {>= "0.11.5"}
+  "ctypes-foreign" {>= "0.4.0"}
+  "atdgen" {>= "2.2.1"}
+  "opam-installer" {>= "2.0.0"}
+  "conf-autoconf" {build}
+  "conf-aclocal" {build}
+  "conf-libtool" {build}
+]
+build: [
+  ["libtoolize"] {os != "macos"}
+  ["glibtoolize"] {os = "macos"}
+  ["aclocal"]
+  ["autoheader"]
+  ["automake" "--add-missing"]
+  ["autoconf"]
+  ["mkdir" "_build"]
+  ["./configure" "--prefix=%{build}%/_build"]
+  [make]
+  [make "install"] # into _build
+  ["ocaml/mk_meta.sh" "%{_:lib}%"] # pass along the lib directory for the rpath in the META
+  [make "-C" "ocaml" "all"]
+  ["./mk_dot_install.sh"]
+  ["./ldconfig.sh"] # fix up .so files if ldconfig didn't do it
+  [make "-C" "ocaml" "test"] {with-test}
+]
+install: [
+  ["opam-installer" "--prefix=%{prefix}%" "libdash.install"]
+]
+dev-repo: "git+https:///github.com/mgree/libdash"
+url {
+  src: "https://github.com/mgree/libdash/archive/v0.3.tar.gz"
+  checksum: "md5=e6d8f86ca8973336f92d2010de21b1ea"
+}
+


### PR DESCRIPTION
Improvements to pretty printer; new `json_to_shell` and `shell_to_json` executables.

Libdash also now has [Python bindings](https://pypi.org/project/libdash/).