### PR TITLE
[new release] pgx_value_ptime, pgx_value_core, pgx_unix, pgx_lwt_unix, pgx_lwt_mirage, pgx_lwt, pgx_async and pgx (2.2)

### DIFF
--- a/packages/pgx/pgx.2.2/opam
+++ b/packages/pgx/pgx.2.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Pure-OCaml PostgreSQL client library"
+description:
+  "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "alcotest" {with-test & >= "1.0.0"}
+  "bisect_ppx" {dev & >= "2.0.0"}
+  "dune" {>= "3.2" & >= "3.2"}
+  "hex"
+  "ipaddr"
+  "camlp-streams"
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+  "ppx_compare" {>= "v0.13.0"}
+  "ppx_custom_printf" {>= "v0.13.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "re" {>= "1.5.0"}
+  "sexplib0" {>= "v0.13.0"}
+  "uuidm"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx/pgx.2.2/opam
+++ b/packages/pgx/pgx.2.2/opam
@@ -4,7 +4,7 @@ description:
   "PGX is a pure-OCaml PostgreSQL client library, supporting Async, LWT, or synchronous operations."
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_async/pgx_async.2.2/opam
+++ b/packages/pgx_async/pgx_async.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Async for IO"
 description: "Pgx using Async for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_async/pgx_async.2.2/opam
+++ b/packages/pgx_async/pgx_async.2.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Pgx using Async for IO"
+description: "Pgx using Async for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest-async" {with-test & >= "1.0.0"}
+  "async_kernel" {>= "v0.13.0"}
+  "async_unix" {>= "v0.13.0"}
+  "async_ssl"
+  "base64" {with-test & >= "3.0.0"}
+  "conduit-async" {>= "1.5.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_value_core" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx_lwt/pgx_lwt.2.2/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt for IO"
+description: "Pgx using Lwt for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "lwt"
+  "logs"
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx_lwt/pgx_lwt.2.2/opam
+++ b/packages/pgx_lwt/pgx_lwt.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt for IO"
 description: "Pgx using Lwt for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.2/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt on Mirage for IO"
 description: "Pgx using Lwt on Mirage for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.2/opam
+++ b/packages/pgx_lwt_mirage/pgx_lwt_mirage.2.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt on Mirage for IO"
+description: "Pgx using Lwt on Mirage for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "lwt"
+  "ocaml" {>= "4.08"}
+  "logs"
+  "mirage-channel"
+  "conduit-mirage" {>= "2.3.0"}
+  "dns-client" {>= "6.0.0"}
+  "mirage-random"
+  "mirage-time"
+  "mirage-clock"
+  "tcpip" {>= "7.0.0"}
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.2/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx using Lwt and Unix libraries for IO"
 description: "Pgx using Lwt and Unix libraries for IO"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_lwt_unix/pgx_lwt_unix.2.2/opam
+++ b/packages/pgx_lwt_unix/pgx_lwt_unix.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pgx using Lwt and Unix libraries for IO"
+description: "Pgx using Lwt and Unix libraries for IO"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest-lwt" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "pgx_lwt" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx_unix/pgx_unix.2.2/opam
+++ b/packages/pgx_unix/pgx_unix.2.2/opam
@@ -4,7 +4,7 @@ description:
   "PGX using the standard library's Unix module for IO (synchronous)"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_unix/pgx_unix.2.2/opam
+++ b/packages/pgx_unix/pgx_unix.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "PGX using the standard library's Unix module for IO (synchronous)"
+description:
+  "PGX using the standard library's Unix module for IO (synchronous)"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx_value_core/pgx_value_core.2.2/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx_value converters for Core types like Date and Time"
+description: "Pgx_value converters for Core types like Date and Time"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "core_kernel" {>= "v0.13.0"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"

--- a/packages/pgx_value_core/pgx_value_core.2.2/opam
+++ b/packages/pgx_value_core/pgx_value_core.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx_value converters for Core types like Date and Time"
 description: "Pgx_value converters for Core types like Date and Time"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_value_ptime/pgx_value_ptime.2.2/opam
+++ b/packages/pgx_value_ptime/pgx_value_ptime.2.2/opam
@@ -3,7 +3,7 @@ synopsis: "Pgx_value converters for Ptime types"
 description: "Pgx_value converters for Ptime types"
 maintainer: ["Arena Developers <silver-snakes@arena.io>"]
 authors: ["Arena Developers <silver-snakes@arena.io>"]
-license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+license: "LGPL-2.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/arenadotio/pgx"
 doc: "https://arenadotio.github.io/pgx"
 bug-reports: "https://github.com/arenadotio/pgx/issues"

--- a/packages/pgx_value_ptime/pgx_value_ptime.2.2/opam
+++ b/packages/pgx_value_ptime/pgx_value_ptime.2.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pgx_value converters for Ptime types"
+description: "Pgx_value converters for Ptime types"
+maintainer: ["Arena Developers <silver-snakes@arena.io>"]
+authors: ["Arena Developers <silver-snakes@arena.io>"]
+license: "LGPL-2.0-only with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/arenadotio/pgx"
+doc: "https://arenadotio.github.io/pgx"
+bug-reports: "https://github.com/arenadotio/pgx/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest" {with-test & >= "1.0.0"}
+  "ptime" {>= "0.8.3"}
+  "ocaml" {>= "4.08"}
+  "pgx" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/arenadotio/pgx.git"
+url {
+  src: "https://github.com/arenadotio/pgx/releases/download/2.2/pgx-2.2.tbz"
+  checksum: [
+    "sha256=e50dfb4e9d124d74da0d82f480357f63f947bb469b49c171ffd5f27c3c69c56a"
+    "sha512=07592f9c9a123b446f2742cc39bf23751dd0590b8028e7ed14f254c6f2c77a23efc616557aff43775354ff49cf71276ac400cf72d2c4d921fa4473d0b3209b21"
+  ]
+}
+x-commit-hash: "1b8fdf1719467916670432605a07c9674e6df76d"


### PR DESCRIPTION
Ocaml postgresql client

- Project page: <a href="https://github.com/arenadotio/pgx">https://github.com/arenadotio/pgx</a>
- Documentation: <a href="https://arenadotio.github.io/pgx">https://arenadotio.github.io/pgx</a>

##### CHANGES:
Added support for ocaml 5.0 deprecations https://github.com/arenadotio/pgx/pull/129



