### PR TITLE
Mark core_unix.v0.15.0 not compatible with OCaml 5.0

### DIFF
--- a/packages/core_unix/core_unix.v0.15.0/opam
+++ b/packages/core_unix/core_unix.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"                    {>= "4.08.0"}
+  "ocaml"                    {>= "4.08.0" & < "5.0"}
   "core"                     {>= "v0.15" & < "v0.16"}
   "core_kernel"              {>= "v0.15" & < "v0.16"}
   "expect_test_helpers_core" {>= "v0.15" & < "v0.16"}


### PR DESCRIPTION
Forgotten in #22270 
Linking with it produces the following errors. e.g.:
```
#=== ERROR while compiling http_async.0.1.0 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | pinned(https://github.com/anuragsoni/http_async/releases/download/0.1.0/http_async-0.1.0.tbz)
# path                 ~/.opam/5.0/.opam-switch/build/http_async.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p http_async -j 31 --promote-install-files=false @install @runtest
# exit-code            1
# env-file             ~/.opam/log/http_async-7-ce3091.env
# output-file          ~/.opam/log/http_async-7-ce3091.out
### output ###
# File "test/dune", line 1, characters 0-123:
# 1 | (library
# 2 |  (name test_async_http)
# 3 |  (inline_tests)
# 4 |  (preprocess
# 5 |   (pps ppx_jane))
# 6 |  (libraries http_async core async shuttle))
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w -24 -g -g -o test/.test_async_http.inline-tests/inline_test_runner_test_async_http.exe /home/opam/.opam/5.0/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /home/opam/.opam/5.0/lib/base/base_internalhash_types /home/opam/.opam/5.0/lib/base/caml/caml.cmxa /home/opam/.opam/5.0/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.0/lib/base/shadow_stdlib/shadow_stdlib.cmxa /home/opam/.opam/5.0/lib/base/base.cmxa -I /home/opam/.opam/5.0/lib/base /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /home/opam/.opam/5.0/lib/ppx_here/runtime-lib/ppx_here_lib.cmxa /home/opam/.opam/5.0/lib/ppx_assert/runtime-lib/ppx_assert_lib.cmxa /home/opam/.opam/5.0/lib/ppx_bench/runtime-lib/ppx_bench_lib.cmxa /home/opam/.opam/5.0/lib/base/md5/md5_lib.cmxa /home/opam/.opam/5.0/lib/fieldslib/fieldslib.cmxa /home/opam/.opam/5.0/lib/variantslib/variantslib.cmxa /home/opam/.opam/5.0/lib/bin_prot/shape/bin_shape_lib.cmxa /home/opam/.opam/5.0/lib/bin_prot/bin_prot.cmxa -I /home/opam/.opam/5.0/lib/bin_prot /home/opam/.opam/5.0/lib/ppx_inline_test/config/inline_test_config.cmxa /home/opam/.opam/5.0/lib/jane-street-headers/jane_street_headers.cmxa /home/opam/.opam/5.0/lib/time_now/time_now.cmxa -I /home/opam/.opam/5.0/lib/time_now /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa /home/opam/.opam/5.0/lib/stdio/stdio.cmxa /home/opam/.opam/5.0/lib/ppx_module_timer/runtime/ppx_module_timer_runtime.cmxa /home/opam/.opam/5.0/lib/typerep/typerep_lib.cmxa /home/opam/.opam/5.0/lib/ppx_expect/common/expect_test_common.cmxa /home/opam/.opam/5.0/lib/ppx_expect/config_types/expect_test_config_types.cmxa /home/opam/.opam/5.0/lib/ppx_expect/collector/expect_test_collector.cmxa -I /home/opam/.opam/5.0/lib/ppx_expect/collector /home/opam/.opam/5.0/lib/ppx_expect/config/expect_test_config.cmxa /home/opam/.opam/5.0/lib/parsexp/parsexp.cmxa /home/opam/.opam/5.0/lib/sexplib/sexplib.cmxa /home/opam/.opam/5.0/lib/ppx_log/types/ppx_log_types.cmxa /home/opam/.opam/5.0/lib/splittable_random/splittable_random.cmxa /home/opam/.opam/5.0/lib/base_quickcheck/base_quickcheck.cmxa /home/opam/.opam/5.0/lib/base_quickcheck/ppx_quickcheck/runtime/ppx_quickcheck_runtime.cmxa /home/opam/.opam/5.0/lib/int_repr/int_repr.cmxa /home/opam/.opam/5.0/lib/base_bigstring/base_bigstring.cmxa -I /home/opam/.opam/5.0/lib/base_bigstring /home/opam/.opam/5.0/lib/core/base_for_tests/base_for_tests.cmxa /home/opam/.opam/5.0/lib/core/validate/validate.cmxa /home/opam/.opam/5.0/lib/core/core.cmxa -I /home/opam/.opam/5.0/lib/core /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/core_kernel/caml_threads/caml_threads.cmxa /home/opam/.opam/5.0/lib/core_unix/error_checking_mutex/error_checking_mutex.cmxa -I /home/opam/.opam/5.0/lib/core_unix/error_checking_mutex /home/opam/.opam/5.0/lib/core_kernel/flags/flags.cmxa /home/opam/.opam/5.0/lib/sexplib/unix/sexplib_unix.cmxa /home/opam/.opam/5.0/lib/core_kernel/caml_unix/caml_unix.cmxa /home/opam/.opam/5.0/lib/core_unix/signal_unix/signal_unix.cmxa -I /home/opam/.opam/5.0/lib/core_unix/signal_unix /home/opam/.opam/5.0/lib/spawn/spawn.cmxa -I /home/opam/.opam/5.0/lib/spawn /home/opam/.opam/5.0/lib/core_unix/core_unix.cmxa -I /home/opam/.opam/5.0/lib/core_unix /home/opam/.opam/5.0/lib/core_kernel/thread_pool_cpu_affinity/thread_pool_cpu_affinity.cmxa /home/opam/.opam/5.0/lib/core_kernel/tuple_pool/tuple_pool.cmxa /home/opam/.opam/5.0/lib/core_kernel/timing_wheel/timing_wheel.cmxa /home/opam/.opam/5.0/lib/async_kernel/config/async_kernel_config.cmxa /home/opam/.opam/5.0/lib/core_kernel/moption/moption.cmxa /home/opam/.opam/5.0/lib/core_kernel/pairing_heap/pairing_heap.cmxa /home/opam/.opam/5.0/lib/core_kernel/sexp_hidden_in_test/sexp_hidden_in_test.cmxa /home/opam/.opam/5.0/lib/core_kernel/uopt/uopt.cmxa /home/opam/.opam/5.0/lib/core_kernel/thread_safe_queue/thread_safe_queue.cmxa /home/opam/.opam/5.0/lib/async_kernel/async_kernel.cmxa /home/opam/.opam/5.0/lib/core_unix/ocaml_c_utils/ocaml_c_utils.cmxa -I /home/opam/.opam/5.0/lib/core_unix/ocaml_c_utils /home/opam/.opam/5.0/lib/core_unix/bigstring_unix/bigstring_unix.cmxa -I /home/opam/.opam/5.0/lib/core_unix/bigstring_unix /home/opam/.opam/5.0/lib/core_kernel/bounded_int_table/bounded_int_table.cmxa /home/opam/.opam/5.0/lib/core_unix/sys_unix/sys_unix.cmxa -I /home/opam/.opam/5.0/lib/core_unix/sys_unix /home/opam/.opam/5.0/lib/core_unix/filename_unix/filename_unix.cmxa -I /home/opam/.opam/5.0/lib/core_unix/filename_unix /home/opam/.opam/5.0/lib/core_kernel/iobuf/iobuf.cmxa /home/opam/.opam/5.0/lib/core_unix/iobuf_unix/iobuf_unix.cmxa -I /home/opam/.opam/5.0/lib/core_unix/iobuf_unix /home/opam/.opam/5.0/lib/core_unix/core_thread/core_thread.cmxa -I /home/opam/.opam/5.0/lib/core_unix/core_thread /home/opam/.opam/5.0/lib/core_unix/nano_mutex/nano_mutex.cmxa /home/opam/.opam/5.0/lib/async_kernel/read_write_pair/read_write_pair.cmxa /home/opam/.opam/5.0/lib/core_unix/squeue/squeue.cmxa /home/opam/.opam/5.0/lib/timezone/timezone.cmxa /home/opam/.opam/5.0/lib/core_unix/time_unix/time_unix.cmxa /home/opam/.opam/5.0/lib/core_unix/time_ns_unix/time_ns_unix.cmxa /home/opam/.opam/5.0/lib/core_unix/linux_ext/linux_ext.cmxa -I /home/opam/.opam/5.0/lib/core_unix/linux_ext /home/opam/.opam/5.0/lib/async_unix/thread_safe_ivar/thread_safe_ivar.cmxa /home/opam/.opam/5.0/lib/async_unix/thread_pool/thread_pool.cmxa /home/opam/.opam/5.0/lib/ocaml_intrinsics/ocaml_intrinsics.cmxa -I /home/opam/.opam/5.0/lib/ocaml_intrinsics /home/opam/.opam/5.0/lib/core_unix/time_stamp_counter/time_stamp_counter.cmxa -I /home/opam/.opam/5.0/lib/core_unix/time_stamp_counter /home/opam/.opam/5.0/lib/core_kernel/uuid/uuid.cmxa /home/opam/.opam/5.0/lib/core_unix/uuid/uuid_unix.cmxa /home/opam/.opam/5.0/lib/async_unix/async_unix.cmxa -I /home/opam/.opam/5.0/lib/async_unix /home/opam/.opam/5.0/lib/async/async_command/async_command.cmxa /home/opam/.opam/5.0/lib/async/async_quickcheck/async_quickcheck.cmxa /home/opam/.opam/5.0/lib/async_kernel/persistent_connection_kernel/persistent_connection_kernel.cmxa /home/opam/.opam/5.0/lib/protocol_version_header/protocol_version_header.cmxa /home/opam/.opam/5.0/lib/async_rpc_kernel/async_rpc_kernel.cmxa /home/opam/.opam/5.0/lib/async/async_rpc/async_rpc.cmxa -I /home/opam/.opam/5.0/lib/async/async_rpc /home/opam/.opam/5.0/lib/async/async.cmxa /home/opam/.opam/5.0/lib/shuttle/shuttle.cmxa src/http_async.cmxa test/test_async_http.cmxa /home/opam/.opam/5.0/lib/ppx_inline_test/runner/lib/ppx_inline_test_runner_lib.cmxa -I /home/opam/.opam/5.0/lib/ppx_inline_test/runner/lib /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/ppx_expect/matcher/expect_test_matcher.cmxa /home/opam/.opam/5.0/lib/ppxlib/print_diff/ppxlib_print_diff.cmxa /home/opam/.opam/5.0/lib/ppx_expect/evaluator/ppx_expect_evaluator.cmxa test/.test_async_http.inline-tests/.test_async_http.inline-tests.eobjs/native/dune__exe__Inline_test_runner_test_async_http.cmx -linkall)
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_mcast_modify':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1111: undefined reference to `get_sockaddr'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_inet4_addr_of_int32':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1610: undefined reference to `alloc_inet_addr'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_inet4_addr_of_int63':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1631: undefined reference to `alloc_inet_addr'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_mcast_get_ttl':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1221: undefined reference to `unix_getsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_mcast_set_ttl':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1227: undefined reference to `unix_setsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_mcast_set_ifname':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1241: undefined reference to `unix_setsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_mcast_get_loop':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1251: undefined reference to `unix_getsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/libcore_unix_stubs.a(core_unix_stubs.o): in function `core_unix_mcast_set_loop':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/core_unix/src/core_unix_stubs.c:1257: undefined reference to `unix_setsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/linux_ext/liblinux_ext_stubs.a(linux_ext_stubs.o): in function `core_linux_gettcpopt_bool_stub':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/linux_ext/src/linux_ext_stubs.c:115: undefined reference to `unix_getsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/linux_ext/liblinux_ext_stubs.a(linux_ext_stubs.o): in function `core_linux_settcpopt_bool_stub':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/linux_ext/src/linux_ext_stubs.c:123: undefined reference to `unix_setsockopt_aux'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/bigstring_unix/libbigstring_unix_stubs.a(bigstring_unix_stubs.o): in function `bigstring_recvfrom_assume_fd_is_nonblocking_stub':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/bigstring_unix/src/bigstring_unix_stubs.c:256: undefined reference to `alloc_sockaddr'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/bigstring_unix/libbigstring_unix_stubs.a(bigstring_unix_stubs.o): in function `bigstring_sendto_nonblocking_no_sigpipe_stub':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/bigstring_unix/src/bigstring_unix_stubs.c:686: undefined reference to `get_sockaddr'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/core_unix/bigstring_unix/libbigstring_unix_stubs.a(recvmmsg.o): in function `recvmmsg_assume_fd_is_nonblocking':
# /home/opam/.opam/5.0/.opam-switch/build/core_unix.v0.15.0/_build/default/bigstring_unix/src/recvmmsg.c:94: undefined reference to `alloc_sockaddr'
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```