### PR TITLE
camlidl < 1.10 does not support OCaml 5.0 (uses deprecated C API)

### DIFF
--- a/packages/camlidl/camlidl.1.05/opam
+++ b/packages/camlidl/camlidl.1.05/opam
@@ -23,7 +23,9 @@ CamlIDL is a stub code generator for OCaml. It automates the
 generation of C stub code required for the Caml/C interface, based on
 an MIDL specification. Also provides some support for Microsoft's COM
 software components."""
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0"}
+]
 extra-files: [
   ["disable-fatal-warn-31.diff" "md5=750eef544a6a4f4835b819ca8d740924"]
   ["cpp-location.diff" "md5=bf3ee8e555285ec9140894cf6b0b19a8"]

--- a/packages/camlidl/camlidl.1.07/opam
+++ b/packages/camlidl/camlidl.1.07/opam
@@ -20,7 +20,7 @@ generation of C stub code required for the Caml/C interface, based on
 an MIDL specification. Also provides some support for Microsoft's COM
 software components."""
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
 ]
 extra-files: [
   ["disable-fatal-warn-31.diff" "md5=750eef544a6a4f4835b819ca8d740924"]

--- a/packages/camlidl/camlidl.1.09/opam
+++ b/packages/camlidl/camlidl.1.09/opam
@@ -17,7 +17,7 @@ generation of C stub code required for the Caml/C interface, based on
 an MIDL specification. Also provides some support for Microsoft's COM
 software components."""
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
 ]
 extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]


### PR DESCRIPTION
```
#=== ERROR while compiling camlidl.1.09 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/camlidl.1.09
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/camlidl-8-c4b11b.env
# output-file          ~/.opam/log/camlidl-8-c4b11b.out
### output ###
# cd compiler; make all
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.09/compiler'
# rm -f config.ml
# sed -e 's|%%CPP%%|cpp|' \
#           config.mlp > config.ml
# chmod -w config.ml
# ocamlc -g -c config.mli
# ocamlc -g -c config.ml
# ocamlc -g -c utils.mli
# ocamlc -g -c utils.ml
# ocamlc -g -c clflags.ml
# ocamlc -g -c idltypes.mli
# ocamlc -g -c prefix.mli
# ocamlc -g -c prefix.ml
# ocamlc -g -c lexpr.mli
# ocamlc -g -c lexpr.ml
# ocamlc -g -c cvttyp.mli
# ocamlc -g -c cvttyp.ml
# ocamlc -g -c variables.mli
# ocamlc -g -c variables.ml
# ocamlc -g -c idlarray.mli
# ocamlc -g -c idlarray.ml
# ocamlc -g -c struct.mli
# ocamlc -g -c struct.ml
# ocamlc -g -c enum.mli
# ocamlc -g -c enum.ml
# ocamlc -g -c union.mli
# ocamlc -g -c union.ml
# ocamlc -g -c cvtval.mli
# ocamlc -g -c cvtval.ml
# ocamlc -g -c structdecl.mli
# ocamlc -g -c structdecl.ml
# ocamlc -g -c enumdecl.mli
# ocamlc -g -c enumdecl.ml
# ocamlc -g -c uniondecl.mli
# ocamlc -g -c uniondecl.ml
# ocamlc -g -c typedef.mli
# ocamlc -g -c typedef.ml
# ocamlc -g -c funct.mli
# ocamlc -g -c funct.ml
# ocamlc -g -c constdecl.mli
# ocamlc -g -c constdecl.ml
# ocamlc -g -c intf.mli
# ocamlc -g -c intf.ml
# ocamlc -g -c file.mli
# ocamlc -g -c file.ml
# ocamlc -g -c predef.mli
# ocamlc -g -c predef.ml
# ocamllex linenum.mll
# 16 states, 331 transitions, table size 1420 bytes
# ocamlc -g -c linenum.mli
# ocamlc -g -c linenum.ml
# ocamlc -g -c parse_aux.mli
# ocamlc -g -c parse_aux.ml
# ocamlyacc -v parser_midl.mly
# 12 shift/reduce conflicts, 4 reduce/reduce conflicts.
# ocamlc -g -c parser_midl.mli
# ocamlc -g -c parser_midl.ml
# ocamllex lexer_midl.mll
# 129 states, 1747 transitions, table size 7762 bytes
# ocamlc -g -c lexer_midl.mli
# ocamlc -g -c lexer_midl.ml
# ocamlc -g -c parse.mli
# ocamlc -g -c parse.ml
# ocamlc -g -c fixlabels.mli
# ocamlc -g -c fixlabels.ml
# ocamlc -g -c normalize.mli
# ocamlc -g -c normalize.ml
# ocamlc -g -c main.ml
# ocamlc -g -o camlidl config.cmo utils.cmo clflags.cmo prefix.cmo lexpr.cmo cvttyp.cmo variables.cmo idlarray.cmo struct.cmo enum.cmo union.cmo cvtval.cmo structdecl.cmo enumdecl.cmo uniondecl.cmo typedef.cmo funct.cmo constdecl.cmo intf.cmo file.cmo predef.cmo linenum.cmo parse_aux.cmo parser_midl.cmo lexer_midl.cmo parse.cmo fixlabels.cmo normalize.cmo main.cmo
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.09/compiler'
# cd runtime; make all
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.09/runtime'
# ocamlc -g -ccopt "-Wall -g" idlalloc.c
# idlalloc.c: In function 'camlidl_find_enum':
# idlalloc.c:35:3: warning: implicit declaration of function 'invalid_argument'; did you mean 'caml_invalid_argument'? [-Wimplicit-function-declaration]
#    35 |   invalid_argument(errmsg);
#       |   ^~~~~~~~~~~~~~~~
#       |   caml_invalid_argument
# idlalloc.c: In function 'camlidl_alloc_flag_list':
# idlalloc.c:47:19: warning: implicit declaration of function 'alloc_small'; did you mean 'caml_alloc_small'? [-Wimplicit-function-declaration]
#    47 |         value v = alloc_small(2, 0);
#       |                   ^~~~~~~~~~~
#       |                   caml_alloc_small
# idlalloc.c: In function 'camlidl_register_allocation':
# idlalloc.c:73:7: warning: implicit declaration of function 'stat_alloc' [-Wimplicit-function-declaration]
#    73 |       stat_alloc(sizeof(struct camlidl_block_list));
#       |       ^~~~~~~~~~
# idlalloc.c:73:7: warning: initialization of 'struct camlidl_block_list *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
# idlalloc.c: In function 'camlidl_malloc':
# idlalloc.c:95:16: warning: initialization of 'void *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
#    95 |   void * res = stat_alloc(sz);
#       |                ^~~~~~~~~~
# idlalloc.c:96:31: error: 'stat_free' undeclared (first use in this function); did you mean 'caml_stat_free'?
#    96 |   camlidl_register_allocation(stat_free, res, ctx);
#       |                               ^~~~~~~~~
#       |                               caml_stat_free
# idlalloc.c:96:31: note: each undeclared identifier is reported only once for each function it appears in
# idlalloc.c: In function 'camlidl_free':
# idlalloc.c:108:5: warning: implicit declaration of function 'stat_free'; did you mean 'caml_stat_free'? [-Wimplicit-function-declaration]
#   108 |     stat_free(tmp);
#       |     ^~~~~~~~~
#       |     caml_stat_free
# idlalloc.c: In function 'camlidl_malloc_string':
# idlalloc.c:114:18: warning: implicit declaration of function 'string_length'; did you mean 'caml_string_length'? [-Wimplicit-function-declaration]
#   114 |   mlsize_t len = string_length(mlstring);
#       |                  ^~~~~~~~~~~~~
#       |                  caml_string_length
# make[1]: *** [Makefile.unix:40: idlalloc.o] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.09/runtime'
# make: *** [Makefile:19: all] Error 2
```