### PR TITLE
3 packages from c-cube/ocaml-containers at 3.10

### DIFF
--- a/packages/containers-data/containers-data.3.10/opam
+++ b/packages/containers-data/containers-data.3.10/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "containers" { = version }
+  "seq"
+  (("ocaml" {with-test & < "4.08"} & "qcheck-core" {>= "0.17" & with-test})
+  | ("ocaml" {with-test & >= "4.08"} & "qcheck-core" {>= "0.18" & with-test}))
+  "iter" { with-test }
+  "gen" { with-test }
+  #"mdx" { with-test & >= "1.5.0" & < "2.0.0" }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.10.tar.gz"
+  checksum: [
+    "md5=050afc34c00ee0ffb1bf545c52d3880f"
+    "sha512=ef4c9c27f6e535df070f2ee9e6357f6f9bf4a8a196e3f274bec00d931bbd775f939a7e8b144accc8c4568df6c25b820aaebad6e12b1d444bccb7c8f7b7989bf0"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.10/opam
+++ b/packages/containers-thread/containers-thread.3.10/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  (("ocaml" {with-test & < "4.08"} & "qcheck-core" {>= "0.17" & with-test})
+  | ("ocaml" {with-test & >= "4.08"} & "qcheck-core" {>= "0.18" & with-test}))
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.10.tar.gz"
+  checksum: [
+    "md5=050afc34c00ee0ffb1bf545c52d3880f"
+    "sha512=ef4c9c27f6e535df070f2ee9e6357f6f9bf4a8a196e3f274bec00d931bbd775f939a7e8b144accc8c4568df6c25b820aaebad6e12b1d444bccb7c8f7b7989bf0"
+  ]
+}

--- a/packages/containers/containers.3.10/opam
+++ b/packages/containers/containers.3.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "dune-configurator"
+  "seq" # compat
+  "either" # compat
+  (("ocaml" {with-test & < "4.08"} & "qcheck-core" {>= "0.17" & with-test})
+  | ("ocaml" {with-test & >= "4.08"} & "qcheck-core" {>= "0.18" & with-test}))
+  "yojson" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "csexp" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.10.tar.gz"
+  checksum: [
+    "md5=050afc34c00ee0ffb1bf545c52d3880f"
+    "sha512=ef4c9c27f6e535df070f2ee9e6357f6f9bf4a8a196e3f274bec00d931bbd775f939a7e8b144accc8c4568df6c25b820aaebad6e12b1d444bccb7c8f7b7989bf0"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.10`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.10`: A set of advanced datatypes for containers
-`containers-thread.3.10`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.1.0