### PR TITLE
omake 0.10.3 is not compatible with ocaml 5

### DIFF
--- a/packages/omake/omake.0.10.3/opam
+++ b/packages/omake/omake.0.10.3/opam
@@ -29,7 +29,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind"
 ]
 synopsis: "Build system designed for scalability and portability"


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/22125

Fails with
```
# File "lm_printf.mli", line 115, characters 37-59:
# 115 | val set_formatter_out_channel      : Pervasives.out_channel -> unit
#                                            ^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# *** Error in directory /home/opam/.opam/5.0/.opam-switch/build/omake.0.10.3/boot: Command failed: ocamlc -safe-string -g -w -40  -c lm_printf.mli
# Command exited with error: ocaml '/home/opam/.opam/5.0/.opam-switch/build/omake.0.10.3/make.ml' '-C' 'boot' 'omake' 'PREFERRED=.opt' 'OCAMLSUFFIX=.opt' 'OCAML=ocaml'
# make: *** [Makefile:12: bootstrap] Error 1
```