### PR TITLE
[new release] wayland (1.1)

### DIFF
--- a/packages/wayland/wayland.1.1/opam
+++ b/packages/wayland/wayland.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Wayland protocol library"
+description:
+  "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0 (excluding schema files)"
+homepage: "https://github.com/talex5/ocaml-wayland"
+doc: "https://talex5.github.io/ocaml-wayland/"
+bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "ocaml" {>= "4.08.0"}
+  "xmlm" {>= "1.3.0"}
+  "lwt" {>= "5.4.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cstruct" {>= "6.0.0"}
+  "cmdliner" {>= "1.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/ocaml-wayland.git"
+url {
+  src:
+    "https://github.com/talex5/ocaml-wayland/releases/download/v1.1/wayland-1.1.tbz"
+  checksum: [
+    "sha256=cdeca72c7ff949cbd0fb4d1e1141e4cf7aa75368db7ced4667dd4404e0fbec2c"
+    "sha512=815a0987a184615df39e0acfb912fbdd7ba2a1ae1e65267d9eeac6a63afe9d205c4d3c335b92f770227ecc93cd88f8e65e84328cd3dc17523b5eb42676e032ee"
+  ]
+}
+x-commit-hash: "c20c69d52f237812c63a8193bc2a0bf6547c08a4"

--- a/packages/wayland/wayland.1.1/opam
+++ b/packages/wayland/wayland.1.1/opam
@@ -4,7 +4,7 @@ description:
   "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
 maintainer: ["talex5@gmail.com"]
 authors: ["talex5@gmail.com"]
-license: "Apache-2.0 (excluding schema files)"
+license: "Apache-2.0 AND LicenseRef-various-licenses-for-the-schema-files"
 homepage: "https://github.com/talex5/ocaml-wayland"
 doc: "https://talex5.github.io/ocaml-wayland/"
 bug-reports: "https://github.com/talex5/ocaml-wayland/issues"


### PR DESCRIPTION
Pure OCaml Wayland protocol library

- Project page: <a href="https://github.com/talex5/ocaml-wayland">https://github.com/talex5/ocaml-wayland</a>
- Documentation: <a href="https://talex5.github.io/ocaml-wayland/">https://talex5.github.io/ocaml-wayland/</a>

##### CHANGES:

- Add update.sh script and update protocols (@MisterDA talex5/ocaml-wayland#25, @talex5 talex5/ocaml-wayland#33).

- Improve proxy module documentation (@talex5 talex5/ocaml-wayland#31).

- Improve "No such object" error (@talex5 talex5/ocaml-wayland#28).

- Make `Handler.cast_version` more general (@talex5 talex5/ocaml-wayland#27).
  Avoids the need to cast to `Handler.t` before using `cast_version`.

- Update to cmdliner.1.1.1 (@MisterDA talex5/ocaml-wayland#26).
