### PR TITLE
Fix core_unix.v0.15.1 source (upstream broke the checksum)

### DIFF
--- a/packages/core_unix/core_unix.v0.15.1/opam
+++ b/packages/core_unix/core_unix.v0.15.1/opam
@@ -30,6 +30,6 @@ Unix-specific extensions to some of the modules defined in [core] and [core_kern
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
 url {
-src: "https://github.com/janestreet/core_unix/archive/refs/tags/v0.15.1.tar.gz"
+src: "https://github.com/ocaml/opam-source-archives/raw/main/core_unix-v0.15.1.tar.gz"
 checksum: "sha256=b467c7c64616d5cc88f42f9660b447247e7a848148336e0ad0de6bd35edce9b3"
 }


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/22309