### PR TITLE
[new release] dnssec, dns, dns-tsig, dns-stub, dns-server, dns-resolver, dns-mirage, dns-client, dns-cli and dns-certify (6.4.0)

### DIFF
--- a/packages/conduit-mirage/conduit-mirage.5.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.5.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "6.4.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.5.1.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.5.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "6.4.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.5.1.1/opam
+++ b/packages/conduit-mirage/conduit-mirage.5.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "6.4.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/conduit-mirage/conduit-mirage.6.0.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "mirage-flow-combinators" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
-  "dns-client" {>= "6.2.0"}
+  "dns-client" {>= "6.2.0" & < "6.4.0"}
   "conduit-lwt" {=version}
   "vchan" {>= "5.0.0"}
   "xenstore"

--- a/packages/dkim-mirage/dkim-mirage.0.3.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0.0"}
   "dkim"       {= version}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "6.4.0"}
   "rresult"    {>= "0.7.0"}
   "mirage-time"
   "mirage-random"

--- a/packages/dkim-mirage/dkim-mirage.0.3.1/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.3.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0.0"}
   "dkim"       {= version}
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.0.0" & < "6.4.0"}
   "mirage-time"
   "mirage-random"
   "mirage-clock"

--- a/packages/dns-certify/dns-certify.6.4.0/opam
+++ b/packages/dns-certify/dns-certify.6.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.13.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-certify/dns-certify.6.4.0/opam
+++ b/packages/dns-certify/dns-certify.6.4.0/opam
@@ -42,8 +42,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-cli/dns-cli.6.4.0/opam
+++ b/packages/dns-cli/dns-cli.6.4.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dnssec" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.13.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-cli/dns-cli.6.4.0/opam
+++ b/packages/dns-cli/dns-cli.6.4.0/opam
@@ -53,8 +53,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-client/dns-client.6.4.0/opam
+++ b/packages/dns-client/dns-client.6.4.0/opam
@@ -45,8 +45,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-client/dns-client.6.4.0/opam
+++ b/packages/dns-client/dns-client.6.4.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "happy-eyeballs" {>= "0.1.0"}
+  "alcotest" {with-test}
+  "tls" {>= "0.15.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "x509" {>= "0.16.0"}
+  "ca-certs"
+  "ca-certs-nss"
+]
+synopsis: "DNS resolver API"
+description: """
+A resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-mirage/dns-mirage.6.4.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.4.0/opam
@@ -42,8 +42,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-mirage/dns-mirage.6.4.0/opam
+++ b/packages/dns-mirage/dns-mirage.6.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-resolver/dns-resolver.6.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "dnssec" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {with-test}
+  "tls" "tls-mirage"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-resolver/dns-resolver.6.4.0/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.0/opam
@@ -41,8 +41,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-server/dns-server.6.4.0/opam
+++ b/packages/dns-server/dns-server.6.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-server/dns-server.6.4.0/opam
+++ b/packages/dns-server/dns-server.6.4.0/opam
@@ -41,8 +41,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-stub/dns-stub.6.4.0/opam
+++ b/packages/dns-stub/dns-stub.6.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-stub/dns-stub.6.4.0/opam
+++ b/packages/dns-stub/dns-stub.6.4.0/opam
@@ -42,8 +42,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns-tsig/dns-tsig.6.4.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.4.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns-tsig/dns-tsig.6.4.0/opam
+++ b/packages/dns-tsig/dns-tsig.6.4.0/opam
@@ -31,8 +31,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dns/dns.6.4.0/opam
+++ b/packages/dns/dns.6.4.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.4.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+  "base64" {>= "3.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/dns/dns.6.4.0/opam
+++ b/packages/dns/dns.6.4.0/opam
@@ -48,8 +48,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dnssec/dnssec.6.4.0/opam
+++ b/packages/dnssec/dnssec.6.4.0/opam
@@ -35,8 +35,8 @@ url {
   src:
     "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
   checksum: [
-    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
-    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+    "sha256=00472d566bbfd66da13642eab5fade12fde56b20dd7ac5c50415b88d052d6175"
+    "sha512=0ddeee4a155852c7ffa619de603e54dabe9ec315b79e4a1cb22a13884f9d3893458f1fa3c7b97f2eda60b29f1bfa401e53d531d8ded1089dcd8497ffa3ad1afb"
   ]
 }
-x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"
+x-commit-hash: "3e5968d38282ad949aa91527f3046bd7b84c75a8"

--- a/packages/dnssec/dnssec.6.4.0/opam
+++ b/packages/dnssec/dnssec.6.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "1.2.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "alcotest" {with-test}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "domain-name" {>= "0.4.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNSSec support for OCaml-DNS"
+description: """
+DNSSec (DNS security extensions) for OCaml-DNS, including
+signing and verifying of RRSIG records.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.0/dns-6.4.0.tbz"
+  checksum: [
+    "sha256=9651c8fc676b8b983d543f447d3e7a0b3ea50edebb8c89cd70c76c965e94e214"
+    "sha512=349407be8ebe576a5d18ec5aba989d05899f1e89c580e4b2b2213a4c0a55e7e5b38ce637b794235764a980c854c8e4adff45426d45a5e420c9de7f357b45d9bc"
+  ]
+}
+x-commit-hash: "e8f33404f1766b2d31bef3cd1f03229f4773220a"

