### PR TITLE
notty >= 0.2.0 incompatible with lwt < 2.6.0

### DIFF
--- a/packages/notty/notty.0.2.0/opam
+++ b/packages/notty/notty.0.2.0/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
-  "lwt" {< "2.5.2"}
+  "lwt" {< "2.6.0"}
   "lwt" {>= "5.0.0"}
 ]
 synopsis: "Declaring terminals"

--- a/packages/notty/notty.0.2.1/opam
+++ b/packages/notty/notty.0.2.1/opam
@@ -24,7 +24,7 @@ depends: [
 depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
-  "lwt" {<"2.5.2"}
+  "lwt" {<"2.6.0"}
   "lwt" {>= "5.0.0"}
 ]
 synopsis: "Declaring terminals."

--- a/packages/notty/notty.0.2.2/opam
+++ b/packages/notty/notty.0.2.2/opam
@@ -30,7 +30,7 @@ depends: [
 depopts: [ "lwt" ]
 conflicts: [
   "ocb-stubblr" {<"0.1.0"}
-  "lwt" {<"2.5.2"}
+  "lwt" {<"2.6.0"}
 ]
 
 url {

--- a/packages/notty/notty.0.2.3/opam
+++ b/packages/notty/notty.0.2.3/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 depopts: [ "lwt" ]
 conflicts: [
-  "lwt" {<"2.5.2"}
+  "lwt" {<"2.6.0"}
 ]
 authors: "David Kaloper <dk505@cam.ac.uk>"
 url {


### PR DESCRIPTION
```
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package 'lwt lwt.unix' -package 'uchar uucp uuseg uutf' -w A-4-33-40-41-42-43-34-44-48-58 -color always -I lwt -I unix -I src -o lwt/notty_lwt.cmx lwt/notty_lwt.ml
# File "lwt/notty_lwt.ml", line 68, characters 25-42:
# Error: Unbound value Lwt_stream.closed
```