### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.14.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.14.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.14.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.14.0/lsp-1.14.0.tbz"
+  checksum: [
+    "sha256=fee3f7d36e3f688a69879a63689c23de24d6120452e6d1249f3ead2a030ff515"
+    "sha512=e828dc54722ba2129598a3e69d692d3fe8fc27781727fff42394878f0fe0522d1ad80f32af2bb480437e3fb3e570a7f5b37cc3ff81be93e2433c852eb0d576f5"
+  ]
+}
+x-commit-hash: "580b5cb7c0099ec37cc4fbc01a7ed940ad64e43e"

--- a/packages/lsp/lsp.1.14.0/opam
+++ b/packages/lsp/lsp.1.14.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "menhir" {>= "20211230" & with-test}
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.14.0/lsp-1.14.0.tbz"
+  checksum: [
+    "sha256=fee3f7d36e3f688a69879a63689c23de24d6120452e6d1249f3ead2a030ff515"
+    "sha512=e828dc54722ba2129598a3e69d692d3fe8fc27781727fff42394878f0fe0522d1ad80f32af2bb480437e3fb3e570a7f5b37cc3ff81be93e2433c852eb0d576f5"
+  ]
+}
+x-commit-hash: "580b5cb7c0099ec37cc4fbc01a7ed940ad64e43e"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.14.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.14.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "omd" {>= "1.3.2" & < "2.0.0~alpha1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14" & < "4.15"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.14.0/lsp-1.14.0.tbz"
+  checksum: [
+    "sha256=fee3f7d36e3f688a69879a63689c23de24d6120452e6d1249f3ead2a030ff515"
+    "sha512=e828dc54722ba2129598a3e69d692d3fe8fc27781727fff42394878f0fe0522d1ad80f32af2bb480437e3fb3e570a7f5b37cc3ff81be93e2433c852eb0d576f5"
+  ]
+}
+x-commit-hash: "580b5cb7c0099ec37cc4fbc01a7ed940ad64e43e"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Code action for inlining let bindings within a module or expression. (ocaml/ocaml-lsp#847)

- Tag "unused code" and "deprecated" warnings, allowing clients to better
  display them. (ocaml/ocaml-lsp#848)

- Refresh merlin configuration after every dune build in watch mode (ocaml/ocaml-lsp#853)

## Fixes

- Respect `showDocument` capabilities. Do not offer commands or code actions
  that rely on this request without client support. (ocaml/ocaml-lsp#836)

- Fix signatureHelp on .mll files: avoid "Document.dune" exceptions
