### PR TITLE
3 packages from gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12.1/json-data-encoding-0.12.1.tar.gz

### DIFF
--- a/packages/json-data-encoding-browser/json-data-encoding-browser.0.12.1/opam
+++ b/packages/json-data-encoding-browser/json-data-encoding-browser.0.12.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (browser support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "2.0"}
+  "json-data-encoding" {= version }
+  "js_of_ocaml" {>= "3.3.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12.1/json-data-encoding-0.12.1.tar.gz"
+  checksum: [
+    "md5=f70939e5bcaae19f5996e05d3baf5536"
+    "sha512=891f3bc6aa12e9968bec9a18fdc594fd435a67b9291a9246cb4e6b9bc030181d5bab7a07a36632e492cbfebab3ad6ad65e9358fb3e41f26027eefb7a3337d0a9"
+  ]
+}

--- a/packages/json-data-encoding-bson/json-data-encoding-bson.0.12.1/opam
+++ b/packages/json-data-encoding-bson/json-data-encoding-bson.0.12.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON (bson support)"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "2.0"}
+  "json-data-encoding" {= version }
+  "ocplib-endian" {>= "1.0"}
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12.1/json-data-encoding-0.12.1.tar.gz"
+  checksum: [
+    "md5=f70939e5bcaae19f5996e05d3baf5536"
+    "sha512=891f3bc6aa12e9968bec9a18fdc594fd435a67b9291a9246cb4e6b9bc030181d5bab7a07a36632e492cbfebab3ad6ad65e9358fb3e41f26027eefb7a3337d0a9"
+  ]
+}

--- a/packages/json-data-encoding/json-data-encoding.0.12.1/opam
+++ b/packages/json-data-encoding/json-data-encoding.0.12.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Type-safe encoding to and decoding from JSON"
+maintainer: "contact@nomadic-labs.com"
+authors: [ "Nomadic Labs" "Ocamlpro" ]
+homepage: "https://gitlab.com/nomadic-labs/json-data-encoding"
+bug-reports: "https://gitlab.com/nomadic-labs/json-data-encoding/issues"
+license: "MIT"
+dev-repo: "git+https://gitlab.com/nomadic-labs/json-data-encoding"
+
+build: [
+  ["dune" "build" "-j" jobs "-p" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "2.0"}
+  "uri" {>= "1.9.0" }
+  "crowbar" { with-test }
+  "alcotest" { with-test }
+  "ocamlformat" { = "0.20.1" & with-doc } # not technically a doc dep; modify when with-dev becomes available
+  "odoc" { with-doc }
+]
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/json-data-encoding/-/archive/0.12.1/json-data-encoding-0.12.1.tar.gz"
+  checksum: [
+    "md5=f70939e5bcaae19f5996e05d3baf5536"
+    "sha512=891f3bc6aa12e9968bec9a18fdc594fd435a67b9291a9246cb4e6b9bc030181d5bab7a07a36632e492cbfebab3ad6ad65e9358fb3e41f26027eefb7a3337d0a9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`json-data-encoding.0.12.1`: Type-safe encoding to and decoding from JSON
-`json-data-encoding-browser.0.12.1`: Type-safe encoding to and decoding from JSON (browser support)
-`json-data-encoding-bson.0.12.1`: Type-safe encoding to and decoding from JSON (bson support)



---
* Homepage: https://gitlab.com/nomadic-labs/json-data-encoding
* Source repo: git+https://gitlab.com/nomadic-labs/json-data-encoding
* Bug tracker: https://gitlab.com/nomadic-labs/json-data-encoding/issues

---
:camel: Pull-request generated by opam-publish v2.1.0