### PR TITLE
omake 0.10.5 is incompatible with ocaml 5

### DIFF
--- a/packages/omake/omake.0.10.5/opam
+++ b/packages/omake/omake.0.10.5/opam
@@ -27,7 +27,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind"
 ]
 conflicts: [ "base-effects" ]


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/22131 Currently fails with
```
# ocamlc -safe-string -strict-sequence -g -w -40  -c lm_printf.mli
# File "lm_printf.mli", line 115, characters 37-59:
# 115 | val set_formatter_out_channel      : Pervasives.out_channel -> unit
#                                            ^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# *** Error in directory /home/opam/.opam/5.0/.opam-switch/build/omake.0.10.5/boot: Command failed: ocamlc -safe-string -strict-sequence -g -w -40  -c lm_printf.mli
# Command exited with error: ocaml '/home/opam/.opam/5.0/.opam-switch/build/omake.0.10.5/make.ml' '-C' 'boot' 'omake' 'PREFERRED=.opt' 'OCAMLSUFFIX=.opt' 'OCAML=ocaml'
# make: *** [Makefile:12: bootstrap] Error 1
```