### PR TITLE
[new release] bitwuzla and bitwuzla-c (1.0.3)

### DIFF
--- a/packages/bitwuzla-c/bitwuzla-c.1.0.3/opam
+++ b/packages/bitwuzla-c/bitwuzla-c.1.0.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP (C API)"
+description: "OCaml binding for the SMT solver Bitwuzla C API."
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "conf-git" {build}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "bitwuzla" {< "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/1.0.3/bitwuzla-1.0.3.tbz"
+  checksum: [
+    "sha256=246d8a2b7074ae6873b53124091759d0b3b6146f53ad436a3941542379976160"
+    "sha512=961c6ff0c0458360c5330a45047968794e0c2b9d18ec8666aa7991a67bbf682a49ed6d7bfd551976da7e8d6e4be137b5c1cf24b449b028123dd55491fd9e9403"
+  ]
+}
+x-commit-hash: "5b3569d8bf4d86e5d81183d210b911eebae176fb"

--- a/packages/bitwuzla/bitwuzla.1.0.3/opam
+++ b/packages/bitwuzla/bitwuzla.1.0.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "SMT solver for AUFBVFP"
+description: """
+
+OCaml binding for the SMT solver Bitwuzla.
+
+Bitwuzla is a Satisfiability Modulo Theories (SMT) solver for the theories of fixed-size bit-vectors, arrays and uninterpreted functions and their combinations. Its name is derived from an Austrian dialect expression that can be translated as “someone who tinkers with bits”."""
+maintainer: ["Frédéric Recoules <frederic.recoules@cea.fr>"]
+authors: ["Frédéric Recoules"]
+license: "MIT"
+tags: ["SMT solver" "SMT-COMP 2020" "AUFBVFP"]
+homepage: "https://bitwuzla.github.io"
+doc: "https://bitwuzla.github.io/docs/ocaml/"
+bug-reports: "https://github.com/bitwuzla/ocaml-bitwuzla/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "bitwuzla-c" {= version}
+  "zarith"
+  "ppx_inline_test" {with-test & >= "v0.13"}
+  "ppx_expect" {with-test & >= "v0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bitwuzla/ocaml-bitwuzla.git"
+available: [ os = "linux" & (os-distribution != "ol" & os-distribution != "centos" | os-version >= 8) ]
+url {
+  src:
+    "https://github.com/bitwuzla/ocaml-bitwuzla/releases/download/1.0.3/bitwuzla-1.0.3.tbz"
+  checksum: [
+    "sha256=246d8a2b7074ae6873b53124091759d0b3b6146f53ad436a3941542379976160"
+    "sha512=961c6ff0c0458360c5330a45047968794e0c2b9d18ec8666aa7991a67bbf682a49ed6d7bfd551976da7e8d6e4be137b5c1cf24b449b028123dd55491fd9e9403"
+  ]
+}
+x-commit-hash: "5b3569d8bf4d86e5d81183d210b911eebae176fb"


### PR DESCRIPTION
SMT solver for AUFBVFP

- Project page: <a href="https://bitwuzla.github.io">https://bitwuzla.github.io</a>
- Documentation: <a href="https://bitwuzla.github.io/docs/ocaml/">https://bitwuzla.github.io/docs/ocaml/</a>

##### CHANGES:

Update [Bitwuzla](https://bitwuzla.github.io/) sources.

Vendor submodules:
- [Bitwuzla](https://github.com/bitwuzla/bitwuzla) commit:a2c3cc2
