### PR TITLE
Package fuzzy_compare.1.0.0

### DIFF
--- a/packages/fuzzy_compare/fuzzy_compare.1.0.0/opam
+++ b/packages/fuzzy_compare/fuzzy_compare.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Fastest bounded Levenshtein comparator over generic structures"
+description: """
+This library does not calculate the edit distance.
+
+Rather, it provides extremely efficient automata that answer whether 2 values are within a predetermined number of edits of one another.
+
+Once generated, an automaton can be reused to compare any 2 values in around 2-8 µs.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/fuzzy_compare"
+dev-repo: "git://github.com/SGrondin/fuzzy_compare"
+doc: "https://github.com/SGrondin/fuzzy_compare"
+bug-reports: "https://github.com/SGrondin/fuzzy_compare/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "core_kernel" { >= "v0.14.0" & < "v0.15.0" }
+  # "ocamlformat" { = "0.19.0" } # Development
+  # "ocaml-lsp-server" # Development
+
+  "uuseg" { with-test }
+  "uunf" { with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/fuzzy_compare/archive/1.0.0.tar.gz"
+  checksum: [
+    "md5=455dc4fbe810bffb087b84ab638994fc"
+    "sha512=52d41e9686b77206dd3b9efdfef3c9511cb8a66927af7548ee5454258232a7f1e3aeb1106ae49f75bc3d04dada962a58ed8e2cfcd5d902f0d5465357dd3541dd"
+  ]
+}


### PR DESCRIPTION
### `fuzzy_compare.1.0.0`
Fastest bounded Levenshtein comparator over generic structures
This library does not calculate the edit distance.

Rather, it provides extremely efficient automata that answer whether 2 values are within a predetermined number of edits of one another.

Once generated, an automaton can be reused to compare any 2 values in around 2-8 µs.



---
* Homepage: https://github.com/SGrondin/fuzzy_compare
* Source repo: git://github.com/SGrondin/fuzzy_compare
* Bug tracker: https://github.com/SGrondin/fuzzy_compare/issues

---
:camel: Pull-request generated by opam-publish v2.1.0