### PR TITLE
uint < 2.0.0 is not compatible with OCaml 5.0 (uses OASIS)

### DIFF
--- a/packages/uint/uint.1.2.1/opam
+++ b/packages/uint/uint.1.2.1/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "uint"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes" {= "base"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling uint.1.2.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/uint.1.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/uint-8-1022e3.env
# output-file          ~/.opam/log/uint-8-1022e3.out
### output ###
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```