### PR TITLE
[new release] http-mirage-client (0.0.1)

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.1/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "HTTP client for MirageOS"
+maintainer: ["team@robur.coop"]
+authors: [
+  "Robur Team <team@robur.coop>"
+]
+license: "MIT"
+homepage: "https://github.com/roburio/http-mirage-client"
+bug-reports: "https://github.com/roburio/http-mirage-client/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "paf" {>= "0.2.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-time" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "lwt" {>= "5.5.0"}
+  "mimic-happy-eyeballs"
+  "httpaf"
+  "alcotest-lwt" {with-test}
+  "mirage-clock-unix" {with-test}
+  "mirage-random-stdlib" {with-test}
+  "mirage-time-unix" {with-test}
+  "h2"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roburio/http-mirage-client.git"
+url {
+  src:
+    "https://github.com/roburio/http-mirage-client/releases/download/v0.0.1/http-mirage-client-0.0.1.tbz"
+  checksum: [
+    "sha256=cb9cbc90520033cdaaffd1f8537834cf63714efdedebe133cc4364c53592f2dd"
+    "sha512=9e015d1c57305e23abf6cfc288477d5d523cbe0ebb467abd002446db7eae6a40d6453844fcc9922835cebac70cb777fe7143e4b63e94cbcf7ccf43ab0a320e83"
+  ]
+}
+x-commit-hash: "59b872bf2b6db79bfb302e9fc6628d04afdff525"

--- a/packages/http-mirage-client/http-mirage-client.0.0.1/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.1/opam
@@ -34,7 +34,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "macos"} # macOS is disabled due to restrictions in sandbox-exec
     "@doc" {with-doc}
   ]
 ]

--- a/packages/http-mirage-client/http-mirage-client.0.0.1/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.1/opam
@@ -18,6 +18,7 @@ depends: [
   "mimic-happy-eyeballs"
   "httpaf"
   "alcotest-lwt" {with-test}
+  "mirage-entropy" {with-test & >= "0.5.0"}
   "mirage-clock-unix" {with-test}
   "mirage-random-stdlib" {with-test}
   "mirage-time-unix" {with-test}


### PR DESCRIPTION
HTTP client for MirageOS

- Project page: <a href="https://github.com/roburio/http-mirage-client">https://github.com/roburio/http-mirage-client</a>

##### CHANGES:

* First release
