### PR TITLE
frama-c: add macOS-specific patch

### DIFF
--- a/packages/frama-c/frama-c.25.0/files/macos.patch
+++ b/packages/frama-c/frama-c.25.0/files/macos.patch
@@ -1,0 +1,14 @@
+diff --git a/src/plugins/value/gen-api.sh b/src/plugins/value/gen-api.sh
+index d00c16fdd4a..a64e6268c2d 100755
+--- a/src/plugins/value/gen-api.sh
++++ b/src/plugins/value/gen-api.sh
+@@ -22,7 +22,8 @@ for i in "$@"
+ do
+     file=$(basename $i)
+     module=${file%.*}
+-    printf '\nmodule %s: sig\n' ${module^}
++    Module="$(echo "${module:0:1}" | tr '[:lower:]' '[:upper:]')${module:1}"
++    printf '\nmodule %s: sig\n' $Module
+     awk '/\[@@@ api_start\]/{flag=1;next} /\[@@@ api_end\]/{flag=0} flag{ print (NF ? "  ":"") $0 }' $i
+     printf 'end\n'
+ done

--- a/packages/frama-c/frama-c.25.0/opam
+++ b/packages/frama-c/frama-c.25.0/opam
@@ -155,3 +155,9 @@ url {
   src: "https://www.frama-c.com/download/frama-c-25.0-Manganese.tar.gz"
   checksum: "sha256=222dcefcd272053540bf5b6cff369efc47b81c28f360eb616669c3f30a8bc29f"
 }
+
+patches: [ "macos.patch" {os = "macos"} ]
+
+extra-files: [
+  [ "macos.patch"  "md5=6bc9560ec66fdfd45c39b13a7f647f18" ]
+]


### PR DESCRIPTION
To avoid issues when users do not have GNU bash installed (e.g. via Homebrew).