### PR TITLE
Update alt-ergo's version with specific patch

### DIFF
--- a/packages/alt-ergo-lib/alt-ergo-lib.2.4.2/files/version_update.patch
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.4.2/files/version_update.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/util/version.ml b/src/lib/util/version.ml
+index 67710c68..761ed2fb 100644
+--- a/src/lib/util/version.ml
++++ b/src/lib/util/version.ml
+@@ -29,7 +29,7 @@
+ (* WARNING: a "cut" is performed on the following file in the Makefile.
+    DO NOT CHANGE its format *)
+ 
+-let _version="dev"
++let _version="2.4.2"
+ 
+ let _release_commit = "(not released)"
+ 

--- a/packages/alt-ergo-lib/alt-ergo-lib.2.4.2/opam
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.4.2/opam
@@ -43,3 +43,6 @@ url {
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"
   ]
 }
+
+patches:["version_update.patch"]
+extra-files:[["version_update.patch" "md5=8944da319134df09dc733a769504867f"]]

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.4.2/files/version_update.patch
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.4.2/files/version_update.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/util/version.ml b/src/lib/util/version.ml
+index 67710c68..761ed2fb 100644
+--- a/src/lib/util/version.ml
++++ b/src/lib/util/version.ml
+@@ -29,7 +29,7 @@
+ (* WARNING: a "cut" is performed on the following file in the Makefile.
+    DO NOT CHANGE its format *)
+ 
+-let _version="dev"
++let _version="2.4.2"
+ 
+ let _release_commit = "(not released)"
+ 

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.4.2/opam
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.4.2/opam
@@ -42,3 +42,6 @@ url {
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"
   ]
 }
+
+patches:["version_update.patch"]
+extra-files:[["version_update.patch" "md5=8944da319134df09dc733a769504867f"]]

--- a/packages/alt-ergo/alt-ergo.2.4.2/files/version_update.patch
+++ b/packages/alt-ergo/alt-ergo.2.4.2/files/version_update.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/util/version.ml b/src/lib/util/version.ml
+index 67710c68..761ed2fb 100644
+--- a/src/lib/util/version.ml
++++ b/src/lib/util/version.ml
+@@ -29,7 +29,7 @@
+ (* WARNING: a "cut" is performed on the following file in the Makefile.
+    DO NOT CHANGE its format *)
+ 
+-let _version="dev"
++let _version="2.4.2"
+ 
+ let _release_commit = "(not released)"
+ 

--- a/packages/alt-ergo/alt-ergo.2.4.2/opam
+++ b/packages/alt-ergo/alt-ergo.2.4.2/opam
@@ -40,3 +40,6 @@ url {
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"
   ]
 }
+
+patches:["version_update.patch"]
+extra-files:[["version_update.patch" "md5=8944da319134df09dc733a769504867f"]]

--- a/packages/altgr-ergo/altgr-ergo.2.4.2/files/version_update.patch
+++ b/packages/altgr-ergo/altgr-ergo.2.4.2/files/version_update.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/util/version.ml b/src/lib/util/version.ml
+index 67710c68..761ed2fb 100644
+--- a/src/lib/util/version.ml
++++ b/src/lib/util/version.ml
+@@ -29,7 +29,7 @@
+ (* WARNING: a "cut" is performed on the following file in the Makefile.
+    DO NOT CHANGE its format *)
+ 
+-let _version="dev"
++let _version="2.4.2"
+ 
+ let _release_commit = "(not released)"
+ 

--- a/packages/altgr-ergo/altgr-ergo.2.4.2/opam
+++ b/packages/altgr-ergo/altgr-ergo.2.4.2/opam
@@ -43,3 +43,7 @@ url {
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"
   ]
 }
+
+patches:["version_update.patch"]
+extra-files:[["version_update.patch" "md5=8944da319134df09dc733a769504867f"]]
+


### PR DESCRIPTION
Just a simple patch for updating alt-ergo to display the correct version number at calls to `--version`.