### PR TITLE
[new release] omigrate (0.3.1)

### DIFF
--- a/packages/omigrate/omigrate.0.3.1/opam
+++ b/packages/omigrate/omigrate.0.3.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Database migrations for Reason and OCaml"
+description: "Database migrations for Reason and OCaml"
+maintainer: ["Thibaut Mattio"]
+authors: ["Thibaut Mattio"]
+license: "MIT"
+homepage: "https://github.com/tmattio/omigrate"
+doc: "https://tmattio.github.io/omigrate/"
+bug-reports: "https://github.com/tmattio/omigrate/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "result" {>= "1.5"}
+  "lwt" {>= "5.3.0"}
+  "uri"
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "fmt"
+  "pgx"
+  "pgx_lwt_unix"
+  "sqlite3" {>= "5.0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tmattio/omigrate.git"
+url {
+  src:
+    "https://github.com/tmattio/omigrate/releases/download/0.3.1/omigrate-0.3.1.tbz"
+  checksum: [
+    "sha256=53dc2e0c0b0426c7ae795b0ad1f2ce8055c723aa0a4957939958df028c11075c"
+    "sha512=aab0ea16aa41d85461987645a2ddb3607391063aa2b4ca9f4da73563062a9acffc9fd43f013b1a520b6dff3c76a09ac48a5e922b297328099580caab05ac69aa"
+  ]
+}
+x-commit-hash: "e02f097f943f913bc67f267fc5881b35f26a7254"

--- a/packages/omigrate/omigrate.0.3.1/opam
+++ b/packages/omigrate/omigrate.0.3.1/opam
@@ -15,7 +15,7 @@ depends: [
   "uri"
   "cmdliner" {>= "1.1.0"}
   "logs"
-  "fmt"
+  "fmt" {>= "0.9.0"}
   "pgx"
   "pgx_lwt_unix"
   "sqlite3" {>= "5.0.1"}


### PR DESCRIPTION
Database migrations for Reason and OCaml

- Project page: <a href="https://github.com/tmattio/omigrate">https://github.com/tmattio/omigrate</a>
- Documentation: <a href="https://tmattio.github.io/omigrate/">https://tmattio.github.io/omigrate/</a>

##### CHANGES:

- Support driver listing (tmattio/omigrate#8, @maiste)
- Simplify migration to version 0.3 (tmattio/omigrate#10, @maiste)
