### PR TITLE
[new release] icalendar (0.1.7)

### DIFF
--- a/packages/icalendar/icalendar.0.1.7/opam
+++ b/packages/icalendar/icalendar.0.1.7/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/icalendar"
+bug-reports: "https://github.com/roburio/icalendar/issues"
+dev-repo: "git+https://github.com/roburio/icalendar.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/icalendar/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test}
+  "fmt"
+  "angstrom" {>= "0.14.0"}
+  "re" {>= "1.7.2"}
+  "uri"
+  "ptime"
+  "ppx_deriving"
+  "gmap" {>= "0.3.0"}
+]
+
+synopsis: "A library to parse and print the iCalendar (RFC 5545) format"
+description: """
+Parse and print .ics files as specified in RFC 5545.
+Supports recurrent events, but only to the day level of detail.
+Does not support vJournal components.
+"""
+url {
+  src:
+    "https://github.com/roburio/icalendar/releases/download/v0.1.7/icalendar-0.1.7.tbz"
+  checksum: [
+    "sha256=4f88b5b211fb8e84c54ead56a2c50a134987e23b9cff418dcd289a6cfc1c25f5"
+    "sha512=e3ed8ad77b9aa767326c9520dd393d808a80c99847599aea281c3b11de6888776e951a6d95a872f0bee5d059b32169de99c4e4adf36aa2ddd65e345dff5f26fa"
+  ]
+}
+x-commit-hash: "6a1b06b666fc8aabf5a528a32037450007d5e1e1"


### PR DESCRIPTION
A library to parse and print the iCalendar (RFC 5545) format

- Project page: <a href="https://github.com/roburio/icalendar">https://github.com/roburio/icalendar</a>
- Documentation: <a href="https://roburio.github.io/icalendar/">https://roburio.github.io/icalendar/</a>

##### CHANGES:

* Fix yearly reoccuring events without any special expansions (bymonth/byday/..)
  (reported by @tobixen in roburio/caldav#28, fixed roburio/icalendar#8 by @hannesm)
