### PR TITLE
[new release] uring (0.4)

### DIFF
--- a/packages/uring/uring.0.4/opam
+++ b/packages/uring/uring.0.4/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Linux io_uring"
+description:
+  "Bindings to the Linux io_uring kernel IO interfaces. See https://github.com/ocaml-multicore/eio for a higher-level API using this."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Sadiq Jaffer" "Thomas Leonard"]
+homepage: "https://github.com/ocaml-multicore/ocaml-uring"
+doc: "https://ocaml-multicore.github.io/ocaml-uring/"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.1"}
+  "ocaml" {>= "4.12.0"}
+  "dune-configurator"
+  "lwt" {with-test & >= "5.0.0"}
+  "bechamel" {>= "0.1.0" & with-test}
+  "logs" {with-test & >= "0.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt" {>= "0.8.10"}
+  "optint" {>= "0.1.0"}
+  "mdx" {>= "2.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-uring.git"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os = "linux"]
+license: ["ISC" "MIT"]
+x-ci-accept-failures: [
+  "centos-7" # default C compiler does not support stdatomic.h
+  "oraclelinux-7" # default C compiler does not support stdatomic.h
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v0.4/uring-0.4.tbz"
+  checksum: [
+    "sha256=7a321904b4159626bed79e8aa5be4a25bdba50941a6b8edff03868df9a118e5f"
+    "sha512=8197783d3aaad987578902dac1b47de5202efda97a521876247e4f087e37f92c08ed4bd7c2eeb23daf11bab5032e055fa70d62f39e877856e5654346da17cdd4"
+  ]
+}
+x-commit-hash: "2291cb27c1c18aee92b237a227728a1f260ac920"


### PR DESCRIPTION
OCaml bindings for Linux io_uring

- Project page: <a href="https://github.com/ocaml-multicore/ocaml-uring">https://github.com/ocaml-multicore/ocaml-uring</a>
- Documentation: <a href="https://ocaml-multicore.github.io/ocaml-uring/">https://ocaml-multicore.github.io/ocaml-uring/</a>

##### CHANGES:

New features:

- Add `Uring.timeout` (@bikallem ocaml-multicore/ocaml-uring#59).

- Add `Uring.read` and `Uring.write` (@haesbaert ocaml-multicore/ocaml-uring#62).
  These are simple wrappers for read(2) and write(2).

- Add `Uring.unlink` (@talex5 ocaml-multicore/ocaml-uring#65).
  This uses unlinkat(2), and so can also be used to remove directories.

- Add support for uring probes (@talex5 ocaml-multicore/ocaml-uring#70).
  Allows checking whether a feature is supported by the kernel at runtime.

- Rename `peek` to `get_cqe_nonblocking` (@talex5 ocaml-multicore/ocaml-uring#67).
  The old name was confusing because it does remove the item from the ring.

- Update to liburing 2.2 (@talex5 ocaml-multicore/ocaml-uring#56).

- Add `Uring.active_ops` (@talex5 ocaml-multicore/ocaml-uring#68).
  Avoids needing to track the value returned by `submit`, which is important as it is sometimes called automatically.

- Add `Uring.iov_max` constant (@talex5 ocaml-multicore/ocaml-uring#76).

- Add `Uring.get_debug_stats` (@talex5 ocaml-multicore/ocaml-uring#64).
  This should make it easier to check that the uring is behaving as expected.

Performance:

- Introduce a Sketch buffer per Uring (@haesbaert ocaml-multicore/ocaml-uring#63).
  The main motivation of this change is to avoid having one malloc per packet in readv(2), writev(2) and friends.

- Use `submit_and_wait` where appropriate (@haesbaert ocaml-multicore/ocaml-uring#69).

- Add a `readv` benchmark (@talex5 ocaml-multicore/ocaml-uring#64).

- Avoid unnecessary use of `CAMLparam` in the C stubs (@haesbaert ocaml-multicore/ocaml-uring#61).

Bug fixes:

- Prevent ring from being used after exit (@talex5 ocaml-multicore/ocaml-uring#78).

Build changes:

- Remove use of notty for formatting benchmark results (@talex5 ocaml-multicore/ocaml-uring#71).
  It prevented uring from being tested on OCaml 5.

- Use MDX for README (@talex5 ocaml-multicore/ocaml-uring#57).

- Convert tests to MDX (@talex5 ocaml-multicore/ocaml-uring#58 ocaml-multicore/ocaml-uring#73).

- Use opam-repository syntax for license (@kit-ty-kate ocaml-multicore/ocaml-uring#72).

- Remove internal `is_dirty` flag (@talex5 ocaml-multicore/ocaml-uring#77).
