### PR TITLE
OCaml 5.0.0~beta1 release

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~beta1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "First beta release of OCaml 5.0.0"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#5.0"
+depends: [
+  "ocaml" {= "5.0.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.0.0-beta1.tar.gz"
+  checksum: "sha256=75329f3cfcc4091cac8f35998ad946ecfc400d43f34119fb7c8b558d13e4633f"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~beta1+options/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First beta release of OCaml 5.0.0"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.0"
+depends: [
+  "ocaml" {= "5.0.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.0.0-beta1.tar.gz"
+  checksum: "sha256=75329f3cfcc4091cac8f35998ad946ecfc400d43f34119fb7c8b558d13e4633f"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [ "ocaml-option-fp" ]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+]


### PR DESCRIPTION
The two usual package for the first beta release for OCaml 5.0.

Compared to the alpha release, there are many small internal runtime fixes (in particular in the systhreads library).

At the user level, the interface of the `Domain` and `Effect` module has been tweaked to be (hopefully) more forward-compatible: 
- Exceptions related to effects are now defined in the `Effecŧ` module. 
- The value `Domain.recommended_domain_count` is no longer a constant and the function `Domain.at_each_spawn` has been removed.
 
The standard library should but stable now.
On Windows compiled executables no longer require the winpthread library to be in the user path.

There were also many internal bug fixes as detailed below.

Stdlib update since 5.0.0~alpha1
-----------------------------------------

+ 11309, 11424, 11427, +11545: Add Domain.recommended_domain_count.
   (Christiano Haesbaert, Konstantin Belousov, review by David Allsopp,
   KC Sivaramakrishnan, Gabriel Scherer, Nicolas Ojeda Bar)

- 11423: Move the effect exceptions to the Effect module

- 11593: Remove Domain.at_each_spawn

Bug fixes since 5.0.0~alpha1
---------------------------------

 - 11303: Ensure that GC is not invoked from bounds check failures
  (Stephen Dolan, review by Sadiq Jaffer and Xavier Leroy)

- 5299, 4787, 11138, 11272, 11506: To help debugging, `Caml_state`
  now dynamically checks that the domain lock is held, and fails
  otherwise (with a fatal error at most entry points of the C API, or
  systematically in debug mode). A new variable `Caml_state_opt` is
  introduced, and is `NULL` when the domain lock is not held. This
  allows to test from C code if the current thread holds the lock of
  its domain.
  (Guillaume Munch-Maccagnoni, review by Florian Angeletti, Damien
  Doligez, Sadiq Jaffer, Xavier Leroy, and Gabriel Scherer)

- 11223: The serialization format of custom blocks changed in 4.08,
  but the deserializer would still support the pre-4.08 format.  OCaml
  5.x removed support for this old format; provide a clear error message
  in this case.
  (Hugo Heuzard, review by Gabriel Scherer)

- 11504, 11522: Use static allocation in `caml_make_float_vect` in
  no-flat-float-array mode, it's more efficient and avoids a a race condition
  (Xavier Leroy, report by Guillaume Munch-Maccagnoni, review by David Allsopp)

- 11461, 11466: Fix gethostbyaddr for IPv6 arguments and make it domain-safe
  (Olivier Nicole, Nicolás Ojeda Bär, David Allsopp and Xavier Leroy,
   review by the same)

- 11479: Make Unix.symlink domain-safe on Windows
  (Olivier Nicole, review by Xavier Leroy and David Allsopp)

- 11294: Switch minimum required autoconf to 2.71.
  (David Allsopp, review by Xavier Leroy)

- 11370, 11373: Don't pass CFLAGS to flexlink during configure.
  (David Allsopp, report by William Hu, review by Xavier Leroy and
   Sébastien Hinderer)

- 11487: Thwart FMA test optimization during configure
  (William Hu, review by David Allsopp and Sébastien Hinderer)

- 11468: Fix regression from 10186 (OCaml 4.13) detecting IPv6 on Windows for
  mingw-w64 i686 port.
  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)

- 11482, 11542: Fix random crash in large closure allocation
  (Damien Doligez, report by Thierry Martinez and Vincent Laviron, review by
   Xavier Leroy)

- 11508, 11509: make Bytes.escaped domain-safe
  (Christiano Haesbaert and Gabriel Scherer,
   review by Xavier Leroy,
   report by Jan Midtgaard and Tom Kelly)

- 11516, 11524: Fix the `deprecated_mutable` attribute.
  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)

- 11576: Fix bug in Bigarray.Genarray.init in the the case of zero-dimensional
  arrays.
  (Nicolás Ojeda Bär, Jeremy Yallop, report by Masayuki Takeda, review by Jeremy
  Yallop and Florian Angeletti)

- 11587: Prevent integer comparison from being used on pointers
  (Vincent Laviron, review by Gabriel Scherer)

Documentation update since 5.0.0~alpha1
----------------------------------------


- 11093: Add tutorials on parallelism features and the relaxed memory model
  (KC Sivaramakrishnan, review by Damien Doligez, Anil Madhavapeddy, Gabriel
  Scherer, Thomas Leonard, Tom Ridge, Xavier Leroy, Luc Maranget, Fabrice
  Buoro, Olivier Nicole, Guillaume Munch-Maccagnoni, Jacques-Henri Jourdan)