### PR TITLE
crunch < 2.0.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/crunch/crunch.1.4.0/opam
+++ b/packages/crunch/crunch.1.4.0/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "crunch"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "cmdliner"
   "ocamlbuild" {build}

--- a/packages/crunch/crunch.1.4.1/opam
+++ b/packages/crunch/crunch.1.4.1/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "crunch"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "cmdliner"
   "ocamlbuild" {build}


### PR DESCRIPTION
Fixes #21891 
```
#=== ERROR while compiling crunch.1.4.1 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/crunch.1.4.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/crunch-8-de7439.env
# output-file          ~/.opam/log/crunch-8-de7439.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```