### PR TITLE
Package soupault.4.2.0

### DIFF
--- a/packages/soupault/soupault.4.2.0/opam
+++ b/packages/soupault/soupault.4.2.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
+* Export extracted metadata to JSON.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.app"
+bug-reports: "https://github.com/dmbaturin/soupault/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.7.3"}
+  "markup" {>= "1.0.0-1"}
+  "otoml" {>= "1.0.2"}
+  "fileutils" {>= "0.6.3"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "re" {>= "1.9.0"}
+  "ezjsonm" {>= "1.2.0"}
+  "yaml" {>= "2.0.0"}
+  "containers" {>= "3.9"}
+  "odate" {>= "0.6"}
+  "spelll" {>= "0.4"}
+  "base64" {>= "3.0.0"}
+  "jingoo" {>= "1.4.2"}
+  "tsort" {>= "2.1.0"}
+  "lua-ml" {>= "0.9.3"}
+  "camomile" {>= "1.0.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/dmbaturin/soupault"
+url {
+  src:
+    "https://codeberg.org/PataphysicalSociety/soupault/archive/4.2.0.tar.gz"
+  checksum: [
+    "md5=f556710ad112c22ab3ec1addbefcd700"
+    "sha512=497cbef57b22a32583f8dad3984b2a906235bddd484a3cb634665ac1b8e995f6fd66e955de1c365972db02976e537f4d7498066d05d06eed73703c3f36ea0e29"
+  ]
+}


### PR DESCRIPTION
### `soupault.4.2.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

With soupault you can:

* Generate ToC and footnotes.
* Insert file content or an HTML snippet in any element.
* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
* Export extracted metadata to JSON.

Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
similar to web browsers.

The website generator mode is optional, you can use it as post-processor for existing sites.



---
* Homepage: https://www.soupault.app
* Source repo: git+https://github.com/dmbaturin/soupault
* Bug tracker: https://github.com/dmbaturin/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.1.0