### PR TITLE
[new release] fileutils (0.6.4)

### DIFF
--- a/packages/fileutils/fileutils.0.6.4/opam
+++ b/packages/fileutils/fileutils.0.6.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Sylvain Le Gall <sylvain+ocaml@le-gall.net>"
+authors: [ "Sylvain Le Gall" ]
+homepage: "https://github.com/gildor478/ocaml-fileutils"
+license: "LGPL-2.1 with OCaml linking exception"
+dev-repo: "git+https://github.com/gildor478/ocaml-fileutils.git"
+bug-reports: "https://github.com/gildor478/ocaml-fileutils/issues"
+doc: "https://gildor478.github.io/ocaml-fileutils/"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.03"}
+  "base-unix"
+  "stdlib-shims"
+  "seq"
+  "dune" {>= "1.11.0"}
+  "ounit2" {with-test & >= "2.0.0"}
+]
+synopsis: "API to manipulate files (POSIX like) and filenames"
+description: """
+This library provides an API to perform POSIX like operations on files like:
+
+- mv
+- cp
+- rm
+- mkdir
+- touch
+- which...
+
+It also provides a module to manipulate abstract filenames:
+
+- classification
+- make_relative: made a filename relative to another
+- make_absolute
+"""
+url {
+  src:
+    "https://github.com/gildor478/ocaml-fileutils/releases/download/v0.6.4/fileutils-0.6.4.tbz"
+  checksum: [
+    "sha256=7a7bb6bc6a36b6ebdac2b4e46a9e9b10d366c5a2d4417a5f1d68a1fbba0a445f"
+    "sha512=7053f8d92655d5631f1ec61ab7f9e3f6e3afedbe435038858dd9a026b9c769c6182afaa436491a398e7c4513b384a609e016718e030855996b2d9d54b461bd19"
+  ]
+}
+x-commit-hash: "324a05938d88c4b645287adbf5ceb74f4ce0daec"


### PR DESCRIPTION
API to manipulate files (POSIX like) and filenames

- Project page: <a href="https://github.com/gildor478/ocaml-fileutils">https://github.com/gildor478/ocaml-fileutils</a>
- Documentation: <a href="https://gildor478.github.io/ocaml-fileutils/">https://gildor478.github.io/ocaml-fileutils/</a>

##### CHANGES:

### Fixed

- Fix documentation for FilePath.is_updir and FilePath.is_subdir. Thanks to
  dmbaturin for the contribution.
- Support for OCaml 5 (thanks to Leonidas-from-XIV and kit-ty-kate)
