### PR TITLE
lambdasoup is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/lambdasoup/lambdasoup.0.5.1/opam
+++ b/packages/lambdasoup/lambdasoup.0.5.1/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "ocamlfind-install"]
 remove: ["ocamlfind" "remove" "lambdasoup"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/lambdasoup/lambdasoup.0.5/opam
+++ b/packages/lambdasoup/lambdasoup.0.5/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "ocamlfind-install"]
 remove: ["ocamlfind" "remove" "lambdasoup"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/lambdasoup/lambdasoup.0.6.1/opam
+++ b/packages/lambdasoup/lambdasoup.0.6.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "ocamlfind-install"]
 remove: ["ocamlfind" "remove" "lambdasoup"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build & >= "1.6.3"}
   "ocamlbuild" {build}
   "markup" {>= "0.7.1"}

--- a/packages/lambdasoup/lambdasoup.0.6.2/opam
+++ b/packages/lambdasoup/lambdasoup.0.6.2/opam
@@ -8,7 +8,7 @@ authors: "Anton Bachin <antonbachin@yahoo.com>"
 maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/aantron/lambda-soup.git"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "markup" {>= "0.7.1"}
   "ounit" {with-test}

--- a/packages/lambdasoup/lambdasoup.0.6.3/opam
+++ b/packages/lambdasoup/lambdasoup.0.6.3/opam
@@ -8,7 +8,7 @@ authors: "Anton Bachin <antonbachin@yahoo.com>"
 maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 dev-repo: "git+https://github.com/aantron/lambda-soup.git"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta10"}
   "markup" {>= "0.7.1"}
   "ounit" {with-test}

--- a/packages/lambdasoup/lambdasoup.0.6.4/opam
+++ b/packages/lambdasoup/lambdasoup.0.6.4/opam
@@ -15,7 +15,7 @@ depends: [
   # As a consequence of depending on Dune, Lambda Soup requires OCaml 4.02.3.
   "dune"
   "markup" {>= "0.7.1"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 
   "bisect_ppx" {dev & >= "2.0.0"}
   "ounit" {dev}

--- a/packages/lambdasoup/lambdasoup.0.6/opam
+++ b/packages/lambdasoup/lambdasoup.0.6/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "ocamlfind-install"]
 remove: ["ocamlfind" "remove" "lambdasoup"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "markup" {>= "0.7"}

--- a/packages/lambdasoup/lambdasoup.0.7.0/opam
+++ b/packages/lambdasoup/lambdasoup.0.7.0/opam
@@ -15,7 +15,7 @@ depends: [
   # As a consequence of depending on Dune, Lambda Soup requires OCaml 4.02.3.
   "dune"
   "markup" {>= "0.7.1"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 
   "bisect_ppx" {dev & >= "2.0.0"}
   "ounit" {with-test}

--- a/packages/lambdasoup/lambdasoup.0.7.1/opam
+++ b/packages/lambdasoup/lambdasoup.0.7.1/opam
@@ -15,7 +15,7 @@ depends: [
   # As a consequence of depending on Dune, Lambda Soup requires OCaml 4.02.3.
   "dune"
   "markup" {>= "0.7.1"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 
   "bisect_ppx" {dev & >= "2.0.0"}
   "ounit" {with-test}

--- a/packages/lambdasoup/lambdasoup.0.7.2/opam
+++ b/packages/lambdasoup/lambdasoup.0.7.2/opam
@@ -15,7 +15,7 @@ depends: [
   # As a consequence of depending on Dune, Lambda Soup requires OCaml 4.02.3.
   "dune"
   "markup" {>= "1.0.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 
   "bisect_ppx" {dev & >= "2.0.0"}
   "ounit2" {with-test}

--- a/packages/lambdasoup/lambdasoup.0.7.3/opam
+++ b/packages/lambdasoup/lambdasoup.0.7.3/opam
@@ -15,7 +15,7 @@ depends: [
   # As a consequence of depending on Dune, Lambda Soup requires OCaml 4.02.3.
   "dune" {>= "2.7.0"}
   "markup" {>= "1.0.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 
   "bisect_ppx" {dev & >= "2.5.0"}
   "ounit2" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling lambdasoup.0.7.3 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/lambdasoup.0.7.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lambdasoup -j 31
# exit-code            1
# env-file             ~/.opam/log/lambdasoup-9-0a696d.env
# output-file          ~/.opam/log/lambdasoup-9-0a696d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +A -warn-error -3 -g -bin-annot -I src/.soup.objs/byte -I /home/opam/.opam/5.0/lib/markup -I /home/opam/.opam/5.0/lib/uutf -intf-suffix .ml -no-alias-deps -o src/.soup.objs/byte/soup.cmo -c -impl src/soup.ml)
# File "src/soup.ml", line 34, characters 24-33:
# 34 |   let lowercase_ascii = lowercase [@ocaml.warning "-3"]
#                              ^^^^^^^^^
# Error: Unbound value lowercase
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w +A -warn-error -3 -g -I src/.soup.objs/byte -I src/.soup.objs/native -I /home/opam/.opam/5.0/lib/markup -I /home/opam/.opam/5.0/lib/uutf -intf-suffix .ml -no-alias-deps -o src/.soup.objs/native/soup.cmx -c -impl src/soup.ml)
# File "src/soup.ml", line 34, characters 24-33:
# 34 |   let lowercase_ascii = lowercase [@ocaml.warning "-3"]
#                              ^^^^^^^^^
# Error: Unbound value lowercase
```