### PR TITLE
ppx_wideopen.0.0.1: fix URLs

### DIFF
--- a/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
+++ b/packages/ppx_wideopen/ppx_wideopen.0.0.1/opam
@@ -3,9 +3,9 @@ maintainer: "Ghiles Ziat <ghiles.ziat@lip6.fr>"
 authors: [
   "Ghiles Ziat <ghiles.ziat@lip6.fr>"
 ]
-homepage: "https://github.com/ghilesZ/parsley"
-bug-reports: "https://github.com/ghilesZ/parsley/issues"
-dev-repo: "git+https://github.com/ghilesZ/parsley"
+homepage: "https://github.com/ghilesZ/ppx_wideopen"
+bug-reports: "https://github.com/ghilesZ/ppx_wideopen/issues"
+dev-repo: "git+https://github.com/ghilesZ/ppx_wideopen"
 
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Accidentally noticed the URLs for this package are wrong, probably from copying the opam file from the parsley package.

cc @ghilesZ 