### PR TITLE
[new release] camyll (0.4.1)

### DIFF
--- a/packages/camyll/camyll.0.4.1/opam
+++ b/packages/camyll/camyll.0.4.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "A static site generator"
+description: """
+Camyll is a static site generator.
+
+Features:
+
+- Conversion from Markdown to HTML
+- Syntax highlighting of any language via user-provided TextMate grammars
+- Post tagging
+- Processing of literate Agda"""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+tags: ["blog" "web" "website"]
+homepage: "https://alan-j-hu.github.io/camyll"
+bug-reports: "https://github.com/alan-j-hu/camyll/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "angstrom" {>= "0.15" & < "0.16"}
+  "calendar" {>= "2.01" & < "4"}
+  "cmdliner" {>= "1.1" & < "2"}
+  "ezjsonm" {>= "1.3" & < "2"}
+  "httpaf" {>= "0.7.1" & < "0.8"}
+  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
+  "jingoo" {>= "1.4" & < "2"}
+  "lambdasoup" {>= "0.7" & < "0.8"}
+  "markup" {>= "0.8" & < "2"}
+  "ocaml" {>= "4.12"}
+  "omd" {= "2.0.0~alpha2"}
+  "otoml" {>= "0.9.3"}
+  "plist-xml" {< "0.4"}
+  "re" {>= "1.9" & < "2"}
+  "slug" {>= "1.0" & < "2"}
+  "textmate-language" {>= "0.3.2" & < "0.4"}
+  "uri" {>= "4.2" & < "5"}
+  "yaml" {>= "3.1" & < "4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/camyll.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/camyll/releases/download/0.4.1/camyll-0.4.1.tbz"
+  checksum: [
+    "sha256=c8d3c09929801a7b7174a6317251d7a6fae990ed1bb4cff1630b25be2dea324a"
+    "sha512=7c124bed262e22240a5cee9f62a4e5f824d4c32e1748c2b82478fd9ae7ff6ef3337eab459244f350fc39ad0225208c88482507bdf67e3e8ccc6dbd8ecd3c88f5"
+  ]
+}
+x-commit-hash: "7a5a4b201d8edea1779997c91f579ef85ff6fc00"


### PR DESCRIPTION
A static site generator

- Project page: <a href="https://alan-j-hu.github.io/camyll">https://alan-j-hu.github.io/camyll</a>

##### CHANGES:

- Upgrade `calendar`, `cmdliner`, and `textmate-language` dependencies and
  replace usage of deprecated `cmdliner` API.
- Catch stray exceptions.
- Support JSON and YAML grammar files.
