### PR TITLE
Remove constraints on opam < 2.0

### DIFF
--- a/packages/apron/apron.20150820/opam
+++ b/packages/apron/apron.20150820/opam
@@ -29,9 +29,6 @@ depends: ["ocaml" "ocamlfind" "camlidl" "mlgmpidl" "conf-perl"]
 depopts: [
   "conf-ppl"
 ]
-available: [
-  opam-version >= "1.2"
-]
 patches: [
   "docker-workaround.diff" { os = "linux" }
 ]

--- a/packages/arakoon/arakoon.1.8.10/opam
+++ b/packages/arakoon/arakoon.1.8.10/opam
@@ -36,7 +36,6 @@ depends: [
   "zarith" {= "1.3"}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.8.11/opam
+++ b/packages/arakoon/arakoon.1.8.11/opam
@@ -36,7 +36,6 @@ depends: [
   "zarith" {= "1.3"}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.8.12/opam
+++ b/packages/arakoon/arakoon.1.8.12/opam
@@ -30,7 +30,6 @@ depends: [
   "sexplib" {= "113.00.00"}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.8.6/opam
+++ b/packages/arakoon/arakoon.1.8.6/opam
@@ -39,7 +39,6 @@ depends: [
   "zarith" {= "1.3"}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.8.7/opam
+++ b/packages/arakoon/arakoon.1.8.7/opam
@@ -36,7 +36,6 @@ depends: [
   "zarith" {= "1.3"}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.8.8/opam
+++ b/packages/arakoon/arakoon.1.8.8/opam
@@ -36,7 +36,6 @@ depends: [
   "zarith" {= "1.3"}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.9.0/opam
+++ b/packages/arakoon/arakoon.1.9.0/opam
@@ -33,7 +33,7 @@ depends: [
   "redis" {>= "0.2.3"}
   "uri" {>= "1.9.1"}
 ]
-available: opam-version >= "1.2" & os != "macos"
+available: os != "macos"
 depexts: ["help2man"] {os-distribution = "ubuntu"}
 synopsis:
   "A distributed key-value store that guarantees consistency above anything else."

--- a/packages/arakoon/arakoon.1.9.17/opam
+++ b/packages/arakoon/arakoon.1.9.17/opam
@@ -34,7 +34,7 @@ depends: [
   "uri" {>= "1.9.2"}
   "ounit"
 ]
-available: opam-version >= "1.2" & os != "macos"
+available: os != "macos"
 depexts: [
   ["help2man"] {os-family = "debian"}
 ]

--- a/packages/base58/base58.0.1.0/opam
+++ b/packages/base58/base58.0.1.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ocamlbuild" {build}
   "num"
 ]
-available: opam-version >= "1.2"
 synopsis: "Base58 encoding and decoding"
 description:
   "This library enables you to encode and decode into base58 representation using the alphabet of your choice."

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
@@ -15,7 +15,6 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "jbuilder" {>= "1.0+beta7"}
 ]
-available: opam-version >= "1.2"
 synopsis:
   "An OCaml implementation of the BUILD_PATH_PREFIX_MAP specification"
 description: "https://reproducible-builds.org/specs/build-path-prefix-map/"

--- a/packages/camlp4/camlp4.4.02.0-1modular-implicits/opam
+++ b/packages/camlp4/camlp4.4.02.0-1modular-implicits/opam
@@ -26,7 +26,6 @@ remove: [
              "%{bin}%/camlp4o.opt" "%{bin}%/camlp4oof.opt" "%{bin}%/camlp4r.opt"
   ]
 ]
-available: opam-version >= "1.2.1"
 bug-reports: "https://github.com/ocaml/camlp4/issues"
 dev-repo: "git+https://github.com/ocaml/camlp4.git"
 synopsis:

--- a/packages/camltc/camltc.0.9.4/opam
+++ b/packages/camltc/camltc.0.9.4/opam
@@ -24,7 +24,6 @@ depends: [
   "lwt" {>= "2.4.4" & < "4.0.0"}
   "ocamlbuild" {build}
 ]
-available: opam-version > "1.2.0"
 depexts: [
   ["git"] {os-family = "debian"}
 ]

--- a/packages/camltc/camltc.0.9.5/opam
+++ b/packages/camltc/camltc.0.9.5/opam
@@ -25,7 +25,6 @@ depends: [
   "logs" {>= "0.5.0"}
   "ocamlbuild" {build}
 ]
-available: opam-version > "1.2.0"
 depexts: [
   ["git"] {os-family = "debian"}
 ]

--- a/packages/camltc/camltc.0.9.6/opam
+++ b/packages/camltc/camltc.0.9.6/opam
@@ -25,7 +25,6 @@ depends: [
   "logs" {>= "0.5.0"}
   "ocamlbuild" {build}
 ]
-available: opam-version > "1.2.0"
 depexts: [
   ["git"] {os-family = "debian"}
 ]

--- a/packages/camltc/camltc.0.9.7.0/opam
+++ b/packages/camltc/camltc.0.9.7.0/opam
@@ -20,7 +20,6 @@ depends: [
   "logs"
   "ocamlbuild" {build}
 ]
-available: opam-version > "1.2.0"
 synopsis: "OCaml bindings for tokyo cabinet"
 authors: ["Jan Doms" "Joost Damad" "Romain Slootmaekers" "Nicolas Trangez"]
 flags: light-uninstall

--- a/packages/charrua-core/charrua-core.0.10/opam
+++ b/packages/charrua-core/charrua-core.0.10/opam
@@ -7,7 +7,6 @@ bug-reports: "https://github.com/mirage/charrua-core/issues"
 dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
 
-available: opam-version >= "1.2"
 build: [
   ["jbuilder" "subst" "-p" name] {dev}
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/charrua-core/charrua-core.0.3/opam
+++ b/packages/charrua-core/charrua-core.0.3/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/haesbaert/charrua-core"
 bug-reports: "https://github.com/haesbaert/charrua-core/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/haesbaert/charrua-core.git"
-available: opam-version >= "1.2"
 build: [
   ["sh" "build.sh"]
 ]

--- a/packages/charrua-core/charrua-core.0.4/opam
+++ b/packages/charrua-core/charrua-core.0.4/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/haesbaert/charrua-core"
 bug-reports: "https://github.com/haesbaert/charrua-core/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/haesbaert/charrua-core.git"
-available: opam-version >= "1.2"
 build: [
   ["sh" "build.sh"]
 ]

--- a/packages/charrua-core/charrua-core.0.5/opam
+++ b/packages/charrua-core/charrua-core.0.5/opam
@@ -7,7 +7,6 @@ bug-reports: "https://github.com/mirage/charrua-core/issues"
 dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
 
-available: opam-version >= "1.2"
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]

--- a/packages/charrua-core/charrua-core.0.6/opam
+++ b/packages/charrua-core/charrua-core.0.6/opam
@@ -7,7 +7,6 @@ bug-reports: "https://github.com/mirage/charrua-core/issues"
 dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
 
-available: opam-version >= "1.2"
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]

--- a/packages/charrua-core/charrua-core.0.7/opam
+++ b/packages/charrua-core/charrua-core.0.7/opam
@@ -7,7 +7,6 @@ bug-reports: "https://github.com/mirage/charrua-core/issues"
 dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
 
-available: opam-version >= "1.2"
 build: [
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false"]
   ["ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "true"]

--- a/packages/charrua-core/charrua-core.0.8/opam
+++ b/packages/charrua-core/charrua-core.0.8/opam
@@ -7,7 +7,6 @@ bug-reports: "https://github.com/mirage/charrua-core/issues"
 dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
 
-available: opam-version >= "1.2"
 build: [
   ["jbuilder" "subst" "-p" name "--name" name] {dev}
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/charrua-core/charrua-core.0.9/opam
+++ b/packages/charrua-core/charrua-core.0.9/opam
@@ -7,7 +7,6 @@ bug-reports: "https://github.com/mirage/charrua-core/issues"
 dev-repo: "git+https://github.com/mirage/charrua-core.git"
 doc: "https://mirage.github.io/charrua-core/api"
 
-available: opam-version >= "1.2"
 build: [
   ["jbuilder" "subst" "-p" name] {dev}
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/charrua-unix/charrua-unix.0.10/opam
+++ b/packages/charrua-unix/charrua-unix.0.10/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/haesbaert/charrua-unix"
 bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/haesbaert/charrua-unix.git"
-available: opam-version >= "1.2"
 build: [
   ["jbuilder" "subst" "-p" name] {dev}
   ["jbuilder" "build" "-p" name "-j" jobs]

--- a/packages/charrua-unix/charrua-unix.0.3/opam
+++ b/packages/charrua-unix/charrua-unix.0.3/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/haesbaert/charrua-unix"
 bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/haesbaert/charrua-unix.git"
-available: opam-version >= "1.2"
 build: [
   ["sh" "build.sh"]
 ]

--- a/packages/charrua-unix/charrua-unix.0.4/opam
+++ b/packages/charrua-unix/charrua-unix.0.4/opam
@@ -5,7 +5,6 @@ homepage: "https://github.com/haesbaert/charrua-unix"
 bug-reports: "https://github.com/haesbaert/charrua-unix/issues"
 license: "ISC"
 dev-repo: "git+https://github.com/haesbaert/charrua-unix.git"
-available: opam-version >= "1.2"
 build: [
   ["sh" "build.sh"]
 ]

--- a/packages/depext/depext.0.8.1/opam
+++ b/packages/depext/depext.0.8.1/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & <= "0.9.8"}
 ]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.0.8/opam
+++ b/packages/depext/depext.0.8/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & <= "0.9.8"}
 ]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.0.9.0/opam
+++ b/packages/depext/depext.0.9.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & <= "0.9.8"}
 ]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.0.9.1/opam
+++ b/packages/depext/depext.0.9.1/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & <= "0.9.8"}
 ]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.1.0.0/opam
