### PR TITLE
magic-mime.1.0.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/magic-mime/magic-mime.1.0.0/opam
+++ b/packages/magic-mime/magic-mime.1.0.0/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "magic-mime"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling magic-mime.1.0.0 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/magic-mime.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/magic-mime-615-61b62e.env
# output-file          ~/.opam/log/magic-mime-615-61b62e.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```