### PR TITLE
Package otoml.1.0.3

### DIFF
--- a/packages/otoml/otoml.1.0.3/opam
+++ b/packages/otoml/otoml.1.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)"
+description: """\
+OTOML is a library for parsing, manipulating, and pretty-printing TOML files.
+
+* Fully 1.0.0-compliant.
+* No extra dependencies: default implementation uses native numbers and represents dates as strings.
+* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
+* Informative parse error reporting.
+* Pretty-printer offers flexible indentation options."""
+maintainer: "daniil+opam@baturin.org"
+authors: "Daniil Baturin <daniil+otoml@baturin.org>"
+license: "MIT"
+homepage: "https://github.com/dmbaturin/otoml"
+bug-reports: "https://github.com/dmbaturin/otoml/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "menhir"
+  "menhirLib" {>= "20200525"}
+  "dune" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/dmbaturin/otoml.git"
+url {
+  src: "https://github.com/dmbaturin/otoml/archive/refs/tags/1.0.3.tar.gz"
+  checksum: [
+    "md5=3dcb9a0165e3535afe8c9842bf7cc1bf"
+    "sha512=98fd4c3374c47c79e1b84c584f74a023cbcbcdcf86d6320ef36436476785dfe36e94f94f64a588b5838bb489efd053146e7f042072da1e19543ce4701c93b054"
+  ]
+}


### PR DESCRIPTION
### `otoml.1.0.3`
TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)
OTOML is a library for parsing, manipulating, and pretty-printing TOML files.

* Fully 1.0.0-compliant.
* No extra dependencies: default implementation uses native numbers and represents dates as strings.
* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
* Informative parse error reporting.
* Pretty-printer offers flexible indentation options.



---
* Homepage: https://github.com/dmbaturin/otoml
* Source repo: git+https://github.com/dmbaturin/otoml.git
* Bug tracker: https://github.com/dmbaturin/otoml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0