### PR TITLE
[new release] mirage-block and mirage-block-combinators (3.0.2)

### DIFF
--- a/packages/mirage-block-combinators/mirage-block-combinators.3.0.2/opam
+++ b/packages/mirage-block-combinators/mirage-block-combinators.3.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: "David Scott"
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "4.0.0"}
+  "logs"
+  "mirage-block" {=version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS using Lwt"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+This package is specialised to the Lwt concurrency library for IO.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v3.0.2/mirage-block-3.0.2.tbz"
+  checksum: [
+    "sha256=5002d47de2f41b599f4ac2e001bfc7a50e8e575d98b58f8650e606eb2854c002"
+    "sha512=5b36b4b8a886f62f87950cae355d14c0ecc8f70f1be1287d5da0b413f7a78020b11e9771cb16ffbbbb5654f6f902c91436cfbbd4a3cc2d9ba9883c0c579d156f"
+  ]
+}
+x-commit-hash: "20e3794e5452b8d37b951cf60ec907e8d96507c7"
+

--- a/packages/mirage-block/mirage-block.3.0.2/opam
+++ b/packages/mirage-block/mirage-block.3.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "dave@recoil.org"
+authors: ["David Scott" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/mirage-block"
+doc: "https://mirage.github.io/mirage-block/"
+bug-reports: "https://github.com/mirage/mirage-block/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.7"}
+  "cstruct" {>= "4.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/mirage-block.git"
+synopsis: "Block signatures and implementations for MirageOS"
+description: """
+This repo contains generic operations over Mirage `BLOCK` devices.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-block/releases/download/v3.0.2/mirage-block-3.0.2.tbz"
+  checksum: [
+    "sha256=5002d47de2f41b599f4ac2e001bfc7a50e8e575d98b58f8650e606eb2854c002"
+    "sha512=5b36b4b8a886f62f87950cae355d14c0ecc8f70f1be1287d5da0b413f7a78020b11e9771cb16ffbbbb5654f6f902c91436cfbbd4a3cc2d9ba9883c0c579d156f"
+  ]
+}
+x-commit-hash: "20e3794e5452b8d37b951cf60ec907e8d96507c7"
+


### PR DESCRIPTION
Block signatures and implementations for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-block">https://github.com/mirage/mirage-block</a>
- Documentation: <a href="https://mirage.github.io/mirage-block/">https://mirage.github.io/mirage-block/</a>

##### CHANGES:

* Document optional buffer size requirement (mirage/mirage-block#54 @reynir)
