### PR TITLE
Add the new versions of z3 to z3_tptp

### DIFF
--- a/packages/z3_tptp/z3_tptp.4.10.1/opam
+++ b/packages/z3_tptp/z3_tptp.4.10.1/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]

--- a/packages/z3_tptp/z3_tptp.4.10.1/opam
+++ b/packages/z3_tptp/z3_tptp.4.10.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.10.1" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.10.1.tar.gz"
+  checksum: [
+    "sha256=a86071a03983b3512c44c2bf130adbc3320770dc0198805f6f51c43b0946e11a"
+    "sha512=6c8e9f074d4b87f9388384d10dcde51fbdf0e1ee58cf2a5d321e3779ac5054a0ec7bfed3df4f8d3563c457ca7f5189ca310909656e500b6a8803f0df2c693baf"
+  ]
+}

--- a/packages/z3_tptp/z3_tptp.4.10.2/opam
+++ b/packages/z3_tptp/z3_tptp.4.10.2/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]

--- a/packages/z3_tptp/z3_tptp.4.10.2/opam
+++ b/packages/z3_tptp/z3_tptp.4.10.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.10.2" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.10.2.tar.gz"
+  checksum: [
+    "sha256=889fd035b833775c8cd2eb4723eb011bf916a3e9bf08ce66b31c548acee7a321"
+    "sha512=d0e54036d403d124a7bbf4cf8de9fd9159bab5151f875b546474563811dfb259bc46650df950802031a180375745fb589acbc79d0065944f0631df378dd6d0c3"
+  ]
+}

--- a/packages/z3_tptp/z3_tptp.4.11.0/opam
+++ b/packages/z3_tptp/z3_tptp.4.11.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.11.0" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.11.0.tar.gz"
+  checksum: [
+    "sha256=afa761ee2c00b66afcf7f77ccf3f9820f97142bba988040ba56ed876443b811c"
+    "sha512=a3fd7e013948de6683b16aca03641bb845d02187152bebdee8c62c2a3f80a7710a1d3b9aef9c1490c2340571bb225f457928ac57a2ed28c0084ced34bcf3e905"
+  ]
+}

--- a/packages/z3_tptp/z3_tptp.4.11.0/opam
+++ b/packages/z3_tptp/z3_tptp.4.11.0/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]

--- a/packages/z3_tptp/z3_tptp.4.8.17/opam
+++ b/packages/z3_tptp/z3_tptp.4.8.17/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]

--- a/packages/z3_tptp/z3_tptp.4.8.17/opam
+++ b/packages/z3_tptp/z3_tptp.4.8.17/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.8.17" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.8.17.tar.gz"
+  checksum: [
+    "sha256=1e57637ce8d5212fd38453df28e2730a18e0a633f723682267be87f5b858a126"
+    "sha512=95517014ec1798c2552253dd5cde6f955896ab297a4f56294f4bc6f2c5428069015f513c6eb9a090a809cfcf4cb1cc38cc83818f19b5b1051e4e6c06f973747d"
+  ]
+}

--- a/packages/z3_tptp/z3_tptp.4.9.1/opam
+++ b/packages/z3_tptp/z3_tptp.4.9.1/opam
@@ -18,6 +18,8 @@ build: [
     "-o" "z3_tptp"
     "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
     "-lz3"
+    "-Wl,-rpath"
+    "-Wl,%{lib}%/stublibs"
   ]
 ]
 install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]

--- a/packages/z3_tptp/z3_tptp.4.9.1/opam
+++ b/packages/z3_tptp/z3_tptp.4.9.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "7895506+MSoegtropIMC@users.noreply.github.com"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+# OK, this is really ugly, but it is quite hard to do this via z3's make system
+# using an already installed opam z3.
+# Also this should be quite robust with just source 2 files and opam knowns the
+# library folder better than any configure script.
+build: [
+  [ "g++"
+    "-I./src/api/c++"
+    "-I./src/api"
+    "-std=c++11"
+    "-L%{lib}%/stublibs"
+    "-o" "z3_tptp"
+    "examples/tptp/tptp5.cpp" "examples/tptp/tptp5.lex.cpp" 
+    "-lz3"
+  ]
+]
+install: [ "cp" "z3_tptp" "%{bin}%/z3_tptp" ]
+depends: [
+  "z3" { = "4.9.1" }
+  "conf-g++" {build}
+]
+synopsis: "TPTP front end for Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.9.1.tar.gz"
+  checksum: [
+    "sha256=ca08ba933481242507b2f8b303c3ebdf5d16b0005d397fb45018321dc639a0d7"
+    "sha512=0c44e10d039c3bf16591a7b94e3a3209bc334635106ac7ae4afda95541d13d4fc39214646662683c26b4874846e0d83813215e189ce5422d13f8ce7c2ac4db51"
+  ]
+}


### PR DESCRIPTION
This PR adds z3_tptp versions for those versions of Z3 which have opam packages.

I tested that the latest version 4.11.0 actually works. I guess the intermediate versions also work (and do not just compile).