### PR TITLE
mirage-block-unix < 2.14.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.0.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.0.0/opam
@@ -14,7 +14,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1"}
   "ppx_cstruct"

--- a/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.1.0/opam
@@ -14,7 +14,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1" & <"3.4.0"}
   "ppx_cstruct"

--- a/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.10.0/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.11.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.1/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.11.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.11.2/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.12.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.12.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0" & < "6.1.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.12.1/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.12.1/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "dune" {>="1.0"}
   "cstruct" {>= "3.0.0" & < "6.1.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.13.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.13.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "6.0.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.14.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.14.0/opam
@@ -8,7 +8,7 @@ bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
 tags:         "org:mirage"
 license:      "ISC"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "6.0.0"}
   "cstruct-lwt"

--- a/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.2.0/opam
@@ -14,7 +14,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.0.1" & <"3.4.0"}
   "ppx_cstruct"

--- a/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.3.0/opam
@@ -14,7 +14,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0" & <"3.4.0"} 
   "ppx_cstruct" {<"3.4.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.4.0/opam
@@ -14,7 +14,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "cstruct" {>= "1.3.0" & <"3.4.0"}
   "ppx_cstruct" {<"3.4.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.5.0/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove:  ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0" & <"3.4.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.6.0/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove:  ["ocamlfind" "remove" "mirage-block-unix"]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.3.0" & <"3.4.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.2/opam
@@ -11,7 +11,7 @@ build: [
   ["jbuilder" "runtest"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta7"}
   "cstruct" {>= "1.3.0" & < "3.4.0"}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.3/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.3/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "cstruct" {>= "3.0.0"}
   "cstruct" {<"3.4.0" & with-test}

--- a/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.8.4/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "cstruct" {>= "3.0.0"}
   "cstruct" {<"3.4.0" & with-test}

--- a/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.9.0/opam
@@ -13,7 +13,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "cstruct" {>= "3.0.0"}
   "cstruct" {<"3.4.0" & with-test}


### PR DESCRIPTION
C stub made incorrect assumptions over uerror. For example:
```
#=== ERROR while compiling chamelon-unix.0.1.1 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | pinned(https://github.com/yomimono/chamelon/releases/download/v0.1.1/chamelon-v0.1.1.tbz)
# path                 ~/.opam/5.0/.opam-switch/build/chamelon-unix.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p chamelon-unix -j 31
# exit-code            1
# env-file             ~/.opam/log/chamelon-unix-9762-9339af.env
# output-file          ~/.opam/log/chamelon-unix-9762-9339af.out
### output ###
# File "src/dune", line 3, characters 15-23:
# 3 |   (public_name chamelon)
#                    ^^^^^^^^
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o src/chamelon.exe /home/opam/.opam/5.0/lib/rresult/rresult.cmxa /home/opam/.opam/5.0/lib/astring/astring.cmxa /home/opam/.opam/5.0/lib/fpath/fpath.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/logs/logs.cmxa /home/opam/.opam/5.0/lib/bos/bos.cmxa /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_cli.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_tty.cmxa /home/opam/.opam/5.0/lib/eqaf/eqaf.cmxa /home/opam/.opam/5.0/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/digestif/c/digestif_c.cmxa -I /home/opam/.opam/5.0/lib/digestif/c /home/opam/.opam/5.0/lib/optint/optint.cmxa /home/opam/.opam/5.0/lib/checkseum/c/checkseum_c.cmxa -I /home/opam/.opam/5.0/lib/checkseum/c /home/opam/.opam/5.0/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.0/lib/cstruct /home/opam/.opam/5.0/lib/ptime/ptime.cmxa /home/opam/.opam/5.0/lib/chamelon/chamelon.cmxa -I /home/opam/.opam/5.0/lib/ocaml /home/opam/.opam/5.0/lib/lwt/lwt.cmxa /home/opam/.opam/5.0/lib/mirage-block/mirage_block.cmxa /home/opam/.opam/5.0/lib/mirage-clock/mirage_clock.cmxa /home/opam/.opam/5.0/lib/mirage-kv/mirage_kv.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.0/lib/mirage-profile/mirage_profile.cmxa /home/opam/.opam/5.0/lib/mirage-logs/mirage_logs.cmxa /home/opam/.opam/5.0/lib/chamelon/kv/kv.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa -I /home/opam/.opam/5.0/lib/ocaml /home/opam/.opam/5.0/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.0/lib/lwt/unix /home/opam/.opam/5.0/lib/cstruct-lwt/cstruct_lwt.cmxa /home/opam/.opam/5.0/lib/io-page/io_page.cmxa /home/opam/.opam/5.0/lib/seq/seq.cmxa /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/re/posix/re_posix.cmxa /home/opam/.opam/5.0/lib/stringext/stringext.cmxa /home/opam/.opam/5.0/lib/uri/uri.cmxa /home/opam/.opam/5.0/lib/mirage-block-unix/mirage_block_unix.cmxa -I /home/opam/.opam/5.0/lib/mirage-block-unix /home/opam/.opam/5.0/lib/mirage-clock-unix/mirage_clock_unix.cmxa -I /home/opam/.opam/5.0/lib/mirage-clock-unix /home/opam/.opam/5.0/lib/logs/logs_cli.cmxa /home/opam/.opam/5.0/lib/logs/logs_fmt.cmxa src/.chamelon.eobjs/native/dune__exe.cmx src/.chamelon.eobjs/native/dune__exe__Common_options.cmx src/.chamelon.eobjs/native/dune__exe__Lfs_ls.cmx src/.chamelon.eobjs/native/dune__exe__Chamelon.cmx)
# /usr/bin/ld: /home/opam/.opam/5.0/lib/mirage-block-unix/libmirage_block_unix_stubs.a(blkgetsize_stubs.o): in function `stub_blkgetsize':
# /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:126: undefined reference to `enter_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:129: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:131: undefined reference to `uerror'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:129: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/mirage-block-unix/libmirage_block_unix_stubs.a(blkgetsize_stubs.o): in function `stub_blkgetsectorsize':
# /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:144: undefined reference to `enter_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:147: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:149: undefined reference to `uerror'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/blkgetsize_stubs.c:147: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/mirage-block-unix/libmirage_block_unix_stubs.a(flock_stubs.o): in function `stub_flock':
# /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/flock_stubs.c:47: undefined reference to `enter_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/flock_stubs.c:49: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/flock_stubs.c:52: undefined reference to `uerror'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/mirage-block-unix/libmirage_block_unix_stubs.a(lseekhole_stubs.o): in function `stub_lseek_data_64':
# /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/lseekhole_stubs.c:46: undefined reference to `uerror'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/mirage-block-unix/libmirage_block_unix_stubs.a(lseekhole_stubs.o): in function `stub_lseek_hole_64':
# /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/lseekhole_stubs.c:69: undefined reference to `uerror'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/mirage-block-unix/libmirage_block_unix_stubs.a(odirect_stubs.o): in function `stub_openfile_direct':
# /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/odirect_stubs.c:47: undefined reference to `enter_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/odirect_stubs.c:63: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/mirage-block-unix.2.13.0/_build/default/lib/odirect_stubs.c:67: undefined reference to `uerror'
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```