### PR TITLE
[new release] ocluster, ocluster-api and current_ocluster (0.2)

### DIFF
--- a/packages/current_ocluster/current_ocluster.0.2/opam
+++ b/packages/current_ocluster/current_ocluster.0.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "OCurrent plugin for OCluster builds"
+description:
+  "Creates a stage in an OCurrent pipeline for submitting jobs to OCluster."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/ocluster"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ppx_deriving"
+  "ocluster-api" {= version}
+  "lwt" {>= "5.6.1"}
+  "current" {>= "0.3"}
+  "current_git" {>= "0.3"}
+  "current_web" {>= "0.3" & with-test}
+  "current_github" {>= "0.3" & with-test}
+  "capnp-rpc-unix" {>= "1.2"}
+  "duration"
+  "logs"
+  "fmt"
+  "prometheus"
+  "ppx_deriving_yojson"
+  "ocaml" {>= "4.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2/ocluster-0.2.tbz"
+  checksum: [
+    "sha256=a6245d78f1f2b4b431596cfe167dfe18497b72c2844b8b7fb99603731eda4192"
+    "sha512=477f16a1abc7de7c8e807ac1b8e33a461865e20358734716707874af2e6fec47f7fe24753cd88d520fe94921d9f1f8da63d96c41ab1dfae9f86be85dd4098c7d"
+  ]
+}
+x-commit-hash: "222011c2ef5100f9ed43234c59d215dc2430bfca"

--- a/packages/ocluster-api/ocluster-api.0.2/opam
+++ b/packages/ocluster-api/ocluster-api.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto API for OCluster"
+description: "OCaml bindings for the OCluster Cap'n Proto API."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/ocluster"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ppx_deriving"
+  "lwt" {>= "5.6.1"}
+  "capnp-rpc-lwt" {>= "1.2"}
+  "fmt"
+  "ppx_deriving_yojson"
+  "ocaml" {>= "4.12.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2/ocluster-0.2.tbz"
+  checksum: [
+    "sha256=a6245d78f1f2b4b431596cfe167dfe18497b72c2844b8b7fb99603731eda4192"
+    "sha512=477f16a1abc7de7c8e807ac1b8e33a461865e20358734716707874af2e6fec47f7fe24753cd88d520fe94921d9f1f8da63d96c41ab1dfae9f86be85dd4098c7d"
+  ]
+}
+x-commit-hash: "222011c2ef5100f9ed43234c59d215dc2430bfca"

