### PR TITLE
upper bounds for upcoming mirage-kv 5.0.0 release

### DIFF
--- a/packages/chamelon/chamelon.0.0.10/opam
+++ b/packages/chamelon/chamelon.0.0.10/opam
@@ -40,7 +40,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "4.0.1" & < "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/packages/chamelon/chamelon.0.0.7/opam
+++ b/packages/chamelon/chamelon.0.0.7/opam
@@ -38,7 +38,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "4.0.1" & < "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/packages/chamelon/chamelon.0.0.8/opam
+++ b/packages/chamelon/chamelon.0.0.8/opam
@@ -38,7 +38,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "4.0.1" & < "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/packages/chamelon/chamelon.0.0.9.1/opam
+++ b/packages/chamelon/chamelon.0.0.9.1/opam
@@ -40,7 +40,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "4.0.1" & < "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/packages/chamelon/chamelon.0.1.1/opam
+++ b/packages/chamelon/chamelon.0.1.1/opam
@@ -41,7 +41,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "4.0.1" & < "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/packages/chamelon/chamelon.0.1.2/opam
+++ b/packages/chamelon/chamelon.0.1.2/opam
@@ -41,7 +41,7 @@ depends: [
   "ptime" {>= "0.8.6"}
   "mirage-block" {>= "3.0.0"}
   "mirage-clock" {>= "2.0.0"}
-  "mirage-kv" {>= "4.0.1"}
+  "mirage-kv" {>= "4.0.1" & < "5.0.0"}
   "mirage-logs" {>= "1.2.0"}
   "optint" {>= "0.0.4"}
 ]

--- a/packages/docteur-solo5/docteur-solo5.0.0.2/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "git" {>= "3.4.0"}
   "hxd" {>= "0.3.1"}
   "lwt" {>= "5.4.0"}
