### PR TITLE
Update links for Nomadic Labs cryptography packages

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.0.0.1/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.1/opam
@@ -4,8 +4,8 @@ synopsis:
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381-hash"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381-hash/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -16,10 +16,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381-hash.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381-hash/-/archive/0.0.1/ocaml-bls12-381-hash-0.0.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/-/archive/0.0.1/ocaml-bls12-381-hash-0.0.1.tar.bz2"
   checksum: [
     "md5=71c1c7a83cb6a7f4606a2e4e8acfdcfb"
     "sha512=294a5c0ff8860d8f730bbf192a3c38f2a0cb8cb0fd05d729eb6ca1782cc95ee967dd5123ecd90cd3f96923c41ddb1a08fa31239116a459cbd50ba0355ff20641"

--- a/packages/bls12-381-signature/bls12-381-signature.0.0.1/opam
+++ b/packages/bls12-381-signature/bls12-381-signature.0.0.1/opam
@@ -4,9 +4,9 @@ synopsis:
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381-signature"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature"
 bug-reports:
-  "https://gitlab.com/dannywillems/ocaml-bls12-381-signature/issues"
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -18,10 +18,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381-signature.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381-signature/-/archive/0.0.1/ocaml-bls12-381-signature-0.0.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature/-/archive/0.0.1/ocaml-bls12-381-signature-0.0.1.tar.bz2"
   checksum: [
     "md5=cdbf6e9ebfbdb85d1c711d0e4e88ec92"
     "sha512=25ecba471bebbc648f91476521680e4e93b6172c271797344b42d9f64100ef63efca133af1e1f6562d74d10a3d35db5d369033b97e468716fe5a1237ec267e1e"

--- a/packages/bls12-381-signature/bls12-381-signature.1.0.0/opam
+++ b/packages/bls12-381-signature/bls12-381-signature.1.0.0/opam
@@ -23,7 +23,7 @@ dev-repo:
   "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381-signature/-/archive/1.0.0/ocaml-bls12-381-signature-1.0.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-signature/-/archive/1.0.0/ocaml-bls12-381-signature-1.0.0.tar.bz2"
   checksum: [
     "md5=f98a01a1bba2579ef09f50e2d439e897"
     "sha512=9b66d8cb26234b306548c1c31069fc91228018336b519c8fa05a2e11fee084b97d0400321390cefd823429ec4e62628221c3730cf639fface9b8a11d4628afb5"

--- a/packages/bls12-381/bls12-381.0.3.14/opam
+++ b/packages/bls12-381/bls12-381.0.3.14/opam
@@ -3,12 +3,12 @@ synopsis: "OCaml binding for bls12-381 from librustzcash"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "conf-rust" {build}
   "ocaml" {>= "4.07"}
-  "dune" {>= "1.7"}
+  "dune" {>= "2.0"}
   "dune-configurator" {build}
   "ff" {>= "0.4.0" & < "0.5.0"}
   "zarith" {>= "1.10" & < "2.0"}
@@ -17,12 +17,13 @@ depends: [
   "tezos-rust-libs" {= "1.0"}
   "alcotest" {with-test}
 ]
+available: arch != "arm32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.3.14/ocaml-bls12-381-0.3.14.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/0.3.14/ocaml-bls12-381-0.3.14.tar.gz"
   checksum: [
     "md5=fb1d1498092721dabfcc0241aefb1d49"
     "sha512=82d2020472b13ff2627b57699b391a63fdb98983837888fb18a40bb4f2029325e9b3a6dcf5217ada83bcd0436d87248b13df83ea78dc4d5c68494aeac0a870b4"

--- a/packages/bls12-381/bls12-381.0.3.15/opam
+++ b/packages/bls12-381/bls12-381.0.3.15/opam
@@ -3,8 +3,8 @@ synopsis: "OCaml binding for bls12-381 from librustzcash"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "conf-rust" {build}
   "ocaml" {>= "4.08"}
@@ -19,10 +19,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.3.15/ocaml-bls12-381-0.3.15.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/0.3.15/ocaml-bls12-381-0.3.15.tar.gz"
   checksum: [
     "md5=bc2be5f59fbdabc1faf64f4c7be79aff"
     "sha512=88282ebaf59aa722ce7499e71e24e5313c7933a137c15f95cce58becd50ed30c4df8ca5eb6b00ee98ed4af6aa4412f6e620e23328b381a4372b2d516122464cc"

--- a/packages/bls12-381/bls12-381.0.4.1/opam
+++ b/packages/bls12-381/bls12-381.0.4.1/opam
@@ -4,8 +4,8 @@ description: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -15,10 +15,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.1/ocaml-bls12-381-0.4.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/0.4.1/ocaml-bls12-381-0.4.1.tar.bz2"
   checksum: [
     "md5=8e9aa7459420c090c2f664554357adf4"
     "sha512=d3d11088fe3a338a7c1e6f62aed8590edccabdde47f0d49cc564bc803d9a5e6aef9917b6f07629f0f831defa7c24294b234a8788661c80a4948dd956b35037b8"

--- a/packages/bls12-381/bls12-381.0.4.2/opam
+++ b/packages/bls12-381/bls12-381.0.4.2/opam
@@ -4,8 +4,8 @@ description: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -14,10 +14,10 @@ depends: [
   "bls12-381-gen" {= version}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/2f6c97bbd86ce05428e9f06ffdf3239982bd9083/ocaml-bls12-381-2f6c97bbd86ce05428e9f06ffdf3239982bd9083.tar.bz2"
   checksum: [
     "md5=3b88994951c586751fb615af236d2285"
     "sha512=90f97d5229a2b000452b9903fc30d938538698aebdf542b799ada56d8f635c38effce93365c1994a9667f88769f696335a0d627baa68fef6cd41573f0aa7299c"

--- a/packages/bls12-381/bls12-381.0.4.3/opam
+++ b/packages/bls12-381/bls12-381.0.4.3/opam
@@ -4,8 +4,8 @@ description: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -14,10 +14,10 @@ depends: [
   "bls12-381-gen" {= version}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/0.4.3/ocaml-bls12-381-0.4.3.tar.bz2"
   checksum: [
     "md5=f81a4562579a69cc0312d6c948678d35"
     "sha512=b9997e85babe1e160bd5ed1d1986584f375a544e120258a18b1f27bf01b86c9a243181e09120ed69fbd611d5ca4721c89a9e3a18e1cf89f7419a430d5b9b2aef"

--- a/packages/bls12-381/bls12-381.0.5.0/opam
+++ b/packages/bls12-381/bls12-381.0.5.0/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -13,10 +13,10 @@ depends: [
   "bls12-381-gen" {= version}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/0.5.0/ocaml-bls12-381-0.5.0.tar.bz2"
   checksum: [
     "md5=5e550e69578c3b991b661c16f012a644"
     "sha512=593051b6de70b8aa433161e8e49f9067cfafb9bbabc0c979958d0f7e1ebd6dd8f95cbb525343b7182a773e44da8d466e7b192578a579442eb58416855362ab77"

--- a/packages/bls12-381/bls12-381.1.0.0/opam
+++ b/packages/bls12-381/bls12-381.1.0.0/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.0.0/ocaml-bls12-381-1.0.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/1.0.0/ocaml-bls12-381-1.0.0.tar.bz2"
   checksum: [
     "md5=64b1732d64a546b3ab7c557c11c88637"
     "sha512=4526cf4824ee39486b393461bbbdf6f4c3f2c0c2d75c111c3e4fe862ef63f5fd75d34ce042870f83d3a7183e899ec4a3671c1576a9317f39d9787781beeab5e1"

--- a/packages/bls12-381/bls12-381.1.0.1/opam
+++ b/packages/bls12-381/bls12-381.1.0.1/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.0.1/ocaml-bls12-381-1.0.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/1.0.1/ocaml-bls12-381-1.0.1.tar.bz2"
   checksum: [
     "md5=77841c4e31fd85b70b8a0e52f80ca37d"
     "sha512=f69d611deb6132d07f0a8ecde7bb118f733de802e241056c5e2b194579c5723a12d58e93410bd56f68a608568de035b61f018d1fea52388f54875d77b8f386c2"

--- a/packages/bls12-381/bls12-381.1.0.2/opam
+++ b/packages/bls12-381/bls12-381.1.0.2/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/f1727556f0fb6589b5e01a9eae8ba8fda8ccd476/ocaml-bls12-381-f1727556f0fb6589b5e01a9eae8ba8fda8ccd476.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/f1727556f0fb6589b5e01a9eae8ba8fda8ccd476/ocaml-bls12-381-f1727556f0fb6589b5e01a9eae8ba8fda8ccd476.tar.bz2"
   checksum: [
     "md5=03d11cf2499950d764c47a0630782c40"
     "sha512=95ea54c9b2c4c7d19f87a3b89090d336aff9ecca54ec8250b0842ab3809224ade1ba66ff987cf3060054475cd92267c3251acf268d57432473349aff56442215"

--- a/packages/bls12-381/bls12-381.1.1.0/opam
+++ b/packages/bls12-381/bls12-381.1.1.0/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.1.0/ocaml-bls12-381-1.1.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/1.1.0/ocaml-bls12-381-1.1.0.tar.bz2"
   checksum: [
     "md5=5f5d356f2e13e8749cd67315579eb54c"
     "sha512=0b9291641cbad0bf5ed9d842a76d8135154b5793040a6002b9fab7607c5d21a0df2e6d30957ea39b2367879e21ea41d5697e328e212e70273447717aa1745a7f"

--- a/packages/bls12-381/bls12-381.1.1.1/opam
+++ b/packages/bls12-381/bls12-381.1.1.1/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/1.1.1/ocaml-bls12-381-1.1.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/1.1.1/ocaml-bls12-381-1.1.1.tar.bz2"
   checksum: [
     "md5=32a535b7e01cc49580bbb951e753d771"
     "sha512=0fcb37697b98709306123bbf2db8658caf914c5cc34af40c336061582e4662f682827bffbfe1fa47fba84365498e422c4f2cdfb8676504a40ea24683335d96e0"

--- a/packages/bls12-381/bls12-381.2.0.0/opam
+++ b/packages/bls12-381/bls12-381.2.0.0/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.0/ocaml-bls12-381-2.0.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/2.0.0/ocaml-bls12-381-2.0.0.tar.bz2"
   checksum: [
     "md5=d1517198f5fd0d02fe0bf0f620880320"
     "sha512=1408455cf390aa7c52a2ddc52d0c33ea04cc17096ec8f6a679595e17646b0e7f4a29f2ce720aedeaba0e545f6ea391d438d56a7f66417f94044db87afefa9dc2"

--- a/packages/bls12-381/bls12-381.2.0.1/opam
+++ b/packages/bls12-381/bls12-381.2.0.1/opam
@@ -3,8 +3,8 @@ synopsis: "Virtual package for BLS12-381 primitives"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -12,10 +12,10 @@ depends: [
   "zarith" {>= "1.10" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/2.0.1/ocaml-bls12-381-2.0.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/2.0.1/ocaml-bls12-381-2.0.1.tar.bz2"
   checksum: [
     "md5=493da0d50891299fb9577e6855653dca"
     "sha512=994ac11cb76b0d83592cfb6b7a6d6f488a5d9c525d9bc1ccd81e797ee56c0e0b9a00d889118b4e5a01282d332d63d94d32ccbb6e063a28c1c53fecbea23dbef6"

--- a/packages/bls12-381/bls12-381.3.0.0/opam
+++ b/packages/bls12-381/bls12-381.3.0.0/opam
@@ -5,8 +5,8 @@ on top of it"""
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -24,10 +24,10 @@ available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 x-ci-accept-failures: ["centos-7" "oraclelinux-7"]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/3.0.0/ocaml-bls12-381-3.0.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/3.0.0/ocaml-bls12-381-3.0.0.tar.bz2"
   checksum: [
     "md5=07e5b2a0c4450229102dd1db0efe07e2"
     "sha512=2403e5f87112da91a49e8f55a49ceb65e58fad00bc93e6882b58f60748df10eddccd23f1b3a7783742bed1907f26904945ac93a174fd80588ae603b833ffa34f"

--- a/packages/bls12-381/bls12-381.3.0.1/opam
+++ b/packages/bls12-381/bls12-381.3.0.1/opam
@@ -6,8 +6,8 @@ on top of it"""
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -24,10 +24,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/3.0.1/ocaml-bls12-381-3.0.1.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/3.0.1/ocaml-bls12-381-3.0.1.tar.bz2"
   checksum: [
     "md5=8c9a5a7e0383e2526705c618658ceed6"
     "sha512=c8d0e762dbbc17557c27b0a2009fd49c19ecd710b88feb3558d131ab8fd9bbb338bacc2ab6670788c3f3ac6f51c717ca6164e62bd204f661eee183cfda0e2376"

--- a/packages/bls12-381/bls12-381.3.0.2/opam
+++ b/packages/bls12-381/bls12-381.3.0.2/opam
@@ -5,8 +5,8 @@ on top of it"""
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -23,10 +23,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/3.0.2/ocaml-bls12-381-3.0.2.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/3.0.2/ocaml-bls12-381-3.0.2.tar.bz2"
   checksum: [
     "md5=6725d524fac86fcb701ec5f94d2045f2"
     "sha512=3622cdd98179091df3f563e3c5117313f1ad8e95d9f9713b6fe327b0b9ec404ea94499bf44309e377f189dfaf5adefd5b1aff0681bcb250bb08cb761415cafe6"

--- a/packages/bls12-381/bls12-381.3.0.3/opam
+++ b/packages/bls12-381/bls12-381.3.0.3/opam
@@ -5,8 +5,8 @@ on top of it"""
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -23,10 +23,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/3.0.3/ocaml-bls12-381-3.0.3.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/3.0.3/ocaml-bls12-381-3.0.3.tar.bz2"
   checksum: [
     "md5=367dcf0ed22d785fd521b838082fa60d"
     "sha512=dd801c6c642f61191762df0619a9e4a05524b7b85b2cd1bd8ddcfebfe78fca39be571c8b6552d91d3ae149683948a577d08e3f896d688ca6aad0ed5dd15e5799"

--- a/packages/bls12-381/bls12-381.4.0.0/opam
+++ b/packages/bls12-381/bls12-381.4.0.0/opam
@@ -5,8 +5,8 @@ on top of it"""
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -23,10 +23,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/4.0.0/ocaml-bls12-381-4.0.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/4.0.0/ocaml-bls12-381-4.0.0.tar.bz2"
   checksum: [
     "md5=82faa0c51f5bf5c846c79f35963ef6f2"
     "sha512=8b1620f3ccde4017e6205d18c7040b26f3b5affbc71237ffc263fe2d625a7276e20b44617a632736f1426bcc8eb184705360506ff88f0f1ecb28c7a0514fef29"

--- a/packages/bls12-381/bls12-381.5.0.0/opam
+++ b/packages/bls12-381/bls12-381.5.0.0/opam
@@ -5,8 +5,8 @@ on top of it"""
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-bls12-381"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-bls12-381/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.8.4"}
@@ -23,10 +23,10 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-bls12-381/-/archive/5.0.0/ocaml-bls12-381-5.0.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/5.0.0/ocaml-bls12-381-5.0.0.tar.bz2"
   checksum: [
     "md5=23aa3e2d11dad58248c0806785419985"
     "sha512=a11602f19275df4a5578eb8182c4507372f676f9ee4c21f02c0b5c96ab9b7d952668ee67578169b21eb88eb953fba1e189bad78fbefb3cd45266a32dd8ca17f7"

--- a/packages/class_group_vdf/class_group_vdf.0.0.1/opam
+++ b/packages/class_group_vdf/class_group_vdf.0.0.1/opam
@@ -21,7 +21,7 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos"
 url {
   src:
-    "https://gitlab.com/rrtoledo/ocaml-chia-vdf/-/archive/v0.0.1/ocaml-chia-vdf-v0.0.1.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-chia-vdf/-/archive/v0.0.1/ocaml-chia-vdf-v0.0.1.tar.gz"
   checksum: [
     "md5=9b61fc1b25d2e8a28c17c61a8bbcae1a"
     "sha512=7beef997574f3c46e0bbfc9fab1cf1265abc6acc83e204f3142aef2359517f1dfd9a641283b6e609c02557ad0f2f4bac355ba897ba365c54e9eae25aa5eccedf"

--- a/packages/class_group_vdf/class_group_vdf.0.0.2/opam
+++ b/packages/class_group_vdf/class_group_vdf.0.0.2/opam
@@ -21,7 +21,7 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos"
 url {
   src:
-    "https://gitlab.com/rrtoledo/ocaml-chia-vdf/-/archive/v0.0.2/ocaml-chia-vdf-v0.0.2.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-chia-vdf/-/archive/v0.0.2/ocaml-chia-vdf-v0.0.2.tar.gz"
   checksum: [
     "md5=2b20dfd020ad9a287f23c9435e5749ed"
     "sha512=bdf7dfa2b0a1c489949388eeba4fef10bffca972b7329765c2739458cae63cc575095a576b59cdd2b4acae25d6647f6dcdb47b53dc54e603a3406990d51163cf"

--- a/packages/class_group_vdf/class_group_vdf.0.0.3/opam
+++ b/packages/class_group_vdf/class_group_vdf.0.0.3/opam
@@ -21,7 +21,7 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos"
 url {
   src:
-    "https://gitlab.com/rrtoledo/ocaml-chia-vdf/-/archive/v0.0.3/ocaml-chia-vdf-v0.0.3.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-chia-vdf/-/archive/v0.0.3/ocaml-chia-vdf-v0.0.3.tar.gz"
   checksum: [
     "md5=aa2d03ad4dcd08f481c99e67e1c13561"
     "sha512=b06b1bf5e81a415a2e3d9c9873bc79b08caa28b65b3d2ddd8e76f20a304b2da6b9f33f1245fb41e93e3a8c77c95e47463aeca4e96cd2fc22f7e06a0d58cf6045"

--- a/packages/class_group_vdf/class_group_vdf.0.0.4/opam
+++ b/packages/class_group_vdf/class_group_vdf.0.0.4/opam
@@ -23,7 +23,7 @@ run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/nomadic-labs/tezos"
 url {
   src:
-    "https://gitlab.com/rrtoledo/ocaml-chia-vdf/-/archive/v0.0.4/ocaml-chia-vdf-v0.0.4.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-chia-vdf/-/archive/v0.0.4/ocaml-chia-vdf-v0.0.4.tar.gz"
   checksum: [
     "md5=9dedb6584bf23877136c328703d47532"
     "sha512=265f4c76fe995524260bff055347a9bb40cce9b5adf0f0222fd71a0cce29d51fe1fbac7b961577b6d28e16c8aa4630805c6365924e6fc0d06c4d07c84d2c6c78"

--- a/packages/ff-bench/ff-bench.0.6.1/opam
+++ b/packages/ff-bench/ff-bench.0.6.1/opam
@@ -4,8 +4,8 @@ description: "Benchmark library for finite fields over the package ff-sig"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -14,10 +14,10 @@ depends: [
   "core_bench" {= "v0.13.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
   checksum: [
     "md5=5853a7487785160bbcf0919f13ace049"
     "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"

--- a/packages/ff-bench/ff-bench.0.6.2/opam
+++ b/packages/ff-bench/ff-bench.0.6.2/opam
@@ -3,8 +3,8 @@ synopsis: "Benchmark library for finite fields over the package ff-sig"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -13,10 +13,10 @@ depends: [
   "core_bench" {>= "v0.13.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
   checksum: [
     "md5=fa68c430de8cba04fb8b7819e4cc4b38"
     "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"

--- a/packages/ff-pbt/ff-pbt.0.5.0/opam
+++ b/packages/ff-pbt/ff-pbt.0.5.0/opam
@@ -6,8 +6,8 @@ description:
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
@@ -16,10 +16,10 @@ depends: [
   "alcotest"
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
   checksum: [
     "md5=bb169cc29473e0f41f3c57382a4b9268"
     "sha512=a23741b42ad362320c2e554b58181941cd8a1e2d078e5c2625126be622216f2efc0d6367e6a4c6a80abd101f10602617c42e821cc4b7175f6891bf2791b0fd27"

--- a/packages/ff-pbt/ff-pbt.0.6.0/opam
+++ b/packages/ff-pbt/ff-pbt.0.6.0/opam
@@ -6,8 +6,8 @@ description:
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -17,10 +17,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.0/ocaml-ff-0.6.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.0/ocaml-ff-0.6.0.tar.gz"
   checksum: [
     "md5=96f94ec915b1662039c7961e0709f9d0"
     "sha512=e81bcdcc934e7b326548833e8085198eb3c3912bc4b5bd50f8c1317409b82bef3bf87ac743abb28aa830048568cb6bdbf54730b0a6994b3c5278bf658a666d98"

--- a/packages/ff-pbt/ff-pbt.0.6.1/opam
+++ b/packages/ff-pbt/ff-pbt.0.6.1/opam
@@ -6,8 +6,8 @@ description:
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -17,10 +17,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
   checksum: [
     "md5=5853a7487785160bbcf0919f13ace049"
     "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"

--- a/packages/ff-pbt/ff-pbt.0.6.2/opam
+++ b/packages/ff-pbt/ff-pbt.0.6.2/opam
@@ -4,8 +4,8 @@ synopsis:
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -15,10 +15,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
   checksum: [
     "md5=fa68c430de8cba04fb8b7819e4cc4b38"
     "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"

--- a/packages/ff-sig/ff-sig.0.5.0/opam
+++ b/packages/ff-sig/ff-sig.0.5.0/opam
@@ -4,18 +4,18 @@ description: "Minimal finite field signatures"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
   "zarith" {>= "1.9.1" & < "2.0"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
   checksum: [
     "md5=bb169cc29473e0f41f3c57382a4b9268"
     "sha512=a23741b42ad362320c2e554b58181941cd8a1e2d078e5c2625126be622216f2efc0d6367e6a4c6a80abd101f10602617c42e821cc4b7175f6891bf2791b0fd27"

--- a/packages/ff-sig/ff-sig.0.6.0/opam
+++ b/packages/ff-sig/ff-sig.0.6.0/opam
@@ -4,8 +4,8 @@ description: "Minimal finite field signatures"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -13,10 +13,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.0/ocaml-ff-0.6.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.0/ocaml-ff-0.6.0.tar.gz"
   checksum: [
     "md5=96f94ec915b1662039c7961e0709f9d0"
     "sha512=e81bcdcc934e7b326548833e8085198eb3c3912bc4b5bd50f8c1317409b82bef3bf87ac743abb28aa830048568cb6bdbf54730b0a6994b3c5278bf658a666d98"

--- a/packages/ff-sig/ff-sig.0.6.1/opam
+++ b/packages/ff-sig/ff-sig.0.6.1/opam
@@ -4,8 +4,8 @@ description: "Minimal finite field signatures"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -13,10 +13,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
   checksum: [
     "md5=5853a7487785160bbcf0919f13ace049"
     "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"

--- a/packages/ff-sig/ff-sig.0.6.2/opam
+++ b/packages/ff-sig/ff-sig.0.6.2/opam
@@ -3,8 +3,8 @@ synopsis: "Minimal finite field signatures"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -12,10 +12,10 @@ depends: [
   "bisect_ppx" {with-test & >= "2.5"}
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
   checksum: [
     "md5=fa68c430de8cba04fb8b7819e4cc4b38"
     "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"

--- a/packages/ff/ff.0.2.1/opam
+++ b/packages/ff/ff.0.2.1/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "dune" {>= "2.0"}
   "zarith" {>= "1.9.1" & < "2.0"}
@@ -13,10 +13,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.2.1/ocaml-ff-0.2.1.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.2.1/ocaml-ff-0.2.1.tar.gz"
   checksum: [
     "md5=86aa724458d6c547559add7312325541"
     "sha512=b689241a61836c7f094e7bb7ba8b640f84c401c82ec388dceacace6599dc3895baca352d7af0b2ee7c2c7a1275d1f0f451e7210e5424614fabea749528f68cf8"

--- a/packages/ff/ff.0.2.2/opam
+++ b/packages/ff/ff.0.2.2/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "dune" {>= "2.0"}
   "zarith" {>= "1.9.1" & < "2.0"}
@@ -13,10 +13,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.2.2/ocaml-ff-0.2.2.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.2.2/ocaml-ff-0.2.2.tar.gz"
   checksum: [
     "md5=15531761e4710f908b35bd3b1c7170f5"
     "sha512=6d1e9fc60dc15953951861e4eaf5b87bef3623b16deb120b705289dd3df7e915975632bb0c7212353722cc02361c3ac109e28372539177ce548c6a15c7fef0f0"

--- a/packages/ff/ff.0.3.0/opam
+++ b/packages/ff/ff.0.3.0/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "dune" {>= "2.0"}
   "zarith" {>= "1.9.1" & < "2.0"}
@@ -13,10 +13,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.3.0/ocaml-ff-0.3.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.3.0/ocaml-ff-0.3.0.tar.gz"
   checksum: [
     "md5=daea43b41cfc0b937692b15fbfa261ed"
     "sha512=a716ad108f83092bad5dfd9cfc2f9f302f7139fafa1568768f6ed4cca3bf0f5a62e9f52959c405637e80d048a080032048ec07500a1136a156a87f909a8d1b34"

--- a/packages/ff/ff.0.4.0/opam
+++ b/packages/ff/ff.0.4.0/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "dune" {>= "2.0"}
   "zarith" {>= "1.9.1" & < "2.0"}
@@ -13,10 +13,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.4.0/ocaml-ff-0.4.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.4.0/ocaml-ff-0.4.0.tar.gz"
   checksum: [
     "md5=ac1198ad3075847b7e8a8f1904ba44d8"
     "sha512=b20e5f114adbcd4d4e9dbf7b8a937776b07787052f6e6b965ffeaa3e3319f4ab9051d64e30a1a34d55f9f08509382b9aabc012988a2f704f3d770a65db48304d"

--- a/packages/ff/ff.0.5.0/opam
+++ b/packages/ff/ff.0.5.0/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.0"}
@@ -16,10 +16,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.5.0/ocaml-ff-0.5.0.tar.gz"
   checksum: [
     "md5=bb169cc29473e0f41f3c57382a4b9268"
     "sha512=a23741b42ad362320c2e554b58181941cd8a1e2d078e5c2625126be622216f2efc0d6367e6a4c6a80abd101f10602617c42e821cc4b7175f6891bf2791b0fd27"

--- a/packages/ff/ff.0.6.0/opam
+++ b/packages/ff/ff.0.6.0/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -17,10 +17,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.0/ocaml-ff-0.6.0.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.0/ocaml-ff-0.6.0.tar.gz"
   checksum: [
     "md5=96f94ec915b1662039c7961e0709f9d0"
     "sha512=e81bcdcc934e7b326548833e8085198eb3c3912bc4b5bd50f8c1317409b82bef3bf87ac743abb28aa830048568cb6bdbf54730b0a6994b3c5278bf658a666d98"

--- a/packages/ff/ff.0.6.1/opam
+++ b/packages/ff/ff.0.6.1/opam
@@ -4,8 +4,8 @@ description: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -17,10 +17,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.1/ocaml-ff-0.6.1.tar.gz"
   checksum: [
     "md5=5853a7487785160bbcf0919f13ace049"
     "sha512=c2e4d3d495a0fe6a5e52ac668d6f7694c7b9161bd0c6fc97cb6ed714a211c397a561feac8c2ea5738182809936c5f8f6e1e64696b0e0f9b3d19e309aa62dd4de"

--- a/packages/ff/ff.0.6.2/opam
+++ b/packages/ff/ff.0.6.2/opam
@@ -3,8 +3,8 @@ synopsis: "OCaml implementation of Finite Field operations"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ff"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ff/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
@@ -16,10 +16,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ff.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ff.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ff/-/archive/0.6.2/ocaml-ff-0.6.2.tar.gz"
   checksum: [
     "md5=fa68c430de8cba04fb8b7819e4cc4b38"
     "sha512=2046126f30704c16bd2dcd735b7eb9b8a6c8751892f895e6c992b0ebb921f7d2c824b9507b74368e3b66b53330dc70a57e70633105b642d021710b34fbc54a5c"

--- a/packages/mec/mec.0.1.0/opam
+++ b/packages/mec/mec.0.1.0/opam
@@ -3,8 +3,8 @@ synopsis: "Mec - Mini Elliptic Curve library"
 maintainer: "Danny Willems <be.danny.willems@gmail.com>"
 authors: "Danny Willems <be.danny.willems@gmail.com>"
 license: "MIT"
-homepage: "https://gitlab.com/dannywillems/ocaml-ec"
-bug-reports: "https://gitlab.com/dannywillems/ocaml-ec/issues"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ec"
+bug-reports: "https://gitlab.com/nomadic-labs/cryptography/ocaml-ec/issues"
 depends: [
   "ocaml" {>= "4.12"}
   "dune" {>= "2.7"}
@@ -20,10 +20,10 @@ depends: [
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://gitlab.com/dannywillems/ocaml-ec.git"
+dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-ec.git"
 url {
   src:
-    "https://gitlab.com/dannywillems/ocaml-ec/-/archive/0.1.0/ocaml-ec-0.1.0.tar.bz2"
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-ec/-/archive/0.1.0/ocaml-ec-0.1.0.tar.bz2"
   checksum: [
     "md5=7c68b531c8011b5d032f0a0d8523e8c5"
     "sha512=f428751c5f2b7c7fc07548551bea0277c9c8c32c1052aecf22787188e7678939dbb091844e29178b2819d724cf843c65774d9211c0a0ede5bf71caff3f2dd1bc"


### PR DESCRIPTION
Updating links for Nomadic Labs repository which were recently consolidated under [gitlab.com/nomadic-labs/cryptography/](https://gitlab.com/nomadic-labs/cryptography)