### PR TITLE
[new release] mirage-xen (8.0.1)

### DIFF
--- a/packages/mirage-xen/mirage-xen.8.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.8.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v8.0.1/mirage-xen-8.0.1.tbz"
+  checksum: [
+    "sha256=c7c8b629bcf411c89f64afe56c32056bd2b0b65d7fc736d857d87d13e12d18fe"
+    "sha512=ff2caa676c95d6990b08acf8a2cda7d6e2b918e82fb395ee1e12de942824facece7c66aad8161d72d34f3a0f322535a3a6a3ea25f531f1444e46252af731edbe"
+  ]
+}
+x-commit-hash: "321230979a46c831c5a433e25929c7e6b9c73e85"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Improve performance and take the opportunity to resolve pending
  processes which are only _paused_ (with `Lwt.pause`) instead to
  waiting a sleeping process (mirage/mirage-xen#49, @TheLortex, @dinosaure)
