### PR TITLE
containers < 3.7 is not compatible with OCaml 5.0

### DIFF
--- a/packages/containers/containers.2.6.1/opam
+++ b/packages/containers/containers.2.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "uutf" {with-test}
   "mdx" {with-test & < "1.5.0"}
   "odoc" {with-doc}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 depopts: ["base-unix" "base-threads"]
 build: [

--- a/packages/containers/containers.2.6/opam
+++ b/packages/containers/containers.2.6/opam
@@ -20,7 +20,7 @@ depends: [
   "uutf" {with-test}
   "mdx" {with-test & < "1.5.0"}
   "odoc" {with-doc}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 depopts: ["base-unix" "base-threads"]
 build: [

--- a/packages/containers/containers.2.7/opam
+++ b/packages/containers/containers.2.7/opam
@@ -18,7 +18,7 @@ depends: [
   "gen" { with-test }
   "uutf" { with-test }
   "odoc" { with-doc }
-  "ocaml" { >= "4.02.0" }
+  "ocaml" { >= "4.02.0" & < "5.0"}
   "ocaml" { with-test & < "4.11" }
 ]
 depopts: [

--- a/packages/containers/containers.2.8.1/opam
+++ b/packages/containers/containers.2.8.1/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "ocaml" { with-test & < "4.11" }
   "dune" { >= "1.1" }
   "dune-configurator"

--- a/packages/containers/containers.2.8/opam
+++ b/packages/containers/containers.2.8/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "ocaml" { with-test & < "4.11" }
   "dune" { >= "1.1" }
   "dune-configurator"

--- a/packages/containers/containers.3.0.1/opam
+++ b/packages/containers/containers.3.0.1/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.0/opam
+++ b/packages/containers/containers.3.0/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.1/opam
+++ b/packages/containers/containers.3.1/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.2/opam
+++ b/packages/containers/containers.3.2/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.3/opam
+++ b/packages/containers/containers.3.3/opam
@@ -7,7 +7,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.4/opam
+++ b/packages/containers/containers.3.4/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.5.1/opam
+++ b/packages/containers/containers.3.5.1/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.5/opam
+++ b/packages/containers/containers.3.5/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.1" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.6.1/opam
+++ b/packages/containers/containers.3.6.1/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.4" }
   "dune-configurator"
   "seq"

--- a/packages/containers/containers.3.6/opam
+++ b/packages/containers/containers.3.6/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
 ]
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" { >= "4.03.0" & < "5.0" }
   "dune" { >= "1.4" }
   "dune-configurator"
   "seq"


### PR DESCRIPTION
```
#=== ERROR while compiling containers.3.6.1 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/containers.3.6.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p containers -j 47
# exit-code            1
# env-file             ~/.opam/log/containers-8-f2d454.env
# output-file          ~/.opam/log/containers-8-f2d454.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -safe-string -g -bin-annot -I src/monomorphic/.containers_monomorphic.objs/byte -no-alias-deps -o src/monomorphic/.containers_monomorphic.objs/byte/cCMonomorphicShims_.cmo -c -impl src/monomorphic/CCMonomorphicShims_.ml)
# File "src/monomorphic/CCMonomorphicShims_.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3 -warn-error -a+8 -w -32-67 -safe-string -nolabels -open CCMonomorphic -g -bin-annot -I src/core/.containers.objs/byte -I /home/opam/.opam/5.0/lib/either -I /home/opam/.opam/5.0/lib/seq -I src/monomorphic/.containers_monomorphic.objs/byte -no-alias-deps -o src/core/.containers.objs/byte/cCShimsFormat_.cmo -c -impl src/core/CCShimsFormat_.ml)
# File "src/core/CCShimsFormat_.ml", line 6, characters 18-29:
# 6 | let pp_open_tag = pp_open_tag
#                       ^^^^^^^^^^^
# Error: Unbound value pp_open_tag
# Hint: Did you mean pp_open_stag?
```