### PR TITLE
Package treeprint.2.2.0

### DIFF
--- a/packages/treeprint/treeprint.2.2.0/opam
+++ b/packages/treeprint/treeprint.2.2.0/opam
@@ -1,25 +1,27 @@
 opam-version: "2.0"
+synopsis: "Printing combinator library with automatic parenthese"
+description: """\
+Treeprint is a small pretty printing combinator library based on Format,
+with automatic parenthese ('(' and ')') insertion: building printing objects
+with their associativity (left/right/nonassoc) and connectivity precedences,
+objects are pretty-printed with parenthese when necessary."""
 maintainer: "jun.furuse@gmail.com"
 authors: "Jun Furuse"
-homepage: "https://gitlab.com/camlspotter/treeprint/"
-bug-reports:
-  "https://gitlab.com/camlspotter/treeprint/-/issues"
-dev-repo: "git+https://gitlab.com/camlspotter/treeprint"
-build: ["jbuilder" "build" "-p" name "-j" jobs]
+license: "MIT"
+homepage: "https://gitlab.com/camlspotter/treeprint"
+bug-reports: "https://gitlab.com/camlspotter/treeprint/-/issues"
 depends: [
-  "ocaml" {>= "4.02.1"}
-  "jbuilder" {>= "1.0+beta7"}
-  "spotlib" {>= "3.0.0"}
-  "ppx_meta_conv" {>= "4.0.0"}
-  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "dune" {build & >= "2.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
+  "spotlib" {>= "4.2.0"}
 ]
-synopsis:
-  "Small tree structure printer with operator associations and precedences"
-description: """
-Treeprint is a small printer combinator library for ASTs with infix,
-prefix and postfix operators with associativity and precedence.
-It provides abstract printing with minimum parentheses insertion."""
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/camlspotter/treeprint"
 url {
-  src: "https://gitlab.com/camlspotter/treeprint/-/archive/2.2.0/treeprint-2.2.0.tar.bz2"
-  checksum: "md5=84e441c3b071324c34cffb34557fcfcf"
+  src:
+    "https://gitlab.com/camlspotter/treeprint/-/archive/2.2.0/treeprint-2.2.0.tar.gz"
+  checksum: [
+    "md5=b5fa1d423047698201bbe31866b63153"
+    "sha512=13ae3f783d0bdf0ef164db3d3e0f30b1228557294bba61f4149f2196c480ba38dc91a661c5d9c1d6429ba2c202373179a00086edcb78faf1cacb20500469cf3f"
+  ]
 }


### PR DESCRIPTION
### `treeprint.2.2.0`
Printing combinator library with automatic parenthese
Treeprint is a small pretty printing combinator library based on Format,
with automatic parenthese ('(' and ')') insertion: building printing objects
with their associativity (left/right/nonassoc) and connectivity precedences,
objects are pretty-printed with parenthese when necessary.



---
* Homepage: https://gitlab.com/camlspotter/treeprint
* Source repo: git+https://gitlab.com/camlspotter/treeprint
* Bug tracker: https://gitlab.com/camlspotter/treeprint/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0