### PR TITLE
[new release] current_incr (0.6.1)

### DIFF
--- a/packages/current_incr/current_incr.0.6.1/opam
+++ b/packages/current_incr/current_incr.0.6.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Self-adjusting computations"
+description: """\
+This is a small, self-contained library for self-adjusting (incremental) computations.
+It was written for OCurrent, but can be used separately too.
+
+It is similar to Jane Street's incremental library, but much smaller and
+has no external dependencies.
+
+It is also similar to the react library, but the results do not depend on the
+behaviour of the garbage collector. In particular, functions stop being called
+as soon as they are no longer needed."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+homepage: "https://github.com/ocurrent/current_incr"
+doc: "https://ocurrent.github.io/current_incr/"
+bug-reports: "https://github.com/ocurrent/current_incr/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.8"}
+  "alcotest" {with-test}
+  "crowbar" {with-test}
+  "mdx" {>= "1.10.0" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/current_incr.git"
+license: "Apache-2.0"
+url {
+  src:
+    "https://github.com/ocurrent/current_incr/releases/download/0.6.1/current_incr-0.6.1.tbz"
+  checksum: [
+    "sha256=86648df3a0940369830f819aa0049d09a6c4f642278cf6d38cd87fcca0f95cc1"
+    "sha512=7e30d310897bc4d067b4021c9453b74d505db5c5d8c429254da238faa40f93da4370a11f7e29973371baca3fa8d55693a052bf4679018ca97bc4aa0cfb11fec6"
+  ]
+}
+x-commit-hash: "87b30560bf66f9eb7b0a4c97a5d7ac3a8bdcb6ca"


### PR DESCRIPTION
Self-adjusting computations

- Project page: <a href="https://github.com/ocurrent/current_incr">https://github.com/ocurrent/current_incr</a>
- Documentation: <a href="https://ocurrent.github.io/current_incr/">https://ocurrent.github.io/current_incr/</a>

##### CHANGES:

* Fix memory leak in readers Queue (ocurrent/current_incr#9, @art-w)
* Expose ?eq for map (ocurrent/current_incr#11, @art-w)
* Add crowbar test (ocurrent/current_incr#10, @art-w)
