### PR TITLE
cohttp < 2.3.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/cohttp/cohttp.0.10.0/opam
+++ b/packages/cohttp/cohttp.0.10.0/opam
@@ -22,7 +22,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.13" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.10.1/opam
+++ b/packages/cohttp/cohttp.0.10.1/opam
@@ -22,7 +22,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.0.11.0/opam
+++ b/packages/cohttp/cohttp.0.11.0/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.0.11.1/opam
+++ b/packages/cohttp/cohttp.0.11.1/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.0.11.2/opam
+++ b/packages/cohttp/cohttp.0.11.2/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.0.12.0/opam
+++ b/packages/cohttp/cohttp.0.12.0/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.0.13.0/opam
+++ b/packages/cohttp/cohttp.0.13.0/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.5.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.0.14.0/opam
+++ b/packages/cohttp/cohttp.0.14.0/opam
@@ -23,7 +23,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}
   "re"

--- a/packages/cohttp/cohttp.0.15.0/opam
+++ b/packages/cohttp/cohttp.0.15.0/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}
   "re"

--- a/packages/cohttp/cohttp.0.15.1/opam
+++ b/packages/cohttp/cohttp.0.15.1/opam
@@ -30,7 +30,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}
   "re"

--- a/packages/cohttp/cohttp.0.15.2/opam
+++ b/packages/cohttp/cohttp.0.15.2/opam
@@ -29,7 +29,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}
   "re"

--- a/packages/cohttp/cohttp.0.16.0/opam
+++ b/packages/cohttp/cohttp.0.16.0/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.16.1/opam
+++ b/packages/cohttp/cohttp.0.16.1/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.17.0/opam
+++ b/packages/cohttp/cohttp.0.17.0/opam
@@ -30,7 +30,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.17.1/opam
+++ b/packages/cohttp/cohttp.0.17.1/opam
@@ -30,7 +30,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.17.2/opam
+++ b/packages/cohttp/cohttp.0.17.2/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.18.0/opam
+++ b/packages/cohttp/cohttp.0.18.0/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.18.1/opam
+++ b/packages/cohttp/cohttp.0.18.1/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.18.2/opam
+++ b/packages/cohttp/cohttp.0.18.2/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.18.3/opam
+++ b/packages/cohttp/cohttp.0.18.3/opam
@@ -27,7 +27,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.19.0/opam
+++ b/packages/cohttp/cohttp.0.19.0/opam
@@ -30,7 +30,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.19.1/opam
+++ b/packages/cohttp/cohttp.0.19.1/opam
@@ -24,7 +24,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.19.2/opam
+++ b/packages/cohttp/cohttp.0.19.2/opam
@@ -24,7 +24,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.19.3/opam
+++ b/packages/cohttp/cohttp.0.19.3/opam
@@ -24,7 +24,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.20.0/opam
+++ b/packages/cohttp/cohttp.0.20.0/opam
@@ -25,7 +25,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.20.1/opam
+++ b/packages/cohttp/cohttp.0.20.1/opam
@@ -25,7 +25,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.20.2/opam
+++ b/packages/cohttp/cohttp.0.20.2/opam
@@ -25,7 +25,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/cohttp/cohttp.0.21.0/opam
+++ b/packages/cohttp/cohttp.0.21.0/opam
@@ -25,7 +25,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "cmdliner" {build & >= "0.9.4"}

--- a/packages/cohttp/cohttp.0.21.1/opam
+++ b/packages/cohttp/cohttp.0.21.1/opam
@@ -25,7 +25,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/cohttp/cohttp.0.22.0/opam
+++ b/packages/cohttp/cohttp.0.22.0/opam
@@ -25,7 +25,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/cohttp/cohttp.0.9.1/opam
+++ b/packages/cohttp/cohttp.0.9.1/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "all"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.0" & < "1.3.2"}

