### PR TITLE
Package monaco_jsoo.1.0.0

### DIFF
--- a/packages/monaco_jsoo/monaco_jsoo.1.0.0/opam
+++ b/packages/monaco_jsoo/monaco_jsoo.1.0.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "JSOO interface for Monaco-editor"
+maintainer: "jun.furuse@dailambda.jp"
+authors: "Jun Furuse"
+license: "MIT"
+homepage: "https://gitlab.com/dailambda/monaco_jsoo/"
+bug-reports: "https://gitlab.com/dailambda/monaco_jsoo/"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.12.1"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dailambda/monaco_jsoo/"
+url {
+  src:
+    "https://gitlab.com/dailambda/monaco_jsoo/-/archive/1.0.0/monaco_jsoo-1.0.0.tar.gz"
+  checksum: [
+    "md5=54c868cc5453d92b79c6bfd85248efcc"
+    "sha512=116cc0001d71d530af02f193b2e72b138eceb9cc44ca4da525c01034d7de8ccf081dd2c4cd807fe858f05419cf62b8118f9a35bdafd6bf2bcc15386a263a1c90"
+  ]
+}


### PR DESCRIPTION
### `monaco_jsoo.1.0.0`
JSOO interface for Monaco-editor



---
* Homepage: https://gitlab.com/dailambda/monaco_jsoo/
* Source repo: git+https://gitlab.com/dailambda/monaco_jsoo/
* Bug tracker: https://gitlab.com/dailambda/monaco_jsoo/

---
:camel: Pull-request generated by opam-publish v2.1.0