### PR TITLE
Package bls12-381-hash.0.0.1

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.0.0.1/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of some cryptographic hash primitives using the scalar field of BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381-hash"
+bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381-hash/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381-hash.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381-hash/-/archive/0.0.1/ocaml-bls12-381-hash-0.0.1.tar.bz2"
+  checksum: [
+    "md5=71c1c7a83cb6a7f4606a2e4e8acfdcfb"
+    "sha512=294a5c0ff8860d8f730bbf192a3c38f2a0cb8cb0fd05d729eb6ca1782cc95ee967dd5123ecd90cd3f96923c41ddb1a08fa31239116a459cbd50ba0355ff20641"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/bls12-381-hash/bls12-381-hash.0.0.1/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "alcotest" {with-test}
   "bisect_ppx" {with-test & >= "2.5"}
 ]
-available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381-hash.git"


### PR DESCRIPTION
### `bls12-381-hash.0.0.1`
Implementation of some cryptographic hash primitives using the scalar field of BLS12-381



---
* Homepage: https://gitlab.com/dannywillems/ocaml-bls12-381-hash
* Source repo: git+https://gitlab.com/dannywillems/ocaml-bls12-381-hash.git
* Bug tracker: https://gitlab.com/dannywillems/ocaml-bls12-381-hash/issues

---
:camel: Pull-request generated by opam-publish v2.1.0