### PR TITLE
Move dkml-compiler from tag tarball to release

### DIFF
--- a/packages/dkml-base-compiler/dkml-base-compiler.4.12.1~v1.0.0/opam
+++ b/packages/dkml-base-compiler/dkml-base-compiler.4.12.1~v1.0.0/opam
@@ -160,7 +160,7 @@ extra-source "dl/dkml-runtime-common.tar.gz" {
   ]
 }
 url {
-  src: "https://github.com/diskuv/dkml-compiler/archive/4.12.1-v1.0.0.tar.gz"
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/4.12.1-v1.0.0/src.tar.gz"
   checksum: [
     "md5=94f9e2619e329ec6b28c0c42c4e0ced5"
     "sha512=9bb83aeccb9054153d879c33d0999e5c648bdf2dbded6f7fc3115c984592fd117ff2d7858edb38c53389bbf480050451e4bcb86ea7e7ff59279e175b48183013"

--- a/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.0/opam
+++ b/packages/dkml-component-staging-ocamlrun/dkml-component-staging-ocamlrun.4.12.1~v1.0.0/opam
@@ -203,7 +203,7 @@ extra-source "dl/homebrew-bundle.tar.gz" {
   ]
 }
 extra-source "dl/dkml-compiler.tar.gz" {
-  src: "https://github.com/diskuv/dkml-compiler/archive/refs/tags/4.12.1-v1.0.0.tar.gz"
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/4.12.1-v1.0.0/src.tar.gz"
   checksum: [
     "sha256=8beda92f97cde6d4a55a836ca6dc9f860bb5f1a6b765b80be4594943288571cf"
   ]

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~dkml20220801/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~dkml20220801/opam
@@ -177,7 +177,7 @@ install: [
 ]
 dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlcompiler.git"
 extra-source "dl/dkml-compiler.tar.gz" {
-  src: "https://github.com/diskuv/dkml-compiler/archive/refs/tags/4.12.1-v1.0.0.tar.gz"
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/4.12.1-v1.0.0/src.tar.gz"
   checksum: [
     "sha256=8beda92f97cde6d4a55a836ca6dc9f860bb5f1a6b765b80be4594943288571cf"
   ]

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~dkml20220801/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~dkml20220801/opam
@@ -201,7 +201,7 @@ install: [
 ]
 dev-repo: "git+https://github.com/diskuv/dkml-component-ocamlcompiler.git"
 extra-source "dl/dkml-compiler.tar.gz" {
-  src: "https://github.com/diskuv/dkml-compiler/archive/refs/tags/4.12.1-v1.0.0.tar.gz"
+  src: "https://github.com/diskuv/dkml-compiler/releases/download/4.12.1-v1.0.0/src.tar.gz"
   checksum: [
     "sha256=8beda92f97cde6d4a55a836ca6dc9f860bb5f1a6b765b80be4594943288571cf"
   ]


### PR DESCRIPTION
My stupidity. I deleted the dkml-compiler tag, realized my mistake, and then re-applied the tag. But GitHub tag archives don't seem to be reproducible after some time elapses.

This PR uses a GitHub release to store the archive. I recovered the original tarball from an Opam download-cache.