### PR TITLE
Disable the tests of dune-release >= 1.5.0 when using opam >= 2.2

### DIFF
--- a/packages/dune-release/dune-release.1.5.0/opam
+++ b/packages/dune-release/dune-release.1.5.0/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "clean"] {with-test}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & opam-version < "2.2"}
 ]
 
 depends: [

--- a/packages/dune-release/dune-release.1.5.1/opam
+++ b/packages/dune-release/dune-release.1.5.1/opam
@@ -49,7 +49,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & opam-version < "2.2"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/dune-release/dune-release.1.5.2/opam
+++ b/packages/dune-release/dune-release.1.5.2/opam
@@ -46,7 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & !(os-distribution = "centos" & os-version < "8") & !(os-distribution = "ol" & os-version < "8")} # Disable the tests on distributions that have old versions of git
+    "@runtest" {with-test & opam-version < "2.2" & !(os-distribution = "centos" & os-version < "8") & !(os-distribution = "ol" & os-version < "8")} # Disable the tests on distributions that have old versions of git
     "@doc" {with-doc}
   ]
 ]

--- a/packages/dune-release/dune-release.1.6.0/opam
+++ b/packages/dune-release/dune-release.1.6.0/opam
@@ -46,7 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & opam-version < "2.2"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/dune-release/dune-release.1.6.1/opam
+++ b/packages/dune-release/dune-release.1.6.1/opam
@@ -46,7 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & opam-version < "2.2"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/dune-release/dune-release.1.6.2/opam
+++ b/packages/dune-release/dune-release.1.6.2/opam
@@ -46,7 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & opam-version < "2.2"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Uses the output of opam lint
```
#=== ERROR while compiling dune-release.1.6.2 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/dune-release.1.6.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dune-release -j 31 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/dune-release-7-58aecb.env
# output-file          ~/.opam/log/dune-release-7-58aecb.out
### output ###
# (cd _build/default/tests/lib && ./tests.exe -e)
# Testing `dune-release'.
# This run has ID `T3H4JJYE'.
# 
#   [OK]          Github                 0   Parse.ssh_uri_from_http https://gi...
#   [OK]          Github                 1   Parse.ssh_uri_from_http git@github...
#   [OK]          Github                 2   Parse.ssh_uri_from_http https://no...
#   [OK]          Github                 3   Parse.ssh_uri_from_http git@not-gi...
#   [OK]          Github                 4   Parse.ssh_uri_from_http git://gith...
#   [OK]          Github                 5   Parse.ssh_uri_from_http git+https:...
#   [OK]          Github_v3_api          0   simple.
#   [OK]          Github_v3_api          1   simple.
#   [OK]          Github_v3_api          2   simple.
#   [OK]          Github_v3_api          3   basic.
#   [OK]          Github_v3_api          4   basic.
#   [OK]          Github_v3_api          5   archive_upload_url.
#   [OK]          Github_v3_api          6   archive_upload_url.
#   [OK]          Github_v3_api          7   release_id.
#   [OK]          Github_v3_api          8   html_url: passing.
#   [OK]          Github_v3_api          9   html_url: handled failure.
#   [OK]          Github_v3_api         10   html_url: unhandled failure.
#   [OK]          Github_v3_api         11   number.
#   [OK]          Github_v4_api          0   basic.
#   [OK]          Github_v4_api          1   Pull_request.Request.node_id: simple.
#   [OK]          Github_v4_api          2   Pull_request.Response.node_id: pas...
#   [OK]          Github_v4_api          3   Pull_request.Response.node_id: unh...
#   [OK]          Github_v4_api          4   Pull_request.Request.ready_for_rev...
#   [OK]          Github_v4_api          5   Pull_request.Response.url: passing.
#   [OK]          Github_v4_api          6   Pull_request.Response.url: unhandl...
#   [OK]          Opam                   0   Version.of_string 1.0.
#   [OK]          Opam                   1   Version.of_string 1.0.0.
#   [OK]          Opam                   2   Version.of_string 1.2.0.
#   [OK]          Opam                   3   Version.of_string 1.2.2.
#   [OK]          Opam                   4   Version.of_string 1.2.2.3.
#   [OK]          Opam                   5   Version.of_string 2.
#   [OK]          Opam                   6   Version.of_string 2.0.
#   [OK]          Opam                   7   Version.of_string 2.0.0.
#   [OK]          Opam                   8   Version.of_string 2.0.1.
#   [OK]          Opam_file              0   upgrade.
#   [OK]          Opam_file              1   upgrade.
#   [OK]          Pkg                    0   is not a valid version field line.
#   [OK]          Pkg                    1   version:""is not a valid version f...
#   [OK]          Pkg                    2   version:"1"is a valid version fiel...
#   [OK]          Pkg                    3   version:     "1"    is a valid ver...
#   [OK]          Pkg                    4   version:"1.jfpojef.adp921709"is a ...
#   [OK]          Pkg                    5   prepare_opam_for_distrib: empty.
#   [OK]          Pkg                    6   prepare_opam_for_distrib: replace ...
#   [OK]          Pkg                    7   prepare_opam_for_distrib: only rep...
#   [OK]          Pkg                    8   distrib_uri:1.
#   [OK]          Pkg                    9   distrib_uri:2.
#   [OK]          Pkg                   10   distrib_uri:3.
#   [OK]          Pkg                   11   distrib_uri:4.
#   [OK]          Pkg                   12   distrib_uri:5.
#   [OK]          Pkg                   13   distrib_uri:6.
#   [OK]          Pkg                   14   distrib_uri:7.
#   [OK]          Pkg                   15   distrib_uri:8.
#   [OK]          Pkg                   16   distrib_uri:9.
#   [OK]          Pkg                   17   ok.
#   [OK]          Pkg                   18   no name.
#   [OK]          Pkg                   19   opam file generation.
#   [OK]          Pkg                   20   leading whitespace.
#   [OK]          Stdext                 0   Path.is_backup_file.
#   [OK]          Stdext                 1   Path.find_files.
#   [OK]          Text                   0   change_log_last_entry empty.
#   [OK]          Text                   1   change_log_last_entry change list 0.
#   [OK]          Text                   2   change_log_last_entry change list 1.
#   [OK]          Text                   3   change_log_last_entry change list 2.
#   [OK]          Text                   4   change_log_last_entry many entries.
#   [OK]          Text                   5   change_log_last_entry keepachangel...
#   [OK]          Text                   6   change_log_last_entry keepachangel...
#   [OK]          Text                   7   rewrite_github_refs rewritten 0.
#   [OK]          Text                   8   rewrite_github_refs rewritten 1.
#   [OK]          Text                   9   rewrite_github_refs not rewritten 0.
#   [OK]          Text                  10   rewrite_github_refs not rewritten 1.
#   [OK]          Text                  11   rewrite_github_refs not rewritten 2.
#   [OK]          Text                  12   rewrite_github_refs not rewritten 3.
#   [OK]          Sos                    0   cmd_error.
#   [OK]          Vcs                    0   git_escape_tag: empty.
#   [OK]          Vcs                    1   git_escape_tag: valid.
#   [OK]          Vcs                    2   git_escape_tag: tilde.
#   [OK]          Vcs                    3   git_unescape_tag: empty.
#   [OK]          Vcs                    4   git_unescape_tag: valid.
#   [OK]          Vcs                    5   git_unescape_tag: tilde.
#   [OK]          Uri_helpers            0   parse: scheme://domain.com/some/path.
#   [OK]          Uri_helpers            1   parse: noscheme.com/some/path.
#   [OK]          Uri_helpers            2   parse: nopath.com.
#   [OK]          Uri_helpers            3   parse: git@github.com:some/path.
#   [OK]          Github_repo            0   from_uri "https://github.com/owner...
#   [OK]          Github_repo            1   from_uri "https://github.com/owner...
#   [OK]          Github_repo            2   from_uri "git+https://github.com/o...
#   [OK]          Github_repo            3   from_uri "git@github.com:owner/rep...
#   [OK]          Github_repo            4   from_uri "ssh://git@github.com:own...
#   [OK]          Github_repo            5   from_uri "git+ssh://git@github.com...
#   [OK]          Github_repo            6   from_uri "https://owner.github.io/...
#   [OK]          Github_repo            7   from_uri "https://owner.github.io/...
#   [OK]          Github_repo            8   from_uri "https://gitlab.com/owner...
#   [OK]          Github_repo            9   https_uri: "Simple".
#   [OK]          Github_repo           10   ssh_uri: "Simple".
#   [OK]          Github_repo           11   from_gh_pages: https://user.github...
#   [OK]          Github_repo           12   from_gh_pages: https://user.github...
#   [OK]          Github_repo           13   from_gh_pages: https://user.github...
#   [OK]          Github_repo           14   from_gh_pages: https://user.github...
#   [OK]          Github_repo           15   from_gh_pages: https://user.github...
# 
# Full test results in `~/.opam/4.14/.opam-switch/build/dune-release.1.6.2/_build/default/tests/lib/_build/_tests/dune-release'.
# Test Successful in 0.019s. 99 tests run.
# File "tests/bin/check/run.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/4b85f877cb0102f59a4e043df04faf9e/default/tests/bin/check/run.t _build/.sandbox/4b85f877cb0102f59a4e043df04faf9e/default/tests/bin/check/run.t.corrected
# diff --git a/_build/.sandbox/4b85f877cb0102f59a4e043df04faf9e/default/tests/bin/check/run.t b/_build/.sandbox/4b85f877cb0102f59a4e043df04faf9e/default/tests/bin/check/run.t.corrected
# index 8fe18f0..ff87e13 100644
# --- a/_build/.sandbox/4b85f877cb0102f59a4e043df04faf9e/default/tests/bin/check/run.t
# +++ b/_build/.sandbox/4b85f877cb0102f59a4e043df04faf9e/default/tests/bin/check/run.t.corrected
# @@ -43,11 +43,14 @@ If the condition described above is fulfilled, there are 4 checks to be performe
#    [FAIL] File LICENSE is missing.
#    [FAIL] File CHANGES is missing.
#    [ OK ] File opam is present.
# -  [ OK ] lint opam file my_pkg.opam.
# +  [FAIL] lint opam file my_pkg.opam:
# +         opam lint -s messages:
# +         <test_directory>/my_pkg.opam: Warnings.
# +                    warning 68: Missing field 'license'
#    [ OK ] opam field synopsis is present
#    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
#    [ OK ] Skipping doc field linting, no doc field found
# -  [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
# +  [FAIL] lint of <project_dir> and package my_pkg failure: 4 errors.
#  
#  Add another package
#  
# @@ -80,22 +83,28 @@ In multi package projects, the whole lint process (including the file lints, eve
#    [FAIL] File LICENSE is missing.
#    [FAIL] File CHANGES is missing.
#    [ OK ] File opam is present.
# -  [ OK ] lint opam file my_pkg.opam.
# +  [FAIL] lint opam file my_pkg.opam:
# +         opam lint -s messages:
# +         <test_directory>/my_pkg.opam: Warnings.
# +                    warning 68: Missing field 'license'
#    [ OK ] opam field synopsis is present
#    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
#    [ OK ] Skipping doc field linting, no doc field found
# -  [FAIL] lint of <project_dir> and package my_pkg failure: 3 errors.
# +  [FAIL] lint of <project_dir> and package my_pkg failure: 4 errors.
#    
#    [-] Performing lint for package my_pkg-sub in <test_directory>
#    [FAIL] File README is missing.
#    [FAIL] File LICENSE is missing.
#    [FAIL] File CHANGES is missing.
#    [ OK ] File opam is present.
# -  [ OK ] lint opam file my_pkg-sub.opam.
# +  [FAIL] lint opam file my_pkg-sub.opam:
# +         opam lint -s messages:
# +         <test_directory>/my_pkg-sub.opam: Warnings.
# +                    warning 68: Missing field 'license'
#    [ OK ] opam field synopsis is present
#    [ OK ] opam fields homepage and dev-repo can be parsed by dune-release
#    [ OK ] Skipping doc field linting, no doc field found
# -  [FAIL] lint of <project_dir> and package my_pkg-sub failure: 3 errors.
# +  [FAIL] lint of <project_dir> and package my_pkg-sub failure: 4 errors.
#  
#  In the same way in which the user can skip the lint check when releasing the tarball, they can also skip it here
#  
```
cc @NathanReb 