### PR TITLE
Update conf-libxcb*

### DIFF
--- a/packages/conf-libxcb-image/conf-libxcb-image.1/opam
+++ b/packages/conf-libxcb-image/conf-libxcb-image.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["xcb-util-image-dev"] {os-family = "alpine"}
   ["xcb-util-image"] {os-family = "arch" | os-family = "archlinux"}
   ["x11-libs/xcb-util-image"] {os-family = "gentoo"}
-  ["x11/xcb-util-image"] {os-family = "bsd" & os != "openbsd"}
+  ["xcb-util-image"] {os-family = "bsd" & os != "openbsd"}
   ["xcb-util-image"] {os = "macos" & os-distribution = "homebrew"}
   ["xorg-xcb-util-image"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-libxcb-keysyms/conf-libxcb-keysyms.1/opam
+++ b/packages/conf-libxcb-keysyms/conf-libxcb-keysyms.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["xcb-util-keysyms-dev"] {os-family = "alpine"}
   ["xcb-util-keysyms"] {os-family = "arch" | os-family = "archlinux"}
   ["x11-libs/xcb-util-keysyms"] {os-family = "gentoo"}
-  ["x11/xcb-util-keysyms"] {os-family = "bsd" & os != "openbsd"}
+  ["xcb-util-keysyms"] {os-family = "bsd" & os != "openbsd"}
   ["xcb-util-keysyms"] {os = "macos" & os-distribution = "homebrew"}
   ["xorg-xcb-util-keysyms"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-libxcb-shm/conf-libxcb-shm.1/opam
+++ b/packages/conf-libxcb-shm/conf-libxcb-shm.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libxcb-dev"] {os-family = "alpine"}
   ["libxcb"] {os-family = "arch" | os-family = "archlinux"}
   ["x11-libs/libxcb"] {os-family = "gentoo"}
-  ["x11/libxcb"] {os-family = "bsd" & os != "openbsd"}
+  ["libxcb"] {os-family = "bsd" & os != "openbsd"}
   ["libxcb"] {os = "macos" & os-distribution = "homebrew"}
   ["xorg-libxcb"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-libxcb-xkb/conf-libxcb-xkb.1/opam
+++ b/packages/conf-libxcb-xkb/conf-libxcb-xkb.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libxcb-dev"] {os-family = "alpine"}
   ["libxcb"] {os-family = "arch" | os-family = "archlinux"}
   ["x11-libs/libxcb"] {os-family = "gentoo"}
-  ["x11/libxcb"] {os-family = "bsd" & os != "openbsd"}
+  ["libxcb"] {os-family = "bsd" & os != "openbsd"}
   ["libxcb"] {os = "macos" & os-distribution = "homebrew"}
   ["xorg-libxcb"] {os = "macos" & os-distribution = "macports"}
 ]

--- a/packages/conf-libxcb/conf-libxcb.1/opam
+++ b/packages/conf-libxcb/conf-libxcb.1/opam
@@ -15,7 +15,7 @@ depexts: [
   ["libxcb-dev"] {os-family = "alpine"}
   ["libxcb"] {os-family = "arch" | os-family = "archlinux"}
   ["x11-libs/libxcb"] {os-family = "gentoo"}
-  ["x11/libxcb"] {os-family = "bsd" & os != "openbsd"}
+  ["libxcb"] {os-family = "bsd" & os != "openbsd"}
   ["libxcb"] {os = "macos" & os-distribution = "homebrew"}
   ["xorg-libxcb"] {os = "macos" & os-distribution = "macports"}
 ]


### PR DESCRIPTION
Regroup all BSD variants with `os-family = "bsd"`, remove the package prefix (appears to be optional).