### PR TITLE
guardian: Remove restrictive constraints

### DIFF
--- a/packages/guardian/guardian.0.0.4/opam
+++ b/packages/guardian/guardian.0.0.4/opam
@@ -21,7 +21,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.6.1"}
   "lwt_ppx" {>= "2.1.0"}
-  "mariadb" {= "1.1.4"}
+  "mariadb" {>= "1.1.4"}
   "ocaml" {>= "4.12.0"}
   "ocamlformat" {>= "0.24.1"}
   "ppx_deriving" {>= "5.2.1"}


### PR DESCRIPTION
Follow up to https://github.com/ocaml/opam-repository/pull/22532#discussion_r1031802151
@mabiede Is there a reason why this constraint was there in the first place?