### PR TITLE
Octez 15.0 packages

### DIFF
--- a/packages/octez-accuser-PtKathma/octez-accuser-PtKathma.15.0/opam
+++ b/packages/octez-accuser-PtKathma/octez-accuser-PtKathma.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-014-PtKathma-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: accuser binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-accuser-PtLimaPt/octez-accuser-PtLimaPt.15.0/opam
+++ b/packages/octez-accuser-PtLimaPt/octez-accuser-PtLimaPt.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-015-PtLimaPt-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: accuser binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-baker-PtKathma/octez-baker-PtKathma.15.0/opam
+++ b/packages/octez-baker-PtKathma/octez-baker-PtKathma.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-014-PtKathma-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: baker binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-baker-PtLimaPt/octez-baker-PtLimaPt.15.0/opam
+++ b/packages/octez-baker-PtLimaPt/octez-baker-PtLimaPt.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-015-PtLimaPt-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: baker binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-client/octez-client.15.0/opam
+++ b/packages/octez-client/octez-client.15.0/opam
@@ -1,0 +1,97 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-rpc-http-client" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-proxy" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-baking-014-PtKathma-commands" { = version }
+  "tezos-protocol-plugin-014-PtKathma" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-baking-015-PtLimaPt-commands" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt" { = version }
+]
+depopts: [
+  "tezos-client-genesis"
+  "tezos-client-demo-counter"
+  "tezos-client-000-Ps9mPmXa"
+  "tezos-client-001-PtCJ7pwo"
+  "tezos-client-002-PsYLVpVv"
+  "tezos-client-003-PsddFKi3"
+  "tezos-client-004-Pt24m4xi"
+  "tezos-client-005-PsBabyM1"
+  "tezos-client-006-PsCARTHA"
+  "tezos-client-007-PsDELPH1"
+  "tezos-protocol-plugin-007-PsDELPH1"
+  "tezos-client-008-PtEdo2Zk"
+  "tezos-protocol-plugin-008-PtEdo2Zk"
+  "tezos-client-009-PsFLoren"
+  "tezos-protocol-plugin-009-PsFLoren"
+  "tezos-client-010-PtGRANAD"
+  "tezos-protocol-plugin-010-PtGRANAD"
+  "tezos-client-011-PtHangz2"
+  "tezos-protocol-plugin-011-PtHangz2"
+  "tezos-client-012-Psithaca"
+  "tezos-protocol-plugin-012-Psithaca"
+  "tezos-client-013-PtJakart"
+  "tezos-protocol-plugin-013-PtJakart"
+  "tezos-client-alpha"
+  "tezos-baking-alpha-commands"
+  "tezos-protocol-plugin-alpha"
+]
+conflicts: [
+  "tezos-client-genesis" { != version }
+  "tezos-client-demo-counter" { != version }
+  "tezos-client-000-Ps9mPmXa" { != version }
+  "tezos-client-001-PtCJ7pwo" { != version }
+  "tezos-client-002-PsYLVpVv" { != version }
+  "tezos-client-003-PsddFKi3" { != version }
+  "tezos-client-004-Pt24m4xi" { != version }
+  "tezos-client-005-PsBabyM1" { != version }
+  "tezos-client-006-PsCARTHA" { != version }
+  "tezos-client-007-PsDELPH1" { != version }
+  "tezos-protocol-plugin-007-PsDELPH1" { != version }
+  "tezos-client-008-PtEdo2Zk" { != version }
+  "tezos-protocol-plugin-008-PtEdo2Zk" { != version }
+  "tezos-client-009-PsFLoren" { != version }
+  "tezos-protocol-plugin-009-PsFLoren" { != version }
+  "tezos-client-010-PtGRANAD" { != version }
+  "tezos-protocol-plugin-010-PtGRANAD" { != version }
+  "tezos-client-011-PtHangz2" { != version }
+  "tezos-protocol-plugin-011-PtHangz2" { != version }
+  "tezos-client-012-Psithaca" { != version }
+  "tezos-protocol-plugin-012-Psithaca" { != version }
+  "tezos-client-013-PtJakart" { != version }
+  "tezos-protocol-plugin-013-PtJakart" { != version }
+  "tezos-client-alpha" { != version }
+  "tezos-baking-alpha-commands" { != version }
+  "tezos-protocol-plugin-alpha" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `octez-client` binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-codec/octez-codec.15.0/opam
+++ b/packages/octez-codec/octez-codec.15.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-base" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-event-logging" { = version }
+  "tezos-signer-services" { = version }
+]
+depopts: [
+  "tezos-client-005-PsBabyM1"
+  "tezos-client-006-PsCARTHA"
+  "tezos-client-007-PsDELPH1"
+  "tezos-client-008-PtEdo2Zk"
+  "tezos-client-009-PsFLoren"
+  "tezos-client-010-PtGRANAD"
+  "tezos-client-011-PtHangz2"
+  "tezos-client-012-Psithaca"
+  "tezos-client-013-PtJakart"
+  "tezos-client-014-PtKathma"
+  "tezos-client-015-PtLimaPt"
+  "tezos-client-alpha"
+]
+conflicts: [
+  "tezos-client-005-PsBabyM1" { != version }
+  "tezos-client-006-PsCARTHA" { != version }
+  "tezos-client-007-PsDELPH1" { != version }
+  "tezos-client-008-PtEdo2Zk" { != version }
+  "tezos-client-009-PsFLoren" { != version }
+  "tezos-client-010-PtGRANAD" { != version }
+  "tezos-client-011-PtHangz2" { != version }
+  "tezos-client-012-Psithaca" { != version }
+  "tezos-client-013-PtJakart" { != version }
+  "tezos-client-014-PtKathma" { != version }
+  "tezos-client-015-PtLimaPt" { != version }
+  "tezos-client-alpha" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `octez-codec` binary to encode and decode values"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-node/octez-node.15.0/opam
+++ b/packages/octez-node/octez-node.15.0/opam
@@ -1,0 +1,107 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-version" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-server" { = version }
+  "tezos-p2p" { = version }
+  "tezos-shell" { = version }
+  "tezos-store" { = version }
+  "tezos-context" { = version }
+  "octez-validator" { = version }
+  "tezos-validation" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-workers" { = version }
+  "tezos-protocol-updater" { = version }
+  "cmdliner" { >= "1.1.0" }
+  "fmt" { >= "0.8.7" }
+  "tls" { >= "0.10" }
+  "prometheus-app" { >= "1.2" }
+  "lwt-exit"
+  "uri" { >= "2.2.0" }
+  "tezos-embedded-protocol-000-Ps9mPmXa" { = version }
+  "tezos-embedded-protocol-014-PtKathma" { = version }
+  "tezos-protocol-plugin-014-PtKathma-registerer" { = version }
+  "tezos-embedded-protocol-015-PtLimaPt" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt-registerer" { = version }
+]
+depopts: [
+  "tezos-embedded-protocol-genesis"
+  "tezos-embedded-protocol-demo-noops"
+  "tezos-embedded-protocol-demo-counter"
+  "tezos-embedded-protocol-001-PtCJ7pwo"
+  "tezos-embedded-protocol-002-PsYLVpVv"
+  "tezos-embedded-protocol-003-PsddFKi3"
+  "tezos-embedded-protocol-004-Pt24m4xi"
+  "tezos-embedded-protocol-005-PsBABY5H"
+  "tezos-embedded-protocol-005-PsBabyM1"
+  "tezos-embedded-protocol-006-PsCARTHA"
+  "tezos-embedded-protocol-007-PsDELPH1"
+  "tezos-protocol-plugin-007-PsDELPH1-registerer"
+  "tezos-embedded-protocol-008-PtEdoTez"
+  "tezos-embedded-protocol-008-PtEdo2Zk"
+  "tezos-protocol-plugin-008-PtEdo2Zk-registerer"
+  "tezos-embedded-protocol-009-PsFLoren"
+  "tezos-protocol-plugin-009-PsFLoren-registerer"
+  "tezos-embedded-protocol-010-PtGRANAD"
+  "tezos-protocol-plugin-010-PtGRANAD-registerer"
+  "tezos-embedded-protocol-011-PtHangz2"
+  "tezos-protocol-plugin-011-PtHangz2-registerer"
+  "tezos-embedded-protocol-012-Psithaca"
+  "tezos-protocol-plugin-012-Psithaca-registerer"
+  "tezos-embedded-protocol-013-PtJakart"
+  "tezos-protocol-plugin-013-PtJakart-registerer"
+  "tezos-embedded-protocol-alpha"
+  "tezos-protocol-plugin-alpha-registerer"
+]
+conflicts: [
+  "tezos-embedded-protocol-genesis" { != version }
+  "tezos-embedded-protocol-demo-noops" { != version }
+  "tezos-embedded-protocol-demo-counter" { != version }
+  "tezos-embedded-protocol-001-PtCJ7pwo" { != version }
+  "tezos-embedded-protocol-002-PsYLVpVv" { != version }
+  "tezos-embedded-protocol-003-PsddFKi3" { != version }
+  "tezos-embedded-protocol-004-Pt24m4xi" { != version }
+  "tezos-embedded-protocol-005-PsBABY5H" { != version }
+  "tezos-embedded-protocol-005-PsBabyM1" { != version }
+  "tezos-embedded-protocol-006-PsCARTHA" { != version }
+  "tezos-embedded-protocol-007-PsDELPH1" { != version }
+  "tezos-protocol-plugin-007-PsDELPH1-registerer" { != version }
+  "tezos-embedded-protocol-008-PtEdoTez" { != version }
+  "tezos-embedded-protocol-008-PtEdo2Zk" { != version }
+  "tezos-protocol-plugin-008-PtEdo2Zk-registerer" { != version }
+  "tezos-embedded-protocol-009-PsFLoren" { != version }
+  "tezos-protocol-plugin-009-PsFLoren-registerer" { != version }
+  "tezos-embedded-protocol-010-PtGRANAD" { != version }
+  "tezos-protocol-plugin-010-PtGRANAD-registerer" { != version }
+  "tezos-embedded-protocol-011-PtHangz2" { != version }
+  "tezos-protocol-plugin-011-PtHangz2-registerer" { != version }
+  "tezos-embedded-protocol-012-Psithaca" { != version }
+  "tezos-protocol-plugin-012-Psithaca-registerer" { != version }
+  "tezos-embedded-protocol-013-PtJakart" { != version }
+  "tezos-protocol-plugin-013-PtJakart-registerer" { != version }
+  "tezos-embedded-protocol-alpha" { != version }
+  "tezos-protocol-plugin-alpha-registerer" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `octez-node` binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-protocol-compiler/octez-protocol-compiler.15.0/opam
+++ b/packages/octez-protocol-compiler/octez-protocol-compiler.15.0/opam
@@ -7,7 +7,6 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
-  "ocaml" { >= "4.14.0" & < "4.15" }
   "tezos-base" { = version }
   "tezos-stdlib-unix" { = version }
   "tezos-version" { = version }

--- a/packages/octez-protocol-compiler/octez-protocol-compiler.15.0/opam
+++ b/packages/octez-protocol-compiler/octez-protocol-compiler.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.14.0" & < "4.15" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-version" { = version }
+  "tezos-protocol-environment" { = version }
+  "lwt" { >= "5.6.0" }
+  "ocp-ocamlres" { >= "0.4" }
+  "base-unix"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol compiler"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-signer/octez-signer.15.0/opam
+++ b/packages/octez-signer/octez-signer.15.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-signer-services" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-server" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-signer-backends" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `octez-signer` binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-tx-rollup-client-PtKathma/octez-tx-rollup-client-PtKathma.15.0/opam
+++ b/packages/octez-tx-rollup-client-PtKathma/octez-tx-rollup-client-PtKathma.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-tx-rollup-014-PtKathma" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: `octez-tx-rollup-client-alpha` client binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-tx-rollup-client-PtLimaPt/octez-tx-rollup-client-PtLimaPt.15.0/opam
+++ b/packages/octez-tx-rollup-client-PtLimaPt/octez-tx-rollup-client-PtLimaPt.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-tx-rollup-015-PtLimaPt" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: `octez-tx-rollup-client-alpha` client binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-tx-rollup-node-PtKathma/octez-tx-rollup-node-PtKathma.15.0/opam
+++ b/packages/octez-tx-rollup-node-PtKathma/octez-tx-rollup-node-PtKathma.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-tx-rollup-014-PtKathma" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: Transaction Rollup node binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-tx-rollup-node-PtLimaPt/octez-tx-rollup-node-PtLimaPt.15.0/opam
+++ b/packages/octez-tx-rollup-node-PtLimaPt/octez-tx-rollup-node-PtLimaPt.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-tx-rollup-015-PtLimaPt" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: Transaction Rollup node binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez-validator/octez-validator.15.0/opam
+++ b/packages/octez-validator/octez-validator.15.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-context" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-shell" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-validation" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-context" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: `octez-validator` binary for external validation of blocks"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez/octez.15.0/opam
+++ b/packages/octez/octez.15.0/opam
@@ -1,0 +1,70 @@
+# This file was automatically generated, do not edit.
+# Edit file manifest/main.ml instead.
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+doc: "https://tezos.gitlab.io"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "ledgerwallet-tezos"
+  "octez-accuser-PtKathma" { = version }
+  "octez-accuser-PtLimaPt" { = version }
+  "octez-baker-PtKathma" { = version }
+  "octez-baker-PtLimaPt" { = version }
+  "octez-client" { = version }
+  "octez-codec" { = version }
+  "octez-node" { = version }
+  "octez-signer" { = version }
+  "octez-tx-rollup-client-PtKathma" { = version }
+  "octez-tx-rollup-client-PtLimaPt" { = version }
+  "octez-tx-rollup-node-PtKathma" { = version }
+  "octez-tx-rollup-node-PtLimaPt" { = version }
+  "tezos-client-000-Ps9mPmXa" { = version }
+  "tezos-client-001-PtCJ7pwo" { = version }
+  "tezos-client-002-PsYLVpVv" { = version }
+  "tezos-client-003-PsddFKi3" { = version }
+  "tezos-client-004-Pt24m4xi" { = version }
+  "tezos-client-005-PsBabyM1" { = version }
+  "tezos-client-006-PsCARTHA" { = version }
+  "tezos-client-007-PsDELPH1" { = version }
+  "tezos-client-008-PtEdo2Zk" { = version }
+  "tezos-client-009-PsFLoren" { = version }
+  "tezos-client-010-PtGRANAD" { = version }
+  "tezos-client-011-PtHangz2" { = version }
+  "tezos-client-012-Psithaca" { = version }
+  "tezos-client-013-PtJakart" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-embedded-protocol-000-Ps9mPmXa" { = version }
+  "tezos-embedded-protocol-001-PtCJ7pwo" { = version }
+  "tezos-embedded-protocol-002-PsYLVpVv" { = version }
+  "tezos-embedded-protocol-003-PsddFKi3" { = version }
+  "tezos-embedded-protocol-004-Pt24m4xi" { = version }
+  "tezos-embedded-protocol-005-PsBABY5H" { = version }
+  "tezos-embedded-protocol-005-PsBabyM1" { = version }
+  "tezos-embedded-protocol-006-PsCARTHA" { = version }
+  "tezos-embedded-protocol-007-PsDELPH1" { = version }
+  "tezos-embedded-protocol-008-PtEdo2Zk" { = version }
+  "tezos-embedded-protocol-008-PtEdoTez" { = version }
+  "tezos-embedded-protocol-009-PsFLoren" { = version }
+  "tezos-embedded-protocol-010-PtGRANAD" { = version }
+  "tezos-embedded-protocol-011-PtHangz2" { = version }
+  "tezos-embedded-protocol-012-Psithaca" { = version }
+  "tezos-embedded-protocol-013-PtJakart" { = version }
+  "tezos-embedded-protocol-014-PtKathma" { = version }
+  "tezos-embedded-protocol-015-PtLimaPt" { = version }
+  "tezos-protocol-plugin-007-PsDELPH1-registerer" { = version }
+  "tezos-protocol-plugin-008-PtEdo2Zk-registerer" { = version }
+  "tezos-protocol-plugin-009-PsFLoren-registerer" { = version }
+  "tezos-protocol-plugin-010-PtGRANAD-registerer" { = version }
+  "tezos-protocol-plugin-011-PtHangz2-registerer" { = version }
+  "tezos-protocol-plugin-012-Psithaca-registerer" { = version }
+  "tezos-protocol-plugin-013-PtJakart-registerer" { = version }
+  "tezos-protocol-plugin-014-PtKathma-registerer" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt-registerer" { = version }
+]
+build: []
+synopsis: "Main virtual package for Octez, an implementation of Tezos."

