### PR TITLE
[new release] multicodec (0.1.0)

### DIFF
--- a/packages/multicodec/multicodec.0.1.0/opam
+++ b/packages/multicodec/multicodec.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Canonical codec of values and types used by various multiformats"
+description:
+  "This library provides OCaml types and values for multicodec."
+maintainer: ["patrick@sirref.org"]
+authors: ["patrick@sirref.org"]
+license: "MIT"
+homepage: "https://github.com/patricoferris/ocaml-multicodec"
+bug-reports: "https://github.com/patricoferris/ocaml-multicodec/issues"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.9"}
+  "mdx"  {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/patricoferris/ocaml-multicodec.git"
+url {
+  src:
+    "https://github.com/patricoferris/ocaml-multicodec/releases/download/v0.1.0/multicodec-0.1.0.tbz"
+  checksum: [
+    "sha256=56aeb4ea2d2a8a473c4d75a83e119bf1151636cd3f469ea29f179810e40b22cb"
+    "sha512=c933b19b437dc87e455b4b7e94f29953bc8b52bcb10f49dec4b614d9261560e6d7ce82a5b577ab99278238550b38f2e480d048339e868b592e9cf337fdf5ba29"
+  ]
+}
+x-commit-hash: "cba0694076db6277833b26000f1ffa068a2cb4ce"


### PR DESCRIPTION
Canonical codec of values and types used by various multiformats

- Project page: <a href="https://github.com/patricoferris/ocaml-multicodec">https://github.com/patricoferris/ocaml-multicodec</a>

##### CHANGES:

- Initial public release
