### PR TITLE
[new release] chamelon and chamelon-unix (0.1.0)

### DIFF
--- a/packages/chamelon-unix/chamelon-unix.0.1.0/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Command-line Unix utilities for chamelon filesystems"
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bos" {>= "0.2.0"}
+  "chamelon" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock-unix" {>= "4.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.1.0/chamelon-v0.1.0.tbz"
+  checksum: [
+    "sha256=416497496af0d8d1f5c71cd4aa56aefdfb47afc02e97afa1b5df6005a236bcbe"
+    "sha512=4b71a34410bc3f969ee0c53e187f93aaefe15c28a88511fc02e78727f37f84d46d1974fc2a3dcff9b4f362e3245c32fc5ad67f27f43bc729f5491cd30321b52f"
+  ]
+}
+x-commit-hash: "28bc3d15d0824f44abf0974031e0be82c592181c"

--- a/packages/chamelon/chamelon.0.1.0/opam
+++ b/packages/chamelon/chamelon.0.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Subset of littlefs filesystem fulfilling MirageOS KV"
+description: """
+Chamelon implements a subset of the littlefs filesystem,
+which was originally designed for microcontroller use.  It exposes
+an interface matching the Mirage_kv.RW module type and operates
+on top of a block device matching Mirage_block.S .
+
+It is extremely not POSIX."""
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "chamelon-unix" {= version & with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-unix" {>= "2.13.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bechamel" {>= "0.2.0" & with-test}
+  "bechamel-js" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.2"}
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "ptime" {>= "0.8.6"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+  "optint" {>= "0.0.4"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.1.0/chamelon-v0.1.0.tbz"
+  checksum: [
+    "sha256=416497496af0d8d1f5c71cd4aa56aefdfb47afc02e97afa1b5df6005a236bcbe"
+    "sha512=4b71a34410bc3f969ee0c53e187f93aaefe15c28a88511fc02e78727f37f84d46d1974fc2a3dcff9b4f362e3245c32fc5ad67f27f43bc729f5491cd30321b52f"
+  ]
+}
+x-commit-hash: "28bc3d15d0824f44abf0974031e0be82c592181c"


### PR DESCRIPTION
Subset of littlefs filesystem fulfilling MirageOS KV

- Project page: <a href="https://github.com/yomimono/chamelon">https://github.com/yomimono/chamelon</a>

##### CHANGES:

* new features: expose and implement `Kv.size t key` and `Kv.get_partial t key ~offset ~length`.
* bugfix: large files could be misread under certain circumstances because the final block index wasn't correctly calculated. remove `bitwise` module and the Base `popcount` it referenced, and instead calculate the block index with a recursive function.
* bugfix: detect unwriteable blocks instead of endlessly splitting to try to accommodate them.
* bugfix: keep track of allocated but not-yet-written blocks, and don't hand them out twice.
* bugfix: check the maximum name length against the block size when mounting a filesystem.
