### PR TITLE
[new release] xapi-rrd (1.9.0)

### DIFF
--- a/packages/xapi-rrd/xapi-rrd.1.9.0/opam
+++ b/packages/xapi-rrd/xapi-rrd.1.9.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "base-bigarray"
   "base-unix"
-  "ppx_deriving_rpc"
+  "ppx_deriving_rpc" {>= "6.1.0"}
   "rpclib"
   "xmlm"
   "uuidm"

--- a/packages/xapi-rrd/xapi-rrd.1.9.0/opam
+++ b/packages/xapi-rrd/xapi-rrd.1.9.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xen.org"
+authors: ["Dave Scott" "Jon Ludlam" "John Else"]
+homepage: "https://github.com/xapi-project/xcp-rrd"
+bug-reports: "https://github.com/xapi-project/xcp-rrd/issues"
+dev-repo: "git+https://github.com/xapi-project/xcp-rrd.git"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: [
+  "org:xapi-project"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.05"}
+  "dune" {>= "2.0.0"}
+  "base-bigarray"
+  "base-unix"
+  "ppx_deriving_rpc"
+  "rpclib"
+  "xmlm"
+  "uuidm"
+  "xapi-stdext-pervasives"
+  "yojson"
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "xapi-stdext-unix" {with-test}
+]
+synopsis: "RRD library for use with xapi"
+description: """
+Round-Robin Databases (RRDs) are constant-space datastructures
+used for archiving historical data where the older data is stored
+at a lower resolution."""
+url {
+  src:
+    "https://github.com/xapi-project/xcp-rrd/releases/download/v1.9.0/xapi-rrd-1.9.0.tbz"
+  checksum: [
+    "sha256=165da683983352b2d951dee5da99f081049a71f14edd2cc67b3161f2c272310b"
+    "sha512=0f56ab2c738f76156fceebef16eaac9338f8ebf98e73a825ac5f3766ffccaa8bcb202cdb712d375655e0dfca34e01b9bd7302097775c95fa3a57c0ab9bdd87cb"
+  ]
+}
+x-commit-hash: "7ce1ac344bae7d6b31678c3ad942a4bd8026d296"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.14.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.14.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "jonathan.ludlam@citrix.com"
 authors: "xen-api@list.xen.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
@@ -9,7 +10,7 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "1.11"}
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.16.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.16.0/opam
@@ -1,6 +1,7 @@
 opam-version: "2.0"
 maintainer: "jonathan.ludlam@citrix.com"
 authors: "xen-api@list.xen.org"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 homepage: "https://xapi-project.github.io/"
@@ -9,7 +10,7 @@ tags: [ "org:xapi-project" ]
 build:  [[ "dune" "build" "-p" name "-j" jobs ]]
 
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "1.11"}
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/xapi-project/stdext"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "1.11"}
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}


### PR DESCRIPTION
RRD library for use with xapi

- Project page: <a href="https://github.com/xapi-project/xcp-rrd">https://github.com/xapi-project/xcp-rrd</a>

##### CHANGES:

* ocamlformat: apply new formatting
* unix: remove code from module
* CA-367236: replace ezjsonm with yojson
* Add license to opam metadata and delete deprecated package
* ci: drop travis
* ci: use github
* maintenance: format code with ocamlformat
* chore: prepare for ocamlformat, use dune 2.0
