### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.3.0)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.3.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.3.0/paf-0.3.0.tbz"
+  checksum: [
+    "sha256=f9192b9962494441e0f0105d35ef76bd885ddbf16bbecee5e6a3abf63070ca65"
+    "sha512=2f384abbb1d81ab49b9fdf3d24cead00f6c04c5f47ee489f85de30aab5d53e3bc944aeca226b1f9ebeb36e5dabe3857dd3f4f53c50bd23feeb171b0d6bf5d12d"
+  ]
+}
+x-commit-hash: "8d458cff44ad9d9fa27d168fcdaf09f90821e48a"

--- a/packages/paf-le/paf-le.0.3.0/opam
+++ b/packages/paf-le/paf-le.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.3.0/paf-0.3.0.tbz"
+  checksum: [
+    "sha256=f9192b9962494441e0f0105d35ef76bd885ddbf16bbecee5e6a3abf63070ca65"
+    "sha512=2f384abbb1d81ab49b9fdf3d24cead00f6c04c5f47ee489f85de30aab5d53e3bc944aeca226b1f9ebeb36e5dabe3857dd3f4f53c50bd23feeb171b0d6bf5d12d"
+  ]
+}
+x-commit-hash: "8d458cff44ad9d9fa27d168fcdaf09f90821e48a"

--- a/packages/paf/paf.0.3.0/opam
+++ b/packages/paf/paf.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic" {>= "0.0.5"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.9.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.3.0/paf-0.3.0.tbz"
+  checksum: [
+    "sha256=f9192b9962494441e0f0105d35ef76bd885ddbf16bbecee5e6a3abf63070ca65"
+    "sha512=2f384abbb1d81ab49b9fdf3d24cead00f6c04c5f47ee489f85de30aab5d53e3bc944aeca226b1f9ebeb36e5dabe3857dd3f4f53c50bd23feeb171b0d6bf5d12d"
+  ]
+}
+x-commit-hash: "8d458cff44ad9d9fa27d168fcdaf09f90821e48a"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Fix a file-descriptor leak when we fail on the TLS handshake (dinosaure/paf-le-chien#72, @TheLortex, @dinosaure, @hannesm)
- Add `reneg` function into `Paf_mirage.Make.TLS` (dinosaure/paf-le-chien#73, @dinosaure)