--- a/packages/octez/octez.15.0/opam
+++ b/packages/octez/octez.15.0/opam
@@ -67,4 +67,4 @@ depends: [
   "tezos-protocol-plugin-015-PtLimaPt-registerer" { = version }
 ]
 build: []
-synopsis: "Main virtual package for Octez, an implementation of Tezos."
+synopsis: "Main virtual package for Octez, an implementation of Tezos"

--- a/packages/tezos-baking-014-PtKathma-commands/tezos-baking-014-PtKathma-commands.15.0/opam
+++ b/packages/tezos-baking-014-PtKathma-commands/tezos-baking-014-PtKathma-commands.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-014-PtKathma" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-baking-014-PtKathma/tezos-baking-014-PtKathma.15.0/opam
+++ b/packages/tezos-baking-014-PtKathma/tezos-baking-014-PtKathma.15.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-micheline" { with-test & = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-crypto" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "uri" { >= "2.2.0" }
+  "tezos-client-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-proxy" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-clic" { = version }
+  "tezos-version" { = version }
+  "tezos-protocol-plugin-014-PtKathma" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-context" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-rpc" { = version }
+  "tezos-rpc-http" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/accuser`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-baking-015-PtLimaPt-commands/tezos-baking-015-PtLimaPt-commands.15.0/opam
+++ b/packages/tezos-baking-015-PtLimaPt-commands/tezos-baking-015-PtLimaPt-commands.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-015-PtLimaPt" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-baking-015-PtLimaPt/tezos-baking-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-baking-015-PtLimaPt/tezos-baking-015-PtLimaPt.15.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-micheline" { with-test & = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-crypto" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "uri" { >= "2.2.0" }
+  "tezos-client-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-proxy" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-clic" { = version }
+  "tezos-version" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-context" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-rpc" { = version }
+  "tezos-rpc-http" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/accuser`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-baking-alpha-commands/tezos-baking-alpha-commands.15.0/opam
+++ b/packages/tezos-baking-alpha-commands/tezos-baking-alpha-commands.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-alpha" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-baking-alpha" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol-specific commands for baking"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-baking-alpha/tezos-baking-alpha.15.0/opam
+++ b/packages/tezos-baking-alpha/tezos-baking-alpha.15.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-micheline" { with-test & = version }
+  "tezos-client-alpha" { = version }
+  "tezos-protocol-alpha" { = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-crypto" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "uri" { >= "2.2.0" }
+  "tezos-client-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-proxy" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-clic" { = version }
+  "tezos-version" { = version }
+  "tezos-protocol-plugin-alpha" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-context" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-rpc" { = version }
+  "tezos-rpc-http" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: base library for `tezos-baker/accuser`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-base-test-helpers/tezos-base-test-helpers.15.0/opam
+++ b/packages/tezos-base-test-helpers/tezos-base-test-helpers.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-event-logging-test-helpers" { = version }
+  "tezos-test-helpers" { = version }
+  "alcotest" { >= "1.5.0" }
+  "alcotest-lwt" { >= "1.5.0" }
+  "qcheck-alcotest" { >= "0.18" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: Tezos base test helpers"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-base/tezos-base.15.0/opam
+++ b/packages/tezos-base/tezos-base.15.0/opam
@@ -7,6 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
+  "ocaml" { >= "4.14.0" }
   "tezos-error-monad" { = version }
   "data-encoding" { >= "0.6" & < "0.7" }
   "tezos-test-helpers" { with-test & = version }

--- a/packages/tezos-base/tezos-base.15.0/opam
+++ b/packages/tezos-base/tezos-base.15.0/opam
@@ -7,7 +7,6 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
-  "ocaml" { >= "4.14.0" }
   "tezos-error-monad" { = version }
   "data-encoding" { >= "0.6" & < "0.7" }
   "tezos-test-helpers" { with-test & = version }

--- a/packages/tezos-base/tezos-base.15.0/opam
+++ b/packages/tezos-base/tezos-base.15.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-error-monad" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-test-helpers" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "tezos-crypto" { = version }
+  "tezos-hacl" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-stdlib-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-rpc" { = version }
+  "tezos-micheline" { = version }
+  "tezos-event-logging" { = version }
+  "ptime" { >= "1.0.0" }
+  "ezjsonm" { >= "1.1.0" }
+  "lwt" { >= "5.6.0" }
+  "ipaddr" { >= "5.0.0" & < "6.0.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: meta-package and pervasive type definitions for Tezos"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-clic/tezos-clic.15.0/opam
+++ b/packages/tezos-clic/tezos-clic.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib" { = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "tezos-stdlib-unix" { = version }
+  "tezos-error-monad" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "lwt" { >= "5.6.0" }
+  "re" { >= "1.7.2" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented command-line-parsing combinators"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-000-Ps9mPmXa/tezos-client-000-Ps9mPmXa.15.0/opam
+++ b/packages/tezos-client-000-Ps9mPmXa/tezos-client-000-Ps9mPmXa.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-001-PtCJ7pwo/tezos-client-001-PtCJ7pwo.15.0/opam
+++ b/packages/tezos-client-001-PtCJ7pwo/tezos-client-001-PtCJ7pwo.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-002-PsYLVpVv/tezos-client-002-PsYLVpVv.15.0/opam
+++ b/packages/tezos-client-002-PsYLVpVv/tezos-client-002-PsYLVpVv.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-003-PsddFKi3/tezos-client-003-PsddFKi3.15.0/opam
+++ b/packages/tezos-client-003-PsddFKi3/tezos-client-003-PsddFKi3.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-004-Pt24m4xi/tezos-client-004-Pt24m4xi.15.0/opam
+++ b/packages/tezos-client-004-Pt24m4xi/tezos-client-004-Pt24m4xi.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-005-PsBabyM1/tezos-client-005-PsBabyM1.15.0/opam
+++ b/packages/tezos-client-005-PsBabyM1/tezos-client-005-PsBabyM1.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.15.0/opam
+++ b/packages/tezos-client-006-PsCARTHA/tezos-client-006-PsCARTHA.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-006-PsCARTHA" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-007-PsDELPH1/tezos-client-007-PsDELPH1.15.0/opam
+++ b/packages/tezos-client-007-PsDELPH1/tezos-client-007-PsDELPH1.15.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-007-PsDELPH1" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-protocol-plugin-007-PsDELPH1" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-008-PtEdo2Zk/tezos-client-008-PtEdo2Zk.15.0/opam
+++ b/packages/tezos-client-008-PtEdo2Zk/tezos-client-008-PtEdo2Zk.15.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-008-PtEdo2Zk" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-008-PtEdo2Zk" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-009-PsFLoren/tezos-client-009-PsFLoren.15.0/opam
+++ b/packages/tezos-client-009-PsFLoren/tezos-client-009-PsFLoren.15.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-009-PsFLoren" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-009-PsFLoren" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+  "ppx_expect"
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-010-PtGRANAD/tezos-client-010-PtGRANAD.15.0/opam
+++ b/packages/tezos-client-010-PtGRANAD/tezos-client-010-PtGRANAD.15.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-010-PtGRANAD" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-010-PtGRANAD" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base-unix" { = version }
+  "ppx_expect"
+  "tezos-signer-backends" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-011-PtHangz2/tezos-client-011-PtHangz2.15.0/opam
+++ b/packages/tezos-client-011-PtHangz2/tezos-client-011-PtHangz2.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-011-PtHangz2" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-011-PtHangz2" { = version }
+  "tezos-crypto" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-micheline" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-012-Psithaca/tezos-client-012-Psithaca.15.0/opam
+++ b/packages/tezos-client-012-Psithaca/tezos-client-012-Psithaca.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-012-Psithaca" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-012-Psithaca" { = version }
+  "tezos-crypto" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-micheline" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-013-PtJakart/tezos-client-013-PtJakart.15.0/opam
+++ b/packages/tezos-client-013-PtJakart/tezos-client-013-PtJakart.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-013-PtJakart" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-013-PtJakart" { = version }
+  "tezos-crypto" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-micheline" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-014-PtKathma/tezos-client-014-PtKathma.15.0/opam
+++ b/packages/tezos-client-014-PtKathma/tezos-client-014-PtKathma.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-014-PtKathma" { = version }
+  "tezos-crypto" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-micheline" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-015-PtLimaPt/tezos-client-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-client-015-PtLimaPt/tezos-client-015-PtLimaPt.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt" { = version }
+  "tezos-crypto" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-micheline" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-alpha/tezos-client-alpha.15.0/opam
+++ b/packages/tezos-client-alpha/tezos-client-alpha.15.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-rpc" { = version }
+  "tezos-protocol-plugin-alpha" { = version }
+  "tezos-crypto" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-client-base-unix" { = version }
+  "uri" { >= "2.2.0" }
+  "tezos-micheline" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "tezos-proxy" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-base-unix/tezos-client-base-unix.15.0/opam
+++ b/packages/tezos-client-base-unix/tezos-client-base-unix.15.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-mockup-commands" { = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "alcotest" { with-test & >= "1.5.0" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "tezos-clic" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-proxy" { = version }
+  "tezos-signer-backends" { = version }
+  "lwt-exit"
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: common helpers for `tezos-client` (unix-specific fragment)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-base/tezos-client-base.15.0/opam
+++ b/packages/tezos-client-base/tezos-client-base.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "alcotest" { with-test & >= "1.5.0" }
+  "tezos-clic" { = version }
+  "tezos-rpc" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-sapling" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: common helpers for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-commands/tezos-client-commands.15.0/opam
+++ b/packages/tezos-client-commands/tezos-client-commands.15.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-rpc" { = version }
+  "tezos-clic" { = version }
+  "tezos-client-base" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-p2p-services" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-signer-backends" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: protocol agnostic commands for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-demo-counter/tezos-client-demo-counter.15.0/opam
+++ b/packages/tezos-client-demo-counter/tezos-client-demo-counter.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-protocol-demo-counter" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-client-genesis/tezos-client-genesis.15.0/opam
+++ b/packages/tezos-client-genesis/tezos-client-genesis.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-client-base" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-protocol-genesis" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-proxy" { = version }
+  "tezos-stdlib-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-context-ops/tezos-context-ops.15.0/opam
+++ b/packages/tezos-context-ops/tezos-context-ops.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-error-monad" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-context" { = version }
+  "tezos-shell-context" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: backend-agnostic operations on contexts"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-context/tezos-context.15.0/opam
+++ b/packages/tezos-context/tezos-context.15.0/opam
@@ -17,8 +17,8 @@ depends: [
   "fmt" { >= "0.8.7" }
   "logs"
   "digestif" { >= "0.7.3" }
-  "irmin" { >= "3.4.0" & < "3.5.0" }
-  "irmin-pack" { >= "3.4.0" & < "3.5.0" }
+  "irmin" { >= "3.4.3" & < "3.5.0" }
+  "irmin-pack" { >= "3.4.3" & < "3.5.0" }
   "tezos-stdlib" { = version }
 ]
 build: [

--- a/packages/tezos-context/tezos-context.15.0/opam
+++ b/packages/tezos-context/tezos-context.15.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "tezos-test-helpers-extra" { with-test & = version }
+  "bigstringaf" { >= "0.2.0" }
+  "fmt" { >= "0.8.7" }
+  "logs"
+  "digestif" { >= "0.7.3" }
+  "irmin" { >= "3.4.0" & < "3.5.0" }
+  "irmin-pack" { >= "3.4.0" & < "3.5.0" }
+  "tezos-stdlib" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: on-disk context abstraction for `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-crypto-dal/tezos-crypto-dal.15.0/opam
+++ b/packages/tezos-crypto-dal/tezos-crypto-dal.15.0/opam
@@ -12,7 +12,7 @@ depends: [
   "data-encoding" { >= "0.6" & < "0.7" }
   "alcotest" { with-test & >= "1.5.0" }
   "qcheck-alcotest" { with-test & >= "0.18" }
-  "tezos-bls12-381-polynomial" { >= "0.1.0" }
+  "tezos-bls12-381-polynomial" { >= "0.1.3" }
   "tezos-crypto" { = version }
   "lwt" { >= "5.6.0" }
 ]

--- a/packages/tezos-crypto-dal/tezos-crypto-dal.15.0/opam
+++ b/packages/tezos-crypto-dal/tezos-crypto-dal.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib" { = version }
+  "tezos-error-monad" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "alcotest" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "tezos-bls12-381-polynomial" { >= "0.1.0" }
+  "tezos-crypto" { = version }
+  "lwt" { >= "5.6.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "DAL cryptographic primitives"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-crypto/tezos-crypto.15.0/opam
+++ b/packages/tezos-crypto/tezos-crypto.15.0/opam
@@ -21,7 +21,7 @@ depends: [
   "tezos-lwt-result-stdlib" { = version }
   "secp256k1-internal" { >= "0.3.0" }
   "tezos-rpc" { = version }
-  "ringo" { >= "0.9" }
+  "ringo" { >= "0.9" & < "1.0.0" }
   "bls12-381" { >= "5.0.0" & < "5.1.0" }
   "bls12-381-signature" { = "1.0.0" }
 ]

--- a/packages/tezos-crypto/tezos-crypto.15.0/opam
+++ b/packages/tezos-crypto/tezos-crypto.15.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib" { = version }
+  "tezos-error-monad" { = version }
+  "zarith" { >= "1.12" & < "1.13" }
+  "zarith_stubs_js"
+  "tezos-hacl" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "alcotest" { with-test & >= "1.5.0" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "lwt" { >= "5.6.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "secp256k1-internal" { >= "0.3.0" }
+  "tezos-rpc" { = version }
+  "ringo" { >= "0.9" }
+  "bls12-381" { >= "5.0.0" & < "5.1.0" }
+  "bls12-381-signature" { = "1.0.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library with all the cryptographic primitives used by Tezos"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.15.0/opam
+++ b/packages/tezos-embedded-protocol-000-Ps9mPmXa/tezos-embedded-protocol-000-Ps9mPmXa.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-000-Ps9mPmXa" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000-Ps9mPmXa (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.15.0/opam
+++ b/packages/tezos-embedded-protocol-001-PtCJ7pwo/tezos-embedded-protocol-001-PtCJ7pwo.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-001-PtCJ7pwo" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.15.0/opam
+++ b/packages/tezos-embedded-protocol-002-PsYLVpVv/tezos-embedded-protocol-002-PsYLVpVv.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-002-PsYLVpVv" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.15.0/opam
+++ b/packages/tezos-embedded-protocol-003-PsddFKi3/tezos-embedded-protocol-003-PsddFKi3.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-003-PsddFKi3" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.15.0/opam
+++ b/packages/tezos-embedded-protocol-004-Pt24m4xi/tezos-embedded-protocol-004-Pt24m4xi.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-004-Pt24m4xi" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.15.0/opam
+++ b/packages/tezos-embedded-protocol-005-PsBABY5H/tezos-embedded-protocol-005-PsBABY5H.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-005-PsBABY5H" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.15.0/opam
+++ b/packages/tezos-embedded-protocol-005-PsBabyM1/tezos-embedded-protocol-005-PsBabyM1.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-005-PsBabyM1" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.15.0/opam
+++ b/packages/tezos-embedded-protocol-006-PsCARTHA/tezos-embedded-protocol-006-PsCARTHA.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-006-PsCARTHA" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-007-PsDELPH1/tezos-embedded-protocol-007-PsDELPH1.15.0/opam
+++ b/packages/tezos-embedded-protocol-007-PsDELPH1/tezos-embedded-protocol-007-PsDELPH1.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-007-PsDELPH1" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-008-PtEdo2Zk/tezos-embedded-protocol-008-PtEdo2Zk.15.0/opam
+++ b/packages/tezos-embedded-protocol-008-PtEdo2Zk/tezos-embedded-protocol-008-PtEdo2Zk.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-008-PtEdo2Zk" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-008-PtEdoTez/tezos-embedded-protocol-008-PtEdoTez.15.0/opam
+++ b/packages/tezos-embedded-protocol-008-PtEdoTez/tezos-embedded-protocol-008-PtEdoTez.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-008-PtEdoTez" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-009-PsFLoren/tezos-embedded-protocol-009-PsFLoren.15.0/opam
+++ b/packages/tezos-embedded-protocol-009-PsFLoren/tezos-embedded-protocol-009-PsFLoren.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-009-PsFLoren" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-010-PtGRANAD/tezos-embedded-protocol-010-PtGRANAD.15.0/opam
+++ b/packages/tezos-embedded-protocol-010-PtGRANAD/tezos-embedded-protocol-010-PtGRANAD.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-010-PtGRANAD" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-011-PtHangz2/tezos-embedded-protocol-011-PtHangz2.15.0/opam
+++ b/packages/tezos-embedded-protocol-011-PtHangz2/tezos-embedded-protocol-011-PtHangz2.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-011-PtHangz2" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-012-Psithaca/tezos-embedded-protocol-012-Psithaca.15.0/opam
+++ b/packages/tezos-embedded-protocol-012-Psithaca/tezos-embedded-protocol-012-Psithaca.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-012-Psithaca" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-013-PtJakart/tezos-embedded-protocol-013-PtJakart.15.0/opam
+++ b/packages/tezos-embedded-protocol-013-PtJakart/tezos-embedded-protocol-013-PtJakart.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-013-PtJakart" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-014-PtKathma/tezos-embedded-protocol-014-PtKathma.15.0/opam
+++ b/packages/tezos-embedded-protocol-014-PtKathma/tezos-embedded-protocol-014-PtKathma.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-015-PtLimaPt/tezos-embedded-protocol-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-embedded-protocol-015-PtLimaPt/tezos-embedded-protocol-015-PtLimaPt.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.15.0/opam
+++ b/packages/tezos-embedded-protocol-alpha/tezos-embedded-protocol-alpha.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-alpha" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition, embedded in `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.15.0/opam
+++ b/packages/tezos-embedded-protocol-demo-counter/tezos-embedded-protocol-demo-counter.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-demo-counter" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.15.0/opam
+++ b/packages/tezos-embedded-protocol-demo-noops/tezos-embedded-protocol-demo-noops.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-demo-noops" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.15.0/opam
+++ b/packages/tezos-embedded-protocol-genesis/tezos-embedded-protocol-genesis.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-genesis" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis (economic-protocol definition, embedded in `octez-node`)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-error-monad/tezos-error-monad.15.0/opam
+++ b/packages/tezos-error-monad/tezos-error-monad.15.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.07" }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "alcotest" { with-test & >= "1.5.0" }
+  "tezos-stdlib" { = version }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "lwt" { >= "5.6.0" }
+  "tezos-lwt-result-stdlib" { = version }
+]
+conflicts: [
+  "result" { < "1.5" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: error monad"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-event-logging-test-helpers/tezos-event-logging-test-helpers.15.0/opam
+++ b/packages/tezos-event-logging-test-helpers/tezos-event-logging-test-helpers.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-error-monad" { = version }
+  "tezos-event-logging" { = version }
+  "tezos-test-helpers" { = version }
+  "alcotest" { >= "1.5.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: test helpers for the event logging library"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-event-logging/tezos-event-logging.15.0/opam
+++ b/packages/tezos-event-logging/tezos-event-logging.15.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-error-monad" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "lwt_log"
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos event logging library"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-hacl/tezos-hacl.15.0/opam
+++ b/packages/tezos-hacl/tezos-hacl.15.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
-  "ocaml" { >= "4.08" }
+  "ocaml" { >= "4.14" }
   "tezos-stdlib" { with-test & = version }
   "tezos-error-monad" { with-test & = version }
   "zarith" { with-test & >= "1.12" & < "1.13" }

--- a/packages/tezos-hacl/tezos-hacl.15.0/opam
+++ b/packages/tezos-hacl/tezos-hacl.15.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.08" }
+  "tezos-stdlib" { with-test & = version }
+  "tezos-error-monad" { with-test & = version }
+  "zarith" { with-test & >= "1.12" & < "1.13" }
+  "zarith_stubs_js" {with-test}
+  "data-encoding" { with-test & >= "0.6" & < "0.7" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "tezos-test-helpers" { with-test & = version }
+  "ctypes" { >= "0.18.0" }
+  "hacl-star-raw"
+  "ezjsonm" { >= "1.1.0" }
+  "hacl-star" { >= "0.4.2" & < "0.5" }
+  "ctypes_stubs_js"
+]
+conflicts: [
+  "hacl_x25519"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: thin layer around hacl-star"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-injector-014-PtKathma/tezos-injector-014-PtKathma.15.0/opam
+++ b/packages/tezos-injector-014-PtKathma/tezos-injector-014-PtKathma.15.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ppx_expect"
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-crypto" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-micheline" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-base" { = version }
+  "tezos-workers" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library building injectors"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-injector-015-PtLimaPt/tezos-injector-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-injector-015-PtLimaPt/tezos-injector-015-PtLimaPt.15.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ppx_expect"
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-crypto" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-micheline" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-base" { = version }
+  "tezos-workers" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library building injectors"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-lazy-containers/tezos-lazy-containers.15.0/opam
+++ b/packages/tezos-lazy-containers/tezos-lazy-containers.15.0/opam
@@ -7,6 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
+  "ocaml" { >= "4.14" }
   "tezos-lwt-result-stdlib" { = version }
   "zarith" { >= "1.12" & < "1.13" }
 ]

--- a/packages/tezos-lazy-containers/tezos-lazy-containers.15.0/opam
+++ b/packages/tezos-lazy-containers/tezos-lazy-containers.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-lwt-result-stdlib" { = version }
+  "zarith" { >= "1.12" & < "1.13" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "A collection of lazy containers whose contents is fetched from arbitrary backend on-demand"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-lwt-result-stdlib/tezos-lwt-result-stdlib.15.0/opam
+++ b/packages/tezos-lwt-result-stdlib/tezos-lwt-result-stdlib.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.12" }
+  "lwt" { >= "5.6.0" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "tezos-test-helpers" { with-test & = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] { with-test & arch != "arm32" & arch != "x86_32" }
+]
+synopsis: "Tezos: error-aware stdlib replacement"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-micheline/tezos-micheline.15.0/opam
+++ b/packages/tezos-micheline/tezos-micheline.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ppx_expect"
+  "uutf"
+  "zarith" { >= "1.12" & < "1.13" }
+  "zarith_stubs_js"
+  "tezos-stdlib" { = version }
+  "tezos-error-monad" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: internal AST and parser for the Michelson language"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-mockup-commands/tezos-mockup-commands.15.0/opam
+++ b/packages/tezos-mockup-commands/tezos-mockup-commands.15.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-client-base" { = version }
+  "tezos-mockup" { = version }
+  "tezos-mockup-registration" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (commands)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-mockup-proxy/tezos-mockup-proxy.15.0/opam
+++ b/packages/tezos-mockup-proxy/tezos-mockup-proxy.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-client-base" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-rpc-http" { = version }
+  "resto-cohttp-self-serving-client" { >= "1.0" }
+  "tezos-rpc-http-client" { = version }
+  "tezos-shell-services" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: local RPCs"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-mockup-registration/tezos-mockup-registration.15.0/opam
+++ b/packages/tezos-mockup-registration/tezos-mockup-registration.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-client-base" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-protocol-environment" { = version }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: protocol registration for the mockup mode"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-mockup/tezos-mockup.15.0/opam
+++ b/packages/tezos-mockup/tezos-mockup.15.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-mockup-registration" { = version }
+  "tezos-client-base" { = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "tezos-mockup-proxy" { = version }
+  "resto-cohttp-self-serving-client" { >= "1.0" }
+  "tezos-rpc" { = version }
+  "tezos-p2p-services" { = version }
+  "tezos-p2p" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-client" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (mockup mode)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-p2p-services/tezos-p2p-services.15.0/opam
+++ b/packages/tezos-p2p-services/tezos-p2p-services.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-p2p`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-p2p/tezos-p2p.15.0/opam
+++ b/packages/tezos-p2p/tezos-p2p.15.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-event-logging-test-helpers" { with-test & = version }
+  "tezos-p2p-services" { = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "astring" {with-test}
+  "lwt-watcher" { = "0.2" }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "ringo" { >= "0.9" }
+  "tezos-version" { = version }
+  "prometheus" { >= "1.2" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for a pool of P2P connections"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-p2p/tezos-p2p.15.0/opam
+++ b/packages/tezos-p2p/tezos-p2p.15.0/opam
@@ -18,7 +18,7 @@ depends: [
   "astring" {with-test}
   "lwt-watcher" { = "0.2" }
   "lwt-canceler" { >= "0.3" & < "0.4" }
-  "ringo" { >= "0.9" }
+  "ringo" { >= "0.9" & < "1.0.0" }
   "tezos-version" { = version }
   "prometheus" { >= "1.2" }
 ]

--- a/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.15.0/opam
+++ b/packages/tezos-protocol-000-Ps9mPmXa/tezos-protocol-000-Ps9mPmXa.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 000_Ps9mPmXa (economic-protocol definition, functor version)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.15.0/opam
+++ b/packages/tezos-protocol-001-PtCJ7pwo/tezos-protocol-001-PtCJ7pwo.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 001_PtCJ7pwo (economic-protocol definition, functor version)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.15.0/opam
+++ b/packages/tezos-protocol-002-PsYLVpVv/tezos-protocol-002-PsYLVpVv.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 002_PsYLVpVv (economic-protocol definition, functor version)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.15.0/opam
+++ b/packages/tezos-protocol-003-PsddFKi3/tezos-protocol-003-PsddFKi3.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: 003_PsddFKi3 (economic-protocol definition, functor version)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.15.0/opam
+++ b/packages/tezos-protocol-004-Pt24m4xi/tezos-protocol-004-Pt24m4xi.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.15.0/opam
+++ b/packages/tezos-protocol-005-PsBABY5H/tezos-protocol-005-PsBABY5H.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.15.0/opam
+++ b/packages/tezos-protocol-005-PsBabyM1/tezos-protocol-005-PsBabyM1.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.15.0/opam
+++ b/packages/tezos-protocol-006-PsCARTHA/tezos-protocol-006-PsCARTHA.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-007-PsDELPH1/tezos-protocol-007-PsDELPH1.15.0/opam
+++ b/packages/tezos-protocol-007-PsDELPH1/tezos-protocol-007-PsDELPH1.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-008-PtEdo2Zk/tezos-protocol-008-PtEdo2Zk.15.0/opam
+++ b/packages/tezos-protocol-008-PtEdo2Zk/tezos-protocol-008-PtEdo2Zk.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-008-PtEdoTez/tezos-protocol-008-PtEdoTez.15.0/opam
+++ b/packages/tezos-protocol-008-PtEdoTez/tezos-protocol-008-PtEdoTez.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-009-PsFLoren/tezos-protocol-009-PsFLoren.15.0/opam
+++ b/packages/tezos-protocol-009-PsFLoren/tezos-protocol-009-PsFLoren.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-010-PtGRANAD/tezos-protocol-010-PtGRANAD.15.0/opam
+++ b/packages/tezos-protocol-010-PtGRANAD/tezos-protocol-010-PtGRANAD.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-011-PtHangz2/tezos-protocol-011-PtHangz2.15.0/opam
+++ b/packages/tezos-protocol-011-PtHangz2/tezos-protocol-011-PtHangz2.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-012-Psithaca/tezos-protocol-012-Psithaca.15.0/opam
+++ b/packages/tezos-protocol-012-Psithaca/tezos-protocol-012-Psithaca.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-013-PtJakart/tezos-protocol-013-PtJakart.15.0/opam
+++ b/packages/tezos-protocol-013-PtJakart/tezos-protocol-013-PtJakart.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-014-PtKathma/tezos-protocol-014-PtKathma.15.0/opam
+++ b/packages/tezos-protocol-014-PtKathma/tezos-protocol-014-PtKathma.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-015-PtLimaPt/tezos-protocol-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-protocol-015-PtLimaPt/tezos-protocol-015-PtLimaPt.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-alpha/tezos-protocol-alpha.15.0/opam
+++ b/packages/tezos-protocol-alpha/tezos-protocol-alpha.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.15.0/opam
+++ b/packages/tezos-protocol-demo-counter/tezos-protocol-demo-counter.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_counter economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.15.0/opam
+++ b/packages/tezos-protocol-demo-noops/tezos-protocol-demo-noops.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: demo_noops economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-environment/tezos-protocol-environment.15.0/opam
+++ b/packages/tezos-protocol-environment/tezos-protocol-environment.15.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
-  "ocaml" { >= "4.12" }
+  "ocaml" { >= "4.14.0" & < "4.15" }
   "tezos-base" { = version }
   "alcotest-lwt" { with-test & >= "1.5.0" }
   "tezos-test-helpers" { with-test & = version }

--- a/packages/tezos-protocol-environment/tezos-protocol-environment.15.0/opam
+++ b/packages/tezos-protocol-environment/tezos-protocol-environment.15.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.12" }
+  "tezos-base" { = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "tezos-test-helpers" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "lwt" { with-test & >= "5.6.0" }
+  "zarith" { >= "1.12" & < "1.13" }
+  "zarith_stubs_js"
+  "bls12-381" { >= "5.0.0" & < "5.1.0" }
+  "tezos-plonk" { >= "0.1.2" }
+  "tezos-crypto-dal" { = version }
+  "class_group_vdf" { >= "0.0.4" }
+  "ringo" { >= "0.9" }
+  "ringo-lwt" { >= "0.9" }
+  "tezos-sapling" { = version }
+  "tezos-micheline" { = version }
+  "tezos-context" { = version }
+  "tezos-scoru-wasm" { = version }
+  "tezos-event-logging" { = version }
+  "tezos-stdlib" { = version }
+  "tezos-crypto" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Interface layer between the protocols and the shell"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}
+description: "The protocol-environment is a two-sided component sitting between the shell and
+the protocols.
+
+On one side, it provides a restricted typing environment to compile the
+protocols against. This is a series of modules which replace the standard
+library of OCaml. These modules purposefully omit many functionalities, thus
+preventing the protocols from, say, directly writing to disk.
+
+On the other side, it provides the shell with specific call-sites in the
+protocols. These are the only entry-points into the otherwise black-box
+protocols."

--- a/packages/tezos-protocol-environment/tezos-protocol-environment.15.0/opam
+++ b/packages/tezos-protocol-environment/tezos-protocol-environment.15.0/opam
@@ -19,7 +19,7 @@ depends: [
   "tezos-plonk" { >= "0.1.2" }
   "tezos-crypto-dal" { = version }
   "class_group_vdf" { >= "0.0.4" }
-  "ringo" { >= "0.9" }
+  "ringo" { >= "0.9" & < "1.0.0" }
   "ringo-lwt" { >= "0.9" }
   "tezos-sapling" { = version }
   "tezos-micheline" { = version }

--- a/packages/tezos-protocol-genesis/tezos-protocol-genesis.15.0/opam
+++ b/packages/tezos-protocol-genesis/tezos-protocol-genesis.15.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-protocol-environment" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: genesis economic-protocol definition"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-007-PsDELPH1-registerer/tezos-protocol-plugin-007-PsDELPH1-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-007-PsDELPH1-registerer/tezos-protocol-plugin-007-PsDELPH1-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-007-PsDELPH1" { = version }
+  "tezos-protocol-plugin-007-PsDELPH1" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-007-PsDELPH1/tezos-protocol-plugin-007-PsDELPH1.15.0/opam
+++ b/packages/tezos-protocol-plugin-007-PsDELPH1/tezos-protocol-plugin-007-PsDELPH1.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-007-PsDELPH1" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-008-PtEdo2Zk-registerer/tezos-protocol-plugin-008-PtEdo2Zk-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-008-PtEdo2Zk-registerer/tezos-protocol-plugin-008-PtEdo2Zk-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-008-PtEdo2Zk" { = version }
+  "tezos-protocol-plugin-008-PtEdo2Zk" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-008-PtEdo2Zk/tezos-protocol-plugin-008-PtEdo2Zk.15.0/opam
+++ b/packages/tezos-protocol-plugin-008-PtEdo2Zk/tezos-protocol-plugin-008-PtEdo2Zk.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-008-PtEdo2Zk" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-009-PsFLoren-registerer/tezos-protocol-plugin-009-PsFLoren-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-009-PsFLoren-registerer/tezos-protocol-plugin-009-PsFLoren-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-009-PsFLoren" { = version }
+  "tezos-protocol-plugin-009-PsFLoren" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-009-PsFLoren/tezos-protocol-plugin-009-PsFLoren.15.0/opam
+++ b/packages/tezos-protocol-plugin-009-PsFLoren/tezos-protocol-plugin-009-PsFLoren.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-009-PsFLoren" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-010-PtGRANAD-registerer/tezos-protocol-plugin-010-PtGRANAD-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-010-PtGRANAD-registerer/tezos-protocol-plugin-010-PtGRANAD-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-010-PtGRANAD" { = version }
+  "tezos-protocol-plugin-010-PtGRANAD" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-010-PtGRANAD/tezos-protocol-plugin-010-PtGRANAD.15.0/opam
+++ b/packages/tezos-protocol-plugin-010-PtGRANAD/tezos-protocol-plugin-010-PtGRANAD.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-010-PtGRANAD" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-011-PtHangz2-registerer/tezos-protocol-plugin-011-PtHangz2-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-011-PtHangz2-registerer/tezos-protocol-plugin-011-PtHangz2-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-011-PtHangz2" { = version }
+  "tezos-protocol-plugin-011-PtHangz2" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-011-PtHangz2/tezos-protocol-plugin-011-PtHangz2.15.0/opam
+++ b/packages/tezos-protocol-plugin-011-PtHangz2/tezos-protocol-plugin-011-PtHangz2.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-011-PtHangz2" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-012-Psithaca-registerer/tezos-protocol-plugin-012-Psithaca-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-012-Psithaca-registerer/tezos-protocol-plugin-012-Psithaca-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-012-Psithaca" { = version }
+  "tezos-protocol-plugin-012-Psithaca" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-012-Psithaca/tezos-protocol-plugin-012-Psithaca.15.0/opam
+++ b/packages/tezos-protocol-plugin-012-Psithaca/tezos-protocol-plugin-012-Psithaca.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-012-Psithaca" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-013-PtJakart-registerer/tezos-protocol-plugin-013-PtJakart-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-013-PtJakart-registerer/tezos-protocol-plugin-013-PtJakart-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-013-PtJakart" { = version }
+  "tezos-protocol-plugin-013-PtJakart" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-013-PtJakart/tezos-protocol-plugin-013-PtJakart.15.0/opam
+++ b/packages/tezos-protocol-plugin-013-PtJakart/tezos-protocol-plugin-013-PtJakart.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-013-PtJakart" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-014-PtKathma-registerer/tezos-protocol-plugin-014-PtKathma-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-014-PtKathma-registerer/tezos-protocol-plugin-014-PtKathma-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-014-PtKathma" { = version }
+  "tezos-protocol-plugin-014-PtKathma" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-014-PtKathma/tezos-protocol-plugin-014-PtKathma.15.0/opam
+++ b/packages/tezos-protocol-plugin-014-PtKathma/tezos-protocol-plugin-014-PtKathma.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-015-PtLimaPt-registerer/tezos-protocol-plugin-015-PtLimaPt-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-015-PtLimaPt-registerer/tezos-protocol-plugin-015-PtLimaPt-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-015-PtLimaPt" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-015-PtLimaPt/tezos-protocol-plugin-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-protocol-plugin-015-PtLimaPt/tezos-protocol-plugin-015-PtLimaPt.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-alpha-registerer/tezos-protocol-plugin-alpha-registerer.15.0/opam
+++ b/packages/tezos-protocol-plugin-alpha-registerer/tezos-protocol-plugin-alpha-registerer.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-embedded-protocol-alpha" { = version }
+  "tezos-protocol-plugin-alpha" { = version }
+  "tezos-shell" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin registerer"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-plugin-alpha/tezos-protocol-plugin-alpha.15.0/opam
+++ b/packages/tezos-protocol-plugin-alpha/tezos-protocol-plugin-alpha.15.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-alpha" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol plugin"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-protocol-updater/tezos-protocol-updater.15.0/opam
+++ b/packages/tezos-protocol-updater/tezos-protocol-updater.15.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-micheline" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-context" { = version }
+  "octez-protocol-compiler" { = version }
+  "tezos-context" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocol dynamic loading for `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-proxy/tezos-proxy.15.0/opam
+++ b/packages/tezos-proxy/tezos-proxy.15.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-shell-services-test-helpers" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "uri" { >= "2.2.0" }
+  "tezos-client-base" { = version }
+  "tezos-mockup-proxy" { = version }
+  "tezos-rpc" { = version }
+  "ringo-lwt" { >= "0.9" }
+  "tezos-clic" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-context" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: proxy"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-requester/tezos-requester.15.0/opam
+++ b/packages/tezos-requester/tezos-requester.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-stdlib" { with-test & = version }
+  "tezos-stdlib-unix" { = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "lwt-watcher" { = "0.2" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: generic resource fetching service"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.15.0/opam
+++ b/packages/tezos-rpc-http-client-unix/tezos-rpc-http-client-unix.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib-unix" { = version }
+  "tezos-base" { = version }
+  "cohttp-lwt-unix" { >= "2.2.0" }
+  "resto-cohttp-client" { >= "1.0" }
+  "tezos-rpc-http-client" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: unix implementation of the RPC client"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-rpc-http-client/tezos-rpc-http-client.15.0/opam
+++ b/packages/tezos-rpc-http-client/tezos-rpc-http-client.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "resto-cohttp-client" { >= "1.0" }
+  "tezos-rpc-http" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http client)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-rpc-http-server/tezos-rpc-http-server.15.0/opam
+++ b/packages/tezos-rpc-http-server/tezos-rpc-http-server.15.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib" { with-test & = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "resto-cohttp-server" { >= "1.0" }
+  "resto-acl" { >= "1.0" }
+  "tezos-rpc" { = version }
+  "tezos-rpc-http" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-rpc-http/tezos-rpc-http.15.0/opam
+++ b/packages/tezos-rpc-http/tezos-rpc-http.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "resto-cohttp" { >= "1.0" }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (http server and client)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-rpc/tezos-rpc.15.0/opam
+++ b/packages/tezos-rpc/tezos-rpc.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-error-monad" { = version }
+  "resto" { >= "1.0" }
+  "resto-directory" { >= "1.0" }
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library of auto-documented RPCs (service and hierarchy descriptions)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-sapling/tezos-sapling.15.0/opam
+++ b/packages/tezos-sapling/tezos-sapling.15.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ctypes" { >= "0.18.0" }
+  "tezos-hacl" { with-test & = version }
+  "tezos-crypto" { = version }
+  "tezos-base" { with-test & = version }
+  "tezos-stdlib" { = version }
+  "tezos-stdlib-unix" { with-test & = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "tezos-base-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "conf-rust"
+  "integers"
+  "integers_stubs_js"
+  "ctypes_stubs_js"
+  "tezos-error-monad" { = version }
+  "tezos-rust-libs" { = "1.1" }
+  "tezos-lwt-result-stdlib" { = version }
+]
+x-opam-monorepo-opam-provided: [
+  "tezos-rust-libs"
+]
+build: [["rm" "-r" "vendors"] ["dune" "build" "-p" name "-j" jobs]]
+synopsis: "OCaml library for the Sapling protocol, using librustzcash"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-scoru-wasm/tezos-scoru-wasm.15.0/opam
+++ b/packages/tezos-scoru-wasm/tezos-scoru-wasm.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-tree-encoding" { = version }
+  "tezos-lazy-containers" { = version }
+  "tezos-webassembly-interpreter" { = version }
+  "tezos-context" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Protocol environment dependency providing WASM functionality for SCORU"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-shell-context/tezos-shell-context.15.0/opam
+++ b/packages/tezos-shell-context/tezos-shell-context.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-protocol-environment" { = version }
+  "tezos-context" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: economic-protocols environment implementation for `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-shell-services-test-helpers/tezos-shell-services-test-helpers.15.0/opam
+++ b/packages/tezos-shell-services-test-helpers/tezos-shell-services-test-helpers.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-test-helpers" { = version }
+  "tezos-shell-services" { = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "alcotest-lwt" { >= "1.5.0" }
+  "qcheck-core"
+  "tezos-context" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: Tezos shell_services test helpers"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-shell-services/tezos-shell-services.15.0/opam
+++ b/packages/tezos-shell-services/tezos-shell-services.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "alcotest" { with-test & >= "1.5.0" }
+  "tezos-p2p-services" { = version }
+  "tezos-version" { = version }
+  "tezos-context" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-shell`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-shell/tezos-shell.15.0/opam
+++ b/packages/tezos-shell/tezos-shell.15.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "tezos-store" { = version }
+  "tezos-context" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-p2p" { = version }
+  "tezos-p2p-services" { = version }
+  "tezos-requester" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-embedded-protocol-demo-noops" { with-test & = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-validation" { = version }
+  "tezos-event-logging-test-helpers" { with-test & = version }
+  "tezos-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "ppx_expect"
+  "lwt-watcher" { = "0.2" }
+  "lwt-canceler" { >= "0.3" & < "0.4" }
+  "prometheus" { >= "1.2" }
+  "tezos-protocol-environment" { = version }
+  "tezos-workers" { = version }
+  "tezos-version" { = version }
+  "lwt-exit"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: core of `octez-node` (gossip, validation scheduling, mempool, ...)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-signer-backends/tezos-signer-backends.15.0/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.15.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-error-monad" { with-test & = version }
+  "tezos-stdlib" { = version }
+  "tezos-crypto" { with-test & = version }
+  "tezos-client-base" { = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "ocplib-endian"
+  "fmt" { >= "0.8.7" }
+  "tezos-base" { = version }
+  "tezos-clic" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-client" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-signer-services" { = version }
+  "tezos-shell-services" { = version }
+  "uri" { >= "2.2.0" }
+]
+depopts: [
+  "ledgerwallet-tezos"
+]
+conflicts: [
+  "ledgerwallet-tezos" { < "0.2.1" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: remote-signature backends for `tezos-client`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-signer-services/tezos-signer-services.15.0/opam
+++ b/packages/tezos-signer-services/tezos-signer-services.15.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-rpc" { = version }
+  "tezos-client-base" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: descriptions of RPCs exported by `tezos-signer`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.15.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.15.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "base-unix"
+  "tezos-error-monad" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "tezos-event-logging" { = version }
+  "tezos-stdlib" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+  "lwt" { >= "5.6.0" }
+  "ipaddr" { >= "5.0.0" & < "6.0.0" }
+  "re" { >= "1.7.2" }
+  "ezjsonm" { >= "1.1.0" }
+  "ptime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" }
+  "lwt_log"
+  "conf-libev"
+  "uri" { >= "2.2.0" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library (unix-specific fragment)"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-stdlib/tezos-stdlib.15.0/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.15.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.12" }
+  "alcotest" { with-test & >= "1.5.0" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "lwt_log" {with-test}
+  "bigstring" {with-test}
+  "lwt" { >= "5.6.0" }
+  "tezos-test-helpers" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "ppx_expect"
+  "hex" { >= "1.3.0" }
+  "zarith" { >= "1.12" & < "1.13" }
+  "zarith_stubs_js"
+  "ringo" { >= "0.9" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: yet-another local-extension of the OCaml standard library"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-stdlib/tezos-stdlib.15.0/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.15.0/opam
@@ -19,7 +19,7 @@ depends: [
   "hex" { >= "1.3.0" }
   "zarith" { >= "1.12" & < "1.13" }
   "zarith_stubs_js"
-  "ringo" { >= "0.9" }
+  "ringo" { >= "0.9" & < "1.0.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-stdlib/tezos-stdlib.15.0/opam
+++ b/packages/tezos-stdlib/tezos-stdlib.15.0/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "MIT"
 depends: [
   "dune" { >= "3.0" }
-  "ocaml" { >= "4.12" }
+  "ocaml" { >= "4.14" }
   "alcotest" { with-test & >= "1.5.0" }
   "alcotest-lwt" { with-test & >= "1.5.0" }
   "lwt_log" {with-test}

--- a/packages/tezos-store/tezos-store.15.0/opam
+++ b/packages/tezos-store/tezos-store.15.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-validation" { = version }
+  "tezos-embedded-protocol-demo-noops" { with-test & = version }
+  "tezos-embedded-protocol-genesis" { with-test & = version }
+  "tezos-embedded-protocol-alpha" { with-test & = version }
+  "tezos-protocol-alpha" { with-test & = version }
+  "tezos-protocol-plugin-alpha" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-test-helpers-extra" { with-test & = version }
+  "tezos-context" { = version }
+  "tezos-protocol-environment" { = version }
+  "lwt-watcher" { = "0.2" }
+  "tezos-protocol-updater" { = version }
+  "tezos-version" { = version }
+  "index" { >= "1.6.0" & < "1.7.0" }
+  "irmin-pack" { >= "3.4.0" & < "3.5.0" }
+  "tezos-shell-context" { = version }
+  "tezos-stdlib" { = version }
+  "ringo-lwt" { >= "0.9" }
+  "camlzip" { >= "1.11" & < "1.12" }
+  "tar"
+  "tar-unix" { = "2.0.0" }
+  "prometheus" { >= "1.2" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: store for `octez-node`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}
+description: "This library provides abstraction for storing and iterating over blocks.
+tezos-store is a virtual library that provides two implementations:
+- tezos-store.real is the default implementation, used in production
+- tezos-store.mocked is used for testing purposes."

--- a/packages/tezos-store/tezos-store.15.0/opam
+++ b/packages/tezos-store/tezos-store.15.0/opam
@@ -26,7 +26,7 @@ depends: [
   "tezos-protocol-updater" { = version }
   "tezos-version" { = version }
   "index" { >= "1.6.0" & < "1.7.0" }
-  "irmin-pack" { >= "3.4.0" & < "3.5.0" }
+  "irmin-pack" { >= "3.4.3" & < "3.5.0" }
   "tezos-shell-context" { = version }
   "tezos-stdlib" { = version }
   "ringo-lwt" { >= "0.9" }

--- a/packages/tezos-test-helpers-extra/tezos-test-helpers-extra.15.0/opam
+++ b/packages/tezos-test-helpers-extra/tezos-test-helpers-extra.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.08" }
+  "tezos-base" { = version }
+  "tezos-crypto" { = version }
+  "tezos-test-helpers" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Test helpers dependent on tezos-base"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-test-helpers/tezos-test-helpers.15.0/opam
+++ b/packages/tezos-test-helpers/tezos-test-helpers.15.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ocaml" { >= "4.12" }
+  "uri" { >= "2.2.0" }
+  "fmt" { >= "0.8.7" }
+  "qcheck-alcotest" { >= "0.18" }
+  "alcotest" { >= "1.5.0" }
+  "lwt" { >= "5.6.0" }
+  "pure-splitmix" { = "0.3" }
+  "data-encoding" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos-agnostic test helpers"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-tree-encoding/tezos-tree-encoding.15.0/opam
+++ b/packages/tezos-tree-encoding/tezos-tree-encoding.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-lazy-containers" { = version }
+  "tezos-lwt-result-stdlib" { = version }
+  "data-encoding" { >= "0.6" & < "0.7" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "A general-purpose library to encode arbitrary data in Merkle trees"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-tx-rollup-014-PtKathma/tezos-tx-rollup-014-PtKathma.15.0/opam
+++ b/packages/tezos-tx-rollup-014-PtKathma/tezos-tx-rollup-014-PtKathma.15.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ppx_expect"
+  "index" { >= "1.6.0" & < "1.7.0" }
+  "tezos-base" { = version }
+  "tezos-crypto" { = version }
+  "tezos-protocol-014-PtKathma" { = version }
+  "tezos-client-014-PtKathma" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-context" { = version }
+  "tezos-baking-014-PtKathma-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-rpc" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-rpc-http-server" { = version }
+  "tezos-micheline" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-shell" { = version }
+  "tezos-store" { = version }
+  "tezos-workers" { = version }
+  "tezos-protocol-plugin-014-PtKathma" { = version }
+  "tezos-injector-014-PtKathma" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-tx-rollup`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-tx-rollup-015-PtLimaPt/tezos-tx-rollup-015-PtLimaPt.15.0/opam
+++ b/packages/tezos-tx-rollup-015-PtLimaPt/tezos-tx-rollup-015-PtLimaPt.15.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "ppx_expect"
+  "index" { >= "1.6.0" & < "1.7.0" }
+  "tezos-base" { = version }
+  "tezos-crypto" { = version }
+  "tezos-protocol-015-PtLimaPt" { = version }
+  "tezos-client-015-PtLimaPt" { = version }
+  "tezos-client-commands" { = version }
+  "tezos-context" { = version }
+  "tezos-baking-015-PtLimaPt-commands" { = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-rpc" { = version }
+  "tezos-rpc-http" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-rpc-http-server" { = version }
+  "tezos-micheline" { = version }
+  "tezos-client-base" { = version }
+  "tezos-client-base-unix" { = version }
+  "tezos-shell" { = version }
+  "tezos-store" { = version }
+  "tezos-workers" { = version }
+  "tezos-protocol-plugin-015-PtLimaPt" { = version }
+  "tezos-injector-015-PtLimaPt" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos/Protocol: protocol specific library for `tezos-tx-rollup`"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-validation/tezos-validation.15.0/opam
+++ b/packages/tezos-validation/tezos-validation.15.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-context" { = version }
+  "tezos-context-ops" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-protocol-updater" { = version }
+  "tezos-stdlib-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: library for blocks validation"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-version/tezos-version.15.0/opam
+++ b/packages/tezos-version/tezos-version.15.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "alcotest" { with-test & >= "1.5.0" }
+  "tezos-base" { = version }
+  "dune-configurator"
+  "ppx_deriving"
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: version information generated from Git"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-webassembly-interpreter/tezos-webassembly-interpreter.15.0/opam
+++ b/packages/tezos-webassembly-interpreter/tezos-webassembly-interpreter.15.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam" "WebAssembly Authors"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "Apache-2.0"
+depends: [
+  "dune" { >= "3.0" }
+  "alcotest" { with-test & >= "1.5.0" }
+  "ppx_deriving"
+  "tezos-lwt-result-stdlib" { = version }
+  "zarith" { >= "1.12" & < "1.13" }
+  "tezos-lazy-containers" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "WebAssembly reference interpreter with tweaks for Tezos"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-webassembly-interpreter/tezos-webassembly-interpreter.15.0/opam
+++ b/packages/tezos-webassembly-interpreter/tezos-webassembly-interpreter.15.0/opam
@@ -7,6 +7,7 @@ dev-repo: "git+https://gitlab.com/tezos/tezos.git"
 license: "Apache-2.0"
 depends: [
   "dune" { >= "3.0" }
+  "ocaml" { >= "4.14" }
   "alcotest" { with-test & >= "1.5.0" }
   "ppx_deriving"
   "tezos-lwt-result-stdlib" { = version }

--- a/packages/tezos-workers/tezos-workers.15.0/opam
+++ b/packages/tezos-workers/tezos-workers.15.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-stdlib" { with-test & = version }
+  "tezos-stdlib-unix" { = version }
+  "tezos-base" { = version }
+  "tezos-test-helpers" { with-test & = version }
+  "tezos-base-test-helpers" { with-test & = version }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "ringo" { >= "0.9" }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: worker library"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/tezos-workers/tezos-workers.15.0/opam
+++ b/packages/tezos-workers/tezos-workers.15.0/opam
@@ -13,7 +13,7 @@ depends: [
   "tezos-test-helpers" { with-test & = version }
   "tezos-base-test-helpers" { with-test & = version }
   "alcotest-lwt" { with-test & >= "1.5.0" }
-  "ringo" { >= "0.9" }
+  "ringo" { >= "0.9" & < "1.0.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]


### PR DESCRIPTION
Octez 15.0 has been released recently. Octez is an implementation of the Tezos blockchain. Note that in this release, the executables have been renamed (from `tezos-*` to `octez-*` in particular), and the corresponding opam packages have been renamed too.

This patch was generated from a new automatic release process so I expect there to be some issues, but `opam install octez` worked on my laptop.