### PR TITLE
[new release] ppx_deriving_yaml (0.2.0)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Deriver"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "mdx" {with-test}
+  "ezjsonm" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.14.0"}
+  "ppx_deriving"
+  "yaml"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.2.0/ppx_deriving_yaml-0.2.0.tbz"
+  checksum: [
+    "sha256=4c79b893ee0904e266710386c434019a2980ef17f43422f47df47ff2038cc334"
+    "sha512=9ca8cfea87e3629057b8509b6d199e79279c9affe33e9b07c470381a71271eef267be5b10c1314c90e8b15fc6b170314040201840a4446004b119d3895ce0e14"
+  ]
+}
+x-commit-hash: "e5ecacdfb9e5f1cee1c5514ed3279546bacb1b2a"

--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.0/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.0/opam
@@ -8,7 +8,7 @@ license: "ISC"
 homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
 bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
 depends: [
-  "dune" {>= "2.6"}
+  "dune" {>= "2.7"}
   "alcotest" {with-test}
   "bos" {with-test}
   "mdx" {with-test}
@@ -17,9 +17,10 @@ depends: [
   "ppxlib" {>= "0.14.0"}
   "ppx_deriving"
   "yaml"
+  "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Yaml PPX Deriver

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

- Add custom `to_yaml` and `of_yaml` attributes (patricoferris/ppx_deriving_yaml#38, @patricoferris)
- Add `skip_unknown` flag to allow partially decoding yaml (patricoferris/ppx_deriving_yaml#40, @code-ghalib)
- Hide record fields with default values in to_yaml output (patricoferris/ppx_deriving_yaml#37, @maurobringolf, reviewed by @sim642 and @patricoferris)
- Expose `to_yaml` and `of_yaml` derivers with `yaml` being an alias (patricoferris/ppx_deriving_yaml#36, @patricoferris)
- Improved error messages (patricoferris/ppx_deriving_yaml#32, @prosper74, reviewed by @patricoferris)
- Add a default attribute for providing placeholder values (patricoferris/ppx_deriving_yaml#31, @prosper74, reviewed by @ayc9, @pitag-ha and @patricoferris)