--- a/packages/cohttp/cohttp.0.9.10/opam
+++ b/packages/cohttp/cohttp.0.9.10/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.11/opam
+++ b/packages/cohttp/cohttp.0.9.11/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.12/opam
+++ b/packages/cohttp/cohttp.0.9.12/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.13/opam
+++ b/packages/cohttp/cohttp.0.9.13/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.14/opam
+++ b/packages/cohttp/cohttp.0.9.14/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.15/opam
+++ b/packages/cohttp/cohttp.0.9.15/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.16/opam
+++ b/packages/cohttp/cohttp.0.9.16/opam
@@ -21,7 +21,7 @@ build:   [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove:  ["ocamlfind" "remove" "cohttp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.4.0" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.2/opam
+++ b/packages/cohttp/cohttp.0.9.2/opam
@@ -19,7 +19,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.2" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.3/opam
+++ b/packages/cohttp/cohttp.0.9.3/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.2" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.4/opam
+++ b/packages/cohttp/cohttp.0.9.4/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.2" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.5/opam
+++ b/packages/cohttp/cohttp.0.9.5/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.2" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.6/opam
+++ b/packages/cohttp/cohttp.0.9.6/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.2" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.7/opam
+++ b/packages/cohttp/cohttp.0.9.7/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.2" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.8/opam
+++ b/packages/cohttp/cohttp.0.9.8/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.0.9.9/opam
+++ b/packages/cohttp/cohttp.0.9.9/opam
@@ -7,7 +7,7 @@ tags: [
 build: [make "PREFIX=%{prefix}%"]
 remove: [["ocamlfind" "remove" "cohttp"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "re"
   "uri" {>= "1.3.8" & < "1.5.0"}

--- a/packages/cohttp/cohttp.1.0.0/opam
+++ b/packages/cohttp/cohttp.1.0.0/opam
@@ -20,7 +20,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "base-bytes"
   "jbuilder" {>= "1.0+beta10"}
   "re"

--- a/packages/cohttp/cohttp.1.0.2/opam
+++ b/packages/cohttp/cohttp.1.0.2/opam
@@ -20,7 +20,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "base-bytes"
   "jbuilder" {>= "1.0+beta10"}
   "re"

--- a/packages/cohttp/cohttp.1.1.0/opam
+++ b/packages/cohttp/cohttp.1.1.0/opam
@@ -20,7 +20,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "re" {>= "1.7.2"}
   "uri" {>= "1.9.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.1.1.1/opam
+++ b/packages/cohttp/cohttp.1.1.1/opam
@@ -14,7 +14,7 @@ tags: ["org:mirage" "org:xapi-project"]
 homepage: "https://github.com/mirage/ocaml-cohttp"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "uri" {>= "1.9.0" & < "2.0.0"}

--- a/packages/cohttp/cohttp.1.2.0/opam
+++ b/packages/cohttp/cohttp.1.2.0/opam
@@ -41,7 +41,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0"}
   "dune" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "uri" {>= "2.0.0" & < "3.0.0"}

--- a/packages/cohttp/cohttp.2.0.0/opam
+++ b/packages/cohttp/cohttp.2.0.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0"}
   "dune" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "uri" {>= "2.0.0" & < "3.0.0"}

--- a/packages/cohttp/cohttp.2.1.2/opam
+++ b/packages/cohttp/cohttp.2.1.2/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0"}
   "dune" {>= "1.1.0"}
   "re" {>= "1.7.2"}
   "uri" {>= "2.0.0" & < "3.0.0"}

--- a/packages/cohttp/cohttp.2.1.3/opam
+++ b/packages/cohttp/cohttp.2.1.3/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0"}
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}

--- a/packages/cohttp/cohttp.2.2.0/opam
+++ b/packages/cohttp/cohttp.2.2.0/opam
@@ -32,7 +32,7 @@ homepage: "https://github.com/mirage/ocaml-cohttp"
 doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0"}
   "dune" {>= "1.1.0"}
   "re" {>= "1.9.0"}
   "uri" {>= "2.0.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling cohttp.2.2.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/cohttp.2.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p cohttp -j 31
# exit-code            1
# env-file             ~/.opam/log/cohttp-9-c7399c.env
# output-file          ~/.opam/log/cohttp-9-c7399c.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I cohttp/scripts/.generate.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/jsonm -I /home/opam/.opam/5.0/lib/uchar -I /home/opam/.opam/5.0/lib/uutf -no-alias-deps -o cohttp/scripts/.generate.eobjs/byte/generate.cmo -c -impl cohttp/scripts/generate.ml)
# File "cohttp/scripts/generate.ml", line 84, characters 2-16:
# 84 |   Printf.kprintf (fun msg ->
#        ^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I cohttp/scripts/.generate.eobjs/byte -I cohttp/scripts/.generate.eobjs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/jsonm -I /home/opam/.opam/5.0/lib/uchar -I /home/opam/.opam/5.0/lib/uutf -intf-suffix .ml -no-alias-deps -o cohttp/scripts/.generate.eobjs/native/generate.cmx -c -impl cohttp/scripts/generate.ml)
# File "cohttp/scripts/generate.ml", line 84, characters 2-16:
# 84 |   Printf.kprintf (fun msg ->
#        ^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I cohttp/src/.cohttp.objs/byte -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/fieldslib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stringext -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/uri-sexp -intf-suffix .ml -no-alias-deps -open Cohttp__ -o cohttp/src/.cohttp.objs/byte/cohttp__Connection.cmo -c -impl cohttp/src/connection.pp.ml)
# File "cohttp/src/connection.ml", line 29, characters 26-44:
# 29 | let compare (a:t) (b:t) = Pervasives.compare a b
#                                ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I cohttp/src/.cohttp.objs/byte -I cohttp/src/.cohttp.objs/native -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/fieldslib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stringext -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/uri-sexp -intf-suffix .ml -no-alias-deps -open Cohttp__ -o cohttp/src/.cohttp.objs/native/cohttp__Connection.cmx -c -impl cohttp/src/connection.pp.ml)
# File "cohttp/src/connection.ml", line 29, characters 26-44:
# 29 | let compare (a:t) (b:t) = Pervasives.compare a b
#                                ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I cohttp/src/.cohttp.objs/byte -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/fieldslib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stringext -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/uri-sexp -intf-suffix .ml -no-alias-deps -open Cohttp__ -o cohttp/src/.cohttp.objs/byte/cohttp__Header.cmo -c -impl cohttp/src/header.pp.ml)
# File "cohttp/src/header.ml", line 36, characters 32-50:
# 36 | let compare = StringMap.compare Pervasives.compare
#                                      ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I cohttp/src/.cohttp.objs/byte -I cohttp/src/.cohttp.objs/native -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/fieldslib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stringext -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/uri-sexp -intf-suffix .ml -no-alias-deps -open Cohttp__ -o cohttp/src/.cohttp.objs/native/cohttp__Header.cmx -c -impl cohttp/src/header.pp.ml)
# File "cohttp/src/header.ml", line 36, characters 32-50:
# 36 | let compare = StringMap.compare Pervasives.compare
#                                      ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```