### PR TITLE
vhd-format-lwt: solve conflicting deps on io-page

### DIFF
--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
@@ -13,7 +13,6 @@ depends: [
   "mirage-block" {>= "2.0.1"}
   "ounit2" {with-test}
   "vhd-format"
-  "io-page-unix" {with-test}
   "dune" {>= "1.0"}
   "io-page" {with-test & >= "2.4.0"}
 ]

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.3/opam
@@ -7,14 +7,14 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "cstruct" {< "6.1.0"}
   "lwt" {>= "3.2.0"}
   "mirage-block" {>= "2.0.1"}
   "ounit2" {with-test}
   "vhd-format"
   "dune" {>= "1.0"}
-  "io-page" {with-test & >= "2.4.0"}
+  "io-page" {with-test & >= "2.4.0" & < "3.0.0"}
 ]
 available: os = "linux" | os = "macos"
 build: [


### PR DESCRIPTION
io-page-unix is only available for 2.3.0 and lower, this conflicts with the requirement of io-page >= 2.4.0.

Remove the former so tests can be run.