### PR TITLE
bonsai.v0.15.0 is not compatible with jsoo4

### DIFF
--- a/packages/bonsai/bonsai.v0.15.0/opam
+++ b/packages/bonsai/bonsai.v0.15.0/opam
@@ -36,7 +36,8 @@ depends: [
   "cohttp-async"             {>= "2.5.6" & < "3.0.0" | >= "5.0.0"}
   "dune"                     {>= "2.0.0"}
   "gen_js_api"               {>= "1.0.8"}
-  "js_of_ocaml-ppx"          {>= "3.9.0"}
+  "js_of_ocaml"              {>= "3.9.0" & < "4.0.0"}
+  "js_of_ocaml-ppx"          {>= "3.9.0" & < "4.0.0"}
   "ocaml-embed-file"         {>= "v0.15" & < "v0.16"}
   "re"                       {>= "1.8.0"}
 ]


### PR DESCRIPTION
(Dom_html.window##.innerHeight changed type)
```
#=== ERROR while compiling bonsai.v0.15.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/bonsai.v0.15.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bonsai -j 31
# exit-code            1
# env-file             ~/.opam/log/bonsai-8-5487c6.env
# output-file          ~/.opam/log/bonsai-8-5487c6.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I web/.bonsai_web.objs/byte -I /home/opam/.opam/4.14/lib/abstract_algebra -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/async_js -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/balanced_reducer -I /home/opam/.opam/4.14/lib/core_kernel/bus -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/weak_array -I /home/opam/.opam/4.14/lib/core_kernel/weak_hashtbl -I /home/opam/.opam/4.14/lib/core_kernel/weak_pointer -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/incr_dom -I /home/opam/.opam/4.14/lib/incr_dom/javascript_profiling -I /home/opam/.opam/4.14/lib/incr_dom/ui_incr -I /home/opam/.opam/4.14/lib/incr_dom/vdom_file_download -I /home/opam/.opam/4.14/lib/incr_map -I /home/opam/.opam/4.14/lib/incr_select -I /home/opam/.opam/4.14/lib/incremental -I /home/opam/.opam/4.14/lib/incremental/incremental_step_function -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/ojs -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/virtual_dom -I /home/opam/.opam/4.14/lib/virtual_dom/css_gen -I /home/opam/.opam/4.14/lib/virtual_dom/ui_effect -I src/.bonsai.objs/byte -I src/protocol/.bonsai_protocol.objs/byte -I web_ui/tailwind_colors/.tailwind_colors.objs/byte -intf-suffix .ml -no-alias-deps -open Bonsai_web__ -o web/.bonsai_web.objs/byte/bonsai_web__Forward_performance_entries.cmo -c -impl web/forward_performance_entries.pp.ml)
# File "web/forward_performance_entries.ml", line 225, characters 42-53:
# 225 |     let start_time = entry##.startTime |> Js.to_float in
#                                                 ^^^^^^^^^^^
# Alert deprecated: Js_of_ocaml.Js.to_float
# [since 2.0].
# File "web/forward_performance_entries.ml", line 226, characters 39-50:
# 226 |     let duration = entry##.duration |> Js.to_float in
#                                              ^^^^^^^^^^^
# Alert deprecated: Js_of_ocaml.Js.to_float
# [since 2.0].
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/byte -I /home/opam/.opam/4.14/lib/abstract_algebra -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/async_js -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/balanced_reducer -I /home/opam/.opam/4.14/lib/core_kernel/bus -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/weak_array -I /home/opam/.opam/4.14/lib/core_kernel/weak_hashtbl -I /home/opam/.opam/4.14/lib/core_kernel/weak_pointer -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/incr_dom -I /home/opam/.opam/4.14/lib/incr_dom/javascript_profiling -I /home/opam/.opam/4.14/lib/incr_dom/ui_incr -I /home/opam/.opam/4.14/lib/incr_dom/vdom_file_download -I /home/opam/.opam/4.14/lib/incr_map -I /home/opam/.opam/4.14/lib/incr_select -I /home/opam/.opam/4.14/lib/incremental -I /home/opam/.opam/4.14/lib/incremental/incremental_step_function -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/ojs -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/virtual_dom -I /home/opam/.opam/4.14/lib/virtual_dom/css_gen -I /home/opam/.opam/4.14/lib/virtual_dom/ui_effect -I extra/.bonsai_extra.objs/byte -I src/.bonsai.objs/byte -I src/protocol/.bonsai_protocol.objs/byte -I web/.bonsai_web.objs/byte -I web_ui/tailwind_colors/.tailwind_colors.objs/byte -intf-suffix .ml -no-alias-deps -open Bonsai_web_ui_element_size_hooks__ -o web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/byte/bonsai_web_ui_element_size_hooks__Visibility_tracker.cmo -c -impl web_ui/element_size_hooks/visibility_tracker.pp.ml)
# File "web_ui/element_size_hooks/visibility_tracker.ml", line 26, characters 54-67:
# 26 |   let%bind.Option window_height = Js.Optdef.to_option window_height in
#                                                            ^^^^^^^^^^^^^
# Error: This expression has type int but an expression was expected of type
#          'a Js_of_ocaml.Js.Optdef.t = 'a Js_of_ocaml.Js.optdef
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I web/.bonsai_web.objs/byte -I web/.bonsai_web.objs/native -I /home/opam/.opam/4.14/lib/abstract_algebra -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/async_js -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/balanced_reducer -I /home/opam/.opam/4.14/lib/core_kernel/bus -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/weak_array -I /home/opam/.opam/4.14/lib/core_kernel/weak_hashtbl -I /home/opam/.opam/4.14/lib/core_kernel/weak_pointer -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/incr_dom -I /home/opam/.opam/4.14/lib/incr_dom/javascript_profiling -I /home/opam/.opam/4.14/lib/incr_dom/ui_incr -I /home/opam/.opam/4.14/lib/incr_dom/vdom_file_download -I /home/opam/.opam/4.14/lib/incr_map -I /home/opam/.opam/4.14/lib/incr_select -I /home/opam/.opam/4.14/lib/incremental -I /home/opam/.opam/4.14/lib/incremental/incremental_step_function -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/ojs -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/virtual_dom -I /home/opam/.opam/4.14/lib/virtual_dom/css_gen -I /home/opam/.opam/4.14/lib/virtual_dom/ui_effect -I src/.bonsai.objs/byte -I src/.bonsai.objs/native -I src/protocol/.bonsai_protocol.objs/byte -I src/protocol/.bonsai_protocol.objs/native -I web_ui/tailwind_colors/.tailwind_colors.objs/byte -I web_ui/tailwind_colors/.tailwind_colors.objs/native -intf-suffix .ml -no-alias-deps -open Bonsai_web__ -o web/.bonsai_web.objs/native/bonsai_web__Forward_performance_entries.cmx -c -impl web/forward_performance_entries.pp.ml)
# File "web/forward_performance_entries.ml", line 225, characters 42-53:
# 225 |     let start_time = entry##.startTime |> Js.to_float in
#                                                 ^^^^^^^^^^^
# Alert deprecated: Js_of_ocaml.Js.to_float
# [since 2.0].
# File "web/forward_performance_entries.ml", line 226, characters 39-50:
# 226 |     let duration = entry##.duration |> Js.to_float in
#                                              ^^^^^^^^^^^
# Alert deprecated: Js_of_ocaml.Js.to_float
# [since 2.0].
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/byte -I web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/native -I /home/opam/.opam/4.14/lib/abstract_algebra -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/async_js -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/balanced_reducer -I /home/opam/.opam/4.14/lib/core_kernel/bus -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/weak_array -I /home/opam/.opam/4.14/lib/core_kernel/weak_hashtbl -I /home/opam/.opam/4.14/lib/core_kernel/weak_pointer -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/incr_dom -I /home/opam/.opam/4.14/lib/incr_dom/javascript_profiling -I /home/opam/.opam/4.14/lib/incr_dom/ui_incr -I /home/opam/.opam/4.14/lib/incr_dom/vdom_file_download -I /home/opam/.opam/4.14/lib/incr_map -I /home/opam/.opam/4.14/lib/incr_select -I /home/opam/.opam/4.14/lib/incremental -I /home/opam/.opam/4.14/lib/incremental/incremental_step_function -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/ojs -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/virtual_dom -I /home/opam/.opam/4.14/lib/virtual_dom/css_gen -I /home/opam/.opam/4.14/lib/virtual_dom/ui_effect -I extra/.bonsai_extra.objs/byte -I extra/.bonsai_extra.objs/native -I src/.bonsai.objs/byte -I src/.bonsai.objs/native -I src/protocol/.bonsai_protocol.objs/byte -I src/protocol/.bonsai_protocol.objs/native -I web/.bonsai_web.objs/byte -I web/.bonsai_web.objs/native -I web_ui/tailwind_colors/.tailwind_colors.objs/byte -I web_ui/tailwind_colors/.tailwind_colors.objs/native -intf-suffix .ml -no-alias-deps -open Bonsai_web_ui_element_size_hooks__ -o web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/native/bonsai_web_ui_element_size_hooks__Weak_map.cmx -c -impl web_ui/element_size_hooks/weak_map.pp.ml)
# File "_none_", line 1:
# Warning 58 [no-cmx-file]: no cmx file was found in path for module Ojs, and its interface was not compiled with -opaque
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/byte -I web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/native -I /home/opam/.opam/4.14/lib/abstract_algebra -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/async_js -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/balanced_reducer -I /home/opam/.opam/4.14/lib/core_kernel/bus -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/reversed_list -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/weak_array -I /home/opam/.opam/4.14/lib/core_kernel/weak_hashtbl -I /home/opam/.opam/4.14/lib/core_kernel/weak_pointer -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/incr_dom -I /home/opam/.opam/4.14/lib/incr_dom/javascript_profiling -I /home/opam/.opam/4.14/lib/incr_dom/ui_incr -I /home/opam/.opam/4.14/lib/incr_dom/vdom_file_download -I /home/opam/.opam/4.14/lib/incr_map -I /home/opam/.opam/4.14/lib/incr_select -I /home/opam/.opam/4.14/lib/incremental -I /home/opam/.opam/4.14/lib/incremental/incremental_step_function -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/js_of_ocaml -I /home/opam/.opam/4.14/lib/js_of_ocaml-compiler/runtime -I /home/opam/.opam/4.14/lib/ojs -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/virtual_dom -I /home/opam/.opam/4.14/lib/virtual_dom/css_gen -I /home/opam/.opam/4.14/lib/virtual_dom/ui_effect -I extra/.bonsai_extra.objs/byte -I extra/.bonsai_extra.objs/native -I src/.bonsai.objs/byte -I src/.bonsai.objs/native -I src/protocol/.bonsai_protocol.objs/byte -I src/protocol/.bonsai_protocol.objs/native -I web/.bonsai_web.objs/byte -I web/.bonsai_web.objs/native -I web_ui/tailwind_colors/.tailwind_colors.objs/byte -I web_ui/tailwind_colors/.tailwind_colors.objs/native -intf-suffix .ml -no-alias-deps -open Bonsai_web_ui_element_size_hooks__ -o web_ui/element_size_hooks/.bonsai_web_ui_element_size_hooks.objs/native/bonsai_web_ui_element_size_hooks__Visibility_tracker.cmx -c -impl web_ui/element_size_hooks/visibility_tracker.pp.ml)
# File "web_ui/element_size_hooks/visibility_tracker.ml", line 26, characters 54-67:
# 26 |   let%bind.Option window_height = Js.Optdef.to_option window_height in
#                                                            ^^^^^^^^^^^^^
# Error: This expression has type int but an expression was expected of type
#          'a Js_of_ocaml.Js.Optdef.t = 'a Js_of_ocaml.Js.optdef
```