### PR TITLE
Package fuzzy_compare.2.0.0

### DIFF
--- a/packages/fuzzy_compare/fuzzy_compare.2.0.0/opam
+++ b/packages/fuzzy_compare/fuzzy_compare.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Fastest bounded Levenshtein comparator over generic structures"
+description: """
+This library does not calculate the edit distance.
+
+Rather, it provides extremely efficient automata that answer whether 2 values are within a predetermined number of edits of one another. Edits are: additions, deletions, replacements.
+
+Once generated, an automaton can be reused to compare any 2 values in around 2-8 µs.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/fuzzy_compare"
+dev-repo: "git://github.com/SGrondin/fuzzy_compare"
+doc: "https://github.com/SGrondin/fuzzy_compare"
+bug-reports: "https://github.com/SGrondin/fuzzy_compare/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "core" { >= "v0.15.0" }
+  # "ocamlformat" { = "0.21.0" } # Development
+  # "ocaml-lsp-server" # Development
+
+  "uuseg" { with-test }
+  "uunf" { with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/fuzzy_compare/archive/2.0.0.tar.gz"
+  checksum: [
+    "md5=3e82d5ab12f1cdb93e0fbae1f386f5bf"
+    "sha512=9c43989323872380b60cb593715214e37190efa6b663fbed9264aaafc0dceed5419cfd858c6e6cafdfa60a1c4ee2ccea6a408bb6f3cd7500dbea081725ba9c25"
+  ]
+}


### PR DESCRIPTION
### `fuzzy_compare.2.0.0`
Fastest bounded Levenshtein comparator over generic structures
This library does not calculate the edit distance.

Rather, it provides extremely efficient automata that answer whether 2 values are within a predetermined number of edits of one another. Edits are: additions, deletions, replacements.

Once generated, an automaton can be reused to compare any 2 values in around 2-8 µs.



---
* Homepage: https://github.com/SGrondin/fuzzy_compare
* Source repo: git://github.com/SGrondin/fuzzy_compare
* Bug tracker: https://github.com/SGrondin/fuzzy_compare/issues

---
:camel: Pull-request generated by opam-publish v2.1.0