### PR TITLE
[new release] ppx_deriving_cad (0.1.1)

### DIFF
--- a/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.1/opam
+++ b/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for OCADml transformation functions"
+description: """
+[@@deriving cad] generates functions for the
+spatial transformation of user defined abstract and record types containing
+types for which said transformation functions are defined, in particular, the types of OCADml (and CAD backend specific implementations)."""
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com>"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com>"]
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/OCADml/ppx_deriving_cad"
+doc: "https://ocadml.github.io/ppx_deriving_cad/"
+bug-reports: "https://github.com/OCADml/ppx_deriving_cad/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.14.0"}
+  "base" {>= "0.14.1" & with-test}
+  "OCADml" {>= "0.1.0" & with-test}
+  "OSCADml" {>= "0.1.0" & with-test}
+  "ppxlib" {>= "0.22.2"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/ppx_deriving_cad.git"
+url {
+  src:
+    "https://github.com/OCADml/ppx_deriving_cad/releases/download/v0.1.1/ppx_deriving_cad-0.1.1.tbz"
+  checksum: [
+    "sha256=563ca09c0e661e0f5f76cd31345177708fb323eb79b7f020a16325356a08be54"
+    "sha512=2074ba09e6ab1c8ddd9ddbf8ffbb0671e17a42a0e40acfa64491c3ee104194a808a39d4182a3fb20bc93861ab66bf7754fd327a8cd33131fec82fb28208a8624"
+  ]
+}
+x-commit-hash: "a2f9768a299c5b92c378e020a9b5512d7bbffded"


### PR DESCRIPTION
PPX Deriver for OCADml transformation functions

- Project page: <a href="https://github.com/OCADml/ppx_deriving_cad">https://github.com/OCADml/ppx_deriving_cad</a>
- Documentation: <a href="https://ocadml.github.io/ppx_deriving_cad/">https://ocadml.github.io/ppx_deriving_cad/</a>

##### CHANGES:

- Remove unhelpful constraints on OCADml and OSCADml versions
