### PR TITLE
[new release] http-lwt-client (0.0.7)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.7/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.7/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.7/http-lwt-client-0.0.7.tbz"
+  checksum: [
+    "sha256=f25eab91bceb7abe5d1c2fec0bba767f09c5762b3127b7778caa3450ae41aa10"
+    "sha512=fa9e83d62c1d9b7cb7c4b17334e030bed4935f196f55e7e6b34f8784e157ed977612af07a1be1f954c8e4134966be51b3b2eb86932c547fc3f0cdf99f713f39c"
+  ]
+}
+x-commit-hash: "ad9590c00659157b4f5ca5ce278fca1865add35b"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* upgrade to h2 0.9.0 API (roburio/http-lwt-client#10 @hannesm)
