### PR TITLE
hkdf 1.0.0: setup.ml uses String.lowercase

### DIFF
--- a/packages/hkdf/hkdf.1.0.0/opam
+++ b/packages/hkdf/hkdf.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "hkdf"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind"
   "cstruct" {>= "1.6.0"}
   "nocrypto" {>= "0.5.0"}


### PR DESCRIPTION
Seen in the lower bounds failure of https://github.com/ocaml/opam-repository/pull/22002

```
#=== ERROR while compiling hkdf.1.0.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/hkdf.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/hkdf-7-91e362.env
# output-file          ~/.opam/log/hkdf-7-91e362.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```