### PR TITLE
Dose3.5.0.1-1: Patch to grep more careful for the ocaml system

### DIFF
--- a/packages/dose3/dose3.5.0.1-2/files/0001-Install-mli-cmx-etc.patch
+++ b/packages/dose3/dose3.5.0.1-2/files/0001-Install-mli-cmx-etc.patch
@@ -1,0 +1,133 @@
+From b5314c20d8e3caf62fe0dc96ad937a2950158b23 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Thu, 2 Mar 2017 12:19:56 +0100
+Subject: [PATCH] Install mli, cmx, etc.
+
+---
+ Makefile | 26 +++++++++++++-------------
+ 1 file changed, 13 insertions(+), 13 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 09464ff..5044d7f 100644
+--- a/Makefile
++++ b/Makefile
+@@ -56,7 +56,7 @@ $(DOSELIBS)/cudf.%:
+ 	@for i in _build/cudf/cudf.*; do \
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -67,7 +67,7 @@ $(DOSELIBS)/common.%: common/*.ml common/*.mli
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -78,7 +78,7 @@ $(DOSELIBS)/versioning.%: versioning/*.ml versioning/*.mli
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -88,7 +88,7 @@ $(DOSELIBS)/algo.%: algo/*.ml algo/*.mli $(DOSELIBS)/common.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -98,7 +98,7 @@ $(DOSELIBS)/debian.%: deb/*.ml deb/*.mli $(DOSELIBS)/pef.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -108,7 +108,7 @@ $(DOSELIBS)/opam.%: opam/*.ml opam/*.mli $(DOSELIBS)/pef.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -118,7 +118,7 @@ $(DOSELIBS)/npm.%: npm/*.ml npm/*.mli $(DOSELIBS)/versioning.% $(DOSELIBS)/pef.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -128,7 +128,7 @@ $(DOSELIBS)/rpm.%: rpm/*.ml $(DOSELIBS)/algo.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -138,7 +138,7 @@ $(DOSELIBS)/pef.%: pef/*.ml pef/*.mli
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -148,7 +148,7 @@ $(DOSELIBS)/csw.%: opencsw/*.ml $(DOSELIBS)/versioning.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ; \
++	  rm -f $(DOSELIBS)/*.mlpack ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -158,7 +158,7 @@ $(DOSELIBS)/doseparse.%: $(DOSELIBS)/pef.% $(DOSELIBS)/debian.%
+ 	  if [ -e $$i ]; then \
+ 	  cp $$i $(DOSELIBS) ; \
+ 		rm $$i ;\
+-	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx $(DOSELIBS)/*.ml ; \
++	  rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.ml ; \
+ 	  fi ; \
+ 	done
+ 
+@@ -168,7 +168,7 @@ $(DOSELIBS)/doseparseNoRpm.%: $(DOSELIBS)/pef.% $(DOSELIBS)/debian.%
+ 	  if [ -e $$i ]; then \
+ 			cp $$i $(DOSELIBS) ;\
+ 			rm $$i ;\
+-			rm -f $(DOSELIBS)/*.mlpack $(DOSELIBS)/*.cmx ;\
++			rm -f $(DOSELIBS)/*.mlpack ;\
+ 	  fi ; \
+ 	done
+ 
+@@ -223,7 +223,7 @@ INSTALL_STUFF_ = META
+ INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cma _build/doselibs/*.cmi)
+ INSTALL_STUFF_ += $(wildcard _build/doselibs/*.cmxa _build/doselibs/*.cmxs)
+ INSTALL_STUFF_ += $(wildcard _build/doselibs/*.a)
+-#INSTALL_STUFF_ += $(wildcard _build/*/*.mli)
++INSTALL_STUFF_ += $(wildcard _build/doselibs/*.mli) $(wildcard _build/doselibs/*.cmti) $(wildcard _build/doselibs/*.cmx)
+ INSTALL_STUFF_ += $(wildcard _build/rpm/*.so)
+ 
+ exclude_cudf = $(wildcard _build/doselibs/*cudf* _build/cudf/*)
+-- 
+2.11.0
+

--- a/packages/dose3/dose3.5.0.1-2/files/0002-dont-make-printconf.patch
+++ b/packages/dose3/dose3.5.0.1-2/files/0002-dont-make-printconf.patch
@@ -1,0 +1,9 @@
+--- a/configure
++++ b/configure
+@@ -6552,6 +6552,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
+ $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
+ fi
+-
+-
+-make printconf

--- a/packages/dose3/dose3.5.0.1-2/files/0003-Fix-for-ocaml-4.06.patch
+++ b/packages/dose3/dose3.5.0.1-2/files/0003-Fix-for-ocaml-4.06.patch
@@ -1,0 +1,52 @@
+From aeca7656f499d7f4595319858f242276920e31bb Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Sat, 2 Dec 2017 12:51:01 +0100
+Subject: [PATCH] Fix for ocaml 4.06
+
+---
+ common/criteria_lexer.mll | 8 ++++----
+ common/util.ml            | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/common/criteria_lexer.mll b/common/criteria_lexer.mll
+index 71f9178..fc4eae3 100644
+--- a/common/criteria_lexer.mll
++++ b/common/criteria_lexer.mll
+@@ -18,7 +18,7 @@
+     let c = Lexing.lexeme_char lexbuf 2 in (* the delimiter can be any character *)
+     (* find the terminating delimiter *)
+     let endpos =
+-      try String.index_from lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) c with
++      try Bytes.index_from lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) c with
+       |Invalid_argument _ ->
+           raise (Format822.Syntax_error (
+             Format822.error lexbuf "String too short"))
+@@ -27,9 +27,9 @@
+             Format822.error lexbuf (Printf.sprintf "cannot find: %c" c)))
+     in
+     let len = endpos - (lexbuf.lex_start_pos + 3) in
+-    let s = String.sub lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) len in
+-    lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_start_pos + ((String.length s)+4);
+-    s
++    let s = Bytes.sub lexbuf.lex_buffer (lexbuf.lex_start_pos + 3) len in
++    lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_start_pos + ((Bytes.length s)+4);
++    Bytes.to_string s
+ 
+ }
+ 
+diff --git a/common/util.ml b/common/util.ml
+index 598f266..36ca3d1 100644
+--- a/common/util.ml
++++ b/common/util.ml
+@@ -87,7 +87,7 @@ module MakeMessages(X : sig val label : string end) = struct
+   let clean label =
+     try 
+       let s = Filename.chop_extension (Filename.basename label) in
+-      String.capitalize s
++      String.capitalize_ascii s
+     with Invalid_argument _ -> label
+ 
+   let create ?(enabled=false) label =
+-- 
+2.11.0
+

--- a/packages/dose3/dose3.5.0.1-2/files/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
+++ b/packages/dose3/dose3.5.0.1-2/files/0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch
@@ -1,0 +1,25 @@
+From b94cf24739818e5aff397e0a83b19ea32dc81f42 Mon Sep 17 00:00:00 2001
+From: Louis Gesbert <louis.gesbert@ocamlpro.com>
+Date: Tue, 6 Feb 2018 10:15:45 +0100
+Subject: [PATCH 3/3] Add "unix" as dependency to dose3.common in META.in
+
+---
+ META.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/META.in b/META.in
+index aa2cd8d..0f9d337 100644
+--- a/META.in
++++ b/META.in
+@@ -8,7 +8,7 @@ package "common" (
+ version = "@PACKAGE_VERSION@"
+ archive(byte) = "common.cma"
+ archive(native) = "common.cmxa"
+-requires = "extlib, re.pcre, cudf, @ZIP@, @BZ2@"
++requires = "extlib, re.pcre, cudf, unix, @ZIP@, @BZ2@"
+ )
+ 
+ package "algo" (
+-- 
+2.11.0
+

--- a/packages/dose3/dose3.5.0.1-2/files/0005-Fix-compatibility-with-ocamlgraph-2.0.patch
+++ b/packages/dose3/dose3.5.0.1-2/files/0005-Fix-compatibility-with-ocamlgraph-2.0.patch
@@ -1,0 +1,31 @@
+From e26e675690b3aff46c97f8e05a198f337b870823 Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Thu, 15 Oct 2020 15:42:32 +0100
+Subject: [PATCH] Fix compatibility with ocamlgraph >= 2.0
+
+---
+ algo/dominators.ml | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/algo/dominators.ml b/algo/dominators.ml
+index 230acd4..27fa96c 100644
+--- a/algo/dominators.ml
++++ b/algo/dominators.ml
+@@ -101,7 +101,13 @@ let dominators_tarjan graph =
+   ) graph;
+ 
+   Util.Timer.start tjntimer;
+-#if OCAMLGRAPHVERSION >= 186
++#if OCAMLGRAPHVERSION >= 200
++  let module Dom = Dominator.Make_graph(struct
++      include G
++      let empty () = create ()
++      let add_edge g v1 v2 = add_edge g v1 v2; g
++    end) in
++#elif OCAMLGRAPHVERSION >= 186
+   let module Dom = Dominator.Make_graph(G) in
+ #else
+   let module Dom = Dominator.Make(G) in
+-- 
+2.29.2
+

--- a/packages/dose3/dose3.5.0.1-2/files/0006-Grep-carefully-for-ocaml-system.patch
+++ b/packages/dose3/dose3.5.0.1-2/files/0006-Grep-carefully-for-ocaml-system.patch
@@ -1,0 +1,22 @@
+diff --git a/configure b/configure
+index 49c02df..165e210 100755
+--- a/configure
++++ b/configure
+@@ -4227,7 +4227,7 @@ if test "$OCAMLBEST" = "opt"; then :
+ else
+   OCAMLBESTCC=$OCAMLC
+ fi
+-OCAML_CC="$($OCAMLBESTCC -config | fgrep native_c_compiler | sed -e "s/native_c_compiler: \(.*\) .*/\1/")"
++OCAML_CC="$($OCAMLBESTCC -config | grep "^native_c_compiler:" | sed -e "s/native_c_compiler: \(.*\) .*/\1/")"
+ ac_ext=c
+ ac_cpp='$CPP $CPPFLAGS'
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+@@ -5315,7 +5315,7 @@ done
+   HAS_RPM=yes
+ fi
+ 
+-OCAML_SYSTEM="$($OCAMLBESTCC -config | fgrep system | sed -e "s/system: \(.*\)/\1/")"
++OCAML_SYSTEM="$($OCAMLBESTCC -config | grep "^system:" | sed -e "s/system: \(.*\)/\1/")"
+ 
+ 
+ if test "${OCAML_OS_TYPE}" = "Win32"; then :

--- a/packages/dose3/dose3.5.0.1-2/opam
+++ b/packages/dose3/dose3.5.0.1-2/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "pietro.abate@inria.fr"
+authors: [
+  "Pietro Abate"
+  "Jaap Boender"
+  "Roberto Di Cosmo"
+  "Johannes Schauer"
+  "Ralf Treinen"
+  "Stefano Zacchiroli"
+  "Jakub Zwolakowski"
+  "Olivier Rosello"
+]
+homepage: "http://www.mancoosi.org/software/"
+bug-reports: "https://gitlab.com/irill/dose3/-/issues"
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://gitlab.com/irill/dose3.git"
+build: [
+  ["./configure"]
+  [make "printconf"]
+  [make "libs" "apps"]
+]
+install: [make "installlib"]
+depends: [
+  "ocaml"
+  "ocamlgraph" {>= "1.8.6"}
+  "cudf" {>= "0.7"}
+  ("extlib" {>= "1.7.0" & < "1.7.8"} | "extlib-compat" {>= "1.7.0"})
+  "re" {>= "1.2.2"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "cppo" {build & >= "1.1.2"}
+]
+conflicts: "dose"
+patches: [
+  "0001-Install-mli-cmx-etc.patch"
+  "0002-dont-make-printconf.patch"
+  "0003-Fix-for-ocaml-4.06.patch" {ocaml:version >= "4.06.0"}
+  "0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch"
+  "0005-Fix-compatibility-with-ocamlgraph-2.0.patch"
+]
+synopsis: "Dose library (part of Mancoosi tools)"
+extra-files: [
+  [
+    "0004-Add-unix-as-dependency-to-dose3.common-in-META.in.patch"
+    "md5=618265012624df95902a98f756f1ca13"
+  ]
+  ["0003-Fix-for-ocaml-4.06.patch" "md5=877eedb18916f9e260525b1aee6da544"]
+  ["0002-dont-make-printconf.patch" "md5=a6e83acee4b55d35f5f30a8ef98df04f"]
+  ["0001-Install-mli-cmx-etc.patch" "md5=977b675e7e6e7ccc5d3d57534370c68c"]
+  ["0005-Fix-compatibility-with-ocamlgraph-2.0.patch" "md5=e17b0f0aaede654a19fb3f0e2e46c61a"]
+  ["0006-Grep-carefully-for-ocaml-system.patch" "md5=fa0a2e53dbe5077b2c6d9d36a5685aa2"]
+]
+url {
+  src: "https://gitlab.com/irill/dose3/-/archive/5.0.1/dose3-5.0.1.tar.gz"
+  checksum: "md5=a81080f36f477fdebf63c4a979e251cd"
+}


### PR DESCRIPTION
Dose3's configure system reports on the OCaml system by grepping for `system` in `ocamlc -config`. However, on some systems, the output of `ocamlc -config` also has the word `system` on unrelated lines. Here is an example:

```
version: 4.14.0
standard_library_default: /tmp/tmp.PADAUCpkbY/opam-root/default/lib/ocaml
standard_library: /tmp/tmp.PADAUCpkbY/opam-root/default/lib/ocaml
ccomp_type: cc
c_compiler: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-cc
ocamlc_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include
ocamlc_cppflags: -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
ocamlopt_cflags: -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include
ocamlopt_cppflags: -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
bytecomp_c_compiler: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
native_c_compiler: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-cc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /tmp/tmp.PADAUCpkbY/test-env/include -D_FILE_OFFSET_BITS=64 -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /tmp/tmp.PADAUCpkbY/test-env/include
bytecomp_c_libraries: -lm -ldl  -lpthread
native_c_libraries: -lm -ldl
native_pack_linker: x86_64-conda-linux-gnu-ld -r -o
ranlib: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-ranlib
architecture: amd64
model: default
int_size: 63
word_size: 64
system: linux
asm: /tmp/tmp.PADAUCpkbY/test-env/bin/x86_64-conda-linux-gnu-as
asm_cfi_supported: true
with_frame_pointers: false
ext_exe:
ext_obj: .o
ext_asm: .s
ext_lib: .a
ext_dll: .so
os_type: Unix
default_executable_name: a.out
systhread_supported: true
host: x86_64-conda-linux-gnu
target: x86_64-conda-linux-gnu
flambda: false
safe_string: true
default_safe_string: true
flat_float_array: true
function_sections: true
afl_instrument: false
windows_unicode: false
supports_shared_libraries: true
naked_pointers: true
exec_magic_number: Caml1999X031
cmi_magic_number: Caml1999I031
cmo_magic_number: Caml1999O031
cma_magic_number: Caml1999A031
cmx_magic_number: Caml1999Y031
cmxa_magic_number: Caml1999Z031
ast_impl_magic_number: Caml1999M031
ast_intf_magic_number: Caml1999N031
cmxs_magic_number: Caml1999D031
cmt_magic_number: Caml1999T031
linear_magic_number: Caml1999L031
```
With this example, the grep causes a malformed
Makefile (`Makefile.config:53: *** missing separator.  Stop.`). This patch fixes this.