### PR TITLE
Remove unnecessary upper bounds for camyll

### DIFF
--- a/packages/camyll/camyll.0.4.0/opam
+++ b/packages/camyll/camyll.0.4.0/opam
@@ -17,22 +17,22 @@ homepage: "https://alan-j-hu.github.io/camyll"
 bug-reports: "https://github.com/alan-j-hu/camyll/issues"
 depends: [
   "dune" {>= "2.7"}
-  "angstrom" {>= "0.15" & < "0.16"}
-  "calendar" {>= "2.01" & < "3"}
-  "cmdliner" {>= "1.0" & < "2"}
-  "httpaf" {>= "0.7.1" & < "0.8"}
-  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
-  "jingoo" {>= "1.4" & < "2"}
-  "lambdasoup" {>= "0.7" & < "0.8"}
-  "markup" {>= "0.8" & < "2"}
+  "angstrom" {>= "0.15"}
+  "calendar" {>= "2.01"}
+  "cmdliner" {>= "1.0"}
+  "httpaf" {>= "0.7.1"}
+  "httpaf-lwt-unix" {>= "0.7.1"}
+  "jingoo" {>= "1.4"}
+  "lambdasoup" {>= "0.7"}
+  "markup" {>= "0.8"}
   "ocaml" {>= "4.12"}
   "omd" {= "2.0.0~alpha2"}
   "otoml" {>= "0.9.3"}
   "plist-xml" {< "0.4"}
-  "re" {>= "1.9" & < "2"}
-  "slug" {>= "1.0" & < "2"}
+  "re" {>= "1.9"}
+  "slug" {>= "1.0"}
   "textmate-language" {>= "0.3.1" & < "0.4"}
-  "uri" {>= "4.2" & < "5"}
+  "uri" {>= "4.2"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/camyll/camyll.0.4.1/opam
+++ b/packages/camyll/camyll.0.4.1/opam
@@ -17,24 +17,24 @@ homepage: "https://alan-j-hu.github.io/camyll"
 bug-reports: "https://github.com/alan-j-hu/camyll/issues"
 depends: [
   "dune" {>= "2.7"}
-  "angstrom" {>= "0.15" & < "0.16"}
-  "calendar" {>= "2.01" & < "4"}
-  "cmdliner" {>= "1.1" & < "2"}
-  "ezjsonm" {>= "1.3" & < "2"}
-  "httpaf" {>= "0.7.1" & < "0.8"}
-  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
-  "jingoo" {>= "1.4" & < "2"}
-  "lambdasoup" {>= "0.7" & < "0.8"}
-  "markup" {>= "0.8" & < "2"}
+  "angstrom" {>= "0.15"}
+  "calendar" {>= "2.01"}
+  "cmdliner" {>= "1.1"}
+  "ezjsonm" {>= "1.3"}
+  "httpaf" {>= "0.7.1"}
+  "httpaf-lwt-unix" {>= "0.7.1"}
+  "jingoo" {>= "1.4"}
+  "lambdasoup" {>= "0.7"}
+  "markup" {>= "0.8"}
   "ocaml" {>= "4.12"}
   "omd" {= "2.0.0~alpha2"}
   "otoml" {>= "0.9.3"}
   "plist-xml" {< "0.4"}
-  "re" {>= "1.9" & < "2"}
-  "slug" {>= "1.0" & < "2"}
+  "re" {>= "1.9"}
+  "slug" {>= "1.0"}
   "textmate-language" {>= "0.3.2" & < "0.4"}
-  "uri" {>= "4.2" & < "5"}
-  "yaml" {>= "3.1" & < "4"}
+  "uri" {>= "4.2"}
+  "yaml" {>= "3.1"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
I realized that I forgot to update the upper bound for `calendar` when I made my new release, forcing me to downgrade it... So I'm taking your advice and removing the upper bounds (except for my own packages).