### PR TITLE
monomorphic is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/monomorphic/monomorphic.1.2/opam
+++ b/packages/monomorphic/monomorphic.1.2/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "monomorphic"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/monomorphic/monomorphic.1.3/opam
+++ b/packages/monomorphic/monomorphic.1.3/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild-pkg" {build}
 ]
 conflicts: [

--- a/packages/monomorphic/monomorphic.1.4/opam
+++ b/packages/monomorphic/monomorphic.1.4/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild-pkg" {build & >= "0.2"}
 ]
 tags: [

--- a/packages/monomorphic/monomorphic.1.5/opam
+++ b/packages/monomorphic/monomorphic.1.5/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/kit-ty-kate/ocaml-monomorphic.git"
 bug-reports: "https://github.com/kit-ty-kate/ocaml-monomorphic/issues"
 build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
 ]
 tags: [

--- a/packages/monomorphic/monomorphic.2.0/opam
+++ b/packages/monomorphic/monomorphic.2.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/kit-ty-kate/ocaml-monomorphic"
 bug-reports: "https://github.com/kit-ty-kate/ocaml-monomorphic/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling monomorphic.2.0 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/monomorphic.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p monomorphic -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/monomorphic-8-86b018.env
# output-file          ~/.opam/log/monomorphic-8-86b018.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.monomorphic.objs/byte -no-alias-deps -o src/.monomorphic.objs/byte/monomorphic.cmi -c -intf src/monomorphic.mli)
# File "src/monomorphic.mli", lines 37-43, characters 30-71:
# 37 | ..............................module type of Stdlib
# 38 |                             with module List := Stdlib.List
# 39 |                              and module ListLabels := Stdlib.ListLabels
# 40 |                              and module StdLabels := Stdlib.StdLabels
# 41 |                              and module Pervasives := Stdlib.Pervasives
# 42 |                              and type in_channel := Stdlib.in_channel
# 43 |                              and type out_channel := Stdlib.out_channel
# Error: Unbound module Stdlib.Pervasives

- (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.monomorphic.objs/byte -no-alias-deps -o src/.monomorphic.objs/byte/monomorphic.cmi -c -intf src/monomorphic.mli)
- File "src/monomorphic.mli", lines 37-43, characters 30-71:
- 37 | ..............................module type of Stdlib
- 38 |                             with module List := Stdlib.List
- 39 |                              and module ListLabels := Stdlib.ListLabels
- 40 |                              and module StdLabels := Stdlib.StdLabels
- 41 |                              and module Pervasives := Stdlib.Pervasives
- 42 |                              and type in_channel := Stdlib.in_channel
- 43 |                              and type out_channel := Stdlib.out_channel
- Error: Unbound module Stdlib.Pervasives
```