### PR TITLE
[new release] rfc1951 and decompress (1.5.1)

### DIFF
--- a/packages/decompress/decompress.1.5.1/opam
+++ b/packages/decompress/decompress.1.5.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "cmdliner"    {>= "1.1.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test & >= "0.8.7"}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.1/decompress-1.5.1.tbz"
+  checksum: [
+    "sha256=cbf395a23171864b09410befb52dfc485ed99cc110840b700decb4212c32a4fe"
+    "sha512=a96b74d3f8f4d7b110bea94988ba897dab8c63f50751bffa498ad5fc2a7fc806b7fc20b90926394b9780f5c2ac93e9a6c7447c7b38366e43b3f5afff3dc4dcc8"
+  ]
+}
+x-commit-hash: "fbc17adb4290cbe12ce2fbefb63834b004c43053"

--- a/packages/rfc1951/rfc1951.1.5.1/opam
+++ b/packages/rfc1951/rfc1951.1.5.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.1/decompress-1.5.1.tbz"
+  checksum: [
+    "sha256=cbf395a23171864b09410befb52dfc485ed99cc110840b700decb4212c32a4fe"
+    "sha512=a96b74d3f8f4d7b110bea94988ba897dab8c63f50751bffa498ad5fc2a7fc806b7fc20b90926394b9780f5c2ac93e9a6c7447c7b38366e43b3f5afff3dc4dcc8"
+  ]
+}
+x-commit-hash: "fbc17adb4290cbe12ce2fbefb63834b004c43053"


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Fix the stream of gzip inflation. If the user wants to know how many bytes
  are available into the output buffer, he/she must be in the DEFLATE internal
  state. Otherwise, we raise an exception. However, such information is not
  available into the API so we decided to say that the full output buffer is
  free when we are into the GZip header state.

  It ensures a real full stream API. (@dinosaure, mirage/decompress#144)
