### PR TITLE
z3 4.8.13 is incompatible with ocaml 5

### DIFF
--- a/packages/z3/z3.4.8.13/opam
+++ b/packages/z3/z3.4.8.13/opam
@@ -19,7 +19,7 @@ install: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"


### PR DESCRIPTION
Currently fails with 

```
#=== ERROR while compiling z3.4.8.13 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/z3.4.8.13
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C build -j 31
# exit-code            2
# env-file             ~/.opam/log/z3-8-c5202e.env
# output-file          ~/.opam/log/z3-8-c5202e.out
### output ###
# make: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/z3.4.8.13/build'
# src/smt/smt_statistics.cpp
# src/util/approx_nat.cpp
# src/util/common_msgs.cpp
# src/util/luby.cpp
# src/api/dll/dll.cpp
# ocamlfind ocamlc -package zarith  -i -I api/ml -c ../src/api/ml/z3enums.ml > api/ml/z3enums.mli
# src/util/approx_set.cpp
# src/util/memory_manager.cpp
# src/util/page.cpp
# src/util/z3_exception.cpp
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3enums.cmi -c api/ml/z3enums.mli
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3enums.cmo -c ../src/api/ml/z3enums.ml
# ocamlfind ocamlc -package zarith  -i -I api/ml -c ../src/api/ml/z3native.ml > api/ml/z3native.mli
# src/util/timeit.cpp
# src/shell/z3_log_frontend.cpp
# src/api/api_commands.cpp
# src/util/bit_util.cpp
# src/util/hash.cpp
# src/util/lbool.cpp
# src/util/mpn.cpp
# src/util/scoped_ctrl_c.cpp
# src/util/scoped_timer.cpp
# src/util/stack.cpp
# src/util/timeout.cpp
# src/util/util.cpp
# src/util/fixed_bit_vector.cpp
# src/util/small_object_allocator.cpp
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3native.cmi -c api/ml/z3native.mli
# src/util/warning.cpp
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3native.cmo -c ../src/api/ml/z3native.ml
# src/api/z3_replayer.cpp
# src/solver/smt_logics.cpp
# src/sat/sat_cutset.cpp
# src/math/automata/automaton.cpp
# src/math/simplex/bit_matrix.cpp
# src/math/dd/dd_bdd.cpp
# src/util/bit_vector.cpp
# src/util/cmd_context_types.cpp
# src/util/debug.cpp
# src/util/min_cut.cpp
# src/util/permutation.cpp
# src/util/prime_generator.cpp
# src/util/region.cpp
# src/util/rlimit.cpp
# src/util/smt2_util.cpp
# src/util/state_graph.cpp
# src/util/statistics.cpp
# src/util/symbol.cpp
# src/util/trace.cpp
# cp ../src/api/ml/z3.mli api/ml/z3.mli
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3.cmi -c api/ml/z3.mli
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3.cmo -c ../src/api/ml/z3.ml
# File "../src/api/ml/z3.ml", line 206, characters 16-34:
# 206 |   let compare = Pervasives.compare
#                       ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:4980: api/ml/z3.cmo] Error 2
# make: *** Waiting for unfinished jobs....
# make: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/z3.4.8.13/build'
```

Seen on https://github.com/ocaml/opam-repository/pull/22098