### PR TITLE
Update links for hacl-star and hacl-star-raw

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1.1/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.1.1/hacl-star.0.1.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.1.1/hacl-star.0.1.1.tar.gz"
   checksum: [
     "md5=b593874d70983135344cd0a3f3119c6f"
     "sha512=d627f94c8ad8d378981d6daa07c77cde1a036f1244a6ecd2b75dfc51dab457ae8057adee98bef0ca0d947fc379d3054cf31eab8199f0f0a8edbdc87d11d9de25"

--- a/packages/hacl-star-raw/hacl-star-raw.0.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.1/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
   checksum: [
     "md5=b1c111f4d3e883f427ce7a86bceb985e"
     "sha512=774c7dca9b44c50307df73d8f850fcf24dc1c5da29b09266316ff19bfa52a7537b39ea799e22066b4fc8664915e1f04c2c51e88301daa122af165c183bf0135d"

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.0/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.0/hacl-star.0.2.0.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.2.0/hacl-star.0.2.0.tar.gz"
   checksum: [
     "md5=19b589ab741a2294da216128ed8d913d"
     "sha512=a50560d0aa975ec41713d03cc5dd4668953d6de21d7e3cbcd6212b75ea18c92f0d7c0f564391b5be705867d93ff14c594a87e429bb0ed24e338f77c0ee623491"

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.1/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.1/hacl-star.0.2.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.2.1/hacl-star.0.2.1.tar.gz"
   checksum: [
     "md5=a8fc22a701608018cded326be1990af9"
     "sha512=de185640ddd9ec63e5f07274f45dee68cea30e476cd58cb7e7be3e7bd6c062b347236e2a20e6b54238212a2c2e351f7717893b79ed9e381419dffeb962fd744c"

--- a/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.2.2/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.2/hacl-star.0.2.2.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.2.2/hacl-star.0.2.2.tar.gz"
   checksum: [
     "md5=bf3bb86bf6dc622182795f03aad9247c"
     "sha512=b5bba6c7c2d1e995a2795d339829ed7bcf77e03a0b8737c6e9d29e4638dd756db1eb13ad8a39b38246bfba5171125cdd1b6c0d36c0ec66c347acd7b85f381190"

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0-1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0-1/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "gcc-compatible"]
 ]
 install: [make "-C" "gcc-compatible" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/v0.3.0/hacl-star-v0.3.0.tar.bz2"
+    "https://github.com/hacl-star/hacl-star/releases/download/v0.3.0/hacl-star-v0.3.0.tar.bz2"
   checksum: [
     "sha256=962a134d46a17e21509076c830039f90f1ef7ae04dfe84d569c9f15c83a002b1"
     "sha512=bd8ae53ae2c8aa72d980e93eb5992b6daa5e6923298c77529d0689687b3ec9a10dc6773e1a573ce2fff8caa858cd939bb9d1c42040fc267d3fe6d886d672a07a"

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.0/hacl-star.0.3.0.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.3.0/hacl-star.0.3.0.tar.gz"
   checksum: [
     "md5=d96f706ad7cc24b0b4bd048a8acf872e"
     "sha512=909b2cc9cfd7d37959768d441fe248eaf09c82072d82a25927fa3a5fb1582602d1196604d8fcc663531b7cd5fc1554129f1dc069b8ba147c5c4c4d8139573485"

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
@@ -9,7 +9,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
@@ -27,10 +27,10 @@ build: [
   [make "-C" "raw"]
 ]
 install: [make "-C" "raw" "install-hacl-star-raw"]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.2/hacl-star.0.3.2.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.3.2/hacl-star.0.3.2.tar.gz"
   checksum: [
     "md5=5b3cb04bdcd3ede759ac9e31125dffde"
     "sha512=272070750040651742f81ee7ef64e4aab5421e65e5e66030341fb60cf134273f79f8cf81d75cc62056d523b184e75866e01a40d332b418c3a9071c4f87d21710"

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
@@ -10,7 +10,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
@@ -30,10 +30,10 @@ build: [
 install: [
   make "-C" "raw" "install-hacl-star-raw"
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
   checksum: [
     "md5=b3ee6ef6c9ad801bfdebcc22cccb7bfa"
     "sha256=bbf28ccf3b56ab85cc9b0a5d2f3e4bfbac1427d3e42c0b4b5596d012265eefd7"

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.1/opam
@@ -10,7 +10,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
@@ -31,10 +31,10 @@ build: [
 install: [
   make "-C" "raw" "install-hacl-star-raw"
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.1/hacl-star.0.4.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.1/hacl-star.0.4.1.tar.gz"
   checksum: [
     "md5=bc59d5548ad7ac1d67403ad9f74bf608"
     "sha256=a8769d99f7534610631d24898380060a30d98a58dcdf0a65b53bf1fd2339731a"

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.2/opam
@@ -10,7 +10,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
@@ -31,10 +31,10 @@ build: [
 install: [
   make "-C" "raw" "install-hacl-star-raw"
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.2/hacl-star.0.4.2.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.2/hacl-star.0.4.2.tar.gz"
   checksum: [
     "md5=3943fe14935f8e9bad3a9d27fb24b19c"
     "sha256=8211bde8a49c9bc63013be5059655fe820d2f03a54d9ff8cf1663754d985ba58"

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.3/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.3/opam
@@ -10,7 +10,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
@@ -31,10 +31,10 @@ build: [
 install: [
   make "-C" "raw" "install-hacl-star-raw"
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.3/hacl-star.0.4.3.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.3/hacl-star.0.4.3.tar.gz"
   checksum: [
     "md5=bb7c369f789ac0ac426336178acfb98c"
     "sha256=f1e25e15ee541866b29d792d291f41f8430a1315e02fa6c6e492783c87f945b2"

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.4/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.4/opam
@@ -10,7 +10,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
@@ -30,10 +30,10 @@ build: [
 install: [
   make "-C" "raw" "install-hacl-star-raw"
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.4/hacl-star.0.4.4.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.4/hacl-star.0.4.4.tar.gz"
   checksum: [
     "md5=cab04a1971aeab8531e58398fba589f6"
     "sha256=621aa0955c009f7e642e1a5f2ffd949ffe6651073afc90833e2a28e67eaf3bc6"

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
@@ -10,7 +10,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "ocamlfind" {build}
@@ -34,10 +34,10 @@ install: [
   [make "-C" "raw" "install-hacl-star-raw"] {!dev}
   [make "-C" "dist/gcc-compatible" "install-hacl-star-raw"] {dev}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
   checksum: [
     "md5=fdcd7a590913428d5d3142872d7089a0"
     "sha256=47bf253f804ec369b2fbc76c892ba89275fde17d7444d291d5eb5c179a05e174"

--- a/packages/hacl-star/hacl-star.0.1.1/opam
+++ b/packages/hacl-star/hacl-star.0.1.1/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -14,10 +14,10 @@ depends: [
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.1.1/hacl-star.0.1.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.1.1/hacl-star.0.1.1.tar.gz"
   checksum: [
     "md5=b593874d70983135344cd0a3f3119c6f"
     "sha512=d627f94c8ad8d378981d6daa07c77cde1a036f1244a6ecd2b75dfc51dab457ae8057adee98bef0ca0d947fc379d3054cf31eab8199f0f0a8edbdc87d11d9de25"

--- a/packages/hacl-star/hacl-star.0.1/opam
+++ b/packages/hacl-star/hacl-star.0.1/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -13,10 +13,10 @@ depends: [
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.1/hacl-star.0.1.tar.gz"
   checksum: [
     "md5=b1c111f4d3e883f427ce7a86bceb985e"
     "sha512=774c7dca9b44c50307df73d8f850fcf24dc1c5da29b09266316ff19bfa52a7537b39ea799e22066b4fc8664915e1f04c2c51e88301daa122af165c183bf0135d"

--- a/packages/hacl-star/hacl-star.0.2.0/opam
+++ b/packages/hacl-star/hacl-star.0.2.0/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -14,10 +14,10 @@ depends: [
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.0/hacl-star.0.2.0.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.2.0/hacl-star.0.2.0.tar.gz"
   checksum: [
     "md5=19b589ab741a2294da216128ed8d913d"
     "sha512=a50560d0aa975ec41713d03cc5dd4668953d6de21d7e3cbcd6212b75ea18c92f0d7c0f564391b5be705867d93ff14c594a87e429bb0ed24e338f77c0ee623491"

--- a/packages/hacl-star/hacl-star.0.2.1/opam
+++ b/packages/hacl-star/hacl-star.0.2.1/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -14,10 +14,10 @@ depends: [
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.1/hacl-star.0.2.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.2.1/hacl-star.0.2.1.tar.gz"
   checksum: [
     "md5=a8fc22a701608018cded326be1990af9"
     "sha512=de185640ddd9ec63e5f07274f45dee68cea30e476cd58cb7e7be3e7bd6c062b347236e2a20e6b54238212a2c2e351f7717893b79ed9e381419dffeb962fd744c"

--- a/packages/hacl-star/hacl-star.0.2.2/opam
+++ b/packages/hacl-star/hacl-star.0.2.2/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -14,10 +14,10 @@ depends: [
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.2.2/hacl-star.0.2.2.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.2.2/hacl-star.0.2.2.tar.gz"
   checksum: [
     "md5=bf3bb86bf6dc622182795f03aad9247c"
     "sha512=b5bba6c7c2d1e995a2795d339829ed7bcf77e03a0b8737c6e9d29e4638dd756db1eb13ad8a39b38246bfba5171125cdd1b6c0d36c0ec66c347acd7b85f381190"

--- a/packages/hacl-star/hacl-star.0.3.0-1/opam
+++ b/packages/hacl-star/hacl-star.0.3.0-1/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -18,10 +18,10 @@ build: [
   ["mv" "ocaml/%{name}%.install" "./"]
 ]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/v0.3.0/hacl-star-v0.3.0.tar.bz2"
+    "https://github.com/hacl-star/hacl-star/releases/download/v0.3.0/hacl-star-v0.3.0.tar.bz2"
   checksum: [
     "sha256=962a134d46a17e21509076c830039f90f1ef7ae04dfe84d569c9f15c83a002b1"
     "sha512=bd8ae53ae2c8aa72d980e93eb5992b6daa5e6923298c77529d0689687b3ec9a10dc6773e1a573ce2fff8caa858cd939bb9d1c42040fc267d3fe6d886d672a07a"

--- a/packages/hacl-star/hacl-star.0.3.0/opam
+++ b/packages/hacl-star/hacl-star.0.3.0/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -15,10 +15,10 @@ depends: [
 available: os-family != "bsd"
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.0/hacl-star.0.3.0.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.3.0/hacl-star.0.3.0.tar.gz"
   checksum: [
     "md5=d96f706ad7cc24b0b4bd048a8acf872e"
     "sha512=909b2cc9cfd7d37959768d441fe248eaf09c82072d82a25927fa3a5fb1582602d1196604d8fcc663531b7cd5fc1554129f1dc069b8ba147c5c4c4d8139573485"

--- a/packages/hacl-star/hacl-star.0.3.2/opam
+++ b/packages/hacl-star/hacl-star.0.3.2/opam
@@ -4,7 +4,7 @@ maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" {>= "4.05.0"}
   "dune" {>= "1.2"}
@@ -15,10 +15,10 @@ depends: [
 available: os-family != "bsd"
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.3.2/hacl-star.0.3.2.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.3.2/hacl-star.0.3.2.tar.gz"
   checksum: [
     "md5=5b3cb04bdcd3ede759ac9e31125dffde"
     "sha512=272070750040651742f81ee7ef64e4aab5421e65e5e66030341fb60cf134273f79f8cf81d75cc62056d523b184e75866e01a40d332b418c3a9071c4f87d21710"

--- a/packages/hacl-star/hacl-star.0.4.0/opam
+++ b/packages/hacl-star/hacl-star.0.4.0/opam
@@ -5,7 +5,7 @@ authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
 doc: "https://hacl-star.github.io/ocaml_doc"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
@@ -24,10 +24,10 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.0/hacl-star.0.4.0.tar.gz"
   checksum: [
     "md5=b3ee6ef6c9ad801bfdebcc22cccb7bfa"
     "sha256=bbf28ccf3b56ab85cc9b0a5d2f3e4bfbac1427d3e42c0b4b5596d012265eefd7"

--- a/packages/hacl-star/hacl-star.0.4.1/opam
+++ b/packages/hacl-star/hacl-star.0.4.1/opam
@@ -9,7 +9,7 @@ authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
 doc: "https://hacl-star.github.io/ocaml_doc"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
@@ -30,10 +30,10 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.1/hacl-star.0.4.1.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.1/hacl-star.0.4.1.tar.gz"
   checksum: [
     "md5=bc59d5548ad7ac1d67403ad9f74bf608"
     "sha256=a8769d99f7534610631d24898380060a30d98a58dcdf0a65b53bf1fd2339731a"

--- a/packages/hacl-star/hacl-star.0.4.2/opam
+++ b/packages/hacl-star/hacl-star.0.4.2/opam
@@ -9,7 +9,7 @@ authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
 doc: "https://hacl-star.github.io/ocaml_doc"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
@@ -30,10 +30,10 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.2/hacl-star.0.4.2.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.2/hacl-star.0.4.2.tar.gz"
   checksum: [
     "md5=3943fe14935f8e9bad3a9d27fb24b19c"
     "sha256=8211bde8a49c9bc63013be5059655fe820d2f03a54d9ff8cf1663754d985ba58"

--- a/packages/hacl-star/hacl-star.0.4.3/opam
+++ b/packages/hacl-star/hacl-star.0.4.3/opam
@@ -9,7 +9,7 @@ authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
 doc: "https://hacl-star.github.io/ocaml_doc"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
@@ -30,10 +30,10 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.3/hacl-star.0.4.3.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.3/hacl-star.0.4.3.tar.gz"
   checksum: [
     "md5=bb7c369f789ac0ac426336178acfb98c"
     "sha256=f1e25e15ee541866b29d792d291f41f8430a1315e02fa6c6e492783c87f945b2"

--- a/packages/hacl-star/hacl-star.0.4.4/opam
+++ b/packages/hacl-star/hacl-star.0.4.4/opam
@@ -9,7 +9,7 @@ authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
 doc: "https://hacl-star.github.io/ocaml_doc"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
@@ -30,10 +30,10 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.4/hacl-star.0.4.4.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.4/hacl-star.0.4.4.tar.gz"
   checksum: [
     "md5=cab04a1971aeab8531e58398fba589f6"
     "sha256=621aa0955c009f7e642e1a5f2ffd949ffe6651073afc90833e2a28e67eaf3bc6"

--- a/packages/hacl-star/hacl-star.0.4.5/opam
+++ b/packages/hacl-star/hacl-star.0.4.5/opam
@@ -9,7 +9,7 @@ authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
 doc: "https://hacl-star.github.io/ocaml_doc"
-bug-reports: "https://github.com/project-everest/hacl-star/issues"
+bug-reports: "https://github.com/hacl-star/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
   "dune" {>= "1.2"}
@@ -31,10 +31,10 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] {ocaml:version >= "4.08"}
 ]
-dev-repo: "git+https://github.com/project-everest/hacl-star.git"
+dev-repo: "git+https://github.com/hacl-star/hacl-star.git"
 url {
   src:
-    "https://github.com/project-everest/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
+    "https://github.com/hacl-star/hacl-star/releases/download/ocaml-v0.4.5/hacl-star.0.4.5.tar.gz"
   checksum: [
     "md5=fdcd7a590913428d5d3142872d7089a0"
     "sha256=47bf253f804ec369b2fbc76c892ba89275fde17d7444d291d5eb5c179a05e174"


### PR DESCRIPTION
The `hacl-star` repo has been moved from the `project-everest` organisation to the `hacl-star` organisation. This PR propagates that change in the relevant links of the already released packages.