### PR TITLE
Fix conf-npm system dependency on OpenSUSE.

### DIFF
--- a/packages/conf-npm/conf-npm.1/opam
+++ b/packages/conf-npm/conf-npm.1/opam
@@ -20,7 +20,7 @@ depexts: [
   ["npm5"] {os-distribution = "macports" & os = "macos"}
   ["nodejs"] {os = "netbsd"}
   ["node"] {os = "openbsd"}
-  ["npm"] {os-family = "suse"}
+  ["npm-default"] {os-family = "suse"}
 ]
 x-ci-accept-failures: [
   "oraclelinux-7" # not available


### PR DESCRIPTION
This is a blind fix based on [this ocaml-ci issue](https://github.com/ocurrent/ocaml-ci/issues/602).