### PR TITLE
[new release] dkim and dkim-mirage (0.4.0)

### DIFF
--- a/packages/dkim-mirage/dkim-mirage.0.4.0/opam
+++ b/packages/dkim-mirage/dkim-mirage.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml for MirageOS"
+description: """A light layer of the dkim library for MirageOS"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "dkim"              {= version}
+  "dns-client"        {>= "6.0.0"}
+  "mirage-time"
+  "mirage-random"
+  "mirage-clock"
+  "tcpip"             {>= "7.0.0"}
+  "lwt"
+  "alcotest"          {with-test}
+  "digestif"          {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.4.0/dkim-0.4.0.tbz"
+  checksum: [
+    "sha256=e3cf23b941ba243719bbe05e352a59d34a42e77437ba629b0e5daad59f033346"
+    "sha512=e713ccd485bfb2c021b292710cf344492a80bb7c68d832642285e37bddd966541696077ed4237bea4184611d0100492d52c1fcb58a82eaf784cc642b74e26542"
+  ]
+}
+x-commit-hash: "81e63131e862e863dfb8be4fb2d3443978c92d0b"

--- a/packages/dkim/dkim.0.4.0/opam
+++ b/packages/dkim/dkim.0.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/ocaml-dkim"
+bug-reports:  "https://github.com/mirage/ocaml-dkim/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-dkim.git"
+doc:          "https://mirage.github.io/ocaml-dkim/"
+license:      "MIT"
+synopsis:     "Implementation of DKIM in OCaml"
+description: """A library and a binary to verify and sign an email
+with the DKIM mechanism described by the RFC 6376"""
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "mrmime"            {>= "0.5.0"}
+  "digestif"          {>= "0.9.0"}
+  "ipaddr"
+  "astring"           {>= "0.8.5"}
+  "base-unix"
+  "hmap"
+  "domain-name"
+  "dns-client"        {>= "6.4.0"}
+  "cmdliner"          {>= "1.1.0"}
+  "logs"
+  "fmt"               {>= "0.8.7"}
+  "fpath"
+  "base64"            {>= "3.0.0"}
+  "mirage-crypto"     {>= "0.9.2"}
+  "mirage-crypto-pk"  {>= "0.9.2"}
+  "x509"              {>= "0.6.3"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest"          {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-dkim/releases/download/v0.4.0/dkim-0.4.0.tbz"
+  checksum: [
+    "sha256=e3cf23b941ba243719bbe05e352a59d34a42e77437ba629b0e5daad59f033346"
+    "sha512=e713ccd485bfb2c021b292710cf344492a80bb7c68d832642285e37bddd966541696077ed4237bea4184611d0100492d52c1fcb58a82eaf784cc642b74e26542"
+  ]
+}
+x-commit-hash: "81e63131e862e863dfb8be4fb2d3443978c92d0b"


### PR DESCRIPTION
Implementation of DKIM in OCaml

- Project page: <a href="https://github.com/mirage/ocaml-dkim">https://github.com/mirage/ocaml-dkim</a>
- Documentation: <a href="https://mirage.github.io/ocaml-dkim/">https://mirage.github.io/ocaml-dkim/</a>

##### CHANGES:

- Upgrade the distribuction with:
  `ocamlformat.0.23.0.`
  `cmdliner.1.1.0`
  `dns.6.4.0` (@dinosaure, @hannesm, mirage/ocaml-dkim#36)
