### PR TITLE
Package secp256k1-internal.0.4.0

### DIFF
--- a/packages/secp256k1-internal/secp256k1-internal.0.4.0/opam
+++ b/packages/secp256k1-internal/secp256k1-internal.0.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings to secp256k1 internal functions (generic operations on the curve)"
+maintainer: "contact@nomadic-labs.com"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Nomadic Labs <contact@nomadic-labs.com>"
+]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-gmp" {build}
+  "dune" {>= "2.7"}
+  "dune-configurator"
+  "cstruct" {>= "6.0.0"}
+  "bigstring" {>= "0.1.1"}
+  "conf-pkg-config"
+  "hex" {with-test & >= "1.4.0"}
+  "alcotest" {with-test}
+  "js_of_ocaml-compiler" {with-test & >= "3.11"}
+]
+available: arch != "x86_32" & arch != "ppc32" & arch != "arm32"
+build: [
+  ["dune" "build" "-j" jobs "-p" name "@install"]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/-/archive/v0.4/ocaml-secp256k1-internal-v0.4.tar.gz"
+  checksum: [
+    "md5=36dd40b21c4604aa566b5088fd1fdbe2"
+    "sha512=8b8067cd2a236a19c3b66f036d625bfa1f224acdc9a66a62aa9554a4ebbd50c74f1e296f4cb7fae1f4bc146ce048d87a298ea22dd3b9fe9260f94e20875d85d2"
+  ]
+}


### PR DESCRIPTION
### `secp256k1-internal.0.4.0`
Bindings to secp256k1 internal functions (generic operations on the curve)



---
* Homepage: https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal
* Source repo: git+https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal
* Bug tracker: https://gitlab.com/nomadic-labs/ocaml-secp256k1-internal/issues

---
:camel: Pull-request generated by opam-publish v2.1.0