### PR TITLE
add depexts for windows

### DIFF
--- a/packages/tsdl/tsdl.0.9.6/opam
+++ b/packages/tsdl/tsdl.0.9.6/opam
@@ -22,6 +22,9 @@ depends: [
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%" ]]
+depexts: [
+  ["SDL2"] {os = "win32" & os-distribution = "cygwinports"}
+]          
 synopsis: "Thin bindings to SDL for OCaml"
 description: """
 Tsdl is an OCaml library providing thin bindings to the cross-platform


### PR DESCRIPTION
This should automatically install SDL2 on windows. Currently cygwin only hosts SDL2 up to 2.0.7, hence the latest tsdl compatible version is 0.9.6 https://cygwin.com/cgi-bin2/package-grep.cgi?grep=libSDL2&arch=x86_64