### PR TITLE
dispatch < 0.4.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/dispatch/dispatch.0.1.0/opam
+++ b/packages/dispatch/dispatch.0.1.0/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "dispatch"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "1.0.2"}
   "result"

--- a/packages/dispatch/dispatch.0.2.0/opam
+++ b/packages/dispatch/dispatch.0.2.0/opam
@@ -30,7 +30,7 @@ remove: [
   ["ocamlfind" "remove" "dispatch"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "1.0.2"}
   "result"

--- a/packages/dispatch/dispatch.0.3.0/opam
+++ b/packages/dispatch/dispatch.0.3.0/opam
@@ -31,7 +31,7 @@ remove: [
   ["ocamlfind" "remove" "dispatch"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "1.0.2"}
   "result"


### PR DESCRIPTION
Fixes #21892 
```
#=== ERROR while compiling dispatch.0.3.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/dispatch.0.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-js-of-ocaml
# exit-code            2
# env-file             ~/.opam/log/dispatch-8-70dd10.env
# output-file          ~/.opam/log/dispatch-8-70dd10.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```