### PR TITLE
Package dkml-runtime-common.1.0.2~prerel7

### DIFF
--- a/packages/dkml-runtime-common/dkml-runtime-common.1.0.2~prerel7/opam
+++ b/packages/dkml-runtime-common/dkml-runtime-common.1.0.2~prerel7/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+synopsis: "Common runtime code used in DKML"
+description: "Common runtime code used in DKML"
+maintainer: "opensource+diskuv-ocaml@support.diskuv.com"
+authors: "Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-runtime-common"
+bug-reports: "https://github.com/diskuv/dkml-runtime-common/issues"
+install: [
+  [".\\install.cmd" "%{_:lib}%"] {os = "win32"}
+  ["./install.sh" "%{_:lib}%"] {!(os = "win32")}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-runtime-common.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-runtime-common/releases/download/1.0.2-prerel7/src.tar.gz"
+  checksum: [
+    "md5=4fefeb6f108a3e5ed40eec10a36eb71e"
+    "sha512=14e062803b4eb5f58a74ec2e8a59736568304e9554c32e67def7d6228fcfaef8d60d3a16c3d71971fe57887d773e33bb91f55feabc1b147fcc6f9aa077846b1c"
+  ]
+}


### PR DESCRIPTION
### `dkml-runtime-common.1.0.2~prerel7`
Common runtime code used in DKML
Common runtime code used in DKML



---
* Homepage: https://github.com/diskuv/dkml-runtime-common
* Source repo: git+https://github.com/diskuv/dkml-runtime-common.git
* Bug tracker: https://github.com/diskuv/dkml-runtime-common/issues

---
:camel: Pull-request generated by opam-publish v2.1.0