### PR TITLE
[new release] edn (0.2.0)

### DIFF
--- a/packages/edn/edn.0.2.0/opam
+++ b/packages/edn/edn.0.2.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Parsing OCaml library for EDN format"
+description:
+  "This library implements EDN parser and generator for OCaml."
+maintainer: "Andrew Rudenko <ceo@prepor.ru>"
+authors: "Andrew Rudenko <ceo@prepor.ru>"
+homepage: "http://github.com/prepor/ocaml-edn"
+license: "ISC"
+bug-reports: "http://github.com/prepor/ocaml-edn/issues"
+dev-repo: "git+https://github.com/prepor/ocaml-edn.git"
+doc: "https://prepor.github.io/ocaml-edn/doc"
+build: [["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.2.0"}
+  "menhir" {>= "20180523"}
+  "ounit2" {with-test}
+]
+depopts: [
+  "cconv"
+]
+url {
+  src:
+    "https://github.com/prepor/ocaml-edn/releases/download/v0.2.0/edn-0.2.0.tbz"
+  checksum: [
+    "sha256=7bf2f24eed0e1d7be00d218dcf27c1de53fed276eaf86bb5ea510df12732cdc0"
+    "sha512=cef755b969e817d43944be53560803b64b379dc2af1ee39ed0a1c83f79bcce8e664ccc0911c7075d9352ee17a4b2a39211d16da724859dff21702b426bb34730"
+  ]
+}
+x-commit-hash: "9e71572a1ccfbdd00fc1a3f7790deaf6ede04061"


### PR DESCRIPTION
Parsing OCaml library for EDN format

- Project page: <a href="http://github.com/prepor/ocaml-edn">http://github.com/prepor/ocaml-edn</a>
- Documentation: <a href="https://prepor.github.io/ocaml-edn/doc">https://prepor.github.io/ocaml-edn/doc</a>

##### CHANGES:

- change stream_from_channel to seq_from_channel
- compatibility with latest menhir and OCaml 5.0
- drop support for OCaml < 4.07
