### PR TITLE
Fix the compilation of ocp-build.1.99.21 with OCaml >= 4.07 and seq < base

### DIFF
--- a/packages/ocp-build/ocp-build.1.99.21/opam
+++ b/packages/ocp-build/ocp-build.1.99.21/opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {< "4.12"}
-  ("seq" {>= "base"} & "ocaml" {>= "4.07.0"} | "seq" & "ocaml")
+  ("seq" {>= "base"} & "ocaml" {>= "4.07.0"} | "seq" {< "base"} & "ocaml" {< "4.07.0"})
   "ocamlfind"
   "cmdliner" {>= "1" & < "1.1.0"}
   "re" {>= "1.7.3"}


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/21867
cc @lefessan 