### PR TITLE
[new release] merlin (4.7-414, 4.7-413, 4.7-412) and merlin-lib (4.7-414)

### DIFF
--- a/packages/merlin-lib/merlin-lib.4.7-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.7-414/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7-414/merlin-4.7-414.tbz"
+  checksum: [
+    "sha256=6c86789309a78adfee8ccdbffe3640e7daf07a8ed8d107c36fe069a13c6cc07b"
+    "sha512=c325c29bea91699739d7cb7df12876b7ffb8edf685deabb5dce5553b570a6bf8ff415c45e3295b674edbc7711f69f4be202b866d157516380f888e80dcee1082"
+  ]
+}
+x-commit-hash: "b01e78e20d60ad22100b4cdb0f8a049da703b55b"

--- a/packages/merlin/merlin.4.7-412/opam
+++ b/packages/merlin/merlin.4.7-412/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.12" & < "4.13"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.7-412/opam
+++ b/packages/merlin/merlin.4.7-412/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.12" & < "4.13"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+  "ppxlib" {with-test}
+]
+conflicts: "seq" {!= "base"}
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7-412/merlin-4.7-412.tbz"
+  checksum: [
+    "sha256=d14dc86bb11b94a50b372f00b97155280099bc63746ab609bfb0568814604f46"
+    "sha512=d13e307d87b4719b56397e54e6f771a3ea77a766ab38b22414c4b1d4d5828b5f790c82f28d3feaf7fe45be10abd50d9a905ece932f43fdad98c88b73b35dd936"
+  ]
+}
+x-commit-hash: "e3d85baec909b8caa8f33c2fd01894368e1d4273"

--- a/packages/merlin/merlin.4.7-413/opam
+++ b/packages/merlin/merlin.4.7-413/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "merlin,dot-merlin-reader" "-j" "1"] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.13" & < "4.14"}
+  "dune" {>= "2.9.0"}
+  "dot-merlin-reader" {>= "4.0"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "csexp" {>= "1.2.3"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+  "ppxlib" {with-test}
+]
+conflicts: "seq" {!= "base"}
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7-413/merlin-4.7-413.tbz"
+  checksum: [
+    "sha256=695986592e1b2412eec2cc432ac9e0fe7d00eaa97227fa670d371869bff98325"
+    "sha512=71068a6b50628c57003b29de3968e41c24b67394dcc1d1f1a0b335211e9d1ef3e527584b868514bd5489db5a130f2ff6fd145d3665a7d2bca5a117074cb08ce8"
+  ]
+}
+x-commit-hash: "01c9b33c8cb7f4471f4e2570388a04281468d8ee"

--- a/packages/merlin/merlin.4.7-413/opam
+++ b/packages/merlin/merlin.4.7-413/opam
@@ -13,10 +13,10 @@ build: [
 depends: [
   "ocaml" {>= "4.13" & < "4.14"}
   "dune" {>= "2.9.0"}
-  "dot-merlin-reader" {>= "4.0"}
+  "dot-merlin-reader" {>= "4.2"}
   "yojson" {>= "2.0.0"}
   "conf-jq" {with-test}
-  "csexp" {>= "1.2.3"}
+  "csexp" {>= "1.5.1"}
   "menhir" {dev}
   "menhirLib" {dev}
   "menhirSdk" {dev}

--- a/packages/merlin/merlin.4.7-414/opam
+++ b/packages/merlin/merlin.4.7-414/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.6"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7-414/merlin-4.7-414.tbz"
+  checksum: [
+    "sha256=6c86789309a78adfee8ccdbffe3640e7daf07a8ed8d107c36fe069a13c6cc07b"
+    "sha512=c325c29bea91699739d7cb7df12876b7ffb8edf685deabb5dce5553b570a6bf8ff415c45e3295b674edbc7711f69f4be202b866d157516380f888e80dcee1082"
+  ]
+}
+x-commit-hash: "b01e78e20d60ad22100b4cdb0f8a049da703b55b"


### PR DESCRIPTION
[new release] merlin and merlin-lib (4.7-414)

CHANGES:

  + merlin binary - Replace custom "holes" AST nodes by extensions. This restores binary compatibility and fixes issues with PPXs when using typed-holes. (ocaml/merlin#1503) - Do not change temporarily Merlin's cwd when starting a PPX (ocaml/merlin#1521, fixes ocaml/merlin#1420) - Fix a parsing issue when declaring the `(??)` custom prefix operator. (ocaml/merlin#1507, fixes ocaml/merlin#1506) - Fix variant constructors' comments grouping (ocaml/merlin#1516, @mheiber, fixes ocaml/merlin#1513) - Filter-out duplicates from the `enclosing` command result (ocaml/merlin#1512) - Add a new `verbosity=smart` mode for type enclosing that only expand modules' types (ocaml/merlin#1374, @ulugbekna) - Improve locate for labels' declarations in the current buffer. (ocaml/merlin#1505, fixes ocaml/merlin#1524) - Fix locate on module without implementation (ocaml/merlin#1522, fixes ocaml/merlin#1519) - Allow program name customization when merlin is used as a library. (ocaml/merlin#1532)
  + editor modes
    - vim: load the plugin when necessary if it wasn't loaded before (ocaml/merlin#1511)
    - emacs: update CI for newer releases and fix some warnings (ocaml/merlin#1454, @mattiase)
  + test suite - Add tests for constructors' documentation (ocaml/merlin#1511) - Add test cases for label comment documentation (ocaml/merlin#1526, @mheiber) - Add a test for the `enclosing` command (ocaml/merlin#1512) - Add tests for interactions between locate and record labels (ocaml/merlin#1505) - Add test showing an issue with locate and implicit transitive deps

[new release] merlin (4.7-413)

CHANGES:

  + merlin binary - Replace custom "holes" AST nodes by extensions. This restores binary compatibility and fixes issues with PPXs when using typed-holes. (ocaml/merlin#1503) - Fix a parsing issue when declaring the `(??)` custom prefix operator. (ocaml/merlin#1507, fixes ocaml/merlin#1506) - Fix variant constructors' comments grouping (ocaml/merlin#1516, @mheiber, fixes ocaml/merlin#1513) - Filter-out duplicates from the `enclosing` command result (ocaml/merlin#1512)
  + editor modes
    - vim: load the plugin when necessary if it wasn't loaded before (ocaml/merlin#1511)
  + test suite - Add tests for constructors' documentation (ocaml/merlin#1511) - Add test cases for label comments documentation (ocaml/merlin#1526, @mheiber) - Add a test for the `enclosing` command (ocaml/merlin#1512)

[new release] merlin (4.7-412)

CHANGES:

  + merlin binary - Replace custom "holes" AST nodes by extensions. This restores binary compatibility and fixes issues with PPXs when using typed-holes. (ocaml/merlin#1503) - Fix a parsing issue when declaring the `(??)` custom prefix operator. (ocaml/merlin#1507, fixes ocaml/merlin#1506) - Fix variant constructors' comments grouping (ocaml/merlin#1516, @mheiber, fixes ocaml/merlin#1513) - Filter-out duplicates from the `enclosing` command result (ocaml/merlin#1512)
  + editor modes
    - vim: load the plugin when necessary if it wasn't loaded before (ocaml/merlin#1511)
  + test suite - Add tests for constructors' documentation (ocaml/merlin#1511) - Add test cases for label comment documentation (ocaml/merlin#1526, @mheiber) - Add a test for the `enclosing` command (ocaml/merlin#1512)