### PR TITLE
2 packages from cryspen/hacl-packages at 0.6.1

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.6.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.6.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
+description: """\
+This package contains a snapshot of the EverCrypt crypto provider and
+the HACL* library, along with automatically generated Ctypes bindings.
+For a higher-level idiomatic API see the `hacl-star` package, of
+which `hacl-star-raw` is a dependency."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Project Everest"
+license: "Apache-2.0"
+homepage: "https://tech.cryspen.com/hacl-packages/"
+bug-reports: "https://github.com/cryspen/hacl-packages/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "ocamlfind" {build}
+  "ctypes" {>= "0.18.0"}
+  "conf-which" {build}
+  "conf-cmake" {build}
+]
+available:
+  arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
+  (os = "freebsd" | os-family != "bsd")
+build: [
+  [make "-C" "hacl-star-raw" "build-c"]
+  [make "-C" "hacl-star-raw" "build-bindings"]
+]
+install: [make "-C" "hacl-star-raw" "install"]
+dev-repo: "git+https://github.com/cryspen/hacl-packages.git"
+url {
+  src:
+    "https://github.com/cryspen/hacl-packages/releases/download/ocaml-v0.6.1/hacl-star.0.6.1.tar.gz"
+  checksum: [
+    "md5=12562af72483908a86ca38845d30c25b"
+    "sha512=410b25fedcd0f8790cda7021237cf5ebf43d770566c86b697da301b18a5b36da347ae20f84544b38a593a55185e7959308a8a369edfc64d09fadb4896c20e0e0"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]

--- a/packages/hacl-star/hacl-star.0.6.1/opam
+++ b/packages/hacl-star/hacl-star.0.6.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "OCaml API for EverCrypt/HACL*"
+description: """\
+Documentation for this library can be found
+[here](https://tech.cryspen.com/hacl-packages/ocaml/main/index.html)."""
+maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
+authors: "Project Everest"
+license: "Apache-2.0"
+homepage: "https://tech.cryspen.com/hacl-packages/"
+doc: "https://tech.cryspen.com/hacl-packages/ocaml/main/index.html"
+bug-reports: "https://github.com/cryspen/hacl-packages/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "hacl-star-raw" {= version}
+  "zarith"
+  "cppo" {build}
+  "alcotest" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+available: os = "freebsd" | os-family != "bsd"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/cryspen/hacl-packages.git"
+url {
+  src:
+    "https://github.com/cryspen/hacl-packages/releases/download/ocaml-v0.6.1/hacl-star.0.6.1.tar.gz"
+  checksum: [
+    "md5=12562af72483908a86ca38845d30c25b"
+    "sha512=410b25fedcd0f8790cda7021237cf5ebf43d770566c86b697da301b18a5b36da347ae20f84544b38a593a55185e7959308a8a369edfc64d09fadb4896c20e0e0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`hacl-star.0.6.1`: OCaml API for EverCrypt/HACL*
-`hacl-star-raw.0.6.1`: Auto-generated low-level OCaml bindings for EverCrypt/HACL*



---
* Homepage: https://tech.cryspen.com/hacl-packages/
* Source repo: git+https://github.com/cryspen/hacl-packages.git
* Bug tracker: https://github.com/cryspen/hacl-packages/issues

---
:camel: Pull-request generated by opam-publish v2.1.0