### PR TITLE
conf-hidapi: install optional dep in arch, mark CI as failing in ol

### DIFF
--- a/packages/conf-hidapi/conf-hidapi.0/opam
+++ b/packages/conf-hidapi/conf-hidapi.0/opam
@@ -12,13 +12,16 @@ depends: ["conf-pkg-config" {build}]
 depexts: [
   ["libhidapi-dev"] {os-family = "debian"}
   ["libhidapi-devel"] {os-family = "suse"}
-  ["hidapi"] {os-distribution = "arch"}
+  ["hidapi" "libusb"] {os-distribution = "arch"}
   ["hidapi-devel"] {os-distribution = "fedora"}
   ["hidapi"] {os = "macos" & os-distribution = "homebrew"}
   ["hidapi"] {os = "freebsd"}
   ["hidapi-dev"] {os-distribution = "alpine"}
   ["epel-release" "hidapi-devel"] {os-distribution = "centos"}
   ["hidapi"] {os-distribution = "nixos"}
+]
+x-ci-accept-failures: [
+  "oraclelinux-8"
 ]
 synopsis: "Virtual package relying on a hidapi system installation"
 description:


### PR DESCRIPTION
Fixes for the `conf-hidapi` package following some CI failures in https://github.com/ocaml/opam-repository/pull/22482