### PR TITLE
3 packages from gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12/json-data-encoding-0.12.tar.gz

### DIFF
--- a/packages/data-encoding/data-encoding.0.6/opam
+++ b/packages/data-encoding/data-encoding.0.6/opam
@@ -12,8 +12,8 @@ depends: [
   "zarith" {>= "1.4"}
   "zarith_stubs_js"
   "hex" {>= "1.3.0"}
-  "json-data-encoding" { = "0.11" }
-  "json-data-encoding-bson" { = "0.11" }
+  "json-data-encoding" { >= "0.11" }
+  "json-data-encoding-bson" { >= "0.11" }
   "alcotest" { with-test }
   "crowbar" { >= "0.2" & with-test }
   "ppx_expect" { with-test }

--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.12/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.12/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12/json-data-encoding-0.12.tar.gz"
+  checksum: [
+    "md5=2f3252c51185fcb2f17b1437b5264c37"
+    "sha512=d413d23b679aab898cce4138c60cf484a4be7272dcd802fd8dfaa03f17ff9d19584976d8b957f60fd5c8abdc3d55d6d62b70ae2d4716bf0c6645b69350678ec5"
+  ]
+}

--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.12/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.12/opam
@@ -13,7 +13,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10"}
-  "dune" {>= "1.7"}
+  "dune" {>= "2.0"}
   "json-data-encoding" {= version }
   "js_of_ocaml" {>= "3.3.0"}
 ]

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.12/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.12/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12/json-data-encoding-0.12.tar.gz"
+  checksum: [
+    "md5=2f3252c51185fcb2f17b1437b5264c37"
+    "sha512=d413d23b679aab898cce4138c60cf484a4be7272dcd802fd8dfaa03f17ff9d19584976d8b957f60fd5c8abdc3d55d6d62b70ae2d4716bf0c6645b69350678ec5"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.12/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.12/opam
@@ -13,7 +13,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10"}
-  "dune" {>= "1.7"}
+  "dune" {>= "2.0"}
   "json-data-encoding" {= version }
   "ocplib-endian" {>= "1.0"}
 ]

--- a/packages/json-data-encoding/json-data-encoding.0.12/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.12/opam
@@ -14,7 +14,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10"}
-  "dune" {>= "1.7"}
+  "dune" {>= "2.0"}
   "uri" {>= "1.9.0" }
   "crowbar" { with-test }
   "alcotest" { with-test }

--- a/packages/json-data-encoding/json-data-encoding.0.12/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.12/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.7"}
+  "uri" {>= "1.9.0" }
+  "crowbar" { with-test }
+  "alcotest" { with-test }
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12/json-data-encoding-0.12.tar.gz"
+  checksum: [
+    "md5=2f3252c51185fcb2f17b1437b5264c37"
+    "sha512=d413d23b679aab898cce4138c60cf484a4be7272dcd802fd8dfaa03f17ff9d19584976d8b957f60fd5c8abdc3d55d6d62b70ae2d4716bf0c6645b69350678ec5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`json-data-encoding.0.12`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.0.12`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.0.12`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://gitlab.com/nomadic-labs/json-data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/json-data-encoding
* Bug tracker: https://gitlab.com/nomadic-labs/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0