### PR TITLE
[new release] coq-serapi (8.16.0+0.16.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.16" & < "8.17"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.16" }
+  "ppx_compare"         {           >= "v0.13.0" & < "v0.16" }
+  "ppx_hash"            {           >= "v0.13.0" & < "v0.16" }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.16.0%2B0.16.0/coq-serapi-8.16.0.0.16.0.tbz"
+  checksum: [
+    "sha256=0b85365f1ae5f4b7aab3613880b2f1899a118e424917714af484554282fcfd7c"
+    "sha512=d21e8c3db016c423b97548d7500b728d7bba926b546ab25f3198b4022cc97cef4d52a80ab0e0fe5f0a0274102169fbd7a60add2fc6f5924ed8bd94ce8bb854e1"
+  ]
+}
+x-commit-hash: "f133304da06d860d3b2ef387318b937686b5e748"

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
@@ -29,7 +29,7 @@ depends: [
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }
   "dune"                {           >= "2.0.1"               }
-  "ppx_import"          { build   & >= "1.5-3"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
   "ppx_deriving"        {           >= "4.2.1"               }
   "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.16" }
   "ppx_compare"         {           >= "v0.13.0" & < "v0.16" }

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
@@ -31,9 +31,9 @@ depends: [
   "dune"                {           >= "2.0.1"               }
   "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
   "ppx_deriving"        {           >= "4.2.1"               }
-  "ppx_sexp_conv"       {           >= "v0.13.0" & < "v0.16" }
-  "ppx_compare"         {           >= "v0.13.0" & < "v0.16" }
-  "ppx_hash"            {           >= "v0.13.0" & < "v0.16" }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }
 ]

--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.0/opam
@@ -37,6 +37,9 @@ depends: [
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
 url {


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serapi] (!) support for Coq 8.16, see upstream changes and SerAPI
            test-suite changes for more information. Remarkable
            changes are:
            - kernel terms are serialized a bit differently now due to
              KerName being used in more places upstream. Some
              internal structures also changes in kernel's env, so be
              attentive if you are depending on them.
            - plugin loading is adapted for 8.16 findlib loading
              method
            (@ejgallego)
 - [deps]   Require cmdliner >= 1.1.0 (@ejgallego)
 - [deps]   Support Jane Street libraries v0.15.0 (@ejgallego)
 - [serapi] New query `Objects` to dump Coq's libobject (@ejgallego)
 - [serlib] Much improved yojson / json support (@ejgallego)
 - [serlib] Coq AST now supports ppx_hash intf (ignoring locations by default)
            (@ejgallego)
 - [serlib] Coq AST now supports ppx_compare intf (ignoring locations by default)
            (@ejgallego)
 - [serlib] Large refactoring on Serlib, using functors, see serlib/README.md
            (@ejgallego)
 - [serapi] (!) Query `Proofs` has changed type and will now return the
            partial terms under construction (ejgallego/coq-serapi#271 , fixes ejgallego/coq-serapi#270, @ejgallego)
