### PR TITLE
Remove bounds on dune version on drom dependencies

### DIFF
--- a/packages/ez_config/ez_config.0.2.0/opam
+++ b/packages/ez_config/ez_config.0.2.0/opam
@@ -33,7 +33,7 @@ install: [
   ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "dune" {>= "2.7.0"}
   "ez_file" {>= "0.3.0" & < "1.0.0"}
   "ppx_inline_test" {with-test}

--- a/packages/ez_config/ez_config.0.2.0/opam
+++ b/packages/ez_config/ez_config.0.2.0/opam
@@ -40,7 +40,7 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0" & < "3.0.0"}
+  "dune" {>= "2.6.0"}
 ]
 
 url {

--- a/packages/ez_config/ez_config.0.2.0/opam
+++ b/packages/ez_config/ez_config.0.2.0/opam
@@ -40,7 +40,6 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0"}
 ]
 
 url {

--- a/packages/ez_file/ez_file.0.3.0/opam
+++ b/packages/ez_file/ez_file.0.3.0/opam
@@ -41,7 +41,7 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0" & < "3.0.0"}
+  "dune" {>= "2.6.0"}
 ]
 
 url {

--- a/packages/ez_file/ez_file.0.3.0/opam
+++ b/packages/ez_file/ez_file.0.3.0/opam
@@ -41,7 +41,6 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0"}
 ]
 
 url {

--- a/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
+++ b/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
@@ -38,7 +38,6 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0"}
 ]
 
 url {

--- a/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
+++ b/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
@@ -38,7 +38,7 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0" & < "3.0.0"}
+  "dune" {>= "2.6.0"}
 ]
 
 url {


### PR DESCRIPTION
Current bounds on the `drom` dependencies prevent installation with dune3. This PR removes these bounds.