### PR TITLE
Update conf-freetype

### DIFF
--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -7,17 +7,19 @@ license: "GPL-1.0-or-later"
 build: [["pkg-config" "freetype2"]]
 depends: ["conf-pkg-config" {build}]
 depexts: [
-  ["libfreetype6-dev"] {os-family = "debian"}
-  ["freetype-dev"] {os-distribution = "alpine"}
-  ["freetype-devel"] {os-distribution = "centos"}
-  ["freetype-devel"] {os-distribution = "fedora"}
-  ["freetype-devel"] {os-distribution = "rhel"}
-  ["libfreetype2-devel"] {os-distribution = "mageia"}
-  ["freetype2-devel"] {os-family = "suse"}
-  ["print/freetype2"] {os = "freebsd"}
-  ["print/freetype2"] {os = "openbsd"}
+  ["libfreetype6-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["freetype-dev"] {os-family = "alpine"}
+  ["freetype-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
+  ["freetype2-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
+  ["freetype2-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
+  ["freetype2"] {os-family = "arch" | os-family = "archlinux"}
+  ["media-libs/freetype"] {os-family = "gentoo"}
+  ["freetype2"] {os = "netbsd"}
+  ["freetype2"] {os = "freebsd"}
+  ["freetype2"] {os = "dragonfly"}
   ["freetype"] {os = "macos" & os-distribution = "homebrew"}
-  ["freetype2"] {os = "win32" & os-distribution = "cygwinports"}
+  ["freetype"] {os = "macos" & os-distribution = "macports"}
+  ["libfreetype-devel"] {os = "cygwin" | os-distribution = "cygwinports"}
 ]
 synopsis: "Virtual package relying on a freetype lib system installation"
 description:


### PR DESCRIPTION
Summary of changes :
- use `os-family` instead of `os-distribution` to capture more derivatives
- Windows: add the Cygwin package, use `libfreetype-devel` instead of `freetype2` (unmaintained)
- Debian & Ubuntu: add `os-family = "ubuntu"` because some (many ?) Ubuntu derivatives (Linux Mint, elementaryOS, ...) only list Ubuntu in os-release:ID_LIKE (or list both, but Ubuntu first)
- Mandriva and derivatives: add `os-family = "mandriva"` and `os-family = "openmandriva"`
- SUSE/OpenSUSE/SLES: add `os-family = "sles"` and `os-family = "opensuse"` to account for the fact that the `os-release:ID` and `os-release:ID_LIKE` field usage seems inconsistent across SUSE variants (sometimes "suse", sometimes "sles", sometimes no `ID_LIKE` field)
- Fedora/RHEL/CentOS: regroup in the same specification (they often share the same package names)
- Arch Linux and derivatives: add the package for this family
- Gentoo and derivatives: add the package for this family
- *BSD: use `os-family = "bsd"` (all BSD variants seem to use the same name for this package)
- MacOS: add the MacPorts package