### PR TITLE
Package lutils.1.54.1

### DIFF
--- a/packages/lutils/lutils.1.54.1/opam
+++ b/packages/lutils/lutils.1.54.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "erwan.jahier@imag.fr"
+authors: "Erwan Jahier"
+license: "CeCILL-2.1"
+homepage:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/issues"
+doc: "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6"
+
+depends: [
+  "ocaml" {>= "4.02" & < "4.14.0" } | ( "ocaml" { >= "4.14.0" } & "camlp-streams" )
+  "dune"  {>= "2.0"}
+  "base-unix"
+  "ocamlfind"
+  "num"
+  "camlp-streams"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils.git"
+synopsis: "Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)"
+description: """
+The lutils library contains various modules shared between tools developped at
+Verimag in the synchronous group. Those modules deal with:
+- generate and parse RIF files
+- generate dro files (to call luciole)
+
+The gnuplot-rif tool vizualise RIF files using gnuplot.
+"""
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutils.v1.54.1.tgz"
+  checksum: [
+    "md5=a4d0e3d40ae4b01609d568b588b6ea7d"
+    "sha512=d3c3b80286b1aa236ba922d9e18a133721fc80126c8b89520fb811dce9400e217aaa75b5d49e03988be7f6bf5f2e1a391d02ceeaa5ec0a0cd5ce218083a29514"
+  ]
+}


### PR DESCRIPTION
### `lutils.1.54.1`
Tools and libs shared by Verimag/synchronous tools (lustre, lutin, rdbg)
The lutils library contains various modules shared between tools developped at
Verimag in the synchronous group. Those modules deal with:
- generate and parse RIF files
- generate dro files (to call luciole)

The gnuplot-rif tool vizualise RIF files using gnuplot.



---
* Homepage: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils.git
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/issues

---
:camel: Pull-request generated by opam-publish v2.1.0