### PR TITLE
[new release] xapi-stdext, xapi-stdext-zerocheck, xapi-stdext-unix, xapi-stdext-threads, xapi-stdext-std, xapi-stdext-pervasives, xapi-stdext-encodings and xapi-stdext-date (4.21.0)

### DIFF
--- a/packages/xapi-stdext-date/xapi-stdext-date.4.21.0/opam
+++ b/packages/xapi-stdext-date/xapi-stdext-date.4.21.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Dates"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "alcotest" {with-test}
+  "astring"
+  "base-unix"
+  "ptime"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.21.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.21.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Encodings"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "alcotest" {>= "0.6.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"

--- a/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.21.0/opam
+++ b/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.21.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Pervasives"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "logs"
+  "odoc" {with-doc}
+  "xapi-backtrace"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.21.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.21.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Stdlib"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.21.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.21.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Threads"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "base-threads"
+  "base-unix"
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Unix"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+available: os-family != "alpine"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/xapi-project/stdext"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml"
+  "ocaml" {>= "4.12.0"}
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}
   "odoc" {with-doc}

--- a/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.21.0/opam
+++ b/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.21.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Zerocheck"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.21.0/xapi-stdext-4.21.0.tbz"
+  checksum: [
+    "sha256=427af021994ba881918c4c3a89d441fb000311d5e7c8e1ffcb1e239d899d7741"
+    "sha512=70c55e0fda2bf641cf1ccb4bcff8040a6a8f0e8a2d58a727492dedbe585a870a914bae83ca36917ed2e54fc978e70c4a95b454424b69065efae08035de8830f2"
+  ]
+}
+x-commit-hash: "986d1aeb566773906eb436a2df9aeb677f56d0fa"


### PR DESCRIPTION
Xapi's standard library extension

- Project page: <a href="https://github.com/xapi-project/stdext">https://github.com/xapi-project/stdext</a>

##### CHANGES:

 - unix: add permissions to write_{bytes,string}_to_file
 - Use a dune version with fixed metadata generation
 - threads, unix: avoid using C functions deprecated in OCaml 5
 - Avoid warnings and add the check to detect them to the CI
 - zerocheck: remove wrong, unused code. It was dangerous to leave it available

I know the previous version hasn't been included yet, but we kinda need this version already 😬