### PR TITLE
draft: irmin: fix release 3.4.3

### DIFF
--- a/packages/irmin-cli/irmin-cli.3.4.3/opam
+++ b/packages/irmin-cli/irmin-cli.3.4.3/opam
@@ -25,7 +25,7 @@ depends: [
   "irmin-pack"    {= version}
   "irmin-graphql" {= version}
   "irmin-tezos"   {= version}
-  "git-unix"      {>= "3.7.0"}
+  "git-unix"      {>= "3.10.0"}
   "digestif"      {>= "0.9.0"}
   "irmin-watcher" {>= "0.2.0"}
   "yaml"          {>= "3.0.0"}

--- a/packages/irmin-git/irmin-git.3.4.3/opam
+++ b/packages/irmin-git/irmin-git.3.4.3/opam
@@ -20,7 +20,7 @@ depends: [
   "irmin"      {= version}
   "ppx_irmin"  {= version}
   "git"        {>= "3.7.0"}
-  "git-unix"   {>= "3.7.0"}
+  "git-unix"   {>= "3.10.0"}
   "digestif"   {>= "0.9.0"}
   "cstruct"
   "fmt"

--- a/packages/irmin-graphql/irmin-graphql.3.4.3/opam
+++ b/packages/irmin-graphql/irmin-graphql.3.4.3/opam
@@ -24,7 +24,7 @@ depends: [
   "cohttp"
   "cohttp-lwt"
   "cohttp-lwt-unix"
-  "git-unix"        {>= "3.7.0"}
+  "git-unix"        {>= "3.10.0"}
   "fmt"
   "lwt"             {>= "5.3.0"}
   "alcotest-lwt"    {with-test & >= "1.1.0"}

--- a/packages/irmin-http/irmin-http.3.4.3/opam
+++ b/packages/irmin-http/irmin-http.3.4.3/opam
@@ -31,7 +31,7 @@ depends: [
   "irmin-git"       {with-test & = version}
   "irmin-fs"        {with-test & = version}
   "irmin-test"      {with-test & = version}
-  "git-unix"        {with-test & >= "3.5.0"}
+  "git-unix"        {with-test & >= "3.10.0"}
   "digestif"        {with-test & >= "0.9.0"}
 ]
 


### PR DESCRIPTION
Some tests in the CI were failing for https://github.com/ocaml/opam-repository/pull/22321, and after some investigation it looks like the problems was in irmin subpackages. This PR is trying to fix the issue.  
