### PR TITLE
Allow the use of rustup in `conf-rust` packages

### DIFF
--- a/packages/conf-rust-2018/conf-rust-2018.1/files/rustc.sh
+++ b/packages/conf-rust-2018/conf-rust-2018.1/files/rustc.sh
@@ -1,0 +1,3 @@
+!/bin/sh
+
+rustc --edition 2018 test.rs || rustup rustc --edition 2018 test.rs

--- a/packages/conf-rust-2018/conf-rust-2018.1/opam
+++ b/packages/conf-rust-2018/conf-rust-2018.1/opam
@@ -4,10 +4,13 @@ authors: "Simon Cruanes"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
-extra-files: ["test.rs" "md5=639e04c270fef8589636e0416761a67b"]
+extra-files: [
+  ["test.rs" "md5=639e04c270fef8589636e0416761a67b"]
+  ["rustc.sh" "sha256=7d1879f34753cea243d47c4260ceb0634a3c5ce694c9a92a2e47fa24e74c6dc8"]
+]
 build: [
   ["cargo" "--version"]
-  ["rustc" "--edition" "2018" "test.rs"]
+  ["sh" "rustc.sh"]
 ]
 depexts: [
   ["cargo"] {os-distribution = "centos" & os-version >= "8"}

--- a/packages/conf-rust-2021/conf-rust-2021.1/files/rustc.sh
+++ b/packages/conf-rust-2021/conf-rust-2021.1/files/rustc.sh
@@ -1,0 +1,3 @@
+!/bin/sh
+
+rustc --edition 2021 test.rs || rustup rustc --edition 2021 test.rs

--- a/packages/conf-rust-2021/conf-rust-2021.1/opam
+++ b/packages/conf-rust-2021/conf-rust-2021.1/opam
@@ -7,10 +7,13 @@ authors: [
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
-extra-files: ["test.rs" "sha256=536e506bb90914c243a12b397b9a998f85ae2cbd9ba02dfd03a9e155ca5ca0f4"]
+extra-files: [
+  ["test.rs" "sha256=536e506bb90914c243a12b397b9a998f85ae2cbd9ba02dfd03a9e155ca5ca0f4"]
+  ["rustc.sh" "sha256=d2c3cfc059db4a6a82d5e8cfc4e923439420f1b9d687a8773f90748996582774"]
+]
 build: [
   ["cargo" "--version"]
-  ["rustc" "--edition" "2021" "test.rs"]
+  ["sh" "rustc.sh"]
 ]
 depexts: [
   ["cargo"] {os-distribution = "centos" & os-version >= "8"}


### PR DESCRIPTION
`rustup` is a tool to manage rust installations. Its functionalities overlap with `opam`. For example, similarly to opam switches, it is possible to have multiple versions of rust installed on the same machine, and have different shells (for different software projects) use different versions. Unfortunately, there is interference in the way that rustup dispatches to different installations and the way opam sandboxes the building of packages.

This PR attempts to fix that. It does so by making the install step try both `rustc` (the binary that is available in the PATH in the sandboxed environment) and `rustup rustc` (the binary that `rustup` dispatches to from the sandboxed environment).

I'm not sure this is the best way to make it all work. It worked on my local machine. And I think it's ok. But maybe there is a better approach. Suggestions welcome.