### PR TITLE
digestif < 0.8.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/digestif/digestif.0.1/opam
+++ b/packages/digestif/digestif.0.1/opam
@@ -16,7 +16,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/digestif/digestif.0.2/opam
+++ b/packages/digestif/digestif.0.2/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/digestif/digestif.0.3/opam
+++ b/packages/digestif/digestif.0.3/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/digestif/digestif.0.4/opam
+++ b/packages/digestif/digestif.0.4/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/digestif/digestif.0.5/opam
+++ b/packages/digestif/digestif.0.5/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" "--tests" "false" ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlbuild" {build & >= "0.11.0"}
   "ocamlfind" {build}
   "topkg" {build}

--- a/packages/digestif/digestif.0.6.1/opam
+++ b/packages/digestif/digestif.0.6.1/opam
@@ -12,7 +12,7 @@ license:      "MIT"
 build: [ "jbuilder" "build" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "base-bytes"
   "base-bigarray"

--- a/packages/digestif/digestif.0.7.1/opam
+++ b/packages/digestif/digestif.0.7.1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"          {>= "4.03.0"}
+  "ocaml"          {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.1"}
   "eqaf"
   "base-bytes"

--- a/packages/digestif/digestif.0.7.2/opam
+++ b/packages/digestif/digestif.0.7.2/opam
@@ -33,7 +33,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"          {>= "4.03.0"}
+  "ocaml"          {>= "4.03.0" & < "5.0"}
   "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"

--- a/packages/digestif/digestif.0.7.3/opam
+++ b/packages/digestif/digestif.0.7.3/opam
@@ -30,7 +30,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"          {>= "4.03.0"}
+  "ocaml"          {>= "4.03.0" & < "5.0"}
   "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"

--- a/packages/digestif/digestif.0.7.4/opam
+++ b/packages/digestif/digestif.0.7.4/opam
@@ -30,7 +30,7 @@ build: [ "dune" "build" "-p" name "-j" jobs ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml"          {>= "4.03.0"}
+  "ocaml"          {>= "4.03.0" & < "5.0"}
   "dune"           {>= "1.9.2" & < "2.6"}
   "eqaf"
   "base-bytes"

--- a/packages/digestif/digestif.0.7/opam
+++ b/packages/digestif/digestif.0.7/opam
@@ -37,7 +37,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"          {>= "4.03.0"}
+  "ocaml"          {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.1"}
   "eqaf"
   "base-bytes"


### PR DESCRIPTION
```
#=== ERROR while compiling digestif.0.7.1 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/digestif.0.7.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p digestif -j 127
# exit-code            1
# env-file             ~/.opam/log/digestif-8-694720.env
# output-file          ~/.opam/log/digestif-8-694720.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -no-keep-locs -g -bin-annot -I src-c/.digestif_c.objs/byte -I /home/opam/.opam/5.0/lib/eqaf -I src-c/native/.rakia.objs/byte -intf-suffix .ml -no-alias-deps -o src-c/.digestif_c.objs/byte/digestif.cmo -c -impl src-c/digestif.ml)
# File "src-c/digestif.ml", line 216, characters 10-28:
# 216 |     match Pervasives.compare (String.length key) block_size with
#                 ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```