### PR TITLE
[new release] ISO3166 (0.1.0)

### DIFF
--- a/packages/ISO3166/ISO3166.0.1.0/opam
+++ b/packages/ISO3166/ISO3166.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "OCaml library for working with ISO3166"
+description: "This OCaml library provides an interface to the ISO3166 standard (a.k.a country codes)"
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "MIT"
+homepage: "https://github.com/geocaml/iso3166"
+bug-reports: "https://github.com/geocaml/iso3166/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {>= "2.9"}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/geocaml/iso3166.git"
+url {
+  src:
+    "https://github.com/geocaml/ISO3166/releases/download/0.1.0/ISO3166-0.1.0.tbz"
+  checksum: [
+    "sha256=3f796838653b5d8df1772ca8c5e22aa2c02c832a83721738551ac6bc08b7ba4e"
+    "sha512=2c5fd35bf70b21a9ff80035a96f9d2cf88147e6684a4abbdd92103925ab8f7ba7843eb76f7cc1323c3e427c05eb11111c406a3f340f494130842000317399646"
+  ]
+}
+x-commit-hash: "fe34467388cf7607ff0414ca0f71f0ef012bdb3f"


### PR DESCRIPTION
OCaml library for working with ISO3166

- Project page: <a href="https://github.com/geocaml/iso3166">https://github.com/geocaml/iso3166</a>

##### CHANGES:

- Initial public release
