### PR TITLE
plebeia-2.0.0: use opam-source-archive

### DIFF
--- a/packages/plebeia/plebeia.2.0.0/opam
+++ b/packages/plebeia/plebeia.2.0.0/opam
@@ -25,7 +25,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dailambda/plebeia/"
 url {
   src:
-    "https://gitlab.com/dailambda/plebeia/-/archive/2.0.0/plebeia-2.0.0.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/plebeia-2.0.0.tar.gz"
   checksum: [
     "md5=f528f42d3e72d400265eb6bc51901fca"
     "sha512=6cf070b2f1ea2e570a106b231a7e8e40c64c91c5a7abeddf072a5c413e74d5d9dd9b7df674cca559ddb33cabc9c0ec0b3a001306397d11b62888aac4cca9fd7e"


### PR DESCRIPTION
Currently fails with `OpamSolution.Fetch_fail("https://gitlab.com/dailambda/plebeia/-/archive/2.0.0/plebeia-2.0.0.tar.gz (Bad checksum, expected md5=f528f42d3e72d400265eb6bc51901fca)")`