### PR TITLE
[new release] OSCADml (0.1.1)

### DIFF
--- a/packages/OSCADml/OSCADml.0.1.1/opam
+++ b/packages/OSCADml/OSCADml.0.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml DSL for 3D solid modelling in OpenSCAD"
+description:
+  "OSCADml is an OCaml front-end to the OpenSCAD CAD programming language."
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: [
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+  "Masaki Nakano<namachan10777@gmail.com>"
+]
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/OCADml/OSCADml"
+doc: "https://ocadml.github.io/OSCADml"
+bug-reports: "https://github.com/OCADml/OSCADml/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.14.0"}
+  "cairo2" {>= "0.6.2"}
+  "OCADml" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OSCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OSCADml/releases/download/v0.1.1/OSCADml-0.1.1.tbz"
+  checksum: [
+    "sha256=cdcd48d6dcbdb156df117ff9d8e66500bc63dace456d459bbe3adebb17349b48"
+    "sha512=c0ad5ad40c8376f59cdab2fb41af38ad8307b25fdb4a677368fd04551c246086df2cdf29826f495cb8e1b001e57a120b08d715881591dd260c46eaa30c4fa33f"
+  ]
+}
+x-commit-hash: "198b20df39959ad884dfe613db733f02fc8a47d3"


### PR DESCRIPTION
OCaml DSL for 3D solid modelling in OpenSCAD

- Project page: <a href="https://github.com/OCADml/OSCADml">https://github.com/OCADml/OSCADml</a>
- Documentation: <a href="https://ocadml.github.io/OSCADml">https://ocadml.github.io/OSCADml</a>

##### CHANGES:

- Add `?incl` parameter to `Scad.to_file` for two file "include" trick
- use `incl:true` in a couple examples
