### PR TITLE
Release caqti-driver-postgresql 1.9.1.

### DIFF
--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.9.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.1.9.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "1.9.0" & < "1.10.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v1.9.1/caqti-v1.9.1.tbz"
+  checksum: [
+    "sha256=3d0060241371dc8704ebfbf23487f6e9adb14ad536d8b0617dff1e33a50f689e"
+    "sha512=5350f540c8b24a0a0e7a615b05cdb769793d0d742bd7c1a9c2c92ff7e72248f2d2ee36a9dad6919466ab2df96c886f17d454477880c56fa267a29439b384680b"
+  ]
+}
+x-commit-hash: "cba1047b9e318bc450be72ab9dfb302aac8e4a78"


### PR DESCRIPTION
We have fixed two bugs in the caqti-driver-postgresql sub-package which I think warrants a release:

  - PostgreSQL expects "=" in query values to be URI-encoded (paurkedal/ocaml-caqti#95).

  - The validation logic for PostgreSQL was missing a call to consume
    available input, meaning that broken pooled connections were reused.
