### PR TITLE
Package bitpack_serializer.0.1.0

### DIFF
--- a/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
+++ b/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
@@ -33,9 +33,9 @@ depends: [
   "ocamlformat" {with-test}
 ]
 url {
-  src: "https://github.com/OCamlPro/bitpack_serializer/archive/v0.1.0.tar.gz"
+  src: "https://github.com/OCamlPro/bitpack_serializer/archive/refs/tags/v0.1.0.tar.gz"
   checksum: [
-    "md5=4cac8d9bf1c8fea008d0f4dbb46d5745"
-    "sha512=7699041434b74bd8b53d0b060781916782f9c4c345cca9b7c052dd2ca4c98059b414eb2e56f3a9489dcb22f74a1b0078a0f3353977b34bf8a57317392657018a"
+    "md5=5739dc1b8f16a64a17bc1d97aa80eef9"
+    "sha512=c80ba1779264a4c2fb38fff81f10b996fb8a8b5aa357e2e25636d16aa8a47e88553061f922329dd34ecc17034d8ec7c219e95ae78796aa1b4db5c010fac0c289"
   ]
 }

--- a/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
+++ b/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
@@ -1,14 +1,14 @@
 opam-version: "2.0"
 license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
-synopsis:"This library provides functions for encoding efficiently simple OCaml data."
-description:"The library provides two main modules.
+synopsis:"This library provides functions for encoding efficiently simple OCaml data"
+description:"The library provides two main modules
 - Buffer: defines buffers for writing and reading compressed data.
 - Lens: an easy to use API for easily defining encoders and decoders."
 authors: ["Steven de Oliveira <de.oliveira.steven@gmail.com>"]
 maintainer: ["Steven de Oliveira <de.oliveira.steven@gmail.com>"]
 homepage:"https://ocamlpro.github.io/bitpack_serializer/bitpack_serializer/index.html"
 bug-reports:"https://https://github.com/OCamlPro/bitpack_serializer/issues"
-dev-repo:"https://github.com/OCamlPro/bitpack_serializer"
+dev-repo:"git+https://github.com/OCamlPro/bitpack_serializer"
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
+++ b/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
@@ -3,12 +3,12 @@ license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
 synopsis:"This library provides functions for encoding efficiently simple OCaml data."
 description:"The library provides two main modules.
 - Buffer: defines buffers for writing and reading compressed data.
-- Lens: an easy to use API for easily defining encoders and decoders.
-"
+- Lens: an easy to use API for easily defining encoders and decoders."
 authors: ["Steven de Oliveira <de.oliveira.steven@gmail.com>"]
 maintainer: ["Steven de Oliveira <de.oliveira.steven@gmail.com>"]
 homepage:"https://ocamlpro.github.io/bitpack_serializer/bitpack_serializer/index.html"
 bug-reports:"https://https://github.com/OCamlPro/bitpack_serializer/issues"
+dev-repo:"https://github.com/OCamlPro/bitpack_serializer"
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
+++ b/packages/bitpack_serializer/bitpack_serializer.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+synopsis:"This library provides functions for encoding efficiently simple OCaml data."
+description:"The library provides two main modules.
+- Buffer: defines buffers for writing and reading compressed data.
+- Lens: an easy to use API for easily defining encoders and decoders.
+"
+authors: ["Steven de Oliveira <de.oliveira.steven@gmail.com>"]
+maintainer: ["Steven de Oliveira <de.oliveira.steven@gmail.com>"]
+homepage:"https://ocamlpro.github.io/bitpack_serializer/bitpack_serializer/index.html"
+bug-reports:"https://https://github.com/OCamlPro/bitpack_serializer/issues"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "zarith" {>= "1.10"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+url {
+  src: "https://github.com/OCamlPro/bitpack_serializer/archive/v0.1.0.tar.gz"
+  checksum: [
+    "md5=4cac8d9bf1c8fea008d0f4dbb46d5745"
+    "sha512=7699041434b74bd8b53d0b060781916782f9c4c345cca9b7c052dd2ca4c98059b414eb2e56f3a9489dcb22f74a1b0078a0f3353977b34bf8a57317392657018a"
+  ]
+}


### PR DESCRIPTION
### `bitpack_serializer.0.1.0`
This library provides functions for encoding efficiently simple OCaml data.
The library provides two main modules.
- Buffer: defines buffers for writing and reading compressed data.
- Lens: an easy to use API for easily defining encoders and decoders.



---
* Homepage: https://ocamlpro.github.io/bitpack_serializer/bitpack_serializer/index.html
* Bug tracker: https://https://github.com/OCamlPro/bitpack_serializer/issues

---
:camel: Pull-request generated by opam-publish v2.0.3