### PR TITLE
codept 0.11: extend compatibility to 5.0

### DIFF
--- a/packages/codept/codept.0.11.1/opam
+++ b/packages/codept/codept.0.11.1/opam
@@ -13,7 +13,7 @@ run-test: [
 depends: [
   "dune" {>= "2.5"}
   "menhir" {build & >= "20180523"}
-  "ocaml" {>= "4.03" & < "4.15~"}
+  "ocaml" {>= "4.03" & < "5.1~"}
 ]
 synopsis: "Alternative ocaml dependency analyzer"
 description:"""


### PR DESCRIPTION
Since OCaml 5.0 shares the same AST as 4.14.0 and codept is using is own compatibility shims for avoiding deprecated functions, the  `codept.0.11.1` version is accidentally compatible with OCaml 5.0.

This PR thus relaxes the OCaml upper-bound constraints in the `codept.0.11.1` opam package.