### PR TITLE
[new release] phantom-algebra (1.0.1)

### DIFF
--- a/packages/phantom-algebra/phantom-algebra.1.0.1/opam
+++ b/packages/phantom-algebra/phantom-algebra.1.0.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/phantom-algebra/phantom-algebra.1.0.1/opam
+++ b/packages/phantom-algebra/phantom-algebra.1.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A strongly-typed tensor library à la GLSL"
+description: """
+Phantom-algebra is a pure OCaml library implementing strongly-typed
+small tensors with dimensions 0 ≤ 4, rank ≤ 2, and limited to square matrices.
+It makes it possible to manipulate vector and matrix expressions with an
+uniform notation while still catching non-sensical operations at compile time."""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "MIT"
+homepage: "https://github.com/Octachron/phantom_algebra"
+bug-reports: "https://github.com/Octachron/phantom_algebra/issues"
+depends: [
+  "dune" {>= "2.5"}
+  "ocaml" {>= "4.06.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/phantom_algebra.git"
+url {
+  src:
+    "https://github.com/Octachron/phantom_algebra/releases/download/1.0.1/phantom-algebra-1.0.1.tbz"
+  checksum: [
+    "sha256=40064821df7ed64443743d42f9dd4f625a6145e3cd64048304e9b47aa3076e3b"
+    "sha512=6ae9fed9005bb73ee68fa1d78f565cc152d08a7da118ed4a123326f3047a124697778defa28d1e2a085377f8c3b46bb43e39dcde348dd2737d49a0f63590d19e"
+  ]
+}
+x-commit-hash: "aaedeb7c6b53bc8cafd432f807134c93be298197"


### PR DESCRIPTION
This PR decreases the number of packages still relying on `jbuilder` by one, and restore the compatibility of the `phantom-algebra` package with recent versions of OCaml.

Note that the main feature of this package is that it tests a very pathological use of the type system... And it might be theoretically useful when bridging GLSL and OCaml.