### PR TITLE
[new release] duration (0.2.1)

### DIFF
--- a/packages/duration/duration.0.2.1/opam
+++ b/packages/duration/duration.0.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/hannesm/duration"
+doc: "https://hannesm.github.io/duration/doc"
+bug-reports: "https://github.com/hannesm/duration/issues"
+depends: [
+  "ocaml" {>= "4.04.2"}
+  "dune" {>= "1.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/hannesm/duration.git"
+synopsis: "Conversions to various time units"
+description: """
+A duration is represented in nanoseconds as an unsigned 64 bit integer.  This
+has a range of up to 584 years.  Functions provided check the input and raise
+on negative or out of bound input.
+"""
+url {
+  src:
+    "https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz"
+  checksum: [
+    "sha256=c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b"
+    "sha512=0de9e15c7d6188872ddd9994f08616c4a1822e4ac92724efa2c312fbb2fc44cd7cbe4b36bcf66a8451d510c1fc95de481760afbcacb8f83e183262595dcf5f0c"
+  ]
+}
+x-commit-hash: "6abe42ebe585a96f79eb91045911b9a73c1db19e"


### PR DESCRIPTION
Conversions to various time units

- Project page: <a href="https://github.com/hannesm/duration">https://github.com/hannesm/duration</a>
- Documentation: <a href="https://hannesm.github.io/duration/doc">https://hannesm.github.io/duration/doc</a>

##### CHANGES:

* Duration.pp: microseconds suffix is now "μs" instead of "us" (hannesm/duration#8 by @MisterDA)
