### PR TITLE
extunix: fix OCaml 5.0 incompatibilites and libexecinfo-dev Alpine depext availability

### DIFF
--- a/packages/extunix/extunix.0.3.1/opam
+++ b/packages/extunix/extunix.0.3.1/opam
@@ -34,7 +34,7 @@ homepage: "https://ygrek.org/p/ocaml-extunix"
 doc: "https://ygrek.org/p/ocaml-extunix"
 bug-reports: "https://github.com/ygrek/extunix/issues"
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0"}
   "dune" {>= "2.2"}
   "dune-configurator" {build}
   "ppxlib" {>= "0.18"}

--- a/packages/extunix/extunix.0.3.2/opam
+++ b/packages/extunix/extunix.0.3.2/opam
@@ -57,7 +57,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ygrek/extunix.git"
-depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
+depexts: [["libexecinfo-dev"] {os = "alpine" & os-version >= "3.5" & os-version < "3.17"}]
 url {
   src: "https://ygrek.org/p/release/ocaml-extunix/ocaml-extunix-0.3.2.tar.gz"
   checksum: [

--- a/packages/extunix/extunix.0.3.2/opam
+++ b/packages/extunix/extunix.0.3.2/opam
@@ -34,7 +34,7 @@ doc: "https://ygrek.org/p/ocaml-extunix"
 bug-reports: "https://github.com/ygrek/extunix/issues"
 depends: [
   "dune" {>= "2.2"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0"}
   "dune-configurator" {build}
   "ppxlib" {>= "0.18" & build}
   "ounit2" {with-test}

--- a/packages/extunix/extunix.0.3.2/opam
+++ b/packages/extunix/extunix.0.3.2/opam
@@ -57,7 +57,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ygrek/extunix.git"
-depexts: [["libexecinfo-dev"] {os = "alpine"}]
+depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
 url {
   src: "https://ygrek.org/p/release/ocaml-extunix/ocaml-extunix-0.3.2.tar.gz"
   checksum: [

--- a/packages/extunix/extunix.0.4.0/opam
+++ b/packages/extunix/extunix.0.4.0/opam
@@ -33,7 +33,7 @@ homepage: "https://github.com/ygrek/extunix"
 bug-reports: "https://github.com/ygrek/extunix/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0"}
   "dune-configurator" {>= "2.9" & build}
   "ppxlib" {>= "0.18" & build}
   "ounit2" {with-test}

--- a/packages/extunix/extunix.0.4.0/opam
+++ b/packages/extunix/extunix.0.4.0/opam
@@ -57,7 +57,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ygrek/extunix.git"
-depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
+depexts: [["libexecinfo-dev"] {os = "alpine" & os-version >= "3.5" & os-version < "3.17"}]
 url {
   src:
     "https://github.com/ygrek/extunix/releases/download/v0.4.0/extunix-0.4.0.tbz"

--- a/packages/extunix/extunix.0.4.0/opam
+++ b/packages/extunix/extunix.0.4.0/opam
@@ -57,7 +57,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ygrek/extunix.git"
-depexts: [["libexecinfo-dev"] {os = "alpine"}]
+depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
 url {
   src:
     "https://github.com/ygrek/extunix/releases/download/v0.4.0/extunix-0.4.0.tbz"

--- a/packages/extunix/extunix.0.4.1/opam
+++ b/packages/extunix/extunix.0.4.1/opam
@@ -57,7 +57,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ygrek/extunix.git"
-depexts: [["libexecinfo-dev"] {os = "alpine"}]
+depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
 url {
   src:
     "https://github.com/ygrek/extunix/releases/download/v0.4.1/extunix-0.4.1.tbz"

--- a/packages/extunix/extunix.0.4.1/opam
+++ b/packages/extunix/extunix.0.4.1/opam
@@ -57,7 +57,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ygrek/extunix.git"
-depexts: [["libexecinfo-dev"] {os = "alpine" & "3.5" <= os-version & os-version < "3.17"}]
+depexts: [["libexecinfo-dev"] {os = "alpine" & os-version >= "3.5" & os-version < "3.17"}]
 url {
   src:
     "https://github.com/ygrek/extunix/releases/download/v0.4.1/extunix-0.4.1.tbz"


### PR DESCRIPTION
Commit removing the package:
https://git.alpinelinux.org/aports/commit/?id=50795a14dee6

There is no out-of-the box replacement. Apparently it was all broken anyway.