### PR TITLE
Dose3.5.0.1-1: Patch to grep more careful for the ocaml system

### DIFF
--- a/packages/dose3/dose3.5.0.1-1/files/0006-Grep-carefully-for-ocaml-system.patch
+++ b/packages/dose3/dose3.5.0.1-1/files/0006-Grep-carefully-for-ocaml-system.patch
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index d73d724..3653943 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -208,7 +208,7 @@ if test "$HAS_BENCHMARK" = "yes" ; then
+ fi
+ 
+ AS_IF([test "$OCAMLBEST" = "opt"],[OCAMLBESTCC=$OCAMLOPT],[OCAMLBESTCC=$OCAMLC])
+-OCAML_CC="$($OCAMLBESTCC -config | fgrep native_c_compiler | sed -e "s/native_c_compiler: \(.*\) .*/\1/")"
++OCAML_CC="$($OCAMLBESTCC -config | grep -P "^native_c_compiler:" | sed -e "s/native_c_compiler: \(.*\) .*/\1/")"
+ AC_PROG_CC(["${OCAML_CC}" gcc cl cc])
+ 
+ AC_HEADER_STDC
+@@ -254,7 +254,7 @@ if test "$HAS_RPM5" = "yes"; then
+   HAS_RPM=yes
+ fi
+ 
+-OCAML_SYSTEM="$($OCAMLBESTCC -config | fgrep system | sed -e "s/system: \(.*\)/\1/")"
++OCAML_SYSTEM="$($OCAMLBESTCC -config | grep -P "^system:" | sed -e "s/system: \(.*\)/\1/")"
+ AC_SUBST(OCAML_SYSTEM)
+ 
+ AS_IF([test "${OCAML_OS_TYPE}" = "Win32"],[

--- a/packages/dose3/dose3.5.0.1-1/opam
+++ b/packages/dose3/dose3.5.0.1-1/opam
@@ -48,6 +48,7 @@ extra-files: [
   ["0002-dont-make-printconf.patch" "md5=a6e83acee4b55d35f5f30a8ef98df04f"]
   ["0001-Install-mli-cmx-etc.patch" "md5=977b675e7e6e7ccc5d3d57534370c68c"]
   ["0005-Fix-compatibility-with-ocamlgraph-2.0.patch" "md5=e17b0f0aaede654a19fb3f0e2e46c61a"]
+  ["0006-Grep-carefully-for-ocaml-system.patch" "md5=9cc2ad44bb1ec06f31fd376e738cc4a3"]
 ]
 url {
   src: "https://gitlab.com/irill/dose3/-/archive/5.0.1/dose3-5.0.1.tar.gz"


### PR DESCRIPTION
Dose3's configure system reports on the OCaml system by grepping for `system` in `ocamlc -config`. However, on some systems, the output of `ocamlc -config` also has the word `system` on unrelated lines. Here is an example:

```
version: 4.14.0
standard_library_default: /tmp/tmp.PADAUCpkbY/opam-root/default/lib/ocaml
standard_library: /tmp/tmp.PADAUCpkbY/opam-root/default/lib/ocaml
ccomp_type: cc
c_compiler: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-cc
ocamlc_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include
ocamlc_cppflags: -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
ocamlopt_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include
ocamlopt_cppflags: -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
bytecomp_c_compiler: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
native_c_compiler: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
bytecomp_c_libraries: -lm -ldl  -lpthread
native_c_libraries: -lm -ldl
native_pack_linker: x86_64-conda-linux-gnu-ld -r -o
ranlib: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-ranlib
architecture: amd64
model: default
int_size: 63
word_size: 64
system: linux
asm: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-as
asm_cfi_supported: true
with_frame_pointers: false
ext_exe:
ext_obj: .o
ext_asm: .s
ext_lib: .a
ext_dll: .so
os_type: Unix
default_executable_name: a.out
systhread_supported: true
host: x86_64-conda-linux-gnu
target: x86_64-conda-linux-gnu
flambda: false
safe_string: true
default_safe_string: true
flat_float_array: true
function_sections: true
afl_instrument: false
windows_unicode: false
supports_shared_libraries: true
naked_pointers: true
exec_magic_number: Caml1999X031
cmi_magic_number: Caml1999I031
cmo_magic_number: Caml1999O031
cma_magic_number: Caml1999A031
cmx_magic_number: Caml1999Y031
cmxa_magic_number: Caml1999Z031
ast_impl_magic_number: Caml1999M031
ast_intf_magic_number: Caml1999N031
cmxs_magic_number: Caml1999D031
cmt_magic_number: Caml1999T031
linear_magic_number: Caml1999L031
```
With this example, the grep causes a malformed
Makefile (`Makefile.config:53: *** missing separator.  Stop.`). This patch fixes this.