### PR TITLE
[new release] irmin project (3.4.0)

### DIFF
--- a/packages/irmin-bench/irmin-bench.3.4.0/opam
+++ b/packages/irmin-bench/irmin-bench.3.4.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.9.0"}
+  "irmin-pack"   {= version}
+  "irmin-test"   {= version}
+  "irmin-tezos"  {= version}
+  "cmdliner"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "repr"         {>= "0.3.0"}
+  "ppx_repr"
+  "re"           {>= "1.9.0"}
+  "fmt"
+  "uuidm"
+  "progress"     {>="0.2.1"}
+  "fpath"        {with-test}
+  "bentov"
+  "mtime"
+  "ppx_deriving"
+  "alcotest"     {with-test}
+  "rusage"
+  "uutf"
+  "uucp"
+  "printbox"     {>= "0.6"}
+  "printbox-text"
+]
+
+available: [
+   # Disabled on 32-bit platforms due to an overly-large int literal in the source
+   arch != "arm32" & arch != "x86_32"
+]
+
+synopsis: "Irmin benchmarking suite"
+description: """
+`irmin-bench` provides access to the Irmin suite for benchmarking storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-chunk/irmin-chunk.3.4.0/opam
+++ b/packages/irmin-chunk/irmin-chunk.3.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Mounir Nasr Allah" "Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "fmt"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "irmin-test" {with-test & = version}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Irmin backend which allow to store values into chunks"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-cli/irmin-cli.3.4.0/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+maintainer:   "Tarides <contact@tarides.com>"
+authors:      ["Tarides"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+available: arch != "arm32" & arch != "x86_32"
+
+depends: [
+  "ocaml"         {>= "4.01.0"}
+  "dune"          {>= "2.9.0"}
+  "irmin"         {= version}
+  "irmin-git"     {= version}
+  "irmin-http"    {= version}
+  "irmin-fs"      {= version}
+  "irmin-pack"    {= version}
+  "irmin-graphql" {= version}
+  "irmin-tezos"   {= version}
+  "git-unix"      {>= "3.7.0"}
+  "digestif"      {>= "0.9.0"}
+  "irmin-watcher" {>= "0.2.0"}
+  "yaml"          {>= "3.0.0"}
+  "astring"
+  "astring"
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "conduit"
+  "conduit-lwt"
+  "conduit-lwt-unix"
+  "logs"
+  "uri"
+  "cmdliner"
+  "cohttp-lwt-unix"
+  "fmt"
+  "git"           {>= "3.7.0"}
+  "happy-eyeballs-lwt"
+  "lwt"           {>= "5.3.0"}
+  "irmin-test"    {with-test & = version}
+  "alcotest"      {with-test}
+  "mdx" {>= "2.0.0" & with-test}
+]
+
+synopsis: "CLI for Irmin"
+description: """
+A simple CLI tool (called `irmin`) to manipulate and inspect Irmin stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-containers/irmin-containers.3.4.0/opam
+++ b/packages/irmin-containers/irmin-containers.3.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["KC Sivaramakrishnan" "Anirudh Sunder Raj"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.03.0"}
+  "dune"         {>= "2.9.0"}
+  "irmin"        {= version}
+  "irmin-fs"     {= version}
+  "ppx_irmin"    {= version}
+  "lwt"          {>= "5.3.0"}
+  "mtime"
+  "alcotest"     {with-test}
+  "alcotest-lwt" {with-test}
+]
+
+synopsis: "Mergeable Irmin data structures"
+description: """
+A collection of simple, ready-to-use mergeable data structures built using
+Irmin. Each data structure works with an arbitrary Irmin backend and is
+customisable in a variety of ways.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-fs/irmin-fs.3.4.0/opam
+++ b/packages/irmin-fs/irmin-fs.3.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.03.0"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "astring"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "alcotest"   {with-test}
+  "irmin-test" {with-test & = version}
+  "irmin-watcher" {with-test & >= "0.2.0"}
+]
+
+synopsis: "Generic file-system backend for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-git/irmin-git.3.4.0/opam
+++ b/packages/irmin-git/irmin-git.3.4.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ # Tests disabled on 32-bit platforms as the Dune build fails in CI:
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "ocaml"      {>= "4.02.3"}
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "ppx_irmin"  {= version}
+  "git"        {>= "3.7.0"}
+  "git-unix"   {>= "3.7.0"}
+  "digestif"   {>= "0.9.0"}
+  "cstruct"
+  "fmt"
+  "astring"
+  "cohttp-lwt-unix"
+  "fpath"
+  "logs"
+  "lwt"        {>= "5.3.0"}
+  "uri"
+  "mimic"
+  "irmin-test" {with-test & = version}
+  "mtime"      {with-test & >= "1.0.0"}
+  "alcotest"   {with-test}
+]
+
+synopsis: "Git backend for Irmin"
+description: """
+`Irmin_git` expose a bi-directional bridge between Git repositories and
+Irmin stores.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-graphql/irmin-graphql.3.4.0/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "Andreas Garnaes <andreas.garnaes@gmail.com>"
+authors:      "Andreas Garnaes <andreas.garnaes@gmail.com>"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"          {>= "4.03.0"}
+  "dune"           {>= "2.9.0"}
+  "irmin"          {= version}
+  "graphql"        {>= "0.14.0"}
+  "graphql-lwt"    {>= "0.14.0"}
+  "graphql-cohttp" {>= "0.14.0"}
+  "graphql_parser" {>= "0.14.0"}
+  "cohttp"
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
+  "git-unix"        {>= "3.7.0"}
+  "fmt"
+  "lwt"             {>= "5.3.0"}
+  "alcotest-lwt"    {with-test & >= "1.1.0"}
+  "yojson"          {with-test}
+  "alcotest"        {with-test & >= "1.2.3"}
+  "logs"            {with-test}
+]
+
+synopsis: "GraphQL server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-http/irmin-http.3.4.0/opam
+++ b/packages/irmin-http/irmin-http.3.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.02.3"}
+  "dune"            {>= "2.9.0"}
+  "crunch"          {>= "2.2.0"}
+  "webmachine"      {>= "0.6.0"}
+  "irmin"           {= version}
+  "ppx_irmin"       {= version}
+  "cohttp-lwt"      {>= "1.0.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "astring"
+  "cohttp"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"             {>= "5.3.0"}
+  "uri"
+  "irmin-git"       {with-test & = version}
+  "irmin-fs"        {with-test & = version}
+  "irmin-test"      {with-test & = version}
+  "git-unix"        {with-test & >= "3.5.0"}
+  "digestif"        {with-test & >= "0.9.0"}
+]
+
+synopsis: "HTTP client and server for Irmin"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.4.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.4.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"         {>= "2.9.0"}
+  "irmin-mirage" {= version}
+  "irmin-git"    {= version}
+  "mirage-kv"    {>= "3.0.0"}
+  "fmt"
+  "git"          {>= "3.7.0"}
+  "lwt"          {>= "5.3.0"}
+  "mirage-clock"
+  "uri"
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-mirage-graphql/irmin-mirage-graphql.3.4.0/opam
+++ b/packages/irmin-mirage-graphql/irmin-mirage-graphql.3.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"          {>= "2.9.0"}
+  "irmin-mirage"  {= version}
+  "irmin-graphql" {= version}
+  "mirage-clock"
+  "cohttp-lwt"
+  "lwt"           {>= "5.3.0"}
+  "uri"
+  "git"           {>= "3.4.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-mirage/irmin-mirage.3.4.0/opam
+++ b/packages/irmin-mirage/irmin-mirage.3.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      "Thomas Gazagnaire"
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"       {>= "2.9.0"}
+  "irmin"      {= version}
+  "fmt"
+  "ptime"
+  "mirage-clock" {>= "3.0.0"}
+]
+
+synopsis: "MirageOS-compatible Irmin stores"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-pack/irmin-pack.3.4.0/opam
+++ b/packages/irmin-pack/irmin-pack.3.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"        {>= "4.08.0"}
+  "dune"         {>= "2.9.0"}
+  "irmin"        {= version}
+  "ppx_irmin"    {= version}
+  "index"        {>= "1.6.0"}
+  "fmt"
+  "logs"
+  "lwt"          {>= "5.4.0"}
+  "mtime"
+  "cmdliner"
+  "optint"       {>= "0.1.0"}
+  "irmin-test"   {with-test & = version}
+  "alcotest-lwt" {with-test}
+  "astring"      {with-test}
+  "alcotest"     {with-test}
+]
+
+synopsis: "Irmin backend which stores values in a pack file"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-test/irmin-test.3.4.0/opam
+++ b/packages/irmin-test/irmin-test.3.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "irmin"        {= version}
+  "ppx_irmin"    {= version}
+  "ocaml"        {>= "4.02.3"}
+  "dune"         {>= "2.9.0"}
+  "alcotest-lwt" {>= "1.5.0"}
+  "mtime"        {>= "1.0.0"}
+  "astring"
+  "fmt"
+  "jsonm"
+  "logs"
+  "lwt"          {>= "5.3.0"}
+  "metrics-unix"
+  "ocaml-syntax-shims"
+  "cmdliner"
+  "metrics" {>= "0.2.0"}
+  "hex" {with-test & >= "1.4.0"}
+  "vector" {with-test & >= "1.0.0"}
+]
+
+synopsis: "Irmin test suite"
+description: """
+`irmin-test` provides access to the Irmin test suite for testing storage backend
+implementations.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin-tezos/irmin-tezos.3.4.0/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Irmin implementation of the Tezos context hash specification"
+description: "Irmin implementation of the Tezos context hash specification"
+maintainer: "Tarides <contact@tarides.com>"
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "MIT"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "2.9.0"}
+  "irmin" {>= version}
+  "irmin-pack" {= version}
+  "ppx_irmin" {= version}
+  "tezos-base58"
+  "digestif" {>= "0.7"}
+  "cmdliner"
+  "fmt"
+  "yojson"
+  "alcotest" {with-test}
+  "hex" {with-test & >= "1.4.0"}
+  "fpath" {with-test}
+  "irmin-test" {with-test & = version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}]
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/irmin/irmin.3.4.0/opam
+++ b/packages/irmin/irmin.3.4.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/irmin"
+bug-reports:  "https://github.com/mirage/irmin/issues"
+dev-repo:     "git+https://github.com/mirage/irmin.git"
+doc:          "https://mirage.github.io/irmin/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"   {>= "4.08.0"}
+  "dune"    {>= "2.9.0"}
+  "repr"    {>= "0.6.0"}
+  "fmt"     {>= "0.8.5"}
+  "uri"     {>= "1.3.12"}
+  "uutf"
+  "jsonm"   {>= "1.0.0"}
+  "lwt"     {>= "5.3.0"}
+  "digestif" {>= "0.9.0"}
+  "ocamlgraph"
+  "logs"    {>= "0.5.0"}
+  "bheap" {>= "2.0.0"}
+  "astring"
+  "mtime" {>= "1.0.0"}
+  "bigstringaf" { >= "0.2.0" }
+  "ppx_irmin" {= version}
+  "irmin-watcher" {>= "0.2.0"}
+  "hex"      {with-test}
+  "alcotest" {>= "1.1.0" & with-test}
+  "alcotest-lwt" {with-test}
+  "qcheck-alcotest" {with-test}
+  "vector" {with-test}
+  "odoc" {(< "2.0.1" | > "2.0.2") & with-doc} # See https://github.com/ocaml/odoc/issues/793
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+
+conflicts: [
+  "result" {< "1.5"} # Requires `Result = Stdlib.Result`
+]
+
+synopsis: """
+Irmin, a distributed database that follows the same design principles as Git
+"""
+description: """
+Irmin is a library for persistent stores with built-in snapshot,
+branching and reverting mechanisms. It is designed to use a large
+variety of backends. Irmin is written in pure OCaml and does not
+depend on external C stubs; it aims to run everywhere, from Linux,
+to browsers and Xen unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"

