### PR TITLE
[new release] notty (0.2.3)

### DIFF
--- a/packages/notty/notty.0.2.3/opam
+++ b/packages/notty/notty.0.2.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+homepage:     "https://github.com/pqwy/notty"
+dev-repo:     "git+https://github.com/pqwy/notty.git"
+bug-reports:  "https://github.com/pqwy/notty/issues"
+doc:          "https://pqwy.github.io/notty/doc"
+maintainer:   "David Kaloper <dk505@cam.ac.uk>"
+license:      "ISC"
+synopsis:     "Declaring terminals"
+description:
+  "Notty is a declarative terminal library for OCaml structured around a notion
+  of composable images. It tries to abstract away the basic terminal programming
+  model, providing something simpler and more expressive."
+
+build: [ [ "dune" "subst" ] {dev}
+         [ "dune" "build" "-p" name "-j" jobs ] ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.7"}
+  "cppo" {build & >= "1.1.0"}
+  "uutf" {>= "1.0.0"}
+]
+depopts: [ "lwt" ]
+conflicts: [ "lwt" {<"2.5.2"} ]
+authors: "David Kaloper <dk505@cam.ac.uk>"
+url {
+  src:
+    "https://github.com/pqwy/notty/releases/download/v0.2.3/notty-0.2.3.tbz"
+  checksum: [
+    "sha256=74659fb14073db4438989891ab24f24bef81aa497dac16d9a67f9a1c9c200824"
+    "sha512=6e21d44fe39f3d80884b87635bebae55cb2b931ef74f9184ba4d74cc3e51cb0b3e976c3b6dc61d377288504e8bfabe21acdc1069eacb30df1fbf6686b80f7c6b"
+  ]
+}
+x-commit-hash: "e035d069370da436f1fc53525c1e16bff3ed687e"


### PR DESCRIPTION
Declaring terminals

- Project page: <a href="https://github.com/pqwy/notty">https://github.com/pqwy/notty</a>
- Documentation: <a href="https://pqwy.github.io/notty/doc">https://pqwy.github.io/notty/doc</a>

##### CHANGES:

* Moved to Dune.
* Renders faster, uses less memory.
* Nested uses of `I.pp_attr` within `I.strf` now stack, instead of replacing.
* Removed dependency on Uucp. Uses internal data instead (Unicode 13).
* Support OCaml 4.08 - 4.14. Thanks to @kit-ty-kate for the 4.14 fixes.
