### PR TITLE
[new release] malfunction (0.4.1)

### DIFF
--- a/packages/malfunction/malfunction.0.4.1/opam
+++ b/packages/malfunction/malfunction.0.4.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "stephen.dolan@cl.cam.ac.uk"
+authors: ["Stephen Dolan"]
+homepage: "https://github.com/stedolan/malfunction"
+bug-reports: "https://github.com/stedolan/malfunction/issues"
+dev-repo: "git+https://github.com/stedolan/malfunction.git"
+license: "LGPL-2.0-or-later"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.04" & < "5.0.0"}
+  "ocamlfind"
+  "dune" {>= "1.2"}
+  "cppo" {build & >= "1.1.0"}
+  "omd" {with-test & < "2.0.0~"}
+  "craml" {with-test}
+  "zarith"
+]
+synopsis: "Compiler back-end for functional languages, based on OCaml"
+description: """
+Malfunction is a high-performance, low-level untyped program
+representation, designed as a target for compilers of functional
+programming languages."""
+url {
+  src:
+    "https://github.com/stedolan/malfunction/releases/download/v0.4.1/malfunction-0.4.1.tbz"
+  checksum: [
+    "sha256=0d5f104c73dda414faa987ecb9daf03101e3c962919746634ad972cb2f891dd5"
+    "sha512=d1109cf4ebe671d1b8ad1210816d6e83d4bde0a14157ffb689fc129b74f2c8f4add34babad96408161c27b2fdf0dfb497cc0a9a2f16f690e7ae90fd101a71860"
+  ]
+}
+x-commit-hash: "4618d42a9c4b4b4a09f1d34014117e13422b3f27"


### PR DESCRIPTION
Compiler back-end for functional languages, based on OCaml

- Project page: <a href="https://github.com/stedolan/malfunction">https://github.com/stedolan/malfunction</a>

##### CHANGES:

Bugfix for integer shift counts
