### PR TITLE
[new release] mirage-kv (5.0.0)

### DIFF
--- a/packages/mirage-kv/mirage-kv.5.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.5.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v5.0.0/mirage-kv-5.0.0.tbz"
+  checksum: [
+    "sha256=1036d74392461017ca8d9e32ccf94a5be6e03a056fa9ee551d4a7f49f6385462"
+    "sha512=f5acef8f8deedf5489e66fe5a088b468e1e691287f67563081564e3d66ad20c542dd600b3a0b118bc3d3d76bd91656ecb1fa31e9645fe9f6b224280a0876d939"
+  ]
+}
+x-commit-hash: "f234ea21fc6dd181358a0055c2400bbcdcc41bf4"


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Add `get_partial` and `size` to the RO interface (@palainp mirage/mirage-kv#28, review by
  @yomimono @hannesm)
* Add `set_partial` and `rename` to the RW interface (@palainp mirage/mirage-kv#28, review by
  @yomimono @hannesm)
* Mirage_kv.Key.pp: escape binary keys (mirage/mirage-kv#30 @hannesm)
