### PR TITLE
Add llvm and conf-llvm for 14.0.6.

### DIFF
--- a/packages/conf-llvm/conf-llvm.14.0.6/files/configure.sh
+++ b/packages/conf-llvm/conf-llvm.14.0.6/files/configure.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+version=${1/%.?.?/}
+
+if hash brew 2>/dev/null; then
+    brew_llvm_config="$(brew --cellar)"/llvm*/${version}*/bin/llvm-config
+fi
+
+shopt -s nullglob
+for llvm_config in llvm-config-$version llvm-config-${version}.0 llvm-config${version}0 llvm-config-mp-$version llvm-config-mp-${version}.0 llvm${version}-config llvm-config-${version}-32 llvm-config-${version}-64 llvm-config $brew_llvm_config; do
+    llvm_version="`$llvm_config --version`" || true
+    case $llvm_version in
+    $version*)
+        echo "config: \"$llvm_config\"" >> conf-llvm.config
+        echo "version: \"$llvm_version\"" >> conf-llvm.config
+        exit 0;;
+    *)
+        echo "Note: '$llvm_config' doesn't match the required version. Got '$llvm_version' but required '$version'."
+        continue;;
+    esac
+done
+
+echo "Error: LLVM ${version} is not installed."
+exit 1

--- a/packages/conf-llvm/conf-llvm.14.0.6/opam
+++ b/packages/conf-llvm/conf-llvm.14.0.6/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "-ex" "configure.sh" version]
+]
+depexts: [
+  ["llvm@14"] {os-distribution = "homebrew" & os = "macos"}
+  ["llvm-14"] {os-distribution = "macports" & os = "macos"}
+  ["llvm-14-dev"] {os-family = "debian"}
+  ["llvm14-dev"] {os-distribution = "alpine"}
+  ["llvm14-devel"] {os-family = "suse"}
+  ["llvm14-devel"] {os-distribution = "fedora"}
+  ["llvm14-devel" "epel-release"] {os-distribution = "centos"}
+  ["devel/llvm14"] {os = "freebsd"}
+]
+synopsis: "Virtual package relying on llvm library installation"
+extra-files: ["configure.sh" "md5=2750506041c4edef4482ce9fb5f30aa1"]
+flags: conf

--- a/packages/llvm/llvm.14.0.6/files/META.patch
+++ b/packages/llvm/llvm.14.0.6/files/META.patch
@@ -1,7 +1,7 @@
-diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+diff --git a/llvm/bindings/ocaml/backends/META.llvm_backend.in b/llvm/bindings/ocaml/backends/META.llvm_backend.in
 index bd23abe0ca4..053e7a4f2e8 100644
---- a/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
-+++ b/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
+--- a/llvm/bindings/ocaml/backends/META.llvm_backend.in
++++ b/llvm/bindings/ocaml/backends/META.llvm_backend.in
 @@ -2,6 +2,8 @@ name = "llvm_@TARGET@"
  version = "@PACKAGE_VERSION@"
  description = "@TARGET@ Backend for LLVM"
@@ -13,10 +13,10 @@ index bd23abe0ca4..053e7a4f2e8 100644
 +archive(byte, llvm.static) = "static/llvm_@TARGET@.cma"
 +archive(native, llvm.static) = "static/llvm_@TARGET@.cmxa"
  directory = "llvm"
-diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+diff --git a/llvm/bindings/ocaml/llvm/META.llvm.in b/llvm/bindings/ocaml/llvm/META.llvm.in
 index 991bbc0600..a118933875 100644
---- a/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
-+++ b/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
+--- a/llvm/bindings/ocaml/llvm/META.llvm.in
++++ b/llvm/bindings/ocaml/llvm/META.llvm.in
 @@ -1,118 +1,148 @@
  name = "llvm"
  version = "@PACKAGE_VERSION@"

