### PR TITLE
hashcons.1.0.1 is not compatible with OCaml 5.0 (uses Array.create)

### DIFF
--- a/packages/hashcons/hashcons.1.0.1/opam
+++ b/packages/hashcons/hashcons.1.0.1/opam
@@ -14,7 +14,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "hashcons"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-which" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling hashcons.1.0.1 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/hashcons.1.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/hashcons-9-6ec181.env
# output-file          ~/.opam/log/hashcons-9-6ec181.out
### output ###
# rm -f .depend
# ocamldep *.mli *.ml > .depend
# ocamlc.opt -c  hashcons.mli
# ocamlc.opt -c  hashcons.ml
# File "hashcons.ml", line 38, characters 12-24:
# 38 |   { table = Array.create sz emptybucket;
#                  ^^^^^^^^^^^^
# Error: Unbound value Array.create
# make: *** [Makefile:106: hashcons.cmo] Error 2
```