### PR TITLE
conduit-async < 2.3.0 is incompatible with sexplib v0.15 when async_ssl is installed

### DIFF
--- a/packages/conduit-async/conduit-async.1.0.0/opam
+++ b/packages/conduit-async/conduit-async.1.0.0/opam
@@ -23,6 +23,7 @@ depopts: [
 ]
 conflicts: [
   "async_ssl" {<"v0.9.0" }
+  "async_ssl" {>= "v0.15"}
 ]
 synopsis: "Network conduit library"
 description: """

--- a/packages/conduit-async/conduit-async.1.0.3/opam
+++ b/packages/conduit-async/conduit-async.1.0.3/opam
@@ -23,6 +23,7 @@ depopts: [
 ]
 conflicts: [
   "async_ssl" {<"v0.9.0" }
+  "async_ssl" {>= "v0.15"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit-async/conduit-async.1.1.0/opam
+++ b/packages/conduit-async/conduit-async.1.1.0/opam
@@ -23,6 +23,7 @@ depopts: [
 ]
 conflicts: [
   "async_ssl" {<"v0.9.0" }
+  "async_ssl" {>= "v0.15"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit-async/conduit-async.1.2.0/opam
+++ b/packages/conduit-async/conduit-async.1.2.0/opam
@@ -26,6 +26,7 @@ depopts: [
 ]
 conflicts: [
   "async_ssl" {<"v0.9.0" }
+  "async_ssl" {>= "v0.15"}
 ]
 synopsis: "An OCaml network connection establishment library"
 description: """

--- a/packages/conduit-async/conduit-async.1.3.0/opam
+++ b/packages/conduit-async/conduit-async.1.3.0/opam
@@ -59,6 +59,7 @@ depopts: [
 ]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conduit-async/conduit-async.1.4.0/opam
+++ b/packages/conduit-async/conduit-async.1.4.0/opam
@@ -22,6 +22,7 @@ depopts: [
 ]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conduit-async/conduit-async.1.5.0/opam