--- a/packages/llvm/llvm.14.0.6/files/META.patch
+++ b/packages/llvm/llvm.14.0.6/files/META.patch
@@ -1,0 +1,199 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
++++ b/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,8 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte, -llvm.static) = "shared/llvm_@TARGET@.cma"
++archive(native, -llvm.static) = "shared/llvm_@TARGET@.cmxa"
++archive(byte, llvm.static) = "static/llvm_@TARGET@.cma"
++archive(native, llvm.static) = "static/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index 991bbc0600..a118933875 100644
+--- a/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
++++ b/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
+@@ -1,118 +1,148 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte, -llvm.static) = "shared/llvm.cma"
++archive(native, -llvm.static) = "shared/llvm.cmxa"
++archive(byte, llvm.static) = "static/llvm.cma"
++archive(native, llvm.static) = "static/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_analysis.cma"
++    archive(native, -llvm.static) = "shared/llvm_analysis.cmxa"
++    archive(byte, llvm.static) = "static/llvm_analysis.cma"
++    archive(native, llvm.static) = "static/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitreader.cma"
++    archive(native, llvm.static) = "static/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitwriter.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitwriter.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitwriter.cma"
++    archive(native, llvm.static) = "static/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_executionengine.cma"
++    archive(native, -llvm.static) = "shared/llvm_executionengine.cmxa"
++    archive(byte, llvm.static) = "static/llvm_executionengine.cma"
++    archive(native, llvm.static) = "static/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_ipo.cma"
++    archive(native, -llvm.static) = "shared/llvm_ipo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_ipo.cma"
++    archive(native, llvm.static) = "static/llvm_ipo.cmxa"
+ )
+ 
+ package "debuginfo" (
+     requires = "llvm"
+-    version = "@PACKAGE_VERSION@"
++    version  = "@PACKAGE_VERSION@"
+     description = "DebugInfo support for LLVM"
+-    archive(byte) = "llvm_debuginfo.cma"
+-    archive(native) = "llvm_debuginfo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_debuginfo.cma"
++    archive(native, -llvm.static) = "shared/llvm_debuginfo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_debuginfo.cma"
++    archive(native, llvm.static) = "static/llvm_debuginfo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_irreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_irreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_irreader.cma"
++    archive(native, llvm.static) = "static/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_scalar_opts.cma"
++    archive(native, -llvm.static) = "shared/llvm_scalar_opts.cmxa"
++    archive(byte, llvm.static) = "static/llvm_scalar_opts.cma"
++    archive(native, llvm.static) = "static/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_transform_utils.cma"
++    archive(native, -llvm.static) = "shared/llvm_transform_utils.cmxa"
++    archive(byte, llvm.static) = "static/llvm_transform_utils.cma"
++    archive(native, llvm.static) = "static/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_vectorize.cma"
++    archive(native, -llvm.static) = "shared/llvm_vectorize.cmxa"
++    archive(byte, llvm.static) = "static/llvm_vectorize.cma"
++    archive(native, llvm.static) = "static/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_passmgr_builder.cma"
++    archive(native, -llvm.static) = "shared/llvm_passmgr_builder.cmxa"
++    archive(byte, llvm.static) = "static/llvm_passmgr_builder.cma"
++    archive(native, llvm.static) = "static/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_target.cma"
++    archive(native, -llvm.static) = "shared/llvm_target.cmxa"
++    archive(byte, llvm.static) = "static/llvm_target.cma"
++    archive(native, llvm.static) = "static/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_linker.cma"
++    archive(native, -llvm.static) = "shared/llvm_linker.cmxa"
++    archive(byte, llvm.static) = "static/llvm_linker.cma"
++    archive(native, llvm.static) = "static/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_all_backends.cma"
++    archive(native, -llvm.static) = "shared/llvm_all_backends.cmxa"
++    archive(byte, llvm.static) = "static/llvm_all_backends.cma"
++    archive(native, llvm.static) = "static/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.14.0.6/files/fix-macos.patch
+++ b/packages/llvm/llvm.14.0.6/files/fix-macos.patch
@@ -1,0 +1,30 @@
+From 98ca3c8802d0ae92a5baf34ffdc454d680276845 Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Sat, 25 Dec 2021 18:21:57 +0000
+Subject: [PATCH 2/2] Fix support for building the OCaml binding on macOS
+
+The output of ocamlmklib is always .a and .so
+---
+ llvm/cmake/modules/AddOCaml.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+index b7e2ba430344..dc80abcc6e75 100644
+--- a/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
++++ b/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
+@@ -40,10 +40,10 @@ function(add_ocaml_library name)
+   set(ocaml_outputs "${bin}/${name}.cma")
+   if( ARG_C )
+     list(APPEND ocaml_outputs
+-         "${bin}/lib${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
++         "${bin}/lib${name}.a")
+     if ( BUILD_SHARED_LIBS )
+       list(APPEND ocaml_outputs
+-           "${bin}/dll${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
++           "${bin}/dll${name}.so")
+     endif()
+   endif()
+   if( HAVE_OCAMLOPT )
+-- 
+2.34.0
+

--- a/packages/llvm/llvm.14.0.6/files/fix-macos.patch
+++ b/packages/llvm/llvm.14.0.6/files/fix-macos.patch
@@ -5,13 +5,13 @@ Subject: [PATCH 2/2] Fix support for building the OCaml binding on macOS
 
 The output of ocamlmklib is always .a and .so
 ---
- llvm/cmake/modules/AddOCaml.cmake | 4 ++--
+ llvm-project/llvm/cmake/modules/AddOCaml.cmake | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
-diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+diff --git a/llvm-project/llvm/cmake/modules/AddOCaml.cmake b/llvm-project/llvm/cmake/modules/AddOCaml.cmake
 index b7e2ba430344..dc80abcc6e75 100644
---- a/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
-+++ b/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
 @@ -40,10 +40,10 @@ function(add_ocaml_library name)
    set(ocaml_outputs "${bin}/${name}.cma")
    if( ARG_C )

--- a/packages/llvm/llvm.14.0.6/files/fix-rhel.patch
+++ b/packages/llvm/llvm.14.0.6/files/fix-rhel.patch
@@ -10,8 +10,8 @@ Subject: [PATCH] Handle RHEL-based distributions (do not have
 
 diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
 index dc80abcc6e75..f51a339f084b 100644
---- a/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
-+++ b/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
 @@ -66,20 +66,22 @@ function(add_ocaml_library name)
      list(APPEND ocaml_flags "-custom")
    endif()

--- a/packages/llvm/llvm.14.0.6/files/fix-rhel.patch
+++ b/packages/llvm/llvm.14.0.6/files/fix-rhel.patch
@@ -1,0 +1,45 @@
+From 58e8402f9000d0dfe67b3df99ed8cd21b8325acd Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Sun, 26 Dec 2021 05:09:10 +0000
+Subject: [PATCH] Handle RHEL-based distributions (do not have
+ libLLVM-<VERSION>.so, only libLLVM.so)
+
+---
+ llvm/cmake/modules/AddOCaml.cmake | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+index dc80abcc6e75..f51a339f084b 100644
+--- a/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
++++ b/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
+@@ -66,20 +66,22 @@ function(add_ocaml_library name)
+     list(APPEND ocaml_flags "-custom")
+   endif()
+ 
++  if(LLVM_OCAML_OUT_OF_TREE)
++    list(APPEND ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
++  endif()
++
+   if(LLVM_LINK_LLVM_DYLIB)
+     list(APPEND ocaml_flags "-lLLVM")
+   else()
+     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-    if( BUILD_SHARED_LIBS )
+-      list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
++
++    if(BUILD_SHARED_LIBS AND LLVM_OCAML_OUT_OF_TREE)
++      list(APPEND ocaml_flags ${LLVM_OCAML_EXTERNAL_LLVM_LIBS})
+     else()
+       foreach( llvm_lib ${llvm_libs} )
+         list(APPEND ocaml_flags "-l${llvm_lib}" )
+       endforeach()
+     endif()
+-    if(LLVM_OCAML_OUT_OF_TREE)
+-      list(APPEND ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
+-    endif()
+ 
+     get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+     foreach(system_lib ${system_libs})
+-- 
+2.34.0
+

--- a/packages/llvm/llvm.14.0.6/files/fix-shared.patch
+++ b/packages/llvm/llvm.14.0.6/files/fix-shared.patch
@@ -10,8 +10,8 @@ Subject: [PATCH 1/2] Add support for out-of-tree shared linked OCaml LLVM
 
 diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
 index 891c9e6d618c..b7e2ba430344 100644
---- a/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
-+++ b/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
 @@ -70,9 +70,16 @@ function(add_ocaml_library name)
      list(APPEND ocaml_flags "-lLLVM")
    else()

--- a/packages/llvm/llvm.14.0.6/files/fix-shared.patch
+++ b/packages/llvm/llvm.14.0.6/files/fix-shared.patch
@@ -1,0 +1,37 @@
+From 7eaf48ca7f0b2ba0b5871b48fbe4a1b1460afbef Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Sat, 25 Dec 2021 18:21:00 +0000
+Subject: [PATCH 1/2] Add support for out-of-tree shared linked OCaml LLVM
+ binding
+
+---
+ llvm/cmake/modules/AddOCaml.cmake | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+index 891c9e6d618c..b7e2ba430344 100644
+--- a/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
++++ b/llvm-14.0.6.src/cmake/modules/AddOCaml.cmake
+@@ -70,9 +70,16 @@ function(add_ocaml_library name)
+     list(APPEND ocaml_flags "-lLLVM")
+   else()
+     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-    foreach( llvm_lib ${llvm_libs} )
+-      list(APPEND ocaml_flags "-l${llvm_lib}" )
+-    endforeach()
++    if( BUILD_SHARED_LIBS )
++      list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
++    else()
++      foreach( llvm_lib ${llvm_libs} )
++        list(APPEND ocaml_flags "-l${llvm_lib}" )
++      endforeach()
++    endif()
++    if(LLVM_OCAML_OUT_OF_TREE)
++      list(APPEND ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
++    endif()
+ 
+     get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+     foreach(system_lib ${system_libs})
+-- 
+2.34.0
+

--- a/packages/llvm/llvm.14.0.6/files/install.sh
+++ b/packages/llvm/llvm.14.0.6/files/install.sh
@@ -27,7 +27,6 @@ function llvm_build {
         -DLLVM_OCAML_OUT_OF_TREE=TRUE \
         -DLLVM_OCAML_INSTALL_PATH="${libdir}" \
         -DLLVM_OCAML_EXTERNAL_LLVM_LIBS="`"$llvm_config" --libs`" \
-        -DLLVM_INCLUDE_BENCHMARKS=FALSE \
         ..
     $make ocaml_all
 

--- a/packages/llvm/llvm.14.0.6/files/install.sh
+++ b/packages/llvm/llvm.14.0.6/files/install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash -ex
+
+llvm_config="$1"
+libdir="$2"
+cmake="$3"
+make="$4"
+action="$5"
+
+function filter_experimental_targets {
+    sed 's/AVR//g' | sed 's/M68k//g' | sed 's/Nios2//g' | xargs
+}
+
+function llvm_build {
+    cd llvm-14.0.6.src
+
+    # Copy the required Common LLVM CMake modules to the source tree
+    cp ../cmake/Modules/* cmake/
+
+    mkdir "build-$1"
+    cd "build-$1"
+
+    "$cmake" \
+        -DCMAKE_BUILD_TYPE="`"$llvm_config" --build-mode`" \
+        -DLLVM_TARGETS_TO_BUILD="`"$llvm_config" --targets-built | filter_experimental_targets | sed 's/ /;/g'`" \
+        -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR="`"$llvm_config" --libdir`" \
+        -DBUILD_SHARED_LIBS=`[ $1 = "shared" ] && echo TRUE || echo FALSE` \
+        -DLLVM_OCAML_OUT_OF_TREE=TRUE \
+        -DLLVM_OCAML_INSTALL_PATH="${libdir}" \
+        -DLLVM_OCAML_EXTERNAL_LLVM_LIBS="`"$llvm_config" --libs`" \
+        -DLLVM_INCLUDE_BENCHMARKS=FALSE \
+        ..
+    $make ocaml_all
+
+    cd ../..
+}
+
+function llvm_install {
+  cd llvm-14.0.6.src
+  if test -d "build-$1"; then
+    cd "build-$1"
+
+    "$cmake" -P bindings/ocaml/cmake_install.cmake
+
+    mkdir "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cma "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cmxa "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/llvm*.a "${libdir}"/llvm/$1
+
+    cd ..
+  fi
+  cd ..
+}
+
+case "$action" in
+"build")
+  if "$llvm_config" --link-static --libs && "$llvm_config" --link-shared --libs; then
+    patch -p1 < META.patch
+    llvm_build static
+    llvm_build shared
+  elif "$llvm_config" --link-static --libs; then
+    sed "s,%%LINKAGE%%,static," link-META.patch | patch -p1
+    llvm_build static
+  elif "$llvm_config" --link-shared --libs; then
+    sed "s,%%LINKAGE%%,shared," link-META.patch | patch -p1
+    llvm_build shared
+  else
+    echo "Link mode not recognized"
+    exit 1
+  fi
+  ;;
+"install")
+  llvm_install static
+  llvm_install shared
+  ;;
+*)
+  echo "Action not recognized"
+  exit 1
+  ;;
+esac

--- a/packages/llvm/llvm.14.0.6/files/install.sh
+++ b/packages/llvm/llvm.14.0.6/files/install.sh
@@ -11,7 +11,7 @@ function filter_experimental_targets {
 }
 
 function llvm_build {
-    cd llvm-14.0.6.src
+    cd llvm
 
     # Copy the required Common LLVM CMake modules to the source tree
     cp ../cmake/Modules/* cmake/
@@ -35,7 +35,7 @@ function llvm_build {
 }
 
 function llvm_install {
-  cd llvm-14.0.6.src
+  cd llvm
   if test -d "build-$1"; then
     cd "build-$1"
 

--- a/packages/llvm/llvm.14.0.6/files/link-META.patch
+++ b/packages/llvm/llvm.14.0.6/files/link-META.patch
@@ -1,7 +1,7 @@
-diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+diff --git a/llvm/bindings/ocaml/backends/META.llvm_backend.in b/llvm/bindings/ocaml/backends/META.llvm_backend.in
 index bd23abe0ca4..053e7a4f2e8 100644
---- a/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
-+++ b/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
+--- a/llvm/bindings/ocaml/backends/META.llvm_backend.in
++++ b/llvm/bindings/ocaml/backends/META.llvm_backend.in
 @@ -2,6 +2,6 @@ name = "llvm_@TARGET@"
  version = "@PACKAGE_VERSION@"
  description = "@TARGET@ Backend for LLVM"
@@ -11,10 +11,10 @@ index bd23abe0ca4..053e7a4f2e8 100644
 +archive(byte) = "%%LINKAGE%%/llvm_@TARGET@.cma"
 +archive(native) = "%%LINKAGE%%/llvm_@TARGET@.cmxa"
  directory = "llvm"
-diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+diff --git a/llvm/bindings/ocaml/llvm/META.llvm.in b/llvm/bindings/ocaml/llvm/META.llvm.in
 index 991bbc0600..255be6dfa3 100644
---- a/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
-+++ b/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
+--- a/llvm/bindings/ocaml/llvm/META.llvm.in
++++ b/llvm/bindings/ocaml/llvm/META.llvm.in
 @@ -1,118 +1,118 @@
  name = "llvm"
  version = "@PACKAGE_VERSION@"

--- a/packages/llvm/llvm.14.0.6/files/link-META.patch
+++ b/packages/llvm/llvm.14.0.6/files/link-META.patch
@@ -1,0 +1,166 @@
+diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
++++ b/llvm-14.0.6.src/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,6 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm_@TARGET@.cma"
++archive(native) = "%%LINKAGE%%/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
+index 991bbc0600..255be6dfa3 100644
+--- a/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
++++ b/llvm-14.0.6.src/bindings/ocaml/llvm/META.llvm.in
+@@ -1,118 +1,118 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm.cma"
++archive(native) = "%%LINKAGE%%/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_analysis.cma"
++    archive(native) = "%%LINKAGE%%/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitwriter.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_executionengine.cma"
++    archive(native) = "%%LINKAGE%%/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_ipo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_ipo.cmxa"
+ )
+ 
+ package "debuginfo" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "DebugInfo support for LLVM"
+-    archive(byte) = "llvm_debuginfo.cma"
+-    archive(native) = "llvm_debuginfo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_debuginfo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_debuginfo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_irreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_scalar_opts.cma"
++    archive(native) = "%%LINKAGE%%/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_transform_utils.cma"
++    archive(native) = "%%LINKAGE%%/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_vectorize.cma"
++    archive(native) = "%%LINKAGE%%/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_passmgr_builder.cma"
++    archive(native) = "%%LINKAGE%%/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_target.cma"
++    archive(native) = "%%LINKAGE%%/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_linker.cma"
++    archive(native) = "%%LINKAGE%%/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_all_backends.cma"
++    archive(native) = "%%LINKAGE%%/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.14.0.6/opam
+++ b/packages/llvm/llvm.14.0.6/opam
@@ -33,7 +33,7 @@ synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [
   ["link-META.patch" "md5=bbb99db647b80baaa34054e1a957f218"]
-  ["install.sh" "md5=32a79d8f105e5b2bc5c2f91cd1f71f65"]
+  ["install.sh" "md5=2db75a6673ad476cdb464dd90021d51a"]
   ["META.patch" "md5=c63515a9c59101ebf71ecf83ddf6ec9f"]
   ["fix-macos.patch" "md5=86664021a2819e4a0a9ebe5f3cafe819"]
   ["fix-shared.patch" "md5=bdc3f688681e9c56d92514ba4ef68cb9"]

--- a/packages/llvm/llvm.14.0.6/opam
+++ b/packages/llvm/llvm.14.0.6/opam
@@ -32,14 +32,14 @@ patches: [
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [
-  ["link-META.patch" "md5=e2a7039c6ee1705d53f18ec573620924"]
-  ["install.sh" "md5=c19620e1e4583e6973942d169f34bd63"]
-  ["META.patch" "md5=c032052ca78662400a7e7b9e377923fe"]
-  ["fix-macos.patch" "md5=e97989a39e8a269bda7f42961fd1e257"]
-  ["fix-shared.patch" "md5=03dfbd81665c6878bbc106b9089010cd"]
-  ["fix-rhel.patch" "md5=7597be5e0cee0b6fabb29020aa055723"]
+  ["link-META.patch" "md5=bbb99db647b80baaa34054e1a957f218"]
+  ["install.sh" "md5=32a79d8f105e5b2bc5c2f91cd1f71f65"]
+  ["META.patch" "md5=c63515a9c59101ebf71ecf83ddf6ec9f"]
+  ["fix-macos.patch" "md5=86664021a2819e4a0a9ebe5f3cafe819"]
+  ["fix-shared.patch" "md5=bdc3f688681e9c56d92514ba4ef68cb9"]
+  ["fix-rhel.patch" "md5=e1db49b76f8795f3d3e276fd9e10db72"]
 ]
 url {
-  src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-14.0.6.src.tar.xz"
-  checksum: "sha256=050922ecaaca5781fdf6631ea92bc715183f202f9d2f15147226f023414f619a"
+  src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
+  checksum: "sha256=8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a"
 }

--- a/packages/llvm/llvm.14.0.6/opam
+++ b/packages/llvm/llvm.14.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+doc: "http://llvm.moe/ocaml"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "git+http://llvm.org/git/llvm.git"
+homepage: "http://llvm.moe"
+build: ["bash" "-ex" "install.sh" "%{conf-llvm:config}%" lib "%{conf-cmake:cmd}%" make "build"]
+install: ["bash" "-ex" "install.sh" "%{conf-llvm:config}%" lib "%{conf-cmake:cmd}%" make "install"]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "ctypes" {>= "0.4"}
+  "ounit" {with-test}
+  "ocamlfind" {build}
+  "conf-llvm" {build & = version}
+  "conf-python-3" {build}
+  "conf-cmake" {build}
+]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
+patches: [
+  "fix-shared.patch"
+  "fix-macos.patch"
+  "fix-rhel.patch"
+]
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+extra-files: [
+  ["link-META.patch" "md5=e2a7039c6ee1705d53f18ec573620924"]
+  ["install.sh" "md5=c19620e1e4583e6973942d169f34bd63"]
+  ["META.patch" "md5=c032052ca78662400a7e7b9e377923fe"]
+  ["fix-macos.patch" "md5=e97989a39e8a269bda7f42961fd1e257"]
+  ["fix-shared.patch" "md5=03dfbd81665c6878bbc106b9089010cd"]
+  ["fix-rhel.patch" "md5=7597be5e0cee0b6fabb29020aa055723"]
+]
+url {
+  src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-14.0.6.src.tar.xz"
+  checksum: "sha256=050922ecaaca5781fdf6631ea92bc715183f202f9d2f15147226f023414f619a"
+}


### PR DESCRIPTION
Hi,

I created an opam package for the latest stable version of LLVM: 14.0.6.

Here is a list of changes from the `llvm-13.0.0` opam package:
* The only change related to bindings is https://github.com/llvm/llvm-project/commit/fe2b2cb58ebb57427c0a12e54a4ed63553c397ab. It adds `.cmt` and `.cmti` files, implementing functionality of [add-cmt-for-llvm-13.patch](https://github.com/ocaml/opam-repository/blob/81f989bd145d1e3b58da418f4e6c5feded5e40f6/packages/llvm/llvm.13.0.0/files/add-cmt-for-llvm-13.patch). So, we don't need this patch anymore.
* [Common LLVM CMake modules](https://github.com/llvm/llvm-project/blob/f28c006a5895fc0e329fe15fead81e37457cb1d1/cmake/README.rst) were moved to the separate directory: `cmake/Modules`. Previously this logic was inlined in files in `llvm/cmake/modules`. So, for now we have two directories in the [`llvm-src` release archive](https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-14.0.6.src.tar.xz): `llvm-14.0.6.src` and `cmake`. Thit means that we cannot install from this archive with `opam` anymore, because [it forbids having multiple root directories in it](https://github.com/ocaml/opam/blob/b2f41ca039144ae39abcb1c41bfb62d15b554415/src/core/opamSystem.ml#L1038). So, I decided to download the whole [`llvm-project-src` sources](https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz) and to work inside the `llvm` subdirectory when installing it.
* There was [a change](https://reviews.llvm.org/D112012) in `llvm/cmake/modules/AddOCaml.cmake` that made it not possible to build the bindings using only [llvm-14.0.6.src.tar.xz](https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-14.0.6.src.tar.xz) when `-DLLVM_INCLUDE_BENCHMARKS` is `TRUE`. The problem is that [we need](https://github.com/llvm/llvm-project/tree/f28c006a5895fc0e329fe15fead81e37457cb1d1/llvm/CMakeLists.txt#L1256) the whole `llvm-project` sources, because we use `../third-party` directory when building `llvm`. But for now we work the `llvm-project` source archive which contains `third-party` subdirectory as well, so this problem is solved.

Other changes that doesn't require the modification of the opam package:
* Commits in the OCaml bindings between 13.0.0 and 14.0.6 in LLVM tree: https://github.com/llvm/llvm-project/commit/6a713120502abc0a42b8d518edea345b60e829f3 and https://github.com/llvm/llvm-project/commit/ec501f15a8b8ace2b283732740d6d65d40d82e09. Both are no functional, so we don't need to update anything in this package.
* `conf-llvm-14` package is exactly the same as `conf-llvm-13`, only version numbers were changed.

Here is the complete diff between `llvm-13.0.0` and `llvm-14.0.6`:

<details>
  <summary>diff</summary>

```diff
diff -r llvm.13.0.0/files/fix-macos.patch llvm.14.0.6/files/fix-macos.patch
8c8
<  llvm/cmake/modules/AddOCaml.cmake | 4 ++--
---
>  llvm-project/llvm/cmake/modules/AddOCaml.cmake | 4 ++--
11c11
< diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
---
> diff --git a/llvm-project/llvm/cmake/modules/AddOCaml.cmake b/llvm-project/llvm/cmake/modules/AddOCaml.cmake
13,14c13,14
< --- a/cmake/modules/AddOCaml.cmake
< +++ b/cmake/modules/AddOCaml.cmake
---
> --- a/llvm/cmake/modules/AddOCaml.cmake
> +++ b/llvm/cmake/modules/AddOCaml.cmake
diff -r llvm.13.0.0/files/fix-rhel.patch llvm.14.0.6/files/fix-rhel.patch
13,14c13,14
< --- a/cmake/modules/AddOCaml.cmake
< +++ b/cmake/modules/AddOCaml.cmake
---
> --- a/llvm/cmake/modules/AddOCaml.cmake
> +++ b/llvm/cmake/modules/AddOCaml.cmake
diff -r llvm.13.0.0/files/fix-shared.patch llvm.14.0.6/files/fix-shared.patch
13,14c13,14
< --- a/cmake/modules/AddOCaml.cmake
< +++ b/cmake/modules/AddOCaml.cmake
---
> --- a/llvm/cmake/modules/AddOCaml.cmake
> +++ b/llvm/cmake/modules/AddOCaml.cmake
diff -r llvm.13.0.0/files/install.sh llvm.14.0.6/files/install.sh
13a14,18
>     cd llvm
> 
>     # Copy the required Common LLVM CMake modules to the source tree
>     cp ../cmake/Modules/* cmake/
> 
28c33
<     cd ..
---
>     cd ../..
31a37
>   cd llvm
43a50
>   cd ..
diff -r llvm.13.0.0/files/link-META.patch llvm.14.0.6/files/link-META.patch
1c1
< diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
---
> diff --git a/llvm/bindings/ocaml/backends/META.llvm_backend.in b/llvm/bindings/ocaml/backends/META.llvm_backend.in
3,4c3,4
< --- a/bindings/ocaml/backends/META.llvm_backend.in
< +++ b/bindings/ocaml/backends/META.llvm_backend.in
---
> --- a/llvm/bindings/ocaml/backends/META.llvm_backend.in
> +++ b/llvm/bindings/ocaml/backends/META.llvm_backend.in
14c14
< diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
---
> diff --git a/llvm/bindings/ocaml/llvm/META.llvm.in b/llvm/bindings/ocaml/llvm/META.llvm.in
16,17c16,17
< --- a/bindings/ocaml/llvm/META.llvm.in
< +++ b/bindings/ocaml/llvm/META.llvm.in
---
> --- a/llvm/bindings/ocaml/llvm/META.llvm.in
> +++ b/llvm/bindings/ocaml/llvm/META.llvm.in
diff -r llvm.13.0.0/files/META.patch llvm.14.0.6/files/META.patch
1c1
< diff --git a/bindings/ocaml/backends/META.llvm_backend.in b/bindings/ocaml/backends/META.llvm_backend.in
---
> diff --git a/llvm/bindings/ocaml/backends/META.llvm_backend.in b/llvm/bindings/ocaml/backends/META.llvm_backend.in
3,4c3,4
< --- a/bindings/ocaml/backends/META.llvm_backend.in
< +++ b/bindings/ocaml/backends/META.llvm_backend.in
---
> --- a/llvm/bindings/ocaml/backends/META.llvm_backend.in
> +++ b/llvm/bindings/ocaml/backends/META.llvm_backend.in
16c16
< diff --git a/bindings/ocaml/llvm/META.llvm.in b/bindings/ocaml/llvm/META.llvm.in
---
> diff --git a/llvm/bindings/ocaml/llvm/META.llvm.in b/llvm/bindings/ocaml/llvm/META.llvm.in
18,19c18,19
< --- a/bindings/ocaml/llvm/META.llvm.in
< +++ b/bindings/ocaml/llvm/META.llvm.in
---
> --- a/llvm/bindings/ocaml/llvm/META.llvm.in
> +++ b/llvm/bindings/ocaml/llvm/META.llvm.in
diff -r llvm.13.0.0/opam llvm.14.0.6/opam
29d28
<   "add-cmt-for-llvm-13.patch"
36,42c35,40
<   ["link-META.patch" "md5=53dc8e72917585d235b9bbb3e06eed2b"]
<   ["install.sh" "md5=f318260916581cbf0a8e7aa2903ac6d2"]
<   ["fix-shared.patch" "md5=818e192b6b54c0e392f2cdb2106b2e6f"]
<   ["add-cmt-for-llvm-13.patch" "md5=248ec7d17ebd1592fc99848016d9452b"]
<   ["META.patch" "md5=4c3cf99d06d2044e2ce5a853e5a16d5e"]
<   ["fix-macos.patch" "md5=ff33b723048e1f1a2d26505f272c8ae9"]
<   ["fix-rhel.patch" "md5=ba4142dbfc65a4b1a09ee7233048c0bf"]
---
>   ["link-META.patch" "md5=bbb99db647b80baaa34054e1a957f218"]
>   ["install.sh" "md5=2db75a6673ad476cdb464dd90021d51a"]
>   ["META.patch" "md5=c63515a9c59101ebf71ecf83ddf6ec9f"]
>   ["fix-macos.patch" "md5=86664021a2819e4a0a9ebe5f3cafe819"]
>   ["fix-shared.patch" "md5=bdc3f688681e9c56d92514ba4ef68cb9"]
>   ["fix-rhel.patch" "md5=e1db49b76f8795f3d3e276fd9e10db72"]
45,46c43,44
<   src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/llvm-13.0.0.src.tar.xz"
<   checksum: "sha256=408d11708643ea826f519ff79761fcdfc12d641a2510229eec459e72f8163020"
---
>   src: "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/llvm-project-14.0.6.src.tar.xz"
>   checksum: "sha256=8b3cfd7bc695bd6cea0f37f53f0981f34f87496e79e2529874fd03a2f9dd3a8a"
```

</details>
