### PR TITLE
[new release] chamelon and chamelon-unix (0.1.1)

### DIFF
--- a/packages/chamelon-unix/chamelon-unix.0.1.1/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Command-line Unix utilities for chamelon filesystems"
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-combinators" {>= "3.0.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bos" {>= "0.2.0"}
+  "chamelon" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.13.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-clock-unix" {>= "4.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.1.1/chamelon-v0.1.1.tbz"
+  checksum: [
+    "sha256=4b56bfe8cc25585ddaee3cda1049e7541b63f730674744d14d762a8ee14b34e4"
+    "sha512=e715cb666cc885a9e179d466c1444b79e5c6f53a167fe6af9e3d567fd2c1c181f6e68b50386f6db1423a0032fca25e4620a94e94aa4c0ab22bc016b7c6827ae8"
+  ]
+}
+x-commit-hash: "602625d105fee39649507b483f02eae1529d00d6"

--- a/packages/chamelon/chamelon.0.1.1/opam
+++ b/packages/chamelon/chamelon.0.1.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: [ "yomimono <maintenance@identity-function.com>" ]
+authors: [ "yomimono <maintenance@identity-function.com>" ]
+homepage: "https://github.com/yomimono/chamelon"
+bug-reports: "https://github.com/yomimono/chamelon/issues"
+dev-repo: "git+https://github.com/yomimono/chamelon.git"
+license: "ISC"
+synopsis: "Subset of littlefs filesystem fulfilling MirageOS KV"
+description: """
+Chamelon implements a subset of the littlefs filesystem,
+which was originally designed for microcontroller use.  It exposes
+an interface matching the Mirage_kv.RW module type and operates
+on top of a block device matching Mirage_block.S .
+
+It is extremely not POSIX."""
+
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "crowbar" {>= "0.2.1" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "mirage-block-combinators" {>= "3.0.0" & with-test}
+  "mirage-block-unix" {>= "2.13.0" & with-test}
+  "mirage-clock-unix" {>= "4.0.0" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "bechamel" {>= "0.2.0" & with-test}
+  "bechamel-js" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.2"}
+  "cstruct" {>= "6.0.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "logs" {>= "0.6.0"}
+  "lwt" {>= "5.3.0"}
+  "ptime" {>= "0.8.6"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-kv" {>= "4.0.1"}
+  "mirage-logs" {>= "1.2.0"}
+  "optint" {>= "0.0.4"}
+]
+url {
+  src:
+    "https://github.com/yomimono/chamelon/releases/download/v0.1.1/chamelon-v0.1.1.tbz"
+  checksum: [
+    "sha256=4b56bfe8cc25585ddaee3cda1049e7541b63f730674744d14d762a8ee14b34e4"
+    "sha512=e715cb666cc885a9e179d466c1444b79e5c6f53a167fe6af9e3d567fd2c1c181f6e68b50386f6db1423a0032fca25e4620a94e94aa4c0ab22bc016b7c6827ae8"
+  ]
+}
+x-commit-hash: "602625d105fee39649507b483f02eae1529d00d6"


### PR DESCRIPTION
CHANGES:

* bugfix: remove dependency cycle between chamelon and chamelon-unix
* bugfix: tag src/runtest with `(package chamelon-unix)`