### PR TITLE
Fix base implicits

### DIFF
--- a/packages/base-implicits/base-implicits.base/opam
+++ b/packages/base-implicits/base-implicits.base/opam
@@ -12,6 +12,6 @@ identifier, should mark this package as a conflict."""
 depends: [
   "ocaml"
   "ocaml-variants"
-    {= "4.02.0+modular-implicits" | = "4.02.1+modular-implicits-ber"}
+    {= "4.02.1+modular-implicits" | = "4.02.1+modular-implicits-ber"}
 ]
 flags: light-uninstall


### PR DESCRIPTION
Fix a small version-number typo in `base-implicits` that prevents installing the modular-implicits variant.