### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.5)

### DIFF
--- a/packages/eio/eio.0.5/opam
+++ b/packages/eio/eio.0.5/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "1.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.5/eio-0.5.tbz"
+  checksum: [
+    "sha256=ceb254a8df0dcf42658014282137f932a75fde959a52e5508f77cf8c65514fd0"
+    "sha512=6943a975f66bb5cdacc534da9d124ea879855a546c5b6874f8d9a943ffef3aadfaf5979aee13b9aaa06277a7233335b92ef3604779f72ed247f54d09abf18275"
+  ]
+}
+x-commit-hash: "d86a4fddc8952f028d1db8de5a23bfb174ac9145"

--- a/packages/eio_linux/eio_linux.0.5/opam
+++ b/packages/eio_linux/eio_linux.0.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.5/eio-0.5.tbz"
+  checksum: [
+    "sha256=ceb254a8df0dcf42658014282137f932a75fde959a52e5508f77cf8c65514fd0"
+    "sha512=6943a975f66bb5cdacc534da9d124ea879855a546c5b6874f8d9a943ffef3aadfaf5979aee13b9aaa06277a7233335b92ef3604779f72ed247f54d09abf18275"
+  ]
+}
+x-commit-hash: "d86a4fddc8952f028d1db8de5a23bfb174ac9145"

--- a/packages/eio_luv/eio_luv.0.5/opam
+++ b/packages/eio_luv/eio_luv.0.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.5/eio-0.5.tbz"
+  checksum: [
+    "sha256=ceb254a8df0dcf42658014282137f932a75fde959a52e5508f77cf8c65514fd0"
+    "sha512=6943a975f66bb5cdacc534da9d124ea879855a546c5b6874f8d9a943ffef3aadfaf5979aee13b9aaa06277a7233335b92ef3604779f72ed247f54d09abf18275"
+  ]
+}
+x-commit-hash: "d86a4fddc8952f028d1db8de5a23bfb174ac9145"

--- a/packages/eio_main/eio_main.0.5/opam
+++ b/packages/eio_main/eio_main.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.5/eio-0.5.tbz"
+  checksum: [
+    "sha256=ceb254a8df0dcf42658014282137f932a75fde959a52e5508f77cf8c65514fd0"
+    "sha512=6943a975f66bb5cdacc534da9d124ea879855a546c5b6874f8d9a943ffef3aadfaf5979aee13b9aaa06277a7233335b92ef3604779f72ed247f54d09abf18275"
+  ]
+}
+x-commit-hash: "d86a4fddc8952f028d1db8de5a23bfb174ac9145"


### PR DESCRIPTION
Effect-based direct-style IO mainloop for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features:

- Add `Eio.Condition` (@TheLortex @talex5 ocaml-multicore/eio#277).
  Allows a fiber to wait for some condition to become true.

- Add `Eio.Net.getaddrinfo` and `getnameinfo` (@bikallem @talex5 ocaml-multicore/eio#278 ocaml-multicore/eio#288 ocaml-multicore/eio#291).
  Convert between host names and addresses.

- Add `Eio.Debug` (@talex5 ocaml-multicore/eio#276).
  Currently, this allows overriding the `traceln` function.

- `Buf_write.create`: make switch optional (@talex5 ocaml-multicore/eio#283).
  This makes things easier for people porting code from Faraday.

Bug fixes:

- Allow sharing of libuv poll handles (@patricoferris @talex5 ocaml-multicore/eio#279).
  Luv doesn't allow two callers to watch the same file handle, so we need to handle that in Eio.

Other changes:

- Upgrade to uring 0.4 (@talex5 ocaml-multicore/eio#290).

- Mention `Mutex`, `Semaphore` and `Condition` in the README (@talex5 ocaml-multicore/eio#281).
