### PR TITLE
faraday < 0.3.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/faraday/faraday.0.1.0/opam
+++ b/packages/faraday/faraday.0.1.0/opam
@@ -26,7 +26,7 @@ remove: [
   ["ocamlfind" "remove" "faraday"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "alcotest" {with-test & >= "0.4.1"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/faraday/faraday.0.2.0/opam
+++ b/packages/faraday/faraday.0.2.0/opam
@@ -24,7 +24,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "faraday"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "alcotest" {with-test & >= "0.4.1" & < "0.8.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling faraday.0.1.0 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/faraday.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --enable-unix --enable-lwt --disable-async
# exit-code            2
# env-file             ~/.opam/log/faraday-7-f5d6d8.env
# output-file          ~/.opam/log/faraday-7-f5d6d8.out
### output ###
# File "./setup.ml", line 581, characters 4-15:
# 581 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```