### PR TITLE
Fix `ocaml-base-compiler.5.0.0~beta1` on bytecode-only architectures

### DIFF
--- a/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
+++ b/packages/ocaml-option-bytecode-only/ocaml-option-bytecode-only.1/opam
@@ -1,7 +1,8 @@
 opam-version: "2.0"
 synopsis: "Compile OCaml without the native-code compiler"
 depends: [
-  "ocaml-variants" {post & >= "4.12.0~"}
+  "ocaml-variants" {post & >= "4.12.0~"} |
+  "ocaml-base-compiler" {post & >= "5.0.0~~" & arch != "arm64" & arch != "x86_64"}
 ]
 conflicts: [ "ocaml-option-afl" "ocaml-option-fp" "ocaml-option-flambda" ]
 maintainer: "platform@lists.ocaml.org"

--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -9,6 +9,11 @@ conflicts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
+    {ocaml-system:version < "5" |
+     ocaml-base-compiler:version < "5" |
+     ocaml-variants:version < "5" |
+     arch = "arm64" |
+     arch = "x86_64" }
   "ocaml-option-default-unsafe-string"
   "ocaml-option-flambda"
   "ocaml-option-fp"


### PR DESCRIPTION
This allows the present version of `ocaml-base-compiler.5.0.0~beta1` to install. I'm tempted to say we should remove the dependency on `ocaml-option-bytecode-only` instead until we finally decide to merge the `+options` package and `ocaml-base-compiler` into 1.

- [x] Checked on i686 Debian `ocaml-base-compiler.5.0.0~beta1` pulls in the bytecode-only package and doesn't allow its removal
- [x] Checked on amd64 Ubuntu `ocaml-base-compiler.5.0.0~beta1` doesn't pull in `ocaml-option-bytecode-only` and it can't be added to the switch
- [x] Checked on amd64 Ubuntu `ocaml-base-compiler.4.14.0` likewise doesn't pull in the package and doesn't allow its installation
- [x] Checked on i686 Debian `ocaml-base-compiler.4.14.0` likewise doesn't pull in the package and doesn't allow its installation