### PR TITLE
Package lwt_domain.0.3.0

### DIFF
--- a/packages/lwt_domain/lwt_domain.0.3.0/opam
+++ b/packages/lwt_domain/lwt_domain.0.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using Domainslib with Lwt"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt_domain"
+doc: "https://ocsigen.org/lwt/dev/api/Lwt_domain"
+bug-reports: "https://github.com/ocsigen/lwt_domain/issues"
+
+authors: [
+  "Sudha Parimala"
+]
+maintainer: [
+  "Sudha Parimala"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt_domain.git"
+
+depends: [
+  "dune" {>= "1.8.0"}
+  "lwt" {>= "5.6.0"}
+  "ocaml" {>= "5.0.0"}
+  "domainslib" {>= "0.5.0"}
+  "base-domains"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocsigen/lwt_domain/archive/0.3.0.tar.gz"
+  checksum: [
+    "md5=fe61f6dd09f8ef735b26c990c41c097b"
+    "sha512=db01ca6d6acffe7eb51961d5a200e6fee25c099b422fd49d5e89ff90c3fbe3e80a044eabbf9a77a89feeaf1cbb56708457efe0cc827eb49643e571e82e3d1cdf"
+  ]
+}


### PR DESCRIPTION
### `lwt_domain.0.3.0`
Helpers for using Domainslib with Lwt



---
* Homepage: https://github.com/ocsigen/lwt_domain
* Source repo: git+https://github.com/ocsigen/lwt_domain.git
* Bug tracker: https://github.com/ocsigen/lwt_domain/issues

---
:camel: Pull-request generated by opam-publish v2.1.0