### PR TITLE
3 packages from andersfugmann/aws-s3 at 4.7.0

### DIFF
--- a/packages/aws-s3/aws-s3.4.7.0/opam
+++ b/packages/aws-s3/aws-s3.4.7.0/opam
@@ -21,6 +21,7 @@ depends: [
   "ezxmlm" {>= "1.1.0"}
   "ppx_protocol_conv_xmlm" {>= "5.0.0"}
   "ppx_protocol_conv_json" {>= "5.0.0"}
+  "yojson"
   "cmdliner" {>= "1.1.0"}
   "ppx_inline_test" {with-test}
   "base64" {>= "3.1.0"}


### PR DESCRIPTION
This pull-request concerns:
-`aws-s3.4.7.0`: Ocaml library for accessing Amazon S3
-`aws-s3-async.4.7.0`: Ocaml library for accessing Amazon S3 - Async version
-`aws-s3-lwt.4.7.0`: Ocaml library for accessing Amazon S3 - Lwt version



---
* Homepage: https://github.com/andersfugmann/aws-s3
* Source repo: git+https://github.com/andersfugmann/aws-s3
* Bug tracker: https://github.com/andersfugmann/aws-s3/issues

---
:camel: Pull-request generated by opam-publish v2.1.0