### PR TITLE
fiat-p256 < 0.2.1 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/fiat-p256/fiat-p256.0.1.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.1.0/opam
@@ -19,7 +19,7 @@ build: [
  ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "alcotest" {with-test & < "1.4.0"}
   "asn1-combinators" {with-test}
   "bigarray-compat"

--- a/packages/fiat-p256/fiat-p256.0.2.0/opam
+++ b/packages/fiat-p256/fiat-p256.0.2.0/opam
@@ -19,6 +19,7 @@ build: [
  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
+  "ocaml" {< "5.0"}
   "alcotest" {with-test & < "1.4.0"}
   "asn1-combinators" {with-test}
   "benchmark" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling fiat-p256.0.2.0 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/fiat-p256.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p fiat-p256 -j 31
# exit-code            1
# env-file             ~/.opam/log/fiat-p256-9-375814.env
# output-file          ~/.opam/log/fiat-p256-9-375814.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I p256/.fiat_p256.objs/byte -I p256/.fiat_p256.objs/native -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -intf-suffix .ml -no-alias-deps -open Fiat_p256__ -o p256/.fiat_p256.objs/native/fiat_p256__Cstruct_util.cmx -c -impl p256/cstruct_util.ml)
# File "p256/cstruct_util.ml", line 3, characters 14-25:
# 3 |   let a_len = Cstruct.len a in
#                   ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "p256/cstruct_util.ml", line 4, characters 14-25:
# 4 |   let b_len = Cstruct.len b in
#                   ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "p256/cstruct_util.ml", line 9, characters 10-28:
# 9 |     match Pervasives.compare a_i b_i with
#               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I p256/.fiat_p256.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -intf-suffix .ml -no-alias-deps -open Fiat_p256__ -o p256/.fiat_p256.objs/byte/fiat_p256__Cstruct_util.cmo -c -impl p256/cstruct_util.ml)
# File "p256/cstruct_util.ml", line 3, characters 14-25:
# 3 |   let a_len = Cstruct.len a in
#                   ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "p256/cstruct_util.ml", line 4, characters 14-25:
# 4 |   let b_len = Cstruct.len b in
#                   ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "p256/cstruct_util.ml", line 9, characters 10-28:
# 9 |     match Pervasives.compare a_i b_i with
#               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I p256/.fiat_p256.objs/byte -I p256/.fiat_p256.objs/native -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -intf-suffix .ml -no-alias-deps -open Fiat_p256__ -o p256/.fiat_p256.objs/native/fiat_p256__Fe.cmx -c -impl p256/fe.ml)
# File "p256/fe.ml", line 26, characters 10-21:
# 26 |   assert (Cstruct.len cs = 32);
#                ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I p256/.fiat_p256.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -intf-suffix .ml -no-alias-deps -open Fiat_p256__ -o p256/.fiat_p256.objs/byte/fiat_p256__Fe.cmo -c -impl p256/fe.ml)
# File "p256/fe.ml", line 26, characters 10-21:
# 26 |   assert (Cstruct.len cs = 32);
#                ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I p256/.fiat_p256.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -intf-suffix .ml -no-alias-deps -open Fiat_p256__ -o p256/.fiat_p256.objs/byte/fiat_p256__Scalar.cmo -c -impl p256/scalar.ml)
# File "p256/scalar.ml", line 9, characters 5-16:
# 9 |   if Cstruct.len cs <> 32 then Error `Invalid_length
#          ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I p256/.fiat_p256.objs/byte -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -intf-suffix .ml -no-alias-deps -open Fiat_p256__ -o p256/.fiat_p256.objs/byte/fiat_p256__Point.cmo -c -impl p256/point.ml)
# File "p256/point.ml", line 50, characters 5-16:
# 50 |   if Cstruct.len cs = 0 then None else Some (Cstruct.get_uint8 cs 0)
#           ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "p256/point.ml", line 53, characters 24-35:
# 53 |   match (first_byte cs, Cstruct.len cs) with
#                              ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
```