### PR TITLE
[new release] mirage-unix (5.0.1)

### DIFF
--- a/packages/mirage-unix/mirage-unix.5.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.5.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-unix"
+bug-reports:  "https://github.com/mirage/mirage-unix/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-unix.git"
+doc:          "https://mirage.github.io/mirage-unix/doc"
+license:      "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.11"}
+  "lwt" {>= "2.4.3"}
+  "duration"
+  "mirage-runtime" {>= "4.0"}
+]
+tags: "org:mirage"
+synopsis: "Unix core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Unix targets, which handles the main loop and timers.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-unix/releases/download/v5.0.1/mirage-unix-5.0.1.tbz"
+  checksum: [
+    "sha256=535a0bce750305c24b715ca07d28b2979a912c3336edc9bf5ab8d3d2f48684f8"
+    "sha512=bd6dafe5276ebcd33bbdf37ff51b70d39989055d595184d4c8f34e6ebac3a843da3aac730ed0ef630522cdb2e43b89e008531db0a83adbe37c7c44606436c4ad"
+  ]
+}
+x-commit-hash: "7118cd0767487f7ecd741fa2cd6c659e832ed973"


### PR DESCRIPTION
Unix core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-unix">https://github.com/mirage/mirage-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-unix/doc">https://mirage.github.io/mirage-unix/doc</a>

##### CHANGES:

* remove superfluous io-page dependency (mirage/mirage-unix#21 @hannesm)
* use GitHub actions for testing on macos and windows (instead of appveyor)
