### PR TITLE
[new release] ppx_deriving_cad (0.1.0)

### DIFF
--- a/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.0/opam
+++ b/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for OCADml transformation functions"
+description: """
+[@@deriving cad] generates functions for the
+spatial transformation of user defined abstract and record types containing
+types for which said transformation functions are defined, in particular, the types of OCADml (and CAD backend specific implementations)."""
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com>"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com>"]
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/OCADml/ppx_deriving_cad"
+doc: "https://ocadml.github.io/ppx_deriving_cad/"
+bug-reports: "https://github.com/OCADml/ppx_deriving_cad/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.14.0"}
+  "base" {>= "0.14.1" & with-test}
+  "OCADml" {>= "0.1.0" & with-test}
+  "OSCADml" {>= "0.1.0" & with-test}
+  "ppxlib" {>= "0.22.2"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/ppx_deriving_cad.git"
+url {
+  src:
+    "https://github.com/OCADml/ppx_deriving_cad/releases/download/v0.1.0/ppx_deriving_cad-0.1.0.tbz"
+  checksum: [
+    "sha256=3b1aec4784cd4a60e210814df6fdf6323b848a42a6c6f29946dabb5c3197e884"
+    "sha512=6af3f353092dd2c06e0ef4ba40fe3ae0c61c6d7758fd07bf48373f01d1145de478a3bce503d142bbbeffa423c3428be8016a78c6150d4cce0d66c8e6270e9221"
+  ]
+}
+x-commit-hash: "5ce65c279f94357c947d6260816d79e5d1875407"

--- a/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.0/opam
+++ b/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.0/opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/OCADml/ppx_deriving_cad/issues"
 depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.14.0"}
-  "base" {>= "0.14.1" & with-test}
+  "base" {>= "v0.14.1" & with-test}
   "OCADml" {>= "0.1.0" & with-test}
   "OSCADml" {>= "0.1.0" & with-test}
   "ppxlib" {>= "0.22.2"}


### PR DESCRIPTION
PPX Deriver for OCADml transformation functions

- Project page: <a href="https://github.com/OCADml/ppx_deriving_cad">https://github.com/OCADml/ppx_deriving_cad</a>
- Documentation: <a href="https://ocadml.github.io/ppx_deriving_cad/">https://ocadml.github.io/ppx_deriving_cad/</a>

##### CHANGES:

- Initial opam release of `ppx_deriving_cad`
