### PR TITLE
Fix bad checksums for archetype-1.3.3 and plebeia.2.0.2

### DIFF
--- a/packages/archetype/archetype.1.3.3/opam
+++ b/packages/archetype/archetype.1.3.3/opam
@@ -47,7 +47,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/completium/archetype-lang.git"
 url {
-  src: "https://github.com/completium/archetype-lang/archive/1.3.3.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/archetype-1.3.3.tar.gz"
   checksum: [
     "md5=e2c64f6101ba6176d300f9866c7c0768"
     "sha512=26cdc92b6456523c42a974866dc43d225835298494ac4f8d3f8408d3407d7f3f753b8d41462495c9708ef78e52c3ed8433ae55e0da114c4832bad7d663d435d5"

--- a/packages/plebeia/plebeia.2.0.2/opam
+++ b/packages/plebeia/plebeia.2.0.2/opam
@@ -25,7 +25,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dailambda/plebeia/"
 url {
   src:
-    "https://gitlab.com/dailambda/plebeia/-/archive/2.0.2/plebeia-2.0.2.tar.gz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/plebeia-2.0.2.tar.gz"
   checksum: [
     "md5=aecc184507170faed53e543195687233"
     "sha512=9799144ea7ebc997681353136393815ac73040e2ae5227f2787c1331bb393dbd318b1fa3ae8d075b383cda4fe7584b80f7f32a4aa99c870a0bd2d76e91024bf5"


### PR DESCRIPTION
Recovered from the opam cache and added to opam-source-archives.
