### PR TITLE
[new release] mirage-monitoring (0.0.3)

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.3/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/mirage-monitoring"
+doc: "https://roburio.github.io/mirage-monitoring"
+dev-repo: "git+https://github.com/roburio/mirage-monitoring.git"
+bug-reports: "https://github.com/roburio/mirage-monitoring/issues"
+license: "AGPL-3.0-only"
+
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune"
+  "logs" {>= "0.6.3"}
+  "metrics" {>= "0.4.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-solo5" {>= "0.9.0"}
+  "mirage-runtime" {>= "4.3.0"}
+  "memtrace-mirage" {>= "0.2.1.2.2"}
+  "mirage-clock" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Monitoring of MirageOS unikernels"
+description: """
+Reporting metrics to Influx, Telegraf. Dynamic adjusting log level and metrics
+sources, memprof profiling.
+"""
+url {
+  src:
+    "https://github.com/roburio/mirage-monitoring/releases/download/v0.0.3/mirage-monitoring-0.0.3.tbz"
+  checksum: [
+    "sha256=89b588f8100dcb8791a898454eaf80bdbb1732bbf4050d7434f90ba242fabe20"
+    "sha512=821b6bf9f8c3c530e3e3f730cca813caefe53614145ec6b4c99099159ccc08d5633517d17a02c12a18d5bd427c09e9d483e9ff28d6494228ed9df40f6b8e5fd4"
+  ]
+}
+x-commit-hash: "8bcf3adfe8020ac9f2c5a9fd8ca5dccfe21961fa"


### PR DESCRIPTION
Monitoring of MirageOS unikernels

- Project page: <a href="https://github.com/roburio/mirage-monitoring">https://github.com/roburio/mirage-monitoring</a>
- Documentation: <a href="https://roburio.github.io/mirage-monitoring">https://roburio.github.io/mirage-monitoring</a>

##### CHANGES:

* Upgrade to Mirage 4.3.0+
