### PR TITLE
[new release] mirage-monitoring (0.0.2)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.2/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "metrics-influx" {>= "0.2.0"}
   "mirage-time" {>= "2.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-solo5" {>= "0.7.0"}
+  "mirage-solo5" {>= "0.9.0"}
   "mirage-runtime"
   "memtrace-mirage" {>= "0.2.1.2.2"}
   "mirage-clock" {>= "4.0.0"}

--- a/packages/mirage-monitoring/mirage-monitoring.0.0.2/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/mirage-monitoring"
+doc: "https://roburio.github.io/mirage-monitoring"
+dev-repo: "git+https://github.com/roburio/mirage-monitoring.git"
+bug-reports: "https://github.com/roburio/mirage-monitoring/issues"
+license: "AGPL-3.0-only"
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune"
+  "logs" {>= "0.6.3"}
+  "metrics" {>= "0.4.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "mirage-runtime"
+  "memtrace-mirage" {>= "0.2.1.2.2"}
+  "mirage-clock" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Monitoring of MirageOS unikernels"
+description: """
+Reporting metrics to Influx, Telegraf. Dynamic adjusting log level and metrics
+sources, memprof profiling.
+"""
+url {
+  src:
+    "https://github.com/roburio/mirage-monitoring/releases/download/v0.0.2/mirage-monitoring-0.0.2.tbz"
+  checksum: [
+    "sha256=8de98abda5e9cf202c2cfe0494faa9822726b3dfb262bc0eef444fc0ca4873c6"
+    "sha512=c48950425733175aa9b48b57b34329be0cfb7aeb8a0f98e07def5f0e2be21f65ebdf9ab2782c21eeb56f7a64f30caef7e332941c649516a889763a95540dd49a"
+  ]
+}
+x-commit-hash: "c7ded0a04f58f247b9b0fd0e0b0147405fe5ca4f"


### PR DESCRIPTION
Monitoring of MirageOS unikernels

- Project page: <a href="https://github.com/roburio/mirage-monitoring">https://github.com/roburio/mirage-monitoring</a>
- Documentation: <a href="https://roburio.github.io/mirage-monitoring">https://roburio.github.io/mirage-monitoring</a>

##### CHANGES:

* Upgrade to MirageOS4 (mirage-solo5 >= 0.7.0), drop usage of deprecated
  OS.MM.malloc_metrics
