### PR TITLE
Package SZXX.2.3.0

### DIFF
--- a/packages/SZXX/SZXX.2.3.0/opam
+++ b/packages/SZXX/SZXX.2.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Asemio"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Streaming ZIP XML XLSX parser"
+description: """
+SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
+SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
+It can also stream data out of ZIP files and XML files without buffering.
+"""
+license: "MIT"
+tags: ["Stream" "ZIP" "XML" "XLSX"]
+homepage: "https://github.com/asemio/SZXX"
+dev-repo: "git://github.com/asemio/SZXX"
+doc: "https://github.com/asemio/SZXX"
+bug-reports: "https://github.com/asemio/SZXX/issues"
+depends: [
+  "ocaml" { >= "4.08.1" }
+  "dune" { >= "1.9.0" }
+
+  "angstrom" { >= "0.15.0" }
+  "core_kernel" { >= "v0.13.0" }
+  "decompress" { >= "1.4.1" }
+  "lwt" { >= "5.3.0" }
+
+  "alcotest-lwt" { with-test }
+  "angstrom-lwt-unix" { >= "0.15.0" & with-test }
+  # "ppx_jane" { with-test }
+  "yojson" { with-test }
+  "ppx_deriving_yojson" { >= "3.5.2" & with-test }
+  # "ocaml-lsp-server" { with-test }
+  # "ocamlformat" { = "0.15.0" & with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/asemio/SZXX/archive/v2.3.0.tar.gz"
+  checksum: [
+    "md5=763bbdd75de4ac6efaa8131b56d15c55"
+    "sha512=f00fffb20fc377284fdfdb9e741d685242ed07c736d4beaacc152a61c53e1ec13ce9e931ae36c806055fadf205e13f70f7f0bb50d000a524fb5440bd145b7267"
+  ]
+}


### PR DESCRIPTION
### `SZXX.2.3.0`
Streaming ZIP XML XLSX parser
SZXX is a streaming, non-seeking and efficient XLSX parser built from ground up for low memory usage.
SZXX is able to output XLSX rows while a file is being read from the file descriptor without buffering any part of the file.
It can also stream data out of ZIP files and XML files without buffering.



---
* Homepage: https://github.com/asemio/SZXX
* Source repo: git://github.com/asemio/SZXX
* Bug tracker: https://github.com/asemio/SZXX/issues

---
:camel: Pull-request generated by opam-publish v2.1.0