### PR TITLE
[new release] binsec (0.6.0)

### DIFF
--- a/packages/binsec/binsec.0.6.0/opam
+++ b/packages/binsec/binsec.0.6.0/opam
@@ -1,0 +1,101 @@
+opam-version: "2.0"
+synopsis: "Semantic analysis of binary executables"
+description: """
+
+BINSEC aims at developing an open-source platform filling the gap between formal
+methods over executable code and binary-level security analyses currently used
+in the security industry.
+
+The project targets the following applicative domains:
+
+    vulnerability analyses
+    malware comprehension
+    code protection
+    binary-level verification
+
+BINSEC is developed at CEA List in scientfic collaboration with Verimag and LORIA.
+
+An overview of some BINSEC features can be found in our SSPREW'17 tutorial."""
+maintainer: ["BINSEC <binsec@saxifrage.saclay.cea.fr>"]
+authors: [
+  "Adel Djoudi"
+  "Benjamin Farinier"
+  "Chakib Foulani"
+  "Dorian Lesbre"
+  "Frédéric Recoules"
+  "Guillaume Girol"
+  "Josselin Feist"
+  "Lesly-Ann Daniel"
+  "Manh-Dung Nguyen"
+  "Mathéo Vergnolle"
+  "Mathilde Ollivier"
+  "Matthieu Lemerre"
+  "Olivier Nicole"
+  "Richard Bonichon"
+  "Robin David"
+  "Sébastien Bardin"
+  "Soline Ducousso"
+  "Ta Thanh Dinh"
+  "Yaëlle Vinçont"
+]
+license: "LGPL-2.1-or-later"
+tags: [
+  "binary code analysis"
+  "symbolic execution"
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "plugins"
+  "abstract interpretation"
+  "dataflow analysis"
+  "linking"
+  "disassembly"
+]
+homepage: "https://binsec.github.io"
+bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.13"}
+  "menhir" {build & >= "20181113"}
+  "ocamlgraph" {>= "1.8.5"}
+  "zarith" {>= "1.4"}
+  "dune-site"
+  "toml"
+  "ounit2" {with-test & >= "2"}
+  "qcheck" {with-test & >= "0.7"}
+  "odoc" {with-doc}
+]
+depopts: ["curses" "llvm" "unisim_archisec" "bitwuzla"]
+conflicts: [
+  "llvm" {< "6.0.0"}
+  "llvm" {>= "13.0.0"}
+  "bitwuzla" {< "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/binsec/binsec.git"
+available: [ arch = "x86_64" | arch = "ppc64" | arch = "arm64" | arch = "sparc64" ]
+url {
+  src:
+    "https://github.com/binsec/binsec/releases/download/0.6.0/binsec-0.6.0.tbz"
+  checksum: [
+    "sha256=e9101e68d317c837d5cff9608c6fba2127dd31ef6373b9b90806780c1d80bb52"
+    "sha512=c01af277239b8cc84fb904c301897f7d2388a8c850c7cb6a53acb8a4f8d51115c8a595c5517843d076421a76f4b2becb16e722b4c90f19a8fa208cce5f3ba274"
+  ]
+}
+x-commit-hash: "e94c05bcd6741df91f180aef700e137008a9f64c"

--- a/packages/binsec/binsec.0.6.0/opam
+++ b/packages/binsec/binsec.0.6.0/opam
@@ -61,7 +61,7 @@ depends: [
   "ocamlgraph" {>= "1.8.5"}
   "zarith" {>= "1.4"}
   "dune-site"
-  "toml"
+  "toml" {>= "6"}
   "ounit2" {with-test & >= "2"}
   "qcheck" {with-test & >= "0.7"}
   "odoc" {with-doc}

--- a/packages/binsec/binsec.0.6.0/opam
+++ b/packages/binsec/binsec.0.6.0/opam
@@ -56,7 +56,7 @@ homepage: "https://binsec.github.io"
 bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.13"}
+  "ocaml" {>= "4.13" & < "5"}
   "menhir" {build & >= "20181113"}
   "ocamlgraph" {>= "1.8.5"}
   "zarith" {>= "1.4"}


### PR DESCRIPTION
Semantic analysis of binary executables

- Project page: <a href="https://binsec.github.io">https://binsec.github.io</a>

##### CHANGES:

** Features

   - New architecture support : RISC V 64bit
   - Catch interrupt signal (`CTRL-C`) in SSE in order to
     print exploration summary gracefully
   - Switch between log and monitor screen in SSE by pressing `space`
     (require `curses`)

** Documentation

   - Broaden the SSE [manual reference](doc/sse/references.md)
   - Add the write-up
	 ["How to read the SSE exploration board"](doc/sse/exploration_board.md)

** Bugs

   - Fix bitvector canonical representation
   - Fix compatibility issues with `unisim-archisec.0.0.3`
   - Fix issues with new experimental SSE engine
