### PR TITLE
Update ocaml-protoc-plugin to 4.3.0

### DIFF
--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.3.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Anders Fugmann <af@issuu.com>"
+license: "APACHE-2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+doc: "https://issuu.github.io/ocaml-protoc-plugin/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.06.0"}
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_deriving" {with-test}
+  "conf-pkg-config" {build}
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+"""
+url {
+  src:
+    "https://github.com/issuu/ocaml-protoc-plugin/releases/download/4.3.0/ocaml-protoc-plugin-4.3.0.tbz"
+  checksum: [
+    "sha256=5534f0b4f6f1e864858d3f42f4cda422c09fe420574a708a0f7dcea84b60c2e6"
+    "sha512=6bb1edaac551869ba5af02b0978ee5a2fabeb5afa94d01059c73985a8b6da0e665f777ce9418ce91774a18159b6217dd263ae37c13254de2b51a3df70a93cc8a"
+  ]
+}
+x-commit-hash: "467a90e4046c414dd177a5f0f8502448d78e7d44"


### PR DESCRIPTION
* Use pkg-config to locate google well known types (thanks @vprevosto)
* Support proto3 optional fields