### PR TITLE
[new release] mirage-block and mirage-block-combinators (3.0.1)

### DIFF
--- a/packages/mirage-block-combinators/mirage-block-combinators.3.0.1/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.3.0.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "mirage-block" {=version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS using Lwt"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+This package is specialised to the Lwt concurrency library for IO.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v3.0.1/mirage-block-3.0.1.tbz"
+  checksum: [
+    "sha256=082a4d6a2208d920d5806650d147237025a532803e2dd6df12ad5aac8273e56f"
+    "sha512=b016a7410d7dcd885b87b480199ccd9722f664d82d57d1a6592b019c30086979b3b8650f017bd4130ef74f4f6d755a61d3b4c4910ff2dc4773c49590cf5f0ae6"
+  ]
+}
+x-commit-hash: "a487526285f480a9fb3ebf85cd7ab72781c9e868"
+

--- a/packages/mirage-block/mirage-block.3.0.1/opam
+++ b/packages/mirage-block/mirage-block.3.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.7"}
+  "cstruct" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v3.0.1/mirage-block-3.0.1.tbz"
+  checksum: [
+    "sha256=082a4d6a2208d920d5806650d147237025a532803e2dd6df12ad5aac8273e56f"
+    "sha512=b016a7410d7dcd885b87b480199ccd9722f664d82d57d1a6592b019c30086979b3b8650f017bd4130ef74f4f6d755a61d3b4c4910ff2dc4773c49590cf5f0ae6"
+  ]
+}
+x-commit-hash: "a487526285f480a9fb3ebf85cd7ab72781c9e868"
+


### PR DESCRIPTION
Block signatures and implementations for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block">https://github.com/mirage/mirage-block</a>
- Documentation: <a href="https://mirage.github.io/mirage-block/">https://mirage.github.io/mirage-block/</a>

##### CHANGES:

* Add Mirage_block.pp_info (mirage/mirage-block#51 @reynir)
* Use GitHub actions for testing on windows and macos (retire AppVeyor)
* Remove io-page dependency (mirage/mirage-block#52 @hannesm)
