### PR TITLE
[new release] domainslib (0.5.0)

### DIFF
--- a/packages/domainslib/domainslib.0.5.0/opam
+++ b/packages/domainslib/domainslib.0.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/doc"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+depends: [
+  "ocaml" {>= "5.00"}
+  "dune" {>= "3.0"}
+  "lockfree" { >= "0.2.0"}
+  "mirage-clock-unix" {with-test}
+]
+build: [
+  "dune" "build" "-p" name
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/domainslib/releases/download/v0.5.0/domainslib-0.5.0.tbz"
+  checksum: [
+    "sha256=aedcbef435214d411c37b04f97c1ba43f1bf309eb3fd4027d113e41bc8400b00"
+    "sha512=58f8a3654428ba48223fe97b8b55bc1597334493b46d22c4de3a414603972cd022d53892ec46b0054c453e2495d523236c95c6c9a48b97fb805cbf3edee90c05"
+  ]
+}
+x-commit-hash: "8130f9bea88fbbb117b68561b9b018a6290ae1ff"

--- a/packages/domainslib/domainslib.0.5.0/opam
+++ b/packages/domainslib/domainslib.0.5.0/opam
@@ -3,7 +3,7 @@ maintainer: "KC Sivaramakrishnan <kc@kcsrk.info>"
 authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
 homepage: "https://github.com/ocaml-multicore/domainslib"
 doc: "https://ocaml-multicore.github.io/domainslib/doc"
-synopsis: "Parallel Structures over Domains for Multicore OCaml"
+synopsis: "Nested-parallel programming library"
 license: "ISC"
 dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
 bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"

--- a/packages/domainslib/domainslib.0.5.0/opam
+++ b/packages/domainslib/domainslib.0.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "mirage-clock-unix" {with-test}
 ]
 build: [
-  "dune" "build" "-p" name
+  "dune" "build" "-p" name "-j" jobs
 ]
 url {
   src:


### PR DESCRIPTION
Nested-parallel programming library 

- Project page: <a href="https://github.com/ocaml-multicore/domainslib">https://github.com/ocaml-multicore/domainslib</a>
- Documentation: <a href="https://ocaml-multicore.github.io/domainslib/doc">https://ocaml-multicore.github.io/domainslib/doc</a>

##### CHANGES:

This release includes:

* Bug fix for `parallel_for_reduce` on empty loops.
* Make Chan.t and Task.promise injective ocaml-multicore/domainslib#69
* Add lockfree dependency ocaml-multicore/domainslib#70
* CI fixes (ocaml-multicore/domainslib#73, ocaml-multicore/domainslib#76)
* Breaking change: Rename `num_additional_domains` to `num_domains` for setup_pool
* Documentation updates (ocaml-multicore/domainslib#80, ocaml-multicore/domainslib#81, ocaml-multicore/domainslib#82)
