### PR TITLE
xen-gnt-unix is not compatible with OCaml 5.0 (bigarray C API change)

### DIFF
--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "jbuilder" {>= "1.0+beta9"}
   "xen-gnt"

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.0.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta9"}
   "xen-gnt" {= "3.0.1"}
   "io-page-unix" {>= "2.0.0"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.3.1.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/ocaml-gnt"
 doc: "https://mirage.github.io/ocaml-gnt/"
 bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.0"}
   "xen-gnt"
   "io-page-unix" {>= "2.0.0"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/ocaml-gnt"
 doc: "https://mirage.github.io/ocaml-gnt/"
 bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.0"}
   "xen-gnt"
   "io-page-unix" {>= "2.0.0"}

--- a/packages/xen-gnt-unix/xen-gnt-unix.4.0.1/opam
+++ b/packages/xen-gnt-unix/xen-gnt-unix.4.0.1/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/mirage/ocaml-gnt"
 doc: "https://mirage.github.io/ocaml-gnt/"
 bug-reports: "https://github.com/mirage/ocaml-gnt/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "1.0"}
   "xen-gnt" {= version}
   "conf-xen"


### PR DESCRIPTION
```
#=== ERROR while compiling xen-gnt-unix.4.0.1 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/xen-gnt-unix.4.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p xen-gnt-unix -j 31
# exit-code            1
# env-file             ~/.opam/log/xen-gnt-unix-9-66798b.env
# output-file          ~/.opam/log/xen-gnt-unix-9-66798b.out
### output ###
# File "lib/dune", line 12, characters 10-22:
# 12 |  (c_names gntshr_stubs gnttab_stubs)
#                ^^^^^^^^^^^^
# (cd _build/default/lib && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -o gntshr_stubs.o -c gntshr_stubs.c)
# gntshr_stubs.c: In function 'gntshr_missing':
# gntshr_stubs.c:47:20: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#    47 |         value *v = caml_named_value("gntshr.missing");
#       |                    ^~~~~~~~~~~~~~~~
# gntshr_stubs.c: In function 'stub_gntshr_share_pages_batched':
# gntshr_stubs.c:54:18: warning: passing argument 1 of 'failwith_xc' from incompatible pointer type [-Wincompatible-pointer-types]
#    54 | #define _G(__g) ((xc_gntshr *)(__g))
#       |                 ~^~~~~~~~~~~~~~~~~~~
#       |                  |
#       |                  xc_gntshr * {aka struct xengntdev_handle *}
# gntshr_stubs.c:133:29: note: in expansion of macro '_G'
#   133 |                 failwith_xc(_G(xgh));
#       |                             ^~
# gntshr_stubs.c:60:39: note: expected 'xc_interface *' {aka 'struct xc_interface_core *'} but argument is of type 'xc_gntshr *' {aka 'struct xengntdev_handle *'}
#    60 | static void failwith_xc(xc_interface *xch)
#       |                         ~~~~~~~~~~~~~~^~~
# gntshr_stubs.c:147:18: warning: implicit declaration of function 'alloc_bigarray_dims' [-Wimplicit-function-declaration]
#   147 |         ml_map = alloc_bigarray_dims(XC_GNTTAB_BIGARRAY, 1,
#       |                  ^~~~~~~~~~~~~~~~~~~
# gntshr_stubs.c: In function 'stub_gntshr_munmap_batched':
# gntshr_stubs.c:166:20: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
#   166 |         int size = Bigarray_val(ml_map)->dim[0];
#       |                    ^~~~~~~~~~~~
# gntshr_stubs.c:166:40: error: invalid type argument of '->' (have 'int')
#   166 |         int size = Bigarray_val(ml_map)->dim[0];
#       |                                        ^~
# gntshr_stubs.c:171:29: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
#   171 |         int result = munmap(Data_bigarray_val(ml_map), size);
#       |                             ^~~~~~~~~~~~~~~~~
#       |                             Caml_ba_array_val
# gntshr_stubs.c:171:29: warning: passing argument 1 of 'munmap' makes pointer from integer without a cast [-Wint-conversion]
#   171 |         int result = munmap(Data_bigarray_val(ml_map), size);
#       |                             ^~~~~~~~~~~~~~~~~~~~~~~~~
#       |                             |
#       |                             int
# In file included from gntshr_stubs.c:27:
# /usr/include/x86_64-linux-gnu/sys/mman.h:76:26: note: expected 'void *' but argument is of type 'int'
#    76 | extern int munmap (void *__addr, size_t __len) __THROW;
#       |                    ~~~~~~^~~~~~
# gntshr_stubs.c:54:18: warning: passing argument 1 of 'failwith_xc' from incompatible pointer type [-Wincompatible-pointer-types]
#    54 | #define _G(__g) ((xc_gntshr *)(__g))
#       |                 ~^~~~~~~~~~~~~~~~~~~
#       |                  |
#       |                  xc_gntshr * {aka struct xengntdev_handle *}
# gntshr_stubs.c:176:29: note: in expansion of macro '_G'
#   176 |                 failwith_xc(_G(xgh));
#       |                             ^~
# gntshr_stubs.c:60:39: note: expected 'xc_interface *' {aka 'struct xc_interface_core *'} but argument is of type 'xc_gntshr *' {aka 'struct xengntdev_handle *'}
#    60 | static void failwith_xc(xc_interface *xch)
#       |                         ~~~~~~~~~~~~~~^~~
```