### PR TITLE
[new release] mirage-solo5 (0.9.1)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.9.1/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.9.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.9.1/mirage-solo5-0.9.1.tbz"
+  checksum: [
+    "sha256=551b7459a014aa5d805056fcaab910a28f64fc86a14db2a5277a664e0921dee9"
+    "sha512=cbaf6bedc24383777e9f7496772e0aa952f00531432fb8224958755cbb036f09e27c428100e3570edac66eb70758e479dd3462024bcaade1fcbc0742f08aab0e"
+  ]
+}
+x-commit-hash: "afbb4a708aa183559e029a2380b0b56a86927cd0"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Improve performance and take the opportunity to resolve pending
  processes which are only _paused_ (with `Lwt.pause`) instead to
  waiting a sleeping process (mirage/mirage-solo5#92, @TheLortex, @dinosaure, @haesbaert, @reynir,
  @hannesm)
