### PR TITLE
[new release] shuttle_ssl and shuttle (0.6.0)

### DIFF
--- a/packages/shuttle/shuttle.0.6.0/opam
+++ b/packages/shuttle/shuttle.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.6.0/shuttle-0.6.0.tbz"
+  checksum: [
+    "sha256=1f239dd21dfe5ed0f46c047856618429cc351bcb11e85e8191169431e5e89391"
+    "sha512=07d575f812910f6d34d751eb6e4ab1165df3e2c58df8edd879963e72617430e278b32a5c4493262abfc5bccfb1928e49b5fb957db730ae5d30bdd9335a9cdcdb"
+  ]
+}
+x-commit-hash: "fab9fbea180d7ef164e991aa00798ac1ef493922"

--- a/packages/shuttle_ssl/shuttle_ssl.0.6.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.6.0/shuttle-0.6.0.tbz"
+  checksum: [
+    "sha256=1f239dd21dfe5ed0f46c047856618429cc351bcb11e85e8191169431e5e89391"
+    "sha512=07d575f812910f6d34d751eb6e4ab1165df3e2c58df8edd879963e72617430e278b32a5c4493262abfc5bccfb1928e49b5fb957db730ae5d30bdd9335a9cdcdb"
+  ]
+}
+x-commit-hash: "fab9fbea180d7ef164e991aa00798ac1ef493922"


### PR DESCRIPTION
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>
- Documentation: <a href="https://anuragsoni.github.io/shuttle/">https://anuragsoni.github.io/shuttle/</a>

##### CHANGES:

* Increase upper bound for core/async to 0.15.0
