### PR TITLE
atd* < 2.10.0 is not compatible with yojson 2.0.0

### DIFF
--- a/packages/atd/atd.1.12.0/opam
+++ b/packages/atd/atd.1.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & < "20211215"}
   "easy-format"
-  "atdgen" {with-test}
+  "atdgen" {with-test & < "2.10.0"}
 ]
 synopsis: "Parser for the ATD data format description language"
 description: """

--- a/packages/atdgen/atdgen.1.13.0/opam
+++ b/packages/atdgen/atdgen.1.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "1.13.0" & < "2.0.0"}
-  "atdgen-runtime"
+  "atdgen-runtime" {< "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1"}
 ]

--- a/packages/atdgen/atdgen.1.2.2/opam
+++ b/packages/atdgen/atdgen.1.2.2/opam
@@ -8,7 +8,7 @@ remove: [
 depends: [
   "ocaml" {< "4.02.0"}
   "ocamlfind"
-  "atd" {= "1.0.2" & < "1.13.0"}
+  "atd" {= "1.0.2"}
   "biniou"
   "yojson"
 ]

--- a/packages/atdgen/atdgen.2.0.0/opam
+++ b/packages/atdgen/atdgen.2.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "2.0.0" & < "2.3.0"}
-  "atdgen-runtime" {>= "2.0.0"}
+  "atdgen-runtime" {>= "2.0.0" & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.2.1"}
 ]

--- a/packages/atdgen/atdgen.2.2.1/opam
+++ b/packages/atdgen/atdgen.2.2.1/opam
@@ -35,8 +35,8 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
   "atd" {>= "2.2.1" & < "2.3.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
 ]

--- a/packages/atdgen/atdgen.2.3.3/opam
+++ b/packages/atdgen/atdgen.2.3.3/opam
@@ -38,9 +38,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "atd" {>= "2.3.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}

--- a/packages/atdgen/atdgen.2.4.0/opam
+++ b/packages/atdgen/atdgen.2.4.0/opam
@@ -72,9 +72,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}

--- a/packages/atdgen/atdgen.2.4.1/opam
+++ b/packages/atdgen/atdgen.2.4.1/opam
@@ -72,9 +72,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}

--- a/packages/atdgen/atdgen.2.5.0/opam
+++ b/packages/atdgen/atdgen.2.5.0/opam
@@ -72,9 +72,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}

--- a/packages/atdgen/atdgen.2.7.0/opam
+++ b/packages/atdgen/atdgen.2.7.0/opam
@@ -72,9 +72,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.7.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0"}
   "odoc" {with-doc}

--- a/packages/atdgen/atdgen.2.8.0/opam
+++ b/packages/atdgen/atdgen.2.8.0/opam
@@ -72,9 +72,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.7.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0" & < "2.0.0"}
   "odoc" {with-doc}

--- a/packages/atdgen/atdgen.2.9.1/opam
+++ b/packages/atdgen/atdgen.2.9.1/opam
@@ -72,9 +72,9 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
-  "atdgen-runtime" {>= "2.1.0"}
-  "atdgen-codec-runtime" {with-test}
+  "atd" {>= "2.7.0" & < "2.10.0"}
+  "atdgen-runtime" {>= "2.1.0" & < "2.10.0"}
+  "atdgen-codec-runtime" {with-test & < "2.10.0"}
   "biniou" {>= "1.0.6"}
   "yojson" {>= "1.7.0" & < "2.0.0"}
   "odoc" {with-doc}

--- a/packages/atdj/atdj.1.13.0/opam
+++ b/packages/atdj/atdj.1.13.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {>= "1.0+beta7"}
   "atd" {>= "1.13.0" & < "2.0.0"}
-  "atdgen" {>= "1.13.0"}
+  "atdgen" {>= "1.13.0" & < "2.10.0"}
   "conf-openjdk" {with-test}
 ]
 synopsis: "Java code generation for ATD."

--- a/packages/atdj/atdj.2.3.3/opam
+++ b/packages/atdj/atdj.2.3.3/opam
@@ -42,7 +42,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.4.0/opam
+++ b/packages/atdj/atdj.2.4.0/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.4.1/opam
+++ b/packages/atdj/atdj.2.4.1/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.5.0/opam
+++ b/packages/atdj/atdj.2.5.0/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.6.0/opam
+++ b/packages/atdj/atdj.2.6.0/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.7.0/opam
+++ b/packages/atdj/atdj.2.7.0/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.8.0/opam
+++ b/packages/atdj/atdj.2.8.0/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdj/atdj.2.9.1/opam
+++ b/packages/atdj/atdj.2.9.1/opam
@@ -76,7 +76,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "re"
   "odoc" {with-doc}
 ]

--- a/packages/atdpy/atdpy.2.3.3/opam
+++ b/packages/atdpy/atdpy.2.3.3/opam
@@ -29,8 +29,8 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
   "alcotest" {with-test}
-  "atd" {>= "2.3.0"}
-  "atdgen" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen" {>= "2.3.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "odoc" {with-doc}
 ]

--- a/packages/atdpy/atdpy.2.4.0/opam
+++ b/packages/atdpy/atdpy.2.4.0/opam
@@ -62,8 +62,8 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
-  "atdgen" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen" {>= "2.3.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "alcotest" {with-test}
   "conf-python-3" {with-test}

--- a/packages/atdpy/atdpy.2.4.1/opam
+++ b/packages/atdpy/atdpy.2.4.1/opam
@@ -62,8 +62,8 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
-  "atdgen" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
+  "atdgen" {>= "2.3.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdpy/atdpy.2.5.0/opam
+++ b/packages/atdpy/atdpy.2.5.0/opam
@@ -62,8 +62,8 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {= version}
-  "atdgen" {>= "2.3.0"}
+  "atd" {= version & < "2.10.0"}
+  "atdgen" {>= "2.3.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdpy/atdpy.2.6.0/opam
+++ b/packages/atdpy/atdpy.2.6.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.6.0"}
+  "atd" {>= "2.6.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdpy/atdpy.2.7.0/opam
+++ b/packages/atdpy/atdpy.2.7.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdpy/atdpy.2.8.0/opam
+++ b/packages/atdpy/atdpy.2.8.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdpy/atdpy.2.9.1/opam
+++ b/packages/atdpy/atdpy.2.9.1/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atds/atds.2.3.3/opam
+++ b/packages/atds/atds.2.3.3/opam
@@ -28,7 +28,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.4.0/opam
+++ b/packages/atds/atds.2.4.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.4.1/opam
+++ b/packages/atds/atds.2.4.1/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.5.0/opam
+++ b/packages/atds/atds.2.5.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.6.0/opam
+++ b/packages/atds/atds.2.6.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.3.0"}
+  "atd" {>= "2.3.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.7.0/opam
+++ b/packages/atds/atds.2.7.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.8.0/opam
+++ b/packages/atds/atds.2.8.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atds/atds.2.9.1/opam
+++ b/packages/atds/atds.2.9.1/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "odoc" {with-doc}
 ]
 dev-repo: "git+https://github.com/ahrefs/atd.git"

--- a/packages/atdts/atdts.2.5.0/opam
+++ b/packages/atdts/atdts.2.5.0/opam
@@ -62,8 +62,8 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {= version}
-  "atdgen" {>= "2.3.0"}
+  "atd" {= version & < "2.10.0"}
+  "atdgen" {>= "2.3.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdts/atdts.2.6.0/opam
+++ b/packages/atdts/atdts.2.6.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.6.0"}
+  "atd" {>= "2.6.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdts/atdts.2.7.0/opam
+++ b/packages/atdts/atdts.2.7.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdts/atdts.2.8.0/opam
+++ b/packages/atdts/atdts.2.8.0/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}

--- a/packages/atdts/atdts.2.9.1/opam
+++ b/packages/atdts/atdts.2.9.1/opam
@@ -62,7 +62,7 @@ bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.08"}
-  "atd" {>= "2.7.0"}
+  "atd" {>= "2.7.0" & < "2.10.0"}
   "cmdliner" {>= "1.1.0"}
   "re"
   "alcotest" {with-test}


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/21965
e.g.
```
#=== ERROR while compiling atdgen.2.2.1 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/atdgen.2.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p atdgen -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/atdgen-6-c80ac3.env
# output-file          ~/.opam/log/atdgen-6-c80ac3.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -w -27 -safe-string -g -I atdgen/src/.atdgen_emit.objs/byte -I atdgen/src/.atdgen_emit.objs/native -I /home/opam/.opam/4.14/lib/atd -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Atdgen_emit -o atdgen/src/.atdgen_emit.objs/native/atdgen_emit__Xb_emit.cmx -c -impl atdgen/src/xb_emit.ml)
# File "atdgen/src/xb_emit.ml", line 89, characters 14-29:
# 89 |       let h = Bi_io.hash_name s in
#                    ^^^^^^^^^^^^^^^
# Error: Unbound module Bi_io
# Hint: Did you mean Biniou?
```