### PR TITLE
New release of Solo5 (v0.7.4)

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.4/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.4/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.4/solo5-v0.7.4.tar.gz"
+  checksum: "sha512=1a47ee4a9e08704ae7aa5f48efdd79e33ae83d4d2f60a2c8ef7db33c85412cd1f0b023b4acc0ad6123377933a2ce6841590cf127fd2c062ff8d1594f36cddda1"
+}

--- a/packages/solo5/solo5.0.7.4/opam
+++ b/packages/solo5/solo5.0.7.4/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+x-ci-accept-failures: [ "centos-7" ]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.4/solo5-v0.7.4.tar.gz"
+  checksum: "sha512=1a47ee4a9e08704ae7aa5f48efdd79e33ae83d4d2f60a2c8ef7db33c85412cd1f0b023b4acc0ad6123377933a2ce6841590cf127fd2c062ff8d1594f36cddda1"
+}


### PR DESCRIPTION
## v0.7.4 (2022-11-04)

* Mark .text execute-only, currently only on OpenBSD (@adamsteen, solo5/solo5#450)
* Allow all log levels to be passed as command line parameter to the tender
  (added --solo5:error, --solo5:warn, --solo5:info) (@reynir, solo5/solo5#532)
* Add tender command line argument --block-sector-size:<block>=int. This allows
  to specify the desired block sector size. The default if not provided is 512,
  the same that was used before (@reynir, solo5/solo5#528, addresses partially solo5/solo5#325)
* Check that the file passed as block device is aligned to the block sector size
  (@reynir, solo5/solo5#527)
* Use `realpath` to determine toolchain paths - allowing tools being symlinks
  as they are on NixOS (@greydot, solo5/solo5#526)
* Allow slack in sleep in test\_time (@greydot, solo5/solo5#525, solo5/solo5#535)
* Fix build when using git worktree (.git being a file) (@reynir, solo5/solo5#531)
* Fix tests on OpenBSD 7.2 (@dinosaure, solo5/solo5#535)
* Add `x-ci-failures` on our OPAM files about CentOS 7 (@dinosaure, solo5/solo5#535)