### PR TITLE
labrys is not compatible with LLVM >= 13

### DIFF
--- a/packages/labrys/labrys.0.1/opam
+++ b/packages/labrys/labrys.0.1/opam
@@ -20,7 +20,7 @@ depends: [
   "re" {>= "1.2.2"}
   "msgpack"
   "uutf" {>= "1.0.0"}
-  "llvm" {>= "3.8"}
+  "llvm" {>= "3.8" & < "13.0"}
   "containers" {>= "2.0" & < "3.0"}
   "craml" {with-test}
 ]


### PR DESCRIPTION
See https://github.com/kit-ty-kate/labrys/pull/10