### PR TITLE
LablGtk 2.18.13

### DIFF
--- a/packages/lablgtk/lablgtk.2.18.13/files/lablgldir.patch
+++ b/packages/lablgtk/lablgtk.2.18.13/files/lablgldir.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index 177e9547..f8a56fe0 100755
+--- a/configure
++++ b/configure
+@@ -4925,7 +4925,7 @@ printf %s "checking lablGL directory... " >&6; }
+       cat > conftest.ml << EOF
+       open Raw
+ EOF
+-      if $CAMLC -c -I "${LABLGLDIR:=+lablGL}" conftest.ml > /dev/null 2>&1 ; then
++      if $CAMLC -c -I "$LABLGLDIR" conftest.ml > /dev/null 2>&1 ; then
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LABLGLDIR" >&5
+ printf "%s\n" "$LABLGLDIR" >&6; }
+       else

--- a/packages/lablgtk/lablgtk.2.18.13/files/lablgtk.install
+++ b/packages/lablgtk/lablgtk.2.18.13/files/lablgtk.install
@@ -1,0 +1,5 @@
+bin: [
+  "src/lablgtk2"
+  "src/gdk_pixbuf_mlsource"
+  "?src/lablgladecc2"
+]

--- a/packages/lablgtk/lablgtk.2.18.13/opam
+++ b/packages/lablgtk/lablgtk.2.18.13/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/lablgtk/"
+bug-reports: "https://github.com/garrigue/lablgtk/issues"
+dev-repo: "git+https://github.com/garrigue/lablgtk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "--prefix" prefix "LABLGLDIR=%{lib}%/lablgl"]
+  [make "world"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "ocamlfind" {>= "1.2.1"}
+  "conf-gtk2" {build}
+  "camlp-streams" {build}
+]
+depopts: [
+  "conf-gtksourceview"
+  "conf-gnomecanvas"
+  "conf-glade"
+  "lablgl"
+]
+conflicts: [
+  "base-domains"
+]
+patches: ["lablgldir.patch"]
+post-messages: [
+  "This package requires gtk+ 2.0 development packages installed on your system"
+    {failure}
+  """
+To solve pkg-config issues, you may need to do
+'export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig' and retry"""
+    {failure & os = "macos"}
+]
+synopsis: "OCaml interface to GTK+"
+extra-files: [
+  ["lablgtk.install" "md5=1a3468258dd50aab33b9844db158b11a"]
+  ["lablgldir.patch" "md5=ea7cb50e7f6aa85968063d059ab46c44"]
+]
+url {
+  src:
+    "https://github.com/garrigue/lablgtk/archive/2.18.13.tar.gz"
+  checksum: "md5=d0a326b99475216cc22232e72c89415f"
+}

--- a/packages/lablgtk/lablgtk.2.18.13/opam
+++ b/packages/lablgtk/lablgtk.2.18.13/opam
@@ -24,9 +24,6 @@ depopts: [
   "conf-glade"
   "lablgl"
 ]
-conflicts: [
-  "base-domains"
-]
 patches: ["lablgldir.patch"]
 post-messages: [
   "This package requires gtk+ 2.0 development packages installed on your system"


### PR DESCRIPTION
Make LablGtk2 compatible with OCaml 5.0.