### PR TITLE
+ledgerwallet.0.3.0

### DIFF
--- a/packages/ledgerwallet-tezos/ledgerwallet-tezos.0.3.0/opam
+++ b/packages/ledgerwallet-tezos/ledgerwallet-tezos.0.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: [ "Vincent Bernardoff <vb@luminar.eu.org>" "Nomadic Labs" ]
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+license: "ISC"
+homepage: "https://github.com/vbmithr/ocaml-ledger-wallet"
+bug-reports: "https://github.com/vbmithr/ocaml-ledger-wallet/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-ledger-wallet"
+doc: "https://vbmithr.github.io/ocaml-ledger-wallet/doc"
+build:    [ "dune" "build"   "-p" name "-j" jobs ]
+# run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.4.0"}
+  "ledgerwallet" {= version}
+  "uecc" { with-test }
+  "hex" { with-test }
+  "secp256k1" { with-test }
+  "alcotest" { with-test }
+]
+synopsis: "Ledger wallet library for OCaml: Tezos app"
+url {
+  src: "https://github.com/vbmithr/ocaml-ledger-wallet/archive/0.3.0.tar.gz"
+  checksum: [
+    "sha256=36cbd59f7773cdc6a269ad3d399d8ad958b56c3502509f60092d5d2503f64641"
+    "sha512=d95aa986383a8d50307680bcc197bcb5cb6a1a42d5a94df9a8019de31062285a266eabdfd5940324adbc19bc4828d03dfd459a9bcab676d13758438bbce6eb15"
+  ]
+}

--- a/packages/ledgerwallet/ledgerwallet.0.3.0/opam
+++ b/packages/ledgerwallet/ledgerwallet.0.3.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: [ "Vincent Bernardoff <vb@luminar.eu.org>" "Nomadic Labs" ]
+maintainer: "Vincent Bernardoff <vb@luminar.eu.org>"
+license: "ISC"
+homepage: "https://github.com/vbmithr/ocaml-ledger-wallet"
+bug-reports: "https://github.com/vbmithr/ocaml-ledger-wallet/issues"
+dev-repo: "git+https://github.com/vbmithr/ocaml-ledger-wallet"
+doc: "https://vbmithr.github.io/ocaml-ledger-wallet/doc"
+build:    [ "dune" "build"   "-p" name "-j" jobs ]
+# run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.4.0"}
+  "rresult" {>= "0.6.0"}
+  "cstruct" {>= "6.0.0"}
+  "hidapi" {>= "1.1.1"}
+]
+synopsis: "Ledger wallet library for OCaml"
+description: """Library to communicate with Ledger hardware wallets
+"""
+url {
+  src: "https://github.com/vbmithr/ocaml-ledger-wallet/archive/0.3.0.tar.gz"
+  checksum: [
+    "sha256=36cbd59f7773cdc6a269ad3d399d8ad958b56c3502509f60092d5d2503f64641"
+    "sha512=d95aa986383a8d50307680bcc197bcb5cb6a1a42d5a94df9a8019de31062285a266eabdfd5940324adbc19bc4828d03dfd459a9bcab676d13758438bbce6eb15"
+  ]
+}

--- a/packages/tezos-signer-backends/tezos-signer-backends.12.0/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.12.0/opam
@@ -16,7 +16,7 @@ depopts: [
   "ledgerwallet-tezos"
 ]
 conflicts: [
-  "ledgerwallet-tezos" { < "0.2.0" }
+  "ledgerwallet-tezos" { < "0.2.1" | >= "0.3.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-signer-backends/tezos-signer-backends.12.3/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.12.3/opam
@@ -16,7 +16,7 @@ depopts: [
   "ledgerwallet-tezos"
 ]
 conflicts: [
-  "ledgerwallet-tezos" { < "0.2.0" }
+  "ledgerwallet-tezos" { < "0.2.1" | >= "0.3.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-signer-backends/tezos-signer-backends.13.0/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.13.0/opam
@@ -26,7 +26,7 @@ depopts: [
   "ledgerwallet-tezos"
 ]
 conflicts: [
-  "ledgerwallet-tezos" { < "0.2.1" }
+  "ledgerwallet-tezos" { < "0.2.1" | >= "0.3.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-signer-backends/tezos-signer-backends.14.0/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.14.0/opam
@@ -27,7 +27,7 @@ depopts: [
   "ledgerwallet-tezos"
 ]
 conflicts: [
-  "ledgerwallet-tezos" { < "0.2.1" }
+  "ledgerwallet-tezos" { < "0.2.1" | >= "0.3.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]

--- a/packages/tezos-signer-backends/tezos-signer-backends.15.0/opam
+++ b/packages/tezos-signer-backends/tezos-signer-backends.15.0/opam
@@ -28,7 +28,7 @@ depopts: [
   "ledgerwallet-tezos"
 ]
 conflicts: [
-  "ledgerwallet-tezos" { < "0.2.1" }
+  "ledgerwallet-tezos" { < "0.2.1" | >= "0.3.0" }
 ]
 build: [
   ["rm" "-r" "vendors"]


### PR DESCRIPTION
This version allows you to use the Speculos emulator of LedgerHQ hardware wallet.