### PR TITLE
Package monomorphic.2.1.0

### DIFF
--- a/packages/monomorphic/monomorphic.2.1.0/opam
+++ b/packages/monomorphic/monomorphic.2.1.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis:
+  "A small library used to shadow polymorphic operators (and functions) contained in the stdlib"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+tags: [
+  "polymorphic" "compare" "equal" "equality" "monomorphic" "unsafe" "safe"
+]
+homepage: "https://github.com/kit-ty-kate/ocaml-monomorphic"
+doc: "https://kit-ty-kate.github.io/ocaml-monomorphic"
+bug-reports: "https://github.com/kit-ty-kate/ocaml-monomorphic/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "cppo" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/ocaml-monomorphic.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocaml-monomorphic/releases/download/2.1.0/monomorphic-2.1.0.tar.gz"
+  checksum: [
+    "md5=ec4c56ac126dc0afe548d95977143f30"
+    "sha512=a3a5e09bca2b40aa3a176b161669159ba3ffe4b28fd7f01e0ad9042dd65d1158c9791182cc6ff469595f37ae4b567d184fd5039c138ca1999e51c1a71482cc34"
+  ]
+}


### PR DESCRIPTION
### `monomorphic.2.1.0`
A small library used to shadow polymorphic operators (and functions) contained in the stdlib



---
* Homepage: https://github.com/kit-ty-kate/ocaml-monomorphic
* Source repo: git+https://github.com/kit-ty-kate/ocaml-monomorphic.git
* Bug tracker: https://github.com/kit-ty-kate/ocaml-monomorphic/issues

---
:camel: Pull-request generated by opam-publish v2.1.0