### PR TITLE
mirage-unix < 3.0.5 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/mirage-unix/mirage-unix.0.9.1/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.1/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.2/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.2/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.3/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.3/opam
@@ -3,7 +3,7 @@ maintainer: "anil@recoil.org"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.4/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.4/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.5/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.5/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.6/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.6/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.7/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.7/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.7.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.0" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.8/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.8/opam
@@ -6,7 +6,7 @@ homepage:     "https://github.com/mirage/mirage-platform"
 bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 remove: [["ocamlfind" "remove" "mirage"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "cstruct" {>= "0.8.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.0.9.9/opam
+++ b/packages/mirage-unix/mirage-unix.0.9.9/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.1.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.0.0/opam
@@ -6,7 +6,7 @@ bug-reports:  "https://github.com/mirage/mirage-platform/issues/"
 build: [make "unix-build"]
 remove: [[make "unix-uninstall" "PREFIX=%{prefix}%"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.1.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.1.1.0/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.0/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.0.1/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.0/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.1/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.2/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.1.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.1.3/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.0/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.1/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.2/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.2/opam
@@ -8,7 +8,7 @@ remove: [
   [make "unix-uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind" {build}
   "lwt" {>= "2.4.3" & < "4.0.0"}

--- a/packages/mirage-unix/mirage-unix.2.2.3/opam
+++ b/packages/mirage-unix/mirage-unix.2.2.3/opam
@@ -8,7 +8,7 @@ build: [make "unix-build"]
 install: [make "unix-install" "PREFIX=%{prefix}%"]
 remove: [make "unix-uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"
   "ocamlfind" {build}

--- a/packages/mirage-unix/mirage-unix.2.3.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.3.1/opam
@@ -8,7 +8,7 @@ build: [make "unix-build"]
 install: [make "unix-install" "PREFIX=%{prefix}%"]
 remove: [make "unix-uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "cstruct" {>= "1.0.1" & <= "1.9.0"}
   "type_conv"
   "conf-which" {build}

--- a/packages/mirage-unix/mirage-unix.2.4.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.0/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "conf-which" {build}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"

--- a/packages/mirage-unix/mirage-unix.2.4.1/opam
+++ b/packages/mirage-unix/mirage-unix.2.4.1/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "conf-which" {build}
   "cstruct" {>= "1.0.1" & < "2.0.0"}
   "ocamlfind"

--- a/packages/mirage-unix/mirage-unix.2.5.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.5.0/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "conf-which" {build}
   "cstruct" {>= "1.0.1"}
   "ocamlfind"

--- a/packages/mirage-unix/mirage-unix.2.6.0/opam
+++ b/packages/mirage-unix/mirage-unix.2.6.0/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "conf-which" {build}
   "cstruct" {>= "1.0.1"}
   "ocamlfind" {build}

--- a/packages/mirage-unix/mirage-unix.3.0.0/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.0/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}

--- a/packages/mirage-unix/mirage-unix.3.0.1/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.1/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}

--- a/packages/mirage-unix/mirage-unix.3.0.3/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.3/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}

--- a/packages/mirage-unix/mirage-unix.3.0.4/opam
+++ b/packages/mirage-unix/mirage-unix.3.0.4/opam
@@ -10,7 +10,7 @@ install: [make "unix-install"   "PREFIX=%{prefix}%"]
 remove:  [make "unix-uninstall" "PREFIX=%{prefix}%"]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "cstruct" {>= "1.0.1"}


### PR DESCRIPTION
```
#=== ERROR while compiling mirage-unix.3.0.4 ==================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mirage-unix.3.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make unix-build
# exit-code            2
# env-file             ~/.opam/log/mirage-unix-8-f48496.env
# output-file          ~/.opam/log/mirage-unix-8-f48496.out
### output ###
# make MIRAGE_OS=unix PREFIX=/usr/local build
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/mirage-unix.3.0.4'
# cd unix && make all MIRAGE_OS=unix
# make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/mirage-unix.3.0.4/unix'
# Makefile:43: warning: overriding recipe for target 'uninstall'
# Makefile:22: warning: ignoring old recipe for target 'uninstall'
# ocaml setup.ml -all 
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
# make[2]: *** [Makefile:16: all] Error 2
# make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/mirage-unix.3.0.4/unix'
# make[1]: *** [Makefile:12: build] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/mirage-unix.3.0.4'
# make: *** [Makefile:30: unix-build] Error 2
```