### PR TITLE
Octez: add octez-proxy-server

### DIFF
--- a/packages/octez-proxy-server/octez-proxy-server.15.0/opam
+++ b/packages/octez-proxy-server/octez-proxy-server.15.0/opam
@@ -1,0 +1,98 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-stdlib-unix" { = version }
+  "cmdliner" { >= "1.1.0" }
+  "lwt-exit"
+  "lwt" { >= "5.6.0" }
+  "tezos-proxy" { = version }
+  "tezos-proxy-server-config" { = version }
+  "tezos-rpc-http-client-unix" { = version }
+  "tezos-rpc-http-server" { = version }
+  "tezos-shell-services" { = version }
+  "tezos-shell-context" { = version }
+  "tezos-version" { = version }
+  "uri" { >= "2.2.0" }
+]
+depopts: [
+  "tezos-client-genesis"
+  "tezos-client-demo-counter"
+  "tezos-client-000-Ps9mPmXa"
+  "tezos-client-001-PtCJ7pwo"
+  "tezos-client-002-PsYLVpVv"
+  "tezos-client-003-PsddFKi3"
+  "tezos-client-004-Pt24m4xi"
+  "tezos-client-005-PsBabyM1"
+  "tezos-client-006-PsCARTHA"
+  "tezos-client-007-PsDELPH1"
+  "tezos-protocol-plugin-007-PsDELPH1"
+  "tezos-client-008-PtEdo2Zk"
+  "tezos-protocol-plugin-008-PtEdo2Zk"
+  "tezos-client-009-PsFLoren"
+  "tezos-protocol-plugin-009-PsFLoren"
+  "tezos-client-010-PtGRANAD"
+  "tezos-protocol-plugin-010-PtGRANAD"
+  "tezos-client-011-PtHangz2"
+  "tezos-protocol-plugin-011-PtHangz2"
+  "tezos-client-012-Psithaca"
+  "tezos-protocol-plugin-012-Psithaca"
+  "tezos-client-013-PtJakart"
+  "tezos-protocol-plugin-013-PtJakart"
+  "tezos-client-014-PtKathma"
+  "tezos-protocol-plugin-014-PtKathma"
+  "tezos-client-015-PtLimaPt"
+  "tezos-protocol-plugin-015-PtLimaPt"
+  "tezos-client-alpha"
+  "tezos-protocol-plugin-alpha"
+]
+conflicts: [
+  "tezos-client-genesis" { != version }
+  "tezos-client-demo-counter" { != version }
+  "tezos-client-000-Ps9mPmXa" { != version }
+  "tezos-client-001-PtCJ7pwo" { != version }
+  "tezos-client-002-PsYLVpVv" { != version }
+  "tezos-client-003-PsddFKi3" { != version }
+  "tezos-client-004-Pt24m4xi" { != version }
+  "tezos-client-005-PsBabyM1" { != version }
+  "tezos-client-006-PsCARTHA" { != version }
+  "tezos-client-007-PsDELPH1" { != version }
+  "tezos-protocol-plugin-007-PsDELPH1" { != version }
+  "tezos-client-008-PtEdo2Zk" { != version }
+  "tezos-protocol-plugin-008-PtEdo2Zk" { != version }
+  "tezos-client-009-PsFLoren" { != version }
+  "tezos-protocol-plugin-009-PsFLoren" { != version }
+  "tezos-client-010-PtGRANAD" { != version }
+  "tezos-protocol-plugin-010-PtGRANAD" { != version }
+  "tezos-client-011-PtHangz2" { != version }
+  "tezos-protocol-plugin-011-PtHangz2" { != version }
+  "tezos-client-012-Psithaca" { != version }
+  "tezos-protocol-plugin-012-Psithaca" { != version }
+  "tezos-client-013-PtJakart" { != version }
+  "tezos-protocol-plugin-013-PtJakart" { != version }
+  "tezos-client-014-PtKathma" { != version }
+  "tezos-protocol-plugin-014-PtKathma" { != version }
+  "tezos-client-015-PtLimaPt" { != version }
+  "tezos-protocol-plugin-015-PtLimaPt" { != version }
+  "tezos-client-alpha" { != version }
+  "tezos-protocol-plugin-alpha" { != version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Octez: `octez-proxy-server` binary"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}

--- a/packages/octez/octez.15.0/opam
+++ b/packages/octez/octez.15.0/opam
@@ -17,6 +17,7 @@ depends: [
   "octez-client" { = version }
   "octez-codec" { = version }
   "octez-node" { = version }
+  "octez-proxy-server" { = version }
   "octez-signer" { = version }
   "octez-tx-rollup-client-PtKathma" { = version }
   "octez-tx-rollup-client-PtLimaPt" { = version }

--- a/packages/tezos-proxy-server-config/tezos-proxy-server-config.15.0/opam
+++ b/packages/tezos-proxy-server-config/tezos-proxy-server-config.15.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "contact@tezos.com"
+authors: ["Tezos devteam"]
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos/issues"
+dev-repo: "git+https://gitlab.com/tezos/tezos.git"
+license: "MIT"
+depends: [
+  "dune" { >= "3.0" }
+  "tezos-base" { = version }
+  "tezos-test-helpers" { with-test & = version }
+  "qcheck-alcotest" { with-test & >= "0.18" }
+  "alcotest-lwt" { with-test & >= "1.5.0" }
+  "uri" { >= "2.2.0" }
+  "tezos-stdlib-unix" { = version }
+]
+build: [
+  ["rm" "-r" "vendors"]
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Tezos: proxy server configuration"
+url {
+  src: "https://gitlab.com/tezos/tezos/-/package_files/58329735/download"
+  checksum: [
+    "sha256=c877d89e9fed2012aa6b541232f54723294d1356baa75bf8af99362ade8d6557"
+    "sha512=a7c37b9e3095978d16c7b82e377deca1d2edda1c441cd031f93c4e5d9d0d95ed8b2198d8a99d10407ef923559b8a7e422f61c3d3393f56fcc791bd073e3ca4fb"
+  ]
+}


### PR DESCRIPTION
This was missing from https://github.com/ocaml/opam-repository/pull/22482. I noticed it after it was merged unfortunately. Luckily the difference is small and should strain the CI much less :)