### PR TITLE
ocamlbuild-pkg is not compatible with OCaml 5.0

### DIFF
--- a/packages/ocamlbuild-pkg/ocamlbuild-pkg.0.1/opam
+++ b/packages/ocamlbuild-pkg/ocamlbuild-pkg.0.1/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild"
 ]

--- a/packages/ocamlbuild-pkg/ocamlbuild-pkg.0.2.1/opam
+++ b/packages/ocamlbuild-pkg/ocamlbuild-pkg.0.2.1/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild"
 ]

--- a/packages/ocamlbuild-pkg/ocamlbuild-pkg.0.2/opam
+++ b/packages/ocamlbuild-pkg/ocamlbuild-pkg.0.2/opam
@@ -9,7 +9,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling ocamlbuild-pkg.0.2.1 ===============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamlbuild-pkg.0.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ocamlbuild-pkg-8-57a927.env
# output-file          ~/.opam/log/ocamlbuild-pkg-8-57a927.out
### output ###
# cat src/ocamlbuild_pkg.ml bootstrap.ml > myocamlbuild.ml
# ocamlbuild -use-ocamlfind ocamlbuild-pkg
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# + ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# File "myocamlbuild.ml", line 324, characters 29-46:
# 324 |     Pathname.dirname modul / String.capitalize (Pathname.basename modul)
#                                    ^^^^^^^^^^^^^^^^^
# Error: Unbound value String.capitalize
# Command exited with code 2.
# make: *** [Makefile:6: all] Error 10
```