### PR TITLE
[new release] melange and mel (0.3.0)

### DIFF
--- a/packages/mel/mel.0.3.0/opam
+++ b/packages/mel/mel.0.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Build system for Melange that defers to Dune for build orchestration"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml"
+  "melange" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "luv" {>= "0.5.11"}
+  "ocaml-migrate-parsetree" {>= "2.3.0"}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.0/melange-0.3.0.tbz"
+  checksum: [
+    "sha256=ddf0d6ec7e0a423ef58edbcbd4cf87b243d8fce5a64fb4bf2acdce6ff3dea2e8"
+    "sha512=aaf3ac25eb25a7f455de5b7c6969f7bfdef8cfcafef31ace8b08f392ab32a2510c86c2785278af65699d4941499bfa8803e4bec2fb743c36ce67faaa3bac75ce"
+  ]
+}
+x-commit-hash: "660be9975b98f2b7defa7506aaa6d96801e24613"

--- a/packages/melange/melange.0.3.0/opam
+++ b/packages/melange/melange.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.14.0" & < "4.15.0"}
+  "melange-compiler-libs" {>= "0.0.1-414"}
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.1.0"}
+  "cppo" {build}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.0/melange-0.3.0.tbz"
+  checksum: [
+    "sha256=ddf0d6ec7e0a423ef58edbcbd4cf87b243d8fce5a64fb4bf2acdce6ff3dea2e8"
+    "sha512=aaf3ac25eb25a7f455de5b7c6969f7bfdef8cfcafef31ace8b08f392ab32a2510c86c2785278af65699d4941499bfa8803e4bec2fb743c36ce67faaa3bac75ce"
+  ]
+}
+x-commit-hash: "660be9975b98f2b7defa7506aaa6d96801e24613"


### PR DESCRIPTION
Toolchain to produce JS from Reason/OCaml

- Project page: <a href="https://github.com/melange-re/melange">https://github.com/melange-re/melange</a>

##### CHANGES:

- [melange] Introduce 2 explicit modes of JavaScript compilation:
  - "Batch compilation": produces `.cmj` and `.js` files at the same time (this
    is the previous behavior -- using `--bs-package-output
    MODULE_SYSTEM:REL_PATH:JS_EXTENSION`)
  - "Separate emission": produces _only_ `.cmj` files with `--bs-stop-after-cmj
    --bs-package-output REL_PATH_ONLY`, and allows emitting JavaScript files
    separately, with `--bs-module-type MODULE_SYSTEM -o
    TARGET_FILE.JS_EXTENSION`
  ([melange-re/melange#384](https://github.com/melange-re/melange/pull/384))
- [mel]: Fix `mel build --watch` exiting after the first change
  ([melange-re/melange#401](https://github.com/melange-re/melange/pull/401))
- [melange]: Remove dependency on `reason`. Reason syntax users should install`
  reason` from their preferred package manager instead, and Melange / Dune will
  find it in `$PATH` ([melange-re/melange#409](https://github.com/melange-re/melange/pull/409))
- [melange]: Remove dependency on `napkin` (the ReScript syntax parser). Users
  that depend on libraries written in ReScript syntax should install the `mel`
  package and Melange / Dune will find the `rescript_syntax` binary in `$PATH`
  ([melange-re/melange#411](https://github.com/melange-re/melange/pull/411))
