### PR TITLE
fix ocb-stubblr missing dependency

### DIFF
--- a/packages/ocb-stubblr/ocb-stubblr.0.0.1/opam
+++ b/packages/ocb-stubblr/ocb-stubblr.0.0.1/opam
@@ -12,6 +12,7 @@ depends: [
   "ocamlbuild" {>= "0.9.3"}
   "topkg" {>= "0.7.8" & < "0.8.0"}
   "astring"
+  "bos"
 ]
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" pinned ]
 synopsis: "OCamlbuild plugin for C stubs"


### PR DESCRIPTION
Missing dependency as per https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/218d91927548221cc32f4cec883a8d57d2048071/variant/compilers,4.08,tsdl.0.9.6,lower-bounds

```
#=== ERROR while compiling tsdl.0.9.6 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.08.1 | pinned(http://erratique.ch/software/tsdl/releases/tsdl-0.9.6.tbz)
# path                 ~/.opam/4.08/.opam-switch/build/tsdl.0.9.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned true
# exit-code            1
# env-file             ~/.opam/log/tsdl-10-abecf6.env
# output-file          ~/.opam/log/tsdl-10-abecf6.out
### output ###
# ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package ocb-stubblr myocamlbuild.ml /home/opam/.opam/4.08/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# + ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package ocb-stubblr myocamlbuild.ml /home/opam/.opam/4.08/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind: Package `bos.setup' not found - required by `ocb-stubblr'
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-tag' 'debug'
#      '-build-dir' '_build' '-plugin-tag' 'package(ocb-stubblr)' 'opam'
#      'pkg/META' 'CHANGES.md' 'LICENSE.md' 'README.md' 'src/tsdl.a'
#      'src/tsdl.cmxs' 'src/tsdl.cmxa' 'src/tsdl.cma' 'src/tsdl.cmx'
#      'src/tsdl.cmi' 'src/tsdl.mli' 'src/tsdl_consts.cmx' 'src/tsdl_top.a'
#      'src/tsdl_top.cmxs' 'src/tsdl_top.cmxa' 'src/tsdl_top.cma'
#      'src/tsdl_top.cmx' 'src/tsdl_top_init.ml' 'src/dlltsdl.so'
#      'src/libtsdl.a' 'README.md' 'CHANGES.md' 'test/min.ml' 'test/minc.c']: exited with 10
```