### PR TITLE
mariadb is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/mariadb/mariadb.1.1.5/opam
+++ b/packages/mariadb/mariadb.1.1.5/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}

--- a/packages/mariadb/mariadb.1.1.6/opam
+++ b/packages/mariadb/mariadb.1.1.6/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.7.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling mariadb.1.1.6 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mariadb.1.1.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/mariadb-7-633adf.env
# output-file          ~/.opam/log/mariadb-7-633adf.out
### output ###
# mariadb_connector: ................................... true
# mariadb_include_base: ................................ mariadb
# mariadb_as_mysql: .................................... false
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```