### PR TITLE
[new release] conduit, conduit-mirage, conduit-lwt, conduit-lwt-unix and conduit-async (6.0.0)

### DIFF
--- a/packages/conduit-async/conduit-async.6.0.0/opam
+++ b/packages/conduit-async/conduit-async.6.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "core" {>= "v0.15.0"}
+  "uri" {>= "4.0.0"}
+  "ppx_here" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.15.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp" {>= "4.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.0.0/conduit-6.0.0.tbz"
+  checksum: [
+    "sha256=5ea8d2d9a5fe69d909083b40b8ebbee2e2b39e8bb5428dc43c5e7a11081f69de"
+    "sha512=5d58479873a06107ea7eeaba7444018e7a09135cc1a6f1fd813aa8279823ceb5f6cf613b5d2573f72e40eeaec9ab651c3e6d4e1f5dcacd95c46a91232c9b5873"
+  ]
+}
+x-commit-hash: "08e2eb6eaa19dd7e0cafea9a345b35e3d717b7c0"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.6.0.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.6.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "logs"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "ca-certs"
+  "lwt_log" {with-test}
+  "ssl" {with-test}
+  "lwt_ssl" {with-test}
+]
+depopts: ["tls" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls" {< "0.14.0"}
+  "ssl" {< "0.5.9"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.0.0/conduit-6.0.0.tbz"
+  checksum: [
+    "sha256=5ea8d2d9a5fe69d909083b40b8ebbee2e2b39e8bb5428dc43c5e7a11081f69de"
+    "sha512=5d58479873a06107ea7eeaba7444018e7a09135cc1a6f1fd813aa8279823ceb5f6cf613b5d2573f72e40eeaec9ab651c3e6d4e1f5dcacd95c46a91232c9b5873"
+  ]
+}
+x-commit-hash: "08e2eb6eaa19dd7e0cafea9a345b35e3d717b7c0"

--- a/packages/conduit-lwt/conduit-lwt.6.0.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.6.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.0.0/conduit-6.0.0.tbz"
+  checksum: [
+    "sha256=5ea8d2d9a5fe69d909083b40b8ebbee2e2b39e8bb5428dc43c5e7a11081f69de"
+    "sha512=5d58479873a06107ea7eeaba7444018e7a09135cc1a6f1fd813aa8279823ceb5f6cf613b5d2573f72e40eeaec9ab651c3e6d4e1f5dcacd95c46a91232c9b5873"
+  ]
+}
+x-commit-hash: "08e2eb6eaa19dd7e0cafea9a345b35e3d717b7c0"

--- a/packages/conduit-mirage/conduit-mirage.6.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "uri" {>= "4.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "dns-client" {>= "6.0.0"}
+  "conduit-lwt" {=version}
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ca-certs-nss"
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+  "tcpip" {>= "7.0.0"}
+  "fmt" {>= "0.8.7"}
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.0.0/conduit-6.0.0.tbz"
+  checksum: [
+    "sha256=5ea8d2d9a5fe69d909083b40b8ebbee2e2b39e8bb5428dc43c5e7a11081f69de"
+    "sha512=5d58479873a06107ea7eeaba7444018e7a09135cc1a6f1fd813aa8279823ceb5f6cf613b5d2573f72e40eeaec9ab651c3e6d4e1f5dcacd95c46a91232c9b5873"
+  ]
+}
+x-commit-hash: "08e2eb6eaa19dd7e0cafea9a345b35e3d717b7c0"

--- a/packages/conduit/conduit.6.0.0/opam
+++ b/packages/conduit/conduit.6.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.0.0/conduit-6.0.0.tbz"
+  checksum: [
+    "sha256=5ea8d2d9a5fe69d909083b40b8ebbee2e2b39e8bb5428dc43c5e7a11081f69de"
+    "sha512=5d58479873a06107ea7eeaba7444018e7a09135cc1a6f1fd813aa8279823ceb5f6cf613b5d2573f72e40eeaec9ab651c3e6d4e1f5dcacd95c46a91232c9b5873"
+  ]
+}
+x-commit-hash: "08e2eb6eaa19dd7e0cafea9a345b35e3d717b7c0"


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* conduit-mirage: delay parsing of nameservers (mirage/ocaml-conduit#415 @reynir, review by @dinosaure)
