### PR TITLE
ocaml 5.0.0~alpha0: conflict with dune >= 3.4

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0~alpha0/opam
@@ -16,6 +16,9 @@ depends: [
   "ocaml-options-vanilla" {post}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
+conflicts: [
+  "dune" {>= "3.4.0"}
+]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~alpha0+options/opam
@@ -16,6 +16,9 @@ depends: [
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
+conflicts: [
+  "dune" {>= "3.4.0"}
+]
 conflict-class: "ocaml-core-compiler"
 flags: [ compiler avoid-version ]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"


### PR DESCRIPTION
This is related to the META files that the compiler now ship. This feature has been added in `5.0.0~alpha1`. Dune is able to determine that, but only has access to the (major, minor) numbers to do this. So recent versions of dune can not be used with `5.0.0~alpha0`.

Historically we've added the conflict on the dune side, but this means that we need to keep adding the conflict on new releases. This commit puts in on the other side, which is easier to maintain since no new incompatible versions of the ocaml compiler are expected.

(We could also remove the existing conflicts on the dune side, but doing so would cause many existing switches to be rebuilt even for users that are not on alpha0).
