### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.1.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.1.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.1.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "io-page" {>= "2.4.0"}
+  "lwt"
+  "mirage-block" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "ptime"
+  "re" {>= "1.7.2"}
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.5.0"}
+  "ounit2" {with-test}
+  "ounit2-lwt" {with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.1.0/tar-2.1.0.tbz"
+  checksum: [
+    "sha256=05cf662c9cfc3fc6cf1e04785b8f65c125df5a617686c4ee86567c59d219cf2c"
+    "sha512=ac0307d3d99c8335f40a86257b328fa78603a6d558477fd7802ec14802e308c8dcddca3ae6609be23e715b4e6e554c10e876f315e5fefa96632f5c992dc0b782"
+  ]
+}
+x-commit-hash: "43ac8b8035296165dab5f5f3880c0ff385c1e18f"

--- a/packages/tar-unix/tar-unix.2.1.0/opam
+++ b/packages/tar-unix/tar-unix.2.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.03.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "re" {>= "1.7.2"}
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.1.0/tar-2.1.0.tbz"
+  checksum: [
+    "sha256=05cf662c9cfc3fc6cf1e04785b8f65c125df5a617686c4ee86567c59d219cf2c"
+    "sha512=ac0307d3d99c8335f40a86257b328fa78603a6d558477fd7802ec14802e308c8dcddca3ae6609be23e715b4e6e554c10e876f315e5fefa96632f5c992dc0b782"
+  ]
+}
+x-commit-hash: "43ac8b8035296165dab5f5f3880c0ff385c1e18f"

--- a/packages/tar/tar.2.1.0/opam
+++ b/packages/tar/tar.2.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "re" {>= "1.7.2"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.1.0/tar-2.1.0.tbz"
+  checksum: [
+    "sha256=05cf662c9cfc3fc6cf1e04785b8f65c125df5a617686c4ee86567c59d219cf2c"
+    "sha512=ac0307d3d99c8335f40a86257b328fa78603a6d558477fd7802ec14802e308c8dcddca3ae6609be23e715b4e6e554c10e876f315e5fefa96632f5c992dc0b782"
+  ]
+}
+x-commit-hash: "43ac8b8035296165dab5f5f3880c0ff385c1e18f"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- `tar-mirage` requires `mirage-block.2.0.0` (@kit-ty-kate, mirage/ocaml-tar#86)
- Remove `io-page-unix` dependency (@hannesm, mirage/ocaml-tar#87)
- Add GZip support (@dinosaure, mirage/ocaml-tar#88)
