### PR TITLE
Release of Esperanto v0.0.1

### DIFF
--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
@@ -18,7 +18,7 @@ build: [
 install: [ make "-C" "toolchain" "install" ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
 description: "A little toolchain for OCaml with Cosmopolitan"
-available: [ arch = "x86_64" ]
+available: [ arch = "x86_64" & os != "macos" ]
 url {
   src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.1/esperanto-v0.0.1.tar.gz"
   checksum: "sha512=a69a5e933469e450d73a82ec3c1760b183af5dce8d66779f123f0025011863e1e8e53bbc907bbc10ff73107a3e4838d8c5daa419077ff71bf2c76e9cfac03e0f"

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
@@ -7,15 +7,15 @@ license: "MIT"
 tags: "org:mirage"
 dev-repo: "git+https://github.com/dinosaure/esperanto.git"
 build: [
-  [ "sh" "-c" "cd toolchain ; ./configure.sh --prefix=%{prefix}%" ]
-  [ "sh" "-c" "cd toolchain ; %{make}% all V=1" ]
+  [ "sh" "-c" "cd toolchain && ./configure.sh --prefix=%{prefix}%" ]
+  [ make "-C" "toolchain" "all" "V=1" ]
 ]
 # We should depend on conf-binutils but the package does not work on FreeBSD
 # even if we can do [pkg install binutils] on FreeBSD 12
 # depends: [
 #   "conf-binutils"
 # ]
-install: [ "sh" "-c" "cd toolchain ; %{make}% install" ]
+install: [ make "-C" "toolchain" "install" ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
 description: "A little toolchain for OCaml with Cosmopolitan"
 available: [ arch = "x86_64" ]

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
@@ -18,7 +18,7 @@ build: [
 install: [ make "-C" "toolchain" "install" ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
 description: "A little toolchain for OCaml with Cosmopolitan"
-available: [ arch = "x86_64" & os != "macos" ]
+available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
 url {
   src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.1/esperanto-v0.0.1.tar.gz"
   checksum: "sha512=a69a5e933469e450d73a82ec3c1760b183af5dce8d66779f123f0025011863e1e8e53bbc907bbc10ff73107a3e4838d8c5daa419077ff71bf2c76e9cfac03e0f"

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/esperanto"
+bug-reports: "https://github.com/dinosaure/esperanto/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/esperanto.git"
+build: [
+  [ "sh" "-c" "cd toolchain ; ./configure.sh --prefix=%{prefix}%" ]
+  [ "sh" "-c" "cd toolchain ; %{make}% all V=1" ]
+]
+# We should depend on conf-binutils but the package does not work on FreeBSD
+# even if we can do [pkg install binutils] on FreeBSD 12
+# depends: [
+#   "conf-binutils"
+# ]
+install: [ "sh" "-c" "cd toolchain ; %{make}% install" ]
+synopsis: "Cosmopolitan toolchain for OCaml compiler"
+description: "A little toolchain for OCaml with Cosmopolitan"
+available: [ arch = "x86_64" ]
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.1/esperanto-v0.0.1.tar.gz"
+  checksum: "sha512=a69a5e933469e450d73a82ec3c1760b183af5dce8d66779f123f0025011863e1e8e53bbc907bbc10ff73107a3e4838d8c5daa419077ff71bf2c76e9cfac03e0f"
+}

--- a/packages/esperanto/esperanto.0.0.1/opam
+++ b/packages/esperanto/esperanto.0.0.1/opam
@@ -7,10 +7,10 @@ license: "MIT"
 tags: "org:mirage"
 dev-repo: "git+https://github.com/dinosaure/gilbraltar.git"
 build: [
-  ["sh" "-c" "cd caml ; ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
-  ["sh" "-c" "cd caml ; %{make}% -j%{jobs}%"]
+  ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
+  [make "-C" "caml" "-j%{jobs}%"]
 ]
-install: ["sh" "-c" "cd caml ; %{make}% install" ]
+install: [make "-C" "caml" "install"]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto/esperanto.0.0.1/opam
+++ b/packages/esperanto/esperanto.0.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/gilbraltar"
+bug-reports: "https://github.com/dinosaure/gilbraltar/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/gilbraltar.git"
+build: [
+  ["sh" "-c" "cd caml ; ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
+  ["sh" "-c" "cd caml ; %{make}% -j%{jobs}%"]
+]
+install: ["sh" "-c" "cd caml ; %{make}% install" ]
+depends: [
+  "conf-which" {build}
+  "conf-gcc" {build}
+  "ocaml-src" {build}
+  "esperanto-cosmopolitan" {build}
+#  "cosmopolitan-pth" {build}
+  "ocaml" {>= "4.13.0" & < "4.15.0"}
+]
+synopsis: "An OCaml compiler with Cosmopolitan"
+description:
+  "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.1/esperanto-v0.0.1.tar.gz"
+  checksum: "sha512=a69a5e933469e450d73a82ec3c1760b183af5dce8d66779f123f0025011863e1e8e53bbc907bbc10ff73107a3e4838d8c5daa419077ff71bf2c76e9cfac03e0f"
+}

--- a/packages/esperanto/esperanto.0.0.1/opam
+++ b/packages/esperanto/esperanto.0.0.1/opam
@@ -13,7 +13,6 @@ build: [
 install: ["sh" "-c" "cd caml ; %{make}% install" ]
 depends: [
   "conf-which" {build}
-  "conf-gcc" {build}
   "ocaml-src" {build}
   "esperanto-cosmopolitan" {build}
 #  "cosmopolitan-pth" {build}


### PR DESCRIPTION
- First release of `esperanto`

NOTE: The CI will probably fail when Esperanto is only tested on Ubuntu and FreeBSD. Let's see.