### PR TITLE
treeprint 2.1.1 needs an upper bound on spotlib

### DIFF
--- a/packages/treeprint/treeprint.2.1.1/opam
+++ b/packages/treeprint/treeprint.2.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ocaml" {>= "4.02.1"}
   "ocamlfind" {build}
   "omake" {build}
-  "spotlib" {>= "3.0.0"}
+  "spotlib" {>= "3.0.0" & < "4.3.0"}
   "ppx_meta_conv" {>= "2.0.0"}
 ]
 synopsis:


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/22386