### PR TITLE
Package: fswatch_async.11-0.1.2

### DIFF
--- a/packages/fswatch_async/fswatch_async.11-0.1.2/opam
+++ b/packages/fswatch_async/fswatch_async.11-0.1.2/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/ocaml-fswatch/"
+bug-reports: "https://github.com/kandu/ocaml-fswatch/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/kandu/ocaml-fswatch"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "fswatch"
+  "async_unix" {>= "v0.11.0"}
+  "dune" {>= "1.4"}
+]
+
+synopsis: "JaneStreet Async extension for fswatch"
+
+url {
+  src: "https://github.com/kandu/ocaml-fswatch/archive/11-0.1.2.tar.gz"
+  checksum: "md5=e9d8f9ec267a7a0e46d6e1499b6029c8"
+}
+


### PR DESCRIPTION
11-0.1.2 (2022-10-14)
----------------------

fswatch\_async


this PR adds janestreet async support for the fswatch bindings.

as mentioned https://github.com/ocaml/opam-repository/issues/22256#issuecomment-1278523088 , build failure on debian/ubuntu is expected.