### PR TITLE
relaxes piqilib's upper bound

### DIFF
--- a/packages/piqilib/piqilib.0.6.16/opam
+++ b/packages/piqilib/piqilib.0.6.16/opam
@@ -7,7 +7,7 @@ homepage: "http://piqi.org"
 license: "Apache-2.0"
 bug-reports: "https://github.com/alavrik/piqi/issues"
 depends: [
-  "ocaml" {>= "4.03"  & < "4.14.0"}
+  "ocaml" {>= "4.03"}
   "dune" {>= "2.0.0"}
   "easy-format"
   "sedlex" {>= "2.0" & < "3.0"}


### PR DESCRIPTION
It builds fine with 4.14.0 on my machine, but let's try 5.0.0, if it won't work, then I will add `& < "5.0.0"`.

cc @alavrik 