### PR TITLE
Package libbinaryen.109.0.1

### DIFF
--- a/packages/libbinaryen/libbinaryen.109.0.1/opam
+++ b/packages/libbinaryen/libbinaryen.109.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {with-test & >= "3.10.0" & < "5.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v109.0.1/libbinaryen-v109.0.1.tar.gz"
+  checksum: [
+    "md5=fa5ead2d8f4d3a50cd0733d237b5a213"
+    "sha512=1a052eb0ac5de1614697ac50f5ed0c949b2373f90d30496e9e4d52c05ef1d7a5d4c3e65dfef6060c1369bb068699703a95d195c120dbb2eb985a82fe6220e90b"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.109.0.1`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
### [109.0.1](https://github.com/grain-lang/libbinaryen/compare/v109.0.0...v109.0.1) (2022-10-25)


### Bug Fixes

* Disable the maybe-uninitialized error in newer gcc ([#69](https://github.com/grain-lang/libbinaryen/issues/69)) ([2b6834a](https://github.com/grain-lang/libbinaryen/commit/2b6834ad6d5fb19618b4a234ae133ddd6918e275))

---
:camel: Pull-request generated by opam-publish v2.0.3