### PR TITLE
notty 0.2.0: conflict with recent lwt

### DIFF
--- a/packages/notty/notty.0.2.0/opam
+++ b/packages/notty/notty.0.2.0/opam
@@ -24,7 +24,8 @@ depends: [
 depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
-  "lwt" {< "2.5.2" | > "5.0.0"}
+  "lwt" {< "2.5.2"}
+  "lwt" {>= "5.0.0"}
 ]
 synopsis: "Declaring terminals"
 description: """

--- a/packages/notty/notty.0.2.0/opam
+++ b/packages/notty/notty.0.2.0/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
-  "lwt" {<"2.5.2"}
+  "lwt" {< "2.5.2" | > "5.0.0"}
 ]
 synopsis: "Declaring terminals"
 description: """

--- a/packages/notty/notty.0.2.2/opam
+++ b/packages/notty/notty.0.2.2/opam
@@ -31,6 +31,7 @@ depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
   "lwt" {<"2.5.2"}
+  "lwt" {>= "5.0.0"}
 ]
 
 url {

--- a/packages/notty/notty.0.2.2/opam
+++ b/packages/notty/notty.0.2.2/opam
@@ -31,7 +31,6 @@ depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
   "lwt" {<"2.5.2"}
-  "lwt" {>= "5.0.0"}
 ]
 
 url {

--- a/packages/notty/notty.0.2.3/opam
+++ b/packages/notty/notty.0.2.3/opam
@@ -22,7 +22,6 @@ depends: [
 depopts: [ "lwt" ]
 conflicts: [
   "lwt" {<"2.5.2"}
-  "lwt" {>= "5.0.0"}
 ]
 authors: "David Kaloper <dk505@cam.ac.uk>"
 url {

--- a/packages/notty/notty.0.2.3/opam
+++ b/packages/notty/notty.0.2.3/opam
@@ -20,7 +20,10 @@ depends: [
   "uutf" {>= "1.0.0"}
 ]
 depopts: [ "lwt" ]
-conflicts: [ "lwt" {<"2.5.2"} ]
+conflicts: [
+  "lwt" {<"2.5.2"}
+  "lwt" {>= "5.0.0"}
+]
 authors: "David Kaloper <dk505@cam.ac.uk>"
 url {
   src:


### PR DESCRIPTION
Due to 
```
the callback passed to Lwt.async must now evaluate to unit Lwt.t, rather
    than _ Lwt.t (#603, requested @cfcs).
```
introduced in lwt 5.0.0

Seen on https://github.com/ocaml/opam-repository/pull/22061