### PR TITLE
Add new CoqIDE version 8.16.0

### DIFF
--- a/packages/coqide/coqide.8.16.0/opam
+++ b/packages/coqide/coqide.8.16.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "coqdev@inria.fr"
+authors: "The Coq development team, INRIA, CNRS, and contributors."
+homepage: "https://coq.inria.fr/"
+bug-reports: "https://github.com/coq/coq/issues"
+dev-repo: "git+https://github.com/coq/coq.git"
+license: "LGPL-2.1-only"
+synopsis: "IDE of the Coq formal proof management system"
+description: """
+CoqIDE is a graphical user interface for interactive development
+of mathematical definitions, executable algorithms, and proofs of theorems
+using the Coq proof assistant.
+"""
+
+depends: [
+  "coq" {= version}
+  "ocamlfind" {>= "1.8.1"}
+  "dune" {>= "2.5.1"}
+  "conf-findutils" {build}
+  "lablgtk3-sourceview3" {>= "3.1.2"}
+  "conf-adwaita-icon-theme"
+]
+build: [
+  [
+    "./configure"
+    "-configdir" "%{lib}%/coq/config"
+    "-prefix" prefix
+    "-mandir" man
+    "-docdir" "%{doc}%/coq"
+    "-libdir" "%{lib}%/coq"
+    "-datadir" "%{share}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+url {
+  src: "https://github.com/coq/coq/archive/refs/tags/V8.16.0.tar.gz"
+  checksum: "sha256=36577b55f4a4b1c64682c387de7abea932d0fd42fc0cd5406927dca344f53587"
+}


### PR DESCRIPTION
This is a followup to #22066, adding CoqIDE 8.16.0 served from the same archive.

cc: @MSoegtropIMC @ppedrot 