### PR TITLE
Package opam-grep.0.4.0

### DIFF
--- a/packages/opam-grep/opam-grep.0.4.0/opam
+++ b/packages/opam-grep/opam-grep.0.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin that greps anything in the sources of every opam packages"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-grep"
+bug-reports: "https://github.com/kit-ty-kate/opam-grep/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "progress" {>= "0.2.1"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.3"}
+  "bos" {>= "0.2.0"}
+]
+available: os != "win32"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-grep.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-grep/releases/download/v0.4.0/opam-grep-0.4.0.tar.gz"
+  checksum: [
+    "md5=2a4cb24224971059020b824d83ed0d2e"
+    "sha512=e64767464c22e71b4bddc3de676633a60713282dd8397274f855472a48136d6503484d75fb8c8993a4f4f906515e7c588c57db1561ca84ea3b0de9c6c61b17c8"
+  ]
+}


### PR DESCRIPTION
### `opam-grep.0.4.0`
An opam plugin that greps anything in the sources of every opam packages



---
* Homepage: https://github.com/kit-ty-kate/opam-grep
* Source repo: git+https://github.com/kit-ty-kate/opam-grep.git
* Bug tracker: https://github.com/kit-ty-kate/opam-grep/issues

---
:camel: Pull-request generated by opam-publish v2.1.0