### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.2.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.2.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.2.0/opam
@@ -29,6 +29,9 @@ depends: [
   "tar-unix" {with-test & = version}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/tar-mirage/tar-mirage.2.2.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.2.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "5.0.0"}
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.5.0"}
+  "mirage-clock-unix" {with-test}
+  "ounit2" {with-test}
+  "ounit2-lwt" {with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.2.0/tar-2.2.0.tbz"
+  checksum: [
+    "sha256=c28647b0491a2e95c315b7c47b2e8ff43e9731375e9945c813a7c6cc866d7d63"
+    "sha512=ac1ef2d86fd4cd55fabf8ce796bd08b44108748a71d46872a22f2abb0e8cb8e58e8eef4935adfe2ab3a831c3ad5633065ce4be46f72c565e426699a52d6a3994"
+  ]
+}
+x-commit-hash: "aea89ef02ea6756bae43c4dd7adc450336a0f00b"

--- a/packages/tar-unix/tar-unix.2.2.0/opam
+++ b/packages/tar-unix/tar-unix.2.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.03.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.2.0/tar-2.2.0.tbz"
+  checksum: [
+    "sha256=c28647b0491a2e95c315b7c47b2e8ff43e9731375e9945c813a7c6cc866d7d63"
+    "sha512=ac1ef2d86fd4cd55fabf8ce796bd08b44108748a71d46872a22f2abb0e8cb8e58e8eef4935adfe2ab3a831c3ad5633065ce4be46f72c565e426699a52d6a3994"
+  ]
+}
+x-commit-hash: "aea89ef02ea6756bae43c4dd7adc450336a0f00b"

--- a/packages/tar/tar.2.2.0/opam
+++ b/packages/tar/tar.2.2.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.2.0/tar-2.2.0.tbz"
+  checksum: [
+    "sha256=c28647b0491a2e95c315b7c47b2e8ff43e9731375e9945c813a7c6cc866d7d63"
+    "sha512=ac1ef2d86fd4cd55fabf8ce796bd08b44108748a71d46872a22f2abb0e8cb8e58e8eef4935adfe2ab3a831c3ad5633065ce4be46f72c565e426699a52d6a3994"
+  ]
+}
+x-commit-hash: "aea89ef02ea6756bae43c4dd7adc450336a0f00b"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- `tar-mirage` requires and implements `mirage-kv.5.0.0` (@hannesm, mirage/ocaml-tar#96)
- `tar-mirage` implements `Mirage_kv.RW` (append-only) (@hannesm, @reynir, @dinosaure, review by @MisterDA, mirage/ocaml-tar#93)
- Update usage of `cstruct` in `tar`: unnecessary memsets removed, use `Cstruct.of_string` (@hannesm, mirage/ocaml-tar#93)
- Fix `tar-mirage` read buffer allocation error (@reynir, review by @hannesm, mirage/ocaml-tar#94)
- `tar` and `tar-mirage` do not require `re` anymore, `tar-mirage` doesn't depend on `iopage` and works with solo5 and other improvements (@hannesm, review by @reynir, mirage/ocaml-tar#90)
