### PR TITLE
Package linenoise.1.4.0

### DIFF
--- a/packages/linenoise/linenoise.1.4.0/opam
+++ b/packages/linenoise/linenoise.1.4.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Lightweight readline alternative"
+maintainer: "Simon Cruanes"
+authors: [ "Edgar Aroutiounian <edgar.factorial@gmail.com>" "Simon Cruanes" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/ocaml-community/ocaml-linenoise"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-linenoise.git"
+bug-reports: "https://github.com/ocaml-community/ocaml-linenoise/issues"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "dune" { >= "1.1" }
+  "result"
+  "ocaml" { >= "4.03.0" }
+  "odoc" {with-doc}
+]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-linenoise/archive/v1.4.0.tar.gz"
+  checksum: [
+    "md5=373cadced7663934b91c64c5bbdf9640"
+    "sha512=d510ffea00d792c63f23a363c5e564fa6c161a2eaffc391c5080325adb26f0bdedf998f11d10e98ec6edb96344e93ac835e5ea5aa683a5b36c9ff0d6d190ecee"
+  ]
+}


### PR DESCRIPTION
### `linenoise.1.4.0`
Lightweight readline alternative



---
* Homepage: https://github.com/ocaml-community/ocaml-linenoise
* Source repo: git+https://github.com/ocaml-community/ocaml-linenoise.git
* Bug tracker: https://github.com/ocaml-community/ocaml-linenoise/issues

---
:camel: Pull-request generated by opam-publish v2.1.0