### PR TITLE
Re-add h2-async 0.9.0, gluten-async 0.3.0

### DIFF
--- a/packages/gluten-async/gluten-async.0.3.0/opam
+++ b/packages/gluten-async/gluten-async.0.3.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "gluten" {= version}
+  "faraday-async" {>= "0.8.2"}
+  "async" { >= "v0.15.0" }
+  "core" { >= "v0.15.0" }
+]
+depopts: [
+  "async_ssl"
+  "tls-async"
+ ]
+synopsis: "Async runtime for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.3.0/gluten-0.3.0.tbz"
+  checksum: [
+    "sha256=f6372d5f71bf9d0253189ec2952044897c317aed06713f4df8498f7cbb9214e5"
+    "sha512=684ceaabaed4ebcba44325985e40a7a1d111d3217978f4d30b078145eadd3b0773ad462b2fb646460caf3e7dbad5d3f704146fb50b95d588d18d869d7ae5e8f7"
+  ]
+}
+x-commit-hash: "12703c908995582efb2fa6c80562bcf8161c753f"

--- a/packages/h2-async/h2-async.0.8.0/opam
+++ b/packages/h2-async/h2-async.0.8.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.7"}
   "faraday-async"
   "async"
-  "gluten-async"
+  "gluten-async" {< "0.3.0"}
   "h2" {>= version}
 ]
 depopts: ["async_ssl"]

--- a/packages/h2-async/h2-async.0.8.0/opam
+++ b/packages/h2-async/h2-async.0.8.0/opam
@@ -15,7 +15,7 @@ depends: [
   "faraday-async"
   "async"
   "gluten-async" {< "0.3.0"}
-  "h2" {>= version}
+  "h2" {= version}
 ]
 depopts: ["async_ssl"]
 synopsis: "Async support for h2"

--- a/packages/h2-async/h2-async.0.9.0/opam
+++ b/packages/h2-async/h2-async.0.9.0/opam
@@ -13,9 +13,9 @@ depends: [
   "ocaml" {>= "4.06"}
   "dune" {>= "1.7"}
   "faraday-async" {>= "0.8.2"}
-  "async"
+  "async" {>= "v0.15.0"}
   "gluten-async" {>= "0.3.0"}
-  "h2" {>= version}
+  "h2" {= version}
 ]
 depopts: ["async_ssl"]
 synopsis: "Async support for h2"

--- a/packages/h2-async/h2-async.0.9.0/opam
+++ b/packages/h2-async/h2-async.0.9.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/ocaml-h2"
+bug-reports: "https://github.com/anmonteiro/ocaml-h2/issues"
+dev-repo: "git+https://github.com/anmonteiro/ocaml-h2.git"
+doc: "https://anmonteiro.github.io/ocaml-h2/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.7"}
+  "faraday-async" {>= "0.8.2"}
+  "async"
+  "gluten-async"
+  "h2" {>= version}
+]
+depopts: ["async_ssl"]
+synopsis: "Async support for h2"
+description: """
+h2 is an implementation of the HTTP/2 specification entirely in OCaml.
+h2-async provides an Async runtime implementation for h2.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/ocaml-h2/releases/download/0.9.0/h2-0.9.0.tbz"
+  checksum: [
+    "sha256=ee08d1849b369ae7d06c89805e22854fd999d641c64871f08c25593397f40b5e"
+    "sha512=a226c64b8084688cc93e19fcf649d228d3e441949ea576ec3d89d5d29404ed07a2e0ed87539d48afc59c3cdd16b9621646ac98a1b62ceefc9c5dec57a73b9ec4"
+  ]
+}
+x-commit-hash: "8ad7db35248e2d321b993fc60390ccfdd54cb096"

--- a/packages/h2-async/h2-async.0.9.0/opam
+++ b/packages/h2-async/h2-async.0.9.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.7"}
   "faraday-async" {>= "0.8.2"}
   "async"
-  "gluten-async"
+  "gluten-async" {>= "0.3.0"}
   "h2" {>= version}
 ]
 depopts: ["async_ssl"]


### PR DESCRIPTION
Should be possible after https://github.com/ocaml/opam-repository/pull/22260