### PR TITLE
[new release] pyre-ast (0.1.9)

### DIFF
--- a/packages/pyre-ast/pyre-ast.0.1.9/opam
+++ b/packages/pyre-ast/pyre-ast.0.1.9/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Full-fidelity Python parser in OCaml"
+description:
+  "pyre-ast is an OCaml library to parse Python source files into abstract syntax trees. Under the hood, it relies on the CPython parser to do the parsing work and therefore the result is always 100% compatible with the official CPython implementation."
+maintainer: ["grievejia@gmail.com"]
+authors: ["Jia Chen"]
+license: "MIT"
+homepage: "https://github.com/grievejia/pyre-ast"
+doc: "https://grievejia.github.io/pyre-ast/doc"
+bug-reports: "https://github.com/grievejia/pyre-ast/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "base" {>= "v0.14.1"}
+  "ppx_sexp_conv" {>= "v0.14.0"}
+  "ppx_compare" {>= "v0.14.0"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_make" {>= "0.2.1"}
+  "stdio" {with-test & >= "v0.14.0"}
+  "sexplib" {with-test & >= "v0.14.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/grievejia/pyre-ast.git"
+url {
+  src:
+    "https://github.com/grievejia/pyre-ast/releases/download/0.1.9/pyre-ast-0.1.9.tbz"
+  checksum: [
+    "sha256=108d13eb1b7d89d750f3780830916e79ae6cbe4176740610ed0e05d0c5826ea1"
+    "sha512=ff9f21e1dff29df73ab57d4eb3eae6f3dbffc4d6d882042d3a6b53c5dd6132594b9a0418f8ff957c9272141afe5a3015aa0d4bd654adda8f0385eb12f1994222"
+  ]
+}
+x-commit-hash: "e832067a8335c559d564b0dc364342185ea7a8bd"


### PR DESCRIPTION
Full-fidelity Python parser in OCaml

- Project page: <a href="https://github.com/grievejia/pyre-ast">https://github.com/grievejia/pyre-ast</a>
- Documentation: <a href="https://grievejia.github.io/pyre-ast/doc">https://grievejia.github.io/pyre-ast/doc</a>

##### CHANGES:

- Bump the bundled CPython version to 3.11.0
- Fixed segfaults when parsing with default filename