-  "mirage-kv" {>= "3.0.1"}
+  "mirage-kv" {>= "3.0.1" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur-solo5/docteur-solo5.0.0.3/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "git" {>= "3.7.0"}
   "hxd" {>= "0.3.1"}
   "lwt" {>= "5.4.0"}
-  "mirage-kv" {>= "3.0.1"}
+  "mirage-kv" {>= "3.0.1" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur-solo5/docteur-solo5.0.0.4/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "git" {>= "3.7.0"}
   "hxd" {>= "0.3.1"}
   "lwt" {>= "5.4.0"}
-  "mirage-kv" {>= "3.0.1"}
+  "mirage-kv" {>= "3.0.1" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur-solo5/docteur-solo5.0.0.5/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "git" {>= "3.7.0"}
   "hxd" {>= "0.3.1"}
   "lwt" {>= "5.4.0"}
-  "mirage-kv" {>= "3.0.1"}
+  "mirage-kv" {>= "3.0.1" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur-unix/docteur-unix.0.0.2/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "git" {>= "3.4.0"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.4.0" & < "5.6.0"}
-  "mirage-kv" {>= "3.0.1"}
+  "mirage-kv" {>= "3.0.1" & < "5.0.0"}
   "mirage" {with-test & < "4.0"}
   "mirage-unix" {with-test}
   "mirage-bootvar-unix" {with-test}

--- a/packages/docteur-unix/docteur-unix.0.0.3/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.3/opam
@@ -19,7 +19,7 @@ depends: [
   "git" {>= "3.7.0"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.4.0" & < "5.6.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur-unix/docteur-unix.0.0.4/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.4/opam
@@ -19,7 +19,7 @@ depends: [
   "git" {>= "3.7.0"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.4.0" & < "5.6.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur-unix/docteur-unix.0.0.5/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "git" {>= "3.7.0"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.4.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/docteur/docteur.0.0.1/opam
+++ b/packages/docteur/docteur.0.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "art" {>= "0.1.0"}
   "carton" {>= "0.4.0"}
   "hxd" {>= "0.3.1"}
-  "mirage-kv" {>= "3.0.1"}
+  "mirage-kv" {>= "3.0.1" & < "5.0.0"}
   "mirage-solo5" {>= "0.6.4" & < "0.7.0"}
   "mirage-unix" {>= "4.0.0"}
   "mirage" {with-test}

--- a/packages/fat-filesystem/fat-filesystem.0.15.0/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.15.0/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-block" {>= "2.0.0"}
   "mirage-block-unix" {>= "2.5.0" & < "2.13.0"}
-  "mirage-kv"
+  "mirage-kv" {< "5.0.0"}
   "mirage-block-combinators" {with-test}
   "io-page-unix" {>= "2.0.0"}
   "io-page" {>= "2.0.0"}

--- a/packages/fat-filesystem/fat-filesystem.0.15.1/opam
+++ b/packages/fat-filesystem/fat-filesystem.0.15.1/opam
@@ -15,7 +15,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "mirage-block" {>= "3.0.0"}
   "mirage-block-unix" {>= "2.13.0"}
-  "mirage-kv" {>= "4.0.0"}
+  "mirage-kv" {>= "4.0.0" & < "5.0.0"}
   "mirage-block-combinators" {with-test}
   "io-page" {>= "2.4.0"}
   "re" {>= "1.7.2"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin-mirage" {< "2.2.0"}
   "irmin-git" {>= "2.0.0" & < "2.2.0"}
   "git-mirage" {>= "2.1.2" & < "3.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.10.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.10.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.10.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.10.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "git-paf"      {>= "3.7.0"}
   "fmt"
   "git"          {>= "3.7.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.10.2/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.10.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.2.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "irmin-mirage" {>= "2.2.0" & < "2.3.0"}
   "irmin-git" {>= "2.2.0" & < "2.3.0"}
   "git-mirage" {>= "2.1.2" & < "3.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 
 synopsis: "MirageOS-compatible Irmin stores"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt" {< "2.3.0"}
   "conduit-mirage" {< "2.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.5.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.5.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.5.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.5.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.5.2/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.5.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.5.3/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.5.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.5.4/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.5.4/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.6.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.6.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.6.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.6.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.7.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.7.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.7.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.7.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.7.2/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.7.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "cohttp"
   "conduit-lwt"
   "conduit-mirage"

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.8.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.8.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "git-paf"      {>= "3.5.0" & < "3.7.0"}
   "fmt"
   "git"          {>= "3.5.0" & < "3.7.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.9.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.9.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "git-paf"      {>= "3.5.0" & < "3.7.0"}
   "fmt"
   "git"          {>= "3.5.0" & < "3.7.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.2.9.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.2.9.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.7.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "git-paf"      {>= "3.5.0" & < "3.7.0"}
   "fmt"
   "git"          {>= "3.5.0" & < "3.7.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.0.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.1.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.2.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.2.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.2.2/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.2.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.3.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.3.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.3.1/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.3.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.3.2/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.3.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/irmin-mirage-git/irmin-mirage-git.3.4.0/opam
+++ b/packages/irmin-mirage-git/irmin-mirage-git.3.4.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"         {>= "2.9.0"}
   "irmin-mirage" {= version}
   "irmin-git"    {= version}
-  "mirage-kv"    {>= "3.0.0"}
+  "mirage-kv"    {>= "3.0.0" & < "5.0.0"}
   "fmt"
   "git"          {>= "3.7.0"}
   "lwt"          {>= "5.3.0"}

--- a/packages/mirage-fs/mirage-fs.3.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.3.0.0/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-device" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 synopsis: "MirageOS signatures for filesystem devices"
 description: """

--- a/packages/mirage-fs/mirage-fs.3.0.1/opam
+++ b/packages/mirage-fs/mirage-fs.3.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-device" {>= "2.0.0"}
   "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 synopsis: "MirageOS signatures for filesystem devices"
 description: """

--- a/packages/mirage-fs/mirage-fs.4.0.0/opam
+++ b/packages/mirage-fs/mirage-fs.4.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt"
   "lwt" {>= "4.0.0"}
   "cstruct" {>= "4.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
 ]
 synopsis: "MirageOS signatures for filesystem devices"
 description: """

--- a/packages/mirage-kv-mem/mirage-kv-mem.3.0.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.3.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "alcotest" {with-test}
   "ppx_deriving" {with-test}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
   "rresult"
   "fmt"
   "ptime"

--- a/packages/mirage-kv-unix/mirage-kv-unix.2.1.0/opam
+++ b/packages/mirage-kv-unix/mirage-kv-unix.2.1.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "ocaml" {>= "4.06.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
   "lwt"
   "ptime"
   "cstruct" {with-test & >= "3.2.0"}

--- a/packages/tar-mirage/tar-mirage.2.0.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page"
   "lwt"
   "mirage-block"
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
   "ptime"
   "re" {>= "1.7.2"}
   "tar" {= version}

--- a/packages/tar-mirage/tar-mirage.2.0.1/opam
+++ b/packages/tar-mirage/tar-mirage.2.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page"
   "lwt"
   "mirage-block" {>= "2.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
   "ptime"
   "re" {>= "1.7.2"}
   "tar" {= version}

--- a/packages/tar-mirage/tar-mirage.2.1.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "io-page" {>= "2.4.0"}
   "lwt"
   "mirage-block" {>= "2.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "5.0.0"}
   "ptime"
   "re" {>= "1.7.2"}
   "tar" {= version}


### PR DESCRIPTION
please see the release announcement at https://github.com/mirage/mirage-kv/releases/tag/v5.0.0, and especially the API breaking change at https://github.com/mirage/mirage-kv/pull/28

- chamelon //cc @yomimono 
- docteur //cc @dinosaure 
- fat-filesystem //cc @djs55 
- irmin-mirage-git //cc @samoht 
- mirage-fs //cc @samoht (deprecated anyways)
- mirage-kv-mem //cc @hannesm 
- mirage-kv-unix //cc @hannesm 
- tar-mirage //cc @djs55 (though @hannesm has some ideas & a patch soon)

This is to pave the way for #22075. I won't fix any of the packages in this PR further.