### PR TITLE
[new release] gmp (6.2.1-3)

### DIFF
--- a/packages/gmp/gmp.6.2.1-3/opam
+++ b/packages/gmp/gmp.6.2.1-3/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Lucas Pluvinage <lucas@tarides.com>"
+license: ["LGPL-3.0-only" "LGPL-2.0-only"]
+authors: "Torbjörn Granlund and contributors"
+homepage: "https://github.com/mirage/ocaml-gmp"
+bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
+substs: [ "src/build.sh" ]
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.6"}
+  "conf-m4"
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: """Dune packaging of the GMP library, suitable for 
+cross-compilation."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gmp/releases/download/6.2.1-3/gmp-6.2.1-3.tbz"
+  checksum: [
+    "sha256=eb2ec4143f5a74f10d7fc7318c323328f3c4fa5455ffd793f6e813423b27f66b"
+    "sha512=975e4808c6887d5e3ac9beb51e9947bbc3b8333abd559f147a6ab6f36731d61de5a886e7b1eda33cd421def906908444cf702500c0f6990a5b57f1d16359b795"
+  ]
+}
+x-commit-hash: "457dabe4e9fe4802a9b9546edb48ce7cf16486ba"


### PR DESCRIPTION
The GNU Multiple Precision Arithmetic Library

- Project page: <a href="https://github.com/mirage/ocaml-gmp">https://github.com/mirage/ocaml-gmp</a>

##### CHANGES:

- CI: test cross-compilation with ocaml-solo5 instead of ocaml-freestanding
  (@TheLortex, mirage/ocaml-gmp#16)
- Use sed -i -e to fix compilation on FreeBSD (@hannesm, mirage/ocaml-gmp#15)
