### PR TITLE
camlidl.1.09.1

### DIFF
--- a/packages/camlidl/camlidl.1.09.1/files/META
+++ b/packages/camlidl/camlidl.1.09.1/files/META
@@ -1,0 +1,5 @@
+description = "Stub generator from IDL description"
+version = "1.09.1"
+archive(byte) = "com.cma"
+archive(byte,plugin) = "com.cma"
+archive(native) = "com.cmxa"

--- a/packages/camlidl/camlidl.1.09.1/files/camlidl.install
+++ b/packages/camlidl/camlidl.1.09.1/files/camlidl.install
@@ -1,0 +1,21 @@
+bin: [
+ "?compiler/camlidl"
+ "?compiler/camlidl.exe"
+]
+lib: [
+  "META"
+  "lib/com.cma"
+  "lib/com.cmxa"
+  "lib/com.cmi"
+ "?lib/com.a"
+ "?lib/com.lib"
+ "?runtime/libcamlidl.a"
+ "?runtime/libcamlidl.lib"
+ "?runtime/cfactory.obj"
+ "?runtime/cfactory.o"
+ "runtime/camlidlruntime.h" { "caml/camlidlruntime.h" }
+]
+stublibs: [
+ "?runtime/dllcamlidl.so"
+ "?runtime/dllcamlidl.dll"
+]

--- a/packages/camlidl/camlidl.1.09.1/opam
+++ b/packages/camlidl/camlidl.1.09.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Stub code generator for OCaml"
+description: """
+CamlIDL is a stub code generator for OCaml. It automates the
+generation of C stub code required for the Caml/C interface, based on
+an MIDL specification. Also provides some support for Microsoft's COM
+software components."""
+maintainer: "Nicolas Berthier <m@nberth.space>"
+authors: ["Xavier Leroy"]
+license: [
+  "QPL-1.0 WITH OCaml-LGPL-linking-exception"
+  "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://github.com/xavierleroy/camlidl"
+dev-repo: "git+https://github.com/xavierleroy/camlidl.git"
+bug-reports: "https://github.com/xavierleroy/camlidl/issues"
+build: [
+  ["mv" "config/Makefile.unix" "config/Makefile"] {os != "win32"}
+  ["mv" "config/Makefile.mingw" "config/Makefile"] {os = "win32"}
+  [make "all"]
+]
+depends: [
+  "ocaml" {>= "4.03"}
+]
+extra-files: [
+  ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
+  ["META" "md5=f12cc59517db6c176c1ec3809dc12bac"]
+]
+url {
+  src:
+    "https://github.com/kit-ty-kate/camlidl/archive/500.tar.gz"
+  checksum: "md5=88176b7d3fcdf9b5b66b1c8a556faa46"
+}


### PR DESCRIPTION
Provides an OCaml 5-compatible version of camlidl, without the breaking changes introduced in camlidl.1.10