### PR TITLE
[new release] caldav (0.2.0)

### DIFF
--- a/packages/caldav/caldav.0.2.0/opam
+++ b/packages/caldav/caldav.0.2.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/caldav"
+bug-reports: "https://github.com/roburio/caldav/issues"
+dev-repo: "git+https://github.com/roburio/caldav.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/caldav/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test & >= "0.8.5"}
+  "ounit" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test}
+  "tcpip" {with-test & >= "3.7.0"}
+  "mirage-clock-unix" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "fmt" {>= "0.8.7"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "ppx_deriving" {>= "4.3"}
+  "lwt" {>= "4.0"}
+  "ptime" {>= "0.8.5"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {with-test & >= "2.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+  "base64" {>= "3.0.0"}
+  "xmlm" {>= "1.3.0"}
+  "tyxml" {>= "4.3.0"}
+  "icalendar" {>= "0.1.2"}
+  "sexplib" {>= "v0.12.0"}
+  "ppx_sexp_conv" {>= "v0.12.0"}
+  "logs" {>= "0.6.3"}
+  "hex" {>= "1.4.0"}
+  "metrics"
+  "re" {>= "1.7.2"}
+  #from webmachine
+  "dispatch" {>= "0.5.0"}
+  "uri" {>= "4.0.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "A CalDAV server"
+description: """
+A CalDAV server (RFC 4791). Supports everything from the roburio/icalendar
+library. Also includes a partial WebDAV implementation.
+"""
+url {
+  src:
+    "https://github.com/roburio/caldav/releases/download/v0.2.0/caldav-0.2.0.tbz"
+  checksum: [
+    "sha256=90bbdb95c2c47c213f576930ace721b642d2c019c748266a8dc32b24b99d54a7"
+    "sha512=f7ff9e4267285d94c6fba51a65a55493d689851e568a3eae81e4a506620d89f2c731fd5c1e43ea5abaa4bbdb17142d2f9d4337612d96fe9677e61ed01cc529fe"
+  ]
+}
+x-commit-hash: "d777b03b9600ba12a167d9e19890bc0d809d2ddf"

--- a/packages/caldav/caldav.0.2.0/opam
+++ b/packages/caldav/caldav.0.2.0/opam
@@ -17,7 +17,7 @@ license: "ISC"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != macos}
 ]
 
 depends: [


### PR DESCRIPTION
A CalDAV server

- Project page: <a href="https://github.com/roburio/caldav">https://github.com/roburio/caldav</a>
- Documentation: <a href="https://roburio.github.io/caldav/">https://roburio.github.io/caldav/</a>

##### CHANGES:

* unikernel: upgrade to mirage 4.3 (roburio/caldav#31 @hannesm)
* bugfix: href_to_principal always returned "/principals" (since v0.1.1)
  (roburio/caldav#24 @hannesm)
* error when principal or calendar already exists when adding a new principal
  (roburio/caldav#24 @hannesm)
* when modifying an ACL, check that all referenced principals exist
  (roburio/caldav#24 @hannesm)
* check for groups and principals on operations thereof (i.e. disallow deleting
  a group when the principal is a user, etc.) and test cases (roburio/caldav#25 @hannesm)
* use batch in Webdav_api instead of Webdav_fs to reduce commits
  (roburio/caldav#26, fixes in roburio/caldav#27 @hannesm)
* bugfix: adding and removing groups and users, only edit prop file once
  (roburio/caldav#27 @hannesm)
* bugfix: compute etag after batch (roburio/caldav#27 @hannesm)
