### PR TITLE
dropbox is not compatible with yojson 2.0.0

### DIFF
--- a/packages/dropbox/dropbox.0.1~772c4a6/opam
+++ b/packages/dropbox/dropbox.0.1~772c4a6/opam
@@ -16,7 +16,7 @@ depends: [
   "ssl"
   "cohttp" {< "0.99"}
   "uri"
-  "atdgen"
+  "atdgen" {< "2.10.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Binding to the Dropbox Remote API"

--- a/packages/dropbox/dropbox.0.2/opam
+++ b/packages/dropbox/dropbox.0.2/opam
@@ -14,8 +14,8 @@ build: [
 ]
 depends: [
   "dune" {>= "1.1"}
-  "atdgen" {>= "1.5.0"}
-  "yojson" {>= "1.6.0"}
+  "atdgen" {>= "1.5.0" & < "2.10.0"}
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "base-bytes"
   "base-unix" {with-test}
   "cohttp"


### PR DESCRIPTION
```
#=== ERROR while compiling dropbox.0.2 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/dropbox.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dropbox -j 31
# exit-code            1
# env-file             ~/.opam/log/dropbox-7-559e65.env
# output-file          ~/.opam/log/dropbox-7-559e65.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -warn-error -3 -g -bin-annot -I src/.dropbox.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -o src/.dropbox.objs/byte/dropbox_t.cmi -c -intf src/dropbox_t.mli)
# File "src/dropbox_t.mli", line 8, characters 12-28:
# 8 | type json = Yojson.Safe.json
#                 ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
```