### PR TITLE
[new release] meldep, melange and mel (0.3.2)

### DIFF
--- a/packages/mel/mel.0.3.2/opam
+++ b/packages/mel/mel.0.3.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis:
+  "Build system for Melange that defers to Dune for build orchestration"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml"
+  "melange" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "luv" {>= "0.5.11"}
+  "ocaml-migrate-parsetree" {>= "2.3.0"}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.2/melange-0.3.2.tbz"
+  checksum: [
+    "sha256=2e74738f624bec755860f09eeb4f446fec16290ab5c5db452645ba003c7b6d14"
+    "sha512=0c45111206dd8e4684e3036788f9ef352b3dddff55705a21c1d04271438a5d0166322e43eefe517d68c9c00390cf5bdb2d166dd2537c38f8af8815718bac0b4a"
+  ]
+}
+x-commit-hash: "01aa3e8566e848ed54550ba4289a061cdb72c2f6"

--- a/packages/melange/melange.0.3.2/opam
+++ b/packages/melange/melange.0.3.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.14.0" & < "4.15.0"}
+  "melange-compiler-libs" {>= "0.0.1-414"}
+  "cmdliner" {>= "1.1.0"}
+  "meldep" {= version}
+  "cppo" {build}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.2/melange-0.3.2.tbz"
+  checksum: [
+    "sha256=2e74738f624bec755860f09eeb4f446fec16290ab5c5db452645ba003c7b6d14"
+    "sha512=0c45111206dd8e4684e3036788f9ef352b3dddff55705a21c1d04271438a5d0166322e43eefe517d68c9c00390cf5bdb2d166dd2537c38f8af8815718bac0b4a"
+  ]
+}
+x-commit-hash: "01aa3e8566e848ed54550ba4289a061cdb72c2f6"

--- a/packages/melange/melange.0.3.2/opam
+++ b/packages/melange/melange.0.3.2/opam
@@ -15,6 +15,7 @@ depends: [
   "ounit" {with-test}
   "odoc" {with-doc}
 ]
+available: arch != "x86_32" & arch != "arm32"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -25,7 +26,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/meldep/meldep.0.3.2/opam
+++ b/packages/meldep/meldep.0.3.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Melange counterpart to `ocamldep` that understands Melange-specific constructs"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml"
+  "cppo" {build}
+  "base64" {>= "3.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "melange-compiler-libs" {>= "0.0.1-414"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/0.3.2/melange-0.3.2.tbz"
+  checksum: [
+    "sha256=2e74738f624bec755860f09eeb4f446fec16290ab5c5db452645ba003c7b6d14"
+    "sha512=0c45111206dd8e4684e3036788f9ef352b3dddff55705a21c1d04271438a5d0166322e43eefe517d68c9c00390cf5bdb2d166dd2537c38f8af8815718bac0b4a"
+  ]
+}
+x-commit-hash: "01aa3e8566e848ed54550ba4289a061cdb72c2f6"


### PR DESCRIPTION
Melange counterpart to `ocamldep` that understands Melange-specific constructs

- Project page: <a href="https://github.com/melange-re/melange">https://github.com/melange-re/melange</a>

##### CHANGES:

- `ppx_rescript_compat` (ReScript compatibility layer): fix conversion for
  cases such as `foo["bar"] = assignment`
  ([melange-re/melange#441](https://github.com/melange-re/melange/pull/441)):
  - These are now correctly converted to the OCaml equivalent:
    `foo##bar #= assignment`
- [mel]: fix merlin generation, broken since `mel` was moved to its own package
  ([melange-re/melange#442](https://github.com/melange-re/melange/pull/442))
