### PR TITLE
Package opam-custom-install.0.3

### DIFF
--- a/packages/opam-custom-install/opam-custom-install.0.3/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to install a package using a custom command"
+description:
+  "Provides the `opam custom-install` command, which allows to wrap a custom install command, and make opam register it as the installation of a given package. This is a prototype provided for the moment as a plugin, but might get integrated into opam if useful."
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: ["org:ocamlpro" "org:opam"]
+homepage: "https://github.com/OCamlPro/opam-custom-install"
+bug-reports: "https://github.com/OCamlPro/opam-custom-install/-/issues"
+depends: [
+  "dune" {>= "1.5"}
+  "opam-client" {>= "2.1.2" & < "2.2.0"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/OCamlPro/opam-custom-install"
+url {
+  src:
+    "https://github.com/OCamlPro/opam-custom-install/archive/refs/tags/0.3.tar.gz"
+  checksum: [
+    "md5=05ea339f8c9715d23c3f4ce84173e3c7"
+    "sha512=a2f8564ad3209f78a7a59e9d7bc5088889f5d2cb013160cf95f88bf9f736139033238eabc83a24fd5e10d0d5944d407da39e32ef44d26064c26671bcc8e0ebf6"
+  ]
+}


### PR DESCRIPTION
### `opam-custom-install.0.3`
An opam plugin to install a package using a custom command
Provides the `opam custom-install` command, which allows to wrap a custom install command, and make opam register it as the installation of a given package. This is a prototype provided for the moment as a plugin, but might get integrated into opam if useful.



---
* Homepage: https://github.com/OCamlPro/opam-custom-install
* Source repo: git+https://github.com/OCamlPro/opam-custom-install
* Bug tracker: https://github.com/OCamlPro/opam-custom-install/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0