### PR TITLE
Add: uucd.15.0.0, uucp.15.0.0, uunf.15.0.0, uuseg.15.0.0

### DIFF
--- a/packages/uucd/uucd.15.0.0/opam
+++ b/packages/uucd/uucd.15.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Unicode character database decoder for OCaml"
+description: """\
+Uucd is an OCaml module to decode the data of the [Unicode character 
+database][1] from its XML [representation][2]. It provides high-level 
+(but not necessarily efficient) access to the data so that efficient 
+representations can be extracted.
+
+Uucd is made of a single module, depends on [Xmlm][xmlm] and is distributed
+under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+[2]: http://www.unicode.org/reports/tr42/
+[xmlm]: http://erratique.ch/software/xmlm 
+
+Home page: http://erratique.ch/software/uucd"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucd programmers"
+license: "ISC"
+tags: ["unicode" "database" "decoder" "org:erratique"]
+homepage: "https://erratique.ch/software/uucd"
+doc: "https://erratique.ch/software/uucd/doc/Uucd"
+bug-reports: "https://github.com/dbuenzli/uucd/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "xmlm"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/uucd.git"
+url {
+  src: "https://erratique.ch/software/uucd/releases/uucd-15.0.0.tbz"
+  checksum:
+    "sha512=022507d380dea2ce5a1a3b2b8f1d18be10454184fd11ddbd1ecbe09d303284b6e1cb59144748ccef4292bb82a469341d81086e1b3024fb9b08ad14b43e12abce"
+}

--- a/packages/uucp/uucp.15.0.0/opam
+++ b/packages/uucp/uucp.15.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Unicode character properties for OCaml"
+description: """\
+Uucp is an OCaml library providing efficient access to a selection of
+character properties of the [Unicode character database][1].
+
+Uucp is independent from any Unicode text data structure and has no
+dependencies. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr44/
+
+Home page: http://erratique.ch/software/uucp"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uucp programmers"
+license: "ISC"
+tags: ["unicode" "text" "character" "org:erratique"]
+homepage: "https://erratique.ch/software/uucp"
+doc: "https://erratique.ch/software/uucp/doc/"
+bug-reports: "https://github.com/dbuenzli/uucp/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucd" {with-test}
+  "uunf" {with-test}
+  "uutf" {with-test}
+]
+depopts: ["uutf" "uunf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.1"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-uunf"
+  "%{uunf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uucp.git"
+url {
+  src: "https://erratique.ch/software/uucp/releases/uucp-15.0.0.tbz"
+  checksum:
+    "sha512=ee4acff5666961766321e85e287fb9d5b8d50533319f22bf6f4eceb943242df2d0e0f4e775c4a140f68ca142837938eaa5926e22362215a3365ffe7f8768923b"
+}

--- a/packages/uunf/uunf.15.0.0/opam
+++ b/packages/uunf/uunf.15.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Unicode text normalization for OCaml"
+description: """\
+Uunf is an OCaml library for normalizing Unicode text. It supports all
+Unicode [normalization forms][nf]. The library is independent from any
+IO mechanism or Unicode text data structure and it can process text
+without a complete in-memory representation.
+
+Uunf has no dependency. It may optionally depend on [Uutf][uutf] for
+support on OCaml UTF-X encoded strings. It is distributed under the
+ISC license.
+
+[nf]: http://www.unicode.org/reports/tr15/
+[uutf]: http://erratique.ch/software/uutf
+
+Home page: http://erratique.ch/software/uunf"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uunf programmers"
+license: "ISC"
+tags: ["unicode" "text" "normalization" "org:erratique"]
+homepage: "https://erratique.ch/software/uunf"
+doc: "https://erratique.ch/software/uunf/doc/Uunf"
+bug-reports: "https://github.com/dbuenzli/uunf/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucd" {dev & >= "15.0.0" & < "16.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+post-messages:
+  "If the build fails with \"ocamlopt.opt got signal and exited\", issue 'ulimit -s unlimited' and retry."
+    {failure & (arch = "ppc64" | arch = "arm64")}
+dev-repo: "git+https://erratique.ch/repos/uunf.git"
+url {
+  src: "https://erratique.ch/software/uunf/releases/uunf-15.0.0.tbz"
+  checksum:
+    "sha512=204d923d4e8d910318180c15087fe53d98d8ec0a8d3c3f6c54219e5e09ee5c5bdf57585e5570d895f8d90647c4eeaa45d9e6e75d58edeb9febee053e0dd47fbc"
+}

--- a/packages/uuseg/uuseg.15.0.0/opam
+++ b/packages/uuseg/uuseg.15.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Unicode text segmentation for OCaml"
+description: """\
+Uuseg is an OCaml library for segmenting Unicode text. It implements
+the locale independent [Unicode text segmentation algorithms][1] to
+detect grapheme cluster, word and sentence boundaries and the
+[Unicode line breaking algorithm][2] to detect line break
+opportunities.
+
+The library is independent from any IO mechanism or Unicode text data
+structure and it can process text without a complete in-memory
+representation.
+
+Uuseg depends on [Uucp](http://erratique.ch/software/uucp) and
+optionally on [Uutf](http://erratique.ch/software/uutf) for support on
+OCaml UTF-X encoded strings. It is distributed under the ISC license.
+
+[1]: http://www.unicode.org/reports/tr29/
+[2]: http://www.unicode.org/reports/tr14/
+
+Homepage: http://erratique.ch/software/uuseg"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The uuseg programmers"
+license: "ISC"
+tags: ["unicode" "text" "segmentation" "org:erratique"]
+homepage: "https://erratique.ch/software/uuseg"
+doc: "https://erratique.ch/software/uuseg/doc/"
+bug-reports: "https://github.com/dbuenzli/uuseg/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {>= "15.0.0" & < "16.0.0"}
+]
+depopts: ["uutf" "cmdliner"]
+conflicts: [
+  "uutf" {< "1.0.0"}
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-uutf"
+  "%{uutf:installed}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/uuseg.git"
+url {
+  src: "https://erratique.ch/software/uuseg/releases/uuseg-15.0.0.tbz"
+  checksum:
+    "sha512=37ea83b582dd779a026cfae11f08f5d67ef79fce65a2cf03f2a9aabc7eb5de60c8e812524fa7531e4ff6e22a3b18228e3438a0143ce43be95f23237cc283576f"
+}


### PR DESCRIPTION
* Add: `uucd.15.0.0` [home](https://erratique.ch/software/uucd), [doc](https://erratique.ch/software/uucd/doc/Uucd), [issues](https://github.com/dbuenzli/uucd/issues)  
  *Unicode character database decoder for OCaml*
* Add: `uucp.15.0.0` [home](https://erratique.ch/software/uucp), [doc](https://erratique.ch/software/uucp/doc/), [issues](https://github.com/dbuenzli/uucp/issues)  
  *Unicode character properties for OCaml*
* Add: `uunf.15.0.0` [home](https://erratique.ch/software/uunf), [doc](https://erratique.ch/software/uunf/doc/Uunf), [issues](https://github.com/dbuenzli/uunf/issues)  
  *Unicode text normalization for OCaml*
* Add: `uuseg.15.0.0` [home](https://erratique.ch/software/uuseg), [doc](https://erratique.ch/software/uuseg/doc/), [issues](https://github.com/dbuenzli/uuseg/issues)  
  *Unicode text segmentation for OCaml*


---

#### `uucd` v15.0.0 2022-09-15 Zagreb

- Support for Unicode 15.0.0

---

#### `uucp` v15.0.0 2022-09-15 Zagreb

- Unicode 15.0.0 support.
- Tool `ucharinfo`: allow to query more than one character at a time.
- Tool `ucharinfo`: tool allow to search characters by name.

---

#### `uunf` v15.0.0 2022-09-15 Zagreb

- Unicode 15.0.0 support.

---

#### `uuseg` v15.0.0 2022-09-15 Zagreb

- Unicode 15.0.0 support.

---

Use `b0 cmd -- .opam.publish uucd.15.0.0 uucp.15.0.0 uunf.15.0.0 uuseg.15.0.0` to update the pull request.