### PR TITLE
Package ppx_tools.6.6

### DIFF
--- a/packages/ppx_tools/ppx_tools.6.6/opam
+++ b/packages/ppx_tools/ppx_tools.6.6/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Tools for authors of ppx rewriters and other syntactic tools"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Alain Frisch <alain.frisch@lexifi.com>"
+license: "MIT"
+tags: "syntax"
+homepage: "https://github.com/ocaml-ppx/ppx_tools"
+bug-reports: "https://github.com/ocaml-ppx/ppx_tools/issues"
+depends: [
+  "ocaml" {>= "4.08.0" & < "5.1.0"}
+  "dune" {>= "1.6"}
+  "cppo" {build & >= "1.1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_tools.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_tools/releases/download/6.6/ppx_tools-6.6.tar.gz"
+  checksum: [
+    "md5=b2af2febba308b294931e7934974f9d5"
+    "sha512=7bbb9a8d9aaa68c54048fde383f7ba2499ac53bbc2d7e3ba907de342ea48ffded69acc2e4ca4c38c2b2b1004b5e004230988a36ad34a4b5361c2a3ad1f858a53"
+  ]
+}


### PR DESCRIPTION
### `ppx_tools.6.6`
Tools for authors of ppx rewriters and other syntactic tools



---
* Homepage: https://github.com/ocaml-ppx/ppx_tools
* Source repo: git+https://github.com/ocaml-ppx/ppx_tools.git
* Bug tracker: https://github.com/ocaml-ppx/ppx_tools/issues

---
:camel: Pull-request generated by opam-publish v2.1.0