### PR TITLE
[new release] routes (2.0.0)

### DIFF
--- a/packages/current_web/current_web.0.3/opam
+++ b/packages/current_web/current_web.0.3/opam
@@ -31,7 +31,7 @@ depends: [
   "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
-  "routes" {>= "0.8.0"}
+  "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.0"}
 ]
 url {

--- a/packages/current_web/current_web.0.4/opam
+++ b/packages/current_web/current_web.0.4/opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-lwt" {>= "2.2.0"}
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml"
-  "routes" {>= "0.8.0"}
+  "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.0"}
   "conf-graphviz"
   "astring" {>= "0.8.5"}

--- a/packages/current_web/current_web.0.5/opam
+++ b/packages/current_web/current_web.0.5/opam
@@ -30,7 +30,7 @@ depends: [
   "cohttp-lwt" {>= "2.2.0"}
   "cohttp-lwt-unix" {>= "2.2.0"}
   "tyxml" {>= "4.4.0"}
-  "routes" {>= "0.8.0"}
+  "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.0"}
   "conf-graphviz"
   "astring" {>= "0.8.5"}

--- a/packages/current_web/current_web.0.6.1/opam
+++ b/packages/current_web/current_web.0.6.1/opam
@@ -31,7 +31,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0"}
   "csv" {>= "2.4"}
-  "routes" {>= "0.8.0"}
+  "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.9"}
   "conf-graphviz"
   "astring" {>= "0.8.5"}

--- a/packages/current_web/current_web.0.6.2/opam
+++ b/packages/current_web/current_web.0.6.2/opam
@@ -32,7 +32,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0"}
   "csv" {>= "2.4"}
-  "routes" {>= "0.8.0"}
+  "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.9"}
   "conf-graphviz"
   "astring" {>= "0.8.5"}

--- a/packages/current_web/current_web.0.6/opam
+++ b/packages/current_web/current_web.0.6/opam
@@ -28,7 +28,7 @@ depends: [
   "prometheus-app" {< "1.2"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0"}
-  "routes" {>= "0.8.0"}
+  "routes" {>= "0.8.0" & < "2.0.0"}
   "dune" {>= "2.9"}
   "conf-graphviz"
   "astring" {>= "0.8.5"}

--- a/packages/routes/routes.2.0.0/opam
+++ b/packages/routes/routes.2.0.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Typed routing for OCaml applications"
+description:
+  "routes provides combinators for adding typed routing to OCaml applications. The core library will be independent of any particular web framework or runtime. It does path based dispatch from a target url to a user provided handler."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "BSD-3-clause"
+tags: ["router" "http"]
+homepage: "https://github.com/anuragsoni/routes"
+doc: "https://anuragsoni.github.io/routes/"
+bug-reports: "https://github.com/anuragsoni/routes/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "base" {with-test}
+  "stdio" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_sexp_value" {with-test}
+  "ppx_custom_printf" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/anuragsoni/routes.git"
+url {
+  src:
+    "https://github.com/anuragsoni/routes/releases/download/2.0.0/routes-2.0.0.tbz"
+  checksum: [
+    "sha256=3b629d698c2b00e504c13b4cd783548063719dcf01580c9c3f5104b81eb0d688"
+    "sha512=428f88812f76c4d99198cea42c5d60a7924fd71acf87def6278544c391b9586a10ce2e34485b83b249f639c15776f30d0efd5bb145775eb49118ea8662005eb3"
+  ]
+}
+x-commit-hash: "1293a809e1e0f1104e99584de6c74dd022dda9ab"


### PR DESCRIPTION
Typed routing for OCaml applications

- Project page: <a href="https://github.com/anuragsoni/routes">https://github.com/anuragsoni/routes</a>
- Documentation: <a href="https://anuragsoni.github.io/routes/">https://anuragsoni.github.io/routes/</a>

##### CHANGES:

* use `ppx_expect` for tests
* add `route` function which is an alias of `@-->` and is used to connect a route pattern to a handler

## Breaking changes

* Drop support for OCaml 4.05-4.07
* Switch to a new model for trailing slash handling. In routes 1.0.0 users needed to be careful about using `/?` and `//?` as the former would only match routes without a trailing slash, and the latter would enforce a trailing slash.
  - Users only need to use `/?` to end routes, and it will cover both routes ending with trailing slashes and without
  - The type used for representing match results has more information about whether it was an exact match, or if it was a match but the input target had a trailing slash at the end.
  - `MatchWithTrailingSlash` informs the user that the current target was considered a match, but that the target has an additional trailing slash
