### PR TITLE
sqlite3 < 4.1.3 incompatible with ocaml 5

### DIFF
--- a/packages/sqlite3/sqlite3.4.0.0/opam
+++ b/packages/sqlite3/sqlite3.4.0.0/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.0.1/opam
+++ b/packages/sqlite3/sqlite3.4.0.1/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.0.2/opam
+++ b/packages/sqlite3/sqlite3.4.0.2/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.0.3/opam
+++ b/packages/sqlite3/sqlite3.4.0.3/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.0.4/opam
+++ b/packages/sqlite3/sqlite3.4.0.4/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.0.6/opam
+++ b/packages/sqlite3/sqlite3.4.0.6/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.1.0/opam
+++ b/packages/sqlite3/sqlite3.4.1.0/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.1.2/opam
+++ b/packages/sqlite3/sqlite3.4.1.2/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}

--- a/packages/sqlite3/sqlite3.4.1.3/opam
+++ b/packages/sqlite3/sqlite3.4.1.3/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "sqlite3"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.3.1"}
   "conf-pkg-config" {build}


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling sqlite3.4.0.0 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/sqlite3.4.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/sqlite3-7-0b1fa1.env
# output-file          ~/.opam/log/sqlite3-7-0b1fa1.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```