### PR TITLE
Update the torch package to 0.17.

### DIFF
--- a/packages/torch/torch.0.17/opam
+++ b/packages/torch/torch.0.17/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+bug-reports:  "https://github.com/LaurentMazare/ocaml-torch/issues"
+homepage:     "https://github.com/LaurentMazare/ocaml-torch"
+dev-repo:     "git+https://github.com/LaurentMazare/ocaml-torch.git"
+license:      "Apache-2.0"
+maintainer:   "Laurent Mazare <lmazare@gmail.com>"
+authors:      [ "Laurent Mazare" ]
+
+build: [["dune" "build" "-p" name "-j" jobs]]
+
+depends: [
+  "base" {>= "v0.11.0"}
+  "cmdliner"
+  "ctypes" {>= "0.11"}
+  "ctypes-foreign"
+  "dune" {>= "1.3.0"}
+  "dune-configurator"
+  "libtorch" {>= "1.13.0" & < "1.14.0"}
+  "npy"
+  "ocaml" {>= "4.08"}
+  "ocaml-compiler-libs"
+  "ppx_custom_printf"
+  "ppx_expect"
+  "ppx_sexp_conv"
+  "sexplib"
+  "stdio"
+]
+
+available: arch = "x86_64" & (os = "linux" | os = "macos")
+x-ci-accept-failures: [
+  "centos-7" # Requires gcc with -std=c++14
+  "oraclelinux-7" # Requires gcc with -std=c++14
+]
+
+synopsis: "PyTorch bindings for OCaml"
+description: """
+The ocaml-torch project provides some OCaml bindings for the PyTorch library.
+This brings to OCaml NumPy-like tensor computations with GPU acceleration and
+tape-based automatic differentiation.
+"""
+
+url {
+  src: "https://github.com/LaurentMazare/ocaml-torch/archive/0.17.tar.gz"
+  checksum: [
+    "md5=c64a4ae1c677f9e2c2528bec6b70e733"
+    "sha512=2617754f8e5d127758ce66519683886d660ea9747659d6a3d58d0eb2e299ba9e3da7e5a559dc784bf36cdad477c59394f6ff93657378c572e17596bde52f4537"
+  ]
+}


### PR DESCRIPTION
This makes ocaml-torch compatible with the latest libtorch 1.13 version.