### PR TITLE
[new release] mirage-nat (3.0.1)

### DIFF
--- a/packages/mirage-nat/mirage-nat.3.0.1/opam
+++ b/packages/mirage-nat/mirage-nat.3.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ipaddr"
+  "cstruct" {>= "6.0.0"}
+  "lru" {>= "0.3.0"}
+  "dune" {>= "1.0"}
+  "tcpip" { >= "7.0.0" }
+  "ethernet" { >= "3.0.0" }
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+  "logs" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v3.0.1/mirage-nat-3.0.1.tbz"
+  checksum: [
+    "sha256=c117b248e32e94692b3c3eb45f1a6032b5281f363d850ed3673610c89dde8a29"
+    "sha512=1481775aa6a4e6812347be29832f99c3811909aff343d0fe25f92f65e00bda5d663cf9a96009959e63521c0123404874b66b54b8d3d5db69eca8b5682b8fc944"
+  ]
+}
+x-commit-hash: "ca43415d503b4178135f1df4ecde5e27b5444aa1"


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- fix Mirage_nat.is_port_free and add a test (mirage/mirage-nat#48 @hannesm)
