### PR TITLE
Package bls12-381-hash.0.0.3

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.0.0.3/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of some cryptographic hash primitives using the scalar field of BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+available:
+  arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/-/archive/0.0.3/ocaml-bls12-381-hash-0.0.3.tar.bz2"
+  checksum: [
+    "md5=0674b0cad13d63d3685b35a5e6941674"
+    "sha512=8ad3f3105a413a98f09bbed2505bcad5bada8ae3b350a6d1a0d1d770e7726a6684a6d3f1d0a9e9fc249bff8374dbbd6a0c6fbd56a618d999bab1dce34174064c"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381-hash.0.0.3`
Implementation of some cryptographic hash primitives using the scalar field of BLS12-381



---
* Homepage: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues

---
:camel: Pull-request generated by opam-publish v2.1.0