### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.3.1)

### DIFF
--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.3.1/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.3.1/opam
@@ -1,0 +1,44 @@
+
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.3.1/happy-eyeballs-0.3.1.tbz"
+  checksum: [
+    "sha256=de866cb7b4d689813bf42265093f07d0fb77498959955c037c86f0e5cb80e2d5"
+    "sha512=11dc45c9fe1c5932bb8649f4173d779b8d124bb021922e8a90fcdad17709348be4c83951bfd6e664426d28a394ec0e004f7de81991403011a27db985be93f3d0"
+  ]
+}
+x-commit-hash: "a5bfff0ed8799dd48791e4dde187c0d2312f6fa0"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.3.1/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.3.1/opam
@@ -1,0 +1,46 @@
+
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.2.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.3.1/happy-eyeballs-0.3.1.tbz"
+  checksum: [
+    "sha256=de866cb7b4d689813bf42265093f07d0fb77498959955c037c86f0e5cb80e2d5"
+    "sha512=11dc45c9fe1c5932bb8649f4173d779b8d124bb021922e8a90fcdad17709348be4c83951bfd6e664426d28a394ec0e004f7de81991403011a27db985be93f3d0"
+  ]
+}
+x-commit-hash: "a5bfff0ed8799dd48791e4dde187c0d2312f6fa0"

--- a/packages/happy-eyeballs/happy-eyeballs.0.3.1/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.3.1/opam
@@ -1,0 +1,41 @@
+
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.3.1/happy-eyeballs-0.3.1.tbz"
+  checksum: [
+    "sha256=de866cb7b4d689813bf42265093f07d0fb77498959955c037c86f0e5cb80e2d5"
+    "sha512=11dc45c9fe1c5932bb8649f4173d779b8d124bb021922e8a90fcdad17709348be4c83951bfd6e664426d28a394ec0e004f7de81991403011a27db985be93f3d0"
+  ]
+}
+x-commit-hash: "a5bfff0ed8799dd48791e4dde187c0d2312f6fa0"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Improve documentation for `Happy_eyeballs.timer` (roburio/happy-eyeballs#24, roburio/happy-eyeballs#25 @reynir, review by @hannesm and @bikallem)
* Demote log levels that are (likely) caused by missing cancellation (roburio/happy-eyeballs#26 @reynir)
