### PR TITLE
reason is not compatible with OCaml 5.0 (the Caml1999N magic numbers have changed)

### DIFF
--- a/packages/reason/reason.3.8.1/opam
+++ b/packages/reason/reason.3.8.1/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "4.03" & < "5.1"}
+  "ocaml"         {>= "4.03" & < "5.0"}
   "dune"          {>= "2.3"}
   "ocamlfind"     {build}
   "menhir"        {>= "20180523"}


### PR DESCRIPTION
See https://github.com/reasonml/reason/commit/3f909247b0a33d83f5f81b4b530a038f1b40e6e9

cc @anmonteiro