### PR TITLE
Package binaryen.0.19.0

### DIFF
--- a/packages/binaryen/binaryen.0.19.0/opam
+++ b/packages/binaryen/binaryen.0.19.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.9.1"}
+  "dune-configurator" {>= "2.9.1"}
+  "js_of_ocaml-compiler" {>= "3.10.0"}
+  "libbinaryen" {>= "109.0.0" & < "110.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.19.0/binaryen-archive-v0.19.0.tar.gz"
+  checksum: [
+    "md5=ac36139d1a52932aca942af6ed9254d2"
+    "sha512=6953e0eac7cc6ffe1230f4ec537639d381153c4be39ff9c346f772f33fcc12288ad2c0f609fa9704e11998b3229dc213907084f5c989c37dff3c2a07a45ebf73"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.19.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.19.0](https://github.com/grain-lang/binaryen.ml/compare/v0.18.0...v0.19.0) (2022-11-19)


### ⚠ BREAKING CHANGES

* Upgrade to libbinaryen v109 (#165)

### Features

* Add `Import.memory_import_get_module` and `Import.memory_import_get_base` functions ([b584500](https://github.com/grain-lang/binaryen.ml/commit/b5845005bd20c3813db11bebb9b47ad616c01c5d))
* Add function to print StackIR ([b584500](https://github.com/grain-lang/binaryen.ml/commit/b5845005bd20c3813db11bebb9b47ad616c01c5d))
* Add function to write StackIR ([b584500](https://github.com/grain-lang/binaryen.ml/commit/b5845005bd20c3813db11bebb9b47ad616c01c5d))
* Add gsi & spill_pointers passes ([b584500](https://github.com/grain-lang/binaryen.ml/commit/b5845005bd20c3813db11bebb9b47ad616c01c5d))
* Add operations on memory ([b584500](https://github.com/grain-lang/binaryen.ml/commit/b5845005bd20c3813db11bebb9b47ad616c01c5d))
* Upgrade to libbinaryen v109 ([#165](https://github.com/grain-lang/binaryen.ml/issues/165)) ([b584500](https://github.com/grain-lang/binaryen.ml/commit/b5845005bd20c3813db11bebb9b47ad616c01c5d))

---
:camel: Pull-request generated by opam-publish v2.0.3