### PR TITLE
Add a warning shown on "opam update" to inform users who are using an out-of-date opam binary

### DIFF
--- a/repo
+++ b/repo
@@ -1,3 +1,8 @@
 opam-version: "2.0"
 browse: "https://opam.ocaml.org/pkg/"
 upstream: "https://github.com/ocaml/opam-repository/tree/master/"
+announce: [
+"""
+[WARNING] Your opam version is out-of-date. Please consider upgrading: https://opam.ocaml.org/doc/Install.html
+""" {opam-version < "2.1.3"}
+]


### PR DESCRIPTION
This will show the following output for people using opam < 2.1.3
```
$ opam update tmp

<><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><><><>
[tmp] synchronised from git+file:///home/kit_ty_kate/work/opam-repository
tmp (at git+file:///home/kit_ty_kate/work/opam-repository): 
    [WARNING] Your opam version is out-of-date. Please consider upgrading: https://opam.ocaml.org/doc/Install.html

```