### PR TITLE
8 packages from gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz

### DIFF
--- a/packages/resto-acl/resto-acl.1.0/opam
+++ b/packages/resto-acl/resto-acl.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "Access Control Lists for Resto"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto" {= version }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.1.0/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.1.0/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" { >= "1.11" }
   "uri" {>= "1.9.0" }
   "resto-cohttp" {= version }
-  "cohttp-lwt" { >= "1.0.0" }
+  "cohttp-lwt" { >= "4.0.0" }
   "lwt" { >= "3.0.0" & < "6.0.0" }
 ]
 url {

--- a/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.1.0/opam
+++ b/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.1.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "resto-cohttp-client" {= version }
+  "resto-cohttp-server" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.1.0/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.1.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "resto-cohttp" {= version }
+  "resto-acl" {= version }
+  "cohttp-lwt-unix" { >= "2.0.0" }
+  "conduit-lwt-unix" { >= "2.0.0" }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.1.0/opam
+++ b/packages/resto-cohttp/resto-cohttp.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto-directory" {= version }
+  "cohttp-lwt" { >= "1.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto-directory/resto-directory.1.0/opam
+++ b/packages/resto-directory/resto-directory.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "resto-json" {= version & with-test }
+  "lwt" { >= "3.0.0" & < "6.0.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto-json/resto-json.1.0/opam
+++ b/packages/resto-json/resto-json.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "resto" {= version }
+  "json-data-encoding" {>= "0.9.1" & < "1.0" }
+  "json-data-encoding-bson" {>= "0.9.1" & < "1.0" }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}

--- a/packages/resto/resto.1.0/opam
+++ b/packages/resto/resto.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" { >= "4.10" }
+  "dune" { >= "1.11" }
+  "uri" {>= "1.9.0" }
+  "json-data-encoding" {>= "0.9.1" & < "1.0" & with-test }
+  "json-data-encoding-bson" {>= "0.9.1" & < "1.0" & with-test }
+  "ezjsonm" {with-test}
+  "lwt" {with-test}
+  "base-unix"{with-test}
+  "alcotest" { >= "1.5.0" & with-test}
+  "alcotest-lwt" { >= "1.5.0" & with-test}
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+]
+
+conflicts: [ "result" {< "1.5"} ]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.0/resto-v1.0.tar.gz"
+  checksum: [
+    "md5=394275a7579c7dbcb29631b447006253"
+    "sha512=20f7d3ee730b4b202707ec7802662733ec2e3db76a7be78d4f794eb22796d8fc54e3e16e5a8e2fff80b391ea84cfbe470044772b815eebfd389d0a6754e1df85"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`resto.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-acl.1.0`: Access Control Lists for Resto
-`resto-cohttp.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-client.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-self-serving-client.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-cohttp-server.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
-`resto-directory.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs
-`resto-json.1.0`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.1.0