### PR TITLE
unix-errno 0.6.0 is incompatible with arm32

### DIFF
--- a/packages/unix-errno/unix-errno.0.6.0/opam
+++ b/packages/unix-errno/unix-errno.0.6.0/opam
@@ -30,6 +30,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
 ]
+available: arch != "arm32"
 dev-repo: "git+https://github.com/xapi-project/ocaml-unix-errno.git"
 url {
   src:


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/22101

```
#=== ERROR while compiling unix-errno.0.6.0 ===================================#
# context              2.2.0~alpha~dev | linux/arm32 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/unix-errno.0.6.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p unix-errno -j 79
# exit-code            1
# env-file             ~/.opam/log/unix-errno-7-58d496.env
# output-file          ~/.opam/log/unix-errno-7-58d496.out
### output ###
# File "lib/.errno.objs/native/_unknown_", line 1, characters 0-0:
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lib/.errno.objs/byte -I lib/.errno.objs/native -I /home/opam/.opam/4.14/lib/integers -I /home/opam/.opam/4.14/lib/result -intf-suffix .ml -no-alias-deps -o lib/.errno.objs/native/errno.cmx -c -impl lib/errno.ml)
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s: Assembler messages:
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2048: Error: value of 65628 too large for field of 2 bytes at 2826
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2049: Error: value of 66201 too large for field of 2 bytes at 2828
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2050: Error: value of 66776 too large for field of 2 bytes at 2830
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2051: Error: value of 67351 too large for field of 2 bytes at 2832
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2052: Error: value of 67926 too large for field of 2 bytes at 2834
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2053: Error: value of 68501 too large for field of 2 bytes at 2836
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2054: Error: value of 69076 too large for field of 2 bytes at 2838
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2055: Error: value of 69649 too large for field of 2 bytes at 2840
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2056: Error: value of 70222 too large for field of 2 bytes at 2842
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2057: Error: value of 70795 too large for field of 2 bytes at 2844
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2058: Error: value of 71368 too large for field of 2 bytes at 2846
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2059: Error: value of 71943 too large for field of 2 bytes at 2848
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2060: Error: value of 72518 too large for field of 2 bytes at 2850
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2061: Error: value of 73093 too large for field of 2 bytes at 2852
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2062: Error: value of 73668 too large for field of 2 bytes at 2854
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2063: Error: value of 74243 too large for field of 2 bytes at 2856
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2064: Error: value of 74816 too large for field of 2 bytes at 2858
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2065: Error: value of 75389 too large for field of 2 bytes at 2860
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2066: Error: value of 75962 too large for field of 2 bytes at 2862
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2067: Error: value of 76535 too large for field of 2 bytes at 2864
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2068: Error: value of 77110 too large for field of 2 bytes at 2866
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2069: Error: value of 77685 too large for field of 2 bytes at 2868
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2070: Error: value of 78260 too large for field of 2 bytes at 2870
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2071: Error: value of 78835 too large for field of 2 bytes at 2872
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2072: Error: value of 79410 too large for field of 2 bytes at 2874
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2073: Error: value of 79983 too large for field of 2 bytes at 2876
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2074: Error: value of 80556 too large for field of 2 bytes at 2878
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2075: Error: value of 81129 too large for field of 2 bytes at 2880
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2076: Error: value of 81702 too large for field of 2 bytes at 2882
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2077: Error: value of 82277 too large for field of 2 bytes at 2884
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2078: Error: value of 82852 too large for field of 2 bytes at 2886
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2079: Error: value of 83427 too large for field of 2 bytes at 2888
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2080: Error: value of 84002 too large for field of 2 bytes at 2890
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2081: Error: value of 84577 too large for field of 2 bytes at 2892
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2082: Error: value of 85150 too large for field of 2 bytes at 2894
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2083: Error: value of 85723 too large for field of 2 bytes at 2896
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2084: Error: value of 86296 too large for field of 2 bytes at 2898
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2085: Error: value of 86869 too large for field of 2 bytes at 2900
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2086: Error: value of 87444 too large for field of 2 bytes at 2902
# /opam-tmp/build_6f0d56_dune/camlasm09a260.s:2087: Error: value of 88019 too large for field of 2 bytes at 2904
# File "lib/errno.ml", line 1:
# Error: Assembler error, input left in file /opam-tmp/build_6f0d56_dune/camlasm09a260.s
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>