### PR TITLE
[new release] mirage-block-solo5 (0.8.1)

### DIFF
--- a/packages/mirage-block-solo5/mirage-block-solo5.0.8.1/opam
+++ b/packages/mirage-block-solo5/mirage-block-solo5.0.8.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-block-solo5"
+dev-repo:     "git+https://github.com/mirage/mirage-block-solo5.git"
+bug-reports:  "https://github.com/mirage/mirage-block-solo5/issues"
+doc:           "https://mirage.github.io/mirage-block-solo5/"
+license:       "ISC"
+authors:      ["Dan Williams" "Martin Lucina"]
+tags: [
+  "org:mirage"
+]
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "2.0"}
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS block interface"
+description:
+  "This library implements the MirageOS block interface for Solo5 targets."
+url {
+  src:
+    "https://github.com/mirage/mirage-block-solo5/releases/download/v0.8.1/mirage-block-solo5-0.8.1.tbz"
+  checksum: [
+    "sha256=315ec10c5c3fcf4475696e4eccb9c52a22c37374a2849e718c3e527c34073c0f"
+    "sha512=6ae88a5377b732113f5e5e2e958293f7a6bfd3bd04b371e3ac719ce307ecc4914577046423d1a2a162c4b3b04a728c34c982832e00a1a4f78ee0cbf2d872e644"
+  ]
+}
+x-commit-hash: "95db9204dbe36aa4019b573b4009845673db201a"


### PR DESCRIPTION
Solo5 implementation of MirageOS block interface

- Project page: <a href="https://github.com/mirage/mirage-block-solo5">https://github.com/mirage/mirage-block-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-block-solo5/">https://mirage.github.io/mirage-block-solo5/</a>

##### CHANGES:

* Check that buffers are aligned before conducting I/O (mirage/mirage-block-solo5#29 @reynir)
* Allow read/write with buffers being multiple of sector_size (mirage/mirage-block-solo5#28 @reynir)
