### PR TITLE
[new release] x509 (0.16.2)

### DIFF
--- a/packages/x509/x509.0.16.2/opam
+++ b/packages/x509/x509.0.16.2/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "6.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf"
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.2/x509-0.16.2.tbz"
+  checksum: [
+    "sha256=65ffd966350091e59ed385cb9aa30a81bc4dfea7bf6759a928cf36bde5d57f62"
+    "sha512=80b198ecb6ed05984a4e7e4dbb08ca685817b914bd9d6d05753c912b1f34a02d2dd60636c240a1c88819e6167c314607725d7cca716281b3ba5ee122c907eedc"
+  ]
+}
+x-commit-hash: "10a91ef799ac4ffaaac4fd8bc0ecf5f0aa8f27d4"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Improve parse error message of Authenticator.of_string (mirage/ocaml-git#593
  by @dinosaure, mirage/ocaml-git#582 by @reynir)
