### PR TITLE
Package lucid.0.1.5

### DIFF
--- a/packages/lucid/lucid.0.1.5/opam
+++ b/packages/lucid/lucid.0.1.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Tarun Agarwal <me@tarunagarwal.me>"
+homepage: "https://github.com/kodwx/Lucid"
+bug-reports: "https://github.com/kodwx/Lucid/issues"
+dev-repo: "git+https://github.com/kodwx/Lucid.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune"  {>= "3.0.0"}
+]
+synopsis: "Super simple logging library for OCaml."
+description: "
+Super simple logging library for OCaml.
+Lucid has no runtime dependencies, but building it requires dune.
+"
+authors: "Tarun Agarwal <me@tarunagarwal.me>"
+url {
+  src: "https://github.com/kodwx/Lucid/archive/v0.1.5.tar.gz"
+  checksum: [
+    "md5=a9ea439ccba707b5a206cf2a316caeda"
+    "sha512=4d2a58563f673d55c47f3fb2d44ce553bf1074762ebc4edb02720e54684b6573a3fb8271450c27656639b5692be1a0d36c681c852dace360182c735a7cd9e82b"
+  ]
+}

--- a/packages/lucid/lucid.0.1.5/opam
+++ b/packages/lucid/lucid.0.1.5/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.13.0"}
   "dune"  {>= "3.0.0"}
 ]
-synopsis: "Super simple logging library for OCaml."
+synopsis: "Super simple logging library for OCaml"
 description: "
 Super simple logging library for OCaml.
 Lucid has no runtime dependencies, but building it requires dune.


### PR DESCRIPTION
### `lucid.0.1.5`
Super simple logging library for OCaml.
Super simple logging library for OCaml.
Lucid has no runtime dependencies, but building it requires dune.



---
* Homepage: https://github.com/kodwx/Lucid
* Source repo: git+https://github.com/kodwx/Lucid.git
* Bug tracker: https://github.com/kodwx/Lucid/issues

---
:camel: Pull-request generated by opam-publish v2.1.0