### PR TITLE
fix lru.0.3.0 dep constraint

### DIFF
--- a/packages/lru/lru.0.3.0-1/opam
+++ b/packages/lru/lru.0.3.0-1/opam
@@ -12,8 +12,8 @@ build: [ [ "dune" "subst" ] {dev}
          [ "dune" "runtest" "-p" name ] {with-test} ]
 depends: [
   "ocaml" {>="5.0"}
-  "dune"  {>= "1.7"}
-  "psq"   {>="0.2.0"}
+  "dune"  {>="1.7"}
+  "psq"   {="0.2.0"}
   "qcheck-core"     {with-test}
   "qcheck-alcotest" {with-test}
   "alcotest"        {with-test}

--- a/packages/lru/lru.0.3.0/opam
+++ b/packages/lru/lru.0.3.0/opam
@@ -9,11 +9,11 @@ bug-reports: "https://github.com/pqwy/lru/issues"
 synopsis: "Scalable LRU caches"
 build: [ [ "dune" "subst" ] {dev}
          [ "dune" "build" "-p" name "-j" jobs ]
-         [ "dune" "runtest" "-p" name ] {with-test} ]
+         [ "dune" "runtest" "-p" name ] {with-test & ocaml:version>="4.07.0"} ]
 depends: [
-  "ocaml" {>="4.03.0" & < "5.0"}
-  "dune"  {>= "1.7"}
-  "psq"   {>="0.2.0"}
+  "ocaml" {>="4.03.0" & <"5.0"}
+  "dune"  {>="1.7"}
+  "psq"   {="0.2.0"}
   "qcheck-core"     {with-test}
   "qcheck-alcotest" {with-test}
   "alcotest"        {with-test}


### PR DESCRIPTION
Tighten the version constraint, in the presence of https://github.com/ocaml/opam-repository/pull/22368.