--- a/packages/libirmin/libirmin.3.4.0/opam
+++ b/packages/libirmin/libirmin.3.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "C bindings for irmin"
+description: "C bindings for irmin using Ctypes inverted stubs"
+maintainer: ["zachshipko@gmail.com"]
+authors: ["Zach Shipko"]
+license: "ISC"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ctypes" {>= "0.19"}
+  "ctypes-foreign" {>= "0.18"}
+  "irmin" {= version}
+  "irmin-cli" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+# Disabled on arm64 linux and s390x because of a SEGFAULT in tests
+available: [ (arch != "arm64" | os = "macos") & arch != "s390x" ]
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d" 

--- a/packages/ppx_irmin/ppx_irmin.3.4.0/opam
+++ b/packages/ppx_irmin/ppx_irmin.3.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Craig Ferguson <craig@tarides.com>"
+homepage: "https://github.com/mirage/irmin"
+bug-reports: "https://github.com/mirage/irmin/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/mirage/irmin.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.9.0"}
+  "ppx_repr" {>= "0.2.0"}
+  "ppxlib" {>= "0.12.0"}
+  "logs" {>= "0.5.0"}
+  "fmt" {with-test & >= "0.8.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+
+synopsis: "PPX deriver for Irmin type representations"
+authors: "Craig Ferguson <craig@tarides.com>"
+url {
+  src:
+    "https://github.com/mirage/irmin/releases/download/3.4.0/irmin-3.4.0.tbz"
+  checksum: [
+    "sha256=9e72efdc13324602d8da46e0492b1f4e09ad524149845e1a9106882f60ad6e1f"
+    "sha512=ae9cb4b086c7b93962aafc2ea339ac85c6d66bdf769f70a16f62fa5c74d9b194e12ac00b510be5ffac5adff3aa20fd69c4ca4067dcc966767fefcf5c02bc9969"
+  ]
+}
+x-commit-hash: "9b2324763b754af9f823ee98c0b5b557cd102b9d"


### PR DESCRIPTION
- Project page: <a href="https://github.com/mirage/irmin">https://github.com/mirage/irmin</a>

##### CHANGES:

### Added

- **irmin**
  - Add `Tree.seq` to `Tree`'s public API (mirage/irmin#1923, @metanivek)

- **irmin-fs**
  - Add unix subpackage, `irmin-fs.unix` (mirage/irmin#1948, @metanivek)

- **irmin-git**
  - Add unix subpackage, `irmin-git.unix` (mirage/irmin#1948, @metanivek)

- **irmin-graphql**
  - Add unix subpackage, `irmin-graphql.unix` (mirage/irmin#1948, @metanivek)

- **irmin-http**
  - Add unix subpackage, `irmin-http.unix` (mirage/irmin#1948, @metanivek)

- **irmin-cli**
  - Add new package for `irmin` command-line tool (mirage/irmin#1951, @metanivek)

- **irmin-pack**
  - Add a garbage collection feature, allowing a user to discard commits older
    than a specified commit.  This feature is only enabled for stores that use
    `Indexing_strategy.minimal`. The primary API is `Store.Gc.run`,
    `Store.Gc.wait`, and `Store.Gc.is_finished`. See `examples/gc.ml` for a
    demonstration of usage.
  - Add a consistency check for the files on disk when opening store (mirage/irmin#2004,
  @icristescu)

### Changed

- **irmin**
  - Replaced `Tree.node_fn` type with more general `Tree.folder` type to
    represent the different ways to use `Tree.fold` (mirage/irmin#1918, @metanivek)

- **irmin-unix**
  - Removed the `irmin-unix` package. Unix backends are now subpackages of their
    relevant backend (see `irmin-fs.unix` and `irmin-git.unix`). The CLI tool is
    in `irmin-cli`. For common unix utilities, see `irmin.unix`. (mirage/irmin#1953, @metanivek)

- **irmin-graphql**
  - Updated to `graphql.0.14.0` (mirage/irmin#1843, @patricoferris, @zshipko)

### Fixed

- **irmin**
  - Fix a bug in Irmin.LRU.clear that disables the cache completly
    after a clear. This is not used in any production code as only
    the GC is clearing LRU so far (mirage/irmin#1998, @samoht)
