### PR TITLE
[ppx_import] [rev-deps] Add ppx_import < 2.0 constraint to all its deps.

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"             }
   "sexplib"             {           >= "v0.11.0" & < "v0.15" }
   "dune"                {           >= "1.2.0"             }
-  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"             }
   "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"             }

--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"             }
   "sexplib"             {           >= "v0.11.0"           }
   "dune"                {           >= "1.4.0"             }
-  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"             }
   "ppx_sexp_conv"       {           >= "v0.11.0"           }
   "yojson"              {           >= "1.7.0"             }

--- a/packages/coq-serapi/coq-serapi.8.10.0+0.7.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.10.0+0.7.2/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"             }
   "sexplib"             {           >= "v0.11.0"           }
   "dune"                {           >= "1.4.0"             }
-  "ppx_import"          { build   & >= "1.5-3"             }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"             }
   "ppx_sexp_conv"       {           >= "v0.11.0"           }
   "yojson"              {           >= "1.7.0"             }

--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.11.0"             }
   "dune"                {           >= "1.2.0"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.11.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.11.0+0.11.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.11.0+0.11.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.14" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.12.0+0.12.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.12.0+0.12.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.14" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.12.0+0.12.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.12.0+0.12.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.13.0+0.13.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.13.0+0.13.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.13.0+0.13.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.13.0+0.13.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.14.0+0.14.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.14.0+0.14.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.15" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.2/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" }
   "yojson"              {           >= "1.7.0"               }

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.1/opam
@@ -12,7 +12,7 @@ depends: [
   "camlp5"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "cmdliner" {>= "0.9.6" & < "1.1.0" }
   "sexplib"

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.12/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_driver" {build & >= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.2/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_driver" {build & >= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4.8/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_driver" {build & >= "v0.10.1"}
   "ppx_sexp_conv" {< "v0.11.0"}

--- a/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.1+0.4/opam
@@ -12,7 +12,7 @@ depends: [
   "camlp5"
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "cmdliner" {>= "0.9.6" & < "1.1.0"}
   "sexplib"

--- a/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
+++ b/packages/coq-serapi/coq-serapi.8.7.2+0.4.13/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.1/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.2/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.3/opam
@@ -14,7 +14,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.4/opam
@@ -15,7 +15,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.5/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.5/opam
@@ -15,7 +15,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.8.0+0.5.6/opam
+++ b/packages/coq-serapi/coq-serapi.8.8.0+0.5.6/opam
@@ -15,7 +15,7 @@ depends: [
   "sexplib" {< "v0.13"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "ppx_import" {>= "1.4"}
+  "ppx_import" {>= "1.4" & < "2.0"}
   "ppx_deriving" {>= "4.2.1"}
   "ppx_sexp_conv" {>= "v0.11.0" & < "v0.13"}
 ]

--- a/packages/coq-serapi/coq-serapi.8.9.0+0.6.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.9.0+0.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"     { >= "1.8.0"            }
   "sexplib"       { >= "v0.11.0" & < "v0.15" }
   "dune"          { >= "1.2.0"    }
-  "ppx_import"    { build & >= "1.5-3"    }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"  { build & >= "4.2.1"    }
   "ppx_sexp_conv" { build & >= "v0.11.0" & < "v0.15" }
 ]

--- a/packages/coq-serapi/coq-serapi.8.9.0+0.6.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.9.0+0.6.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlfind"     { >= "1.8.0"            }
   "sexplib"       { >= "v0.11.0" & < "v0.15" }
   "dune"          { >= "1.2.0"    }
-  "ppx_import"    { build & >= "1.5-3"    }
+  "ppx_import" {build & >= "1.5-3" & < "2.0"}
   "ppx_deriving"  { build & >= "4.2.1"    }
   "ppx_sexp_conv" { build & >= "v0.11.0" & < "v0.15" }
 ]

--- a/packages/elpi/elpi.1.10.0/opam
+++ b/packages/elpi/elpi.1.10.0/opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "1.6"}
   "conf-time" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"
 description: """

--- a/packages/elpi/elpi.1.10.1/opam
+++ b/packages/elpi/elpi.1.10.1/opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "1.6"}
   "conf-time" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"
 description: """

--- a/packages/elpi/elpi.1.10.2/opam
+++ b/packages/elpi/elpi.1.10.2/opam
@@ -24,7 +24,7 @@ depends: [
   "cmdliner" {with-test}
   "dune" {>= "1.6"}
   "conf-time" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "ELPI - Embeddable λProlog Interpreter"
 description: """

--- a/packages/frama-c/frama-c.25.0/opam
+++ b/packages/frama-c/frama-c.25.0/opam
@@ -120,7 +120,7 @@ depends: [
   "ocamlgraph" { >= "1.8.8" }
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "ppx_import" {>= "1.8.0"}
+  "ppx_import" {>= "1.8.0" & < "2.0"}
   "why3" { >= "1.5.0" }
   "yojson" {>= "1.6.0" & ( < "2.0.0" | ! with-test) }
   "zarith" {>= "1.5"}

--- a/packages/frama-c/frama-c.25.0~beta/opam
+++ b/packages/frama-c/frama-c.25.0~beta/opam
@@ -122,7 +122,7 @@ depends: [
   "yojson" {>= "1.6.0"}
   "zarith" {>= "1.5"}
   "ppx_deriving"
-  "ppx_import" {>= "1.8.0"}
+  "ppx_import" {>= "1.8.0" & < "2.0"}
 ]
 
 conflicts: [ 

--- a/packages/goblint/goblint.1.0.0/opam
+++ b/packages/goblint/goblint.1.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "xml-light" {build}
   "ppx_distr_guards"
   "ppx_monadic"
-  "ppx_import"
+  "ppx_import" {< "2.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "yojson" {< "1.6.0"}

--- a/packages/modelica_ml/modelica_ml.0.2.0/opam
+++ b/packages/modelica_ml/modelica_ml.0.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ocamlgraph"
   "ppx_deriving" {= "1.0"}
   "ppx_deriving_yojson" {= "2.0"}
-  "ppx_import"
+  "ppx_import" {< "2.0"}
   "ppx_monadic"
   "sedlex"
   "ocamlbuild" {build}

--- a/packages/pa_ppx/pa_ppx.0.01/opam
+++ b/packages/pa_ppx/pa_ppx.0.01/opam
@@ -43,7 +43,7 @@ depends: [
   "ppx_deriving_protobuf" { >= "2.7" }
   "uint" { >= "2.0.1" }
   "ounit2" { >= "2.2.3" }
-  "ppx_import" { >= "1.7.1" }
+  "ppx_import" {>= "1.7.1" & < "2.0"}
   "ppx_deriving_yojson" { >= "3.5.2" }
   "ppx_here" { >= "v0.13.0" }
   "ppx_sexp_conv" { >= "v0.13.0" }

--- a/packages/pa_ppx/pa_ppx.0.02/opam
+++ b/packages/pa_ppx/pa_ppx.0.02/opam
@@ -38,7 +38,7 @@ depends: [
   "ppx_deriving_protobuf" {>= "2.7"}
   "uint" {>= "2.0.1"}
   "ounit2" {>= "2.2.3"}
-  "ppx_import" {>= "1.7.1"}
+  "ppx_import" {>= "1.7.1" & < "2.0"}
   "ppx_deriving_yojson" {>= "3.5.2"}
   "ppx_here" {>= "v0.13.0"}
   "ppx_sexp_conv" {>= "v0.13.0"}

--- a/packages/pa_ppx/pa_ppx.0.03/opam
+++ b/packages/pa_ppx/pa_ppx.0.03/opam
@@ -45,7 +45,7 @@ depends: [
   "sexplib"
   "ppx_deriving_protobuf" { >= "2.7" }
   "uint" { >= "2.0.1" }
-  "ppx_import" { with-test & >= "1.7.1" }
+  "ppx_import" {with-test & >= "1.7.1" & < "2.0"}
   "ppx_deriving_yojson" { with-test & >= "3.5.2" }
   "ppx_here" { with-test & >= "v0.13.0" }
   "ppx_sexp_conv" { with-test & >= "v0.13.0" }

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "alcotest" {with-test}
-  "ppx_import" {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & < "2.0"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.2.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.2.0/opam
@@ -23,7 +23,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "alcotest" {with-test}
-  "ppx_import" {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & < "2.0"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.3.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.3.1/opam
@@ -23,7 +23,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "alcotest" {with-test}
-  "ppx_import" {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & < "2.0"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.0/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.0/opam
@@ -23,7 +23,7 @@ depends: [
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "alcotest" {with-test}
-  "ppx_import" {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & < "2.0"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.4.1/opam
@@ -30,7 +30,7 @@ depends: [
   "ppxfind"      {build}
   "cppo"         {build}
   "alcotest"     {with-test}
-  "ppx_import"   {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & < "2.0"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.5.1/opam
+++ b/packages/ppx_deriving_cmdliner/ppx_deriving_cmdliner.0.5.1/opam
@@ -30,7 +30,7 @@ depends: [
   "ppxfind"      {build}
   "cppo"         {build}
   "alcotest"     {with-test}
-  "ppx_import"   {with-test & >= "1.1"}
+  "ppx_import" {with-test & >= "1.1" & < "2.0"}
 ]
 synopsis: "Cmdliner.Term.t generator"
 description: """

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.1/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_deriving" {>= "3.0" & < "4.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Morphism generator for OCaml >=4.02"

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.2/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.2/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_deriving" {>= "3.0" & < "4.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "Morphism generator for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ppx_deriving" {>= "3.0" & < "4.0"}
   "ocamlfind" {build}
   "ounit" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "Morphism generator for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4.1/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind" {build}
   "cppo_ocamlbuild" {build}
   "ounit" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "Morphism generator for OCaml >=4.02"
 description: """

--- a/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
+++ b/packages/ppx_deriving_morphism/ppx_deriving_morphism.0.4/opam
@@ -31,7 +31,7 @@ depends: [
   "cppo_ocamlbuild" {build}
   "result"
   "ounit" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 synopsis: "Morphism generator for OCaml >=4.02"
 description: """

--- a/packages/systemverilog/systemverilog.0.0.1/opam
+++ b/packages/systemverilog/systemverilog.0.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
   "astring" {build & >= "0.8.3"}
-  "ppx_import" {>= "1.2"}
+  "ppx_import" {>= "1.2" & < "2.0"}
   "menhir" {build & >= "20170418" & < "20200525"}
 ]
 build:

--- a/packages/uwt/uwt.0.0.1/opam
+++ b/packages/uwt/uwt.0.0.1/opam
@@ -27,7 +27,7 @@ depends: [
   "omake" {build}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 depexts: ["pkgconf" "libuv"] {os = "freebsd"}
 post-messages: [

--- a/packages/uwt/uwt.0.0.2/opam
+++ b/packages/uwt/uwt.0.0.2/opam
@@ -27,7 +27,7 @@ depends: [
   "omake" {build}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 depexts: [
   ["pkgconf" "libuv"] {os = "freebsd"}

--- a/packages/uwt/uwt.0.0.3/opam
+++ b/packages/uwt/uwt.0.0.3/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 depopts: [
   "conf-libuv"

--- a/packages/uwt/uwt.0.0.4/opam
+++ b/packages/uwt/uwt.0.0.4/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.4.7" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 depopts: [
   "conf-libuv"

--- a/packages/uwt/uwt.0.1.0/opam
+++ b/packages/uwt/uwt.0.1.0/opam
@@ -30,7 +30,7 @@ depends: [
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.2.0/opam
+++ b/packages/uwt/uwt.0.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.2.1/opam
+++ b/packages/uwt/uwt.0.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.2.2/opam
+++ b/packages/uwt/uwt.0.2.2/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.2.3/opam
+++ b/packages/uwt/uwt.0.2.3/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.6.0" & < "4.0.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.2.4/opam
+++ b/packages/uwt/uwt.0.2.4/opam
@@ -31,7 +31,7 @@ depends: [
   "lwt" {>= "2.6.0" & < "4.0"}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.3.0.2/opam
+++ b/packages/uwt/uwt.0.3.0.2/opam
@@ -32,7 +32,7 @@ depends: [
   "lwt_log" {with-test}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.3.0/opam
+++ b/packages/uwt/uwt.0.3.0/opam
@@ -32,7 +32,7 @@ depends: [
   "lwt_log" {with-test}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/uwt/uwt.0.3.2/opam
+++ b/packages/uwt/uwt.0.3.2/opam
@@ -33,7 +33,7 @@ depends: [
   "lwt_log" {with-test}
   "ounit" {with-test & >= "2.0"}
   "ppx_deriving" {with-test & >= "2.0"}
-  "ppx_import" {with-test & >= "1.0"}
+  "ppx_import" {with-test & >= "1.0" & < "2.0"}
 ]
 synopsis: "libuv bindings"
 description: """

--- a/packages/wikitext/wikitext.1.0.0/opam
+++ b/packages/wikitext/wikitext.1.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml" {with-test}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_deriving" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 url {
   src: "https://github.com/geneanet/ocaml-wikitext/archive/1.0.0.tar.gz"

--- a/packages/wikitext/wikitext.2.0.0/opam
+++ b/packages/wikitext/wikitext.2.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml" {with-test}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_deriving" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 url {
   src: "https://github.com/geneanet/ocaml-wikitext/archive/2.0.0.tar.gz"

--- a/packages/wikitext/wikitext.2.0.1/opam
+++ b/packages/wikitext/wikitext.2.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml" {with-test}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_deriving" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 url {
   src: "https://github.com/geneanet/ocaml-wikitext/archive/2.0.1.tar.gz"

--- a/packages/wikitext/wikitext.2.1.0/opam
+++ b/packages/wikitext/wikitext.2.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml" {with-test}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_deriving" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 url {
   src: "https://github.com/geneanet/ocaml-wikitext/archive/2.1.0.tar.gz"

--- a/packages/wikitext/wikitext.3.0.0/opam
+++ b/packages/wikitext/wikitext.3.0.0/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml" {with-test}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_deriving" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 url {
   src: "https://github.com/geneanet/ocaml-wikitext/archive/3.0.0.tar.gz"

--- a/packages/wikitext/wikitext.3.0.1/opam
+++ b/packages/wikitext/wikitext.3.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "js_of_ocaml" {with-test}
   "ounit" {with-test & >= "2.0.0"}
   "ppx_deriving" {with-test}
-  "ppx_import" {with-test}
+  "ppx_import" {with-test & < "2.0"}
 ]
 url {
   src: "https://github.com/geneanet/ocaml-wikitext/archive/3.0.1.tar.gz"


### PR DESCRIPTION
Syntax for ppx_import 2.0 will change in an incompatible way; this PR
is thus a preventive action to avoid breakage for all the packages
that use it.

Note that most users depend on ppx_import only for tests.