### PR TITLE
ffmpeg < 1.0 is not compatible with OCaml 5.0 (uses String.uppercase)

### DIFF
--- a/packages/ffmpeg/ffmpeg.0.1.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.0/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "ffmpeg"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
 ]

--- a/packages/ffmpeg/ffmpeg.0.1.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.1/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "ffmpeg"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
 ]

--- a/packages/ffmpeg/ffmpeg.0.1.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.1.2/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "ffmpeg"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
 ]

--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "ffmpeg"]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "base-bigarray"

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "ffmpeg"]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "base-bigarray"

--- a/packages/ffmpeg/ffmpeg.0.3.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.3.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
 synopsis:
   "Bindings for the ffmpeg library which provides functions for decoding audio and video files"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "conf-autoconf" {dev & build}

--- a/packages/ffmpeg/ffmpeg.0.4.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.0/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
 synopsis:
   "Bindings for the ffmpeg library which provides functions for decoding audio and video files"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "conf-autoconf" {dev & build}

--- a/packages/ffmpeg/ffmpeg.0.4.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.1/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
 synopsis:
   "Bindings for the ffmpeg library which provides functions for decoding audio and video files"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "conf-autoconf" {dev & build}

--- a/packages/ffmpeg/ffmpeg.0.4.2/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.2/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
 synopsis:
   "Bindings for the ffmpeg library which provides functions for decoding audio and video files"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "conf-autoconf" {dev & build}

--- a/packages/ffmpeg/ffmpeg.0.4.3/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.3/opam
@@ -6,7 +6,7 @@ bug-reports: "https://github.com/savonet/ocaml-ffmpeg/issues"
 synopsis:
   "Bindings for the ffmpeg library which provides functions for decoding audio and video files"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind" {build}
   "conf-pkg-config" {build}
   "conf-autoconf" {dev & build}


### PR DESCRIPTION
```
#=== ERROR while compiling ffmpeg.0.4.3 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ffmpeg.0.4.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ffmpeg-8-7a1643.env
# output-file          ~/.opam/log/ffmpeg-8-7a1643.out
### output ###
# make -C src all
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ffmpeg.0.4.3/src'
# /home/opam/.opam/5.0/bin/ocamlc -c gen_code_stubs.c
# /home/opam/.opam/5.0/bin/ocamlc -custom str.cma gen_code_stubs.o gen_code.ml -o gen_code
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The str subdirectory has been
# automatically added to the search path, but you should add -I +str to the
# command-line to silence this alert (e.g. by adding str to the list of
# libraries in your dune file, or adding use_str to your _tags file for
# ocamlbuild, or using -package str for ocamlfind).
# File "gen_code.ml", line 30, characters 19-28:
# 30 |   let id = String.(uppercase(sub id 0 1) ^ lowercase(sub id 1 (length id - 1))) in
#                         ^^^^^^^^^
# Error: Unbound value uppercase
# make[1]: *** [Makefile:67: gen-code] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/ffmpeg.0.4.3/src'
# make: *** [Makefile:11: all] Error 2
```