### PR TITLE
molenc >= 5.0.0 requires at least bst.2.0.0

### DIFF
--- a/packages/molenc/molenc.11.4.0/opam
+++ b/packages/molenc/molenc.11.4.0/opam
@@ -17,7 +17,7 @@ install: [
 ]
 depends: [
   "batteries"
-  "bst"
+  "bst" {>= "2.0.0"}
   "conf-graphviz"
   "conf-python-3"
   "conf-rdkit"

--- a/packages/molenc/molenc.15.4.0/opam
+++ b/packages/molenc/molenc.15.4.0/opam
@@ -22,7 +22,7 @@ install: [
 ]
 depends: [
   "batteries" {>= "3.0.0" & < "3.4.0"}
-  "bst"
+  "bst" {>= "2.0.0"}
   "conf-graphviz"
   "conf-python-3"
   "conf-rdkit"

--- a/packages/molenc/molenc.5.0.0/opam
+++ b/packages/molenc/molenc.5.0.0/opam
@@ -15,7 +15,7 @@ install: [
   ["cp" "bin/molenc_scan.sh" "%{bin}%/molenc_scan.sh"]
 ]
 depends: [
-  "bst"
+  "bst" {>= "2.0.0"}
   "dune" {>= "1.11"}
   "batteries"
   "dolog" {>= "4.0.0" & < "5.0.0"}

--- a/packages/molenc/molenc.5.0.1/opam
+++ b/packages/molenc/molenc.5.0.1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 depends: [
   "batteries"
-  "bst"
+  "bst" {>= "2.0.0"}
   "conf-python-3"
   "conf-rdkit"
   "dolog" {>= "4.0.0" & < "5.0.0"}

--- a/packages/molenc/molenc.7.0.1/opam
+++ b/packages/molenc/molenc.7.0.1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 depends: [
   "batteries"
-  "bst"
+  "bst" {>= "2.0.0"}
   "conf-python-3"
   "conf-rdkit"
   "cpm" {>= "9.0.0"}

--- a/packages/molenc/molenc.8.0.2/opam
+++ b/packages/molenc/molenc.8.0.2/opam
@@ -16,7 +16,7 @@ install: [
 ]
 depends: [
   "batteries"
-  "bst"
+  "bst" {>= "2.0.0"}
   "conf-python-3"
   "conf-rdkit"
   "cpm" {>= "9.0.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling molenc.5.0.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/molenc.5.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p molenc -j 31
# exit-code            1
# env-file             ~/.opam/log/molenc-7-60cc39.env
# output-file          ~/.opam/log/molenc-7-60cc39.out
### output ###
# File "/home/opam/.opam/4.14/lib/bst/bst.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
#       ocamlc src/.molenc.objs/byte/molenc__Utls.{cmi,cmo,cmt}
# File "src/utls.ml", line 332, characters 13-31:
# 332 |   Array.sort Pervasives.compare xs;
#                    ^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
#       ocamlc src/.molenc.objs/byte/molenc__Atom_env.{cmi,cmo,cmt}
# File "src/atom_env.ml", line 30, characters 16-32:
# 30 |   let strings = BatString.nsplit s ~by:"," in
#                      ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
# File "src/atom_env.ml", line 50, characters 22-38:
# 50 |   let layer_strings = BatString.nsplit s ~by:";" in
#                            ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
#       ocamlc src/.molenc.objs/byte/molenc__MyList.{cmi,cmo,cmt}
# File "src/myList.ml", line 27, characters 14-30:
# 27 |   map of_str (BatString.nsplit s' ~by:";")
#                    ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
#       ocamlc src/.molenc.objs/byte/molenc__Ap_types.{cmi,cmo,cmt}
# File "src/ap_types.ml", line 54, characters 25-41:
# 54 |       let dist_strings = BatString.nsplit line ~by:" " in
#                               ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
#     ocamlopt src/.molenc.objs/native/molenc__Utls.{cmx,o}
# File "src/utls.ml", line 332, characters 13-31:
# 332 |   Array.sort Pervasives.compare xs;
#                    ^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Stdlib.Pervasives
# Use Stdlib instead.
# 
# If you need to stay compatible with OCaml < 4.07, you can use the 
# stdlib-shims library: https://github.com/ocaml/stdlib-shims
#     ocamlopt src/.molenc.objs/native/molenc__Atom_env.{cmx,o}
# File "src/atom_env.ml", line 30, characters 16-32:
# 30 |   let strings = BatString.nsplit s ~by:"," in
#                      ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
# File "src/atom_env.ml", line 50, characters 22-38:
# 50 |   let layer_strings = BatString.nsplit s ~by:";" in
#                            ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
#     ocamlopt src/.molenc.objs/native/molenc__MyList.{cmx,o}
# File "src/myList.ml", line 27, characters 14-30:
# 27 |   map of_str (BatString.nsplit s' ~by:";")
#                    ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
#     ocamlopt src/.molenc.objs/native/molenc__Ap_types.{cmx,o}
# File "src/ap_types.ml", line 54, characters 25-41:
# 54 |       let dist_strings = BatString.nsplit line ~by:" " in
#                               ^^^^^^^^^^^^^^^^
# Alert deprecated: BatString.nsplit
# Use split_on_string instead.
#       ocamlc src/.encoder.eobjs/byte/butina.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.encoder.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/num -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parmap -I src/.molenc.objs/byte -no-alias-deps -o src/.encoder.eobjs/byte/butina.cmo -c -impl src/butina.ml)
# File "src/butina.ml", line 68, characters 12-15:
# 68 |   let bst = BST.(create 1 Two_bands (Array.of_list molecules)) in
#                  ^^^
# Error: This module is not a structure; it has type
#        functor (C : Bst__Bisec_tree.Config) ->
#          sig
#            type t = Bst.Bisec_tree.Make(FpMol)(C).t
#            val create : FpMol.t array -> t
#            val sample_distances : int -> FpMol.t array -> float array
#            val nearest_neighbor : FpMol.t -> t -> FpMol.t * float
#            val neighbors : FpMol.t -> float -> t -> FpMol.t list
#            val to_list : t -> FpMol.t list
#            val is_empty : t -> bool
#            val find : FpMol.t -> t -> FpMol.t
#            val mem : FpMol.t -> t -> bool
#            val root : t -> FpMol.t
#            val check : t -> bool
#            val inspect : t -> FpMol.t list
#            val dump :
#              int -> t -> (Bst.Bisec_tree.direction list * FpMol.t list) list
#          end
#       ocamlc src/.encoder.eobjs/byte/filter.{cmi,cmo,cmt} (exit 2)
```