### PR TITLE
[new release] ca-certs-nss (3.83)

### DIFF
--- a/packages/ca-certs-nss/ca-certs-nss.3.83/opam
+++ b/packages/ca-certs-nss/ca-certs-nss.3.83/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "X.509 trust anchors extracted from Mozilla's NSS"
+description: """
+Trust anchors extracted from Mozilla's NSS certdata.txt package,
+to be used in MirageOS unikernels.
+"""
+maintainer: ["Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs-nss"
+doc: "https://mirage.github.io/ca-certs-nss/doc"
+bug-reports: "https://github.com/mirage/ca-certs-nss/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "mirage-crypto"
+  "mirage-clock" {>= "3.0.0"}
+  "x509" {>= "0.15.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" {build}
+  "fmt" {build & >= "0.8.7"}
+  "bos" {build}
+  "astring" {build}
+  "cmdliner" {build & >= "1.1.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ca-certs-nss.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/ca-certs-nss/releases/download/v3.83/ca-certs-nss-3.83.tbz"
+  checksum: [
+    "sha256=e1d5a75daf5fd4cf384c63eaca9800feac4f8f844efd2623fc5f688796da881f"
+    "sha512=57248d3b67476dfdb5d5d94e58d2c33f36413869b6665dc1e401561fd5af04c8eedc50200fa49d815cffa72fd2f644b58093756bc663d4d05b6f29088149c303"
+  ]
+}
+x-commit-hash: "a4586093e75a289ba083dbabdca6791e17a928b2"


### PR DESCRIPTION
X.509 trust anchors extracted from Mozilla's NSS

- Project page: <a href="https://github.com/mirage/ca-certs-nss">https://github.com/mirage/ca-certs-nss</a>
- Documentation: <a href="https://mirage.github.io/ca-certs-nss/doc">https://mirage.github.io/ca-certs-nss/doc</a>

##### CHANGES:

* Update to NSS 3.83 (Sep 15th 2022)
