### PR TITLE
Package bls12-381-hash.1.0.0

### DIFF
--- a/packages/bls12-381-hash/bls12-381-hash.1.0.0/opam
+++ b/packages/bls12-381-hash/bls12-381-hash.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis:
+  "Implementation of some cryptographic hash primitives using the scalar field of BLS12-381"
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "2.8.4"}
+  "bls12-381" {>= "5.0.0"}
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5"}
+]
+available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
+build: ["dune" "build" "-j" jobs "-p" name "@install"]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/-/archive/1.0.0/ocaml-bls12-381-hash-1.0.0.tar.gz"
+  checksum: [
+    "md5=9b4bd4c42e4542b777f13666f72da9e3"
+    "sha512=c9465f26c50624d95bb55a878bb78dff2703bd352445221bfef434cad2edb040cef95f33f44dcfe96949e52ba7ff9aeeab24cffd2d80fcb97e45085dad336701"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381-hash.1.0.0`
Implementation of some cryptographic hash primitives using the scalar field of BLS12-381



---
* Homepage: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381-hash/issues

---
:camel: Pull-request generated by opam-publish v2.1.0