### PR TITLE
[new release] dockerfile, dockerfile-opam and dockerfile-cmd (8.1.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
@@ -42,7 +42,6 @@ depends: [
   "logs"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
-  "rresult" {>= "0.7.0"}
   "odoc" {with-doc}
 ]
 build: [
@@ -61,6 +60,7 @@ build: [
 ]
 conflicts: [
    "result" {< "1.5"}
+   "rresult" {< "0.7.0"}
  ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
 url {

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
@@ -58,6 +58,9 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+conflicts: [
+   "result" {< "1.5"}
+ ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
 url {
   src:

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-cmd/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "bos"
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.1.0/dockerfile-8.1.0.tbz"
+  checksum: [
+    "sha256=7d01e40d0f128160dd3ad078221ea42c306720fd2c65e941c456895e21e7b227"
+    "sha512=92a402c09c65b01ed2faf7687c24721b7baa54e623e2b85401c8816f6afbeb3aec0cc0c2cb4282ca8377f7552aac834573c6b0deb16832a0c50984063256ce9b"
+  ]
+}
+x-commit-hash: "3074cdaa605ef38b323652028c05e624a4a7e187"

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
@@ -35,7 +35,7 @@ doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-cmd/"
 bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
 depends: [
   "dune" {>= "3.0"}
-  "bos"
+  "bos" {>= "0.2"}
   "cmdliner"
   "dockerfile-opam" {= version}
   "fmt" {>= "0.8.7"}

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.1.0/opam
@@ -42,6 +42,7 @@ depends: [
   "logs"
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
+  "rresult" {>= "0.7.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/dockerfile-opam/dockerfile-opam.8.1.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.1.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-opam/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring"
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.2.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.1.0/dockerfile-8.1.0.tbz"
+  checksum: [
+    "sha256=7d01e40d0f128160dd3ad078221ea42c306720fd2c65e941c456895e21e7b227"
+    "sha512=92a402c09c65b01ed2faf7687c24721b7baa54e623e2b85401c8816f6afbeb3aec0cc0c2cb4282ca8377f7552aac834573c6b0deb16832a0c50984063256ce9b"
+  ]
+}
+x-commit-hash: "3074cdaa605ef38b323652028c05e624a4a7e187"

--- a/packages/dockerfile-opam/dockerfile-opam.8.1.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.1.0/opam
@@ -38,7 +38,7 @@ depends: [
   "astring"
   "dockerfile" {= version}
   "fmt" {>= "0.8.7"}
-  "ocaml-version" {>= "3.2.0"}
+  "ocaml-version" {>= "3.5.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "odoc" {with-doc}

--- a/packages/dockerfile/dockerfile.8.1.0/opam
+++ b/packages/dockerfile/dockerfile.8.1.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.1.0/dockerfile-8.1.0.tbz"
+  checksum: [
+    "sha256=7d01e40d0f128160dd3ad078221ea42c306720fd2c65e941c456895e21e7b227"
+    "sha512=92a402c09c65b01ed2faf7687c24721b7baa54e623e2b85401c8816f6afbeb3aec0cc0c2cb4282ca8377f7552aac834573c6b0deb16832a0c50984063256ce9b"
+  ]
+}
+x-commit-hash: "3074cdaa605ef38b323652028c05e624a4a7e187"


### PR DESCRIPTION
Dockerfile eDSL in OCaml

- Project page: <a href="https://github.com/ocurrent/ocaml-dockerfile">https://github.com/ocurrent/ocaml-dockerfile</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/">https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/</a>

##### CHANGES:

- Add Fedora 36 and 37 and deprecate 34 and 35. (@MisterDA #125, #126)
- Add Ubuntu 22.10. (@MisterDA #124)
- Support STOPSIGNAL instruction. (@MisterDA #121, review by @avsm)
- Support HEALTHCHECK instruction. (@MisterDA #122, review by @avsm)
- Various LCU Updates, deprecate Windows 10 20H2
  (@mtelvers #128 #115 #109 #107)
- Update to bubblewrap 0.6.2 when building from source in a distro
  packaging an outdated version (@MisterDA #120)
- Add Alpine 3.16 (3.15 is now tier 2 and 3.14 is deprecated)
  (@raphael-proust #119)
- Refactor to be able to install Cygwin and OCaml for Windows in a
  separate multistage build image, then copy. Docker Engine 20.10.18
  for Windows is currently buggy and doesn't allow it.
  (@MisterDA #114)
- Support `ARG` Dockerfile instruction (@MisterDA #116 #117)
- Bump to OCaml 4.08 and remove dependencies on result and rresult (@MisterDA #106)
- Wrap libraries:
  + `Dockerfile_gen` from the `dockerfile-cmd` package becomes `Dockerfile_cmd.Gen`;
  + `Dockerfile_distro`, `Dockerfile_linux`, `Dockerfile_windows` from the
    `dockerfile_opam` package respectively become `Dockerfile_opam.Distro`,
    `Dockerfile_opam.Linux`, `Dockerfile_opam.Windows`. (@MisterDA #106, #113)
- Generate opam images using BuildKit 1.4 syntax for Dockerfiles. (@MisterDA #105)
- Support BuildKit 1.4 syntax of here-documents in `COPY` instructions. (@MisterDA #99)
- Support BuildKit 1.4 `--link` flag in `ADD` and `COPY` instructions. (@MisterDA #99)

