### PR TITLE
Package catala.0.7.0

### DIFF
--- a/packages/catala/catala.0.7.0/opam
+++ b/packages/catala/catala.0.7.0/opam
@@ -75,7 +75,7 @@ depexts: [
 url {
   src: "https://github.com/CatalaLang/catala/archive/0.7.0.tar.gz"
   checksum: [
-    "md5=1dcefcc8834e1958ccafcd355ba44ec8"
-    "sha512=cdc9fca31d250f6e6ef06d4a8767cc952f7fafb3cbf514e64ddd8b8533ca8a2f0a0de53609d11cb866734e2f33f47335c7990dee136d47621a574aee5823cb88"
+    "md5=6dbbc2f50c23693f26ab6f048e78172f"
+    "sha512=a5701e14932d8a866e2aa3731f76df85ff2a68b4fa943fd510c535913573274d66eaec1ae6fcae17f20b475876048a9ab196ef6d8c23d4ea6b90b986aa0a6daa"
   ]
 }

--- a/packages/catala/catala.0.7.0/opam
+++ b/packages/catala/catala.0.7.0/opam
@@ -27,7 +27,6 @@ depends: [
   "menhir" {>= "20200211"}
   "menhirLib" {>= "20200211"}
   "ocaml" {>= "4.13.0"}
-  "ocamlfind" {!= "1.9.5"}
   "ocamlgraph" {>= "1.8.8"}
   "ppx_yojson_conv" {>= "0.14.0"}
   "re" {>= "1.9.0"}

--- a/packages/catala/catala.0.7.0/opam
+++ b/packages/catala/catala.0.7.0/opam
@@ -1,0 +1,81 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description:
+  "Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information"
+maintainer: ["contact@catala-lang.org"]
+authors: [
+  "Denis Merigoux"
+  "Nicolas Chataing"
+  "Emile Rolley"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Alain Delaët-Tixeuil"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ANSITerminal" {>= "0.8.2"}
+  "benchmark" {>= "1.6"}
+  "bindlib" {>= "5.0.1"}
+  "calendar" {>= "2.04"}
+  "cmdliner" {>= "1.1.0"}
+  "cppo" {>= "1"}
+  "dune" {>= "2.8"}
+  "js_of_ocaml-ppx" {>= "3.8.0"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "ocaml" {>= "4.13.0"}
+  "ocamlfind" {!= "1.9.5"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_yojson_conv" {>= "0.14.0"}
+  "re" {>= "1.9.0"}
+  "sedlex" {>= "2.4"}
+  "ubase" {>= "0.05"}
+  "unionFind" {>= "20200320"}
+  "visitors" {>= "20200210"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {cataladevmode & = "0.21.0"}
+  "obelisk" {cataladevmode}
+  "conf-npm" {cataladevmode}
+  "conf-python-3-dev" {cataladevmode}
+  "z3" {catalaz3mode}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.11"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+depexts: [
+  ["groff" "colordiff" "latexmk" "python3-pip" "pandoc"]
+    {cataladevmode & os-family = "debian"}
+  ["groff" "colordiff" "texlive" "py3-pip" "py3-pygments"]
+    {cataladevmode & os-distribution = "alpine"}
+  ["groff" "colordiff" "latex-mk" "python-pygments" "pandoc"]
+    {cataladevmode & os-family = "arch"}
+]
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.7.0.tar.gz"
+  checksum: [
+    "md5=1dcefcc8834e1958ccafcd355ba44ec8"
+    "sha512=cdc9fca31d250f6e6ef06d4a8767cc952f7fafb3cbf514e64ddd8b8533ca8a2f0a0de53609d11cb866734e2f33f47335c7990dee136d47621a574aee5823cb88"
+  ]
+}

--- a/packages/catala/catala.0.7.0/opam
+++ b/packages/catala/catala.0.7.0/opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "cppo" {>= "1"}
   "dune" {>= "2.8"}
-  "js_of_ocaml-ppx" {>= "3.8.0"}
+  "js_of_ocaml-ppx" {>= "4.0.0"}
   "menhir" {>= "20200211"}
   "menhirLib" {>= "20200211"}
   "ocaml" {>= "4.13.0"}


### PR DESCRIPTION
### `catala.0.7.0`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.1.0