### PR TITLE
[new release] decoders, decoders-yojson, decoders-sexplib, decoders-msgpck, decoders-jsonm, decoders-jsonaf, decoders-ezxmlm, decoders-ezjsonm, decoders-cbor and decoders-bencode (1.0.0)

### DIFF
--- a/packages/decoders-bencode/decoders-bencode.0.3.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "bencode" {< "2.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-bencode/decoders-bencode.0.4.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "bencode" {>= "2.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-bencode/decoders-bencode.0.5.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "bencode" {>= "2.0"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-bencode/decoders-bencode.0.6.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "bencode" {>= "2.0"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-bencode/decoders-bencode.1.0.0/opam
+++ b/packages/decoders-bencode/decoders-bencode.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bencode backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Simon Cruanes <simon@imandra.ai>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "bencode" {>= "2.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-cbor/decoders-cbor.0.3.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "cbor"
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-cbor/decoders-cbor.0.4.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "cbor"
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-cbor/decoders-cbor.0.5.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "cbor"
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-cbor/decoders-cbor.0.6.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "cbor"
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-cbor/decoders-cbor.1.0.0/opam
+++ b/packages/decoders-cbor/decoders-cbor.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "CBOR backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "cbor"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.3.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "ezjsonm" {>= "0.4.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.4.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "ezjsonm" {>= "0.4.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.5.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "ezjsonm" {>= "0.4.0"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.0.6.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "ezjsonm" {>= "0.4.0"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-ezjsonm/decoders-ezjsonm.1.0.0/opam
+++ b/packages/decoders-ezjsonm/decoders-ezjsonm.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Ezjsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "ezjsonm" {>= "0.4.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-ezxmlm/decoders-ezxmlm.1.0.0/opam
+++ b/packages/decoders-ezxmlm/decoders-ezxmlm.1.0.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Ezxmlm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "ezxmlm" {>= "1.1.0"}
+  "containers" {with-test & >= "0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-jsonaf/decoders-jsonaf.1.0.0/opam
+++ b/packages/decoders-jsonaf/decoders-jsonaf.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Jsonaf backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: [
+  "Vlad Dumitru <vlad@dumitru.net>" "Matt Bray <mattjbray@gmail.com>"
+]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.10.0"}
+  "decoders" {= version}
+  "jsonaf" {>= "0.15.0"}
+  "odoc" {with-doc}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-jsonm/decoders-jsonm.0.4.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders"
+  "decoders" {< "1.0.0"}
   "jsonm"
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-jsonm/decoders-jsonm.0.5.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders"
+  "decoders" {< "1.0.0"}
   "jsonm"
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-jsonm/decoders-jsonm.0.6.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders"
+  "decoders" {< "1.0.0"}
   "jsonm"
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-jsonm/decoders-jsonm.1.0.0/opam
+++ b/packages/decoders-jsonm/decoders-jsonm.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Jsonm backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "jsonm"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-msgpck/decoders-msgpck.0.5.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.5.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "msgpck" {>= "1.3"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-msgpck/decoders-msgpck.0.6.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.0.6.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "msgpck" {>= "1.3"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-msgpck/decoders-msgpck.1.0.0/opam
+++ b/packages/decoders-msgpck/decoders-msgpck.1.0.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Msgpck backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: [
+  "Matt Bray <mattjbray@gmail.com>" "Simon Cruanes <simon@imandra.ai>"
+]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "msgpck" {>= "1.3"}
+  "ocplib-endian" {>= "0.6"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & ocaml:version >= "4.08"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-sexplib/decoders-sexplib.0.3.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "sexplib0"
   "sexplib"
   "odoc" {with-doc}

--- a/packages/decoders-sexplib/decoders-sexplib.0.4.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
   "containers" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "sexplib0"
   "sexplib"
   "odoc" {with-doc}

--- a/packages/decoders-sexplib/decoders-sexplib.0.5.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "sexplib0"
   "sexplib"
   "odoc" {with-doc}

--- a/packages/decoders-sexplib/decoders-sexplib.0.6.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "sexplib0"
   "sexplib"
   "odoc" {with-doc}

--- a/packages/decoders-sexplib/decoders-sexplib.1.0.0/opam
+++ b/packages/decoders-sexplib/decoders-sexplib.1.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Sexplib backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "sexplib0"
+  "sexplib"
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders-yojson/decoders-yojson.0.3.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.3.0/opam
@@ -28,7 +28,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "yojson" {< "2.0.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-yojson/decoders-yojson.0.4.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.4.0/opam
@@ -28,7 +28,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "ounit" {with-test}
-  "decoders" {>= "0.3.0"}
+  "decoders" {>= "0.3.0" & < "1.0.0"}
   "yojson" {< "2.0.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.03.0" }

--- a/packages/decoders-yojson/decoders-yojson.0.5.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.5.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.2.1"}
+  "decoders" {>= "0.2.1" & < "1.0.0"}
   "yojson" {< "2.0.0"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-yojson/decoders-yojson.0.6.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.0.6.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "2.0"}
-  "decoders" {>= "0.6.0"}
+  "decoders" {>= "0.6.0" & < "1.0.0"}
   "yojson" {< "2.0.0"}
   "odoc" {with-doc}
   "containers" {with-test}

--- a/packages/decoders-yojson/decoders-yojson.1.0.0/opam
+++ b/packages/decoders-yojson/decoders-yojson.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Yojson backend for decoders"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "decoders" {= version}
+  "yojson" {>= "1.6.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"

--- a/packages/decoders/decoders.1.0.0/opam
+++ b/packages/decoders/decoders.1.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Elm-inspired decoders for Ocaml"
+description:
+  "A combinator library for \"decoding\" JSON-like values into your own Ocaml types, inspired by Elm's `Json.Decode` and `Json.Encode`."
+maintainer: ["Matt Bray <mattjbray@gmail.com>"]
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+depends: [
+  "dune" {>= "3.1"}
+  "ocaml" {>= "4.03.0"}
+  "odoc" {with-doc}
+  "containers" {with-test & >= "0.16"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mattjbray/ocaml-decoders.git"
+url {
+  src:
+    "https://github.com/mattjbray/ocaml-decoders/releases/download/v1.0.0/decoders-1.0.0.tbz"
+  checksum: [
+    "sha256=47fe79c4102d0f710eff3ceaef313100d9df3c7945834d3cf38a39742a573597"
+    "sha512=6fe4e9f99d865fb24c8b1da08ba485282fc8eaf6ed48cedbe8109cae863ad441a95b2643b4ea217a6b012f149682ca69af436ed26a3d646903738fce5651a229"
+  ]
+}
+x-commit-hash: "0e0afb7e988aa746a1d6d7f1e8ee8ba2e875e382"


### PR DESCRIPTION
Elm-inspired decoders for Ocaml

- Project page: <a href="https://github.com/mattjbray/ocaml-decoders">https://github.com/mattjbray/ocaml-decoders</a>
- Documentation: <a href="https://mattjbray.github.io/ocaml-decoders/">https://mattjbray.github.io/ocaml-decoders/</a>

##### CHANGES:

* Extract and expose `Decoder.t`, useful for "decoding" things outside of the JSON family (mattjbray/ocaml-decoders#40, @mattjbray).
* Add `Decoders.Xml.S` to `decoders`, create `decoders-ezxmlm`, and add `Decoders_bs_xml` to `bs-decoders` (mattjbray/ocaml-decoders#49, @mattjbray).
* BREAKING: namespace `bs-decoders` modules under `Decoders`. To upgrade,
  replace `Decoders_bs` with `Decoders.Bs_json` (mattjbray/ocaml-decoders#49, @mattjbray).
* Add `decoders-jsonaf` (mattjbray/ocaml-decoders#50, @dvmitrv).
