### PR TITLE
Release mbr-format.1.0.0 and mirage-block-partition

### DIFF
--- a/packages/mbr-format/mbr-format.1.0.0/opam
+++ b/packages/mbr-format/mbr-format.1.0.0/opam
@@ -22,6 +22,7 @@ conflicts: [
   "result" {< "1.5"}
 ]
 synopsis: "A simple library for manipulating Master Boot Records"
+license: "ISC"
 url {
   src:
     "https://github.com/mirage/ocaml-mbr/releases/download/v1.0.0/mbr-format-1.0.0.tbz"

--- a/packages/mbr-format/mbr-format.1.0.0/opam
+++ b/packages/mbr-format/mbr-format.1.0.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune"
+  "dune" {>= "3.4.0"}
   "lwt"
   "cstruct" {>= "6.0.0"}
   "ppx_cstruct"

--- a/packages/mbr-format/mbr-format.1.0.0/opam
+++ b/packages/mbr-format/mbr-format.1.0.0/opam
@@ -18,6 +18,9 @@ depends: [
   "fmt" {with-test}
   "alcotest" {with-test}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 synopsis: "A simple library for manipulating Master Boot Records"
 url {
   src:

--- a/packages/mbr-format/mbr-format.1.0.0/opam
+++ b/packages/mbr-format/mbr-format.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   ["Reynir Björnsson <reynir@reynir.dk>" "dave.scott@eu.citrix.com"]
+authors:      "dave.scott@eu.citrix.com"
+homepage:     "https://github.com/mirage/ocaml-mbr"
+bug-reports:  "https://github.com/mirage/ocaml-mbr/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-mbr.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "lwt"
+  "cstruct" {>= "6.0.0"}
+  "ppx_cstruct"
+  "fmt" {with-test}
+  "alcotest" {with-test}
+]
+synopsis: "A simple library for manipulating Master Boot Records"
+url {
+  src:
+    "https://github.com/mirage/ocaml-mbr/releases/download/v1.0.0/mbr-format-1.0.0.tbz"
+  checksum: [
+    "sha256=8007ab4cf6b9bca89db8dc29ad4b5689b712cb303868e553cc583f5a995fa787"
+    "sha512=5bb55faf907b3cc6bd8fbd56bac6b7bfcd0ab37a62daf0235accc66c6a9e89a15e72f8274d725bbace1c815d72959c9894f053dd22a6f31d65bd7f8f9ec948a3"
+  ]
+}
+x-commit-hash: "c59c701c0dfb1c5cd5e05b0f474b3702870fbdd6"

--- a/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
+++ b/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
@@ -26,6 +26,9 @@ depends: [
   "alcotest" { with-test }
   "alcotest-lwt" { with-test }
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 url {
   src:
     "https://github.com/reynir/mirage-block-partition/releases/download/v0.1.0/mirage-block-partition-0.1.0.tbz"

--- a/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
+++ b/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: [ "Reynir Björnsson <reynir@reynir.dk>" ]
+authors: [ "Reynir Björnsson <reynir@reynir.dk>" ]
+homepage: "https://github.com/reynir/mirage-block-partition"
+bug-reports: "https://github.com/reynir/mirage-block-partition/issues"
+dev-repo: "git+https://github.com/reynir/mirage-block-partition.git"
+license: "ISC"
+synopsis: "Mirage block device partitioning"
+description: """
+Mirage-block-partition lets you view a mirage block device as smaller partitions.
+"""
+
+build: [
+  [ "dune" "subst" ] { dev }
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] { with-test }
+]
+depends: [
+  "dune" {>= "3.4"}
+  "ocaml" {>= "4.08.0"}
+  "mirage-block"
+  "lwt"
+  "mbr-format" {>= "1.0.0"}
+
+  "mirage-block-combinators" { with-test }
+  "alcotest" { with-test }
+  "alcotest-lwt" { with-test }
+]
+url {
+  src:
+    "https://github.com/reynir/mirage-block-partition/releases/download/v0.1.0/mirage-block-partition-0.1.0.tbz"
+  checksum: [
+    "sha256=cef80c615dcdefad27055e9d309077896d73e8be0ca001c69698cf372ed60c0a"
+    "sha512=d8c75976c97028bb738a25d61078234b9b36c20a225b8cbf30d3c9afeaba94f1734fd98ab3af7508d334d6884f9bfde0d36d8d544d99c5eb5f8b156bd4f60505"
+  ]
+}
+x-commit-hash: "6e7b212276a67e72a4a8ea2725242ca38d560077"

--- a/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
+++ b/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "dune" {>= "3.4"}
   "ocaml" {>= "4.08.0"}
-  "mirage-block"
+  "mirage-block" {>= "3.0.0"}
   "lwt"
   "mbr-format" {>= "1.0.0"}
 

--- a/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
+++ b/packages/mirage-block-partition/mirage-block-partition.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "3.4"}
   "ocaml" {>= "4.08.0"}
   "mirage-block" {>= "3.0.0"}
-  "lwt"
+ "lwt" {>= "5.6.0"}
   "mbr-format" {>= "1.0.0"}
 
   "mirage-block-combinators" { with-test }


### PR DESCRIPTION
`mbr-format` lives at https://github.com/mirage/ocaml-mbr and `mirage-block-partition` lives at https://github.com/reynir/mirage-block-partition.