### PR TITLE
Package ocamlbuild.0.14.2

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.2/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/ocamlbuild/"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+]
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.14.2.tar.gz"
+  checksum: [
+    "md5=2f407fadd57b073155a6aead887d9676"
+    "sha512=f568bf10431a1f701e8bd7554dc662400a0d978411038bbad93d44dceab02874490a8a5886a9b44e017347e7949997f13f5c3752f74e1eb5e273d2beb19a75fd"
+  ]
+}


### PR DESCRIPTION
### `ocamlbuild.0.14.2`
OCamlbuild is a build system with builtin rules to easily build most OCaml projects



---
* Homepage: https://github.com/ocaml/ocamlbuild/
* Source repo: git+https://github.com/ocaml/ocamlbuild.git
* Bug tracker: https://github.com/ocaml/ocamlbuild/issues

---
:camel: Pull-request generated by opam-publish v2.1.0