### PR TITLE
tezos-stdlib < 8.0 is not compatible with OCaml 5.0

### DIFF
--- a/packages/tezos-stdlib/tezos-stdlib.7.0/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.0/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "dune" {with-test & < "3.0"}
-  "ocaml" { >= "4.08.0" }
+  "ocaml" { >= "4.08.0" & < "5.0" }
   "hex" {>= "1.3.0"}
   "lwt"
   "zarith"

--- a/packages/tezos-stdlib/tezos-stdlib.7.1/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.1/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "dune" {with-test & < "3.0"}
-  "ocaml" { >= "4.08.0" }
+  "ocaml" { >= "4.08.0" & < "5.0" }
   "hex" {>= "1.3.0"}
   "lwt"
   "zarith"

--- a/packages/tezos-stdlib/tezos-stdlib.7.2/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.2/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "dune" {with-test & < "3.0"}
-  "ocaml" { >= "4.08.0" }
+  "ocaml" { >= "4.08.0" & < "5.0" }
   "hex" {>= "1.3.0"}
   "lwt"
   "zarith"

--- a/packages/tezos-stdlib/tezos-stdlib.7.3/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.3/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "dune" {with-test & < "3.0"}
-  "ocaml" { >= "4.08.0" }
+  "ocaml" { >= "4.08.0" & < "5.0" }
   "hex" {>= "1.3.0"}
   "lwt"
   "zarith"

--- a/packages/tezos-stdlib/tezos-stdlib.7.4/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.7.4/opam
@@ -9,7 +9,7 @@ depends: [
   "tezos-tooling" { with-test & = version }
   "dune" { >= "1.11" }
   "dune" {with-test & < "3.0"}
-  "ocaml" { >= "4.08.0" }
+  "ocaml" { >= "4.08.0" & < "5.0" }
   "hex" {>= "1.3.0"}
   "lwt"
   "zarith"


### PR DESCRIPTION
```
#=== ERROR while compiling tezos-stdlib.7.4 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/tezos-stdlib.7.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tezos-stdlib -j 31
# exit-code            1
# env-file             ~/.opam/log/tezos-stdlib-8-5959be.env
# output-file          ~/.opam/log/tezos-stdlib-8-5959be.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib_stdlib/.tezos_stdlib.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/zarith -intf-suffix .ml -no-alias-deps -open Tezos_stdlib -o src/lib_stdlib/.tezos_stdlib.objs/byte/tezos_stdlib__WeakRingTable.cmo -c -impl src/lib_stdlib/weakRingTable.ml)
# File "src/lib_stdlib/weakRingTable.ml", line 98, characters 32-38:
# 98 |     let i = Nativeint.of_int @@ M.hash seed k in
#                                      ^^^^^^
# Error: Unbound value M.hash
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/lib_stdlib/.tezos_stdlib.objs/byte -I src/lib_stdlib/.tezos_stdlib.objs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/hex -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/zarith -intf-suffix .ml -no-alias-deps -open Tezos_stdlib -o src/lib_stdlib/.tezos_stdlib.objs/native/tezos_stdlib__WeakRingTable.cmx -c -impl src/lib_stdlib/weakRingTable.ml)
# File "src/lib_stdlib/weakRingTable.ml", line 98, characters 32-38:
# 98 |     let i = Nativeint.of_int @@ M.hash seed k in
#                                      ^^^^^^
# Error: Unbound value M.hash
```