### PR TITLE
[new release] netchannel and mirage-net-xen (2.1.2)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.2/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "netchannel" {= version}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.2/mirage-net-xen-2.1.2.tbz"
+  checksum: [
+    "sha256=9539b070d2a26aae4474974ce1469a015759fa14c25f953d30f298febde2edfc"
+    "sha512=5a465539a5b8a9d63de3005493f22d9428f5cc6c6155a4157d2b6bb0e604cfcd081894c40f6b223dfe6fec8e47c94371513d1fea8d2b62133a61c4ebcb3c6468"
+  ]
+}
+x-commit-hash: "939dfcbfc31f6c396532c08d8857f2672d90f2f3"

--- a/packages/netchannel/netchannel.2.1.2/opam
+++ b/packages/netchannel/netchannel.2.1.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "7.0.0"}
+  "ipaddr" {>= "3.0.0"}
+  "mirage-profile" {>="0.3"}
+  "shared-memory-ring" {>="3.0.0"}
+  "sexplib" {>= "113.01.00"}
+  "logs" {>= "0.5.0"}
+  "lwt-dllist"
+  "result" {>= "1.5"}
+  "macaddr" {>= "5.2.0"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+
+Note: the `Netif` module is the public API.
+The `Netchannel` API is still under development.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.2/mirage-net-xen-2.1.2.tbz"
+  checksum: [
+    "sha256=9539b070d2a26aae4474974ce1469a015759fa14c25f953d30f298febde2edfc"
+    "sha512=5a465539a5b8a9d63de3005493f22d9428f5cc6c6155a4157d2b6bb0e604cfcd081894c40f6b223dfe6fec8e47c94371513d1fea8d2b62133a61c4ebcb3c6468"
+  ]
+}
+x-commit-hash: "939dfcbfc31f6c396532c08d8857f2672d90f2f3"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* netback: go to closed state before removing vif from xenstore (@palainp,
  mirage/mirage-net-xen#105, addresses mirage/qubes-mirage-firewall#157)
