### PR TITLE
[new release] merlin and merlin-lib (4.7-500)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.6/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.6/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08" & < "5.0.0"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.9.0"}
   "merlin-lib" {>= "4.6"}
   "ocamlfind" {>= "1.6.0"}

--- a/packages/merlin-lib/merlin-lib.4.7-500/opam
+++ b/packages/merlin-lib/merlin-lib.4.7-500/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7-500/merlin-4.7-500.tbz"
+  checksum: [
+    "sha256=7a561bff4bd5be8862f726057bfe786eb6fa421e9fca23759183d1ab97cfd731"
+    "sha512=519bc77caa704fd26f9451ad4010243899581740c398639969bdd63ab2aa595c86a4e896677f612fed3681044a3ab153755dc3a14a760f953b2b0ad538c51cc1"
+  ]
+}
+x-commit-hash: "2fd3d4cb28292dd757cec027378becf6a2e4cefc"

--- a/packages/merlin/merlin.4.6.1~5.0preview/opam
+++ b/packages/merlin/merlin.4.6.1~5.0preview/opam
@@ -68,3 +68,4 @@ See https://github.com/OCamlPro/opam-user-setup
 url {
   src: "git+https://github.com/kit-ty-kate/merlin.git#500"
 }
+available: false # preview

--- a/packages/merlin/merlin.4.7-500/opam
+++ b/packages/merlin/merlin.4.7-500/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.6"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7-500/merlin-4.7-500.tbz"
+  checksum: [
+    "sha256=7a561bff4bd5be8862f726057bfe786eb6fa421e9fca23759183d1ab97cfd731"
+    "sha512=519bc77caa704fd26f9451ad4010243899581740c398639969bdd63ab2aa595c86a4e896677f612fed3681044a3ab153755dc3a14a760f953b2b0ad538c51cc1"
+  ]
+}
+x-commit-hash: "2fd3d4cb28292dd757cec027378becf6a2e4cefc"


### PR DESCRIPTION
CHANGES:

  + merlin binary - Replace custom "holes" AST nodes by extensions. This restores binary compatibility and fixes issues with PPXs when using typed-holes. (ocaml/merlin#1503) - Do not change temporarily Merlin's cwd when starting a PPX (ocaml/merlin#1521, fixes ocaml/merlin#1420) - Fix a parsing issue when declaring the `(??)` custom prefix operator. (ocaml/merlin#1507, fixes ocaml/merlin#1506) - Fix variant constructors' comments grouping (ocaml/merlin#1516, @mheiber, fixes ocaml/merlin#1513) - Filter-out duplicates from the `enclosing` command result (ocaml/merlin#1512) - Add a new `verbosity=smart` mode for type enclosing that only expand modules' types (ocaml/merlin#1374, @ulugbekna) - Improve locate for labels' declarations in the current buffer. (ocaml/merlin#1505, fixes ocaml/merlin#1524) - Fix locate on module without implementation (ocaml/merlin#1522, fixes ocaml/merlin#1519) - Allow program name customization when merlin is used as a library. (ocaml/merlin#1532)
  + editor modes
    - vim: load the plugin when necessary if it wasn't loaded before (ocaml/merlin#1511)
    - emacs: update CI for newer releases and fix some warnings (ocaml/merlin#1454, @mattiase)
  + test suite - Add tests for constructors' documentation (ocaml/merlin#1511) - Add test cases for label comment documentation (ocaml/merlin#1526, @mheiber) - Add a test for the `enclosing` command (ocaml/merlin#1512) - Add tests for interactions between locate and record labels (ocaml/merlin#1505) - Add test showing an issue with locate and implicit transitive deps