### PR TITLE
Update conf-libwayland and conf-wayland-protocols

### DIFF
--- a/packages/conf-libwayland/conf-libwayland.1/opam
+++ b/packages/conf-libwayland/conf-libwayland.1/opam
@@ -4,16 +4,24 @@ homepage: "https://wayland.freedesktop.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Wayland dev team"
 license: "MIT"
-build: ["wayland-scanner" "--version"]
+available: [ os != "macos" & os != "win32" & os != "cygwin" ]
+build: [
+  ["wayland-scanner" "--version"]
+  ["pkg-config" "--exists" "wayland-client"]
+]
+depends: [
+  "conf-pkg-config" {build}
+]
 depexts: [
-  ["libwayland-dev"] {os-family = "debian"}
-  ["wayland-devel"] {os-distribution = "fedora"}
-  ["wayland-devel"] {os-distribution = "rhel"}
-  ["wayland-devel"] {os-distribution = "centos"}
-  ["wayland-devel"] {os-family = "suse"}
-  ["wayland-dev"] {os-distribution = "alpine"}
-  ["wayland"] {os-distribution = "arch"}
-  ["wayland"] {os = "freebsd"}
+  ["libwayland-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["wayland-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
+  ["wayland-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
+  ["wayland-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
+  ["wayland-dev"] {os-family = "alpine"}
+  ["wayland"] {os-family = "arch" | os-family = "archlinux"}
+  ["dev-libs/wayland"] {os-family = "gentoo"}
+  ["dev-util/wayland-scanner"] {os-family = "gentoo"}
+  ["wayland"] {os-family = "bsd"}
 ]
 synopsis: "Virtual package relying on libwayland"
 description:

--- a/packages/conf-libwayland/conf-libwayland.1/opam
+++ b/packages/conf-libwayland/conf-libwayland.1/opam
@@ -19,8 +19,7 @@ depexts: [
   ["wayland-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
   ["wayland-dev"] {os-family = "alpine"}
   ["wayland"] {os-family = "arch" | os-family = "archlinux"}
-  ["dev-libs/wayland"] {os-family = "gentoo"}
-  ["dev-util/wayland-scanner"] {os-family = "gentoo"}
+  ["dev-libs/wayland" "dev-util/wayland-scanner"] {os-family = "gentoo"}
   ["wayland"] {os-family = "bsd"}
 ]
 synopsis: "Virtual package relying on libwayland"

--- a/packages/conf-wayland-protocols/conf-wayland-protocols.1/opam
+++ b/packages/conf-wayland-protocols/conf-wayland-protocols.1/opam
@@ -4,19 +4,20 @@ homepage: "https://wayland.freedesktop.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Wayland dev team"
 license: "MIT"
+available: [ os != "macos" & os != "win32" & os != "cygwin" ]
 build: ["pkg-config" "--exists" "wayland-protocols"]
 depends: [
   "conf-pkg-config" {build}
 ]
 depexts: [
-  ["wayland-protocols"] {os-family = "debian"}
-  ["wayland-protocols-devel"] {os-distribution = "fedora"}
-  ["wayland-protocols-devel"] {os-distribution = "rhel"}
-  ["wayland-protocols-devel"] {os-distribution = "centos"}
-  ["wayland-protocols-devel"] {os-family = "suse"}
-  ["wayland-protocols"] {os-distribution = "alpine"}
-  ["wayland-protocols"] {os-family = "arch"}
-  ["wayland-protocols"] {os = "freebsd"}
+  ["wayland-protocols"] {os-family = "debian" | os-family = "ubuntu"}
+  ["wayland-protocols-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
+  ["wayland-protocols-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
+  ["wayland-protocols-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
+  ["wayland-protocols"] {os-family = "alpine"}
+  ["wayland-protocols"] {os-family = "arch" | os-family = "archlinux"}
+  ["dev-libs/wayland-protocols"] {os-family = "gentoo"}
+  ["wayland-protocols"] {os-family = "bsd"}
 ]
 synopsis: "Virtual package relying on wayland-protocols"
 description:


### PR DESCRIPTION
Summary of changes :
- (conf-libwayland only) change build command to both test for the `wayland-scanner` tool and the `libwayland-client` library: while most OSes/distributions have these two artifacts in the same package, some (Debian, Mandriva and Gentoo families) actually use two packages, so only testing for `wayland-scanner` would result in the library not being installed if `wayland-scanner` is installed before (or, we could also have a separate package for `wayland-scanner`...)
- use `os-family` instead of `os-distribution` to capture more derivatives
- Debian & Ubuntu: add `os-family = "ubuntu"` because some (many ?) Ubuntu derivatives (Linux Mint, elementaryOS, ...) only list Ubuntu in os-release:ID_LIKE (or list both, but Ubuntu first)
- Mandriva and derivatives: add the packages for this family
- SUSE/OpenSUSE/SLES: add `os-family = "sles"` and `os-family = "opensuse"` to account for the fact that the `os-release:ID` and `os-release:ID_LIKE` field usage seems inconsistent across SUSE variants (sometimes "suse", sometimes "sles", sometimes no `ID_LIKE` field)
- Fedora/RHEL/CentOS: regroup in the same specification (they often share the same package names)
- Arch Linux: add `os-family = "archlinux"` in addition of `os-family = "arch"` (I have seen both in Arch and its derivatives)
- Gentoo and derivatives: add the packages for this family (with an explicit `wayland-scanner`, as it is only considered a build dependency on this system)
- *BSD: use `os-family = "bsd"` (all BSD variants seem to use the same name for these two packages)
