### PR TITLE
Split conf-srt into conf-srt-openssl and conf-srt-gnutls when relevant.

### DIFF
--- a/packages/conf-srt-gnutls/conf-srt-gnutls.1/opam
+++ b/packages/conf-srt-gnutls/conf-srt-gnutls.1/opam
@@ -1,0 +1,17 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://srt.org/doxygen/trunk/index.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "srt dev team"
+license: "MPL-2.0"
+build: ["pkg-config" "--exists" "srt"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libsrt-gnutls-dev" "libgnutls28-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+]
+synopsis: "Virtual package relying on srt build with gnutls"
+description:
+  "This package can only install if the srt library is installed on the system and compiled against gnutls."
+flags: conf

--- a/packages/conf-srt-openssl/conf-srt-openssl.1/opam
+++ b/packages/conf-srt-openssl/conf-srt-openssl.1/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://srt.org/doxygen/trunk/index.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "srt dev team"
+license: "MPL-2.0"
+build: ["pkg-config" "--exists" "srt"]
+depends: [
+  "conf-pkg-config" {build}
+]
+depexts: [
+  ["libsrt-openssl-dev" "libssl-dev"] {os-distribution = "debian" | os-distribution = "ubuntu"}
+  ["srt" "openssl"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Virtual package relying on srt compiled with openssl"
+description:
+  "This package can only install if the srt library is installed on the system and compiled using openssl."
+flags: conf

--- a/packages/conf-srt/conf-srt.2/opam
+++ b/packages/conf-srt/conf-srt.2/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://srt.org/doxygen/trunk/index.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "srt dev team"
+license: "MPL-2.0"
+build: ["pkg-config" "--exists" "srt"]
+depends: [
+  "conf-pkg-config" {build}
+  "conf-srt-openssl" {os-distribution = "debian" | os-distribution = "ubuntu" | os = "macos" & os-distribution = "homebrew"} | "conf-srt-gnutls" {os-distribution = "debian" | os-distribution = "ubuntu"}
+]
+depexts: [
+  ["srt-devel"] {os-distribution = "centos" | os-distribution = "fedora" | os-family = "suse"}
+  ["libsrt-dev"] {os-distribution = "alpine"}
+  ["srt"] {os = "freebsd" | os-distribution = "arch" | os-distribution = "nixos"}
+]
+synopsis: "Virtual package relying on srt"
+description:
+  "This package can only install if the srt library is installed on the system."
+flags: conf


### PR DESCRIPTION
The depext for `conf-srt` have some issues due to the fact that some OS/distributions are specializing them between `openssl` and `gnutls`:
* `homebrew` expects `openssl` but does not install it with `srt` (seems like a bug frankly)
* `debian` has been specializing into `gnutls`/`openssl` for a while
* `ubuntu` has started picking up those changes since the `22.04`/`jammy` LTS release

Thus, this PR bumps `conf-srt` and adds `conf-srt-openssl` and `conf-srt-gnutls` and adds relevant dependencies.

This will break compatibility with older versions of ubuntu but I'm not sure if there is a better way to do and this is clearly the solution moving forward.