### PR TITLE
Package lustre-v6.6.107.1

### DIFF
--- a/packages/lustre-v6/lustre-v6.6.107.1/opam
+++ b/packages/lustre-v6/lustre-v6.6.107.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "The Lustre V6 Verimag compiler"
+description: """\
+This package contains:
+  - lv6: the (current) name of the compiler (and interpreter via -exec)
+  - the lustre-v6 ocaml lib: allows to call the Lustre v6 interpreter from ocaml
+  - the lustre-v6 rdbg plugin: allows to debug Lustre v6 program wth rdbg.
+
+The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/
+
+For more information: https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6
+"""
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: "Erwan Jahier and Pascal Raymond"
+license: "CeCILL-2.1"
+homepage: "https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix"
+  "extlib" {build} | "extlib-compat" {build}
+  "dune" {>= "2.0"}
+  "ocamlfind"
+  "lutils" {>= "1.49"}
+  "rdbg" {>= "1.196.9"}
+  "num"
+  "yaml"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+dev-repo:
+  "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lustre-v6.v6.107.1.tgz"
+  checksum: [
+    "md5=4b642b106a76e19de3751afb53ccdcf4"
+    "sha512=ec6d35f0f4da219490cad7969d86e9128b7c3f03baa507f662b038b1915383581eda697ddb0e734a1a5311ef6b0908b1d0cf375a0be5dbb1aa7e9e79848037cc"
+  ]
+}

--- a/packages/lustre-v6/lustre-v6.6.107.1/opam
+++ b/packages/lustre-v6/lustre-v6.6.107.1/opam
@@ -17,7 +17,7 @@ homepage: "https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6"
 bug-reports:
   "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6/issues"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {> "4.05"}
   "base-unix"
   "extlib" {build} | "extlib-compat" {build}
   "dune" {>= "2.0"}

--- a/packages/lustre-v6/lustre-v6.6.107.1/opam
+++ b/packages/lustre-v6/lustre-v6.6.107.1/opam
@@ -17,7 +17,7 @@ homepage: "https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6"
 bug-reports:
   "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6/issues"
 depends: [
-  "ocaml" {> "4.05"}
+  "ocaml" {>= "4.06"}
   "base-unix"
   "extlib" {build} | "extlib-compat" {build}
   "dune" {>= "2.0"}


### PR DESCRIPTION
### `lustre-v6.6.107.1`
The Lustre V6 Verimag compiler
This package contains:
  - lv6: the (current) name of the compiler (and interpreter via -exec)
  - the lustre-v6 ocaml lib: allows to call the Lustre v6 interpreter from ocaml
  - the lustre-v6 rdbg plugin: allows to debug Lustre v6 program wth rdbg.

The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/

For more information: https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6



---
* Homepage: https://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/lustre-v6
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6
* Bug tracker: https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6/issues

---
:camel: Pull-request generated by opam-publish v2.1.0