### PR TITLE
Package bwd.2.1.0

### DIFF
--- a/packages/bwd/bwd.2.1.0/opam
+++ b/packages/bwd/bwd.2.1.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Backward lists"
+description: """
+This OCaml package defines backward lists that are isomorphic to lists.
+They are useful when one wishes to give a different type to the lists that are semantically in reverse.
+In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
+With backward lists having a different type, it is impossible to make those mistakes.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/ocaml-bwd"
+bug-reports: "https://github.com/RedPRL/ocaml-bwd/issues"
+dev-repo: "git+https://github.com/RedPRL/ocaml-bwd.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.12"}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {>= "2.0" & with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/ocaml-bwd/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=be731bd8c2d78cf1e8c41c2155a16b2e"
+    "sha512=62e7eaac21eece4c415b96df4c35bfbe80d3e4f11b55724af79cda70d37a2bcc3edfd8d55cffb3a4cfcc58ca5d7e6680d983e2d949cb6125140d44a4297b5183"
+  ]
+}


### PR DESCRIPTION
### `bwd.2.1.0`
Backward lists
This OCaml package defines backward lists that are isomorphic to lists.
They are useful when one wishes to give a different type to the lists that are semantically in reverse.
In our experience, it is easy to miss List.rev or misuse List.rev_append when both semantically forward and backward lists are present.
With backward lists having a different type, it is impossible to make those mistakes.



---
* Homepage: https://github.com/RedPRL/ocaml-bwd
* Source repo: git+https://github.com/RedPRL/ocaml-bwd.git
* Bug tracker: https://github.com/RedPRL/ocaml-bwd/issues

---
:camel: Pull-request generated by opam-publish v2.1.0