### PR TITLE
LablTk 8.06.13 and OCamlBrowser 5.0.0

### DIFF
--- a/packages/labltk/labltk.8.06.13/opam
+++ b/packages/labltk/labltk.8.06.13/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-verbose" "-installbindir" bin]
+  [make "library" "opt"]
+]
+install: [
+  [make "install"]
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCaml interface to Tcl/Tk"
+description: "ocamlbrowser is now a separate package.\n\
+             For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.13.tar.gz"
+  checksum: "md5=d1d59ef6d190d5332a56eb6d9f7f7d96"
+}

--- a/packages/ocamlbrowser/ocamlbrowser.5.0.0/opam
+++ b/packages/ocamlbrowser/ocamlbrowser.5.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "garrigue@math.nagoya-u.ac.jp"
+authors: ["Jacques Garrigue et al., Nagoya University"]
+homepage: "https://garrigue.github.io/labltk/"
+bug-reports: "https://github.com/garrigue/labltk/issues"
+dev-repo: "git+https://github.com/garrigue/labltk.git"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+build: [
+  ["./configure" "-use-findlib" "-installbindir" bin]
+  [make "all"]
+]
+install: [
+  [make "install-browser"]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "labltk" {>= "8.06.13"}
+  "ocamlfind" {build}
+  "conf-tcl"
+  "conf-tk"
+]
+post-messages: [
+  "This package requires Tcl/Tk with its development packages installed on your system" {failure}
+]
+synopsis: "OCamlBrowser Library Explorer"
+description: "Require LablTk. For details, see https://garrigue.github.io/labltk/"
+url {
+  src: "https://github.com/garrigue/labltk/archive/refs/tags/8.06.13.tar.gz"
+  checksum: "md5=d1d59ef6d190d5332a56eb6d9f7f7d96"
+}


### PR DESCRIPTION
This release ensures compatibility with OCaml 5.0, both for LablTk and OCamlBrowser.

LablTk should still work with older versions of OCaml (but there are no fixes for them).