### PR TITLE
Allow use of pkcs11 and pkcs11-driver on macOS

### DIFF
--- a/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.1.0.0/opam
@@ -28,7 +28,6 @@ conflicts: [
   "integers" { >= "0.5.0" }
 ]
 tags: ["org:cryptosense"]
-available: [os != "macos"]
 synopsis: "Bindings to the PKCS#11 cryptographic API"
 description: """
 This library contains ctypes bindings to the PKCS#11 API.

--- a/packages/pkcs11-driver/pkcs11-driver.1.0.1/opam
+++ b/packages/pkcs11-driver/pkcs11-driver.1.0.1/opam
@@ -27,7 +27,6 @@ conflicts: [
   "ctypes" { < "0.12.0" }
 ]
 tags: ["org:cryptosense"]
-available: [os != "macos"]
 synopsis: "Bindings to the PKCS#11 cryptographic API"
 description: """
 This library contains ctypes bindings to the PKCS#11 API.

--- a/packages/pkcs11/pkcs11.1.0.0/opam
+++ b/packages/pkcs11/pkcs11.1.0.0/opam
@@ -27,7 +27,6 @@ conflicts: [
   "ppx_core" {< "v0.9.3"}
 ]
 tags: ["org:cryptosense"]
-available: [os != "macos"]
 synopsis: "PKCS#11 ocaml types"
 description: """
 This library contains type definitions for the PKCS#11 API.

--- a/packages/pkcs11/pkcs11.1.0.1/opam
+++ b/packages/pkcs11/pkcs11.1.0.1/opam
@@ -24,7 +24,6 @@ depends: [
   "ounit" {with-test}
 ]
 tags: ["org:cryptosense"]
-available: [os != "macos"]
 synopsis: "PKCS#11 OCaml types"
 description: """
 This library contains type definitions for the PKCS#11 API.


### PR DESCRIPTION
Out of the 4 libraries provided by https://github.com/cryptosense/pkcs11, only `pkcs11-rev` is currently incompatible with macOS. We declared `pkcs11` and `pkcs11-driver` (1.0.0+) as incompatible by mistake.