### PR TITLE
molenc.5.0.0 added batteries lower bound

### DIFF
--- a/packages/molenc/molenc.5.0.0/opam
+++ b/packages/molenc/molenc.5.0.0/opam
@@ -17,7 +17,7 @@ install: [
 depends: [
   "bst" {>= "2.0.0"}
   "dune" {>= "1.11"}
-  "batteries"
+  "batteries" {>= "2.9.0"}
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "minicli"
   "conf-rdkit"


### PR DESCRIPTION
apparently, this is the only constraint I need to add so this compiles w/ ocaml-4.04.0. The lbound was found by hand; which is quite boring and time consuming to do.