### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.1.0)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.1.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.1.0/paf-0.1.0.tbz"
+  checksum: [
+    "sha256=24826310211b6a36aea306d7a2dd7dbed883853a4601089208163400764ec993"
+    "sha512=2fb74889bad5d5a9164fa77618de1f96a89037a7fbe9b8f849933188fc2432ab4be99b298b871a2831e421963667a974bea3a329a471b5ab0b0787552d622f56"
+  ]
+}
+x-commit-hash: "dd07f97299db1970081885a752ec1fff9bb38063"

--- a/packages/paf-le/paf-le.0.1.0/opam
+++ b/packages/paf-le/paf-le.0.1.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.1.0/paf-0.1.0.tbz"
+  checksum: [
+    "sha256=24826310211b6a36aea306d7a2dd7dbed883853a4601089208163400764ec993"
+    "sha512=2fb74889bad5d5a9164fa77618de1f96a89037a7fbe9b8f849933188fc2432ab4be99b298b871a2831e421963667a974bea3a329a471b5ab0b0787552d622f56"
+  ]
+}
+x-commit-hash: "dd07f97299db1970081885a752ec1fff9bb38063"

--- a/packages/paf/paf.0.1.0/opam
+++ b/packages/paf/paf.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic" {>= "0.0.5"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.9.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.1.0/paf-0.1.0.tbz"
+  checksum: [
+    "sha256=24826310211b6a36aea306d7a2dd7dbed883853a4601089208163400764ec993"
+    "sha512=2fb74889bad5d5a9164fa77618de1f96a89037a7fbe9b8f849933188fc2432ab4be99b298b871a2831e421963667a974bea3a329a471b5ab0b0787552d622f56"
+  ]
+}
+x-commit-hash: "dd07f97299db1970081885a752ec1fff9bb38063"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Fix the Let's encrypt support (@dinosaure, dinosaure/paf-le-chien#65)
- Update the codebase with `ocamlformat.0.23.0` (@dinosaure, dinosaure/paf-le-chien#66)
- Update the project with `h2.0.9.0` (@dinosaure, dinosaure/paf-le-chien#67)
