### PR TITLE
[new release] mirage-block-unix (2.14.2)

### DIFF
--- a/packages/mirage-block-unix/mirage-block-unix.2.14.2/opam
+++ b/packages/mirage-block-unix/mirage-block-unix.2.14.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+authors:      "Dave Scott <dave@recoil.org>"
+maintainer:   "dave@recoil.org"
+homepage:     "https://github.com/mirage/mirage-block-unix"
+dev-repo:     "git+https://github.com/mirage/mirage-block-unix.git"
+doc:          "https://mirage.github.io/mirage-block-unix/"
+bug-reports:  "https://github.com/mirage/mirage-block-unix/issues"
+tags:         "org:mirage"
+license:      "ISC"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-block" {>= "2.0.0"}
+  "rresult"
+  "uri" {>= "1.9.0"}
+  "logs"
+  "lwt" {>= "5.4.2"}
+  "ounit2" {with-test}
+  "diet" {with-test & >= "0.4"}
+  "fmt" {with-test}
+  "conf-linux-libc-dev" {os = "linux"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "MirageOS disk block driver for Unix"
+description: """
+Unix implementation of the Mirage `BLOCK_DEVICE` interface.
+
+This module provides raw I/O to files and block devices with as little
+caching as possible.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block-unix/releases/download/v2.14.2/mirage-block-unix-2.14.2.tbz"
+  checksum: [
+    "sha256=e91780cddfa909de5c7265ce87a1a54b11e8e06b84829b712e16bada7f9d06c1"
+    "sha512=3f2c51f19a129e479e26313605ff05b4925228f1e124c7ba1a25170fc1661d53143d7c4802100c6460008007ccb39de44f3486284dcd523bd3f3f2ba04b05b65"
+  ]
+}
+x-commit-hash: "98efe7ad179994cbae5eba4549dd92c486731bcf"


### PR DESCRIPTION
MirageOS disk block driver for Unix

- Project page: <a href="https://github.com/mirage/mirage-block-unix">https://github.com/mirage/mirage-block-unix</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-unix/">https://mirage.github.io/mirage-block-unix/</a>

##### CHANGES:

* Raise an exception on connect if the file is not aligned to the `sector_size` (mirage/mirage-block-unix#117, @reynir)
* Demote log to debug when an error is returned (mirage/mirage-block-unix#119 @reynir, fixes mirage/mirage-block-unix#109)
* Remove io-page dependency (mirage/mirage-block-unix#118 @hannesm)
* Add GitHub actions for testing on macos and windows (retire Appveyor)
