### PR TITLE
mirage-clock-unix.1.0.0: Add missing dependency

### DIFF
--- a/packages/mirage-clock-unix/mirage-clock-unix.1.0.0/opam
+++ b/packages/mirage-clock-unix/mirage-clock-unix.1.0.0/opam
@@ -10,6 +10,7 @@ remove: ["ocamlfind" "remove" "mirage-clock-unix"]
 depends: [
   "ocaml"
   "ocamlfind"
+  "ocamlbuild"
   "mirage-types" {>= "0.3.0" & < "3.0.0"}
 ]
 synopsis: "A Mirage-compatible Clock library for Unix"


### PR DESCRIPTION
```
#=== ERROR while installing mirage-clock-unix.1.0.0 ===========================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mirage-clock-unix.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh install make unix-install
# exit-code            2
# env-file             ~/.opam/log/mirage-clock-unix-8-3b1374.env
# output-file          ~/.opam/log/mirage-clock-unix-8-3b1374.out
### output ###
# OS=unix ./build true
# ./build: 6: ocamlbuild: not found
# ocamlfind: [WARNING] No such file: /home/opam/.opam/5.0/lib/mirage-clock-unix/META
# ocamlfind: _build/unix/mirage-clock.cmxs: No such file or directory
# make: *** [Makefile:14: unix-install] Error 2
```