### PR TITLE
Package bls12-381-hash.0.0.5

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.0.0.5/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.0.0.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of some cryptographic hash primitives using the scalar field of BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/-/archive/0.0.5/ocaml-bls12-381-hash-0.0.5.tar.gz"
+  checksum: [
+    "md5=9b70629e551cc0e3f86d72b3532dafb3"
+    "sha512=cdcf8004edeecbf18706b735c2a837348ce9a19df5ab9d3e37a7b0e216199d43c41f8ba81fc55b0fb08b1192538d699a79927219397639b27c378b457e92b33b"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381-hash.0.0.5`
Implementation of some cryptographic hash primitives using the scalar field of BLS12-381



---
* Homepage: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues

---
:camel: Pull-request generated by opam-publish v2.1.0