### PR TITLE
[new release] js_of_ocaml-ocamlbuild (5.0)

### DIFF
--- a/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.5.0/opam
+++ b/packages/js_of_ocaml-ocamlbuild/js_of_ocaml-ocamlbuild.5.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "An ocamlbuild plugin to compile to JavaScript using js_of_ocaml"
+description:
+  "An ocamlbuild plugin to compile to JavaScript using js_of_ocaml"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: ["LGPL-2.1-or-later"]
+homepage: "https://github.com/ocsigen/js_of_ocaml-ocamlbuild"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml-ocamlbuild/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.04"}
+  "ocamlbuild"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml-ocamlbuild.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml-ocamlbuild/releases/download/5.0/js_of_ocaml-ocamlbuild-5.0.tbz"
+  checksum: [
+    "sha256=aa59bcbf1ce27bcb2a3eb77a8a2c1ff17e9ddbe0f240e3a198ca1cebb0a1c07b"
+    "sha512=86f6ea777eb15ae289c2033874ecd007d3e8f861d73f4ee6fd5e95ed70b574718c3cf569aa007dc8a9ff943a441b99f51a12b8cf8999ae32a37989795d304bf5"
+  ]
+}
+x-commit-hash: "9b81d6f59204666aa5925e63a901c817dc8fb05c"


### PR DESCRIPTION
An ocamlbuild plugin to compile to JavaScript using js_of_ocaml

- Project page: <a href="https://github.com/ocsigen/js_of_ocaml-ocamlbuild">https://github.com/ocsigen/js_of_ocaml-ocamlbuild</a>

##### CHANGES:

* Use jsoo_runtime instead of linkops(javascript) in META files (ocsigen/js_of_ocaml-ocamlbuild#2)
