### PR TITLE
[new release] magic-mime (1.3.0)

### DIFF
--- a/packages/magic-mime/magic-mime.1.3.0/opam
+++ b/packages/magic-mime/magic-mime.1.3.0/opam
@@ -27,7 +27,7 @@ depends: [
   "dune"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {

--- a/packages/magic-mime/magic-mime.1.3.0/opam
+++ b/packages/magic-mime/magic-mime.1.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Map filenames to common MIME types"
+description: """
+This library contains a database of MIME types that maps filename extensions
+into MIME types suitable for use in many Internet protocols such as HTTP or
+e-mail.  It is generated from the `mime.types` file found in Unix systems, but
+has no dependency on a filesystem since it includes the contents of the
+database as an ML datastructure.
+
+For example, here's how to lookup MIME types in the [utop] REPL:
+
+    #require "magic-mime";;
+    Magic_mime.lookup "/foo/bar.txt";;
+    - : bytes = "text/plain"
+    Magic_mime.lookup "bar.css";;
+    - : bytes = "text/css"
+"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy" "Maxence Guesdon"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-magic-mime"
+doc: "https://mirage.github.io/ocaml-magic-mime/"
+bug-reports: "https://github.com/mirage/ocaml-magic-mime/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-magic-mime.git"
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-magic-mime/releases/download/v1.3.0/magic-mime-1.3.0.tbz"
+  checksum: [
+    "sha256=d835948a288d7efd9c49e1958b9f54260769ff4a0eb1f0829541876622f7cd9c"
+    "sha512=15da02dcd044805401454cca25cf4b564ffcf1cd929f7422fd43c7911e3c20f6e456bd49be4c1916b706104a1f4acc5bb06c7e52bf6b8cc8895c519a0a0ac051"
+  ]
+}
+x-commit-hash: "afcac590cbe6e970ba3048b643fb923e97a9a3c1"


### PR DESCRIPTION
Map filenames to common MIME types

- Project page: <a href="https://github.com/mirage/ocaml-magic-mime">https://github.com/mirage/ocaml-magic-mime</a>
- Documentation: <a href="https://mirage.github.io/ocaml-magic-mime/">https://mirage.github.io/ocaml-magic-mime/</a>

##### CHANGES:

* Allow an optional default if the MIME type is unknown (@hannesm, mirage/ocaml-magic-mime#25)
* Add a function to map MIME type to file extensions (@DolphinChips, mirage/ocaml-magic-mime#24)
* Fix documentation (@MisterDA, mirage/ocaml-magic-mime#23)
