### PR TITLE
timed is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/timed/timed.1.0/opam
+++ b/packages/timed/timed.1.0/opam
@@ -11,7 +11,7 @@ build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Timed references for imperative state"


### PR DESCRIPTION
```
#=== ERROR while compiling timed.1.0 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/timed.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/timed-7-f96460.env
# output-file          ~/.opam/log/timed-7-f96460.out
### output ###
# [OPT] timed.cmi
# [OPT] timed.cmx
# File "timed.ml", line 77, characters 16-30:
# 77 |     let count = Pervasives.ref 0
#                      ^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [GNUmakefile:25: timed.cmx] Error 2
```