### PR TITLE
obus is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/obus/obus.1.1.8/opam
+++ b/packages/obus/obus.1.1.8/opam
@@ -9,7 +9,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "obus"]]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "lwt" {>= "2.7.0" & < "5.0.0"}
   "lwt_react"

--- a/packages/obus/obus.1.2.0/opam
+++ b/packages/obus/obus.1.2.0/opam
@@ -13,6 +13,7 @@ build: [
 ]
 
 depends: [
+  "ocaml" {< "5.0"}
   "dune" {>= "1.4"}
   "menhir" {build & >= "20180528"}
   "xmlm"

--- a/packages/obus/obus.1.2.1/opam
+++ b/packages/obus/obus.1.2.1/opam
@@ -13,6 +13,7 @@ build: [
 ]
 
 depends: [
+  "ocaml" {< "5.0"}
   "dune" {>= "1.4"}
   "menhir" {build & >= "20180528"}
   "xmlm"

--- a/packages/obus/obus.1.2.2/opam
+++ b/packages/obus/obus.1.2.2/opam
@@ -13,6 +13,7 @@ build: [
 ]
 
 depends: [
+  "ocaml" {< "5.0"}
   "dune" {>= "1.4"}
   "menhir" {build & >= "20180528"}
   "xmlm"

--- a/packages/obus/obus.1.2.3/opam
+++ b/packages/obus/obus.1.2.3/opam
@@ -13,6 +13,7 @@ build: [
 ]
 
 depends: [
+  "ocaml" {< "5.0"}
   "dune" {>= "1.4"}
   "menhir" {build & >= "20180528"}
   "xmlm"


### PR DESCRIPTION
```
#=== ERROR while compiling obus.1.2.3 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/obus.1.2.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p obus -j 255
# exit-code            1
# env-file             ~/.opam/log/obus-8-22dfe9.env
# output-file          ~/.opam/log/obus-8-22dfe9.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -bin-annot -I src/internals/.obus_internals.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/xmlm -intf-suffix .ml -no-alias-deps -o src/internals/.obus_internals.objs/byte/oBus_path.cmo -c -impl src/internals/oBus_path.pp.ml)
# File "src/internals/oBus_path.ml", line 17, characters 14-32:
# 17 | let compare = Pervasives.compare
#                    ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -I src/internals/.obus_internals.objs/byte -I src/internals/.obus_internals.objs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/xmlm -intf-suffix .ml -no-alias-deps -o src/internals/.obus_internals.objs/native/oBus_path.cmx -c -impl src/internals/oBus_path.pp.ml)
# File "src/internals/oBus_path.ml", line 17, characters 14-32:
# 17 | let compare = Pervasives.compare
#                    ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/menhir src/idl/parser.mly --base src/idl/parser --infer-read-reply src/idl/parser__mock.mli.inferred)
# Warning: one state has shift/reduce conflicts.
# Warning: one state has reduce/reduce conflicts.
# Warning: 2 shift/reduce conflicts were arbitrarily resolved.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -bin-annot -I src/protocol/.obus.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/lwt_react -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/react -I /home/opam/.opam/5.0/lib/xmlm -I src/internals/.obus_internals.objs/byte -intf-suffix .ml -no-alias-deps -o src/protocol/.obus.objs/byte/oBus_wire.cmo -c -impl src/protocol/oBus_wire.pp.ml)
# File "src/protocol/oBus_wire.ml", line 513, characters 71-89:
# 513 | module FD_map = Map.Make(struct type t = Unix.file_descr let compare = Pervasives.compare end)
#                                                                              ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -bin-annot -I src/protocol/.obus.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/lwt_react -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/react -I /home/opam/.opam/5.0/lib/xmlm -I src/internals/.obus_internals.objs/byte -intf-suffix .ml -no-alias-deps -o src/protocol/.obus.objs/byte/oBus_connection.cmo -c -impl src/protocol/oBus_connection.pp.ml)
# File "src/protocol/oBus_connection.ml", line 134, characters 30-48:
# 134 | let compare : t -> t -> int = Pervasives.compare
#                                     ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -bin-annot -I src/protocol/.obus.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/lwt_react -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/react -I /home/opam/.opam/5.0/lib/xmlm -I src/internals/.obus_internals.objs/byte -intf-suffix .ml -no-alias-deps -o src/protocol/.obus.objs/byte/oBus_peer.cmo -c -impl src/protocol/oBus_peer.pp.ml)
# File "src/protocol/oBus_peer.ml", line 17, characters 14-32:
# 17 | let compare = Pervasives.compare
#                    ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -bin-annot -I src/protocol/.obus.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/lwt_react -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/react -I /home/opam/.opam/5.0/lib/xmlm -I src/internals/.obus_internals.objs/byte -intf-suffix .ml -no-alias-deps -o src/protocol/.obus.objs/byte/oBus_proxy.cmo -c -impl src/protocol/oBus_proxy.pp.ml)
# File "src/protocol/oBus_proxy.ml", line 20, characters 14-32:
# 20 | let compare = Pervasives.compare
#                    ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-7-9-27-32-33-34-35-37-38-39 -g -bin-annot -I src/protocol/.obus.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/lwt_react -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/react -I /home/opam/.opam/5.0/lib/xmlm -I src/internals/.obus_internals.objs/byte -intf-suffix .ml -no-alias-deps -o src/protocol/.obus.objs/byte/oBus_signal.cmo -c -impl src/protocol/oBus_signal.pp.ml)
# File "src/protocol/oBus_signal.ml", line 122, characters 19-37:
# 122 |      let compare = Pervasives.compare
#                          ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```