### PR TITLE
RELEASE Snowflake.0.02.03

### DIFF
--- a/packages/Snowflake/Snowflake.0.02.03/opam
+++ b/packages/Snowflake/Snowflake.0.02.03/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Snowflake : A Generic Symbolic Dynamic Programming framework"
+maintainer: "Joan Thibault <joan.thibault@ens-rennes.fr>"
+authors: "Joan Thibault <joan.thibault@ens-rennes.fr>"
+license: "LGPL-3.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://gitlab.com/boreal-ldd/snowflake"
+bug-reports: "https://gitlab.com/boreal-ldd/snowflake"
+depends: [
+	"ocaml" {>= "4.13"}
+	"GuaCaml" {>= "0.05"}
+	"mlbdd" {>= "0.7.2"}
+	"ocamlbuild" {build}
+	"ocamlfind" {build}
+]
+build: make
+install: [make "install"]
+dev-repo: "git+https://gitlab.com/boreal-ldd/snowflake"
+url {
+	src:"https://gitlab.com/boreal-ldd/snowflake/-/archive/v0.02.03/snowflake-v0.02.03.tar.gz"
+	checksum:"md5=99cd645da2216dd2bb225bda1bf57d7b"
+}

--- a/packages/Snowflake/Snowflake.0.02.03/opam
+++ b/packages/Snowflake/Snowflake.0.02.03/opam
@@ -17,5 +17,5 @@ install: [make "install"]
 dev-repo: "git+https://gitlab.com/boreal-ldd/snowflake"
 url {
 	src:"https://gitlab.com/boreal-ldd/snowflake/-/archive/v0.02.03/snowflake-v0.02.03.tar.gz"
-	checksum:"md5=99cd645da2216dd2bb225bda1bf57d7b"
+	checksum:"md5=e47bee554483743d5991ddaab3fa4483"
 }


### PR DESCRIPTION
- renamed RBTF into CoSTreD to match [Constraint System Decomposition](https://hal.archives-ouvertes.fr/hal-03740562/)
- added circuit and graphviz export facility