### PR TITLE
ocamlbuild.0.14.1 does not work on OCaml 5.1 (fixed in 0.14.2)

### DIFF
--- a/packages/ocamlbuild/ocamlbuild.0.14.1/opam
+++ b/packages/ocamlbuild/ocamlbuild.0.14.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocaml/ocamlbuild/"
 doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
 bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.1"}
 ]
 conflicts: [
   "base-ocamlbuild"


### PR DESCRIPTION
Sister PR to https://github.com/ocaml/opam-repository/pull/22182