### PR TITLE
tar < 2.0.1 is not compatible with OCaml 5.0

### DIFF
--- a/packages/tar/tar.0.9.0/opam
+++ b/packages/tar/tar.0.9.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "ppx_tools"
   "ppx_cstruct" {<"3.4.0"}

--- a/packages/tar/tar.1.0.0/opam
+++ b/packages/tar/tar.1.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.0"}
   "ppx_tools" {build}
   "ppx_cstruct" {>= "3.1.0"}

--- a/packages/tar/tar.1.0.1/opam
+++ b/packages/tar/tar.1.0.1/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.0"}
   "ppx_tools" {build}
   "ppx_cstruct" {>= "3.1.0"}

--- a/packages/tar/tar.1.1.0/opam
+++ b/packages/tar/tar.1.1.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-tar"
 doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.0"}
   "ppx_tools" {build}
   "ppx_cstruct" {>= "3.6.0"}

--- a/packages/tar/tar.2.0.0/opam
+++ b/packages/tar/tar.2.0.0/opam
@@ -15,7 +15,7 @@ doc: "https://mirage.github.io/ocaml-tar/"
 bug-reports: "https://github.com/mirage/ocaml-tar/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ppx_cstruct" {build & >= "3.6.0"}
   "cstruct" {>= "6.0.0"}
   "re" {>= "1.7.2"}


### PR DESCRIPTION
```
#=== ERROR while compiling tar.2.0.0 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/tar.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tar -j 71 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/tar-8-d44422.env
# output-file          ~/.opam/log/tar-8-d44422.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I lib/.tar.objs/byte -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/re/str -I /home/opam/.opam/5.0/lib/seq -no-alias-deps -o lib/.tar.objs/byte/tar.cmi -c -intf lib/tar.pp.mli)
# File "lib/tar.mli", line 217, characters 90-98:
# 217 |     val create_gen : ?level:Header.compatibility -> (Header.t * (IO.out_channel -> unit)) Stream.t -> IO.out_channel -> unit
#                                                                                                 ^^^^^^^^
# Error: Unbound module Stream
```