### PR TITLE
[new release] carton, carton-git and carton-lwt (0.5.0)

### DIFF
--- a/packages/carton-git/carton-git.0.5.0/opam
+++ b/packages/carton-git/carton-git.0.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "carton-lwt" {= version}
+  "bigstringaf" {>= "0.9.0"}
+  "lwt"
+  "fpath"
+  "result"
+  "fmt" {>= "0.8.9"}
+  "base-unix"
+  "decompress" {>= "1.4.3"}
+  "astring" {>= "0.8.5"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.1.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.6" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.5.0/git-carton-v0.5.0.tbz"
+  checksum: [
+    "sha256=4d38e4a5630e21ce059d76b11be1ef3e5fce3b2469d8566ba8b7f1a371137925"
+    "sha512=643dc8885b2933cfd1b60e41e852d0a9608439cf95fe7ad9ff53c3ede15487c0c392270f6e7f0c34b3993e7f65a3f1e5d014dc91091e6980719c476b325055d5"
+  ]
+}
+x-commit-hash: "803cd7b76540c15f99d0867568cd58dab581c809"

--- a/packages/carton-lwt/carton-lwt.0.5.0/opam
+++ b/packages/carton-lwt/carton-lwt.0.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACK file in OCaml"
+description: """\
+Carton is an implementation of the PACK file
+in OCaml. PACK file is used by Git to store Git objects. Carton is more
+abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "carton" {= version}
+  "lwt"
+  "decompress" {>= "1.4.3"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.9.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "cstruct" {>= "6.1.0" & with-test}
+  "fmt" {>= "0.8.9" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+  "result" {>= "1.5" & with-test}
+  "rresult" {>= "0.6.0" & with-test}
+  "ke" {>= "0.6" & with-test}
+  "base64" {>= "3.4.0" & with-test}
+  "bos" {>= "0.2.0" & with-test}
+  "checkseum" {>= "0.3.3" & with-test}
+  "digestif" {>= "1.1.2" & with-test}
+  "fpath" {>= "0.7.3" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.5.0/git-carton-v0.5.0.tbz"
+  checksum: [
+    "sha256=4d38e4a5630e21ce059d76b11be1ef3e5fce3b2469d8566ba8b7f1a371137925"
+    "sha512=643dc8885b2933cfd1b60e41e852d0a9608439cf95fe7ad9ff53c3ede15487c0c392270f6e7f0c34b3993e7f65a3f1e5d014dc91091e6980719c476b325055d5"
+  ]
+}
+x-commit-hash: "803cd7b76540c15f99d0867568cd58dab581c809"

--- a/packages/carton/carton.0.5.0/opam
+++ b/packages/carton/carton.0.5.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Implementation of PACKv2 file in OCaml"
+description: """\
+Carton is an implementation of the PACKv2 file
+in OCaml. PACKv2 file is used by Git to store Git objects.
+Carton is more abstracted when it can store any objects."""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "ke" {>= "0.6"}
+  "duff" {>= "0.5"}
+  "decompress" {>= "1.4.3"}
+  "cstruct" {>= "6.1.0"}
+  "optint" {>= "0.0.4"}
+  "bigstringaf" {>= "0.9.0"}
+  "checkseum" {>= "0.3.3"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "hxd" {>= "0.3.2"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "result"
+  "rresult"
+  "fpath"
+  "base64" {with-test & >= "3.0.0"}
+  "bos"
+  "digestif" {>= "1.1.2"}
+  "base-unix" {with-test}
+  "base-threads" {with-test}
+  "alcotest" {with-test}
+  "crowbar" {with-test & >= "0.2.1"}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "lwt" {>= "5.3.0" & with-test}
+  "ocamlfind" {>= "1.8.1" & with-test}
+  "mirage-flow" {>= "2.0.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/carton-v0.5.0/git-carton-v0.5.0.tbz"
+  checksum: [
+    "sha256=4d38e4a5630e21ce059d76b11be1ef3e5fce3b2469d8566ba8b7f1a371137925"
+    "sha512=643dc8885b2933cfd1b60e41e852d0a9608439cf95fe7ad9ff53c3ede15487c0c392270f6e7f0c34b3993e7f65a3f1e5d014dc91091e6980719c476b325055d5"
+  ]
+}
+x-commit-hash: "803cd7b76540c15f99d0867568cd58dab581c809"


### PR DESCRIPTION
Implementation of PACKv2 file in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Add missing dependencies on Unix (@dra27, mirage/ocaml-git#573)
- Be able to choose the zlib compression level when we generate a PACK file (@dinosaure, mirage/ocaml-git#578)
- Fix spurious bug when we encode a patch into a PACK file (@dinosaure, mirage/ocaml-git#578)
- Add an accessor to get the hash `ctx` computed by the first-pass of a PACK file (@dinosaure, mirage/ocaml-git#584)
- Fix how we record the _weight_ of Git objects into a PACK file (@dinosaure, mirage/ocaml-git#591)
