### PR TITLE
[new release] http-lwt-client (0.0.8)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.0.8/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.0.8/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.0.8/http-lwt-client-0.0.8.tbz"
+  checksum: [
+    "sha256=25d62c02c567fda43e1fdb526701f9e9cb69aaf1f458afa44e0a1647d77396a2"
+    "sha512=af5c30b9af6b2b5ce8c3ac92d917eb5510e45c21e6e512c116b329bcf3236b35c40bc79b2d3d52bc160c9d81fc0e8bbd3fcac92bb33aa13743948b3b578e7afe"
+  ]
+}
+x-commit-hash: "f44b2280399af989bb35628814a2fec0d31fbfb5"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* use Status.is_redirection instead of a match on the polymorphic variant, to
  support unknown 3xx codes (such as 308) (roburio/http-lwt-client#11 @hannesm)
* add some yield in the main loop to allow concurrency with other fibers (issue
  roburio/http-lwt-client#12 by @kit-ty-kate, fixed in roburio/http-lwt-client#13 by @dinosaure)
* hurl: add a no-follow flag (@hannesm)