+++ b/packages/conduit-async/conduit-async.1.5.0/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: ["async_ssl"]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conduit-async/conduit-async.2.0.0/opam
+++ b/packages/conduit-async/conduit-async.2.0.0/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: ["async_ssl"]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conduit-async/conduit-async.2.0.1/opam
+++ b/packages/conduit-async/conduit-async.2.0.1/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: ["async_ssl"]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conduit-async/conduit-async.2.0.2/opam
+++ b/packages/conduit-async/conduit-async.2.0.2/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: ["async_ssl"]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conduit-async/conduit-async.2.1.0/opam
+++ b/packages/conduit-async/conduit-async.2.1.0/opam
@@ -20,6 +20,7 @@ depends: [
 depopts: ["async_ssl"]
 conflicts: [
   "async_ssl" {< "v0.9.0"}
+  "async_ssl" {>= "v0.15"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
(uses sexp_opaque)
```
#=== ERROR while compiling conduit-async.1.3.0 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.11.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.11/.opam-switch/build/conduit-async.1.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p conduit-async -j 31
# exit-code            1
# env-file             ~/.opam/log/conduit-async-7-0884e9.env
# output-file          ~/.opam/log/conduit-async-7-0884e9.out
### output ###
#        ocaml (internal)
# ocamlfind: Package `launchd.lwt' not found
# ocamlfind: Package `lwt_ssl' not found
# ocamlfind: Package `tls.lwt' not found
# Configuration
#   launchd: false
#   ssl    : false
#   tls    : false
# File "/home/opam/.opam/4.11/lib/bigstringaf/bigstringaf.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.11/lib/ocaml-compiler-libs/bytecomp/ocaml-compiler-libs.bytecomp.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.11/lib/ocaml-compiler-libs/common/ocaml-compiler-libs.common.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.11/lib/ocaml-compiler-libs/shadow/ocaml-compiler-libs.shadow.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.11/lib/ocaml-compiler-libs/toplevel/ocaml-compiler-libs.toplevel.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
# File "/home/opam/.opam/4.11/lib/ppx_derivers/ppx_derivers.dune", line 1, characters 0-0:
# Warning: .dune files are ignored since 2.0. Reinstall the library with dune
# >= 2.0 to get rid of this warning and enable support for the subsystem this
# library provides.
#       ocamlc async/.conduit_async.objs/byte/conduit_async__Private_ssl.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.11/bin/ocamlc.opt -w -40 -g -bin-annot -I async/.conduit_async.objs/byte -I /home/opam/.opam/4.11/lib/angstrom -I /home/opam/.opam/4.11/lib/astring -I /home/opam/.opam/4.11/lib/async -I /home/opam/.opam/4.11/lib/async/async_command -I /home/opam/.opam/4.11/lib/async/async_quickcheck -I /home/opam/.opam/4.11/lib/async/async_rpc -I /home/opam/.opam/4.11/lib/async_kernel -I /home/opam/.opam/4.11/lib/async_kernel/config -I /home/opam/.opam/4.11/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.11/lib/async_kernel/read_write_pair -I /home/opam/.opam/4.11/lib/async_rpc_kernel -I /home/opam/.opam/4.11/lib/async_ssl -I /home/opam/.opam/4.11/lib/async_ssl/bindings -I /home/opam/.opam/4.11/lib/async_unix -I /home/opam/.opam/4.11/lib/async_unix/thread_pool -I /home/opam/.opam/4.11/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/4.11/lib/base -I /home/opam/.opam/4.11/lib/base/base_internalhash_types -I /home/opam/.opam/4.11/lib/base/caml -I /home/opam/.opam/4.11/lib/base/md5 -I /home/opam/.opam/4.11/lib/base/shadow_stdlib -I /home/opam/.opam/4.11/lib/base_bigstring -I /home/opam/.opam/4.11/lib/base_quickcheck -I /home/opam/.opam/4.11/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.11/lib/bigarray-compat -I /home/opam/.opam/4.11/lib/bigstringaf -I /home/opam/.opam/4.11/lib/bin_prot -I /home/opam/.opam/4.11/lib/bin_prot/shape -I /home/opam/.opam/4.11/lib/bytes -I /home/opam/.opam/4.11/lib/conduit -I /home/opam/.opam/4.11/lib/core -I /home/opam/.opam/4.11/lib/core/base_for_tests -I /home/opam/.opam/4.11/lib/core/validate -I /home/opam/.opam/4.11/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.11/lib/core_kernel/caml_threads -I /home/opam/.opam/4.11/lib/core_kernel/caml_unix -I /home/opam/.opam/4.11/lib/core_kernel/flags -I /home/opam/.opam/4.11/lib/core_kernel/iobuf -I /home/opam/.opam/4.11/lib/core_kernel/moption -I /home/opam/.opam/4.11/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.11/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.11/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.11/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.11/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.11/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.11/lib/core_kernel/uopt -I /home/opam/.opam/4.11/lib/core_kernel/uuid -I /home/opam/.opam/4.11/lib/core_unix -I /home/opam/.opam/4.11/lib/core_unix/bigstring_unix -I /home/opam/.opam/4.11/lib/core_unix/core_thread -I /home/opam/.opam/4.11/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.11/lib/core_unix/filename_unix -I /home/opam/.opam/4.11/lib/core_unix/iobuf_unix -I /home/opam/.opam/4.11/lib/core_unix/linux_ext -I /home/opam/.opam/4.11/lib/core_unix/nano_mutex -I /home/opam/.opam/4.11/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/4.11/lib/core_unix/signal_unix -I /home/opam/.opam/4.11/lib/core_unix/squeue -I /home/opam/.opam/4.11/lib/core_unix/sys_unix -I /home/opam/.opam/4.11/lib/core_unix/time_ns_unix -I /home/opam/.opam/4.11/lib/core_unix/time_stamp_counter -I /home/opam/.opam/4.11/lib/core_unix/time_unix -I /home/opam/.opam/4.11/lib/core_unix/uuid -I /home/opam/.opam/4.11/lib/ctypes -I /home/opam/.opam/4.11/lib/fieldslib -I /home/opam/.opam/4.11/lib/int_repr -I /home/opam/.opam/4.11/lib/integers -I /home/opam/.opam/4.11/lib/ipaddr -I /home/opam/.opam/4.11/lib/jane-street-headers -I /home/opam/.opam/4.11/lib/ocaml/threads -I /home/opam/.opam/4.11/lib/ocaml_intrinsics -I /home/opam/.opam/4.11/lib/parsexp -I /home/opam/.opam/4.11/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_expect/collector -I /home/opam/.opam/4.11/lib/ppx_expect/common -I /home/opam/.opam/4.11/lib/ppx_expect/config -I /home/opam/.opam/4.11/lib/ppx_expect/config_types -I /home/opam/.opam/4.11/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_inline_test/config -I /home/opam/.opam/4.11/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_log/types -I /home/opam/.opam/4.11/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.11/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.11/lib/protocol_version_header -I /home/opam/.opam/4.11/lib/sexplib -I /home/opam/.opam/4.11/lib/sexplib/unix -I /home/opam/.opam/4.11/lib/sexplib0 -I /home/opam/.opam/4.11/lib/spawn -I /home/opam/.opam/4.11/lib/splittable_random -I /home/opam/.opam/4.11/lib/stdio -I /home/opam/.opam/4.11/lib/stringext -I /home/opam/.opam/4.11/lib/time_now -I /home/opam/.opam/4.11/lib/timezone -I /home/opam/.opam/4.11/lib/typerep -I /home/opam/.opam/4.11/lib/uri -I /home/opam/.opam/4.11/lib/variantslib -no-alias-deps -open Conduit_async__ -o async/.conduit_async.objs/byte/conduit_async__Private_ssl.cmo -c -impl async/private_ssl.pp.ml)
# File "async/private_ssl_real.ml", line 19, characters 39-50:
# Error: Unbound type constructor sexp_opaque
```