### PR TITLE
conf-ruby: add rubygems depext on oraclelinux

### DIFF
--- a/packages/conf-ruby/conf-ruby.1.0.0/opam
+++ b/packages/conf-ruby/conf-ruby.1.0.0/opam
@@ -19,7 +19,7 @@ depexts: [
   ["ruby"] {os-distribution = "nixos"}
   ["ruby"] {os = "openbsd"}
   ["ruby"] {os-family = "suse"}
-  ["ruby"] {os-distribution = "ol"}
+  ["ruby" "rubygems"] {os-distribution = "ol"}
 ]
 synopsis: "Virtual package relying on Ruby"
 description:


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/21998#issuecomment-1219594066 it turned out that ruby doesn't work on oraclelinux as installed by conf-ruby.

The problem can be reproduced directly in `docker run -it --rm ocaml/opam:oraclelinux-8-ocaml-4.14`:
1. Install ruby as per conf-ruby: `sudo yum install -y ruby`.
2. conf-ruby build command works fine: `ruby --version`
3. `ruby` itself crashes with
    ```
    Traceback (most recent call last):
    	1: from <internal:gem_prelude>:2:in `<internal:gem_prelude>'
    <internal:gem_prelude>:2:in `require': cannot load such file -- rubygems.rb (LoadError)
    ```
4. Install rubygems also: `sudo yum install -y rubygems`
5. Now `ruby` at least starts without crashing.

centos and fedora don't have this problem: there `ruby` seems to have `rubygems` as a dependency. I guess this is some sort of oraclelinux screw-up that it doesn't.