### PR TITLE
ssl is incompatible with ocaml-option-nnpchecker

### DIFF
--- a/packages/ssl/ssl.0.5.11/opam
+++ b/packages/ssl/ssl.0.5.11/opam
@@ -12,6 +12,9 @@ depends: [
   "base-unix"
   "conf-libssl"
 ]
+conflicts: [
+  "ocaml-option-nppchecker"
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/ssl/ssl.0.5.12/opam
+++ b/packages/ssl/ssl.0.5.12/opam
@@ -15,6 +15,9 @@ depends: [
   "base-unix"
   "conf-libssl"
 ]
+conflicts: [
+  "ocaml-option-nppchecker"
+]
 synopsis: "Bindings for OpenSSL"
 authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
 url {


### PR DESCRIPTION
Upstream fix: https://github.com/savonet/ocaml-ssl/pull/98