### PR TITLE
[new release] cairo2, cairo2-pango and cairo2-gtk (0.6.4)

### DIFF
--- a/packages/cairo2-gtk/cairo2-gtk.0.6.4/opam
+++ b/packages/cairo2-gtk/cairo2-gtk.0.6.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {>= "2.0.0"}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2" {= version}
+  "lablgtk"
+]
+synopsis: "Rendering Cairo on Gtk2 canvas"
+description: """
+This provides the link between Cairo and Lablgtk.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.4/cairo2-0.6.4.tbz"
+  checksum: [
+    "sha256=40357352d7205d3a5735855643830cb345f2db838ff9d19a532018760d468a05"
+    "sha512=2fd755b32253a4c441146fb41d13bf7ad4ce3828bc479ece296fb58350e20c7349c22457ad99fa080407b5150ce337a753221043f18b7b641f4c5bc98e37e799"
+  ]
+}
+x-commit-hash: "aa096da2aafe6a59ea48ed7b4907e451757b8b91"

--- a/packages/cairo2-pango/cairo2-pango.0.6.4/opam
+++ b/packages/cairo2-pango/cairo2-pango.0.6.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.02"}
+  "base-bigarray"
+  "dune" {>= "2.7.0"}
+  "conf-pkg-config" {build}
+  "conf-cairo"
+  "cairo2" {= version}
+  "lablgtk"
+]
+synopsis: "Interface between Cairo and Pango (for Gtk2)"
+description: """
+This package provides a way to use Pango (lablgtk, Gtk2) with Cairo.
+"""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.4/cairo2-0.6.4.tbz"
+  checksum: [
+    "sha256=40357352d7205d3a5735855643830cb345f2db838ff9d19a532018760d468a05"
+    "sha512=2fd755b32253a4c441146fb41d13bf7ad4ce3828bc479ece296fb58350e20c7349c22457ad99fa080407b5150ce337a753221043f18b7b641f4c5bc98e37e799"
+  ]
+}
+x-commit-hash: "aa096da2aafe6a59ea48ed7b4907e451757b8b91"

--- a/packages/cairo2/cairo2.0.6.4/opam
+++ b/packages/cairo2/cairo2.0.6.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: [ "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+           "Pierre Hauweele <pierre@hauweele.net>" ]
+license: "LGPL-3.0"
+homepage: "https://github.com/Chris00/ocaml-cairo"
+dev-repo: "git+https://github.com/Chris00/ocaml-cairo.git"
+bug-reports: "https://github.com/Chris00/ocaml-cairo/issues"
+doc: "https://Chris00.github.io/ocaml-cairo/doc"
+tags: ["Cairo" "stroke" "drawing" "tutorial"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "base-bigarray"
+  "dune" {>= "2.7.0"}
+  "dune-configurator" {>= "2.7.0"}
+  "conf-cairo"
+]
+depopts: [
+  "conf-freetype"
+]
+conflicts: [
+  "cairo" {= "0.4.1"}
+  "cairo" {= "0.4.2"}
+]
+post-messages: [
+  "Try to re-run the install command with PKG_CONFIG_PATH pointing a pkg-config path including libffi, e.g. if you use homebrew you can try PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig" {failure & os = "macos"}
+]
+synopsis: "Binding to Cairo, a 2D Vector Graphics Library"
+description: """
+This is a binding to Cairo, a 2D graphics library with support for
+multiple output devices. Currently supported output targets include
+the X Window System, Quartz, Win32, image buffers, PostScript, PDF,
+and SVG file output."""
+url {
+  src:
+    "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.4/cairo2-0.6.4.tbz"
+  checksum: [
+    "sha256=40357352d7205d3a5735855643830cb345f2db838ff9d19a532018760d468a05"
+    "sha512=2fd755b32253a4c441146fb41d13bf7ad4ce3828bc479ece296fb58350e20c7349c22457ad99fa080407b5150ce337a753221043f18b7b641f4c5bc98e37e799"
+  ]
+}
+x-commit-hash: "aa096da2aafe6a59ea48ed7b4907e451757b8b91"


### PR DESCRIPTION
Binding to Cairo, a 2D Vector Graphics Library

- Project page: <a href="https://github.com/Chris00/ocaml-cairo">https://github.com/Chris00/ocaml-cairo</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-cairo/doc">https://Chris00.github.io/ocaml-cairo/doc</a>

##### CHANGES:

- Be compatible with OCaml 5.0 (@kit-ty-kate).
