### PR TITLE
Release GuaCaml v0.05

### DIFF
--- a/packages/GuaCaml/GuaCaml.0.03.01/opam
+++ b/packages/GuaCaml/GuaCaml.0.03.01/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/guacaml"
 bug-reports: "https://gitlab.com/boreal-ldd/guacaml"
 depends: [
-	"ocaml" {>= "4.08"}
+	"ocaml" {>= "4.08" & < "5.0"}
 	"ocamlbuild" {build}
 	"ocamlfind" {build}
 ]

--- a/packages/GuaCaml/GuaCaml.0.04/opam
+++ b/packages/GuaCaml/GuaCaml.0.04/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/guacaml"
 bug-reports: "https://gitlab.com/boreal-ldd/guacaml"
 depends: [
-	"ocaml" {>= "4.13"}
+	"ocaml" {>= "4.13" & < "5.0"}
 	"ocamlbuild" {build}
 	"ocamlfind" {build}
 ]

--- a/packages/GuaCaml/GuaCaml.0.04/opam
+++ b/packages/GuaCaml/GuaCaml.0.04/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/guacaml"
 bug-reports: "https://gitlab.com/boreal-ldd/guacaml"
 depends: [
-	"ocaml" {>= "4.13" & < "5.0"}
+	"ocaml" {>= "4.13"}
 	"ocamlbuild" {build}
 	"ocamlfind" {build}
 ]

--- a/packages/GuaCaml/GuaCaml.0.05/opam
+++ b/packages/GuaCaml/GuaCaml.0.05/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "GuaCaml : Generic Unspecific Algorithmic in OCaml"
+maintainer: "Joan Thibault <joan.thibault@ens-rennes.fr>"
+authors: "Joan Thibault <joan.thibault@ens-rennes.fr>"
+license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://gitlab.com/boreal-ldd/guacaml"
+bug-reports: "https://gitlab.com/boreal-ldd/guacaml"
+depends: [
+	"ocaml" {>= "4.13"}
+	"ocamlbuild" {build}
+	"ocamlfind" {build}
+]
+build: make
+install: [make "install"]
+dev-repo: "git+https://gitlab.com/boreal-ldd/guacaml#release"
+url {
+	src:"https://gitlab.com/boreal-ldd/guacaml/-/archive/v0.05/guacaml-v0.05.tar.gz"
+}

--- a/packages/GuaCaml/GuaCaml.0.05/opam
+++ b/packages/GuaCaml/GuaCaml.0.05/opam
@@ -15,4 +15,5 @@ install: [make "install"]
 dev-repo: "git+https://gitlab.com/boreal-ldd/guacaml#release"
 url {
 	src:"https://gitlab.com/boreal-ldd/guacaml/-/archive/v0.05/guacaml-v0.05.tar.gz"
+	checksum:"md5=6ec6238bca1d0f419bec6a2eeaee5983"
 }

--- a/packages/Snowflake/Snowflake.0.02.02/opam
+++ b/packages/Snowflake/Snowflake.0.02.02/opam
@@ -7,7 +7,7 @@ homepage: "https://gitlab.com/boreal-ldd/snowflake"
 bug-reports: "https://gitlab.com/boreal-ldd/snowflake"
 depends: [
 	"ocaml" {>= "4.08"}
-	"GuaCaml" {>= "0.03"}
+	"GuaCaml" {>= "0.03" & < "0.05"}
 	"mlbdd" {>= "0.7.2"}
 	"ocamlbuild" {build}
 	"ocamlfind" {build}

--- a/packages/Snowflake/Snowflake.0.02.02/opam
+++ b/packages/Snowflake/Snowflake.0.02.02/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/snowflake"
 bug-reports: "https://gitlab.com/boreal-ldd/snowflake"
 depends: [
-	"ocaml" {>= "4.08" & < "5.0"}
+	"ocaml" {>= "4.08"}
 	"GuaCaml" {>= "0.03" & < "0.05"}
 	"mlbdd" {>= "0.7.2"}
 	"ocamlbuild" {build}

--- a/packages/Snowflake/Snowflake.0.02.02/opam
+++ b/packages/Snowflake/Snowflake.0.02.02/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/snowflake"
 bug-reports: "https://gitlab.com/boreal-ldd/snowflake"
 depends: [
-	"ocaml" {>= "4.08"}
+	"ocaml" {>= "4.08" & < "5.0"}
 	"GuaCaml" {>= "0.03" & < "0.05"}
 	"mlbdd" {>= "0.7.2"}
 	"ocamlbuild" {build}


### PR DESCRIPTION
New release of GuaCaml

- graph related modules have been largely refactore
- added export to GraphViz
- introduced some tiny meta-programming-like features