+++ b/packages/depext/depext.1.0.0/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & <= "0.9.8"}
 ]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.1.0.1/opam
+++ b/packages/depext/depext.1.0.1/opam
@@ -34,7 +34,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & <= "0.9.8"}
 ]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.1.0.2/opam
+++ b/packages/depext/depext.1.0.2/opam
@@ -33,7 +33,7 @@ depends: [
   "ocaml"
   "cmdliner" {build & = "0.9.8"}
 ]
-available: [ opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.1.0.3/opam
+++ b/packages/depext/depext.1.0.3/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git"
 build: [make]
-available: [opam-version >= "1.1.0" & os != "freebsd" & opam-version < "2.0.0~beta5"]
+available: os != "freebsd" & opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.1.0.4/opam
+++ b/packages/depext/depext.1.0.4/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git"
 build: [make]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/depext/depext.1.0.5/opam
+++ b/packages/depext/depext.1.0.5/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/ocaml/opam-depext/issues"
 license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git+https://github.com/ocaml/opam-depext.git"
 build: [make]
-available: [opam-version >= "1.1.0" & opam-version < "2.0.0~beta5"]
+available: opam-version < "2.0.0~beta5"
 synopsis: "Query and install external dependencies of OPAM packages"
 description: """
 opam-depext is a simple program intended to facilitate the interaction between

--- a/packages/dune/dune.1.10.0/opam
+++ b/packages/dune/dune.1.10.0/opam
@@ -37,8 +37,6 @@ conflicts: [
   "dune-release" {< "1.3.0"}
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.11.0/opam
+++ b/packages/dune/dune.1.11.0/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.11.1/opam
+++ b/packages/dune/dune.1.11.1/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.11.2/opam
+++ b/packages/dune/dune.1.11.2/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.11.3/opam
+++ b/packages/dune/dune.1.11.3/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.11.4/opam
+++ b/packages/dune/dune.1.11.4/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.2.0/opam
+++ b/packages/dune/dune.1.2.0/opam
@@ -6,8 +6,6 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"
 license: "MIT"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.2.1/opam
+++ b/packages/dune/dune.1.2.1/opam
@@ -6,8 +6,6 @@ bug-reports: "https://github.com/ocaml/dune/issues"
 dev-repo: "git+https://github.com/ocaml/dune.git"
 license: "MIT"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.3.0/opam
+++ b/packages/dune/dune.1.3.0/opam
@@ -9,8 +9,6 @@ depends: [
   "ocaml" {>= "4.02" & < "4.08.0"}
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.4.0/opam
+++ b/packages/dune/dune.1.4.0/opam
@@ -9,8 +9,6 @@ depends: [
   "ocaml" {>= "4.02" & < "4.08.0"}
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.5.0/opam
+++ b/packages/dune/dune.1.5.0/opam
@@ -9,8 +9,6 @@ depends: [
   "ocaml" {>= "4.02" & < "4.08.0"}
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.5.1/opam
+++ b/packages/dune/dune.1.5.1/opam
@@ -9,8 +9,6 @@ depends: [
   "ocaml" {>= "4.02" & < "4.08.0"}
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.6.0/opam
+++ b/packages/dune/dune.1.6.0/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.6.1/opam
+++ b/packages/dune/dune.1.6.1/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.6.2/opam
+++ b/packages/dune/dune.1.6.2/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.6.3/opam
+++ b/packages/dune/dune.1.6.3/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.7.0/opam
+++ b/packages/dune/dune.1.7.0/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.7.1/opam
+++ b/packages/dune/dune.1.7.1/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.7.2/opam
+++ b/packages/dune/dune.1.7.2/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.7.3/opam
+++ b/packages/dune/dune.1.7.3/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.8.0/opam
+++ b/packages/dune/dune.1.8.0/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.8.1/opam
+++ b/packages/dune/dune.1.8.1/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.8.2/opam
+++ b/packages/dune/dune.1.8.2/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.9.0/opam
+++ b/packages/dune/dune.1.9.0/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.9.1/opam
+++ b/packages/dune/dune.1.9.1/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.9.2/opam
+++ b/packages/dune/dune.1.9.2/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.1.9.3/opam
+++ b/packages/dune/dune.1.9.3/opam
@@ -11,8 +11,6 @@ depends: [
   "base-threads"
 ]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml"]
   ["./boot.exe" "--release" "--subst"] {pinned}
   ["./boot.exe" "--release" "-j" jobs]

--- a/packages/dune/dune.2.0.0/opam
+++ b/packages/dune/dune.2.0.0/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.0.1/opam
+++ b/packages/dune/dune.2.0.1/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.1.1/opam
+++ b/packages/dune/dune.2.1.1/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.1.2/opam
+++ b/packages/dune/dune.2.1.2/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.1.3/opam
+++ b/packages/dune/dune.2.1.3/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.2.0/opam
+++ b/packages/dune/dune.2.2.0/opam
@@ -37,8 +37,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.3.0/opam
+++ b/packages/dune/dune.2.3.0/opam
@@ -33,8 +33,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.3.1/opam
+++ b/packages/dune/dune.2.3.1/opam
@@ -33,8 +33,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.4.0/opam
+++ b/packages/dune/dune.2.4.0/opam
@@ -33,8 +33,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.5.0/opam
+++ b/packages/dune/dune.2.5.0/opam
@@ -33,8 +33,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.5.1/opam
+++ b/packages/dune/dune.2.5.1/opam
@@ -33,8 +33,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.6.0/opam
+++ b/packages/dune/dune.2.6.0/opam
@@ -34,8 +34,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.6.1/opam
+++ b/packages/dune/dune.2.6.1/opam
@@ -34,8 +34,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.6.2/opam
+++ b/packages/dune/dune.2.6.2/opam
@@ -34,8 +34,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.7.0/opam
+++ b/packages/dune/dune.2.7.0/opam
@@ -34,8 +34,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.7.1/opam
+++ b/packages/dune/dune.2.7.1/opam
@@ -34,8 +34,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.8.0/opam
+++ b/packages/dune/dune.2.8.0/opam
@@ -38,8 +38,6 @@ dev-repo: "git+https://github.com/ocaml/dune.git"
 patches: ["add-missing-version.patch"]
 extra-files: ["add-missing-version.patch" "md5=afde317f7bfc202aa04f380f66e67e52"]
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.8.1/opam
+++ b/packages/dune/dune.2.8.1/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.8.2/opam
+++ b/packages/dune/dune.2.8.2/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.8.4/opam
+++ b/packages/dune/dune.2.8.4/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.8.5/opam
+++ b/packages/dune/dune.2.8.5/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.9.0/opam
+++ b/packages/dune/dune.2.9.0/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.9.1/opam
+++ b/packages/dune/dune.2.9.1/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.9.2/opam
+++ b/packages/dune/dune.2.9.2/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.2.9.3/opam
+++ b/packages/dune/dune.2.9.3/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.3.0.2/opam
+++ b/packages/dune/dune.3.0.2/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/dune/dune.3.0.3/opam
+++ b/packages/dune/dune.3.0.3/opam
@@ -36,8 +36,6 @@ conflicts: [
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
-  # opam 2 sets OPAM_SWITCH_PREFIX, so we don't need a hardcoded path
-  ["ocaml" "configure.ml" "--libdir" lib] {opam-version < "2"}
   ["ocaml" "bootstrap.ml" "-j" jobs]
   ["./dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
 ]

--- a/packages/gen-bs/gen-bs.0.1.0/opam
+++ b/packages/gen-bs/gen-bs.0.1.0/opam
@@ -16,7 +16,6 @@ depends: [
   "webidl" {>= "1.3"}
   "yojson" {>= "1.4.0"}
 ]
-available: opam-version >= "1.2"
 synopsis: "generate bucklescript code from Javascript type specifications"
 description: """
 * generate bucklescript code from Web IDL

--- a/packages/llvm/llvm.3.6/opam
+++ b/packages/llvm/llvm.3.6/opam
@@ -20,7 +20,6 @@ depexts: [
   ["llvm-3.6-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm36"] {os = "macos" & os-distribution = "homebrew"}
 ]
-available: opam-version >= "1.2"
 install: ["bash" "-ex" "./install.sh" version make prefix lib]
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."

--- a/packages/llvm/llvm.3.7/opam
+++ b/packages/llvm/llvm.3.7/opam
@@ -21,7 +21,6 @@ depexts: [
   ["llvm-3.7-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm37"] {os = "macos" & os-distribution = "homebrew"}
 ]
-available: opam-version >= "1.2"
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 flags: light-uninstall

--- a/packages/llvm/llvm.3.8/opam
+++ b/packages/llvm/llvm.3.8/opam
@@ -19,7 +19,6 @@ depends: [
   "conf-llvm" {build & = "3.8"}
   "conf-python-2-7" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 flags: light-uninstall

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: [os = "linux" & opam-version < "2.0.0"]
+available: false
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
+++ b/packages/mirage-xen-ocaml/mirage-xen-ocaml.3.0.5/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-src"
   "ocamlbuild" {build}
 ]
-available: [os = "linux" & opam-version < "2.0.0"]
+available: false
 synopsis: "MirageOS headers for the OCaml runtime"
 description:
   "The package contains the OCaml runtime patches and build system."

--- a/packages/ocaml-monadic/ocaml-monadic.0.1.0/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-available: opam-version >= "1.2"
 maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
 authors: "JHU PL Lab <pl.cs@jhu.edu>"
 license: "BSD-3-Clause"

--- a/packages/ocaml-monadic/ocaml-monadic.0.1.1/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.1.1/opam
@@ -20,7 +20,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Lightweight monadic syntax extension."
 description:
   "This project contains a lightweight PPX extension for OCaml to support natural monadic syntax."

--- a/packages/ocaml-monadic/ocaml-monadic.0.2.0/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.2.0/opam
@@ -20,7 +20,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Lightweight monadic syntax extension."
 description:
   "This project contains a lightweight PPX extension for OCaml to support natural monadic syntax."

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.0/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.0/opam
@@ -20,7 +20,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Lightweight monadic syntax extension."
 description:
   "This project contains a lightweight PPX extension for OCaml to support natural monadic syntax."

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.1/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.1/opam
@@ -20,7 +20,6 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Lightweight monadic syntax extension."
 description:
   "This project contains a lightweight PPX extension for OCaml to support natural monadic syntax."

--- a/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
+++ b/packages/ocaml-monadic/ocaml-monadic.0.3.2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-available: opam-version >= "1.2"
 maintainer: "JHU PL Lab <pl.cs@jhu.edu>"
 authors: "JHU PL Lab <pl.cs@jhu.edu>"
 license: "BSD-3-Clause"

--- a/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/opam
+++ b/packages/ocaml-protoc-yojson/ocaml-protoc-yojson.0.2.0/opam
@@ -17,7 +17,6 @@ depends: [
   "ocamlbuild" {build}
   "yojson" {< "2.0.0"}
 ]
-available: opam-version >= "1.2"
 synopsis:
   "JSON Runtime based on Yojson library for `ocaml-protoc` generated code"
 description:

--- a/packages/ocaml-protoc/ocaml-protoc.1.2.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.1.2.0/opam
@@ -22,7 +22,6 @@ depends: [
   "ocamlbuild" {build}
   "ppx_deriving_protobuf"
 ]
-available: opam-version >= "1.2"
 synopsis: "A Protobuf Compiler for OCaml"
 description:
   "'ocaml-protoc' is a compiler of Protobuf file (.proto) to OCaml code. The compiler generate OCaml types with associated decoding/encoding functions following the Protobuf format."

--- a/packages/orocksdb/orocksdb.0.2.1/opam
+++ b/packages/orocksdb/orocksdb.0.2.1/opam
@@ -19,7 +19,6 @@ depends: [
   "depext" {build}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 post-messages: [
   "
   This package requires rocksdb library installed in /usr/local/lib.

--- a/packages/pla/pla.1.0/opam
+++ b/packages/pla/pla.1.0/opam
@@ -19,7 +19,6 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Ppx templating library using verbatim strings."
 description:
   "Pla is a simple library and ppx syntax extension to create composable templates based on verbatim strings"

--- a/packages/pla/pla.1.1/opam
+++ b/packages/pla/pla.1.1/opam
@@ -19,7 +19,6 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Ppx templating library using verbatim strings."
 description:
   "Pla is a simple library and ppx syntax extension to create composable templates based on verbatim strings"

--- a/packages/pla/pla.1.2/opam
+++ b/packages/pla/pla.1.2/opam
@@ -11,7 +11,6 @@ depends: [
   "jbuilder" {>= "1.0+beta7"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
-available: opam-version >= "1.2"
 synopsis: "Ppx templating library using verbatim strings."
 description:
   "Pla is a simple library and ppx syntax extension to create composable templates based on verbatim strings"

--- a/packages/polyglot/polyglot.1.0.0/opam
+++ b/packages/polyglot/polyglot.1.0.0/opam
@@ -20,7 +20,6 @@ depends: [
   "ocamlbuild" {build}
 ]
 depopts: ["cmdliner" "base-unix"]
-available: opam-version >= "1.2"
 synopsis: "Filters to convert XHTML into polyglot HTML5"
 description: """
 polyglot is a MirageOS-compatible library and a command line filter

--- a/packages/ppx_deriving/ppx_deriving.1.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.0/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 url {
   src: "https://github.com/whitequark/ppx_deriving/archive/v1.0.tar.gz"

--- a/packages/ppx_deriving/ppx_deriving.1.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.1.1/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.2.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.0/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.1/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.2.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.2.2/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.3.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.0/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.3.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.1/opam
@@ -31,7 +31,6 @@ depends: [
   "ocamlfind" {build & >= "1.5.4"}
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving/ppx_deriving.3.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.2/opam
@@ -31,7 +31,6 @@ depends: [
   "ppx_tools" {>= "0.99.2"}
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving/ppx_deriving.3.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.3.3/opam
@@ -33,7 +33,6 @@ depends: [
   "ppx_tools" {>= "4.02.3"}
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving/ppx_deriving.4.0/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.0/opam
@@ -34,7 +34,6 @@ depends: [
   "result"
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving/ppx_deriving.4.1.5/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1.5/opam
@@ -34,7 +34,6 @@ depends: [
   "result"
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.4.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.1/opam
@@ -34,7 +34,6 @@ depends: [
   "result"
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 patches: [ "fix_ppx_deriving_make_mllib.patch" ]
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving/ppx_deriving.4.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2.1/opam
@@ -36,7 +36,6 @@ depends: [
   "result"
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving/ppx_deriving.4.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.4.2/opam
@@ -36,7 +36,6 @@ depends: [
   "result"
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Type-driven code generation for OCaml >=4.02"
 description: """
 ppx_deriving provides common infrastructure for generating

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.4/opam
@@ -28,7 +28,6 @@ depends: [
   "result" {with-test}
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Very simple ppx deriver of command line parser for Ocaml >=4.02"
 description:
   "Very simple ppx deriver of command line parser for Ocaml >=4.02"

--- a/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
+++ b/packages/ppx_deriving_argparse/ppx_deriving_argparse.0.0.5/opam
@@ -28,7 +28,6 @@ depends: [
   "result" {with-test}
   "ounit" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Very simple ppx deriver of command line parser for Ocaml >=4.02"
 description:
   "Very simple ppx deriver of command line parser for Ocaml >=4.02"

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
@@ -31,7 +31,6 @@ depends: [
   "ounit" {with-test}
   "ppx_import" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Morphism generator for OCaml >=4.02"
 description: """
 ppx_deriving_morphism is a ppx_deriving plugin that provides

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
@@ -33,7 +33,6 @@ depends: [
   "ounit" {with-test}
   "ppx_import" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Morphism generator for OCaml >=4.02"
 description: """
 ppx_deriving_morphism is a ppx_deriving plugin that provides

--- a/packages/ppx_distr_guards/ppx_distr_guards.0.1/opam
+++ b/packages/ppx_distr_guards/ppx_distr_guards.0.1/opam
@@ -15,7 +15,6 @@ depends: [
   "ocamlbuild" {build}
   "ppx_tools" {with-test}
 ]
-available: opam-version >= "1.2"
 synopsis: "Extension to distribute guards over or-patterns."
 description:
   "`function%distr A x, _ | _, A x when p x -> e` will result in `function A x, _ when p x -> e | _, A x when p x -> e`"

--- a/packages/ppx_getenv/ppx_getenv.1.1/opam
+++ b/packages/ppx_getenv/ppx_getenv.1.1/opam
@@ -28,7 +28,6 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
-available: opam-version >= "1.2"
 synopsis:
   "A syntax extension to insert value of an environment variable as a string"
 url {

--- a/packages/ppx_import/ppx_import.1.1/opam
+++ b/packages/ppx_import/ppx_import.1.1/opam
@@ -32,7 +32,6 @@ depends: [
   "ounit" {with-test}
   "ppx_deriving" {with-test & >= "2.0"}
 ]
-available: opam-version >= "1.2.2"
 synopsis:
   "A syntax extension for importing declarations from interface files"
 url {

--- a/packages/ppx_import/ppx_import.1.2/opam
+++ b/packages/ppx_import/ppx_import.1.2/opam
@@ -32,7 +32,6 @@ depends: [
   "ounit" {with-test}
   "ppx_deriving" {with-test & >= "2.0"}
 ]
-available: opam-version >= "1.2.2"
 synopsis:
   "A syntax extension for importing declarations from interface files"
 url {

--- a/packages/ppx_import/ppx_import.1.3/opam
+++ b/packages/ppx_import/ppx_import.1.3/opam
@@ -32,7 +32,6 @@ depends: [
   "ounit" {with-test}
   "ppx_deriving" {with-test & >= "2.0"}
 ]
-available: opam-version >= "1.2.2"
 synopsis:
   "A syntax extension for importing declarations from interface files"
 url {

--- a/packages/ppx_import/ppx_import.1.4/opam
+++ b/packages/ppx_import/ppx_import.1.4/opam
@@ -32,7 +32,6 @@ depends: [
   "ounit" {with-test}
   "ppx_deriving" {with-test & >= "2.0"}
 ]
-available: opam-version >= "1.2.2"
 synopsis:
   "A syntax extension for importing declarations from interface files"
 url {

--- a/packages/ppx_import/ppx_import.1.5/opam
+++ b/packages/ppx_import/ppx_import.1.5/opam
@@ -32,7 +32,6 @@ depends: [
   "ounit" {with-test}
   "ppx_deriving" {with-test & >= "2.0"}
 ]
-available: opam-version >= "1.2.2"
 synopsis:
   "A syntax extension for importing declarations from interface files"
 url {

--- a/packages/tidy/tidy.0-2009-0.1.1/opam
+++ b/packages/tidy/tidy.0-2009-0.1.1/opam
@@ -10,7 +10,6 @@ tags: [
   "tidy"
 ]
 dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-tidy"
-available: opam-version >= "1.2.1"
 build: [
   [make]
 ]

--- a/packages/tidy/tidy.1-4.9.30-0.1.1/opam
+++ b/packages/tidy/tidy.1-4.9.30-0.1.1/opam
@@ -10,7 +10,6 @@ tags: [
   "tidy"
 ]
 dev-repo: "hg+https://bitbucket.org/zandoye/ocaml-tidy"
-available: opam-version >= "1.2.1"
 build: [
   [make]
 ]


### PR DESCRIPTION
While working on some upstreaming:
- All the files in the repository are headed `opam-version: "2.0"` and can't be lexed by OPAM 1.x, so remove `available` constraints when less than 2.0
- Dune 1.x and 2.x contain a workaround for OPAM 1.x which can consequently never be evaluated
- #12457 is now equivalent to `available: false`