### PR TITLE
[new release] http-lwt-client (0.2.0)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.0/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.2.0/http-lwt-client-0.2.0.tbz"
+  checksum: [
+    "sha256=a84ec8d6f125f53ecb3a2d2dde76b4a7d8ca14ce4888dfd66b00e426febb2c53"
+    "sha512=c0e3ee7b35c0f18b532b1ad421dee78ae114f7c4e6b857341432fd57c1b1d4f2cbdf0a116f0c9af4d4a3a19e29499922bfc5e1118ee69717acf72e6af39c9d4c"
+  ]
+}
+x-commit-hash: "2bba6fb323ef37742d89926aeabde440b02a7bda"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* API: In the body function passed to request, the response is the first
  argument. This allows a client to do different stuff with the body, depending
  on the response code (and/or content type etc.) (roburio/http-lwt-client#15 by @hannesm, reviewed and
  suggested by @reynir in https://git.robur.io/robur/http-mirage-client/pulls/2)
