### PR TITLE
sentry is not compatible with yojson 2.0.0 (uses Yojson.Basic.json)

### DIFF
--- a/packages/sentry/sentry.v0.10.1/opam
+++ b/packages/sentry/sentry.v0.10.1/opam
@@ -10,7 +10,7 @@ doc: "https://brendanlong.github.io/sentry-ocaml"
 bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
 depends: [
   "async_unix" {>= "v0.13.0" & < "v0.14"}
-  "atdgen"
+  "atdgen" {< "2.10.0"}
   "bisect_ppx" {dev & >= "2.0.0"}
   "cohttp" {>= "2.0.0"}
   "cohttp-async" {>= "2.0.0"}
@@ -23,7 +23,7 @@ depends: [
   "sexplib" {>= "v0.13.0" & < "v0.14"}
   "uuidm"
   "uri"
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/sentry/sentry.v0.11.0/opam
+++ b/packages/sentry/sentry.v0.11.0/opam
@@ -10,7 +10,7 @@ doc: "https://brendanlong.github.io/sentry-ocaml"
 bug-reports: "https://github.com/brendanlong/sentry-ocaml/issues"
 depends: [
   "core" {>= "v0.13.0"}
-  "atdgen"
+  "atdgen" {< "2.10.0"}
   "bisect_ppx" {dev & >= "2.0.0"}
   "cohttp" {>= "2.0.0"}
   "cohttp-async" {>= "2.0.0"}
@@ -23,7 +23,7 @@ depends: [
   "sexplib" {>= "v0.13.0"}
   "uuidm"
   "uri"
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
```
#=== ERROR while compiling sentry.v0.11.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/sentry.v0.11.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sentry -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/sentry-7-5a69d6.env
# output-file          ~/.opam/log/sentry-7-5a69d6.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -3 -g -bin-annot -I src/.sentry.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/async -I /home/opam/.opam/4.14/lib/async/async_command -I /home/opam/.opam/4.14/lib/async/async_quickcheck -I /home/opam/.opam/4.14/lib/async/async_rpc -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/async_unix -I /home/opam/.opam/4.14/lib/async_unix/thread_pool -I /home/opam/.opam/4.14/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-async -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-async -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/bigstring_unix -I /home/opam/.opam/4.14/lib/core/error_checking_mutex -I /home/opam/.opam/4.14/lib/core/iobuf_unix -I /home/opam/.opam/4.14/lib/core/linux_ext -I /home/opam/.opam/4.14/lib/core/nano_mutex -I /home/opam/.opam/4.14/lib/core/squeue -I /home/opam/.opam/4.14/lib/core/time_stamp_counter -I /home/opam/.opam/4.14/lib/core/uuid -I /home/opam/.opam/4.14/lib/core_kernel -I /home/opam/.opam/4.14/lib/core_kernel/base_for_tests -I /home/opam/.opam/4.14/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_kernel/iobuf -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/rope -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/uuid -I /home/opam/.opam/4.14/lib/core_kernel/version_util -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/json-derivers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re2 -I /home/opam/.opam/4.14/lib/re2/c -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/timezone -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Sentry__ -o src/.sentry.objs/byte/sentry__Json.cmi -c -intf src/json.pp.mli)
# File "src/json.mli", line 2, characters 9-26:
# 2 | type t = Yojson.Basic.json [@@deriving sexp_of]
#              ^^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Basic.json
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -w -3 -g -bin-annot -I src/.sentry.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/async -I /home/opam/.opam/4.14/lib/async/async_command -I /home/opam/.opam/4.14/lib/async/async_quickcheck -I /home/opam/.opam/4.14/lib/async/async_rpc -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/async_unix -I /home/opam/.opam/4.14/lib/async_unix/thread_pool -I /home/opam/.opam/4.14/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-async -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-async -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/bigstring_unix -I /home/opam/.opam/4.14/lib/core/error_checking_mutex -I /home/opam/.opam/4.14/lib/core/iobuf_unix -I /home/opam/.opam/4.14/lib/core/linux_ext -I /home/opam/.opam/4.14/lib/core/nano_mutex -I /home/opam/.opam/4.14/lib/core/squeue -I /home/opam/.opam/4.14/lib/core/time_stamp_counter -I /home/opam/.opam/4.14/lib/core/uuid -I /home/opam/.opam/4.14/lib/core_kernel -I /home/opam/.opam/4.14/lib/core_kernel/base_for_tests -I /home/opam/.opam/4.14/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_kernel/iobuf -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/rope -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/uuid -I /home/opam/.opam/4.14/lib/core_kernel/version_util -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/json-derivers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re2 -I /home/opam/.opam/4.14/lib/re2/c -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/timezone -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Sentry__ -o src/.sentry.objs/byte/sentry__Payloads_t.cmi -c -intf src/payloads_t.pp.mli)
# File "src/payloads_t.mli", line 54, characters 12-29:
# 54 | type json = Yojson.Basic.json
#                  ^^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Basic.json
```