### PR TITLE
[new release] mirage-kv-mem (3.1.0)

### DIFF
--- a/packages/mirage-kv-mem/mirage-kv-mem.3.1.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.3.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/mirage/mirage-kv-mem"
+doc: "https://mirage.github.io/mirage-kv-mem/"
+bug-reports: "https://github.com/mirage/mirage-kv-mem/issues"
+dev-repo: "git+https://github.com/mirage/mirage-kv-mem.git"
+tags: [ "org:mirage" "org:robur" ]
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "ppx_deriving" {with-test}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-kv" {>= "5.0.0"}
+  "fmt"
+  "ptime"
+  "mirage-clock-unix" {>= "3.0.0"}
+]
+
+synopsis: "In-memory key value store for MirageOS"
+description: """
+Implements the mirage-kv interface, but does not provide a persistent data storage.
+Use for testing or amnesia.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-mem/releases/download/v3.1.0/mirage-kv-mem-3.1.0.tbz"
+  checksum: [
+    "sha256=f57829be8dadb6d6630f75e83e9cedc6d71ccb877fc2545652c0222893a26509"
+    "sha512=53e9f6a55cac640e03e7a340f8d5dd8b7f690aa42825c17f235ea5b5ee2b1c26eb212f0bb335baafeed76d852913adc0b558e7f042829998af0e889451cb41ca"
+  ]
+}
+x-commit-hash: "8f0c9bf052c6634eeb1c00fafd419fe2e360b084"

--- a/packages/mirage-kv-mem/mirage-kv-mem.3.1.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.3.1.0/opam
@@ -31,6 +31,7 @@ depends: [
   "ptime"
   "mirage-clock-unix" {>= "3.0.0"}
 ]
+conflicts: [ "result" {< "1.5"} ]
 
 synopsis: "In-memory key value store for MirageOS"
 description: """


### PR DESCRIPTION
In-memory key value store for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-kv-mem">https://github.com/mirage/mirage-kv-mem</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-mem/">https://mirage.github.io/mirage-kv-mem/</a>

##### CHANGES:

* upgrade to mirage-kv 5.0.0 interface (mirage/mirage-kv-mem#4 @hannesm)
