### PR TITLE
Package opus.0.2.2-1

### DIFF
--- a/packages/opus/opus.0.2.2-1/opam
+++ b/packages/opus/opus.0.2.2-1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Bindings to libopus"
+maintainer: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
+license: "GPL-2.0"
+homepage: "https://github.com/savonet/ocaml-opus"
+bug-reports: "https://github.com/savonet/ocaml-opus/issues"
+depends: [
+  "conf-libogg"
+  "conf-libopus"
+  "conf-pkg-config"
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8"}
+  "dune-configurator"
+  "ogg" {>= "0.7.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/savonet/ocaml-opus.git"
+url {
+  src: "https://github.com/savonet/ocaml-opus/archive/v0.2.2.tar.gz"
+  checksum: [
+    "md5=8e4f833477997732b0c0aec4d42420c9"
+    "sha512=e9931a80550ed3566cebc4e07204192319fdb02c88519f6711c57ec2cb8d68e13f641bd843c815244010e4be8fbada95d826063e33297113a5c3743c3a4e2a5d"
+  ]
+}


### PR DESCRIPTION
### `opus.0.2.2-1`
Bindings to libopus



---
* Homepage: https://github.com/savonet/ocaml-opus
* Source repo: git+https://github.com/savonet/ocaml-opus.git
* Bug tracker: https://github.com/savonet/ocaml-opus/issues

---
:camel: Pull-request generated by opam-publish v2.1.0