### PR TITLE
[new release] rfc1951 and decompress (1.5.0)

### DIFF
--- a/packages/decompress/decompress.1.5.0/opam
+++ b/packages/decompress/decompress.1.5.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "cmdliner"    {>= "1.1.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test & >= "0.8.7"}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.0/decompress-1.5.0.tbz"
+  checksum: [
+    "sha256=73183dc1186ab6cf1ca641146f6948f2fae6a69729ec0a1e62943385f9895077"
+    "sha512=31508b4ae16f6850fd86391f4bb3f950bba12ac45398c8ddb1b6e74f6a96f6a150b81377d6fd49146f1f0789c43a761d709d1d73a782d9c0df0d00a3c9663c89"
+  ]
+}
+x-commit-hash: "30d1c93cb875806a784156baf1f7c0f1b2d10d99"

--- a/packages/rfc1951/rfc1951.1.5.0/opam
+++ b/packages/rfc1951/rfc1951.1.5.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.0/decompress-1.5.0.tbz"
+  checksum: [
+    "sha256=73183dc1186ab6cf1ca641146f6948f2fae6a69729ec0a1e62943385f9895077"
+    "sha512=31508b4ae16f6850fd86391f4bb3f950bba12ac45398c8ddb1b6e74f6a96f6a150b81377d6fd49146f1f0789c43a761d709d1d73a782d9c0df0d00a3c9663c89"
+  ]
+}
+x-commit-hash: "30d1c93cb875806a784156baf1f7c0f1b2d10d99"


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Update with `ocamlformat.0.20.0` (@dinosaure, mirage/decompress#133)
- Add `lzo` into the binary (@dinosaure, mirage/decompress#140)
- Be able to deflate/inflate files (@dinosaure, mirage/decompress#141)
- Implement the zero-compression into zlib/gzip (@dinosaure, mirage/decompress#142)
  **breaking change**: The behavior of flat block changed. The user does not
  specify how many bytes he/she wants to give. He/She can just specify that
  he/she wants a `Flat` block. The `Flat` block will contains what the queue
  has and nothing more: if the queue has 4 elements, we will encode a `Flat`
  block with 4 elements, if the queue has more than 65535 elements, we will
  encore only 65535 elements into the `Flat` block.

  The user is not able to _stream_ a `Flat` block: we can not fill one `Flat`
  block with multiple `Await`. This behavior is specific to the `Flat` block,
  the rest (`Fixed` and `Dynamic` blocks) did not change.

  For higher level API, the `level = 0` informs the _deflator_ to copy as is
  input - no compression was done for `zlib` and `gzip` and we emit only `Flat`
  blocks. By default, the `level = 4` is given so you probably will not notice
  anything but be care that we shifted compression level and `0` becomes a
  level without compression.
