### PR TITLE
[new release] zmq, zmq-lwt and zmq-async (5.2.1)

### DIFF
--- a/packages/zmq-async/zmq-async.5.2.1/opam
+++ b/packages/zmq-async/zmq-async.5.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async-aware bindings to ZMQ"
+maintainer: ["Anders Fugmann <anders@fugmann.net>"]
+authors: ["Rudi Grinberg"]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1"}
+  "zmq" {= version}
+  "async_unix" {>= "v0.11.0" & < "v0.16"}
+  "async_kernel" {>= "v0.11.0" & < "v0.16"}
+  "base" {>= "v0.11.0" & < "v0.16"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/issuu/ocaml-zmq.git"
+url {
+  src:
+    "https://github.com/issuu/ocaml-zmq/releases/download/5.2.1/zmq-5.2.1.tbz"
+  checksum: [
+    "sha256=85529f693ad416a101b2fe61141ec9c2c47adf43340ca9ea841d101e9c5c1ca7"
+    "sha512=b0c8e1f0ef0466fe4c45ebcb6d5d975931d7cbaac906a440d1123a1557caf8ca4d47c8f6877dd25db96a2b5b136be49b4f345eb1f98c249476cea203ec9297ac"
+  ]
+}
+x-commit-hash: "66837f98c55042bcdf00c805529e4d1f173ce77a"

--- a/packages/zmq-async/zmq-async.5.2.1/opam
+++ b/packages/zmq-async/zmq-async.5.2.1/opam
@@ -9,9 +9,9 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.04.1"}
   "zmq" {= version}
-  "async_unix" {>= "v0.11.0" & < "v0.16"}
-  "async_kernel" {>= "v0.11.0" & < "v0.16"}
-  "base" {>= "v0.11.0" & < "v0.16"}
+  "async_unix" {>= "v0.11.0"}
+  "async_kernel" {>= "v0.11.0"}
+  "base" {>= "v0.11.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/zmq-lwt/zmq-lwt.5.2.1/opam
+++ b/packages/zmq-lwt/zmq-lwt.5.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lwt-aware bindings to ZMQ"
+maintainer: ["Anders Fugmann <anders@fugmann.net>"]
+authors: ["Anders Fugmann <anders@fugmann.net>"]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "zmq" {= version}
+  "lwt" {>= "2.6.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/issuu/ocaml-zmq.git"
+url {
+  src:
+    "https://github.com/issuu/ocaml-zmq/releases/download/5.2.1/zmq-5.2.1.tbz"
+  checksum: [
+    "sha256=85529f693ad416a101b2fe61141ec9c2c47adf43340ca9ea841d101e9c5c1ca7"
+    "sha512=b0c8e1f0ef0466fe4c45ebcb6d5d975931d7cbaac906a440d1123a1557caf8ca4d47c8f6877dd25db96a2b5b136be49b4f345eb1f98c249476cea203ec9297ac"
+  ]
+}
+x-commit-hash: "66837f98c55042bcdf00c805529e4d1f173ce77a"

--- a/packages/zmq/zmq.5.2.1/opam
+++ b/packages/zmq/zmq.5.2.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for ZeroMQ 4.x"
+description: """
+This library contains basic bindings for ZMQ.
+Lwt aware bindings to zmq are availble though package zmq-lwt
+Async aware bindings to zmq are available though package zmq-async"""
+maintainer: ["Anders Fugmann <anders@fugmann.net>"]
+authors: ["Anders Fugmann" "Pedro Borges" "Peter Zotov"]
+license: "MIT"
+homepage: "https://github.com/issuu/ocaml-zmq"
+bug-reports: "https://github.com/issuu/ocaml-zmq/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "conf-zmq"
+  "ounit2" {with-test}
+  "dune-configurator"
+  "odoc" {with-doc}
+]
+conflicts: ["ocaml-zmq"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/issuu/ocaml-zmq.git"
+url {
+  src:
+    "https://github.com/issuu/ocaml-zmq/releases/download/5.2.1/zmq-5.2.1.tbz"
+  checksum: [
+    "sha256=85529f693ad416a101b2fe61141ec9c2c47adf43340ca9ea841d101e9c5c1ca7"
+    "sha512=b0c8e1f0ef0466fe4c45ebcb6d5d975931d7cbaac906a440d1123a1557caf8ca4d47c8f6877dd25db96a2b5b136be49b4f345eb1f98c249476cea203ec9297ac"
+  ]
+}
+x-commit-hash: "66837f98c55042bcdf00c805529e4d1f173ce77a"


### PR DESCRIPTION
OCaml bindings for ZeroMQ 4.x

- Project page: <a href="https://github.com/issuu/ocaml-zmq">https://github.com/issuu/ocaml-zmq</a>

##### CHANGES:

* Forward compatibility with Lwt 6.0 (issuu/ocaml-zmq#122, @andersfugmann)
* Fix wrong fd type for zmq-async, effecting s390x (issuu/ocaml-zmq#123, @andersfugmann)
