### PR TITLE
[new release] melange-compiler-libs (0.0.1-414)

### DIFF
--- a/packages/melange-compiler-libs/melange-compiler-libs.0.0.1-414/opam
+++ b/packages/melange-compiler-libs/melange-compiler-libs.0.0.1-414/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/melange-re/melange-compiler-libs/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.14.0" & < "4.15.0"}
-  "menhir"
+  "menhir" {>= "20201214"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/melange-compiler-libs/melange-compiler-libs.0.0.1-414/opam
+++ b/packages/melange-compiler-libs/melange-compiler-libs.0.0.1-414/opam
@@ -3,6 +3,7 @@ synopsis:
   "Compiler libraries for Melange, a toolchain to produce JavaScript from OCaml"
 maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
 authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/melange-re/melange-compiler-libs"
 bug-reports: "https://github.com/melange-re/melange-compiler-libs/issues"
 depends: [

--- a/packages/melange-compiler-libs/melange-compiler-libs.0.0.1-414/opam
+++ b/packages/melange-compiler-libs/melange-compiler-libs.0.0.1-414/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler libraries for Melange, a toolchain to produce JavaScript from OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+homepage: "https://github.com/melange-re/melange-compiler-libs"
+bug-reports: "https://github.com/melange-re/melange-compiler-libs/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0" & < "4.15.0"}
+  "menhir"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+url {
+  src:
+    "https://github.com/melange-re/melange-compiler-libs/releases/download/0.0.1-414/melange-compiler-libs-0.0.1-414.tbz"
+  checksum: [
+    "sha256=dad8d77adc458224aeaac72e52d0e8d04189c4913102dc21c329556120dff8b4"
+    "sha512=28dd4b05290855e9f54a472e9f05a8c5a4996919c3c2147eec358f5862443a265cb8115c8aaf7431b3f29af19212ca34f27206373d94334f433e540be9e3e884"
+  ]
+}
+x-commit-hash: "52b6ffbafb143b556ebacba3cea0c843106a2bf5"


### PR DESCRIPTION
Compiler libraries for Melange, a toolchain to produce JavaScript from OCaml

- Project page: <a href="https://github.com/melange-re/melange-compiler-libs">https://github.com/melange-re/melange-compiler-libs</a>

##### CHANGES:

- Initial public release
