### PR TITLE
[new release] confero (0.1.1)

### DIFF
--- a/packages/confero/confero.0.1.1/opam
+++ b/packages/confero/confero.0.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Unicode Collation"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://paurkedal.github.com/paurkedal/confero/"
+bug-reports: "https://paurkedal.github.com/paurkedal/confero/issues"
+dev-repo: "git+https://github.com/paurkedal/confero.git"
+depends: [
+  "angstrom" {>= "0.14.0"}
+  "angstrom-unix"
+  "cmdliner"
+  "dune" {>= "2.9"}
+  "fmt" {>= "0.8.7"}
+  "iso639"
+  "ocaml" {>= "4.08.1"}
+  "uucp" {>= "15.0.0"}
+  "uunf" {>= "15.0.0"}
+  "uutf"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+extra-source "lib/ducet/allkeys.txt" {
+  src: "https://www.unicode.org/Public/UCA/15.0.0/allkeys.txt"
+  checksum: "sha512=26dda70e65d38afd5da36fce32a89615880a50e10518545d638fc0112aa7816e3c245bd719de7d55dd205c82581415fc04a86f3401f3e91607f0caaf368c0761"
+}
+url {
+  src:
+    "https://github.com/paurkedal/confero/releases/download/v0.1.1/confero-0.1.1.tbz"
+  checksum: [
+    "sha256=12984479e7255f9d3116f127fefca530760bacc12ee5a8ef54a1b2fff3093c72"
+    "sha512=4c2cd9fc1048b551f47d5a411a2a9800d4a13a77f920c774e9c881fed787e4e1cd53f008e856a09b0dbf4e15a899a70de95376f4ca90e4d20fa97f672abd38ab"
+  ]
+}
+x-commit-hash: "5c3eb851ac84f538b374d66442bc3578a08b4383"


### PR DESCRIPTION
I'm making a new attempt to publish this new package after the first version failed to compile with OCaml 4 on the CI due to stack overflows (#22510).  The stack overflows were caused by very large arrays in the generated source code.

Confero implements the Unicode 15.0.0 Collation Algorithm and ships with the DUCET language-neutral mapping.

CHANGES:

  - Make it possible to compile the library with OCaml 4 using a small stack size (like 4096 KiB).