### PR TITLE
hidapi.1.1.1 is incompatible with ocaml.5.0

### DIFF
--- a/packages/hidapi/hidapi.1.1.1/opam
+++ b/packages/hidapi/hidapi.1.1.1/opam
@@ -8,7 +8,7 @@ doc: "https://vbmithr.github.io/ocaml-hidapi/doc"
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "1.8.2"}
   "dune-configurator"
   "conf-hidapi" {build}


### PR DESCRIPTION
Should resolve the 5.0 lowerbounds failure of https://github.com/ocaml/opam-repository/pull/22527