### PR TITLE
Package bls12-381-hash.0.0.2

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.0.0.2/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of some cryptographic hash primitives using the scalar field of BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+available:
+  arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git"
+url {
+  src:
+    "https://gitlab.com/dannywillems/ocaml-bls12-381-hash/-/archive/0.0.2/ocaml-bls12-381-hash-0.0.2.tar.bz2"
+  checksum: [
+    "md5=e858f6d093fd5ea10a3be56b0f2ec0f8"
+    "sha512=f5fbeaefa182d4f7cee78a19e6503933002c12caf84ede29b501965a7e95c2e38c797af22fbdee4747ea629a6852ed5e9292c9950c3de5fa2ea053171a768b84"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381-hash.0.0.2`
Implementation of some cryptographic hash primitives using the scalar field of BLS12-381



---
* Homepage: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues

---
:camel: Pull-request generated by opam-publish v2.1.0