### PR TITLE
Package mastodon-archive-viewer.0.4.0

### DIFF
--- a/packages/mastodon-archive-viewer/mastodon-archive-viewer.0.4.0/opam
+++ b/packages/mastodon-archive-viewer/mastodon-archive-viewer.0.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "View your Mastodon archive offline"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+tags: ["mastodon" "ActivityPub"]
+homepage: "https://github.com/kit-ty-kate/mastodon-archive-viewer"
+bug-reports: "https://github.com/kit-ty-kate/mastodon-archive-viewer/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.1"}
+  "containers" {>= "3.0"}
+  "ezjsonm" {>= "1.0.0"}
+  "ptime" {>= "1.0.0"}
+  "tyxml" {>= "4.3.0"}
+  "cmdliner" {>= "1.1.0"}
+  "ffmpeg-av" {>= "1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/mastodon-archive-viewer.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/mastodon-archive-viewer/releases/download/0.4.0/mastodon-archive-viewer-0.4.0.tar.gz"
+  checksum: [
+    "md5=ac7608171caa745cbc7b85f3cf287593"
+    "sha512=a9c3a2cd0908b03726e57dc8e693d5e50b1156017f84287f55a6070769566fbdaf1dd87dc3676aec0ec01fded6c05015c78ce508b347c1001a47cb726868e054"
+  ]
+}


### PR DESCRIPTION
### `mastodon-archive-viewer.0.4.0`
View your Mastodon archive offline



---
* Homepage: https://github.com/kit-ty-kate/mastodon-archive-viewer
* Source repo: git+https://github.com/kit-ty-kate/mastodon-archive-viewer.git
* Bug tracker: https://github.com/kit-ty-kate/mastodon-archive-viewer/issues

---
:camel: Pull-request generated by opam-publish v2.1.0