### PR TITLE
[new release] colombe, sendmail and sendmail-lwt (0.7.0)

### DIFF
--- a/packages/colombe/colombe.0.7.0/opam
+++ b/packages/colombe/colombe.0.7.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.7.0/colombe-0.7.0.tbz"
+  checksum: [
+    "sha256=6dcf2b125140de0ac956b6930226b2546be53bb33248783270e477d5463b58e6"
+    "sha512=c1db3b96657be97469627b6e1bf7d9ddcd088957056d8aea1c8a0cad0750a37de9749dafa7479c86d1f6a92fd660a1a8f6fca6fa8a48a4e2c75ebc48edb910c3"
+  ]
+}
+x-commit-hash: "c1e6e62c8036c8c9bb9ef9be8950db18fe114076"

--- a/packages/sendmail-lwt/sendmail-lwt.0.7.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.7.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.7.0/colombe-0.7.0.tbz"
+  checksum: [
+    "sha256=6dcf2b125140de0ac956b6930226b2546be53bb33248783270e477d5463b58e6"
+    "sha512=c1db3b96657be97469627b6e1bf7d9ddcd088957056d8aea1c8a0cad0750a37de9749dafa7479c86d1f6a92fd660a1a8f6fca6fa8a48a4e2c75ebc48edb910c3"
+  ]
+}
+x-commit-hash: "c1e6e62c8036c8c9bb9ef9be8950db18fe114076"

--- a/packages/sendmail/sendmail.0.7.0/opam
+++ b/packages/sendmail/sendmail.0.7.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "0.13.0"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.7.0/colombe-0.7.0.tbz"
+  checksum: [
+    "sha256=6dcf2b125140de0ac956b6930226b2546be53bb33248783270e477d5463b58e6"
+    "sha512=c1db3b96657be97469627b6e1bf7d9ddcd088957056d8aea1c8a0cad0750a37de9749dafa7479c86d1f6a92fd660a1a8f6fca6fa8a48a4e2c75ebc48edb910c3"
+  ]
+}
+x-commit-hash: "c1e6e62c8036c8c9bb9ef9be8950db18fe114076"


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Implement the `LOGIN` mechanism when we want to send an email (@dinosaure, issued by @aronerben & @mabiede, mirage/colombe#60, mirage/colombe#61)
- Update the codebase with `ocamlformat` (@dinosaure, mirage/colombe#62, mirage/colombe#64)
