### PR TITLE
mirage-clock-xen: add missing dependency on ocamlbuild

### DIFF
--- a/packages/mirage-clock-xen/mirage-clock-xen.1.0.0/opam
+++ b/packages/mirage-clock-xen/mirage-clock-xen.1.0.0/opam
@@ -11,6 +11,7 @@ remove: [
 depends: [
   "ocaml"
   "ocamlfind"
+  "ocamlbuild" {build}
   "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
 dev-repo: "git+https://github.com/mirage/mirage-clock"

--- a/packages/mirage-clock-xen/mirage-clock-xen.1.1/opam
+++ b/packages/mirage-clock-xen/mirage-clock-xen.1.1/opam
@@ -10,6 +10,7 @@ remove: ["ocamlfind" "remove" "mirage-clock-xen"]
 depends: [
   "ocaml"
   "ocamlfind"
+  "ocamlbuild" {build}
   "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
 dev-repo: "git+https://github.com/mirage/mirage-clock"


### PR DESCRIPTION
```
#=== ERROR while installing mirage-clock-xen.1.1 ==============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mirage-clock-xen.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh install make xen-install
# exit-code            2
# env-file             ~/.opam/log/mirage-clock-xen-8-249dc5.env
# output-file          ~/.opam/log/mirage-clock-xen-8-249dc5.out
### output ###
# OS=xen ./build true
# ./build: 6: ocamlbuild: not found
# ocamlfind: [WARNING] No such file: /home/opam/.opam/5.0/lib/mirage-clock-xen/META
# ocamlfind: _build/xen/mirage-clock.cmxs: No such file or directory
# make: *** [Makefile:14: xen-install] Error 2
```