### PR TITLE
elpi is not compatible with Yojson 2.0.0 (used by atd* >= 2.10.0)

### DIFF
--- a/packages/elpi/elpi.1.16.1/opam
+++ b/packages/elpi/elpi.1.16.1/opam
@@ -25,8 +25,8 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "2.8.0"}
   "conf-time" {with-test}
-  "atdgen" {>= "2.9.1"}
-  "atdts" {>= "2.9.1"}
+  "atdgen" {>= "2.9.1" & < "2.10.0"}
+  "atdts" {>= "2.9.1" & < "2.10.0"}
 ]
 depopts: [
   "elpi-option-legacy-parser"

--- a/packages/elpi/elpi.1.16.3/opam
+++ b/packages/elpi/elpi.1.16.3/opam
@@ -25,8 +25,8 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "2.8.0"}
   "conf-time" {with-test}
-  "atdgen" {>= "2.9.1"}
-  "atdts" {>= "2.9.1"}
+  "atdgen" {>= "2.9.1" & < "2.10.0"}
+  "atdts" {>= "2.9.1" & < "2.10.0"}
 ]
 depopts: [
   "elpi-option-legacy-parser"

--- a/packages/elpi/elpi.1.16.4/opam
+++ b/packages/elpi/elpi.1.16.4/opam
@@ -25,8 +25,8 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "2.8.0"}
   "conf-time" {with-test}
-  "atdgen" {>= "2.9.1"}
-  "atdts" {>= "2.9.1"}
+  "atdgen" {>= "2.9.1" & < "2.10.0"}
+  "atdts" {>= "2.9.1" & < "2.10.0"}
 ]
 depopts: [
   "elpi-option-legacy-parser"

--- a/packages/elpi/elpi.1.16.5/opam
+++ b/packages/elpi/elpi.1.16.5/opam
@@ -25,8 +25,8 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "2.8.0"}
   "conf-time" {with-test}
-  "atdgen" {>= "2.9.1"}
-  "atdts" {>= "2.9.1"}
+  "atdgen" {>= "2.9.1" & < "2.10.0"}
+  "atdts" {>= "2.9.1" & < "2.10.0"}
 ]
 depopts: [
   "elpi-option-legacy-parser"


### PR DESCRIPTION
```
#=== ERROR while compiling elpi.1.16.5 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/elpi.1.16.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build make build DUNE_OPTS=-p elpi -j 31
# exit-code            2
# env-file             ~/.opam/log/elpi-7-efb0ff.env
# output-file          ~/.opam/log/elpi-7-efb0ff.out
### output ###
# dune build -p elpi -j 31 @all
# (cd _build/default/src/parser && /home/opam/.opam/4.14/bin/menhir tokens.mly grammar.mly token_precedence.mly --base grammar --compile-errors error_messages.txt) > _build/default/src/parser/error_messages.ml
# Read 319 sample input sentences and 40 error messages.
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.elpi_trace_elaborator.eobjs/byte -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Dune__exe -o src/.elpi_trace_elaborator.eobjs/byte/dune__exe__Elpi_trace_elaborator.cmo -c -impl src/elpi_trace_elaborator.ml)
# File "src/elpi_trace_elaborator.ml", line 668, characters 14-16:
# 668 |   write_trace ob cards;
#                     ^^
# Error: This expression has type Bi_outbuf.t
#        but an expression was expected of type Buffer.t
```