### PR TITLE
hxd.0.1.0 is not compatible with OCaml 5.0

### DIFF
--- a/packages/hxd/hxd.0.1.0/opam
+++ b/packages/hxd/hxd.0.1.0/opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "dune" {>= "1.8"}
   "base-bytes"
   "base-bigarray"


### PR DESCRIPTION
```
#=== ERROR while compiling hxd.0.1.0 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/hxd.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p hxd -j 31
# exit-code            1
# env-file             ~/.opam/log/hxd-7-151225.env
# output-file          ~/.opam/log/hxd-7-151225.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.hxd.objs/byte -no-alias-deps -open Hxd__ -o lib/.hxd.objs/byte/hxd__Fmt.cmo -c -impl lib/fmt.ml)
# File "lib/fmt.ml", line 17, characters 21-58:
# 17 | let meta_store ppf = Format.pp_get_formatter_tag_functions ppf ()
#                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Format.pp_get_formatter_tag_functions
# Hint: Did you mean pp_get_formatter_stag_functions?
```