### PR TITLE
[new release] oniguruma (0.1.2)

### DIFF
--- a/packages/oniguruma/oniguruma.0.1.2/opam
+++ b/packages/oniguruma/oniguruma.0.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Bindings to the Oniguruma regular expression library"
+description: "Bindings to the Oniguruma regular expression library."
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "BSD-2-Clause"
+tags: ["regex"]
+homepage: "https://github.com/alan-j-hu/ocaml-oniguruma"
+doc: "https://v3.ocaml.org/p/oniguruma/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-oniguruma/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "conf-oniguruma" {= "1"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator" {>= "2.9" & build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-oniguruma.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-oniguruma/releases/download/0.1.2/oniguruma-0.1.2.tbz"
+  checksum: [
+    "sha256=e3f63ffdda3cc3cf9f71a8169e8fb97690026dbd22ab7ce0a87891feb8058765"
+    "sha512=4d8561b50bf13a792d05d2ac775948ab6f913730202c40012aa1ac7caf5a2f2aba26f7e1dcb3f93528e2be79602fd26de62346bec7d8986d9c48efdb71f94409"
+  ]
+}
+x-commit-hash: "288bea880ff0c059069d3ae1656cb93c97781446"


### PR DESCRIPTION
Bindings to the Oniguruma regular expression library

- Project page: <a href="https://github.com/alan-j-hu/ocaml-oniguruma">https://github.com/alan-j-hu/ocaml-oniguruma</a>
- Documentation: <a href="https://v3.ocaml.org/p/oniguruma/">https://v3.ocaml.org/p/oniguruma/</a>

##### CHANGES:

- Add `name_to_group_numbers`.
- Use direct field assignment to initialize blocks allocated with
  `caml_alloc_small`.
