### PR TITLE
treeprint.2.2.0: Add missing dependency (jbuilder uses OMP1 for ppxs)

### DIFF
--- a/packages/treeprint/treeprint.2.2.0/opam
+++ b/packages/treeprint/treeprint.2.2.0/opam
@@ -11,6 +11,7 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "spotlib" {>= "3.0.0"}
   "ppx_meta_conv" {>= "4.0.0"}
+  "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 synopsis:
   "Small tree structure printer with operator associations and precedences"


### PR DESCRIPTION
```
#=== ERROR while compiling treeprint.2.2.0 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/treeprint.2.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p treeprint -j 31
# exit-code            1
# env-file             ~/.opam/log/treeprint-933-2ab35d.env
# output-file          ~/.opam/log/treeprint-933-2ab35d.out
### output ###
# Error: I couldn't find 'ocaml-migrate-parsetree.driver-main'.
# I need this library in order to use ppx rewriters.
# See the manual for details.
# Hint: opam install ocaml-migrate-parsetree

- Error: I couldn't find 'ocaml-migrate-parsetree.driver-main'.
- I need this library in order to use ppx rewriters.
- See the manual for details.
- Hint: opam install ocaml-migrate-parsetree
```