### PR TITLE
Package bls12-381-signature.1.0.0

### DIFF
--- a/packages/bls12-381-signature/bls12-381-signature.1.0.0/opam
+++ b/packages/bls12-381-signature/bls12-381-signature.1.0.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of BLS signatures for the pairing-friendly curve BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+  "integers_stubs_js" {with-test}
+]
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381-signature/-/archive/1.0.0/ocaml-bls12-381-signature-1.0.0.tar.bz2"
+  checksum: [
+    "md5=f98a01a1bba2579ef09f50e2d439e897"
+    "sha512=9b66d8cb26234b306548c1c31069fc91228018336b519c8fa05a2e11fee084b97d0400321390cefd823429ec4e62628221c3730cf639fface9b8a11d4628afb5"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381-signature.1.0.0`
Implementation of BLS signatures for the pairing-friendly curve BLS12-381



---
* Homepage: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature/issues

---
:camel: Pull-request generated by opam-publish v2.1.0