### PR TITLE
opam-core >= 2.0.0~rc2 < 2.0.1 requires jbuilder >= 1.0+beta20

### DIFF
--- a/packages/opam-core/opam-core.2.0.0/opam
+++ b/packages/opam-core/opam-core.2.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "jbuilder" {>= "1.0+beta17"}
+  "jbuilder" {>= "1.0+beta20"}
   "cppo" {build}
 ]
 conflicts: "extlib-compat"

--- a/packages/opam-core/opam-core.2.0.0/opam
+++ b/packages/opam-core/opam-core.2.0.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "jbuilder" {>= "1.0+beta20"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"
 synopsis: "Core library for opam 2.0"

--- a/packages/opam-core/opam-core.2.0.0~rc/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc/opam
@@ -25,7 +25,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "jbuilder" {>= "1.0+beta12"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: [
   "dune"

--- a/packages/opam-core/opam-core.2.0.0~rc2/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc2/opam
@@ -26,7 +26,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "jbuilder" {>= "1.0+beta17"}
+  "jbuilder" {>= "1.0+beta20"}
   "cppo" {build}
 ]
 conflicts: "extlib-compat"

--- a/packages/opam-core/opam-core.2.0.0~rc2/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc2/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "jbuilder" {>= "1.0+beta20"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"
 synopsis: "Core library for opam 2.0"

--- a/packages/opam-core/opam-core.2.0.0~rc3/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc3/opam
@@ -26,7 +26,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "jbuilder" {>= "1.0+beta17"}
+  "jbuilder" {>= "1.0+beta20"}
   "cppo" {build}
 ]
 conflicts: "extlib-compat"

--- a/packages/opam-core/opam-core.2.0.0~rc3/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc3/opam
@@ -27,7 +27,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "jbuilder" {>= "1.0+beta20"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"
 synopsis: "Core library for opam 2.0"

--- a/packages/opam-core/opam-core.2.0.1/opam
+++ b/packages/opam-core/opam-core.2.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "jbuilder" {>= "1.0+beta20"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.0.1/opam
+++ b/packages/opam-core/opam-core.2.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-bigarray"
   "ocamlgraph"
   "re" {>= "1.5.0"}
-  "jbuilder" {>= "1.0+beta17"}
+  "jbuilder" {>= "1.0+beta20"}
   "cppo" {build}
 ]
 conflicts: ["extlib-compat"]

--- a/packages/opam-core/opam-core.2.0.2/opam
+++ b/packages/opam-core/opam-core.2.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "dune" {>= "1.2.1"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.0.3/opam
+++ b/packages/opam-core/opam-core.2.0.3/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "dune" {>= "1.2.1"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.0.4/opam
+++ b/packages/opam-core/opam-core.2.0.4/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "dune" {>= "1.2.1"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.0.5/opam
+++ b/packages/opam-core/opam-core.2.0.5/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "dune" {>= "1.2.1"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.0.6/opam
+++ b/packages/opam-core/opam-core.2.0.6/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "dune" {>= "1.2.1"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.0.7/opam
+++ b/packages/opam-core/opam-core.2.0.7/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.5.0"}
   "dune" {>= "1.2.1"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: ["extlib-compat"]
 build: [

--- a/packages/opam-core/opam-core.2.1.0~beta2/opam
+++ b/packages/opam-core/opam-core.2.1.0~beta2/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.9.0"}
   "dune" {>= "1.5.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"
 url {

--- a/packages/opam-core/opam-core.2.1.0~beta4/opam
+++ b/packages/opam-core/opam-core.2.1.0~beta4/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlgraph"
   "re" {>= "1.9.0"}
   "dune" {>= "1.5.0"}
-  "cppo" {build}
+  "cppo" {build & >= "1.1.0"}
 ]
 conflicts: "extlib-compat"
 url {


### PR DESCRIPTION
```
#=== ERROR while compiling opam-core.2.0.0 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.07/.opam-switch/build/opam-core.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make opam-core.install
# exit-code            2
# env-file             ~/.opam/log/opam-core-7-9f750b.env
# output-file          ~/.opam/log/opam-core-7-9f750b.out
### output ###
# jbuilder build  -p opam-core opam-core.install
# File "src/client/jbuild", line 37, characters 13-23:
# Error: Unknown constructor universe
# make: *** [Makefile:101: opam-core.install] Error 1
```