### PR TITLE
[new release] obuilder and obuilder-spec (0.5)

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.5/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "fmt" {>= "0.8.9"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.5/obuilder-0.5.tbz"
+  checksum: [
+    "sha256=3d317a28079ca83d372675732fe04b5ed865efad1f3439e97fe20d96fa72bae5"
+    "sha512=52fa409cfe9c5b90841802004de7d4fbf7d0dc81900e0ad871a85a67bde7e3572a3cc9e13facc3d0933ed61eefd9d84e83ff613d6515c550978ad55ab03b14d2"
+  ]
+}
+x-commit-hash: "1022ec8318dacc05c63ab1a7968f43af2fe970d1"

--- a/packages/obuilder/obuilder.0.5/opam
+++ b/packages/obuilder/obuilder.0.5/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "lwt" {>= "5.6.1"}
+  "astring"
+  "fmt" {>= "0.8.9"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "tar-unix" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha" {>= "1.15.1"}
+  "sqlite3"
+  "obuilder-spec" {= version}
+  "ocaml" {>= "4.14.0"}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.5/obuilder-0.5.tbz"
+  checksum: [
+    "sha256=3d317a28079ca83d372675732fe04b5ed865efad1f3439e97fe20d96fa72bae5"
+    "sha512=52fa409cfe9c5b90841802004de7d4fbf7d0dc81900e0ad871a85a67bde7e3572a3cc9e13facc3d0933ed61eefd9d84e83ff613d6515c550978ad55ab03b14d2"
+  ]
+}
+x-commit-hash: "1022ec8318dacc05c63ab1a7968f43af2fe970d1"


### PR DESCRIPTION
Run build scripts for CI

- Project page: <a href="https://github.com/ocurrent/obuilder">https://github.com/ocurrent/obuilder</a>
- Documentation: <a href="https://ocurrent.github.io/obuilder/">https://ocurrent.github.io/obuilder/</a>

##### CHANGES:

- Add --fuse-path to allow selection of the path redirected by FUSE (@mtelvers ocurrent/obuilder#128, reviewed by @MisterDA )
- Pre-requisites for Windows support using docker for Windows (@MisterDA ocurrent/obuilder#116, reviewed by @tmcgilchrist)
- Additional tests and prerequistes for Windows support (@MisterDA ocurrent/obuilder#130, reviewed by @tmcgilchrist)
- Add support for Docker/Windows spec (@MisterDA ocurrent/obuilder#117, reviewed by @tmcgilchrist)
- Depend on Lwt.5.6.1 for bugfixes (@MisterDA ocurrent/obuilder#108, reviewed by @tmcgilchrist)

- Add macOS support (@patricoferris ocurrent/obuilder#87, reviewed by @tmcgilchrist @talex5 @kit-ty-kate)
- Enable macOS tests only on macOS (@MisterDA ocurrent/obuilder#126, reviewed by @tmcgilchrist)
- Dune 3.0 generates empty intf for executables (@MisterDA ocurrent/obuilder#111, reviewed by @talex5)
- Fix warnings and CI failure (@MisterDA ocurrent/obuilder#110, reviewed by @talex5)

- Expose store root and cmdliner term with non-required store (@MisterDA ocurrent/obuilder#119, reviewed by @tmcgilchrist)
- Expose Rsync_store module (@MisterDA ocurrent/obuilder#114, reviewed by @talex5)
- Rsync hard-links to save space (@art-w ocurrent/obuilder#102, reviewed by @patricoferris)
