### PR TITLE
[new release] ssl (0.5.12)

### DIFF
--- a/packages/ssl/ssl.0.5.10/opam
+++ b/packages/ssl/ssl.0.5.10/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"
   "base-unix"

--- a/packages/ssl/ssl.0.5.11/opam
+++ b/packages/ssl/ssl.0.5.11/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/savonet/ocaml-ssl"
 bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"
   "base-unix"

--- a/packages/ssl/ssl.0.5.12/opam
+++ b/packages/ssl/ssl.0.5.12/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+  "base-unix"
+  "conf-libssl"
+]
+synopsis: "Bindings for OpenSSL"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+url {
+  src:
+    "https://github.com/savonet/ocaml-ssl/releases/download/0.5.12/ssl-0.5.12.tbz"
+  checksum: [
+    "sha256=e60c4dc60636516d82db785e5533ddbaabca5f96483f04a0d6aa6f43b5e9e79e"
+    "sha512=0ab2b491765d0405cd28b8479f4a03de9191ba87ba7d77ca013c48508c2bbfead21ff91202d5df978efedad767652476bbfc977243ca4190580dac6a2086e65d"
+  ]
+}
+x-commit-hash: "e630f27a371503caab927aed7d909a49746dcbb1"

--- a/packages/ssl/ssl.0.5.4/opam
+++ b/packages/ssl/ssl.0.5.4/opam
@@ -15,7 +15,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" name]]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-which" {build}
   "conf-libssl"

--- a/packages/ssl/ssl.0.5.5/opam
+++ b/packages/ssl/ssl.0.5.5/opam
@@ -11,7 +11,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" name]]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-which" {build}
   "conf-libssl"

--- a/packages/ssl/ssl.0.5.6/opam
+++ b/packages/ssl/ssl.0.5.6/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune"
   "dune-configurator"
   "base-unix"

--- a/packages/ssl/ssl.0.5.7/opam
+++ b/packages/ssl/ssl.0.5.7/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "1.2.1"}
   "dune-configurator"
   "base-unix"

--- a/packages/ssl/ssl.0.5.8/opam
+++ b/packages/ssl/ssl.0.5.8/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "1.2.1"}
   "dune-configurator"
   "base-unix"

--- a/packages/ssl/ssl.0.5.9/opam
+++ b/packages/ssl/ssl.0.5.9/opam
@@ -8,7 +8,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "1.2.1"}
   "dune-configurator"
   "base-unix"


### PR DESCRIPTION
Bindings for OpenSSL

- Project page: <a href="https://github.com/savonet/ocaml-ssl">https://github.com/savonet/ocaml-ssl</a>

##### CHANGES:

- Add a few verification functions (savonet/ocaml-ssl#71):
  - `add_extra_chain_cert` to send additional chain certificates to the peer.
  - `add_cert_to_store`: to allow verification of the peer certificate CA.
  - `set_ip`: sets the expected IP address to be verified on a SSL socket.
- Improve `use_certificate_from_string` (savonet/ocaml-ssl#71) to read any type of key (rather
  than just RSA).
- Fix a segmentation fault in the ALPN selection callback under OCaml 5 (savonet/ocaml-ssl#89).
- Audit the C FFI and add `CAMLparamX` and `CAMLreturn` calls (savonet/ocaml-ssl#90).
