### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.4)

### DIFF
--- a/packages/eio/eio.0.4/opam
+++ b/packages/eio/eio.0.4/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.0.0~alpha0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "1.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.4/eio-0.4.tbz"
+  checksum: [
+    "sha256=774563e56bff9a7272e71258409a4bce24bb32465c7615ee8cc405d424355df0"
+    "sha512=03dff43b73b3b79987504d98439e65babe8c59ca8b72fd0718b87923b8a019ce41ef992ac304c3000523e163b9a4dfe43bbf6683641e175e9fe74b33ed9a5ed9"
+  ]
+}
+x-commit-hash: "34d1d26ac4f5d5b506a7a216c2c205d83f09110c"

--- a/packages/eio/eio.0.4/opam
+++ b/packages/eio/eio.0.4/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "5.0.0~alpha0"}
+  "ocaml" {>= "5.0.0"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"

--- a/packages/eio_linux/eio_linux.0.4/opam
+++ b/packages/eio_linux/eio_linux.0.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.4/eio-0.4.tbz"
+  checksum: [
+    "sha256=774563e56bff9a7272e71258409a4bce24bb32465c7615ee8cc405d424355df0"
+    "sha512=03dff43b73b3b79987504d98439e65babe8c59ca8b72fd0718b87923b8a019ce41ef992ac304c3000523e163b9a4dfe43bbf6683641e175e9fe74b33ed9a5ed9"
+  ]
+}
+x-commit-hash: "34d1d26ac4f5d5b506a7a216c2c205d83f09110c"

--- a/packages/eio_luv/eio_luv.0.4/opam
+++ b/packages/eio_luv/eio_luv.0.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.4/eio-0.4.tbz"
+  checksum: [
+    "sha256=774563e56bff9a7272e71258409a4bce24bb32465c7615ee8cc405d424355df0"
+    "sha512=03dff43b73b3b79987504d98439e65babe8c59ca8b72fd0718b87923b8a019ce41ef992ac304c3000523e163b9a4dfe43bbf6683641e175e9fe74b33ed9a5ed9"
+  ]
+}
+x-commit-hash: "34d1d26ac4f5d5b506a7a216c2c205d83f09110c"

--- a/packages/eio_main/eio_main.0.4/opam
+++ b/packages/eio_main/eio_main.0.4/opam
@@ -25,7 +25,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/eio_main/eio_main.0.4/opam
+++ b/packages/eio_main/eio_main.0.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.4/eio-0.4.tbz"
+  checksum: [
+    "sha256=774563e56bff9a7272e71258409a4bce24bb32465c7615ee8cc405d424355df0"
+    "sha512=03dff43b73b3b79987504d98439e65babe8c59ca8b72fd0718b87923b8a019ce41ef992ac304c3000523e163b9a4dfe43bbf6683641e175e9fe74b33ed9a5ed9"
+  ]
+}
+x-commit-hash: "34d1d26ac4f5d5b506a7a216c2c205d83f09110c"


### PR DESCRIPTION
Effect-based direct-style IO mainloop for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

Note: Eio 0.4 drops compatibility with OCaml 4.12+domains. Use OCaml 5.0.0~alpha1 instead.

API changes:

- `Eio.Dir` has gone. Use `Eio.Path` instead (@talex5 ocaml-multicore/eio#266 ocaml-multicore/eio#270).

- `Eio_unix.FD.{take,peek}` were renamed to `take_opt`/`peek_opt` to make way for non-optional versions.

New features:

- Fiber-local storage (@SquidDev ocaml-multicore/eio#256).
  Attach key/value bindings to fibers. These are inherited across forks.

- `Eio.Path.{unlink,rmdir,rename}` (@talex5 ocaml-multicore/eio#264 ocaml-multicore/eio#265).

- `Eio_main.run` can now return a value (@talex5 ocaml-multicore/eio#263).
  This is useful for e.g. cmdliner.

- `Eio_unix.socketpair` (@talex5 ocaml-multicore/eio#260).

- `Fiber.fork_daemon` (@talex5 ocaml-multicore/eio#252).
  Create a helper fiber that does not prevent the switch from exiting.

- Add `Fiber.{iter,map,filter,fiter_map}` (@talex5 ocaml-multicore/eio#248 ocaml-multicore/eio#250).
  These are concurrent versions of the corresponding operations in `List`.

Bug fixes:

- Fix scheduling fairness in luv backend (@talex5 ocaml-multicore/eio#269).

- Implement remaining shutdown commands for luv (@talex5 ocaml-multicore/eio#268).

- Fix IPv6 support with uring backend (@haesbaert ocaml-multicore/eio#261 ocaml-multicore/eio#262).

- Use `Eio.Net.Connection_reset` exception in more places (@talex5 ocaml-multicore/eio#257).

- Report use of closed FDs better (@talex5 ocaml-multicore/eio#255).
  Using a closed FD could previously cause the whole event loop to exit.

- Some fixes for cancellation (@talex5 ocaml-multicore/eio#254).

- Ensure `Buf_write` still flushes if an exception is raised (@talex5 ocaml-multicore/eio#246).

- Do not allow close on `accept_fork` socket (@talex5 ocaml-multicore/eio#245).

Documentation:

- Document integrations with Unix, Lwt and Async (@talex5 ocaml-multicore/eio#247).

- Add a Dockerfile for easy testing (@talex5 ocaml-multicore/eio#224).
