### PR TITLE
[new release] meldep, melange and mel (0.3.1)

### DIFF
--- a/packages/mel/mel.0.3.1/opam
+++ b/packages/mel/mel.0.3.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Build system for Melange that defers to Dune for build orchestration"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml"
+  "melange" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "luv" {>= "0.5.11"}
+  "ocaml-migrate-parsetree" {>= "2.3.0"}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.1/melange-0.3.1.tbz"
+  checksum: [
+    "sha256=b9cbcc9193e523f493ea96b95dfb0d70b077290d9342ee2201214406dbd537c0"
+    "sha512=e07282ced49c1a799116252e0fbcd3db608ce1b412f181a7b868faed20f83a6a0fea3b66be8613a81671eac7a6184fc2743483eb69b7fb6e285dcf672821360e"
+  ]
+}
+x-commit-hash: "db4e70ce7d690309ec9b451062cc762163f9a288"

--- a/packages/melange/melange.0.3.1/opam
+++ b/packages/melange/melange.0.3.1/opam
@@ -15,6 +15,7 @@ depends: [
   "ounit" {with-test}
   "odoc" {with-doc}
 ]
+available: arch != "x86_32" & arch != "arm32"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -25,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/melange/melange.0.3.1/opam
+++ b/packages/melange/melange.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.14.0" & < "4.15.0"}
+  "melange-compiler-libs" {>= "0.0.1-414"}
+  "cmdliner" {>= "1.1.0"}
+  "meldep" {= version}
+  "cppo" {build}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.1/melange-0.3.1.tbz"
+  checksum: [
+    "sha256=b9cbcc9193e523f493ea96b95dfb0d70b077290d9342ee2201214406dbd537c0"
+    "sha512=e07282ced49c1a799116252e0fbcd3db608ce1b412f181a7b868faed20f83a6a0fea3b66be8613a81671eac7a6184fc2743483eb69b7fb6e285dcf672821360e"
+  ]
+}
+x-commit-hash: "db4e70ce7d690309ec9b451062cc762163f9a288"

--- a/packages/meldep/meldep.0.3.1/opam
+++ b/packages/meldep/meldep.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Melange counterpart to `ocamldep` that understands Melange-specific constructs"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml"
+  "cppo" {build}
+  "base64" {>= "3.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "melange-compiler-libs" {>= "0.0.1-414"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.1/melange-0.3.1.tbz"
+  checksum: [
+    "sha256=b9cbcc9193e523f493ea96b95dfb0d70b077290d9342ee2201214406dbd537c0"
+    "sha512=e07282ced49c1a799116252e0fbcd3db608ce1b412f181a7b868faed20f83a6a0fea3b66be8613a81671eac7a6184fc2743483eb69b7fb6e285dcf672821360e"
+  ]
+}
+x-commit-hash: "db4e70ce7d690309ec9b451062cc762163f9a288"


### PR DESCRIPTION
Melange counterpart to `ocamldep` that understands Melange-specific constructs

- Project page: <a href="https://github.com/melange-re/melange">https://github.com/melange-re/melange</a>

##### CHANGES:

- Disable warning 69 (`unused-field` in record) for the private record
  generated by the `bs.deriving` attribute
  ([melange-re/melange#414](https://github.com/melange-re/melange/pull/414))
- Disable warning 20 (`ignored-extra-argument`) when applying
  `foo##fn arg1 arg2`
  ([melange-re/melange#416](https://github.com/melange-re/melange/pull/416)):
  - in cases such as `external x : < .. > Js.t = ""`, the typechecker doesn't
    know the arity of the function, even though Melange will emit an uncurried
    function call.
- Disable warning 61 (`unboxable-type-in-prim-decl`) in `external` declarations
  ([melange-re/melange#415](https://github.com/melange-re/melange/pull/415)):
  - Melange externals are substantially different from OCaml externals. This
    warning doesn't make sense in a JS runtime.
- melc: introduce `--bs-module-name` flag to specify the original file name for
  the current compilation unit
  ([melange-re/melange#413](https://github.com/melange-re/melange/pull/413))
  - Dune's namespacing implementation generates modules such as
    `lib__Original_name`. Passing `--bs-module-name original_name` allows
    melange to issue correct `import` / `require` statements to the unmangled
    JS file names.
