### PR TITLE
pgx.2.0 is not compatible with ocaml 5

### DIFF
--- a/packages/pgx/pgx.2.0/opam
+++ b/packages/pgx/pgx.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.11"}
   "hex"
   "ipaddr"
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "odoc" {with-doc}
   "ppx_compare" {>= "v0.13.0"}
   "ppx_custom_printf" {>= "v0.13.0"}


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling pgx.2.0 ============================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/pgx.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pgx -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/pgx-7-9cda9a.env
# output-file          ~/.opam/log/pgx-7-9cda9a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I pgx/src/.pgx.objs/byte -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/hex -I /home/opam/.opam/5.0/lib/ipaddr -I /home/opam/.opam/5.0/lib/macaddr -I /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/uuidm -intf-suffix .ml -no-alias-deps -open Pgx__ -o pgx/src/.pgx.objs/byte/pgx__Pgx_value.cmo -c -impl pgx/src/pgx_value.pp.ml)
# File "pgx/src/pgx_value.ml", line 108, characters 34-45:
# 108 |     if List.exists (fun c -> c <> Stream.next stream) target
#                                         ^^^^^^^^^^^
# Error: Unbound module Stream
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I pgx/src/.pgx.objs/byte -I pgx/src/.pgx.objs/native -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/hex -I /home/opam/.opam/5.0/lib/ipaddr -I /home/opam/.opam/5.0/lib/macaddr -I /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/uuidm -intf-suffix .ml -no-alias-deps -open Pgx__ -o pgx/src/.pgx.objs/native/pgx__Pgx_value.cmx -c -impl pgx/src/pgx_value.pp.ml)
# File "pgx/src/pgx_value.ml", line 108, characters 34-45:
# 108 |     if List.exists (fun c -> c <> Stream.next stream) target
#                                         ^^^^^^^^^^^
# Error: Unbound module Stream
```
Seen on https://github.com/ocaml/opam-repository/pull/22244