### PR TITLE
2 packages from cryspen/hacl-packages at 0.5.0

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.5.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.5.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """\
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Project Everest"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "ocamlfind" {build}
+  "ctypes" {>= "0.18.0"}
+  "conf-which" {build}
+  "conf-cmake" {build}
+]
+available:
+  arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
+  (os = "freebsd" | os-family != "bsd")
+build: [
+  [make "-C" "hacl-star-raw" "build-c"]
+  [make "-C" "hacl-star-raw" "build-bindings"]
+]
+install: [make "-C" "hacl-star-raw" "install"]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/cryspen/hacl-packages/releases/download/ocaml-v0.5.0/hacl-star.0.5.0.tar.gz"
+  checksum: [
+    "md5=340626ebd7668e41f2f7b51798e15dc4"
+    "sha512=37e3bcd29961a3e13634d76993ae4b01f56adf9a9145a4dc9c72f04fcf1430f0e9fe75fac46e9a645f36a5441ec15cb00ff5026b686c5e7ade5084bc88405552"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/hacl-star/hacl-star.0.5.0/opam
+++ b/packages/hacl-star/hacl-star.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+description: """\
+Documentation for this library can be found
+[here](https://hacl-star.github.io/ocaml_doc/hacl-star/index.html)."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Project Everest"
+license: "Apache-2.0"
+homepage: "https://hacl-star.github.io/"
+doc: "https://hacl-star.github.io/ocaml_doc"
+bug-reports: "https://github.com/project-everest/hacl-star/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+  "odoc" {with-doc}
+]
+available: os = "freebsd" | os-family != "bsd"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+url {
+  src:
+    "https://github.com/cryspen/hacl-packages/releases/download/ocaml-v0.5.0/hacl-star.0.5.0.tar.gz"
+  checksum: [
+    "md5=340626ebd7668e41f2f7b51798e15dc4"
+    "sha512=37e3bcd29961a3e13634d76993ae4b01f56adf9a9145a4dc9c72f04fcf1430f0e9fe75fac46e9a645f36a5441ec15cb00ff5026b686c5e7ade5084bc88405552"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.5.0`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.5.0`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://hacl-star.github.io/
* Source repo: git+https://github.com/project-everest/hacl-star.git
* Bug tracker: https://github.com/project-everest/hacl-star/issues

---
:camel: Pull-request generated by opam-publish v2.1.0