### PR TITLE
[new release] xapi-stdext, xapi-stdext-zerocheck, xapi-stdext-unix, xapi-stdext-threads, xapi-stdext-std, xapi-stdext-pervasives, xapi-stdext-encodings and xapi-stdext-date (4.20.0)

### DIFF
--- a/packages/xapi-stdext-date/xapi-stdext-date.4.20.0/opam
+++ b/packages/xapi-stdext-date/xapi-stdext-date.4.20.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Dates"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "1.11"}
+  "alcotest" {with-test}
+  "astring"
+  "base-unix"
+  "ptime"
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.20.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.20.0/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/xapi-project/stdext/issues"
 depends: [
   "ocaml"
   "dune" {>= "1.11"}
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "0.6.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.20.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.20.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Encodings"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"

--- a/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.20.0/opam
+++ b/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.20.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Pervasives"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "logs"
+  "odoc" {with-doc}
+  "xapi-backtrace"
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.20.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.20.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Stdlib"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "1.11"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.20.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.20.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Threads"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "base-threads"
+  "base-unix"
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Unix"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {< "5.0"}
+  "dune" {>= "1.11"}
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
@@ -13,6 +13,7 @@ depends: [
   "odoc" {with-doc}
   "xapi-stdext-pervasives" {= version}
 ]
+available: os-family != "alpine"
 build: [
   [
     "dune"

--- a/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.20.0/opam
+++ b/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.20.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Zerocheck"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "ocaml" {< "5.0"}
+  "dune" {>= "1.11"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.20.0/xapi-stdext-4.20.0.tbz"
+  checksum: [
+    "sha256=ec93bcab02739d32f8ef09c30db57101bba7d58bb9a503a57dbfc9d81644b4e6"
+    "sha512=30db713ad51a9b1dc806bbb88aecec19ed22598a3c23da26aa80cbba431ba18b67e7f6e3834f1a848e75bfb9beeee2a171ddf0547f8c08f36c119a804aeaaf68"
+  ]
+}
+x-commit-hash: "79eadd4009efebc59d50b34f128bc43b710fa4da"


### PR DESCRIPTION
Xapi's standard library extension

- Project page: <a href="https://github.com/xapi-project/stdext">https://github.com/xapi-project/stdext</a>

##### CHANGES:

 - date: consolidate the types into a single t
 - date: add conversion functions that have semantic meaning, the previous functions containing 'float' and 'string' will be deprecated in a future release.
