### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.2.0)

### DIFF
--- a/packages/git-paf/git-paf.3.7.0/opam
+++ b/packages/git-paf/git-paf.3.7.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.0.7"}
+  "paf" {>= "0.0.7" & < "0.2.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.7.1/opam
+++ b/packages/git-paf/git-paf.3.7.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.0.7"}
+  "paf" {>= "0.0.7" & < "0.2.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.8.0/opam
+++ b/packages/git-paf/git-paf.3.8.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.0.7"}
+  "paf" {>= "0.0.7" & < "0.2.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.8.1/opam
+++ b/packages/git-paf/git-paf.3.8.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.0.7"}
+  "paf" {>= "0.0.7" & < "0.2.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.9.0/opam
+++ b/packages/git-paf/git-paf.3.9.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.0.7"}
+  "paf" {>= "0.0.7" & < "0.2.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/git-paf/git-paf.3.9.1/opam
+++ b/packages/git-paf/git-paf.3.9.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "git" {= version}
   "mimic" {>= "0.0.4"}
-  "paf" {>= "0.0.7"}
+  "paf" {>= "0.0.7" & < "0.2.0"}
   "ca-certs-nss"
   "fmt"
   "ipaddr"

--- a/packages/paf-cohttp/paf-cohttp.0.2.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.2.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"           {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
 dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
 url {
   src:

--- a/packages/paf-cohttp/paf-cohttp.0.2.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.2.0/paf-0.2.0.tbz"
+  checksum: [
+    "sha256=4f3851c454cf90b300b0b3e5d0e342f034612511acb45e7cf9044a6c6b896551"
+    "sha512=9099f013c18d7cb019bac334ac29d56d6d3966cc301bcbf52653dcb1e9fde7f8213b7ea6be1189a9b0b19167314b4580f84ecc8478c7ac830dba34b78b7829ee"
+  ]
+}
+x-commit-hash: "62fd9f9dccd06a42c781a83437565570e4a072c0"

--- a/packages/paf-le/paf-le.0.2.0/opam
+++ b/packages/paf-le/paf-le.0.2.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.2.0/paf-0.2.0.tbz"
+  checksum: [
+    "sha256=4f3851c454cf90b300b0b3e5d0e342f034612511acb45e7cf9044a6c6b896551"
+    "sha512=9099f013c18d7cb019bac334ac29d56d6d3966cc301bcbf52653dcb1e9fde7f8213b7ea6be1189a9b0b19167314b4580f84ecc8478c7ac830dba34b78b7829ee"
+  ]
+}
+x-commit-hash: "62fd9f9dccd06a42c781a83437565570e4a072c0"

--- a/packages/paf/paf.0.2.0/opam
+++ b/packages/paf/paf.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic" {>= "0.0.5"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.9.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.2.0/paf-0.2.0.tbz"
+  checksum: [
+    "sha256=4f3851c454cf90b300b0b3e5d0e342f034612511acb45e7cf9044a6c6b896551"
+    "sha512=9099f013c18d7cb019bac334ac29d56d6d3966cc301bcbf52653dcb1e9fde7f8213b7ea6be1189a9b0b19167314b4580f84ecc8478c7ac830dba34b78b7829ee"
+  ]
+}
+x-commit-hash: "62fd9f9dccd06a42c781a83437565570e4a072c0"

--- a/packages/paf/paf.0.2.0/opam
+++ b/packages/paf/paf.0.2.0/opam
@@ -32,7 +32,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
 dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
 url {
   src:


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Fix several issues about h2 protocols (@dinosaure, dinosaure/paf-le-chien#70)
- Delete the `Time` device (@dinosaure, @hannesm, dinosaure/paf-le-chien#70)
- Upgrade the distribution with the new interface of `Alpn` module and `Paf_mirage` (@dinosaure, dinosaure/paf-le-chien#70)
- Update unikernels (@dinosaure, dinosaure/paf-le-chien#70)
