### PR TITLE
Package ocaml-protoc-plugin.4.3.0

### DIFF
--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.3.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.3.0/opam
@@ -20,7 +20,7 @@ depends: [
   "ppx_inline_test" {with-test}
   "ppx_deriving" {with-test}
   "conf-pkg-config" {build}
-  "dune-configurator" {with-test}
+  "dune-configurator"
 ]
 
 

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.3.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.3.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Anders Fugmann <anders@fugmann.net>"
+license: "APACHE-2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+doc: "https://issuu.github.io/ocaml-protoc-plugin/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_deriving" {with-test}
+  "conf-pkg-config" {build}
+  "dune-configurator" {with-test}
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+"""
+url {
+  src: "https://github.com/issuu/ocaml-protoc-plugin/archive/4.3.0.tar.gz"
+  checksum: [
+    "md5=dbaadfb6768e761ef39cf7d5a3967885"
+    "sha512=4d440e43deb823f1a2f4a1d587a9915093fd3e54b977ddc4083b8d981976389b846f83b1f7f7b9bfa2fe9db7ccdb257b51aa578b363af7d5357f772b07c4383d"
+  ]
+}


### PR DESCRIPTION
### `ocaml-protoc-plugin.4.3.0`
Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file
The plugin generates ocaml type definitions,
serialization and deserialization functions from a protobuf file.
The types generated aims to create ocaml idiomatic types;
- messages are mapped into modules
- oneof constructs are mapped to polymorphic variants
- enums are mapped to adt's
- map types are mapped to assoc lists
- all integer types are mapped to int by default (exact mapping is also possible)
- all floating point types are mapped to float.
- packages are mapped to nested modules



---
* Homepage: https://github.com/issuu/ocaml-protoc-plugin
* Source repo: git+https://github.com/issuu/ocaml-protoc-plugin
* Bug tracker: https://github.com/issuu/ocaml-protoc-plugin/issues

---
:camel: Pull-request generated by opam-publish v2.1.0