### PR TITLE
atd <= 2.2.1 incompatible with ocaml 5

### DIFF
--- a/packages/atd/atd.1.13.0/opam
+++ b/packages/atd/atd.1.13.0/opam
@@ -11,7 +11,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0" }
   "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & < "20211215"}
   "easy-format"

--- a/packages/atd/atd.2.0.0/opam
+++ b/packages/atd/atd.2.0.0/opam
@@ -17,7 +17,7 @@ build: [
 # ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & < "20211215"}
   "easy-format"

--- a/packages/atd/atd.2.2.1/opam
+++ b/packages/atd/atd.2.2.1/opam
@@ -26,7 +26,7 @@ license: "MIT"
 homepage: "https://github.com/ahrefs/atd"
 bug-reports: "https://github.com/ahrefs/atd/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "dune" {>= "2.0"}
   "menhir" {< "20211215"}
   "easy-format"


### PR DESCRIPTION
Seen on #22478 

```
=== ERROR while compiling atd.2.2.1 ==========================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/atd.2.2.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p atd -j 255 @install
 exit-code            1
 env-file             ~/.opam/log/atd-7-f956ac.env
 output-file          ~/.opam/log/atd-7-f956ac.out
 (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27 -safe-string -g -bin-annot -I atd/src/.atd.objs/byte -I /home/opam/.opam/5.0/lib/easy-format -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/seq -no-alias-deps -open Atd -o atd/src/.atd.objs/byte/atd__Import.cmo -c -impl atd/src/import.ml)
 File "atd/src/import.ml", line 3, characters 24-46:
 3 |   let lowercase_ascii = StringLabels.lowercase
                             ^^^^^^^^^^^^^^^^^^^^^^
 Error: Unbound value StringLabels.lowercase
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>