### PR TITLE
[new release] ssl (0.5.13)

### DIFF
--- a/packages/ssl/ssl.0.5.13/opam
+++ b/packages/ssl/ssl.0.5.13/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+  "base-unix"
+  "conf-libssl"
+]
+synopsis: "Bindings for OpenSSL"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+url {
+  src:
+    "https://github.com/savonet/ocaml-ssl/releases/download/0.5.13/ssl-0.5.13.tbz"
+  checksum: [
+    "sha256=d68550952c8fed5e7922b273597a4da801c254edd21a971360f510529e1c2b39"
+    "sha512=0d6b4265bf75c3d9b7f262486ab52410f9a16208193171d7a5b74e4e233dfab847c153aa711aaf9114f4997546c4c39d45273ce20e9cbdaaf5d41c58c1635adc"
+  ]
+}
+x-commit-hash: "d9f9695947498b43afe47d7078b6d53f77104717"


### PR DESCRIPTION
Bindings for OpenSSL

- Project page: <a href="https://github.com/savonet/ocaml-ssl">https://github.com/savonet/ocaml-ssl</a>

##### CHANGES:

- Add `Ssl.close_notify` to perform a one-way shutdown (savonet/ocaml-ssl#63, savonet/ocaml-ssl#96).
