### PR TITLE
[new release] doi2bib (0.6.2)

### DIFF
--- a/packages/doi2bib/doi2bib.0.6.2/opam
+++ b/packages/doi2bib/doi2bib.0.6.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Small CLI to get a bibtex entry from a DOI, an arXiv ID or a PubMed ID"
+maintainer: ["marcello.seri@gmail.com"]
+authors: ["Marcello Seri"]
+license: "MIT"
+homepage: "https://github.com/mseri/doi2bib"
+bug-reports: "https://github.com/mseri/doi2bib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "astring" {>= "0.8.0"}
+  "cohttp-lwt-unix" {>= "2.5.0"}
+  "cmdliner" {>= "1.1.0"}
+  "clz" {>= "0.1.0"}
+  "ezxmlm" {>= "1.1.0"}
+  "lwt" {>= "5.5.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "tls" {>= "0.12.0"}
+  "re" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mseri/doi2bib.git"
+url {
+  src:
+    "https://github.com/mseri/doi2bib/releases/download/0.6.2/doi2bib-0.6.2.tbz"
+  checksum: [
+    "sha256=ab89390d4e7d0eb536871c7b9a98b1a5f38adaace2918f9a7885cf2af2856206"
+    "sha512=7b05214afba26416de5b2471cc53e8d8ba0b31f675b59654c98ac3c692288f5670b1bf2b636ee2a891658b00816575522cfdce56b397e48f8bf3c67d965df0f4"
+  ]
+}
+x-commit-hash: "1fb69292159cd3c5a9a5a41dcc8037e8ca6aa583"

--- a/packages/doi2bib/doi2bib.0.6.2/opam
+++ b/packages/doi2bib/doi2bib.0.6.2/opam
@@ -30,7 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
CHANGES:

- Workaround for %-escapes in crossref's doi url field