### PR TITLE
[new release] dkml-package-console, dkml-install, dkml-install-runner and dkml-install-installer (0.3.1)

### DIFF
--- a/packages/dkml-install-installer/dkml-install-installer.0.3.1/opam
+++ b/packages/dkml-install-installer/dkml-install-installer.0.3.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Build tools for DKML installers"
+description:
+  "Build-time executables that can generate Dune include files which will compile essential end-user executables."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "crunch" {>= "3.2.0"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.3.1/dkml-install-0.3.1.tbz"
+  checksum: [
+    "sha256=e48dddd64742d654c962be7138539ef3811298b1119a29e043553f07f7621960"
+    "sha512=0c21208b0e8e046314139d30c26f194e4e767d14696ea3c3e0d3ddd7c5e777887f0ddd83188008824d14dd14d0ce89af92e72984d598541a418e1fbe248d2d0e"
+  ]
+}
+x-commit-hash: "d72e746d924e821992a5a7955829480075806f91"

--- a/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
+++ b/packages/dkml-install-runner/dkml-install-runner.0.3.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Runner executable for Diskuv OCaml (DKML) installation"
+description:
+  "The runner executable is responsible for loading and running all DKML installation components."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dune" {>= "2.9"}
+  "ppx_expect" {>= "v0.14.1"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "diskuvbox" {>= "0.1.1"}
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.3.1/dkml-install-0.3.1.tbz"
+  checksum: [
+    "sha256=e48dddd64742d654c962be7138539ef3811298b1119a29e043553f07f7621960"
+    "sha512=0c21208b0e8e046314139d30c26f194e4e767d14696ea3c3e0d3ddd7c5e777887f0ddd83188008824d14dd14d0ce89af92e72984d598541a418e1fbe248d2d0e"
+  ]
+}
+x-commit-hash: "d72e746d924e821992a5a7955829480075806f91"

--- a/packages/dkml-install/dkml-install.0.3.1/opam
+++ b/packages/dkml-install/dkml-install.0.3.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "API and registry for Diskuv OCaml (DKML) installation components"
+description:
+  "All DKML installation components implement the interfaces exposed in this API."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dune" {>= "2.9"}
+  "ppx_deriving" {>= "5.2.1"}
+  "result" {>= "1.5"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.0.4"}
+  "fmt" {>= "0.8.9"}
+  "tsort" {>= "2.1.0"}
+  "diskuvbox" {>= "0.1.1" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.3.1/dkml-install-0.3.1.tbz"
+  checksum: [
+    "sha256=e48dddd64742d654c962be7138539ef3811298b1119a29e043553f07f7621960"
+    "sha512=0c21208b0e8e046314139d30c26f194e4e767d14696ea3c3e0d3ddd7c5e777887f0ddd83188008824d14dd14d0ce89af92e72984d598541a418e1fbe248d2d0e"
+  ]
+}
+x-commit-hash: "d72e746d924e821992a5a7955829480075806f91"

--- a/packages/dkml-package-console/dkml-package-console.0.3.1/opam
+++ b/packages/dkml-package-console/dkml-package-console.0.3.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "Console setup and uninstall executables for Diskuv OCaml (DKML) installation"
+description:
+  "The setup and uninstall executables are responsible for launching the DKML runners."
+maintainer: ["opensource+diskuv-ocaml@support.diskuv.com"]
+authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dkml-install-api"
+bug-reports: "https://github.com/diskuv/dkml-install-api/issues"
+#   Components can be assembled on any "host" build machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/host_abi.ml
+#   into a installer that will run on any end-user machine defined in
+#   https://github.com/diskuv/dkml-install-api/blob/5cfd7b57c79d990c76a9bdc8f8f0fa9f6fd5346f/runner/src/ocaml_abi.ml
+available: os = "win32" | os = "linux" | os = "macos"
+depends: [
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {>= "1.5.3" & with-doc}
+  "dkml-install" {= version}
+  "dkml-install-runner" {= version}
+  "dune" {>= "2.9"}
+  "diskuvbox" {>= "0.1.1"}
+  "crunch" {>= "3.2.0"}
+  "dkml-component-xx-console" {>= "0.1.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/diskuv/dkml-install-api.git"
+url {
+  src:
+    "https://github.com/diskuv/dkml-install-api/releases/download/0.3.1/dkml-install-0.3.1.tbz"
+  checksum: [
+    "sha256=e48dddd64742d654c962be7138539ef3811298b1119a29e043553f07f7621960"
+    "sha512=0c21208b0e8e046314139d30c26f194e4e767d14696ea3c3e0d3ddd7c5e777887f0ddd83188008824d14dd14d0ce89af92e72984d598541a418e1fbe248d2d0e"
+  ]
+}
+x-commit-hash: "d72e746d924e821992a5a7955829480075806f91"


### PR DESCRIPTION
Console setup and uninstall executables for Diskuv OCaml (DKML) installation

- Project page: <a href="https://github.com/diskuv/dkml-install-api">https://github.com/diskuv/dkml-install-api</a>

##### CHANGES:

* Add `Context.Abi_v2.word_size`
* Reduce logs for info level and narrow width on errors
