### PR TITLE
fstar is not compatible with ppxlib >= 0.26.0

### DIFF
--- a/packages/fstar/fstar.2021.06.06/opam
+++ b/packages/fstar/fstar.2021.06.06/opam
@@ -21,7 +21,7 @@ depends: [
   "menhir" {build & >= "20161115"}
   "pprint" {build & >= "20130324" & <= "20211129"}
   "sedlex" {build & >= "2.0" & < "2.4"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.26.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "process"

--- a/packages/fstar/fstar.2022.01.15/opam
+++ b/packages/fstar/fstar.2022.01.15/opam
@@ -21,7 +21,7 @@ depends: [
   "menhir" {build & >= "20161115"}
   "pprint" {build & >= "20130324"}
   "sedlex" {build & >= "2.0"}
-  "ppxlib" {>= "0.22.0"}
+  "ppxlib" {>= "0.22.0" & < "0.26.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "process"


### PR DESCRIPTION
```
#=== ERROR while compiling fstar.2022.01.15 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/fstar.2022.01.15
# command              ~/.opam/opam-init/hooks/sandbox.sh build make PREFIX=/home/opam/.opam/4.14 -j 31
# exit-code            2
# env-file             ~/.opam/log/fstar-7-b99f95.env
# output-file          ~/.opam/log/fstar-7-b99f95.out
# + ocamlfind ocamlc -c -g -thread -package stdint -package compiler-libs -package compiler-libs.common -package menhirLib -package dynlink -package pprint -package sedlex -package yojson -package ppxlib -package process -package batteries -package zarith -package ppx_deriving.std -package ppx_deriving_yojson -I src/extraction/ml -I ulib/ml -I src/ocaml-output -I src/tests/ml -I src/tactics/ml -I src/prettyprint/ml -I src/parser/ml -I src/fstar/ml -I src/basic/ml -o src/extraction/ml/FStar_Extraction_ML_PrintML.cmo src/extraction/ml/FStar_Extraction_ML_PrintML.ml
# File "src/extraction/ml/FStar_Extraction_ML_PrintML.ml", line 195, characters 55-74:
# 195 |      Ppat_construct (path_to_ident (path', name), Some (build_pattern pat))
#                                                              ^^^^^^^^^^^^^^^^^^^
# Error: This expression has type
#          Ppxlib_ast.Parsetree.pattern = Parsetree.pattern
#        but an expression was expected of type
#          string Astlib.Ast_414.Asttypes.loc list *
#          Ppxlib_ast.Parsetree.pattern
# Command exited with code 2.
# make[1]: *** [Makefile:119: _build/src/fstar/ml/main.native] Error 10
# make[1]: Leaving directory '/home/opam/.opam/4.14/.opam-switch/build/fstar.2022.01.15/src/ocaml-output'
# make: *** [Makefile:6: all] Error 2