### PR TITLE
[new release] lru (0.3.1)

### DIFF
--- a/packages/lru/lru.0.3.1/opam
+++ b/packages/lru/lru.0.3.1/opam
@@ -12,7 +12,7 @@ build: [ [ "dune" "subst" ] {dev}
          [ "dune" "runtest" "-p" name ] {with-test & ocaml:version >= "4.07.0"} ]
 depends: [
   "ocaml" {>="4.03.0"}
-  "dune"  {build & >= "1.7"}
+  "dune"  {>= "1.7"}
   "psq"   {>="0.2.0"}
   "qcheck-core"     {with-test}
   "qcheck-alcotest" {with-test}

--- a/packages/lru/lru.0.3.1/opam
+++ b/packages/lru/lru.0.3.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "David Kaloper Meršinjak <dk505@cam.ac.uk>"
+authors: ["David Kaloper Meršinjak <dk505@cam.ac.uk>"]
+homepage: "https://github.com/pqwy/lru"
+doc: "https://pqwy.github.io/lru/doc"
+license: "ISC"
+dev-repo: "git+https://github.com/pqwy/lru.git"
+bug-reports: "https://github.com/pqwy/lru/issues"
+synopsis: "Scalable LRU caches"
+build: [ [ "dune" "subst" ] {dev}
+         [ "dune" "build" "-p" name "-j" jobs ]
+         [ "dune" "runtest" "-p" name ] {with-test & ocaml:version >= "4.07.0"} ]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {build & >= "1.7"}
+  "psq"   {>="0.2.0"}
+  "qcheck-core"     {with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest"        {with-test}
+]
+description: """
+Lru provides weight-bounded finite maps that can remove the least-recently-used
+(LRU) bindings in order to maintain a weight constraint.
+"""
+url {
+  src: "https://github.com/pqwy/lru/releases/download/v0.3.1/lru-0.3.1.tbz"
+  checksum: [
+    "sha256=6cbe23d27a7d5b244f869c0b88140d47f70f413a6462ef35c0009325d4b236fd"
+    "sha512=81144e258d6e488d4677ade91132401b6f8871c72aadf2f1c190c4dee918c71c5df10c4e690c5bf1ab0f364d87989d44aec3695310a3477f6473eb17c1261734"
+  ]
+}
+x-commit-hash: "cf049b90bfc5a36ad2c5fb01cf5bd04de80766e7"


### PR DESCRIPTION
Scalable LRU caches

- Project page: <a href="https://github.com/pqwy/lru">https://github.com/pqwy/lru</a>
- Documentation: <a href="https://pqwy.github.io/lru/doc">https://pqwy.github.io/lru/doc</a>

##### CHANGES:

- Ocaml 5.0 compatible. Thanks to @samoht for the report.
- tweak ordering implementation in `F.of_list`
