### PR TITLE
hilite 0.1: add upper-bound on textmate-language for tests

### DIFF
--- a/packages/hilite/hilite.0.1.0/opam
+++ b/packages/hilite/hilite.0.1.0/opam
@@ -13,6 +13,7 @@ depends: [
   "yojson"
   "omd" {>= "2.0.0~alpha2"}
   "textmate-language" {>= "0.3.0"}
+  "textmate-language" {with-test & < "0.3.2"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling hilite.0.1.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/hilite.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p hilite -j 31 --promote-install-files=false @install @runtest
# exit-code            1
# env-file             ~/.opam/log/hilite-7-6f8a2d.env
# output-file          ~/.opam/log/hilite-7-6f8a2d.out
### output ###
# File "test/test_md.expected", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/test_md.expected _build/default/test/test_md.output
# diff --git a/_build/default/test/test_md.expected b/_build/default/test/test_md.output
# index 9917231..0a41764 100644
# --- a/_build/default/test/test_md.expected
# +++ b/_build/default/test/test_md.output
# @@ -1,3 +1,3 @@
#  ((paragraph "OCaml is a great language, e.g.")
#   (html
# -  "<pre><code><span class='ocaml-keyword'>let </span><span class='ocaml-entity-name-function-binding'>add</span><span class='ocaml-source'> </span><span class='ocaml-source'>a</span><span class='ocaml-source'> </span><span class='ocaml-source'>b</span><span class='ocaml-source'> </span><span class='ocaml-keyword-operator'>=</span><span class='ocaml-source'> </span><span class='ocaml-source'>a</span><span class='ocaml-source'> </span><span class='ocaml-keyword-operator'>+</span><span class='ocaml-source'> </span><span class='ocaml-source'>b</span><span class='ocaml-source'> \n</span></code></pre>"))
# +  "<pre><code><span class='ocaml-keyword'>let</span><span class='ocaml-source'> </span><span class='ocaml-entity-name-function-binding'>add</span><span class='ocaml-source'> </span><span class='ocaml-source'>a</span><span class='ocaml-source'> </span><span class='ocaml-source'>b</span><span class='ocaml-source'> </span><span class='ocaml-keyword-operator'>=</span><span class='ocaml-source'> </span><span class='ocaml-source'>a</span><span class='ocaml-source'> </span><span class='ocaml-keyword-operator'>+</span><span class='ocaml-source'> </span><span class='ocaml-source'>b</span><span class='ocaml-source'> \n</span></code></pre>"))
```

Seen on https://github.com/ocaml/opam-repository/pull/22181