### PR TITLE
[new release] gmp (6.2.1-4)

### DIFF
--- a/packages/gmp/gmp.6.2.1-4/opam
+++ b/packages/gmp/gmp.6.2.1-4/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Lucas Pluvinage <lucas@tarides.com>"
+license: ["LGPL-3.0-only" "LGPL-2.0-only"]
+authors: "Torbjörn Granlund and contributors"
+homepage: "https://github.com/mirage/ocaml-gmp"
+bug-reports: "https://github.com/mirage/ocaml-gmp/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-gmp.git"
+substs: [ "src/build.sh" ]
+build: [
+ [ "dune" "build" "-p" name "-j" jobs ]
+ [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.6"}
+  "conf-m4"
+]
+synopsis: "The GNU Multiple Precision Arithmetic Library"
+description: """Dune packaging of the GMP library, suitable for 
+cross-compilation."""
+url {
+  src:
+    "https://github.com/mirage/ocaml-gmp/releases/download/6.2.1-4/gmp-6.2.1-4.tbz"
+  checksum: [
+    "sha256=cc8fa6fa12f7aba1947b6da7b5c527b8b9a1fb0c655276be51d0718002232b71"
+    "sha512=94b8a0a30762a2342ca70e8e5365489aea90bba12794bae86cb6676baacac0639be981131d6ee610dbf5961355a55426546f446e918c5223e363390a85bd3809"
+  ]
+}
+x-commit-hash: "b4bb9b0a47da25464b087b6f858180efd0aa6589"


### PR DESCRIPTION
The GNU Multiple Precision Arithmetic Library

- Project page: <a href="https://github.com/mirage/ocaml-gmp">https://github.com/mirage/ocaml-gmp</a>

##### CHANGES:

- Build system: when used in a monorepo, do not invoke `opam` to figure out the
  level of parallelism. Instead, use `sysctl` to obtain the number of cores and
  provide `1` as a default value. (@RyanGibb, mirage/ocaml-gmp#18)
