### PR TITLE
[new release] clangml.4.8.0

### DIFF
--- a/packages/clangml/clangml.4.7.0/opam
+++ b/packages/clangml/clangml.4.7.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/thierry-martinez/clangml/"
 doc: "https://github.com/thierry-martinez/clangml/blob/v4.7.0/README.md"
 bug-reports: "https://github.com/thierry-martinez/clangml/issues"
 depends: [
-  "conf-libclang" {<= "14"}
+  "conf-libclang" {< "15"}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "1.11.0"}

--- a/packages/clangml/clangml.4.7.0/opam
+++ b/packages/clangml/clangml.4.7.0/opam
@@ -10,7 +10,6 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/clangml/"
 doc: "https://github.com/thierry-martinez/clangml/blob/v4.7.0/README.md"
 bug-reports: "https://github.com/thierry-martinez/clangml/issues"
-available: arch != "s390x"
 depends: [
   "conf-libclang" {<= "14"}
   "conf-ncurses"

--- a/packages/clangml/clangml.4.7.0/opam
+++ b/packages/clangml/clangml.4.7.0/opam
@@ -10,6 +10,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/clangml/"
 doc: "https://github.com/thierry-martinez/clangml/blob/v4.7.0/README.md"
 bug-reports: "https://github.com/thierry-martinez/clangml/issues"
+available: arch != "s390x"
 depends: [
   "conf-libclang" {<= "14"}
   "conf-ncurses"

--- a/packages/clangml/clangml.4.8.0/opam
+++ b/packages/clangml/clangml.4.8.0/opam
@@ -10,6 +10,7 @@ license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/clangml/"
 doc: "https://github.com/thierry-martinez/clangml/blob/v4.8.0/README.md"
 bug-reports: "https://github.com/thierry-martinez/clangml/issues"
+available: arch != "s390x"
 depends: [
   "conf-libclang" {<= "15"}
   "conf-ncurses"

--- a/packages/clangml/clangml.4.8.0/opam
+++ b/packages/clangml/clangml.4.8.0/opam
@@ -12,7 +12,7 @@ doc: "https://github.com/thierry-martinez/clangml/blob/v4.8.0/README.md"
 bug-reports: "https://github.com/thierry-martinez/clangml/issues"
 available: arch != "s390x"
 depends: [
-  "conf-libclang" {<= "15"}
+  "conf-libclang" {< "16"}
   "conf-ncurses"
   "conf-zlib"
   "dune" {>= "3.0"}

--- a/packages/clangml/clangml.4.8.0/opam
+++ b/packages/clangml/clangml.4.8.0/opam
@@ -8,13 +8,13 @@ maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 license: "BSD-2-Clause"
 homepage: "https://github.com/thierry-martinez/clangml/"
-doc: "https://github.com/thierry-martinez/clangml/blob/v4.7.0/README.md"
+doc: "https://github.com/thierry-martinez/clangml/blob/v4.8.0/README.md"
 bug-reports: "https://github.com/thierry-martinez/clangml/issues"
 depends: [
-  "conf-libclang" {<= "14"}
+  "conf-libclang" {<= "15"}
   "conf-ncurses"
   "conf-zlib"
-  "dune" {>= "1.11.0"}
+  "dune" {>= "3.0"}
   "stdcompat" {>= "19"}
   "ocaml" {>= "4.08.0"}
   "ocamlfind" {build & >= "1.8.0"}
@@ -35,6 +35,6 @@ build: [
     "@runtest" {with-test}
     "@doc" {with-doc}]]
 url {
-  src: "https://github.com/thierry-martinez/clangml/releases/download/v4.7.0/clangml.4.7.0.tar.gz"
-  checksum: "sha512=129bcb1faeadadafca3b62d00e4abc683dd83f94c1e27527d29d8ae7531692d7a13b1c54a813caf9104a006c58ff4d2335b60e034d26e59bb73c0f73d60adc70"
+  src: "https://github.com/thierry-martinez/clangml/releases/download/v4.8.0/clangml.4.8.0.tar.gz"
+  checksum: "sha512=493f3693b445268a589c98315d918d0633bd2e76eba34067023d502b10957c1f6bbce3b0c1799c81e06eb3ec6f16158cbafb964228fdb3e303aa74cd57c125b1"
 }

--- a/packages/conf-libclang/conf-libclang.14/opam
+++ b/packages/conf-libclang/conf-libclang.14/opam
@@ -19,7 +19,7 @@ depexts: [
   ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
     {os-distribution = "ol" & os-version >= "8"}
   ["llvm-clang-devel"] {os-family = "suse"}
-  ["devel/llvm13"] {os = "freebsd"}
+  ["devel/llvm14"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]
 x-ci-accept-failures: [

--- a/packages/conf-libclang/conf-libclang.15/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.15/files/configure.sh
@@ -1,0 +1,125 @@
+#!/bin/bash -ex
+
+clean_tempdir () {
+    rm -f "$tempdir/test_libclang.c" "$tempdir/test_libclang.o" \
+       "$tempdir/test_libclang"
+    rmdir "$tempdir"
+}
+
+maximum_version=15
+
+shopt -s nullglob
+for version in default $(seq $maximum_version -1 3); do
+    if [ "$version" = default ]; then
+        for kind in system brew none; do
+            case $kind in
+            system)
+                llvm_config=$(command -v llvm-config) || continue
+                ;;
+            brew)
+                llvm_config="$(brew --prefix)/opt/llvm/bin/llvm-config" || continue
+                ;;
+            none)
+                continue
+                ;;
+            esac
+            llvm_version="$($llvm_config --version)" || continue
+            next_version=$((maximum_version + 1))
+            if [\
+                $(printf "${llvm_version%%.*}\n$next_version" | sort -n | head -n1)\
+                    = $next_version ]; then
+                continue
+            fi
+            break
+        done
+    else
+        if hash brew 2>/dev/null; then
+           brew_llvm_config="$(brew --cellar llvm)"/${version}*/bin/llvm-config
+        fi
+        for llvm_config in \
+            llvm-config-${version} llvm-config-${version}.0 \
+            llvm-config${version}0 llvm-config${version} \
+            llvm-config-${version}-32 llvm-config-${version}-64 \
+            llvm-config-mp-$version \
+            llvm-config-mp-${version}.0 $brew_llvm_config \
+            /usr/lib64/llvm/${version}/bin/llvm-config \
+            /usr/lib/llvm/${version}/bin/llvm-config; do
+            llvm_version="$($llvm_config --version)" || continue
+            break
+        done
+        if [ -z "$llvm_version" ]; then
+            continue
+        fi
+    fi
+
+    LLVM_CFLAGS="$($llvm_config --cflags)"
+    LLVM_LDFLAGS="$($llvm_config --ldflags)"
+    LLVM_LIBDIR="$($llvm_config --libdir)"
+    
+    # These filters enable compilation with gcc.
+    # Filter -Wstring-conversion for OpenSUSE
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Wstring-conversion //')"
+    
+    # Filter -Werror=unguarded-availability-new and -Wcovered-switch-default
+    # (which appear with LLVM 7)
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Werror=unguarded-availability-new //')"
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Wcovered-switch-default //')"
+    
+    # Filter "-Wdelete-non-virtual-dtor" (warning only)
+    LLVM_CFLAGS="$(echo $LLVM_CFLAGS | sed 's/-Wdelete-non-virtual-dtor //')"
+
+    tempdir="$(mktemp -d)"        
+    cat >"$tempdir/test_libclang.c" <<EOF
+#include <clang-c/Index.h>
+#include <stdlib.h>
+
+int
+main(int argc, char *argv[])
+{
+  CXIndex idx = clang_createIndex(1, 1);
+  clang_disposeIndex(idx);
+  return EXIT_SUCCESS;
+}
+EOF
+
+    CC=cc
+    if "$CC" -o "$tempdir/test_libclang.o" -c $LLVM_CFLAGS \
+        "$tempdir/test_libclang.c" &&
+      "$CC" -o "$tempdir/test_libclang" \
+          $LLVM_LDFLAGS "$tempdir/test_libclang.o" \
+          "-lclang" "-Wl,-rpath,$LLVM_LIBDIR" &&
+      "$tempdir/test_libclang"; then
+        true
+    else
+        clean_tempdir
+        continue
+    fi
+
+    clean_tempdir
+    checksum=
+    for hasher in \
+        "sha512:sha512sum" \
+        "sha512:shasum -a 512" \
+        "md5:md5sum" \
+        "md5:md5 -q"; do
+        hasher_output=$(${hasher#*:} "$llvm_config") || continue
+        checksum="${hasher%%:*}=${hasher_output%% *}"
+        break
+    done
+    if [ -z "$checksum" ]; then
+        echo "Error: Unable to find a hasher"
+        exit 1
+    fi
+    cat >"conf-libclang.config" <<EOF
+opam-version: "2.0"
+file-depends: [ "$llvm_config" "$checksum" ]
+variables {
+    config: "$llvm_config"
+    version: "$llvm_version"
+}
+EOF
+    exit 0
+done
+
+echo "Error: No usable version of LLVM <=14.0.x found."
+exit 1

--- a/packages/conf-libclang/conf-libclang.15/opam
+++ b/packages/conf-libclang/conf-libclang.15/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "The LLVM team"
+homepage: "http://llvm.org"
+bug-reports: "https://llvm.org/bugs/"
+license: "MIT"
+build: [
+  ["bash" "-ex" "configure.sh" version]
+]
+depexts: [
+  ["llvm"] {os = "macos"}
+  ["llvm" "clang"] {os-distribution = "arch"}
+  ["libclang-dev" "llvm-dev"] {os-family = "debian"}
+  ["clang-dev" "llvm-dev" "clang-static"] {os-distribution = "alpine"}
+  ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
+    {os-distribution = "centos"}
+  ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
+    {os-distribution = "fedora"}
+  ["clang-devel" "llvm-devel" "llvm-static" "zlib-devel"]
+    {os-distribution = "ol" & os-version >= "8"}
+  ["llvm-clang-devel"] {os-family = "suse"}
+  ["devel/llvm14"] {os = "freebsd"}
+  ["sys-devel/clang"] {os-distribution = "gentoo"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-7" # clang-devel is not available
+  "alpine-3.13" # unavailable system package 'llvm-dev'
+  "alpine-3.14" # unavailable system package 'llvm-dev'
+  "opensuse-15.3" # unavailable system package 'llvm-clang-devel'
+]
+extra-files: [[
+  "configure.sh" "sha512=495b1915a845c75033449e8a86b35e399320a50d63cee959f5685dedb085c5efc2a27d5c2672c90c38444a5af4edd212cf2e23bb2b34aaedc5cf271073dce087"
+]]
+synopsis: "Virtual package relying on the installation of llvm and clang libraries (<= 15.0.x)"
+flags: conf


### PR DESCRIPTION
This commit pushes a new release of clangml.4.8.0, compatible with
the upcoming LLVM/Clang 15. Changes are:

- Support for Clang/LLVM 15.0.0

- `Ast.character_kind` and `Ast.string_kind` are now distinct
  types (aliases for `Clang.clang_ext_characterkind` and
  `Clang.clang_ext_stringkind` respectively.
  The constructor `Ordinary` replaced the former constructor `Ascii`
  for `string_kind`, to match the new convention used by
  `clang::StringLiteral::StringKind` from Clang 15.0.0.
  The constructor `Ascii` for `character_kind` is left unchanged.

- https://github.com/thierry-martinez/clangml/issues/1, https://github.com/thierry-martinez/clangml/pull/2: `Ast.Var` and `Ast.Function` constructors now have a `storage`
  field in addition to the computed `linkage`, exposing the value
  previously accessible via `cursor_get_storage_class`. The
  storage classes are now correctly printed by the printer.
  (reported by Ronan, rsaill/n47, https://github.com/thierry-martinez/clangml/issues/1)

- https://github.com/thierry-martinez/clangml/issues/3, https://github.com/thierry-martinez/clangml/pull/4: fix `Clang.Expr.radix_of_integer_literal` when the literal
  comes from a macro expansion, and fix printing of unsigned/long
  integer literals with `Clang.Printer`.
  (reported by Ronan, rsaill/n47, https://github.com/thierry-martinez/clangml/issues/3)