### PR TITLE
Update conf-libpng

### DIFF
--- a/packages/conf-libpng/conf-libpng.1/opam
+++ b/packages/conf-libpng/conf-libpng.1/opam
@@ -14,15 +14,13 @@ depexts: [
   ["libpng-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["libpng-devel"] {os-family = "mandriva" | os-family = "openmandriva" | os-family = "mageia"}
   ["libpng-devel"] {os-family = "fedora" | os-family = "rhel" | os-family = "centos"}
+  ["libpng-devel"] {os-family = "suse" | os-family = "opensuse" | os-family = "sles"}
   ["libpng-dev"] {os-family = "alpine"}
   ["libpng"] {os-family = "arch" | os-family = "archlinux"}
   ["media-libs/libpng"] {os-family = "gentoo"}
   ["png"] {os = "freebsd" | os = "dragonfly" | os = "netbsd" | os = "openbsd"}
   ["libpng"] {os = "macos" & os-distribution = "homebrew"}
   ["libpng"] {os = "macos" & os-distribution = "macports"}
-]
-x-ci-accept-failures: [
-  "opensuse-15.3" # does not have libpng
 ]
 synopsis: "Virtual package relying on a libpng system installation"
 description:


### PR DESCRIPTION
Following the discussion in #22225, add back the SUSE packages `libpng-devel`.