### PR TITLE
[new release] coq-serapi (8.16.0+0.16.1)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.1/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.16" & < "8.17"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.16.0%2B0.16.1/coq-serapi-8.16.0.0.16.1.tbz"
+  checksum: [
+    "sha256=f1070e6fa36ecf042319a14f621f26a331075f3777dfb85a0afbac6e3323e9d4"
+    "sha512=efbd947aa6750672f089b7b8604c798033793510eea1c45f4265df5f548b2ecdd3e69d5cb49b0714c09de1012fe358f618c9b1f4610a33339a151b4fdac42321"
+  ]
+}
+x-commit-hash: "d42663cdfd6d731ce7b2d83c8230f8c0f725dcf2"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [sertop] Allow to set `--coqlib` using the `COQLIB` environment
            variable. The cmdline argument option still has
            precedence.
 - [serapi] Allow to parse expressions too with
            `(Parse (entry Constr) $text)` (@ejgallego, fixes ejgallego/coq-serapi#272)
