### PR TITLE
Fix build incompatiblity beetween dolmen_type.0.5 and seq

### DIFF
--- a/packages/dolmen_type/dolmen_type.0.5/opam
+++ b/packages/dolmen_type/dolmen_type.0.5/opam
@@ -14,6 +14,9 @@ depends: [
   "uutf"
   "odoc" { with-doc }
 ]
+conflicts: [
+  "seq" {!= "base" }
+]
 tags: [ "logic" "type" "typechecking" "first order" "polymorphism" ]
 homepage: "https://github.com/Gbury/dolmen"
 dev-repo: "git+https://github.com/Gbury/dolmen.git"


### PR DESCRIPTION
Should fix #21584 (see the issue for more information on the issue).