### PR TITLE
[new release] OCADml (0.1.2)

### DIFF
--- a/packages/OCADml/OCADml.0.1.2/opam
+++ b/packages/OCADml/OCADml.0.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.13.0"}
+  "cairo2" {>= "0.6.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.1.2/OCADml-0.1.2.tbz"
+  checksum: [
+    "sha256=84515077825c4d2245f71d3767c276158b14380f482b7565da248a5c7db17c57"
+    "sha512=70af67d9ab5dd00d646e4266784d433f2659f92a556a004965ec8cfd13dce1e644ad54c651c054e2ee74e811851d54d35877053adbf064b71b944b54a3a298b7"
+  ]
+}
+x-commit-hash: "a152b3a551b89086c44a37f1d2cac5730955edd9"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- Add v4 (4d vector) type at top level (use abstracted in Quaternion)
