### PR TITLE
[new release] opam-monorepo (0.3.4)

### DIFF
--- a/packages/opam-monorepo/opam-monorepo.0.3.4/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.4/opam
@@ -23,7 +23,7 @@ conflicts: [
   "dune-configurator" {= "2.7.0" | = "2.7.1"}
 ]
 dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
-build: [ "dune" "build" "-p" name "-j" jobs "@install" "@lib/test/runtest" {with-test} ]
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@test/lib/runtest" {with-test} ]
 flags: [ plugin ]
 url {
   src:

--- a/packages/opam-monorepo/opam-monorepo.0.3.4/opam
+++ b/packages/opam-monorepo/opam-monorepo.0.3.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Assemble and manage fully vendored Dune repositories"
+description: """
+The opam monorepo plugin provides a convenient interface to bridge the
+opam package manager with having a local copy of all the source
+code required to build a project using the dune build tool."""
+maintainer: ["anil@recoil.org"]
+authors: [
+  "Anil Madhavapeddy" "Nathan Rebours" "Lucas Pluvinage" "Jules Aguillon"
+]
+license: "ISC"
+homepage: "https://github.com/ocamllabs/opam-monorepo"
+doc: "https://ocamllabs.github.io/opam-monorepo"
+bug-reports: "https://github.com/ocamllabs/opam-monorepo/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+  "conf-pkg-config"
+]
+conflicts: [
+  "dune-build-info" {= "2.7.0" | = "2.7.1"}
+  "dune-configurator" {= "2.7.0" | = "2.7.1"}
+]
+dev-repo: "git+https://github.com/ocamllabs/opam-monorepo.git"
+build: [ "dune" "build" "-p" name "-j" jobs "@install" "@lib/test/runtest" {with-test} ]
+flags: [ plugin ]
+url {
+  src:
+    "https://github.com/ocamllabs/opam-monorepo/releases/download/0.3.4/opam-monorepo-0.3.4.tbz"
+  checksum: [
+    "sha256=cadc320f08ce8c3ab974d9d17b1c6330516355a69de24aa1fa780237d9618d5e"
+    "sha512=d06dff795f3ed7e38e5ed9b3594674db7cbcf18c199d76f7ff583ce341504394ed979544b2440efcc297b45e7b970d802490008e70e39b7db295ce72125afb3a"
+  ]
+}
+x-commit-hash: "e7239aa1e645a4f02ef4a72b9ca71c369afb2d15"


### PR DESCRIPTION
Assemble and manage fully vendored Dune repositories

- Project page: <a href="https://github.com/ocamllabs/opam-monorepo">https://github.com/ocamllabs/opam-monorepo</a>
- Documentation: <a href="https://ocamllabs.github.io/opam-monorepo">https://ocamllabs.github.io/opam-monorepo</a>

##### CHANGES:

### Added

- Add support for specifying remote URLs in `x-opam-monorepo-repositories`
  (ocamllabs/opam-monorepo#284, ocamllabs/opam-monorepo#317, @Leonidas-from-XIV)

### Fixed

- Enable locking of packages with depexts even with uninitialized system
  package manager state (ocamllabs/opam-monorepo#322, @Leonidas-from-XIV)
- Fix a bug where `pull` would crash if the lock file contained no package to
  vendor (ocamllabs/opam-monorepo#321, @NathanReb)
- Display a better error message when the depext command fails when getting the
  status of the packages (ocamllabs/opam-monorepo#258, ocamllabs/opam-monorepo#323, @RyanGibb, @Julow)
- Take `archive-mirrors` from the global opam configuration into account to
  allow more local caches (ocamllabs/opam-monorepo#337, @hannesm)
- Log at WARN level when opam-monorepo chooses a source for a package that
  doesn't match the package's version (ocamllabs/opam-monorepo#352, @reynir)
