### PR TITLE
Package bls12-381-hash.0.0.4

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.0.0.4/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of some cryptographic hash primitives using the scalar field of BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+available:
+  arch != "ppc64" & arch != "arm32" & arch != "x86_32" & arch != "s390x"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/-/archive/0.0.4/ocaml-bls12-381-hash-0.0.4.tar.bz2"
+  checksum: [
+    "md5=5c79c937147dfb3f953296d8e6bc4ab9"
+    "sha512=ad04b93254f5134914d527193289def1cea3455ae5e1e3b5e015de1274e6c3f22e8df02e87507564725e1259cb34798cc33387a50e9888e5231279d15bf09cca"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381-hash.0.0.4`
Implementation of some cryptographic hash primitives using the scalar field of BLS12-381



---
* Homepage: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues

---
:camel: Pull-request generated by opam-publish v2.1.0