### PR TITLE
catala.0.7.0: remvove references to dev variables

### DIFF
--- a/packages/catala/catala.0.7.0/opam
+++ b/packages/catala/catala.0.7.0/opam
@@ -38,11 +38,6 @@ depends: [
   "zarith_stubs_js" {>= "v0.14.1"}
   "alcotest" {with-test & >= "1.5.0"}
   "odoc" {with-doc}
-  "ocamlformat" {cataladevmode & = "0.21.0"}
-  "obelisk" {cataladevmode}
-  "conf-npm" {cataladevmode}
-  "conf-python-3-dev" {cataladevmode}
-  "z3" {catalaz3mode}
 ]
 depopts: ["z3"]
 conflicts: [
@@ -63,14 +58,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/CatalaLang/catala.git"
-depexts: [
-  ["groff" "colordiff" "latexmk" "python3-pip" "pandoc"]
-    {cataladevmode & os-family = "debian"}
-  ["groff" "colordiff" "texlive" "py3-pip" "py3-pygments"]
-    {cataladevmode & os-distribution = "alpine"}
-  ["groff" "colordiff" "latex-mk" "python-pygments" "pandoc"]
-    {cataladevmode & os-family = "arch"}
-]
 url {
   src: "https://github.com/CatalaLang/catala/archive/0.7.0.tar.gz"
   checksum: [


### PR DESCRIPTION
There is apparently a bad interaction with opam's current --strict option. These variables are used as a workaround for the
lack of the forthcoming --for-dev flag. We'll need to remember to filter out these variables from the in-source opam file when publishing the next versions of the package.