### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.6)

### DIFF
--- a/packages/eio/eio.0.6/opam
+++ b/packages/eio/eio.0.6/opam
@@ -25,6 +25,8 @@ depends: [
 ]
 conflicts: [
   "ocaml-base-compiler" {< "5.0.0~beta1"}
+  "ocaml-variants" {< "5.0.0~beta1"}
+  "ocaml-system" {< "5.0.0~beta1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/eio/eio.0.6/opam
+++ b/packages/eio/eio.0.6/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "1.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-base-compiler" {< "5.0.0~beta1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.6/eio-0.6.tbz"
+  checksum: [
+    "sha256=ead3eea352dd3d7d11a81ffdbeee6ca94d5e6b3f46de264b4e59689360b3ef38"
+    "sha512=0543643da7861f533f9b7ebee8aa30a6868b48ae1e19211666a9b860e9ff8d8a9e135f214a4603d0329f2027277701f6ffd900b6fba3405a538eebc301edaf29"
+  ]
+}
+x-commit-hash: "9faa07bb934e7e44521f84eec110429faaab8ed4"

--- a/packages/eio_linux/eio_linux.0.6/opam
+++ b/packages/eio_linux/eio_linux.0.6/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.6/eio-0.6.tbz"
+  checksum: [
+    "sha256=ead3eea352dd3d7d11a81ffdbeee6ca94d5e6b3f46de264b4e59689360b3ef38"
+    "sha512=0543643da7861f533f9b7ebee8aa30a6868b48ae1e19211666a9b860e9ff8d8a9e135f214a4603d0329f2027277701f6ffd900b6fba3405a538eebc301edaf29"
+  ]
+}
+x-commit-hash: "9faa07bb934e7e44521f84eec110429faaab8ed4"

--- a/packages/eio_luv/eio_luv.0.6/opam
+++ b/packages/eio_luv/eio_luv.0.6/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.6/eio-0.6.tbz"
+  checksum: [
+    "sha256=ead3eea352dd3d7d11a81ffdbeee6ca94d5e6b3f46de264b4e59689360b3ef38"
+    "sha512=0543643da7861f533f9b7ebee8aa30a6868b48ae1e19211666a9b860e9ff8d8a9e135f214a4603d0329f2027277701f6ffd900b6fba3405a538eebc301edaf29"
+  ]
+}
+x-commit-hash: "9faa07bb934e7e44521f84eec110429faaab8ed4"

--- a/packages/eio_main/eio_main.0.6/opam
+++ b/packages/eio_main/eio_main.0.6/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.6/eio-0.6.tbz"
+  checksum: [
+    "sha256=ead3eea352dd3d7d11a81ffdbeee6ca94d5e6b3f46de264b4e59689360b3ef38"
+    "sha512=0543643da7861f533f9b7ebee8aa30a6868b48ae1e19211666a9b860e9ff8d8a9e135f214a4603d0329f2027277701f6ffd900b6fba3405a538eebc301edaf29"
+  ]
+}
+x-commit-hash: "9faa07bb934e7e44521f84eec110429faaab8ed4"


### PR DESCRIPTION
Effect-based direct-style IO mainloop for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

Changes:

- Update to OCaml 5.0.0~beta1 (@anmonteiro @talex5 ocaml-multicore/eio#346).

- Add API for seekable read/writes (@nojb ocaml-multicore/eio#307).

- Add `Flow.write` (@haesbaert ocaml-multicore/eio#318).
  This provides an optimised alternative to `copy` in the case where you are writing from a buffer.

- Add `Net.with_tcp_connect` (@bikallem ocaml-multicore/eio#302).
  Convenience function for opening a TCP connection.

- Add `Eio.Time.Timeout` (@talex5 ocaml-multicore/eio#320).
  Makes it easier to pass timeouts around.

- Add `Eio_mock.Clock` (@talex5 ocaml-multicore/eio#328).
  Control time in tests.

- Add `Buf_read.take_while1` and `skip_while1` (@bikallem ocaml-multicore/eio#309).
  These fail if no characters match.

- Make the type parameter for `Promise.t` covariant (@anmonteiro ocaml-multicore/eio#300).

- Move list functions into a dedicated submodule (@raphael-proust ocaml-multicore/eio#315).

- Direct implementation of `Flow.source_string` (@c-cube ocaml-multicore/eio#317).
  Slightly faster.

Bug fixes:

- `Condition.broadcast` must interlock as well (@haesbaert ocaml-multicore/eio#324).

- Split the reads into no more than 2^32-1 for luv (@haesbaert @talex5 @EduardoRFS ocaml-multicore/eio#343).
  Luv uses a 32 bit int for buffer sizes and wraps if the value passed is too big.

- eio_luv: allow `Net.connect` to be cancelled (@talex5 @nojb ocaml-multicore/eio#311).

- eio_main: Use dedicated log source (@anmonteiro ocaml-multicore/eio#326).

- linux_eio: fix kernel version number in log message (@talex5 @nojb ocaml-multicore/eio#314).

- Account for stack differences in the socketpair test (issue ocaml-multicore/eio#312) (@haesbaert ocaml-multicore/eio#313).

Documentation:

- Add Best Practices section to README (@talex5 ocaml-multicore/eio#299).

- Documentation improvements (@talex5 ocaml-multicore/eio#295 ocaml-multicore/eio#337).
