### PR TITLE
sha < 1.15.2 is not compatible with OCaml 5.0

### DIFF
--- a/packages/sha/sha.1.10/opam
+++ b/packages/sha/sha.1.10/opam
@@ -15,7 +15,7 @@ install: [make "install"]
 remove: [["ocamlfind" "remove" "sha"]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
 ]
 synopsis: "Binding to the SHA cryptographic functions"

--- a/packages/sha/sha.1.11/opam
+++ b/packages/sha/sha.1.11/opam
@@ -15,7 +15,7 @@ install: [make "install"]
 remove: [["ocamlfind" "remove" "sha"]]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind"
 ]
 synopsis: "Binding to the SHA cryptographic functions"

--- a/packages/sha/sha.1.12/opam
+++ b/packages/sha/sha.1.12/opam
@@ -15,7 +15,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta13"}
   "ounit" {with-test}
 ]

--- a/packages/sha/sha.1.15.1/opam
+++ b/packages/sha/sha.1.15.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/djs55/ocaml-sha"
 bug-reports: "https://github.com/djs55/ocaml-sha/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "stdlib-shims" {>= "0.3.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
```
#=== ERROR while compiling sha.1.15.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/sha.1.15.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sha -j 47 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/sha-8-87518f.env
# output-file          ~/.opam/log/sha-8-87518f.out
### output ###
# File "dune", line 18, characters 20-32:
# 18 |   (names sha1_stubs sha256_stubs sha512_stubs)))
#                          ^^^^^^^^^^^^
# (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -Wall -O3 -funroll-loops -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdlib-shims -o sha256_stubs.o -c sha256_stubs.c)
# sha256_stubs.c: In function 'stub_sha256_update_bigarray':
# sha256_stubs.c:96:31: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
#    96 |         unsigned char *data = Data_bigarray_val(buf);
#       |                               ^~~~~~~~~~~~~~~~~
#       |                               Caml_ba_array_val
# sha256_stubs.c:96:31: warning: initialization of 'unsigned char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
# sha256_stubs.c:97:22: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
#    97 |         size_t len = Bigarray_val(buf)->dim[0];
#       |                      ^~~~~~~~~~~~
# sha256_stubs.c:97:39: error: invalid type argument of '->' (have 'int')
#    97 |         size_t len = Bigarray_val(buf)->dim[0];
#       |                                       ^~
# File "dune", line 18, characters 9-19:
# 18 |   (names sha1_stubs sha256_stubs sha512_stubs)))
#               ^^^^^^^^^^
# (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -Wall -O3 -funroll-loops -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdlib-shims -o sha1_stubs.o -c sha1_stubs.c)
# sha1_stubs.c: In function 'stub_sha1_update_bigarray':
# sha1_stubs.c:97:31: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
#    97 |         unsigned char *data = Data_bigarray_val(buf);
#       |                               ^~~~~~~~~~~~~~~~~
#       |                               Caml_ba_array_val
# sha1_stubs.c:97:31: warning: initialization of 'unsigned char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
# sha1_stubs.c:98:22: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
#    98 |         size_t len = Bigarray_val(buf)->dim[0];
#       |                      ^~~~~~~~~~~~
# sha1_stubs.c:98:39: error: invalid type argument of '->' (have 'int')
#    98 |         size_t len = Bigarray_val(buf)->dim[0];
#       |                                       ^~
# File "dune", line 18, characters 33-45:
# 18 |   (names sha1_stubs sha256_stubs sha512_stubs)))
#                                       ^^^^^^^^^^^^
# (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -Wall -O3 -funroll-loops -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdlib-shims -o sha512_stubs.o -c sha512_stubs.c)
# sha512_stubs.c: In function 'stub_sha512_update_bigarray':
# sha512_stubs.c:96:31: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
#    96 |         unsigned char *data = Data_bigarray_val(buf);
#       |                               ^~~~~~~~~~~~~~~~~
#       |                               Caml_ba_array_val
# sha512_stubs.c:96:31: warning: initialization of 'unsigned char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
# sha512_stubs.c:97:22: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
#    97 |         size_t len = Bigarray_val(buf)->dim[0];
#       |                      ^~~~~~~~~~~~
# sha512_stubs.c:97:39: error: invalid type argument of '->' (have 'int')
#    97 |         size_t len = Bigarray_val(buf)->dim[0];
#       |                                       ^~
```