### PR TITLE
Package tdigest.1.0.0

### DIFF
--- a/packages/tdigest/tdigest.1.0.0/opam
+++ b/packages/tdigest/tdigest.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+  "Will Welch"
+]
+synopsis: "OCaml implementation of the T-Digest algorithm"
+description: """
+The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.
+
+The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.
+
+Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/tdigest"
+dev-repo: "git://github.com/SGrondin/tdigest"
+doc: "https://github.com/SGrondin/tdigest"
+bug-reports: "https://github.com/SGrondin/tdigest/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "core_kernel" { >= "v0.14.0" & < "v0.15.0" }
+  # "ocamlformat" { = "0.19.0" } # Development
+  # "ocaml-lsp-server" # Development
+
+  "alcotest" { with-test }
+  "yojson" { with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/tdigest/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=d17532085ce53b390d1b9446a176337c"
+    "sha512=ec193b47c9167aceaec593de9fd4c98baf2f5831acec4ba851e59c05738a6f24d921aa79488a08f68a714db6e1e03f590f9f9f1be56970ba84336e3cada06ff6"
+  ]
+}


### PR DESCRIPTION
### `tdigest.1.0.0`
OCaml implementation of the T-Digest algorithm
The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.

The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.

Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.



---
* Homepage: https://github.com/SGrondin/tdigest
* Source repo: git://github.com/SGrondin/tdigest
* Bug tracker: https://github.com/SGrondin/tdigest/issues

---
:camel: Pull-request generated by opam-publish v2.1.0