### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-lwt and js_of_ocaml-compiler (4.1.0)

### DIFF
--- a/packages/brr/brr.0.0.1/opam
+++ b/packages/brr/brr.0.0.1/opam
@@ -15,7 +15,7 @@ depends:
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}
   "js_of_ocaml-compiler" {>= "3.7.1"}
-  "js_of_ocaml-toplevel" {>= "3.7.1"}
+  "js_of_ocaml-toplevel" {>= "3.7.1" & < "4.1.0"}
   "note"
 ]
 build:

--- a/packages/brr/brr.0.0.2/opam
+++ b/packages/brr/brr.0.0.2/opam
@@ -12,7 +12,7 @@ depends: ["ocaml" {>= "4.08.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "js_of_ocaml-compiler" {>= "3.7.1"}
-          "js_of_ocaml-toplevel" {>= "3.7.1"}
+          "js_of_ocaml-toplevel" {>= "3.7.1" & < "4.1.0"}
           "note"]
 build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
 url {

--- a/packages/brr/brr.0.0.3/opam
+++ b/packages/brr/brr.0.0.3/opam
@@ -12,7 +12,7 @@ depends: ["ocaml" {>= "4.08.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "js_of_ocaml-compiler" {>= "4.0.0"}
-          "js_of_ocaml-toplevel" {>= "4.0.0"}
+          "js_of_ocaml-toplevel" {>= "4.0.0" & < "4.1.0"}
           "note"]
 build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04" & < "5.1"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.4.1.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.4.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.4.1.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.4.1.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.4.1.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.4.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.4.1.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.4.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/js_of_ocaml/js_of_ocaml.4.1.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.4.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/4.1.0/js_of_ocaml-4.1.0.tbz"
+  checksum: [
+    "sha256=91793f29a5af3deaba3f7d35ceab11e739cfe0a5cc30556f6201461a6d4236ef"
+    "sha512=43f91c1f37939dfc894558a23a8ca163e6f316db442bdd0a5909bd095f5b0eb596d0943883452f4b78641da71222a775476877ea9ba0500583700d1fb35e04a5"
+  ]
+}
+x-commit-hash: "9cb30b78c1a4bde6176652b94c96b26e1140f8a4"

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.10.1/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.10.1/opam
@@ -12,6 +12,7 @@ install: [ make "install" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.12.1"}
+  "js_of_ocaml-lwt" {< "4.1.0"}
   "calendar"
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.12.2/opam
@@ -12,6 +12,7 @@ install: [ make "install" ]
 depends: [
   "ocaml" {>= "4.08.0"}
   "eliom" {>= "6.12.1"}
+  "js_of_ocaml-lwt" {< "4.1.0"}
   "calendar" {>= "2.0.0"}
 ]
 depexts: [

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.7.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.7.0/opam
@@ -13,6 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.10.1"}
+  "js_of_ocaml-lwt" {< "4.1.0"}
   "calendar" {>= "2.00"}
 ]
 url {

--- a/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
+++ b/packages/ocsigen-toolkit/ocsigen-toolkit.2.8.0/opam
@@ -13,6 +13,7 @@ remove: [ make "uninstall" ]
 depends: [
   "ocaml" {>= "4.07.0"}
   "eliom" {>= "6.12.1"}
+  "js_of_ocaml-lwt" {< "4.1.0"}
   "calendar" {>= "2.00"}
 ]
 url {


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Compiler: initial support for OCaml 5 (ocsigen/js_of_ocaml#1265,ocsigen/js_of_ocaml#1303)
* Compiler: bump magic number to match the 5.0.0~alpha0 release (ocsigen/js_of_ocaml#1288)
* Compiler: complain when runtime and compiler built-in primitives disagree (ocsigen/js_of_ocaml#1312)
* Compiler: more efficient implementation of Js_traverse.freevar
* Compiler: more efficient implementation of Js_traverse.rename_variable
* Compiler: --linkall now export all compilation units in addition to primitives (ocsigen/js_of_ocaml#1324)
* Compiler: improve --dynlink, one no longer need to pass --toplevel to use Dynlink (ocsigen/js_of_ocaml#1324)
* Compiler: toplevel runtime files "+toplevel.js" and "+dynlink.js" are added automatically (ocsigen/js_of_ocaml#1324)
* Misc: switch to cmdliner.1.1.0
* Misc: remove old binaries jsoo_link, jsoo_fs
* Misc: remove uchar dep
* Misc: use 4.14 in the CI
* Misc: switch to dune 3
* Lib: add missing options for Intl.DateTimeFormat
* Lib: add missing options for Intl.NumberFormat
* Lib: wheel event binding
* Lib: add normalize in js_string (ES6)
* Lib: more complete transition event bindings
* Lib: remove support for old browser-specific transition events
* Runtime: Implement weak semantic for weak and ephemeron
* Runtime: Implement Gc.finalise_last
* Runtime: Implement buffer for in_channels
* Runtime: add support for unix_opendir, unix_readdir, unix_closedir, win_findfirst, win_findnext, win_findclose
* Runtime: Dont use require when target-env is browser
* Runtime: Implements Parsing.set_trace (ocsigen/js_of_ocaml#1308)
* Test: track external used in the stdlib and unix

## Bug fixes
* Compiler: fix quadratic behavior of dominance frontier (fix ocsigen/js_of_ocaml#1300)
* Compiler: fix rewriter bug in share_constant (fix ocsigen/js_of_ocaml#1247)
* Compiler: fix miscompilation of mutually recursive functions in loop (ocsigen/js_of_ocaml#1321)
* Compiler: fix bug while minifying/renaming try-catch blocks
* Compiler: no dead code elimination for caml_js_get
* Runtime: fix ocamlyacc parse engine (ocsigen/js_of_ocaml#1307)
* Runtime: fix Out_channel.is_buffered, set_buffered
* Runtime: fix format wrt alternative
* Runtime: fix Digest.channel
* Runtime: sync channel seek / pos with the native runtime
* Misc: fix installation with dune 3 without opam
* Node: Only write small chunks to stdout/stderr so they flush
* Deriving: fix for nested polymorphic variants
