### PR TITLE
[new release] pyast.0.2.0

### DIFF
--- a/packages/pyast/pyast.0.1.0/opam
+++ b/packages/pyast/pyast.0.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "cmdliner" {>= "1.0.4"}
   "redirect" {>= "0.2.0"}
   "stdcompat" {>= "10"}
-  "menhir" {>= "20210419" & < "20211215"}
+  "menhir" {>= "20210419"}
   "pattern" {with-test & >= "0.3.0"}
   "alcotest" {with-test & >= "1.4.0"}
   "conf-python-3-dev" {with-test}

--- a/packages/pyast/pyast.0.2.0/opam
+++ b/packages/pyast/pyast.0.2.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Python AST"
 description: """
 This library provides versioned abstract syntax tree for all Python
-versions from Python 2.5 to Python 3.10.
+versions from Python 2.5 to Python 3.11.
 """
 maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
 authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
@@ -40,6 +40,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/thierry.martinez/pyast.git"
 url {
-  src: "https://github.com/thierry-martinez/pyast/archive/refs/tags/v0.1.1.tar.gz"
-  checksum: "sha512=7f8d19d2c87b7ad0da3d58ae68177701fe7271d62a9a5bc13630d069ed643b50d8307e1fde34998c171f5410a5f9d8ff115234e8d2b34ccb10eb36752e9e90d8"
+  src: "https://github.com/thierry-martinez/pyast/releases/download/v0.2.0/pyast.0.2.0.tar.gz"
+  checksum: "sha512=6457a333f472e72198307e65b1c3c9b4e7815547d3b84ad90338a05f3b4b701e371e109400c8a6f7ee0d629807a8b5c44489ce61c73484482271f8095a67816b"
 }


### PR DESCRIPTION
This merge-request adds the new release of pyast.0.2.0. Here is the change log:

- Support for Python 3.10.2 and 3.11.0

- Better conversion for slices between versions

Moreover, the merge-request removes the upper-bound on menhir introduced 24f30611d76 since it does not seem to be needed (see https://github.com/thierry-martinez/pyast/issues/8).