### PR TITLE
Update conf-libfontconfig

### DIFF
--- a/packages/conf-libfontconfig/conf-libfontconfig.1/opam
+++ b/packages/conf-libfontconfig/conf-libfontconfig.1/opam
@@ -15,8 +15,7 @@ depexts: [
   ["fontconfig-dev"] {os-family = "alpine"}
   ["fontconfig"] {os-family = "arch" | os-family = "archlinux"}
   ["media-libs/fontconfig"] {os-family = "gentoo"}
-  ["x11-fonts/fontconfig"] {os = "freebsd" | os = "dragonfly"}
-  ["fonts/fontconfig"] {os = "netbsd"}
+  ["fontconfig"] {os-family = "bsd" & os != "openbsd"}
   ["fontconfig"] {os = "macos" & os-distribution = "homebrew"}
   ["fontconfig"] {os = "macos" & os-distribution = "macports"}
 ]


### PR DESCRIPTION
Regroup all BSD variants with `os-family = "bsd"`, remove the package prefix (appears to be optional).