### PR TITLE
Package gitlab_pipeline_notifier.0.1

### DIFF
--- a/packages/gitlab_pipeline_notifier/gitlab_pipeline_notifier.0.1/opam
+++ b/packages/gitlab_pipeline_notifier/gitlab_pipeline_notifier.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Watches GitLab pipelines and notifies on status updates using 'send-notify'"
+description:
+  "Watches new pipelines in a specified set of GitLab projects and notifies the user on updates using 'send-notify'."
+maintainer: "arvid.jakobsson@nomadic-labs.com"
+authors: "Arvid Jakobsson"
+license: "MIT"
+tags: ["topics" "gitlab"]
+homepage: "https://gitlab.com/arvidnl/gitlab_pipeline_notifier"
+doc: "https://gitlab.com/arvidnl/gitlab_pipeline_notifier"
+bug-reports: "https://gitlab.com/arvidnl/gitlab_pipeline_notifier/-/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.0"}
+  "lwt" {>= "5.6.0"}
+  "gitlab" {>= "0.1.5"}
+  "gitlab-unix" {>= "0.1.5"}
+  "ISO8601"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/arvidnl/gitlab_pipeline_notifier.git"
+url {
+  src:
+    "https://gitlab.com/arvidnl/gitlab_pipeline_notifier/-/archive/v0.1/gitlab_pipeline_notifier-v0.1.tar.gz"
+  checksum: [
+    "md5=6e9671e91dab6f217a1bd6bbdd22e0df"
+    "sha512=66fe2405aff4690f8abd7c9958eda92b175342d4d52ce06db095e8f1016691667375d5e9f36c6de92c377106a411c80a2913b47d053577fae2f0c1d6607ad3f7"
+  ]
+}


### PR DESCRIPTION
### `gitlab_pipeline_notifier.0.1`
Watches GitLab pipelines and notifies on status updates using 'send-notify'
Watches new pipelines in a specified set of GitLab projects and notifies the user on updates using 'send-notify'.



---
* Homepage: https://gitlab.com/arvidnl/gitlab_pipeline_notifier
* Source repo: git+https://gitlab.com/arvidnl/gitlab_pipeline_notifier.git
* Bug tracker: https://gitlab.com/arvidnl/gitlab_pipeline_notifier/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0