### PR TITLE
Update conf-xkbcommon

### DIFF
--- a/packages/conf-xkbcommon/conf-xkbcommon.1/opam
+++ b/packages/conf-xkbcommon/conf-xkbcommon.1/opam
@@ -17,7 +17,7 @@ depexts: [
   ["libxkbcommon-dev"] {os-family = "alpine"}
   ["libxkbcommon"] {os-family = "arch" | os-family = "archlinux"}
   ["x11-libs/libxkbcommon"] {os-family = "gentoo"}
-  ["libxkbcommon"] {os-family = "bsd" & os != "openbsd"}
+  ["libxkbcommon"] {os = "freebsd" | os = "dragonfly" | os = "netbsd"}
   ["xkbcommon"] {os = "openbsd"}
   ["libxkbcommon"] {os = "macos" & os-distribution = "homebrew"}
   ["libxkbcommon"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-xkbcommon/conf-xkbcommon.1/opam
+++ b/packages/conf-xkbcommon/conf-xkbcommon.1/opam
@@ -9,15 +9,18 @@ depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["libxkbcommon-dev"] {os-family = "debian"}
-  ["libxkbcommon-devel"] {os-distribution = "fedora"}
-  ["libxkbcommon-devel"] {os-distribution = "rhel"}
-  ["libxkbcommon-devel"] {os-distribution = "centos"}
-  ["libxkbcommon-devel"] {os-family = "suse"}
-  ["libxkbcommon-dev"] {os-distribution = "alpine"}
-  ["libxkbcommon"] {os-distribution = "arch"}
-  ["libxkbcommon"] {os = "freebsd"}
+  ["libxkbcommon-devel"] {os = "cygwin" | os-distribution = "cygwinports"}
+  ["libxkbcommon-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libxkbcommon-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
+  ["libxkbcommon-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
+  ["libxkbcommon-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
+  ["libxkbcommon-dev"] {os-family = "alpine"}
+  ["libxkbcommon"] {os-family = "arch" | os-family = "archlinux"}
+  ["x11-libs/libxkbcommon"] {os-family = "gentoo"}
+  ["libxkbcommon"] {os-family = "bsd" & os != "openbsd"}
+  ["xkbcommon"] {os = "openbsd"}
   ["libxkbcommon"] {os = "macos" & os-distribution = "homebrew"}
+  ["libxkbcommon"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Virtual package relying on xkbcommon"
 description:


### PR DESCRIPTION
Summary of changes :
- use `os-family` instead of `os-distribution` to capture more derivatives
- Windows: add the Cygwin package
- Debian & Ubuntu: add `os-family = "ubuntu"` because some (many ?) Ubuntu derivatives (Linux Mint, elementaryOS, ...) only list Ubuntu in `os-release:ID_LIKE` (or list both, but Ubuntu first)
- Mandriva and derivatives: add the package for this family
- SUSE/OpenSUSE/SLES: add `os-family = "sles"` and `os-family = "opensuse"` to account for the fact that the `os-release:ID` and `os-release:ID_LIKE` field usage seems inconsistent across SUSE variants (sometimes "suse", sometimes "sles", sometimes no `ID_LIKE` field)
- Fedora/RHEL/CentOS: regroup in the same specification (they often share the same package names)
- Arch Linux: add `os-family = "archlinux"` in addition of `os-family = "arch"` (I have seen both in Arch and its derivatives)
- Gentoo and derivatives: add the package for this family
- *BSD: use `os-family = "bsd"` (all BSD variants seem to use the same name for this package)
- MacOS: add the MacPorts package