### PR TITLE
Release shuttle 0.5.0

### DIFF
--- a/packages/http_async/http_async.0.0.2/opam
+++ b/packages/http_async/http_async.0.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.4.0"}
+  "shuttle" {>= "0.4.0" & < "0.5.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/http_async/http_async.0.0.3/opam
+++ b/packages/http_async/http_async.0.0.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.4.0"}
+  "shuttle" {>= "0.4.0" & < "0.5.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/shuttle/shuttle.0.5.0/opam
+++ b/packages/shuttle/shuttle.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.14"}
+  "core" {>= "v0.14"}
+  "core_unix" {>= "v0.14"}
+  "ppx_jane" {>= "v0.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.5.0/shuttle-0.5.0.tbz"
+  checksum: [
+    "sha256=34064bd0bf538ef231ef82971ff43103dc894f7bd8b4c6bbb928dacfbcb9d25d"
+    "sha512=d7c69a00a4732398f011b3b38d31642a46522b2d547837969d567d92bc467995a609b57fec2f839894f41dfac8c2652fa5698273572edc3711eb5edcc2731eeb"
+  ]
+}
+x-commit-hash: "845367f92323ad8e21c329465b25af1f7b417a37"

--- a/packages/shuttle_ssl/shuttle_ssl.0.5.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.14" & < "v0.16"}
+  "async_ssl" {>= "v0.14" & < "v0.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.5.0/shuttle-0.5.0.tbz"
+  checksum: [
+    "sha256=34064bd0bf538ef231ef82971ff43103dc894f7bd8b4c6bbb928dacfbcb9d25d"
+    "sha512=d7c69a00a4732398f011b3b38d31642a46522b2d547837969d567d92bc467995a609b57fec2f839894f41dfac8c2652fa5698273572edc3711eb5edcc2731eeb"
+  ]
+}
+x-commit-hash: "845367f92323ad8e21c329465b25af1f7b417a37"


### PR DESCRIPTION
CHANGES:

* Remove Buffer_is_full in favor of Bytebuffers that can grow upto a user provided max size
* Flush operations reports if the write operations encountered an error
* Reliably wakeup pending flushes when there is an error encountered while flushing pending bytes