### PR TITLE
add ocaml-sat-solvers.0.7.1

### DIFF
--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7.1/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [ "Oliver Friedmann"
+           "Martin Lange"
+           "Maurice Herwig" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/tcsprojects/ocaml-sat-solvers"
+dev-repo: "git://github.com/tcsprojects/ocaml-sat-solvers.git"
+bug-reports: "https://github.com/tcsprojects/ocaml-sat-solvers/issues"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
+  ["ocaml" "setup.ml" "-build"] {with-test}
+  ["ocaml" "setup.ml" "-test"] {with-test}
+]
+install: ["ocaml" "setup.ml" "-install"]
+depends: [
+  "ocaml" {>= "4.08.0" & < "5.0"}
+  "minisat" {>= "0.4"}
+  "z3" {>= "4.8.11"}
+  "ocamlbuild" {build}
+  "ocamlfind" {build}
+]
+synopsis: "An abstraction layer for integrating SAT Solvers into OCaml"
+description: "An abstraction layer for integrating SAT Solvers into OCaml."
+flags: light-uninstall
+url {
+  src: "https://github.com/tcsprojects/ocaml-sat-solvers/archive/refs/tags/v0.7.1.tar.gz"
+  checksum: "md5=7e5ccb4b21397c04c579aecd3c618825"
+}

--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7.1/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.7.1/opam
@@ -24,7 +24,6 @@ depends: [
 ]
 synopsis: "An abstraction layer for integrating SAT Solvers into OCaml"
 description: "An abstraction layer for integrating SAT Solvers into OCaml."
-flags: light-uninstall
 url {
   src: "https://github.com/tcsprojects/ocaml-sat-solvers/archive/refs/tags/v0.7.1.tar.gz"
   checksum: "md5=7e5ccb4b21397c04c579aecd3c618825"


### PR DESCRIPTION
The ocaml-sat-solvers version 0.7.1 fixed the missing inclusion of Timing module in library at version 0.7. 