### PR TITLE
Package libbinaryen.109.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.109.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.109.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {with-test & >= "3.10.0" & < "5.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v109.0.0/libbinaryen-v109.0.0.tar.gz"
+  checksum: [
+    "md5=274a889bbe00d6b1847f09cb5aa28a1a"
+    "sha512=7dc9f06a37c92e8893ba5365a6f79b81347e1554bfde508a819e62491430218c5f5360fb34eec5a34cf5074c1e7404cddf71f201578c84976ed567f9ae89a254"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.109.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [109.0.0](https://github.com/grain-lang/libbinaryen/compare/v108.0.0...v109.0.0) (2022-10-20)


### ⚠ BREAKING CHANGES

* Update binaryen to version_109 (#65)

### Features

* Update binaryen to version_109 ([#65](https://github.com/grain-lang/libbinaryen/issues/65)) ([f79c848](https://github.com/grain-lang/libbinaryen/commit/f79c84871122d40c4dacbb2f9db8c40657b85677))

---
:camel: Pull-request generated by opam-publish v2.0.3