### PR TITLE
[new release] nbd, nbd-unix and nbd-tool (6.0.1)

### DIFF
--- a/packages/nbd-tool/nbd-tool.6.0.1/opam
+++ b/packages/nbd-tool/nbd-tool.6.0.1/opam
@@ -30,7 +30,7 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
-  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test & os != "macos" & os-distribution != "alpine"}
 ]
 dev-repo: "git+https://github.com/xapi-project/nbd.git"
 url {

--- a/packages/nbd-tool/nbd-tool.6.0.1/opam
+++ b/packages/nbd-tool/nbd-tool.6.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Network Block Device (NBD) protocol implementation"
+description: """
+This library allows applications to export and consume block
+devices using the NBD protocol (as used by Linux, qemu etc)"""
+maintainer: "Xapi project maintainers"
+authors: ["Jonathan Ludlam" "David Scott" "Thomas Sanders"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/xapi-project/nbd"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "lwt" {>= "2.7.0"}
+  "lwt_log"
+  "mirage-block-unix"
+  "nbd-unix" {=version}
+  "odoc" {with-doc}
+  "uri"
+]
+depexts: [
+  ["qemu-img" "nbd" "nmap-ncat"] {with-test & os-family = "rhel"}
+  ["qemu-utils" "nbd-client" "netcat-openbsd"] {with-test & os-family = "debian"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/xapi-project/nbd.git"
+url {
+  src:
+    "https://github.com/xapi-project/nbd/releases/download/6.0.1/nbd-6.0.1.tbz"
+  checksum: [
+    "sha256=2bd3db48f84d5cc3e67ef46d323034118a6936276b2ca2689c871733482d59d0"
+    "sha512=c8588b81a7e99609c934b7f720caf50d0cee1fd3f86465ead3f9a5da2de94cb8d14a767b365efe66f5e75112889bf2debc97b33f71ec58afb877b06c11d49c22"
+  ]
+}
+x-commit-hash: "aa1bfc5eb58c1defd89cd96bb98f7b6a72fadf42"

--- a/packages/nbd-unix/nbd-unix.6.0.1/opam
+++ b/packages/nbd-unix/nbd-unix.6.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Network Block Device (NBD) protocol implementation"
+description: """
+This library allows applications to export and consume block
+devices using the NBD protocol (as used by Linux, qemu etc)"""
+maintainer: "Xapi project maintainers"
+authors: ["Jonathan Ludlam" "David Scott" "Thomas Sanders"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/xapi-project/nbd"
+doc: "https://xapi-project.github.io/nbd/nbd-unix/index.html"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "bigarray-compat"
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct-lwt"
+  "io-page" {>= "2.4.0"}
+  "lwt" {>= "2.7.0"}
+  "lwt_ssl"
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-unix"
+  "nbd" {=version}
+  "odoc" {with-doc}
+  "ssl"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+dev-repo: "git+https://github.com/xapi-project/nbd.git"
+url {
+  src:
+    "https://github.com/xapi-project/nbd/releases/download/6.0.1/nbd-6.0.1.tbz"
+  checksum: [
+    "sha256=2bd3db48f84d5cc3e67ef46d323034118a6936276b2ca2689c871733482d59d0"
+    "sha512=c8588b81a7e99609c934b7f720caf50d0cee1fd3f86465ead3f9a5da2de94cb8d14a767b365efe66f5e75112889bf2debc97b33f71ec58afb877b06c11d49c22"
+  ]
+}
+x-commit-hash: "aa1bfc5eb58c1defd89cd96bb98f7b6a72fadf42"

--- a/packages/nbd/nbd.6.0.1/opam
+++ b/packages/nbd/nbd.6.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Xapi project maintainers"
+authors: [ "Jonathan Ludlam" "David Scott" "Thomas Sanders" ]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/nbd"
+doc: "https://xapi-project.github.io/nbd/nbd/index.html"
+dev-repo: "git+https://github.com/xapi-project/nbd.git"
+bug-reports: "https://github.com/xapi-project/nbd/issues"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "dune" {>= "2.7.0"}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "cstruct" {>= "6.0.0"}
+  "io-page" {>= "2.4.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix"
+  "lwt" {>= "2.7.0"}
+  "lwt_log"
+  "odoc" {with-doc}
+  "ppx_cstruct" {>= "3.1.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "rresult"
+  "sexplib"
+  "uri"
+]
+conflicts: ["result" {< "1.5"}]
+tags: [ "org:mirage" "org:xapi-project" ]
+synopsis: "Network Block Device (NBD) protocol implementation"
+description: """
+This library allows applications to export and consume block
+devices using the NBD protocol (as used by Linux, qemu etc)"""
+url {
+  src:
+    "https://github.com/xapi-project/nbd/releases/download/6.0.1/nbd-6.0.1.tbz"
+  checksum: [
+    "sha256=2bd3db48f84d5cc3e67ef46d323034118a6936276b2ca2689c871733482d59d0"
+    "sha512=c8588b81a7e99609c934b7f720caf50d0cee1fd3f86465ead3f9a5da2de94cb8d14a767b365efe66f5e75112889bf2debc97b33f71ec58afb877b06c11d49c22"
+  ]
+}
+x-commit-hash: "aa1bfc5eb58c1defd89cd96bb98f7b6a72fadf42"


### PR DESCRIPTION
Network Block Device (NBD) protocol implementation

- Project page: <a href="https://github.com/xapi-project/nbd">https://github.com/xapi-project/nbd</a>
- Documentation: <a href="https://xapi-project.github.io/nbd/nbd/index.html">https://xapi-project.github.io/nbd/nbd/index.html</a>

##### CHANGES:

* Require mirage-block 3.0.0, drop io-page-unix.
