### PR TITLE
github.4.0.0 is not compatible with yojson 2.0.0

### DIFF
--- a/packages/github/github.4.0.0/opam
+++ b/packages/github/github.4.0.0/opam
@@ -29,8 +29,8 @@ depends: [
   "cohttp" {>= "0.99.0"}
   "cohttp-lwt" {>= "0.99"}
   "lwt" {>= "2.4.4"}
-  "atdgen" {>= "2.0.0"}
-  "yojson" {>= "1.2.0"}
+  "atdgen" {>= "2.0.0" & < "2.10.0"}
+  "yojson" {>= "1.2.0" & < "2.0.0"}
   "stringext"
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling github.4.0.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/github.4.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p github -j 31
# exit-code            1
# env-file             ~/.opam/log/github-7-a72c04.env
# output-file          ~/.opam/log/github-7-a72c04.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -principal -strict-sequence -g -safe-string -w A-E-41-42-44-48 -w -27-32 -g -bin-annot -I lib/.github.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -o lib/.github.objs/byte/github_t.cmi -c -intf lib/github_t.mli)
# File "lib/github_t.mli", line 94, characters 12-28:
# 94 | type json = Yojson.Safe.json
#                  ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -principal -strict-sequence -g -safe-string -w A-E-41-42-44-48 -w -27-32 -g -bin-annot -I lib/.github.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -o lib/.github.objs/byte/github_json.cmo -c -impl lib/github_json.ml)
# File "lib/github_json.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
```