### PR TITLE
spotlib: Add a missing depopt (library spotlib.curl is defined as (optional) in dune)

### DIFF
--- a/packages/spotlib/spotlib.4.0.3/opam
+++ b/packages/spotlib/spotlib.4.0.3/opam
@@ -13,6 +13,9 @@ depends: [
   "ppx_test" {>= "1.6.0"}
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
+depopts: [
+  "curl"
+]
 synopsis: "Useful functions for OCaml programming used by @camlspotter"
 description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.

--- a/packages/spotlib/spotlib.4.1.0/opam
+++ b/packages/spotlib/spotlib.4.1.0/opam
@@ -12,6 +12,9 @@ depends: [
   "ocaml" {>= "4.08.0" & < "4.12.0"}
   "ppx_test" {>= "1.7.0"}
 ]
+depopts: [
+  "curl"
+]
 synopsis: "Useful functions for OCaml programming used by @camlspotter"
 description: """
 Spotlib is a small library package used for several softwares by Jun Furuse.

--- a/packages/spotlib/spotlib.4.2.0/opam
+++ b/packages/spotlib/spotlib.4.2.0/opam
@@ -13,6 +13,9 @@ depends: [
   "ocaml" {>= "4.08.0" & < "5.0"}
   "ppx_test" {>= "1.8.0"}
 ]
+depopts: [
+  "curl"
+]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/camlspotter/spotlib"
 url {


### PR DESCRIPTION
Noticed in https://github.com/ocaml/opam-repository/pull/22386
cc @camlspotter 