### PR TITLE
ppx_rapper 3.1.0: update caqti lower bound

### DIFF
--- a/packages/ppx_rapper/ppx_rapper.3.1.0/opam
+++ b/packages/ppx_rapper/ppx_rapper.3.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "pg_query" {>= "0.9.6"}
   "ppxlib" {>= "0.3.1"}
   "base" {>= "v0.11.1"}
-  "caqti" {>= "1.2.0"}
+  "caqti" {>= "1.7.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Otherwise fails with 
```
#=== ERROR while compiling ppx_rapper_lwt.3.1.0 ===============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/ppx_rapper_lwt.3.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_rapper_lwt -j 31 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/ppx_rapper_lwt-7-4f659c.env
# output-file          ~/.opam/log/ppx_rapper_lwt-7-4f659c.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I test/runtime/.test_compiles.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/calendar -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti-type-calendar -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_rapper/runtime -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I lib-lwt/.ppx_rapper_lwt.objs/byte -no-alias-deps -open Dune__exe -o test/runtime/.test_compiles.eobjs/byte/dune__exe__Test_compiles_base.cmo -c -impl test/runtime/test_compiles_base.pp.ml)
# File "test/runtime/test_compiles_base.ml", lines 8-14, characters 2-12:
#  8 | ..[%rapper
#  9 |     execute
# 10 |       {sql|
# 11 |       UPDATE users
# 12 |       SET (username, email, bio) = (%string{username}, %string{email}, %string?{bio})
# 13 |       WHERE id = %int{id}
# 14 |       |sql}]
# Error: Unbound module Caqti_request.Infix
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I test/runtime/.test_compiles.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/calendar -I /home/opam/.opam/4.14/lib/caqti -I /home/opam/.opam/4.14/lib/caqti-lwt -I /home/opam/.opam/4.14/lib/caqti-type-calendar -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_rapper/runtime -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I lib-lwt/.ppx_rapper_lwt.objs/byte -no-alias-deps -open Dune__exe -o test/runtime/.test_compiles.eobjs/byte/dune__exe__Test_compiles.cmo -c -impl test/runtime/test_compiles.pp.ml)
# File "test/runtime/test_compiles.ml", lines 6-12, characters 2-12:
#  6 | ..[%rapper
#  7 |     execute
#  8 |       {sql|
#  9 |       UPDATE users
# 10 |       SET (username, email, bio) = (%string{username}, %string{email}, %string?{bio})
# 11 |       WHERE id = %int{id}
# 12 |       |sql}]
# Error: Unbound module Caqti_request.Infix
```
Seen on https://github.com/ocaml/opam-repository/pull/22070