### PR TITLE
[new release] tls-eio (0.15.5)

### DIFF
--- a/packages/tls-eio/tls-eio.0.15.5/opam
+++ b/packages/tls-eio/tls-eio.0.15.5/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+authors:      ["Thomas Leonard"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
+  "x509" {>= "0.15.0"}
+  "eio" {>= "0.6"}
+  "eio_main" {>= "0.6" with-test}
+  "mdx" {with-test}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml - Eio"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.15.5/tls-0.15.5.tbz"
+  checksum: [
+    "sha256=d2ffee5d4c2e30606a5832ce330d1d6d6502d037261c3dee129b24868dccc452"
+    "sha512=8eaa321f2b029d089876b8c34e48240fd2497565257733c9633e7c2620e20fed276e97cb62444245824eec5a02e420e550444729bfcfaeca380327f302497ec2"
+  ]
+}
+x-commit-hash: "762e4d691352fd2ea36e409ed11eea32f0d94d16"

--- a/packages/tls-eio/tls-eio.0.15.5/opam
+++ b/packages/tls-eio/tls-eio.0.15.5/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.0"}
-  "tls" {= version}
+  "tls" {= "0.15.4"}
   "mirage-crypto-rng" {>= "0.8.0"}
   "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
   "x509" {>= "0.15.0"}


### PR DESCRIPTION
Transport Layer Security purely in OCaml - Eio

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* tls-eio release only: fix end-of-file handling (mirleft/ocaml-tls#454 @talex5), avoid
  deprecation warnings (mirleft/ocaml-tls#454 @hannesm)
