### PR TITLE
[new release] dkml-workflows (1.0.0)

### DIFF
--- a/packages/dkml-workflows/dkml-workflows.1.0.0/opam
+++ b/packages/dkml-workflows/dkml-workflows.1.0.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis:
+  "GitLab CI/CD and GitHub Action workflows used by and with Diskuv OCaml (DKML) tooling"
+description:
+  "GitLab CI/CD and GitHub Action workflows used by and with Diskuv OCaml (DKML) tooling."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-workflows"
+bug-reports: "https://github.com/diskuv/dkml-workflows/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.1"}
+  "crunch" {>= "3.2.0"}
+  "jingoo" {>= "1.4.4"}
+  "uutf" {>= "1.0.3"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-workflows.git"
+# Until Dune 3+ the auto-generated '.opam' will have an invalid ["dune" "install" ...] step
+# that messes up with cross-compilation. Customized it to remove it.
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc}]
+]
+url {
+  src:
+    "https://github.com/diskuv/dkml-workflows/releases/download/1.0.0/dkml-workflows-1.0.0.tbz"
+  checksum: [
+    "sha256=cce60466c295727f4756f308d08372f73ad32c90d2557c86f40840fd5c36325d"
+    "sha512=6f52c5c14d03c3361208e7c1d128c5a3936c4b3d93fbe5d0c62da119062078c1d38e2bed99efeb0b5abe1472140d407a8b238708339f8a9a113deb27640b28e0"
+  ]
+}
+x-commit-hash: "bd6cc6e4cca912ab79101ce2377fe1ee29b80bb5"


### PR DESCRIPTION
GitLab CI/CD and GitHub Action workflows used by and with Diskuv OCaml (DKML) tooling

- Project page: <a href="https://github.com/diskuv/dkml-workflows">https://github.com/diskuv/dkml-workflows</a>

##### CHANGES:

New Features:
1. Support GitLab CI/CD
2. Support desktop testing on Windows
3. GitHub now uses a composite action rather than a child
   workflow, resulting in less artifact copying and
   quicker builds.

There are significant breaking changes. It will be far easier
to onboard with [the new version `v1` instructions](https://github.com/diskuv/dkml-workflows/tree/v1#readme)
and then remove your `v0` code, rather than try to do an in-place upgrade:
* Any custom build logic you have in your GitHub workflow should go into
  the new `ci/build-test.sh`. Alternatively, if you don't care about ever running troubleshooting
  CI on your desktop or GitLab, directly into your new `.github/workflows/build-with-dkml.yml`.

Breaking changes:
- The GitHub child workflow has been replaced by a GitHub composite action
- Input variables have been renamed to allow the same variable names between GitHub Actions and
  GitLab CI/CD (the latter does not support dashes in variable names).

  | Old Name                  | New Name                  |
  | ------------------------- | ------------------------- |
  | cache-prefix              | CACHE_PREFIX              |
  | ocaml-compiler            | OCAML_COMPILER            |
  | dkml-compiler             | DKML_COMPILER             |
  | conf-dkml-cross-toolchain | CONF_DKML_CROSS_TOOLCHAIN |
  | diskuv-opam-repository    | DISKUV_OPAM_REPOSITORY    |
  | ocaml-options             | ocaml_options             |
  | vsstudio-arch             | vsstudio_arch             |
  | vsstudio-hostarch         | vsstudio_hostarch         |
  | vsstudio-dir              | vsstudio_dir              |
  | vsstudio-vcvarsver        | vsstudio_vcvarsver        |
  | vsstudio-winsdkver        | vsstudio_winsdkver        |
  | vsstudio-msvspreference   | vsstudio_msvspreference   |
  | vsstudio-cmakegenerator   | vsstudio_cmakegenerator   |

- Matrix variables have been renamed to allow the same variable names between GitHub Actions and
  GitLab CI/CD (the latter does not support dashes in variable names).

- The shell matrix variable `default_shell` has been renamed `gh_unix_shell`

- The operating system matrix variable has been reorganized to distingush GitHub
  from GitLab:

  - `os` is now `gh_os` and in use only for GitHub Actions
  - `gl_tags` and `gl_image` are the new GitLab CI/CD equivalents. GitLab CI/CD uses tags like
    `[shared-windows, windows, windows-1809]` to specify the type of runner machine to use,
    and for macOS image you can supply an XCode version like `macos-11-xcode-12`.

