### PR TITLE
Some fixes of base-domains and js_of_ocaml-compiler.4.1.0

### DIFF
--- a/packages/base-domains/base-domains.base/opam
+++ b/packages/base-domains/base-domains.base/opam
@@ -6,7 +6,6 @@ Domains-based parallelism distributed with the Multicore OCaml compiler"
 depends: [
   "ocaml" {>= "5.0"} |
   "ocaml-variants" {
-    = "4.14.0+domains" |
     = "4.12.0+domains+effects" |
     = "4.12.0+domains" |
     = "4.10.0+multicore" |

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
@@ -27,6 +27,7 @@ depopts: ["ocamlfind"]
 conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
+  "ocaml-variants" {= "4.12.0+domains" | = "4.12.0+domains+effects"}
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [


### PR DESCRIPTION
* @kayceesrk   `base-domains`  depends on non-existent `ocaml-variants.4.14.0+variants`
* @hhugo `js_of_ocaml-compiler.4.1.0` no more conflict with `base-domains` (as ocaml 5 compatible), but doesn't work with `ocaml-variants.4.12.0+domains`.
