### PR TITLE
[new release] pyml.20220905

### DIFF
--- a/packages/pyml/pyml.20220905/opam
+++ b/packages/pyml/pyml.20220905/opam
@@ -32,5 +32,5 @@ depends: [
 depopts: ["utop"]
 url {
   src: "https://github.com/thierry-martinez/pyml/releases/download/20220905/pyml.20220905.tar.gz"
-  checksum: "sha512=8fe2164e5533c064279c716f57edc3a0c147a770472ce2aef582449f0514bdbe2c2623de6c07e59e6b1310655d4ef13956a8a9f26f2c3ed109a93007fe3b6132"
+  checksum: "sha512=7c3a37f9f396e02529769b3db824fc1e8ad63064a1abeaac52f7fbbc4ef698f8a56643e80afc446667f4e885c5a28a8b7e5f695aad126477e895be26eb30b005"
 }

--- a/packages/pyml/pyml.20220905/opam
+++ b/packages/pyml/pyml.20220905/opam
@@ -21,6 +21,7 @@ build: [
 ]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
+available: arch != "s390x"
 depends: [
   "ocaml" {>= "3.12.1"}
   "dune" {>= "2.8.0"}

--- a/packages/pyml/pyml.20220905/opam
+++ b/packages/pyml/pyml.20220905/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Thierry Martinez <martinez@nsup.org>"
+authors: "Thierry Martinez <martinez@nsup.org>"
+homepage: "http://github.com/thierry-martinez/pyml"
+bug-reports: "http://github.com/thierry-martinez/pyml/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/thierry-martinez/pyml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+synopsis: "OCaml bindings for Python"
+description: "OCaml bindings for Python 2 and Python 3"
+depends: [
+  "ocaml" {>= "3.12.1"}
+  "dune" {>= "2.8.0"}
+  "ocamlfind" {build}
+  "stdcompat" {>= "18"}
+  "conf-python-3-dev" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["utop"]
+url {
+  src: "https://github.com/thierry-martinez/pyml/releases/download/20220905/pyml.20220905.tar.gz"
+  checksum: "sha512=8fe2164e5533c064279c716f57edc3a0c147a770472ce2aef582449f0514bdbe2c2623de6c07e59e6b1310655d4ef13956a8a9f26f2c3ed109a93007fe3b6132"
+}


### PR DESCRIPTION
This commit pushes the new release pyml.20220905, with the following
change log:

- Support for OCaml 5.0

- Support for Python 3.11.
  All OCaml exceptions raised in callbacks are now encapsulated with their
  backtrace in Python exceptions instead of bypassing the Python interpreter.
  The former behavior led to segmentation faults in the test-suite, and nothing
  indicate that previous versions of Python were supposed to support that well.
  *The new behavior can break existing code*, especially code relying on
  `Py.Run.simple_string`, which now catches all exceptions, including OCaml
  exceptions. If you need proper exception handling, you can use `Py.Run.eval`.
  (reported by Jerry James,
  https://github.com/thierry-martinez/pyml/issues/84)

- New function `Py.Object.dir`.

- New functions `Py.Err.set_interrupt` and, for Python >=3.10,
 `Py.Err.set_interrupt_ex`.

- New functions
  `Py.Dict.{to_bindings_seq, to_bindings_seq_map, to_bindings_string_seq}`.

- New function `Py.Capsule.create`, equivalent to `Py.Capsule.make`, but
  returning the record `{ wrap; unwrap }` of the new type `'a Py.Capsule.t`
  instead of a pair.

- Do not let `python` capture `sigint` by default (can be changed by passing
  `~python_sigint:true` to `Py.initialize`): `Ctrl+C` now interrupts the
  program, even after `Py.initialize` is called.
  (reported by Arulselvan Madhavan,
  https://github.com/thierry-martinez/pyml/issues/83)

- Bindings for exceptions: `PyExc_EncodingWarning` (added in Python 3.10),
  `PyExc_ResourceWarning` (added in Python 3.2)
  (reported by Jerry James,
  https://github.com/thierry-martinez/pyml/issues/84)

- Fixes in bindings for `PyCompilerFlags`, `PyMarshal_WriteObjectToFile`,
  and `PySet_Clear`
  (reported by Jerry James,
  https://github.com/thierry-martinez/pyml/issues/84)