### PR TITLE
[new release] stdint (0.7.1)

### DIFF
--- a/packages/stdint/stdint.0.7.1/opam
+++ b/packages/stdint/stdint.0.7.1/opam
@@ -24,11 +24,11 @@ conversion to readable strings (binary, octal, decimal, hexademical), conversion
 to and from buffers in both big endian and little endian byte order."""
 depends: [
   "ocaml" {>= "4.03"}
-  "qcheck" {test}
+  "qcheck" {with-test}
   "dune" {>= "1.10"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/stdint/stdint.0.7.1/opam
+++ b/packages/stdint/stdint.0.7.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: ["Markus W. Weissmann <markus.weissmann@in.tum.de>"]
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+homepage: "https://github.com/andrenth/ocaml-stdint"
+doc: "https://andrenth.github.io/ocaml-stdint/"
+license: "MIT"
+dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
+synopsis: "Signed and unsigned integer types having specified widths"
+description: """
+The stdint library provides signed and unsigned integer types of various fixed
+widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical), conversion
+to and from buffers in both big endian and little endian byte order."""
+depends: [
+  "ocaml" {>= "4.03"}
+  "qcheck" {test}
+  "dune" {>= "1.10"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/andrenth/ocaml-stdint/releases/download/0.7.1/stdint-0.7.1.tbz"
+  checksum: [
+    "sha256=3387ca659b500efd83bb52792d61e56ba2f8bf7198f488ae35daf499d73396b4"
+    "sha512=c594b88848f9119cb9401e21cc6b464913d0f6d058ea60424dde367c072aac541371ee3f70c87f19232cba9328f44a4ec3c925eebb0992fce662ebddd9a0e579"
+  ]
+}
+x-commit-hash: "e9ed8e84e730ca8f3750e2a82cd5b46c2ea70d9a"


### PR DESCRIPTION
Signed and unsigned integer types having specified widths

- Project page: <a href="https://github.com/andrenth/ocaml-stdint">https://github.com/andrenth/ocaml-stdint</a>
- Documentation: <a href="https://andrenth.github.io/ocaml-stdint/">https://andrenth.github.io/ocaml-stdint/</a>

##### CHANGES:

## Fixes:

* Fix undefined reference to `get_uint128` (andrenth/ocaml-stdint#62)
* Add `[@@noalloc]` where possible (andrenth/ocaml-stdint#64)
* Fix compatibility with 5.0 (andrenth/ocaml-stdint#68)
