### PR TITLE
Update conf-libpng

### DIFF
--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -21,6 +21,9 @@ depexts: [
   ["libpng"] {os = "macos" & os-distribution = "homebrew"}
   ["libpng"] {os = "macos" & os-distribution = "macports"}
 ]
+x-ci-accept-failures: [
+  "opensuse-15.3" # does not have libpng
+]
 synopsis: "Virtual package relying on a libpng system installation"
 description:
   "This package can only install if the libpng is installed on the system."

--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -10,10 +10,17 @@ homepage: "http://www.libpng.org/pub/png/libpng.html"
 license: "Zlib"
 build: [["pkg-config" "libpng"]]
 depexts: [
-  ["libpng-dev"] {os-family = "debian" & os-distribution != "ubuntu"}
-  ["libpng-devel"] {os-distribution = "mageia"}
-  ["libpng12-dev"] {os-distribution = "ubuntu"}
-  ["libpng"] {os = "win32" & os-distribution = "cygwinports"}
+  ["libpng-devel"] {os = "cygwin" | os-distribution = "cygwinports"}
+  ["libpng-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["libpng-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
+  ["libpng16-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
+  ["libpng-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
+  ["libpng-dev"] {os-family = "alpine"}
+  ["libpng"] {os-family = "arch" | os-family = "archlinux"}
+  ["media-libs/libpng"] {os-family = "gentoo"}
+  ["png"] {os-family = "bsd"}
+  ["libpng"] {os = "macos" & os-distribution = "homebrew"}
+  ["libpng"] {os = "macos" & os-distribution = "macports"}
 ]
 synopsis: "Virtual package relying on a libpng system installation"
 description:

--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -13,7 +13,6 @@ depexts: [
   ["libpng-devel"] {os = "cygwin" | os-distribution = "cygwinports"}
   ["libpng-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libpng-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
-  ["libpng16-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
   ["libpng-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
   ["libpng-dev"] {os-family = "alpine"}
   ["libpng"] {os-family = "arch" | os-family = "archlinux"}

--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -18,7 +18,7 @@ depexts: [
   ["libpng-dev"] {os-family = "alpine"}
   ["libpng"] {os-family = "arch" | os-family = "archlinux"}
   ["media-libs/libpng"] {os-family = "gentoo"}
-  ["png"] {os-family = "bsd"}
+  ["png"] {os = "freebsd" | os = "dragonfly" | os = "netbsd" | os = "openbsd"}
   ["libpng"] {os = "macos" & os-distribution = "homebrew"}
   ["libpng"] {os = "macos" & os-distribution = "macports"}
 ]


### PR DESCRIPTION
Summary of changes :
- use `os-family` instead of `os-distribution` to capture more derivatives
- Windows: use package `libpng-devel` instead of `libpng`, add `os = "cygwin"`
- Debian & Ubuntu: regroup Debian and Ubuntu, use `libpng-dev` for both, add `os-family = "ubuntu"` because some (many ?) Ubuntu derivatives (Linux Mint, elementaryOS, ...) only list Ubuntu in os-release:ID_LIKE (or list both, but Ubuntu first)

Add packages for :
- Mandriva and derivatives (same as Mageia)
- SUSE/OpenSUSE/SLES (note: no generic `libpng-devel` package, so use `libpng16-devel`)
- Fedora/RHEL/CentOS
- Alpine
- Arch Linux
- Gentoo and derivatives
- *BSD
- macOS
