### PR TITLE
conf-postgresql for alpine >= 3.15

### DIFF
--- a/packages/conf-postgresql/conf-postgresql.1/opam
+++ b/packages/conf-postgresql/conf-postgresql.1/opam
@@ -20,7 +20,8 @@ depexts: [
   ["postgresql-devel"] {os-distribution = "ol" & os-version < "8"}
   ["postgresql-devel"] {os-distribution = "fedora" & os-version < "30"}
   ["postgresql-server-devel"] {os-family = "suse"}
-  ["postgresql-dev"] {os-distribution = "alpine"}
+  ["postgresql-dev"] {os-distribution = "alpine" & os-version < "3.15"}
+  ["postgresql14-dev"] {os-distribution = "alpine" & os-version >= "3.15"}
   ["postgresql"] {os = "win32" & os-distribution = "cygwinports"}
   ["postgresql-libs"] {os-family = "arch"}
   ["postgresql"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
Since v3.15 alpine provides several versions of postgresql but removes the "generic" package 'postgresql-dev`! This is a bad news for us as it means conf-postgresql has to pick one "hardwired" version...

See https://pkgs.alpinelinux.org/packages?name=postgresql*-dev&branch=v3.15&repo=&arch=x86_64&maintainer=