### PR TITLE
[new release] build_path_prefix_map 0.3

### DIFF
--- a/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.2/opam
@@ -20,6 +20,6 @@ synopsis:
 description: "https://reproducible-builds.org/specs/build-path-prefix-map/"
 url {
   src:
-    "https://gitlab.com/gasche/build_path_prefix_map/repository/0.2/archive.tar.gz"
-  checksum: "md5=41db2fdf2e5098b6c4cf4131df704339"
+    "https://gitlab.com/gasche/build_path_prefix_map/-/archive/0.2/archive.tar.gz"
+    checksum: "sha256=cc2f16803cd1086937320069374e328c34509ed531e8175ffca4d670a73fdebc"
 }

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.3/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "An OCaml implementation of the BUILD_PATH_PREFIX_MAP specification"
+description: "https://reproducible-builds.org/specs/build-path-prefix-map/"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: [ "Gabriel Scherer <gabriel.scherer@gmail.com>" ]
+license: "MIT"
+homepage: "https://gitlab.com/gasche/build_path_prefix_map"
+doc: "https://gitlab.com/gasche/build_path_prefix_map/blob/master/README.md"
+bug-reports: "https://gitlab.com/gasche/build_path_prefix_map/issues"
+dev-repo: "git+https://gitlab.com/gasche/build_path_prefix_map.git"
+depends: [
+  "dune" {>= "1.11"}
+  "crowbar" {with-test}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+url {
+  src: "https://gitlab.com/gasche/build_path_prefix_map/-/archive/0.3/archive.tar.gz"
+  checksum: "sha256=23445af07bbd3bcd836d179c5feafbda9d353e23bc7eb00f0ba56de287b09145"
+}

--- a/packages/build_path_prefix_map/build_path_prefix_map.0.3/opam
+++ b/packages/build_path_prefix_map/build_path_prefix_map.0.3/opam
@@ -10,11 +10,12 @@ doc: "https://gitlab.com/gasche/build_path_prefix_map/blob/master/README.md"
 bug-reports: "https://gitlab.com/gasche/build_path_prefix_map/issues"
 dev-repo: "git+https://gitlab.com/gasche/build_path_prefix_map.git"
 depends: [
+  "ocaml" {>= "4.04"}
   "dune" {>= "1.11"}
   "crowbar" {with-test}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
 supports OCaml 5.0 (kprintf -> ksprintf)