### PR TITLE
sqlite3 3.0.0 is not compatible with ocaml 5

### DIFF
--- a/packages/sqlite3/sqlite3.3.0.0/opam
+++ b/packages/sqlite3/sqlite3.3.0.0/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlfind" {build & >= "1.3.1"}
   "ocamlbuild" {build}
   "conf-pkg-config" {build}


### PR DESCRIPTION
The setup.ml file uses String.lowercase
```
#=== ERROR while compiling sqlite3.3.0.0 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/sqlite3.3.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/sqlite3-7-688af9.env
# output-file          ~/.opam/log/sqlite3-7-688af9.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```
Seen on https://github.com/ocaml/opam-repository/pull/22070