### PR TITLE
Add missing lower-bound constraints to xxhash

### DIFF
--- a/packages/xxhash/xxhash.0.1/opam
+++ b/packages/xxhash/xxhash.0.1/opam
@@ -15,9 +15,9 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "xxhash"]
 depends: [
   "ocaml"
-  "oasis" {build}
+  "oasis" {>= "0.4.7" & build}
   "ocamlbuild" {!= "0.9.0" & build}
-  "ctypes"
+  "ctypes" {>= "0.6.0"}
   "conf-xxhash"
 ]
 synopsis: "Bindings for xxHash, an extremely fast hash algorithm"


### PR DESCRIPTION
cherry-pick from https://github.com/ocaml/opam-repository/pull/22153
cc @LasseBlaauwbroek

For ctypes:
```
#=== ERROR while compiling xxhash.0.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.04.2 | pinned(https://github.com/314eter/ocaml-xxhash/archive/v0.1.tar.gz)
# path                 ~/.opam/4.04/.opam-switch/build/xxhash.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -build
# exit-code            1
# env-file             ~/.opam/log/xxhash-7-545bd8.env
# output-file          ~/.opam/log/xxhash-7-545bd8.out
### output ###
# W: Cannot find source file matching module 'Xxhash_bindings' in library xxhash.
# W: Use InterfacePatterns or ImplementationPatterns to define this file with feature "source_patterns".
# W: Cannot find source file matching module 'Xxhash_generated' in library xxhash.
# W: Use InterfacePatterns or ImplementationPatterns to define this file with feature "source_patterns".
# W: Cannot find source file matching module 'Xxhash_bindings' in library xxhash.
# W: Use InterfacePatterns or ImplementationPatterns to define this file with feature "source_patterns".
# W: Cannot find source file matching module 'Xxhash_generated' in library xxhash.
# W: Use InterfacePatterns or ImplementationPatterns to define this file with feature "source_patterns".
# W: Cannot find source file matching module 'Xxhash_bindings' in library xxhash.
# W: Use InterfacePatterns or ImplementationPatterns to define this file with feature "source_patterns".
# W: Cannot find source file matching module 'Xxhash_generated' in library xxhash.
# W: Use InterfacePatterns or ImplementationPatterns to define this file with feature "source_patterns".
# /home/opam/.opam/4.04/bin/ocamlopt.opt unix.cmxa -I /home/opam/.opam/4.04/lib/ocamlbuild /home/opam/.opam/4.04/lib/ocamlbuild/ocamlbuildlib.cmxa myocamlbuild.ml /home/opam/.opam/4.04/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# /home/opam/.opam/4.04/bin/ocamlfind ocamldep -package ctypes.stubs -modules stubs/xxhash_stubgen.ml > stubs/xxhash_stubgen.ml.depends
# /home/opam/.opam/4.04/bin/ocamlfind ocamldep -package ctypes.stubs -modules stubs/xxhash_bindings.ml > stubs/xxhash_bindings.ml.depends
# /home/opam/.opam/4.04/bin/ocamlfind ocamlc -c -g -annot -bin-annot -package ctypes.stubs -I stubs -o stubs/xxhash_bindings.cmo stubs/xxhash_bindings.ml
# + /home/opam/.opam/4.04/bin/ocamlfind ocamlc -c -g -annot -bin-annot -package ctypes.stubs -I stubs -o stubs/xxhash_bindings.cmo stubs/xxhash_bindings.ml
# File "stubs/xxhash_bindings.ml", line 31, characters 29-51:
# Error: Unbound value Unsigned.UInt.to_int64
# Hint: Did you mean to_int?
# Command exited with code 2.
# E: Failure("Command ''/home/opam/.opam/4.04/bin/ocamlbuild' stubs/xxhash_stubgen.native lib/libxxhash_stubs.a lib/dllxxhash_stubs.so lib/xxhash.cma lib/xxhash.cmxa lib/xxhash.a lib/xxhash.cmxs -tag debug' terminated with error code 10")
```
For oasis the provided log only shows a failure for `ctypes.0.1.1` so this needs further debug