--- a/packages/ocluster/ocluster.0.2/opam
+++ b/packages/ocluster/ocluster.0.2/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "Distribute build jobs to workers"
+description: """
+OCluster manages a pool of build workers.
+A build scheduler service accepts build jobs from clients and distributes them to worker machines using Cap'n Proto.
+Workers register themselves by connecting to the scheduler (and workers do not need to be able to accept incoming network connections).
+
+The scheduler can manage multiple pools (e.g. `linux-x86_64` and `linux-arm32`).
+Clients say which pool should handle their requests.
+At the moment, two build types are provided: building a Dockerfile, or building an OBuilder spec.
+In either case, the build may done in the context of some Git commit.
+The scheduler tries to schedule similar builds on the same machine, to benefit from caching."""
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/ocurrent/ocluster"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ppx_expect" {>= "v0.14.1"}
+  "prometheus"
+  "ppx_sexp_conv"
+  "dune-build-info"
+  "ocluster-api" {= version}
+  "lwt" {>= "5.6.1"}
+  "capnp-rpc-lwt"
+  "capnp-rpc-net"
+  "capnp-rpc-unix" {>= "1.2"}
+  "extunix" {>= "0.3.2"}
+  "winsvc" {>= "1.0.1" & os = "win32"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "fmt"
+  "conf-libev" {os != "win32"}
+  "digestif" {>= "0.8"}
+  "fpath"
+  "lwt-dllist"
+  "prometheus-app" {>= "1.2"}
+  "cohttp-lwt-unix"
+  "sqlite3"
+  "obuilder"
+  "psq"
+  "mirage-crypto" {>= "0.8.5"}
+  "ocaml" {>= "4.12.0"}
+  "current_ocluster" {= version & with-test}
+  "alcotest" {>= "1.0.0" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2/ocluster-0.2.tbz"
+  checksum: [
+    "sha256=a6245d78f1f2b4b431596cfe167dfe18497b72c2844b8b7fb99603731eda4192"
+    "sha512=477f16a1abc7de7c8e807ac1b8e33a461865e20358734716707874af2e6fec47f7fe24753cd88d520fe94921d9f1f8da63d96c41ab1dfae9f86be85dd4098c7d"
+  ]
+}
+x-commit-hash: "222011c2ef5100f9ed43234c59d215dc2430bfca"


### PR DESCRIPTION
Distribute build jobs to workers

- Project page: <a href="https://github.com/ocurrent/ocluster">https://github.com/ocurrent/ocluster</a>

##### CHANGES:

- Update OBuilder to pull in Windows prereqs (@MisterDA ocurrent/ocluster#196, reviewed by @tmcgilchrist)
- Worker pool capacity metric (@mtelvers ocurrent/ocluster#195, reviewed by @talex5)
- Update Ocluster to be macOS capable (@patricoferris ocurrent/ocluster#152, reviewed by @tmcgilchrist)
- Use rsync-hardlink from OBuilder rsync store (@MisterDA ocurrent/ocluster#189, reviewed by @tmcgilchrist)
- Various Dune 3 fixes (@MisterDA ocurrent/ocluster#187, reviewed by @talex5)
- Switch from Debian to Ubuntu for Worker Builds (@mtelvers ocurrent/ocluster#185, reviewed by @dra27)
- Update to Prometheus 1.2 (@mtelvers ocurrent/ocluster#183, reviewed by @MisterDA)
- Default to GitLab merge-requests refspecs (@MisterDA ocurrent/ocluster#180, reviewed by @tmcgilchrist)
- GitLab: allow fetching merge-requests from remote origin (@MisterDA ocurrent/ocluster#175, reviewed by @tmcgilchrist)
- Updated Dockerfile* and .dockerignore (@mtelvers ocurrent/ocluster#178, reviewed by @tmcgilchrist and @MisterDA)
- Upgrade lwt to 5.5.0 (@maiste ocurrent/ocluster#171 ocurrent/ocluster#181, reviewed by @dra27)
- Added --terse option to ocluster-admin-show and added new command ocluster-admin-exec (@mtelvers ocurrent/ocluster#165, reviewed by @tmcgilchrist and @dra27)
- Support custom jobs, adds custom job specifications to the cluster API. (@patricoferris ocurrent/ocluster#156, reviewed by @talex5)
- Continuing the joy of submodule URL changes (@dra27 ocurrent/ocluster#164)
- Update ocaml/opam-repository SHA includes tar-unix.2.0.1 (@mtelvers ocurrent/ocluster#161, reviewed by @dra27)
- Run git submodule update when resetting the git clone (@MisterDA ocurrent/ocluster#163, reviewed by @tmcgilchrist)
- Cmdliner.1.1.0 support (@MisterDA ocurrent/ocluster#160)
- Explicitly set confirmation levels to allow for manually triggered jobs. (@tmcgilchrist ocurrent/ocluster#159, reviewed by @TheLortex)
- Merge Obuilder with rsync store (@MisterDA ocurrent/ocluster#155, reviewed by @talex5)
- Sqlite3 remove usage of "FALSE" for compatibility with older versions (@art-w ocurrent/ocluster#150, reviewed by @talex5)
- Revert adopting GNU tar format (@dra27 ocurrent/ocluster#148)
- Update obuilder to latest (@mtelvers ocurrent/ocluster#147)
- Fix deprecations in Fmt 0.8.10 (@tmcgilchrist ocurrent/ocluster#145)
- Lwt_unix.yield was deprecated in favor of Lwt.pause (@MisterDA ocurrent/ocluster#142, reviewed by @dra27)
- Remove runc build from Dockerfile.worker (@talex5 ocurrent/ocluster#140)
- Add Windows support (@MisterDA ocurrent/ocluster#128, reviewed by @dra27 and @talex5)
- Admin client: fix ref-counting on progress display (@talex5 ocurrent/ocluster#138)
- Add --verbose to README examples (@talex5 ocurrent/ocluster#137)
- Use --connect for the worker capability too (@talex5 ocurrent/ocluster#136)
- Make free-space check work on Windows (@talex5 ocurrent/ocluster#134)
- Support Fmt.cli and Logs.cli (@MisterDA ocurrent/ocluster#133, reviewed by @talex5)
- Windows support prerequisites (@talex5 and @MisterDA ocurrent/ocluster#132)
- Update to capnp-rpc 1.2 and fix connection handling (@talex5 ocurrent/ocluster#131)
- Improve reporting of connection errors (@talex5 ocurrent/ocluster#130)
- Depend on more current_* modules to build examples (@MisterDA ocurrent/ocluster#129, reviewed by @talex5)
- Add ca-certificates to Dockerfile (@talex5 ocurrent/ocluster#127)
- API to wait for a worker to drain, useful for scripts that need to wait for a worker to stop before continuing. (@talex5 ocurrent/ocluster#126)
- Allow pausing/unpausing/forgetting unconnected workers (@talex5 ocurrent/ocluster#125)
- Fix ref-leak when rejecting duplicate workers (@talex5 ocurrent/ocluster#124)
- Improve handling of a worker's active state (@talex5 ocurrent/ocluster#123)
- Report better error on duplicate worker registration (@talex5 ocurrent/ocluster#122)
- Switch pool tests to expect tests (@talex5 ocurrent/ocluster#121)
- Add timestamps to OBuilder logs (@talex5 ocurrent/ocluster#120)
- Fix opam constraint on digestif (@kit-ty-kate ocurrent/ocluster#118, reviewed by @talex5)
- Add support for secrets. Secrets are a way to transmit sensitive key-value pairs to workers, without having them displayed in any log files. (@TheLortex ocurrent/ocluster#116, reviewed by @talex5)
- Add optional label to build_obuilder (@TheLortex ocurrent/ocluster#113, reviewed by @talex5)
