### PR TITLE
gen < 0.5.1 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/gen/gen.0.2.2/opam
+++ b/packages/gen/gen.0.2.2/opam
@@ -12,7 +12,7 @@ remove: [
     ["ocamlfind" "remove" "gen"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/gen/gen.0.5/opam
+++ b/packages/gen/gen.0.5/opam
@@ -13,7 +13,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "gen"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling gen.0.5 ============================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/gen.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --disable-docs --disable-tests --disable-bench
# exit-code            2
# env-file             ~/.opam/log/gen-7-44de78.env
# output-file          ~/.opam/log/gen-7-44de78.out
### output ###
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```