### PR TITLE
camlpdf is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/camlpdf/camlpdf.2.3/opam
+++ b/packages/camlpdf/camlpdf.2.3/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/johnwhitington/camlpdf"
 build: [[make]]
 install: [[make "install"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Read, write and modify PDF files"

--- a/packages/camlpdf/camlpdf.2.4/opam
+++ b/packages/camlpdf/camlpdf.2.4/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [[make]]
 install: [[make "install"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-which" {build}
 ]

--- a/packages/camlpdf/camlpdf.2.5/opam
+++ b/packages/camlpdf/camlpdf.2.5/opam
@@ -8,7 +8,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: [[make]]
 install: [[make "install"]]
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.0"}
   "ocamlfind" {build}
   "conf-which" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling camlpdf.2.5 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/camlpdf.2.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/camlpdf-8-316c38.env
# output-file          ~/.opam/log/camlpdf-8-316c38.out
### output ###
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlpdf.2.5'
# ocamldep pdfmerge.mli > ._bcdi/pdfmerge.di
# ocamldep pdftype0.mli > ._bcdi/pdftype0.di
# ocamldep pdftruetype.mli > ._bcdi/pdftruetype.di
# ocamldep pdftype1.mli > ._bcdi/pdftype1.di
# ocamldep pdfcff.mli > ._bcdi/pdfcff.di
# ocamldep pdfocg.mli > ._bcdi/pdfocg.di
# ocamldep pdfdate.mli > ._bcdi/pdfdate.di
# ocamldep pdfshapes.mli > ._bcdi/pdfshapes.di
# ocamldep pdfgraphics.mli > ._bcdi/pdfgraphics.di
# ocamldep pdfstandard14.mli > ._bcdi/pdfstandard14.di
# ocamldep pdftext.mli > ._bcdi/pdftext.di
# ocamldep pdfglyphlist.mli > ._bcdi/pdfglyphlist.di
# ocamldep pdfafmdata.mli > ._bcdi/pdfafmdata.di
# ocamldep pdfafm.mli > ._bcdi/pdfafm.di
# ocamldep pdfimage.mli > ._bcdi/pdfimage.di
# ocamldep pdfspace.mli > ._bcdi/pdfspace.di
# ocamldep pdffun.mli > ._bcdi/pdffun.di
# ocamldep pdfannot.mli > ._bcdi/pdfannot.di
# ocamldep pdfpage.mli > ._bcdi/pdfpage.di
# ocamldep pdfpagelabels.mli > ._bcdi/pdfpagelabels.di
# ocamldep pdfmarks.mli > ._bcdi/pdfmarks.di
# ocamldep pdfdest.mli > ._bcdi/pdfdest.di
# ocamldep pdfops.mli > ._bcdi/pdfops.di
# ocamldep pdfjpeg.mli > ._bcdi/pdfjpeg.di
# ocamldep pdfread.mli > ._bcdi/pdfread.di
# ocamldep pdfgenlex.mli > ._bcdi/pdfgenlex.di
# ocamldep pdfwrite.mli > ._bcdi/pdfwrite.di
# ocamldep pdfcodec.mli > ._bcdi/pdfcodec.di
# ocamldep pdfflate.mli > ._bcdi/pdfflate.di
# ocamldep pdfcrypt.mli > ._bcdi/pdfcrypt.di
# ocamldep pdf.mli > ._bcdi/pdf.di
# ocamldep pdfcryptprimitives.mli > ._bcdi/pdfcryptprimitives.di
# ocamldep pdfpaper.mli > ._bcdi/pdfpaper.di
# ocamldep pdfunits.mli > ._bcdi/pdfunits.di
# ocamldep pdftransform.mli > ._bcdi/pdftransform.di
# ocamldep pdfio.mli > ._bcdi/pdfio.di
# ocamldep pdfutil.mli > ._bcdi/pdfutil.di
# ocamldep pdfmerge.ml > ._d/pdfmerge.d
# ocamldep pdftype0.ml > ._d/pdftype0.d
# ocamldep pdftruetype.ml > ._d/pdftruetype.d
# ocamldep pdftype1.ml > ._d/pdftype1.d
# ocamldep pdfcff.ml > ._d/pdfcff.d
# ocamldep pdfocg.ml > ._d/pdfocg.d
# ocamldep pdfdate.ml > ._d/pdfdate.d
# ocamldep pdfshapes.ml > ._d/pdfshapes.d
# ocamldep pdfgraphics.ml > ._d/pdfgraphics.d
# ocamldep pdfstandard14.ml > ._d/pdfstandard14.d
# ocamldep pdftext.ml > ._d/pdftext.d
# ocamldep pdfglyphlist.ml > ._d/pdfglyphlist.d
# ocamldep pdfafmdata.ml > ._d/pdfafmdata.d
# ocamldep pdfafm.ml > ._d/pdfafm.d
# ocamldep pdfimage.ml > ._d/pdfimage.d
# ocamldep pdfspace.ml > ._d/pdfspace.d
# ocamldep pdffun.ml > ._d/pdffun.d
# ocamldep pdfannot.ml > ._d/pdfannot.d
# ocamldep pdfpage.ml > ._d/pdfpage.d
# ocamldep pdfpagelabels.ml > ._d/pdfpagelabels.d
# ocamldep pdfmarks.ml > ._d/pdfmarks.d
# ocamldep pdfdest.ml > ._d/pdfdest.d
# ocamldep pdfops.ml > ._d/pdfops.d
# ocamldep pdfjpeg.ml > ._d/pdfjpeg.d
# ocamldep pdfread.ml > ._d/pdfread.d
# ocamldep pdfgenlex.ml > ._d/pdfgenlex.d
# ocamldep pdfwrite.ml > ._d/pdfwrite.d
# ocamldep pdfcodec.ml > ._d/pdfcodec.d
# ocamldep pdfflate.ml > ._d/pdfflate.d
# ocamldep pdfcrypt.ml > ._d/pdfcrypt.d
# ocamldep pdf.ml > ._d/pdf.d
# ocamldep pdfcryptprimitives.ml > ._d/pdfcryptprimitives.d
# ocamldep pdfpaper.ml > ._d/pdfpaper.d
# ocamldep pdfunits.ml > ._d/pdfunits.d
# ocamldep pdftransform.ml > ._d/pdftransform.d
# ocamldep pdfio.ml > ._d/pdfio.d
# ocamldep pdfutil.ml > ._d/pdfutil.d
# ocamlc -c -cc "cc" -ccopt "-fPIC  \
# 			-DPIC   \
# 			    -o flatestubs.o " flatestubs.c
# ocamlc -c -cc "cc" -ccopt "-fPIC  \
# 			-DPIC   \
# 			    -o rijndael-alg-fst.o " rijndael-alg-fst.c
# ocamlc -c -cc "cc" -ccopt "-fPIC  \
# 			-DPIC   \
# 			    -o stubs-aes.o " stubs-aes.c
# ocamlc -c -cc "cc" -ccopt "-fPIC  \
# 			-DPIC   \
# 			    -o sha2.o " sha2.c
# ocamlc -c -cc "cc" -ccopt "-fPIC  \
# 			-DPIC   \
# 			    -o stubs-sha2.o " stubs-sha2.c
# ar rcs libcamlpdf_stubs.a  flatestubs.o rijndael-alg-fst.o stubs-aes.o sha2.o stubs-sha2.o
# ocamlc -c -bin-annot pdfutil.mli
# ocamlc -c -bin-annot -g -safe-string -w -3 pdfutil.ml
# File "pdfutil.ml", line 303, characters 13-27:
# 303 | let i32max = Pervasives.max
#                    ^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make[1]: *** [OCamlMakefile:1076: pdfutil.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlpdf.2.5'
# make: *** [OCamlMakefile:792: byte-code-library] Error 2
```