### PR TITLE
[new release] shuttle_ssl and shuttle (0.5.0)

### DIFF
--- a/packages/http_async/http_async.0.0.2/opam
+++ b/packages/http_async/http_async.0.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.4.0"}
+  "shuttle" {>= "0.4.0" & < "0.5.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/http_async/http_async.0.0.3/opam
+++ b/packages/http_async/http_async.0.0.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.4.0"}
+  "shuttle" {>= "0.4.0" & < "0.5.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/shuttle/shuttle.0.5.0/opam
+++ b/packages/shuttle/shuttle.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.14"}
+  "core" {>= "v0.14"}
+  "core_unix" {>= "v0.14"}
+  "ppx_jane" {>= "v0.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.5.0/shuttle-0.5.0.tbz"
+  checksum: [
+    "sha256=4d469f8acf557afb0fb1fc0a885fc41521b0ab31475f4c8e3ad7445f64500c3e"
+    "sha512=7d9c4fb7ce253ed209b5470e53c3ae1e218fc769753686d7d68bb387ec328b3df1e76165d6e06e62f3f57aaf11a0dd9d8578be866d6a8b27de35957343c9615a"
+  ]
+}
+x-commit-hash: "39b973b8d504bc3b02a44a0ecf6afc1c386089ae"

--- a/packages/shuttle_ssl/shuttle_ssl.0.5.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.14"}
+  "async_ssl" {>= "v0.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.5.0/shuttle-0.5.0.tbz"
+  checksum: [
+    "sha256=4d469f8acf557afb0fb1fc0a885fc41521b0ab31475f4c8e3ad7445f64500c3e"
+    "sha512=7d9c4fb7ce253ed209b5470e53c3ae1e218fc769753686d7d68bb387ec328b3df1e76165d6e06e62f3f57aaf11a0dd9d8578be866d6a8b27de35957343c9615a"
+  ]
+}
+x-commit-hash: "39b973b8d504bc3b02a44a0ecf6afc1c386089ae"


### PR DESCRIPTION
Async_ssl support for shuttle

- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Remove Buffer_is_full in favor of Bytebuffers that can grow upto a user provided max size
* Flush operations reports if the write operations encountered an error
* Reliably wakeup pending flushes when there is an error encountered while flushing pending bytes
