### PR TITLE
Package treeprint.2.3.0

### DIFF
--- a/packages/treeprint/treeprint.2.3.0/opam
+++ b/packages/treeprint/treeprint.2.3.0/opam
@@ -11,7 +11,7 @@ license: "MIT"
 homepage: "https://gitlab.com/camlspotter/treeprint"
 bug-reports: "https://gitlab.com/camlspotter/treeprint/-/issues"
 depends: [
-  "dune" {build & >= "2.0"}
+  "dune" {>= "2.0"}
   "ocaml" {>= "4.12.0" & < "5.0.0"}
   "spotlib" {>= "4.2.0"}
 ]

--- a/packages/treeprint/treeprint.2.3.0/opam
+++ b/packages/treeprint/treeprint.2.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Printing combinator library with automatic parenthese"
+description: """\
+Treeprint is a small pretty printing combinator library based on Format,
+with automatic parenthese ('(' and ')') insertion: building printing objects
+with their associativity (left/right/nonassoc) and connectivity precedences,
+objects are pretty-printed with parenthese when necessary."""
+maintainer: "jun.furuse@gmail.com"
+authors: "Jun Furuse"
+license: "MIT"
+homepage: "https://gitlab.com/camlspotter/treeprint"
+bug-reports: "https://gitlab.com/camlspotter/treeprint/-/issues"
+depends: [
+  "dune" {build & >= "2.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
+  "spotlib" {>= "4.2.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/camlspotter/treeprint"
+url {
+  src:
+    "https://gitlab.com/camlspotter/treeprint/-/archive/2.3.0/treeprint-2.3.0.tar.gz"
+  checksum: [
+    "md5=a811f3e108d7cd14c7eca3494807ec2e"
+    "sha512=ab94a1f9efeea23b91a12b15bb918c30b00d1cea382d3d5cf461bc55efd4bb8691fc77976b70093324bd6985d94c1f93eadd81c424f5214a043f0ba84296deba"
+  ]
+}


### PR DESCRIPTION
### `treeprint.2.3.0`
Printing combinator library with automatic parenthese
Treeprint is a small pretty printing combinator library based on Format,
with automatic parenthese ('(' and ')') insertion: building printing objects
with their associativity (left/right/nonassoc) and connectivity precedences,
objects are pretty-printed with parenthese when necessary.



---
* Homepage: https://gitlab.com/camlspotter/treeprint
* Source repo: git+https://gitlab.com/camlspotter/treeprint
* Bug tracker: https://gitlab.com/camlspotter/treeprint/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0