### PR TITLE
Package monaco_jsoo.1.0.1

### DIFF
--- a/packages/monaco_jsoo/monaco_jsoo.1.0.1/opam
+++ b/packages/monaco_jsoo/monaco_jsoo.1.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "JSOO interface for Monaco-editor"
+maintainer: "jun.furuse@dailambda.jp"
+authors: "Jun Furuse"
+license: "MIT"
+homepage: "https://gitlab.com/dailambda/monaco_jsoo/"
+bug-reports: "https://gitlab.com/dailambda/monaco_jsoo/"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.12.1"}
+  "js_of_ocaml-compiler"
+  "js_of_ocaml-ppx"
+  "js_of_ocaml-lwt"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dailambda/monaco_jsoo/"
+url {
+  src:
+    "https://gitlab.com/dailambda/monaco_jsoo/-/archive/1.0.1/monaco_jsoo-1.0.1.tar.gz"
+  checksum: [
+    "md5=48d04d9224b8f58ca3fa82db9a69f9a6"
+    "sha512=c925094f3c89521a1fec3290e5e98e65f350c1536d81534f5308e8adc2331cd7cb593d5b6b69d73a1be82543ea9b4caa3bee0e8589f3b23c5484f31c5eb4d8ca"
+  ]
+}


### PR DESCRIPTION
### `monaco_jsoo.1.0.1`
JSOO interface for Monaco-editor



---
* Homepage: https://gitlab.com/dailambda/monaco_jsoo/
* Source repo: git+https://gitlab.com/dailambda/monaco_jsoo/
* Bug tracker: https://gitlab.com/dailambda/monaco_jsoo/

---
:camel: Pull-request generated by opam-publish v2.1.0