### PR TITLE
[new release] OSCADml (0.1.1)

### DIFF
--- a/packages/OSCADml/OSCADml.0.1.1/opam
+++ b/packages/OSCADml/OSCADml.0.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml DSL for 3D solid modelling in OpenSCAD"
+description:
+  "OSCADml is an OCaml front-end to the OpenSCAD CAD programming language."
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: [
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+  "Masaki Nakano<namachan10777@gmail.com>"
+]
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/OCADml/OSCADml"
+doc: "https://ocadml.github.io/OSCADml"
+bug-reports: "https://github.com/OCADml/OSCADml/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.13.0"}
+  "cairo2" {>= "0.6.2"}
+  "OCADml" {<= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OSCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OSCADml/releases/download/v0.1.1/OSCADml-0.1.1.tbz"
+  checksum: [
+    "sha256=5858909dea5bf1c177c4c1186c94c8d6494e75bdedb163842da9d25c01482e86"
+    "sha512=f76381dc1702fe93dbd242b55745b289c70823a98097153c05b2983f28ac8a7ab8caf63a50f9569112ba8edaa35d4b8e3385e20a77f6713af283c54e799e5bf8"
+  ]
+}
+x-commit-hash: "2383b89d98b275267748c43f623e83aef0a69242"


### PR DESCRIPTION
OCaml DSL for 3D solid modelling in OpenSCAD

- Project page: <a href="https://github.com/OCADml/OSCADml">https://github.com/OCADml/OSCADml</a>
- Documentation: <a href="https://ocadml.github.io/OSCADml">https://ocadml.github.io/OSCADml</a>

##### CHANGES:

- Add `?incl` parameter to `Scad.to_file` for two file "include" trick
- use `incl:true` in a couple examples
