### PR TITLE
Package rdbg.1.199.0

### DIFF
--- a/packages/lutils/lutils.1.44/opam
+++ b/packages/lutils/lutils.1.44/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocaml" "%{etc}%/lutils/setup.ml" "-C" "%{etc}%/lutils" "-uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "4.14"}
   "base-unix"
   "camlp4"
   "ocamlbuild" {build}

--- a/packages/lutils/lutils.1.49.5/opam
+++ b/packages/lutils/lutils.1.49.5/opam
@@ -16,7 +16,7 @@ homepage:
 bug-reports:
   "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutils/"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "4.14"}
   "base-unix"
   "ocamlbuild" {build}
   "ocamlfind"

--- a/packages/lutils/lutils.1.51.2/opam
+++ b/packages/lutils/lutils.1.51.2/opam
@@ -9,7 +9,7 @@ bug-reports:
 doc: "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6"
 
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "4.14"}
   "dune"  {>= "2.0"}
   "base-unix"
   "ocamlfind"

--- a/packages/rdbg/rdbg.1.199.0/opam
+++ b/packages/rdbg/rdbg.1.199.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "RDBG: a reactive programs debugger"
+description: """\
+The library rdbg contains all the ocaml modules needed to use rdbg,
+a reactive programs debugger.
+
+The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/
+"""
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: "Erwan Jahier"
+license: "CECILL-2.1"
+homepage:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix"
+  "lutils" {>= "1.51"}
+  "ocamlfind"
+  "dune" {>= "2.0"}
+  "ounit" {build & >= "2.0.0"}
+  "num"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/rdbg.v1.199.0.tgz"
+  checksum: [
+    "md5=da1c08e352dae8155c089823bf490f42"
+    "sha512=6076eaa3608a313f8ac71a4f5aa4fcc64aeb0c646d581e5035110d4c80f94de34f2ba26f90a9a1e92a7f788c9e799f1f7b0e3728c853a21983ad732f0ee60352"
+  ]
+}


### PR DESCRIPTION
### `rdbg.1.199.0`
RDBG: a reactive programs debugger
The library rdbg contains all the ocaml modules needed to use rdbg,
a reactive programs debugger.

The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/



---
* Homepage: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg.git
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/rdbg/issues

---
:camel: Pull-request generated by opam-publish v2.1.0