### PR TITLE
2 packages from mransan/ocaml-protoc at 2.3

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.3/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+post-messages: [
+"The runtime library is now called \"pbrt\"."
+]
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="2.0"}
+  "stdlib-shims"
+  "pbrt" {= version}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.3.0.tar.gz"
+  checksum: [
+    "md5=14cb15d70a4ab90f692e132cbf640b11"
+    "sha512=063a6a6a1c267ca3e965775f18e5362a58d7a0de92bcee90e57b6004fb79106c03ad1a4c04bd2d259e8d1d0461d2e2bd0b1c7862c58f763364d1cff62bba37a3"
+  ]
+}

--- a/packages/pbrt/pbrt.2.3/opam
+++ b/packages/pbrt/pbrt.2.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Runtime library for Protobuf tooling"
+description: "Runtime library for Protobuf tooling"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+post-messages: [
+"Pbrt: runtime library for ocaml-protoc.
+
+A shim library named \"ocaml-protoc\" still exists, to ease the
+migration."
+]
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "pbrt,ocaml-protoc" "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="2.0"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.3.0.tar.gz"
+  checksum: [
+    "md5=14cb15d70a4ab90f692e132cbf640b11"
+    "sha512=063a6a6a1c267ca3e965775f18e5362a58d7a0de92bcee90e57b6004fb79106c03ad1a4c04bd2d259e8d1d0461d2e2bd0b1c7862c58f763364d1cff62bba37a3"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocaml-protoc.2.3`: Protobuf compiler for OCaml
-`pbrt.2.3`: Runtime library for Protobuf tooling



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.1.0