### PR TITLE
h2 and h2-mirage: fix lower bounds on gluten and base64

### DIFF
--- a/packages/h2-mirage/h2-mirage.0.6.1/opam
+++ b/packages/h2-mirage/h2-mirage.0.6.1/opam
@@ -13,10 +13,10 @@ depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt"
   "h2-lwt" {>= version}
-  "gluten-lwt" {>= "0.2.0"}
+  "gluten-lwt" {>= "0.2.0" & < "0.3.0"}
   "dune" {>= "1.7"}
   "lwt"
-  "gluten-mirage"
+  "gluten-mirage" {< "0.3.0"}
   "conduit-mirage" {>= "2.0.2" & < "2.3.0"}
   "mirage-flow" {>= "2.0.0"}
   "cstruct"

--- a/packages/h2-mirage/h2-mirage.0.8.0/opam
+++ b/packages/h2-mirage/h2-mirage.0.8.0/opam
@@ -13,10 +13,10 @@ depends: [
   "ocaml" {>= "4.06"}
   "faraday-lwt"
   "h2-lwt" {>= version}
-  "gluten-lwt" {>= "0.2.0"}
+  "gluten-lwt" {>= "0.2.0" & < "0.3.0"}
   "dune" {>= "1.7"}
   "lwt"
-  "gluten-mirage"
+  "gluten-mirage" {< "0.3.0"}
   "conduit-mirage" {>= "2.0.2"}
   "mirage-flow" {>= "2.0.0"}
   "cstruct"

--- a/packages/h2/h2.0.5.0/opam
+++ b/packages/h2/h2.0.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}
-  "base64"
+  "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.5.0"}
   "angstrom" {>= "0.11.2" & < "0.14.0"}
   "faraday" {>= "0.5.0"}

--- a/packages/h2/h2.0.6.0/opam
+++ b/packages/h2/h2.0.6.0/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}
-  "base64"
+  "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.5.0"}
   "angstrom" {>= "0.14.0"}
   "faraday" {>= "0.5.0"}

--- a/packages/h2/h2.0.6.1/opam
+++ b/packages/h2/h2.0.6.1/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}
-  "base64"
+  "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.5.0"}
   "angstrom" {>= "0.14.0"}
   "faraday" {>= "0.5.0"}

--- a/packages/h2/h2.0.7.0/opam
+++ b/packages/h2/h2.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}
-  "base64"
+  "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.5.0"}
   "angstrom" {>= "0.14.0"}
   "faraday" {>= "0.5.0"}

--- a/packages/h2/h2.0.8.0/opam
+++ b/packages/h2/h2.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "alcotest" {with-test}
   "yojson" {with-test}
   "hex" {with-test}
-  "base64"
+  "base64" {>= "3.0.0"}
   "bigstringaf" {>= "0.5.0"}
   "angstrom" {>= "0.14.0"}
   "faraday" {>= "0.5.0"}


### PR DESCRIPTION
as requested in https://github.com/ocaml/opam-repository/pull/21958

the lower-bounds checks were failing for base64 < 3.0 e.g. https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/6840c074490e2d6db2d850d6d8b7980e63ce9e95/variant/compilers,4.11,h2-mirage.0.8.0,lower-bounds