### PR TITLE
[new release] http, cohttp, cohttp-top, cohttp-server-lwt-unix, cohttp-mirage, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo, cohttp-eio, cohttp-curl, cohttp-curl-lwt, cohttp-curl-async and cohttp-async (6.0.0~alpha0)

### DIFF
--- a/packages/cohttp-async/cohttp-async.6.0.0~alpha0/opam
+++ b/packages/cohttp-async/cohttp-async.6.0.0~alpha0/opam
@@ -58,7 +58,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@cohttp-async/runtest" {with-test}
+    "@cohttp-async/runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/cohttp-async/cohttp-async.6.0.0~alpha0/opam
+++ b/packages/cohttp-async/cohttp-async.6.0.0~alpha0/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "async_kernel" {>= "v0.14.0"}
+  "async_unix" {>= "v0.14.0"}
+  "async" {>= "v0.14.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "core_unix" {>= "v0.14.0"}
+  "conduit-async" {>= "1.2.0"}
+  "magic-mime"
+  "mirage-crypto" {with-test}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "ipaddr"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-async/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0" & arch != "s390x"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha0/opam
@@ -28,7 +28,7 @@ depends: [
   "core_unix" {>= "v0.14.0"}
   "async_kernel"
   "async_unix"
-  "cohttp-async" {with-test}
+  "cohttp-async" {with-test & =version}
   "uri" {with-test & >= "4.2.0"}
   "fmt" {with-test}
   "ounit" {with-test}

--- a/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Cohttp client using Curl & Async as the backend"
+description: """
+An HTTP client that relies on Curl + Async for the backend. Does not require
+conduit for SSL."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocurl"
+  "http" {= version}
+  "stringext"
+  "cohttp-curl" {= version}
+  "core"
+  "core_unix" {>= "v0.14.0"}
+  "async_kernel"
+  "async_unix"
+  "cohttp-async" {with-test}
+  "uri" {with-test & >= "4.2.0"}
+  "fmt" {with-test}
+  "ounit" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-curl-async/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha0/opam
@@ -47,7 +47,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@cohttp-curl-async/runtest" {with-test}
+    "@cohttp-curl-async/runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha0/opam
@@ -28,9 +28,9 @@ depends: [
   "lwt" {>= "5.3.0"}
   "uri" {with-test & >= "4.2.0"}
   "alcotest" {with-test}
-  "cohttp-lwt-unix" {with-test}
-  "cohttp" {with-test}
-  "cohttp-lwt" {with-test}
+  "cohttp-lwt-unix" {with-test & =version}
+  "cohttp" {with-test & =version}
+  "cohttp-lwt" {with-test & =version}
   "conduit-lwt" {with-test}
   "ounit" {with-test}
   "odoc" {with-doc}

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Cohttp client using Curl & Lwt as the backend"
+description: """
+An HTTP client that relies on Curl + Lwt for the backend. Does not require
+conduit for SSL."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ocurl"
+  "http" {= version}
+  "cohttp-curl" {= version}
+  "stringext"
+  "lwt" {>= "5.3.0"}
+  "uri" {with-test & >= "4.2.0"}
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "cohttp" {with-test}
+  "cohttp-lwt" {with-test}
+  "conduit-lwt" {with-test}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-curl-lwt/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha0/opam
@@ -47,7 +47,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@cohttp-curl-lwt/runtest" {with-test}
+    "@cohttp-curl-lwt/runtest" {with-test & os != "macos"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/cohttp-curl/cohttp-curl.6.0.0~alpha0/opam
+++ b/packages/cohttp-curl/cohttp-curl.6.0.0~alpha0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Shared code between the individual cohttp-curl clients"
+description: "Use cohttp-curl-lwt or cohttp-curl-async"
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ocurl"
+  "http" {= version}
+  "stringext"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-curl/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation with eio backend"
+description:
+  "A CoHTTP server and client implementation based on `eio` library. `cohttp-eio`features a multicore capable HTTP 1.1 server. The library promotes and is built with direct style of coding as opposed to a monadic."
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "base-domains"
+  "eio" {>= "0.6"}
+  "eio_main" {with-test}
+  "mdx" {with-test}
+  "uri" {with-test}
+  "fmt"
+  "http" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-eio/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha0/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "logs"
+  "lwt" {>= "3.0.0"}
+  "lwt_ppx" {with-test}
+  "conf-npm" {with-test}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-lwt-jsoo/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha0/opam
@@ -55,7 +55,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@cohttp-lwt-unix/runtest" {with-test}
+    "@cohttp-lwt-unix/runtest" {with-test  & os != "macos"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha0/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "lwt" {>= "3.0.0"}
+  "conduit-lwt" {>= "5.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0"}
+  "fmt" {>= "0.8.2"}
+  "base-unix"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "magic-mime"
+  "logs"
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-lwt-unix/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-lwt/cohttp-lwt.6.0.0~alpha0/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.6.0.0~alpha0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt concurrency library
+to multiplex IO.  It implements as much of the logic in an OS-independent way
+as possible, so that more specialised modules can be tailored for different
+targets.  For example, you can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo`
+for a Unix or JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same IO logic
+from this module."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+  "uri" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-lwt/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha0/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2"}
+  "conduit-mirage" {>= "2.3.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp-lwt" {= version}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "magic-mime"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "cohttp" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-mirage/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha0/opam
+++ b/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Lightweight Cohttp + Lwt based HTTP server"
+description: """
+This server implementation is faster than cohttp-lwt-unix and is independent of
+conduit.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "lwt" {>= "5.5.0"}
+  "conduit-lwt-unix" {with-test}
+  "cohttp-lwt-unix" {with-test & = version}
+  "cohttp-lwt" {with-test & = version}
+  "lwt"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-server-lwt-unix/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp-top/cohttp-top.6.0.0~alpha0/opam
+++ b/packages/cohttp-top/cohttp-top.6.0.0~alpha0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "cohttp" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp-top/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/cohttp/cohttp.6.0.0~alpha0/opam
+++ b/packages/cohttp/cohttp.6.0.0~alpha0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "http" {= version}
+  "ocaml" {>= "4.08"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@cohttp/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"

--- a/packages/http/http.6.0.0~alpha0/opam
+++ b/packages/http/http.6.0.0~alpha0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Type definitions of HTTP essentials"
+description: """
+This package contains essential type definitions used in Cohttp. It is designed
+to have no dependencies and make it easy for other packages to easily
+interoperate with Cohttp."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08"}
+  "ppx_expect" {with-test}
+  "alcotest" {with-test}
+  "base_quickcheck" {with-test}
+  "ppx_assert" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_compare" {with-test}
+  "ppx_here" {with-test}
+  "core" {with-test & >= "v0.13.0"}
+  "core_bench" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "sexplib0" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@http/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha0/cohttp-eio-6.0.0.alpha0.tbz"
+  checksum: [
+    "sha256=2ed4acd5ea309ca064731ec9f02a4b4afcec1ab000f471da68ae81355130b56e"
+    "sha512=e741293352d8376eaf7ccc7ba986dc8fd33cc560b8a786d4b4f8cffde5f1d78651dd5dbb944db00e57a48f25bffdde8d6d7b8c5828605ed02f295c297ef87fdd"
+  ]
+}
+x-commit-hash: "ba9ca0791c3fd6242e28026feaa41fe4ac453089"


### PR DESCRIPTION
Cohttp is an OCaml library for creating HTTP daemons. It has a portable HTTP parser, and implementations using various asynchronous programming libraries:

- Http provides essential type definitions used in Cohttp and an extremely fast http parser. It is designed to have no dependencies and make it easy for other packages to easily interoperate with Cohttp.
- Cohttp_lwt_unix uses the [Lwt](https://ocsigen.org/lwt/) library, and specifically the UNIX bindings. It uses [ocaml-tls](https://github.com/mirleft/ocaml-tls) as the TLS implementation to handle HTTPS connections.
- Cohttp_async uses the [Async](https://realworldocaml.org/v1/en/html/concurrent-programming-with-async.html) library and async_ssl to handle HTTPS connections.
- Cohttp_lwt exposes an OS-independent Lwt interface, which is used by the [Mirage](https://mirage.io/) interface to generate standalone microkernels (use the cohttp-mirage subpackage).
- Cohttp_lwt_jsoo compiles to a JavaScript module that maps the Cohttp calls to XMLHTTPRequests. This is used to compile OCaml libraries like the GitHub bindings to JavaScript and still run efficiently.
- Cohttp_curl uses libcurl (via ocurl), and also provides an lwt and an async backend.
- Cohttp_eio uses eio to leverage new features from multicore ocaml.

Links:
- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation for the alpha version needs to be generated locally with `dune build @doc`

##### CHANGES:

- cohttp-eio: ensure "Host" header is the first header in http client requests (bikallem mirage/ocaml-cohttp#939)
- cohttp-eio: add TE header in client. Check TE header is server (bikallem mirage/ocaml-cohttp#941)
- cohttp-eio: add User-Agent header to request from Client (bikallem mirage/ocaml-cohttp#940)
- cohttp-eio: add Content-Length header to request/response (bikallem mirage/ocaml-cohttp#929)
- cohttp-eio: add cohttp-eio client api - Cohttp_eio.Client (bikallem mirage/ocaml-cohttp#879)
- http: add requires_content_length function for requests and responses (bikallem mirage/ocaml-cohttp#879)
- cohttp-eio: use Eio.Buf_write and improve server API (talex5 mirage/ocaml-cohttp#887)
- cohttp-eio: update to Eio 0.3 (talex5 mirage/ocaml-cohttp#886)
- cohttp-eio: convert to Eio.Buf_read (talex5 mirage/ocaml-cohttp#882)
- cohttp lwt client: Connection cache and explicit pipelining (madroach mirage/ocaml-cohttp#853)
- http: add Http.Request.make and simplify Http.Response.make (bikallem mseri mirage/ocaml-cohttp#878)
- http: add pretty printer functions (bikallem mirage/ocaml-cohttp#880)
- New eio based client and server on top of the http library (bikallem mirage/ocaml-cohttp#857)
- New curl based clients (rgrinberg mirage/ocaml-cohttp#813)
  + cohttp-curl-lwt for an Lwt backend
  + cohttp-curl-async for an Async backend
- Completely new Parsing layers for servers (anuragsoni mirage/ocaml-cohttp#819)
  + Cohttp now uses an optimized parser for requests.
  + The new parser produces much less temporary buffers during read operations
    in servers.
- Faster header comparison (gasche mirage/ocaml-cohttp#818)
- Introduce http package containing common signatures and structures useful for
  compatibility with cohttp - and no dependencies (rgrinberg mirage/ocaml-cohttp#812)
- async(server): allow reading number of active connections (anuragsoni mirage/ocaml-cohttp#809)
- Various internal refactors (rgrinberg, mseri, mirage/ocaml-cohttp#802, mirage/ocaml-cohttp#812, mirage/ocaml-cohttp#820, mirage/ocaml-cohttp#800, mirage/ocaml-cohttp#799,
  mirage/ocaml-cohttp#797)
- http (all cohttp server backends): Consider the connection header in response
  in addition to the request when deciding on whether to keep a connection
  alive (anuragsoni, mirage/ocaml-cohttp#843)
  + The user provided Response can contain a connection header. That header
    will also be considered in addition to the connection header in requests
    when deciding whether to use keep-alive. This allows a handler to decide to
    close a connection even if the client requested a keep-alive in the
    request.
- async(server): allow creating a server without using conduit (anuragsoni mirage/ocaml-cohttp#839)
  + Add `Cohttp_async.Server.Expert.create` and
    `Cohttp_async.Server.Expert.create_with_response_action`that can be used to
    create a server without going through Conduit. This allows creating an
    async TCP server using the Tcp module from `Async_unix` and lets the user
    have more control over how the `Reader.t` and `Writer.t` are created.
- http(header): faster `to_lines` and `to_frames` implementation (mseri mirage/ocaml-cohttp#847)
- cohttp(cookies): use case-insensitive comparison to check for `set-cookies` (mseri mirage/ocaml-cohttp#858)
- New lwt based server implementation: cohttp-server-lwt-unix
  + This new implementation does not depend on conduit and has a simpler and
    more flexible API
- async: Adapt cohttp-curl-async to work with core_unix.
- *Breaking changes*
  + refactor: move opam metadata to dune-project (rgrinberg mirage/ocaml-cohttp#811)
  + refactor: deprecate Cohttp_async.Io (rgrinberg mirage/ocaml-cohttp#807)
  + fix: move more internals to Private (rgrinberg mirage/ocaml-cohttp#806)
  + fix: deprecate transfer encoding field (rgrinberg mirage/ocaml-cohttp#805)
  + refactor: deprecate Cohttp_async.Body_raw (rgrinberg mirage/ocaml-cohttp#804)
  + fix: deprecate more aliases (rgrinberg mirage/ocaml-cohttp#803)
  + refactor: deprecate connection value(rgrinberg mirage/ocaml-cohttp#798)
  + refactor: deprecate using attributes (rgrinberg mirage/ocaml-cohttp#796)
  + cleanup: remove cohttp-{curl,server}-async (rgrinberg mirage/ocaml-cohttp#904)
  + cleanup: remove cohttp-{curl,server,proxy}-lwt (rgrinberg mirage/ocaml-cohttp#904)
  + fix: all parsers now follow the spec and require `\r\n` endings.
    Previously, the `\r` was optional. (rgrinberg, mirage/ocaml-cohttp#921)
- `cohttp-lwt-jsoo`: do not instantiate `XMLHttpRequest` object on boot (mefyl mirage/ocaml-cohttp#922)
