### PR TITLE
[new release] coq-lsp (0.1.0)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.1.0/opam
+++ b/packages/coq-lsp/coq-lsp.0.1.0/opam
@@ -1,0 +1,41 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+  "ocaml"        { >= "4.13.1" }
+  "dune"         { >= "3.0.2"  }
+
+  # Not yet required, install Coq deps instead
+  "coq"            {         >= "8.16.0" & < "8.17" }
+  "coq-serapi"     {         >= "8.16.0" & < "8.17" }
+  "camlp-streams"  {         >= "5.0"               }
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.1.0/coq-lsp-0.1.0.tbz"
+  checksum: [
+    "sha256=d2e95a517ff35f59150c4f8399dc23899923a9cc93fce190efaa05422d3bbcf5"
+    "sha512=5593afa6fef241a63cf685fe6e4af42482884aa9078d080503f1aa7987da5f96cc95ddb48b1393ac1bd240e3510f4f7a61fe83882c0f5f8a38c0279eed4a0a11"
+  ]
+}
+x-commit-hash: "73ce7522af43310c7a653a7810dfdd68bc3ffd39"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

-----------------------

 - Location-aware cache for incremental Coq interpretation (@ejgallego)
 - Smart, structure-aware error recovery (@ejgallego)
 - Configure flags reading _CoqProject file (@artagnon, ejgallego/coq-lsp#3)
 - Interruption support (@ejgallego , @Alizter, ejgallego/coq-lsp#27, ejgallego/coq-lsp#32, ejgallego/coq-lsp#34)
 - Markdown support (@ejgallego, ejgallego/coq-lsp#62)
 - Goal display (@ejgallego @corwin-of-amber, ejgallego/coq-lsp#69)
 - User-side configuration (@ejgallego, ejgallego/coq-lsp#67)
 - Allow to configure before/after goal display (@ejgallego, ejgallego/coq-lsp#78)
 - Allow requests to interrupt checking (@ejgallego, ejgallego/coq-lsp#76)
