### PR TITLE
Orsetto (all versions) incompatible w/ OCaml 5.0.

### DIFF
--- a/packages/orsetto/orsetto.1.0.2/opam
+++ b/packages/orsetto/orsetto.1.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 license: "BSD-2-Clause"
 depends: [
-    ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
+    ("ocaml" { >= "4.07" & < "5.0~" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
     "conjury" { build & >= "2.0" & < "3.0~" }
     "uucd" { build & = "12.0.0" }

--- a/packages/orsetto/orsetto.1.0.3/opam
+++ b/packages/orsetto/orsetto.1.0.3/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 license: "BSD-2-Clause"
 depends: [
-    ("ocaml" { >= "4.07" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
+    ("ocaml" { >= "4.07" & < "5.0~" } | ("seq" & "ocaml" { >= "4.06.1" & < "4.07" }))
     "stdlib-shims" { >= "0.1" }
     "conjury" { build & >= "2.0.1" & < "3.0~" }
     "uucd" { build & = "13.0.0" }

--- a/packages/orsetto/orsetto.1.1.1/opam
+++ b/packages/orsetto/orsetto.1.1.1/opam
@@ -37,7 +37,7 @@ tags: [
 ]
 license: "BSD-2-Clause"
 depends: [
-    "ocaml" { >= "4.08.1" }
+    "ocaml" { >= "4.08.1" & < "5.0~" }
     "conjury" { build & >= "2.0.1" & < "3.0~" }
     "omake" { build & >= "0.10.3" }
     "uucd" { build & = "14.0.0" }

--- a/packages/orsetto/orsetto.1.1.2/opam
+++ b/packages/orsetto/orsetto.1.1.2/opam
@@ -37,7 +37,7 @@ tags: [
 ]
 license: "BSD-2-Clause"
 depends: [
-    "ocaml" { >= "4.08.1" }
+    "ocaml" { >= "4.08.1" & < "5.0~" }
     "conjury" { build & >= "2.0.1" & < "3.0~" }
     "omake" { build & >= "0.10.3" }
     "uucd" { build & = "15.0.0" }

--- a/packages/orsetto/orsetto.1.1/opam
+++ b/packages/orsetto/orsetto.1.1/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://bitbucket.org/jhw/orsetto"
 tags: [ "org:conjury.org" ]
 license: "BSD-2-Clause"
 depends: [
-    "ocaml" { >= "4.08.1" }
+    "ocaml" { >= "4.08.1" & < "5.0~" }
     "conjury" { build & >= "2.0.1" & < "3.0~" }
     "omake" { build & >= "0.10.3" }
     "uucd" { build & = "13.0.0" }


### PR DESCRIPTION
Applies dependency constraint to limit Orsetto packages to `ocaml < "5.0~"`.