### PR TITLE
mlgmpidl uses bigarray which is not available in ocaml5

### DIFF
--- a/packages/mlgmpidl/mlgmpidl.1.2.11/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.11/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "ocamlfind" {build}
   "camlidl"
   "conf-gmp"

--- a/packages/mlgmpidl/mlgmpidl.1.2.12/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.12/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1" < "5"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "ocamlfind" {build}
   "camlidl" {< "1.10"}
   "conf-gmp"

--- a/packages/mlgmpidl/mlgmpidl.1.2.13/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.13/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1" < "5"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "ocamlfind" {build}
   "camlidl" {< "1.10"}
   "conf-gmp"

--- a/packages/mlgmpidl/mlgmpidl.1.2.14/opam
+++ b/packages/mlgmpidl/mlgmpidl.1.2.14/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1" < "5"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "ocamlfind" {build & >= "1.5.6"}
   "camlidl" {< "1.10"}
   "conf-gmp"


### PR DESCRIPTION
Fixes the [broken CI](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/56df113f393328b92421c5c63ad0f4a70bad6bb0/variant/compilers,5.0,bddrand.2.71.15) of the [currently opened verimag PR](https://github.com/ocaml/opam-repository/pull/22397)

TL;DR:

```

#=== ERROR while compiling mlgmpidl.1.2.11 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mlgmpidl.1.2.11
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/mlgmpidl-7-83cb63.env
# output-file          ~/.opam/log/mlgmpidl-7-83cb63.out
### output ###
# tmpdir=$(mktemp -d tmp.XXXXXX);				\
# trap "rm -rf ${tmpdir};" EXIT QUIT INT;			\
# { cp mpz.idl ${tmpdir}/mpz.idl;					\
#   /home/opam/.opam/5.0/bin/camlidl -no-include -prepro cpp ${tmpdir}/mpz.idl;		\
#   /usr/bin/perl perlscript_c.pl < ${tmpdir}/mpz_stubs.c >mpz_caml.c;	\
#   /usr/bin/perl perlscript_caml.pl < ${tmpdir}/mpz.ml >mpz.ml;		\
#   /usr/bin/perl perlscript_caml.pl < ${tmpdir}/mpz.mli >mpz.mli; }
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package "bigarray" -annot -g -c mpz.mli
# ocamlfind: Package `bigarray' not found
# make: *** [Makefile:280: mpz.cmi] Error 2
```