### PR TITLE
[new release] toc (0.1.0)

### DIFF
--- a/packages/toc/toc.0.1.0/opam
+++ b/packages/toc/toc.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A generator of table of contents for Github Markdown files"
+maintainer: ["Thomas Gazagnaire"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/samoht/toc"
+bug-reports: "https://github.com/samoht/toc/issues"
+depends: [
+  "alcotest" {with-test}
+  "ocaml"
+  "dune" {>= "3.5"}
+  "omd" {>= "2.0.0~alpha2"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "fmt"
+  "astring"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/samoht/toc.git"
+url {
+  src: "https://github.com/samoht/toc/releases/download/0.1.0/toc-0.1.0.tbz"
+  checksum: [
+    "sha256=39b0838e508e1b54bf26c8c32efb2206e726a5ae6aceaafaa26d0df51293ec44"
+    "sha512=c34e54770b70f1892c548838f5d123b222c7cfbe17f40a9f9f02663936665d6088200d8282fee0810544dcf94c4bd30861fb72f15680f8f0c955db8c6da0690c"
+  ]
+}
+x-commit-hash: "46eaaeed42835b7651da21fc24698117c1107191"


### PR DESCRIPTION
A generator of table of contents for Github Markdown files

- Project page: <a href="https://github.com/samoht/toc">https://github.com/samoht/toc</a>

##### CHANGES:

- Initial release
