### PR TITLE
[new release] mirage-qubes and mirage-qubes-ipv4 (0.9.3)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.3/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.0.9.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "mirage-random" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "cstruct" { >= "6.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.3/mirage-qubes-0.9.3.tbz"
+  checksum: [
+    "sha256=0bdcb1a6372620cbfebc492490db43cc5ca21cad116bd009db235a0685121b0f"
+    "sha512=7da37ab85f3a2031a2f7906fda17cf21e6bf44d79468534c1601db9fcd7d1b70a214f22f3587846e4286f9215235a9f9534ddea1b678e334a27710376b1b45a7"
+  ]
+}
+x-commit-hash: "f36c6fd792ce00198dd4e358e7bdef09bdec32d9"

--- a/packages/mirage-qubes/mirage-qubes.0.9.3/opam
+++ b/packages/mirage-qubes/mirage-qubes.0.9.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "ppx_cstruct"
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "6.0.0" }
+  "lwt"
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v0.9.3/mirage-qubes-0.9.3.tbz"
+  checksum: [
+    "sha256=0bdcb1a6372620cbfebc492490db43cc5ca21cad116bd009db235a0685121b0f"
+    "sha512=7da37ab85f3a2031a2f7906fda17cf21e6bf44d79468534c1601db9fcd7d1b70a214f22f3587846e4286f9215235a9f9534ddea1b678e334a27710376b1b45a7"
+  ]
+}
+x-commit-hash: "f36c6fd792ce00198dd4e358e7bdef09bdec32d9"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- implement Qrexec protocol version 3 (mirage/mirage-qubes#60 @reynir @palainp, fixes mirage/mirage-qubes#38)
