### PR TITLE
fix linking problems with z3_tptp program

### DIFF
--- a/packages/z3_tptp/z3_tptp.4.8.13/opam
+++ b/packages/z3_tptp/z3_tptp.4.8.13/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]

--- a/packages/z3_tptp/z3_tptp.4.8.14/opam
+++ b/packages/z3_tptp/z3_tptp.4.8.14/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]


### PR DESCRIPTION
Currently, after installing a `z3_tptp` package, the `z3_tptp` program gives error messages like this whenever it is run:
```
z3_tptp: error while loading shared libraries: libz3.so: cannot open shared object file: No such file or directory
```
This update fixes the problem with the packages by modifying compilation options. The background and motivation can be seen in https://github.com/coq/platform/issues/248

cc: @MSoegtropIMC 