### PR TITLE
[new release] sail_smt_backend, sail_output, sail_ocaml_backend, sail_manifest, sail_lem_backend, sail_latex_backend, sail_coq_backend, sail_c_backend, sail and libsail (0.15)

### DIFF
--- a/packages/libsail/libsail.0.15/opam
+++ b/packages/libsail/libsail.0.15/opam
@@ -30,7 +30,7 @@ bug-reports: "https://github.com/rems-project/sail/issues"
 depends: [
   "dune" {>= "3.0"}
   "dune-site" {>= "3.0.2"}
-  "menhir" {build}
+  "menhir" {build & >= "20180523"}
   "ott" {>= "0.28" & build}
   "lem" {>= "2018-12-14"}
   "linksem" {>= "0.3"}

--- a/packages/libsail/libsail.0.15/opam
+++ b/packages/libsail/libsail.0.15/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "dune-site" {>= "3.0.2"}
+  "menhir" {build}
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "conf-zlib"
+  "yojson" {>= "1.6.0"}
+  "pprint"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail/sail.0.15/opam
+++ b/packages/sail/sail.0.15/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "sail_manifest" {= version & build}
+  "sail_ocaml_backend" {= version & post}
+  "sail_c_backend" {= version & post}
+  "sail_smt_backend" {= version & post}
+  "sail_lem_backend" {= version & post}
+  "sail_coq_backend" {= version & post}
+  "sail_latex_backend" {= version & post}
+  "sail_output" {= version & post}
+  "linenoise" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+substs: [ "src/bin/manifest.ml" ]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_c_backend/sail_c_backend.0.15/opam
+++ b/packages/sail_c_backend/sail_c_backend.0.15/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_coq_backend/sail_coq_backend.0.15/opam
+++ b/packages/sail_coq_backend/sail_coq_backend.0.15/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Coq translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_latex_backend/sail_latex_backend.0.15/opam
+++ b/packages/sail_latex_backend/sail_latex_backend.0.15/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to LaTeX formating"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_lem_backend/sail_lem_backend.0.15/opam
+++ b/packages/sail_lem_backend/sail_lem_backend.0.15/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to Lem translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_manifest/sail_manifest.0.15/opam
+++ b/packages/sail_manifest/sail_manifest.0.15/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Helper tool for compiling Sail"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_ocaml_backend/sail_ocaml_backend.0.15/opam
+++ b/packages/sail_ocaml_backend/sail_ocaml_backend.0.15/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to OCaml translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_output/sail_output.0.15/opam
+++ b/packages/sail_output/sail_output.0.15/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Example Sail output plugin"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"

--- a/packages/sail_smt_backend/sail_smt_backend.0.15/opam
+++ b/packages/sail_smt_backend/sail_smt_backend.0.15/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.15/sail-0.15.tbz"
+  checksum: [
+    "sha256=6849fb16af6a3a1f70a9202ceffeb91f0d5afe0dc403d7a29b42b065dc3510fb"
+    "sha512=64219a4824c428798937f1f2b3d4e8c7b2ff0cb3a835e82a7e98b6c337d16f7496d0f94cb7c65f2c74089a53598e6df04624485f1db0c1ca11ba8fc9dea281d6"
+  ]
+}
+x-commit-hash: "10b7ffc4628cf6e3b6aae0657b1a998b945b8085"


### PR DESCRIPTION
Sail to C translation

- Project page: <a href="https://github.com/rems-project/sail">https://github.com/rems-project/sail</a>

##### CHANGES:

##### More modular codebase and dune build system

The Sail internals have been refactored into seperate packages for
each Sail backend (c/lem/coq and so on). The shared parts of Sail are
now contained in a separate libsail OCaml library. The main Sail
executable links together all the Sail backends into a single
executable.

With this architecture new backends can be implemented outside the
main Sail repository as _plugins_, and loaded via `sail -plugin`.

The Sail build system has been transitioned from the legacy ocamlbuild
system to dune.

This has been a significant refactoring of the core Sail codebase, and
while all efforts have been taken to ensure backwards-compatibility
and minimize any potential breakage, it is possible there exists some.

##### New pattern completeness checker

Sail now has a new pattern completeness checker that can generate
counterexamples for incomplete patterns. It is designed to be less
noisy, as it only issues warnings when it can guarantee that the
pattern is incomplete.

##### Implicit casts now forbidden by default

Previously they were only forbidden by the `-dno_cast` flag (which is
used by both sail-riscv and sail-arm). This behavior is now the
default and this flag is ignored. The `-allow_deprecated_casts` flag
must be used to enable this now. Implicit casts will be fully removed
in the next Sail release.

##### New concurrency interface (EXPERIMENTAL)

This release contains a new way of interfacing with external
concurrency models by way of user defined effects. See
lib/concurrency_interface for an example. This is currently
experimental and not fully supported in all backends. Definition of
new effects is currently only allowed with the `$sail_internal`
directive (see below).

##### No more explicit effect annotations (DEPRECATION)

Explicit effect annotations are now deprecated and do nothing. This
change relates to the previous change to allow custom outcomes in the
event monad, as the effect system no-longer corresponded in any
meaningful way with whether functions would become monadic or not in
Sail's theorem prover backends.

Function specifications (`val` keyword) can now be marked as `pure`. If
this is done, the functions _must_ have no side-effects. The
requirements for a function to be pure in this sense are stricter than
they were previously - a pure function must not:

* Throw an exception
* Exit (either explicitly or by failing an assertion)
* Contain a possibly incomplete pattern match
* Read or write any register
* Call any impure function

This more strict notion of purity fixes some long-standing bugs when
generating theorem prover definitions from Sail.

Note that functions do not have to be explictly marked pure to be
considered pure. Purity will be inferred automatically. The pure
annotation is used to declare primitive functions as pure, and make it
a hard error if a function is inferred to be impure.

There are two places in the language where code must be pure:

* Top level let-bindings `let x = exp`
* Loop and function termination measures

##### Stricter typechecking for mutable variables (MINOR BREAKING)

Previously Sail allowed some assignment constructions that were a bit
complex, for example one could declare a variable and modify an
existing one in the same statement, e.g.

```
x: int = 1;
(x, y: int) = (2, 3);
```

This is now forbidden, so l-expressions can either modify existing
variables or declare new ones, but never both simultaneously. This
change is primarily to increase readability, and simplify the language
internally.

In the future we may move further towards a world where new
assignments must be declared with a `var` keyword, like the `let`
keyword.

Variable declarations are now forbidden in places where their scope is
not syntactically obvious, for example:

```
val f : (unit, int) -> unit
...
f(x: int = 3, x)
```

The breakage caused by this change should be minor as we hope
well-written Sail specifications do not declare variables in this way.

##### GCC style error message formatting

Error messages are now formatted as per:

https://www.gnu.org/prep/standards/standards.html#Errors

which should allow better editor integration

##### sail_internal directive

A new directive `$sail_internal` has been introduced. When placed in a
file this allows the use of experimental or unstable functionality. It
also allows the use of various identifiers that are ordinarily
forbidden. Its primary purpose is to allow the Sail library to be
implemented using new unstable features that may change, without them
being exposed (and therefore relied upon) by downstream users.

As such, any Sail file using this directive may become broken at any
point.