--- a/packages/git-mirage/git-mirage.3.7.0/opam
+++ b/packages/git-mirage/git-mirage.3.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   "awa" {>= "0.0.5"}
   "awa-mirage" {>= "0.0.5" & < "0.1.0"}
   "dns" {>= "6.1.3"}
-  "dns-client" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"
   "tls-mirage"
   "uri"

--- a/packages/git-mirage/git-mirage.3.7.1/opam
+++ b/packages/git-mirage/git-mirage.3.7.1/opam
@@ -17,7 +17,7 @@ depends: [
   "awa" {>= "0.1.0"}
   "awa-mirage" {>= "0.1.0"}
   "dns" {>= "6.1.3"}
-  "dns-client" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"
   "tls-mirage"
   "uri"

--- a/packages/git-mirage/git-mirage.3.8.0/opam
+++ b/packages/git-mirage/git-mirage.3.8.0/opam
@@ -16,7 +16,7 @@ depends: [
   "awa" {>= "0.1.0"}
   "awa-mirage" {>= "0.1.0"}
   "dns" {>= "6.1.3"}
-  "dns-client" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"
   "tls-mirage"
   "uri"

--- a/packages/git-mirage/git-mirage.3.8.1/opam
+++ b/packages/git-mirage/git-mirage.3.8.1/opam
@@ -17,7 +17,7 @@ depends: [
   "awa" {>= "0.1.0"}
   "awa-mirage" {>= "0.1.0"}
   "dns" {>= "6.1.3"}
-  "dns-client" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"
   "tls-mirage"
   "uri"


### PR DESCRIPTION
DNSSec support for OCaml-DNS

- Project page: <a href="https://github.com/mirage/ocaml-dns">https://github.com/mirage/ocaml-dns</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dns/">https://mirage.github.io/ocaml-dns/</a>

##### CHANGES:

* dns-client: demote log level of response to debug (mirage/ocaml-dns#317 @hannesm)
* dns-client: use DNS-over-TLS for uncensoreddns.org only (mirage/ocaml-dns#320 @hannesm)
* API: dns-client: connect returns the protocol (UDP/TCP), allowing mixed UDP
  and TCP namerservers being used (mirage/ocaml-dns#322 @hannesm)
* dns-client-mirage: allow hostname in authenticator, improve error message and
  documentation (mirage/ocaml-dns#319 mirage/ocaml-dns#322 @hannesm)
* dns-client-mirage: support UDP nameservers as "udp:<IP>" in
  nameserver_of_string (mirage/ocaml-dns#322 @reynir @hannesm)
* API: dns-client, dns-stub, dns-resolver: ?size is now ?cache_size (mirage/ocaml-dns#322
  @hannesm, suggested by @reynir)
