### PR TITLE
pyml < 20220322 is not compatible with OCaml 5.0 (uses deprecated C API)

### DIFF
--- a/packages/pyml/pyml.20161224/opam
+++ b/packages/pyml/pyml.20161224/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "pyml"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
 ]
 synopsis: "``py.ml``: OCaml bindings for Python"

--- a/packages/pyml/pyml.20170730/opam
+++ b/packages/pyml/pyml.20170730/opam
@@ -9,7 +9,7 @@ build: [make "all" "pymltop" "pymlutop" {utop:installed}]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
 ]
 depopts: ["utop"]

--- a/packages/pyml/pyml.20170807/opam
+++ b/packages/pyml/pyml.20170807/opam
@@ -9,7 +9,7 @@ build: [make "all" "pymltop" "pymlutop" {utop:installed}]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
 ]
 depopts: ["utop"]

--- a/packages/pyml/pyml.20200518/opam
+++ b/packages/pyml/pyml.20200518/opam
@@ -11,7 +11,7 @@ run-test: [make "test"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "13"}
   "conf-python-3-dev" {with-test}

--- a/packages/pyml/pyml.20210226/opam
+++ b/packages/pyml/pyml.20210226/opam
@@ -11,7 +11,7 @@ run-test: [make "test"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "13"}
   "conf-python-3-dev" {with-test}

--- a/packages/pyml/pyml.20210924/opam
+++ b/packages/pyml/pyml.20210924/opam
@@ -23,7 +23,7 @@ run-test: [make "test"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "17"}

--- a/packages/pyml/pyml.20211015/opam
+++ b/packages/pyml/pyml.20211015/opam
@@ -23,7 +23,7 @@ run-test: [make "test"]
 synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "17"}


### PR DESCRIPTION
```
#=== ERROR while compiling pyml.20211015 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/pyml.20211015
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pyml -j 127 @install
# exit-code            1
# env-file             ~/.opam/log/pyml-8-e1394c.env
# output-file          ~/.opam/log/pyml-8-e1394c.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pyml.objs/byte -I /home/opam/.opam/5.0/lib/stdcompat -no-alias-deps -o .pyml.objs/byte/pyml_arch.cmi -c -intf pyml_arch.mli)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pyml.objs/byte -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/byte/pyutils.cmo -c -impl pyutils.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pyml.objs/byte -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/byte/pyml_arch.cmo -c -impl pyml_arch.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I .pyml.objs/byte -I .pyml.objs/native -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/native/pyml_arch.cmx -c -impl pyml_arch.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I .pyml.objs/byte -I .pyml.objs/native -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/native/pyutils.cmx -c -impl pyutils.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# File "dune", line 4, characters 37-48:
# 4 |   (foreign_stubs (language c) (names numpy_stubs pyml_stubs))
#                                          ^^^^^^^^^^^
# (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdcompat -o numpy_stubs.o -c numpy_stubs.c)
# numpy_stubs.c: In function 'pyarray_of_bigarray_wrapper':
# numpy_stubs.c:36:21: error: 'BIGARRAY_KIND_MASK' undeclared (first use in this function)
#    36 |     switch (flags & BIGARRAY_KIND_MASK) {
#       |                     ^~~~~~~~~~~~~~~~~~
# numpy_stubs.c:36:21: note: each undeclared identifier is reported only once for each function it appears in
# numpy_stubs.c:62:9: warning: implicit declaration of function 'failwith'; did you mean 'caml_failwith'? [-Wimplicit-function-declaration]
#    62 |         failwith("Caml integers are unsupported for NumPy array");
#       |         ^~~~~~~~
#       |         caml_failwith
# In file included from numpy_stubs.c:6:
# numpy_stubs.c: In function 'bigarray_of_pyarray_wrapper':
# /home/opam/.opam/5.0/lib/ocaml/caml/custom.h:48:27: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#    48 | #define Custom_ops_val(v) (*((const struct custom_operations **) (v)))
#       |                           ^
# numpy_stubs.c:180:40: note: in expansion of macro 'Custom_ops_val'
#   180 |     struct custom_operations *oldops = Custom_ops_val(bigarray);
#       |                                        ^~~~~~~~~~~~~~
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pyml.objs/byte -I /home/opam/.opam/5.0/lib/stdcompat -no-alias-deps -o .pyml.objs/byte/pywrappers.cmo -c -impl pywrappers.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pyml.objs/byte -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/byte/pycaml.cmo -c -impl pycaml.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I .pyml.objs/byte -I .pyml.objs/native -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/native/pywrappers.cmx -c -impl pywrappers.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pyml.objs/byte -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/byte/py.cmo -c -impl py.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I .pyml.objs/byte -I .pyml.objs/native -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/native/py.cmx -c -impl py.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I .pyml.objs/byte -I .pyml.objs/native -I /home/opam/.opam/5.0/lib/stdcompat -intf-suffix .ml -no-alias-deps -o .pyml.objs/native/pycaml.cmx -c -impl pycaml.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdcompat -o pyml_stubs.o -c pyml_stubs.c)
# pyml_stubs.c: In function 'xmalloc':
# pyml_stubs.c:24:9: warning: implicit declaration of function 'failwith'; did you mean 'caml_failwith'? [-Wimplicit-function-declaration]
#    24 |         failwith("Virtual memory exhausted\n");
#       |         ^~~~~~~~
#       |         caml_failwith
# In file included from pyml_stubs.c:3:
# pyml_wrappers.inc: In function 'Python_PyImport_GetMagicNumber_wrapper':
# pyml_wrappers.inc:1030:16: warning: implicit declaration of function 'copy_int64'; did you mean 'caml_copy_int64'? [-Wimplicit-function-declaration]
#  1030 |     CAMLreturn(copy_int64(result));
#       |                ^~~~~~~~~~
# /home/opam/.opam/5.0/lib/ocaml/caml/memory.h:423:29: note: in definition of macro 'CAMLreturnT'
#   423 |   type caml__temp_result = (result); \
#       |                             ^~~~~~
# pyml_wrappers.inc:1030:5: note: in expansion of macro 'CAMLreturn'
#  1030 |     CAMLreturn(copy_int64(result));
#       |     ^~~~~~~~~~
```