### PR TITLE
5 packages from www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutin.v2.71.15.tgz

### DIFF
--- a/packages/bddrand/bddrand.2.71.15/opam
+++ b/packages/bddrand/bddrand.2.71.15/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "A simple front-end to the lutin Random toss machinary"
+description: "A simple front-end to the lutin Random toss machinary"
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+license: "CECILL-2.1"
+authors: [
+  "Erwan Jahier" "Pascal Raymond"
+]
+homepage: "http://www-verimag.imag.fr/"
+dev-repo: "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+bug-reports: "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix" {build}
+  "dune" {>= "2.0"}
+  "lutin"{>= "2.71"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutin.v2.71.15.tgz"
+  checksum: [
+    "md5=a7da42464f4ad0619bc4e759f2defca3"
+    "sha512=2142fe82b22c10f1baaf8591d177f2497c00b93e4f9d92b50e4ff24b34ecbc9d5dc8537efa21c94c09623501a1ef26292cfad36fa12fdde5cbe0add716b9c7cb"
+  ]
+}

--- a/packages/ezdl/ezdl.2.71.15/opam
+++ b/packages/ezdl/ezdl.2.71.15/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Easy dynamic linking of C functions from ocaml"
+description: "Easy dynamic linking of C functions from ocaml"
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: [
+  "Pascal Raymond"
+]
+license: "CECILL-2.1"
+tags: ["clib:stdc" "clib:camlidl"]
+homepage: "http://www-verimag.imag.fr/"
+dev-repo: "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+bug-reports: "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix" {build}
+  "camlidl"
+  "dune" {>= "2.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutin.v2.71.15.tgz"
+  checksum: [
+    "md5=a7da42464f4ad0619bc4e759f2defca3"
+    "sha512=2142fe82b22c10f1baaf8591d177f2497c00b93e4f9d92b50e4ff24b34ecbc9d5dc8537efa21c94c09623501a1ef26292cfad36fa12fdde5cbe0add716b9c7cb"
+  ]
+}

--- a/packages/gbddml/gbddml.2.71.15/opam
+++ b/packages/gbddml/gbddml.2.71.15/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "The Verimag bdd library"
+description: "A BDD library in C + an ocaml wrapper"
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: "Pascal Raymond"
+license: "CECILL-2.1"
+homepage: "http://www-verimag.imag.fr/"
+dev-repo: "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-unix" {build}
+  "dune" {>= "2.0"}
+  "camlidl" {>= "1.09"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutin.v2.71.15.tgz"
+  checksum: [
+    "md5=a7da42464f4ad0619bc4e759f2defca3"
+    "sha512=2142fe82b22c10f1baaf8591d177f2497c00b93e4f9d92b50e4ff24b34ecbc9d5dc8537efa21c94c09623501a1ef26292cfad36fa12fdde5cbe0add716b9c7cb"
+  ]
+}

--- a/packages/lutin/lutin.2.71.15/opam
+++ b/packages/lutin/lutin.2.71.15/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Lutin: modeling stochastic reactive systems"
+description: """
+Lutin is a language to model stochastic reactive systems. It has been
+initially designed to model environments and perform automated testing
+of reactive systems with Lurette.
+"""
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: [
+  "Erwan Jahier" "Pascal Raymond" "Yvan Roux"
+]
+license: "CECILL-2.1"
+tags: ["clib:stdc" "clib:camlidl"]
+homepage: "http://www-verimag.imag.fr/Lutin.html"
+dev-repo: "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+bug-reports:
+  "https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin/issues"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-bigarray"
+  "conf-gmp"
+  "conf-mpfr"
+  "conf-m4" {build}
+  "conf-perl" {build}
+  "base-unix" {build}
+  "num"
+  "camlidl"
+  "graphics"
+  "extlib" {build} | "extlib-compat" {build}
+  "lustre-v6"
+  "lutils" {>= "1.49"}
+  "mlgmpidl"
+  "dune" {>= "2.0"}
+  "ocamlfind"
+  "rdbg" {>= "1.196.9"}
+  "gbddml"
+  "ezdl"
+  "camlp-streams"
+  "polka"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutin.v2.71.15.tgz"
+  checksum: [
+    "md5=a7da42464f4ad0619bc4e759f2defca3"
+    "sha512=2142fe82b22c10f1baaf8591d177f2497c00b93e4f9d92b50e4ff24b34ecbc9d5dc8537efa21c94c09623501a1ef26292cfad36fa12fdde5cbe0add716b9c7cb"
+  ]
+}

--- a/packages/polka/polka.2.71.15/opam
+++ b/packages/polka/polka.2.71.15/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Polka: convex polyhedron library by Bertrand Jeannet (now part of apron)"
+maintainer: "erwan.jahier@univ-grenoble-alpes.fr"
+authors: [
+  "Bertrand Jeannnet"
+]
+license: "LGPL-2.1-or-later"
+tags: ["clib:stdc" "clib:camlidl"]
+homepage: "http://www-verimag.imag.fr/Lutin.html"
+dev-repo: "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin"
+bug-reports: "http://www-verimag.imag.fr/Lutin.html"
+depends: [
+  "ocaml" {>= "4.05"}
+  "base-bigarray"
+  "conf-gmp"
+  "conf-mpfr"
+  "conf-m4" {build}
+  "conf-perl" {build}
+  "base-unix" {build}
+  "num"
+  "camlidl"
+  "extlib" {build} | "extlib-compat" {build}
+  "mlgmpidl"
+  "dune" {>= "2.0"}
+  "ocamlfind"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+post-messages:
+  "The last version can be obtained via (opam repo add) http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/opam-repository/"
+url {
+  src:
+    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lutin.v2.71.15.tgz"
+  checksum: [
+    "md5=a7da42464f4ad0619bc4e759f2defca3"
+    "sha512=2142fe82b22c10f1baaf8591d177f2497c00b93e4f9d92b50e4ff24b34ecbc9d5dc8537efa21c94c09623501a1ef26292cfad36fa12fdde5cbe0add716b9c7cb"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`bddrand.2.71.15`: A simple front-end to the lutin Random toss machinary
-`ezdl.2.71.15`: Easy dynamic linking of C functions from ocaml
-`gbddml.2.71.15`: The Verimag bdd library
-`lutin.2.71.15`: Lutin: modeling stochastic reactive systems
-`polka.2.71.15`: Polka: convex polyhedron library by Bertrand Jeannet (now part of apron)



---
* Source repo: git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lutin

---
:camel: Pull-request generated by opam-publish v2.1.0