### PR TITLE
calendar is not compatible with OCaml 5.0

### DIFF
--- a/packages/calendar/calendar.1.10/opam
+++ b/packages/calendar/calendar.1.10/opam
@@ -13,7 +13,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "conf-autoconf"
   "ocamlfind"
 ]

--- a/packages/calendar/calendar.2.03.2/opam
+++ b/packages/calendar/calendar.2.03.2/opam
@@ -10,7 +10,10 @@ build: [
   [make]
 ]
 remove: [["ocamlfind" "remove" "calendar"]]
-depends: ["ocaml" {>= "3.09"} "ocamlfind"]
+depends: [
+  "ocaml" {>= "3.09" & < "5.0"}
+  "ocamlfind"
+]
 install: [make "install"]
 synopsis: "Library for handling dates and times in your program"
 flags: light-uninstall

--- a/packages/calendar/calendar.2.04/opam
+++ b/packages/calendar/calendar.2.04/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "calendar"]]
 depends: [
-  "ocaml" {>= "3.09"}
+  "ocaml" {>= "3.09" & < "5.0"}
   "ocamlfind" {build}
 ]
 install: [make "install"]


### PR DESCRIPTION
```
#=== ERROR while compiling calendar.2.04 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/calendar.2.04
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure
# exit-code            2
# env-file             ~/.opam/log/calendar-8-d7decd.env
# output-file          ~/.opam/log/calendar-8-d7decd.out
### output ###
# checking for ocamlc... ocamlc
# ocaml version is 5.0.0+dev6-2022-07-21: Unsupported version!
