### PR TITLE
Package spotlib.4.3.0

### DIFF
--- a/packages/spotlib/spotlib.4.3.0/opam
+++ b/packages/spotlib/spotlib.4.3.0/opam
@@ -9,9 +9,12 @@ license: "MIT"
 homepage: "https://gitlab.com/camlspotter/spotlib"
 bug-reports: "https://gitlab.com/camlspotter/spotlib/-/issues"
 depends: [
-  "dune" {build & >= "2.0"}
+  "dune" {>= "2.0"}
   "ocaml" {>= "4.12.0" & < "5.0.0"}
   "ppx_test" {>= "1.8.0"}
+]
+depopts: [
+  "curl"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/camlspotter/spotlib"

--- a/packages/spotlib/spotlib.4.3.0/opam
+++ b/packages/spotlib/spotlib.4.3.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Useful functions for OCaml programming used by @camlspotter"
+description: """\
+Spotlib is a small library package used for several softwares by Jun Furuse.
+It is almost a poor replication of Jane Street Core, but it is small."""
+maintainer: "jun.furuse@gmail.com"
+authors: "Jun Furuse"
+license: "MIT"
+homepage: "https://gitlab.com/camlspotter/spotlib"
+bug-reports: "https://gitlab.com/camlspotter/spotlib/-/issues"
+depends: [
+  "dune" {build & >= "2.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
+  "ppx_test" {>= "1.8.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/camlspotter/spotlib"
+url {
+  src:
+    "https://gitlab.com/camlspotter/spotlib/-/archive/4.3.0/spotlib-4.3.0.tar.gz"
+  checksum: [
+    "md5=7fff71bfc23ad664bf0b53fd19c50300"
+    "sha512=a3f5e6088ee31d0c69043054470b4b08b9e26b74b55affdfdf1cb62b8fe09f960568491cc5095ed6cf95fd83cde3d7485c1a3966c5c8342f7a9861525946ffc7"
+  ]
+}


### PR DESCRIPTION
### `spotlib.4.3.0`
Useful functions for OCaml programming used by @camlspotter
Spotlib is a small library package used for several softwares by Jun Furuse.
It is almost a poor replication of Jane Street Core, but it is small.



---
* Homepage: https://gitlab.com/camlspotter/spotlib
* Source repo: git+https://gitlab.com/camlspotter/spotlib
* Bug tracker: https://gitlab.com/camlspotter/spotlib/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0