### PR TITLE
opam-core < 2.0.7 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/opam-core/opam-core.2.0.0/opam
+++ b/packages/opam-core/opam-core.2.0.0/opam
@@ -21,7 +21,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.0~beta5/opam
+++ b/packages/opam-core/opam-core.2.0.0~beta5/opam
@@ -19,7 +19,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.0~rc2/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc2/opam
@@ -21,7 +21,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.0~rc3/opam
+++ b/packages/opam-core/opam-core.2.0.0~rc3/opam
@@ -21,7 +21,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.1/opam
+++ b/packages/opam-core/opam-core.2.0.1/opam
@@ -16,7 +16,7 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.2/opam
+++ b/packages/opam-core/opam-core.2.0.2/opam
@@ -16,7 +16,7 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.3/opam
+++ b/packages/opam-core/opam-core.2.0.3/opam
@@ -16,7 +16,7 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.4/opam
+++ b/packages/opam-core/opam-core.2.0.4/opam
@@ -16,7 +16,7 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.5/opam
+++ b/packages/opam-core/opam-core.2.0.5/opam
@@ -16,7 +16,7 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"

--- a/packages/opam-core/opam-core.2.0.6/opam
+++ b/packages/opam-core/opam-core.2.0.6/opam
@@ -16,7 +16,7 @@ authors: [
 homepage: "https://opam.ocaml.org/"
 bug-reports: "https://github.com/ocaml/opam/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "base-unix"
   "base-bigarray"
   "ocamlgraph"


### PR DESCRIPTION
```
#=== ERROR while compiling opam-core.2.0.6 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/opam-core.2.0.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build make opam-core.install
# exit-code            2
# env-file             ~/.opam/log/opam-core-8-1345f6.env
# output-file          ~/.opam/log/opam-core-8-1345f6.out
### output ###
# dune build  -p opam-core opam-core.install
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +a-4-40-42-44-48 -safe-string -g -bin-annot -I src/core/.opam_core.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocamlgraph -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -no-alias-deps -o src/core/.opam_core.objs/byte/opamStubsTypes.cmo -c -impl src/core/opamStubsTypes.ml)
# File "src/core/opamStubsTypes.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +a-4-40-42-44-48 -safe-string -g -bin-annot -I src/core/.opam_core.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocamlgraph -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/core/.opam_core.objs/byte/opamProcess.cmo -c -impl src/core/opamProcess.ml)
# File "src/core/opamProcess.ml", line 385, characters 11-28:
# 385 |      flush Pervasives.stdout);
#                  ^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```