### PR TITLE
vecosek-scene is not compatible with yojson 2.0.0

### DIFF
--- a/packages/vecosek-scene/vecosek-scene.0.0.0/opam
+++ b/packages/vecosek-scene/vecosek-scene.0.0.0/opam
@@ -16,8 +16,8 @@ depends: [
   "jbuilder" {>= "1.0+beta20"}
   "nonstd"
   "sosa"
-  "yojson"
-  "atdgen"
+  "yojson" {< "2.0.0"}
+  "atdgen" {< "2.10.0"}
 ]
 synopsis: ""
 description: """


### PR DESCRIPTION
```
#=== ERROR while compiling vecosek-scene.0.0.0 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/vecosek-scene.0.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p vecosek-scene -j 31
# exit-code            1
# env-file             ~/.opam/log/vecosek-scene-7-24dbb7.env
# output-file          ~/.opam/log/vecosek-scene-7-24dbb7.out
### output ###
#       ocamlc src/lib/.vecosek_scene.objs/vecosek_scene__Scene.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/.vecosek_scene.objs -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/nonstd -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sosa -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Vecosek_scene -o src/lib/.vecosek_scene.objs/vecosek_scene__Scene.cmo -c -impl src/lib/scene.ml)
# File "src/lib/scene.ml", line 107, characters 31-35:
# 107 |     Scene_format_j.write_scene obuf scene;
#                                      ^^^^
# Error: This expression has type Bi_outbuf.t
#        but an expression was expected of type Buffer.t
#     ocamlopt src/lib/.vecosek_scene.objs/vecosek_scene__Scene.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I src/lib/.vecosek_scene.objs -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/nonstd -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sosa -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Vecosek_scene -o src/lib/.vecosek_scene.objs/vecosek_scene__Scene.cmx -c -impl src/lib/scene.ml)
# File "src/lib/scene.ml", line 107, characters 31-35:
# 107 |     Scene_format_j.write_scene obuf scene;
#                                      ^^^^
# Error: This expression has type Bi_outbuf.t
#        but an expression was expected of type Buffer.t
```