### PR TITLE
xenstore < 2.1.1 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/xenstore/xenstore.1.0.0/opam
+++ b/packages/xenstore/xenstore.1.0.0/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {< "0.5.2"}
   "lwt" {< "4.0.0"}
   "ounit"

--- a/packages/xenstore/xenstore.1.1.0/opam
+++ b/packages/xenstore/xenstore.1.1.0/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {< "0.5.2"}
   "lwt" {< "4.0.0"}
   "ounit"

--- a/packages/xenstore/xenstore.1.2.0/opam
+++ b/packages/xenstore/xenstore.1.2.0/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0" & <= "1.9.0"}
   "type_conv" {build}
   "lwt" {< "4.0.0"}

--- a/packages/xenstore/xenstore.1.2.1/opam
+++ b/packages/xenstore/xenstore.1.2.1/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0" & <= "1.9.0"}
   "type_conv" {build}
   "lwt" {< "4.0.0"}

--- a/packages/xenstore/xenstore.1.2.2/opam
+++ b/packages/xenstore/xenstore.1.2.2/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "xenstore"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0" & <= "1.9.0"}
   "type_conv" {build}
   "lwt" {< "4.0.0"}

--- a/packages/xenstore/xenstore.1.2.3/opam
+++ b/packages/xenstore/xenstore.1.2.3/opam
@@ -21,7 +21,7 @@ build: [
 install: [make "install"]
 remove:  ["ocamlfind" "remove" "xenstore"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0" & <= "1.9.0"}
   "type_conv" {build}
   "lwt" {< "4.0.0"}

--- a/packages/xenstore/xenstore.1.2.5/opam
+++ b/packages/xenstore/xenstore.1.2.5/opam
@@ -16,7 +16,7 @@ install: [make "install"]
 remove:  ["ocamlfind" "remove" "xenstore"]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "cstruct" {>= "0.6.0" & <= "1.9.0"}
   "type_conv" {build}

--- a/packages/xenstore/xenstore.2.0.0/opam
+++ b/packages/xenstore/xenstore.2.0.0/opam
@@ -19,7 +19,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta9"}
   "cstruct" {>= "3.2.0" & < "3.4.0"}
   "ppx_cstruct" {<"3.4.0"}

--- a/packages/xenstore/xenstore.2.1.0/opam
+++ b/packages/xenstore/xenstore.2.1.0/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/mirage/ocaml-xenstore"
 doc: "https://mirage.github.io/ocaml-xenstore/"
 bug-reports: "https://github.com/mirage/ocaml-xenstore/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "3.2.0"}
   "ppx_cstruct" {>= "3.2.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling xenstore.2.1.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/xenstore.2.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p xenstore -j 31
# exit-code            1
# env-file             ~/.opam/log/xenstore-7-502534.env
# output-file          ~/.opam/log/xenstore-7-502534.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -safe-string -g -I core/.xenstore.objs/byte -I core/.xenstore.objs/native -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o core/.xenstore.objs/native/xs_protocol.cmx -c -impl core/xs_protocol.pp.ml)
# File "core/xs_protocol.ml", line 14, characters 5-15:
# 14 | open Pervasives
#           ^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I core/.xenstore.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o core/.xenstore.objs/byte/xs_protocol.cmo -c -impl core/xs_protocol.pp.ml)
# File "core/xs_protocol.ml", line 14, characters 5-15:
# 14 | open Pervasives
#           ^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I client_unix/.xenstore_unix.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/stdlib-shims -I core/.xenstore.objs/byte -intf-suffix .ml -no-alias-deps -o client_unix/.xenstore_unix.objs/byte/xs_client_unix.cmo -c -impl client_unix/xs_client_unix.ml)
# File "client_unix/xs_client_unix.ml", line 152, characters 18-32:
# 152 |   let error fmt = Printf.kprintf !logger fmt
#                         ^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
```