### PR TITLE
[new release] mirage-nat (3.0.0)

### DIFF
--- a/packages/mirage-nat/mirage-nat.3.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.3.0.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ipaddr"
+  "cstruct" {>= "6.0.0"}
+  "lru" {>= "0.3.0"}
+  "dune" {>= "1.0"}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" { >= "3.0.0" }
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+  "logs" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v3.0.0/mirage-nat-3.0.0.tbz"
+  checksum: [
+    "sha256=76d93101f64335f72a9be297f8a78da50048833273b90885aabe83b5566aea06"
+    "sha512=971320fe2880beebab87d748a20ca20a404b7e28fdc332f78199ddda95dfc75ac1784ed362a4be35b8212466f6f8eee123b4ea01b076b2c54e41eb2b94a00633"
+  ]
+}
+x-commit-hash: "78a32e8ad6630d5b49b64f7f988a174dc4359280"


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- remove Lwt.t monad, lwt dependency (mirage/mirage-nat#47 @hannesm)
- remove ppx_deriving dependency (mirage/mirage-nat#47 @hannesm)
- revise mutable state: use "mutable foo : x" instead of "foo : x ref" (mirage/mirage-nat#47 @hannesm)
- add Mirage_nat.is_port_free (mirage/mirage-nat#47 @hannesm)
- revise Mirage_nat.add to take a port_generator (unit -> int option) (mirage/mirage-nat#47 @hannesm)
