### PR TITLE
[new release] stdint (0.7.2)

### DIFF
--- a/packages/stdint/stdint.0.7.2/opam
+++ b/packages/stdint/stdint.0.7.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Signed and unsigned integer types having specified widths"
+description: """
+The stdint library provides signed and unsigned integer types of various fixed
+widths: 8, 16, 24, 32, 40, 48, 56, 64 and 128 bit.
+
+This interface is similar to Int32 and Int64 from the base library but provides
+more functions and constants like arithmetic and bit-wise operations, constants
+like maximum and minimum values, infix operators conversion to and from every
+other integer type (including int, float and nativeint), parsing from and
+conversion to readable strings (binary, octal, decimal, hexademical), conversion
+to and from buffers in both big endian and little endian byte order."""
+maintainer: ["Markus W. Weissmann <markus.weissmann@in.tum.de>"]
+authors: [
+  "Andre Nathan <andre@digirati.com.br>"
+  "Jeff Shaw <shawjef3@msu.edu>"
+  "Markus W. Weissmann <markus.weissmann@in.tum.de>"
+  "Florian Pichlmeier <florian.pichlmeier@mytum.de>"
+]
+license: "MIT"
+homepage: "https://github.com/andrenth/ocaml-stdint"
+doc: "https://andrenth.github.io/ocaml-stdint/"
+bug-reports: "https://github.com/andrenth/ocaml-stdint/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.03"}
+  "qcheck" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/andrenth/ocaml-stdint/releases/download/0.7.2/stdint-0.7.2.tbz"
+  checksum: [
+    "sha256=1560198d8bc9c7af3ea952c40dabe82666694210ecc3fdf9bbfeb43211e977e6"
+    "sha512=b0319c2e7490e58effc7a01f2c5635d3468e501741478249e012dda039729609f7bb7d3cb6239eed709f1c043bc23a1c6cff777b174d215fbf6f2eba9f0d023d"
+  ]
+}
+x-commit-hash: "11c1e6b4e6ef4142cff0f82b685b317284e354c5"

--- a/packages/stdint/stdint.0.7.2/opam
+++ b/packages/stdint/stdint.0.7.2/opam
@@ -29,7 +29,7 @@ depends: [
 ]
 dev-repo: "git+https://github.com/andrenth/ocaml-stdint.git"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
Signed and unsigned integer types having specified widths

- Project page: <a href="https://github.com/andrenth/ocaml-stdint">https://github.com/andrenth/ocaml-stdint</a>
- Documentation: <a href="https://andrenth.github.io/ocaml-stdint/">https://andrenth.github.io/ocaml-stdint/</a>

##### CHANGES:

- Fix compatibility with OCaml 5.0 on 32-bits systems (andrenth/ocaml-stdint#69, @MisterDA)
- Fix build system, opam file, and documentation (andrenth/ocaml-stdint#69, @MisterDA)
