### PR TITLE
ott is not compatible with OCaml 5.0 (uses Array.create)

### DIFF
--- a/packages/ott/ott.0.26/opam
+++ b/packages/ott/ott.0.26/opam
@@ -20,7 +20,7 @@ run as a filter, taking a LaTeX/Coq/Isabelle/HOL source file with embedded
 (symbolic) terms of the defined language, parsing them and replacing them by
 target-system terms."""
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 extra-files: [
   ["ott.install" "md5=63ba0bb1e9f81e1b25b0727d22f8eaa1"]

--- a/packages/ott/ott.0.27/opam
+++ b/packages/ott/ott.0.27/opam
@@ -19,7 +19,7 @@ run as a filter, taking a LaTeX/Coq/Isabelle/HOL source file with embedded
 (symbolic) terms of the defined language, parsing them and replacing them by
 target-system terms."""
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 extra-files: ["ott.install" "md5=63ba0bb1e9f81e1b25b0727d22f8eaa1"]
 url {

--- a/packages/ott/ott.0.28/opam
+++ b/packages/ott/ott.0.28/opam
@@ -19,7 +19,7 @@ run as a filter, taking a LaTeX/Coq/Isabelle/HOL source file with embedded
 (symbolic) terms of the defined language, parsing them and replacing them by
 target-system terms."""
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
 ]
 extra-files: ["ott.install" "md5=ef718a2cb8ec39a14ac2e81d15227ff2"]
 url {

--- a/packages/ott/ott.0.29/opam
+++ b/packages/ott/ott.0.29/opam
@@ -5,7 +5,7 @@ license: ["BSD-3-Clause" "LGPL-2.1-only"]
 homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 build: [make "world"]
 dev-repo: "git+https://github.com/ott-lang/ott.git"

--- a/packages/ott/ott.0.30/opam
+++ b/packages/ott/ott.0.30/opam
@@ -5,7 +5,7 @@ license: "part BSD3, part LGPL 2.1"
 homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 build: [make "world"]
 dev-repo: "git+https://github.com/ott-lang/ott.git"

--- a/packages/ott/ott.0.31/opam
+++ b/packages/ott/ott.0.31/opam
@@ -5,7 +5,7 @@ license: "part BSD3, part LGPL 2.1"
 homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 build: [
   [make "world"]

--- a/packages/ott/ott.0.32/opam
+++ b/packages/ott/ott.0.32/opam
@@ -5,7 +5,7 @@ license: ["BSD-3-Clause" "LGPL-2.1-only"]
 homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlbuild" {with-test}
   "ocamlfind" {with-test}
   "pprint" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling ott.0.32 ===========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ott.0.32
# command              ~/.opam/opam-init/hooks/sandbox.sh build make world
# exit-code            2
# env-file             ~/.opam/log/ott-8-152977.env
# output-file          ~/.opam/log/ott-8-152977.out
### output ###
# cd src; make install
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ott.0.32/src'
# ocamllex grammar_lexer.mll
# 374 states, 16439 transitions, table size 68000 bytes
# 3397 additional bytes used for bindings
# ocamlyacc -v grammar_parser.mly
# 2 rules never reduced
# ocamldep location.ml types.ml auxl.ml merge.ml global_option.ml grammar_lexer.ml grammar_parser.mli grammar_parser.ml version.ml grammar_pp.ml parse_table.ml glr.ml new_term_parser.ml term_parser.ml dependency.ml bounds.ml context_pp.ml quotient_rules.ml grammar_typecheck.ml transform.ml substs_pp.ml subrules_pp.ml embed_pp.ml defns.ml ln_transform.ml coq_induct.ml system_pp.ml lex_menhir_pp.ml align.ml main.ml align.mli bounds.mli coq_induct.mli defns.mli dependency.mli embed_pp.mli grammar_typecheck.mli merge.mli subrules_pp.mli substs_pp.mli system_pp.mli lex_menhir_pp.mli transform.mli term_parser.mli > .depend
# mkdir ../bin
# cd .. && tar -zxvf ocamlgraph-1.7.tar.gz
# ocamlgraph-1.7/
# ocamlgraph-1.7/bin/
# ocamlgraph-1.7/src/
# ocamlgraph-1.7/src/blocks.ml
# ocamlgraph-1.7/src/builder.ml
# ocamlgraph-1.7/src/builder.mli
# ocamlgraph-1.7/src/classic.ml
# ocamlgraph-1.7/src/classic.mli
# ocamlgraph-1.7/src/cliquetree.ml
# ocamlgraph-1.7/src/cliquetree.mli
# ocamlgraph-1.7/src/coloring.ml
# ocamlgraph-1.7/src/coloring.mli
# ocamlgraph-1.7/src/components.ml
# ocamlgraph-1.7/src/components.mli
# ocamlgraph-1.7/src/delaunay.ml
# ocamlgraph-1.7/src/delaunay.mli
# ocamlgraph-1.7/src/dot.ml
# ocamlgraph-1.7/src/dot.mli
# ocamlgraph-1.7/src/dot_ast.mli
# ocamlgraph-1.7/src/dot_lexer.ml
# ocamlgraph-1.7/src/dot_lexer.mll
# ocamlgraph-1.7/src/dot_parser.ml
# ocamlgraph-1.7/src/dot_parser.mli
# ocamlgraph-1.7/src/dot_parser.mly
# ocamlgraph-1.7/src/flow.ml
# ocamlgraph-1.7/src/flow.mli
# ocamlgraph-1.7/src/gmap.ml
# ocamlgraph-1.7/src/gmap.mli
# ocamlgraph-1.7/src/gml.ml
# ocamlgraph-1.7/src/gml.mli
# ocamlgraph-1.7/src/gml.mll
# ocamlgraph-1.7/src/graphviz.ml
# ocamlgraph-1.7/src/graphviz.mli
# ocamlgraph-1.7/src/imperative.ml
# ocamlgraph-1.7/src/imperative.mli
# ocamlgraph-1.7/src/kruskal.ml
# ocamlgraph-1.7/src/kruskal.mli
# ocamlgraph-1.7/src/mcs_m.ml
# ocamlgraph-1.7/src/mcs_m.mli
# ocamlgraph-1.7/src/md.ml
# ocamlgraph-1.7/src/md.mli
# ocamlgraph-1.7/src/minsep.ml
# ocamlgraph-1.7/src/minsep.mli
# ocamlgraph-1.7/src/oper.ml
# ocamlgraph-1.7/src/oper.mli
# ocamlgraph-1.7/src/pack.ml
# ocamlgraph-1.7/src/pack.mli
# ocamlgraph-1.7/src/path.ml
# ocamlgraph-1.7/src/path.mli
# ocamlgraph-1.7/src/persistent.ml
# ocamlgraph-1.7/src/persistent.mli
# ocamlgraph-1.7/src/rand.ml
# ocamlgraph-1.7/src/rand.mli
# ocamlgraph-1.7/src/sig.mli
# ocamlgraph-1.7/src/sig_pack.mli
# ocamlgraph-1.7/src/strat.ml
# ocamlgraph-1.7/src/strat.mli
# ocamlgraph-1.7/src/topological.ml
# ocamlgraph-1.7/src/topological.mli
# ocamlgraph-1.7/src/traverse.ml
# ocamlgraph-1.7/src/traverse.mli
# ocamlgraph-1.7/src/util.ml
# ocamlgraph-1.7/src/util.mli
# ocamlgraph-1.7/src/version.ml
# ocamlgraph-1.7/lib/
# ocamlgraph-1.7/lib/bitv.ml
# ocamlgraph-1.7/lib/bitv.mli
# ocamlgraph-1.7/lib/heap.ml
# ocamlgraph-1.7/lib/heap.mli
# ocamlgraph-1.7/lib/unionfind.ml
# ocamlgraph-1.7/lib/unionfind.mli
# ocamlgraph-1.7/Makefile.in
# ocamlgraph-1.7/configure
# ocamlgraph-1.7/configure.in
# ocamlgraph-1.7/META.in
# ocamlgraph-1.7/.depend
# ocamlgraph-1.7/editor/
# ocamlgraph-1.7/editor/ed_display.ml
# ocamlgraph-1.7/editor/ed_draw.ml
# ocamlgraph-1.7/editor/ed_graph.ml
# ocamlgraph-1.7/editor/ed_hyper.ml
# ocamlgraph-1.7/editor/ed_main.ml
# ocamlgraph-1.7/editor/Makefile
# ocamlgraph-1.7/editor/tests/
# ocamlgraph-1.7/editor/tests/dep_ed.dot
# ocamlgraph-1.7/editor/tests/dep_why.dot
# ocamlgraph-1.7/editor/tests/fsm.dot
# ocamlgraph-1.7/editor/tests/parcours.dot
# ocamlgraph-1.7/editor/tests/softmaint.dot
# ocamlgraph-1.7/editor/tests/transparency.dot
# ocamlgraph-1.7/editor/tests/twopi2.dot
# ocamlgraph-1.7/editor/tests/unix.dot
# ocamlgraph-1.7/editor/tests/world.dot
# ocamlgraph-1.7/editor/tests/de_bruijn4.gml
# ocamlgraph-1.7/editor/tests/divisors12.gml
# ocamlgraph-1.7/editor/tests/full10.gml
# ocamlgraph-1.7/editor/tests/full20.gml
# ocamlgraph-1.7/editor/tests/full30.gml
# ocamlgraph-1.7/editor/tests/full50.gml
# ocamlgraph-1.7/editor/tests/rand_100_10.gml
# ocamlgraph-1.7/editor/tests/rand_100_300.gml
# ocamlgraph-1.7/editor/tests/rand_10_10.gml
# ocamlgraph-1.7/editor/tests/rand_10_40.gml
# ocamlgraph-1.7/editor/tests/rand_50_300.gml
# ocamlgraph-1.7/editor/tests/ring_100.gml
# ocamlgraph-1.7/editor/tests/test.gml
# ocamlgraph-1.7/editor/tests/test2,1_2.gml
# ocamlgraph-1.7/editor/tests/test2,1_3.gml
# ocamlgraph-1.7/editor/tests/test2,1_3tot.gml
# ocamlgraph-1.7/editor/tests/test2_2.gml
# ocamlgraph-1.7/view_graph/
# ocamlgraph-1.7/view_graph/viewGraph_core.ml
# ocamlgraph-1.7/view_graph/viewGraph_select.ml
# ocamlgraph-1.7/view_graph/viewGraph_test.ml
# ocamlgraph-1.7/view_graph/viewGraph_utils.ml
# ocamlgraph-1.7/view_graph/viewGraph_core.mli
# ocamlgraph-1.7/view_graph/viewGraph_select.mli
# ocamlgraph-1.7/view_graph/viewGraph_utils.mli
# ocamlgraph-1.7/view_graph/README
# ocamlgraph-1.7/view_graph/Makefile
# ocamlgraph-1.7/dgraph/
# ocamlgraph-1.7/dgraph/dGraphContainer.ml
# ocamlgraph-1.7/dgraph/dGraphMake.ml
# ocamlgraph-1.7/dgraph/dGraphModel.ml
# ocamlgraph-1.7/dgraph/dGraphRandModel.ml
# ocamlgraph-1.7/dgraph/dGraphSubTree.ml
# ocamlgraph-1.7/dgraph/dGraphTreeLayout.ml
# ocamlgraph-1.7/dgraph/dGraphTreeModel.ml
# ocamlgraph-1.7/dgraph/dGraphView.ml
# ocamlgraph-1.7/dgraph/dGraphViewItem.ml
# ocamlgraph-1.7/dgraph/dGraphViewer.ml
# ocamlgraph-1.7/dgraph/xDot.ml
# ocamlgraph-1.7/dgraph/xDotDraw.ml
# ocamlgraph-1.7/dgraph/dGraphContainer.mli
# ocamlgraph-1.7/dgraph/dGraphModel.mli
# ocamlgraph-1.7/dgraph/dGraphRandModel.mli
# ocamlgraph-1.7/dgraph/dGraphSubTree.mli
# ocamlgraph-1.7/dgraph/dGraphTreeLayout.mli
# ocamlgraph-1.7/dgraph/dGraphTreeModel.mli
# ocamlgraph-1.7/dgraph/dGraphView.mli
# ocamlgraph-1.7/dgraph/dGraphViewItem.mli
# ocamlgraph-1.7/dgraph/xDot.mli
# ocamlgraph-1.7/dgraph/xDotDraw.mli
# ocamlgraph-1.7/examples/
# ocamlgraph-1.7/examples/color.ml
# ocamlgraph-1.7/examples/demo.ml
# ocamlgraph-1.7/examples/demo_planar.ml
# ocamlgraph-1.7/examples/sudoku.ml
# ocamlgraph-1.7/tests/
# ocamlgraph-1.7/tests/bench.ml
# ocamlgraph-1.7/tests/check.ml
# ocamlgraph-1.7/tests/dot.ml
# ocamlgraph-1.7/tests/strat.ml
# ocamlgraph-1.7/tests/test.ml
# ocamlgraph-1.7/README
# ocamlgraph-1.7/FAQ
# ocamlgraph-1.7/CREDITS
# ocamlgraph-1.7/INSTALL
# ocamlgraph-1.7/COPYING
# ocamlgraph-1.7/LICENSE
# ocamlgraph-1.7/CHANGES
# cd ../ocamlgraph-1.7 && patch -p1 < ../ocamlgraph-safe-string.patch
# patching file lib/bitv.ml
# Hunk #1 succeeded at 459 with fuzz 2 (offset 10 lines).
# cd ../ocamlgraph-1.7 && ./configure
# checking for ocamlc... ocamlc
# ocaml version is 5.0.0+dev10-2022-11-25
# ocaml library path is /home/opam/.opam/5.0/lib/ocaml
# checking for ocamlopt... ocamlopt
# checking ocamlopt version... ok
# checking for ocamlc.opt... ocamlc.opt
# checking ocamlc.opt version... ok
# checking for ocamlopt.opt... ocamlopt.opt
# checking ocamlc.opt version... ok
# checking for ocamldep... ocamldep
# checking for ocamllex... ocamllex
# checking for ocamllex.opt... ocamllex.opt
# checking for ocamlyacc... ocamlyacc
# checking for ocamldoc... ocamldoc
# checking for ocamldoc.opt... ocamldoc.opt
# checking for ocamlweb... true
# checking for ocamlfind... no
# checking for /home/opam/.opam/5.0/lib/ocaml/lablgtk2/lablgtk.cmxa... no
# checking Win32 platform... no
# configure: WARNING: lablgnomecanvas not found: the graph editor and view_graph will not be compiled
# configure: creating ./config.status
# config.status: creating Makefile
# cd ../ocamlgraph-1.7 && \
# make OCAMLOPT='ocamlopt -w y -g -dtypes -unsafe -inline 9 -I src -I lib' graph.cmxa
# make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ott.0.32/ocamlgraph-1.7'
# sed -e s/VERSION/1.7/ -e s/CMA/graph.cma/ -e s/CMXA/graph.cmxa/ \
# 	META.in > META
# rm -f src/version.ml
# echo "let version = \""1.7"\"" > src/version.ml
# echo "let date = \""`date`"\"" >> src/version.ml
# rm -f .depend
# ocamldep -slash -I src -I lib -I editor -I view_graph -I dgraph\
# 	lib/*.ml lib/*.mli \
# 	src/*.ml src/*.mli \
# 	editor/*.mli editor/*.ml \
# 	view_graph/*.mli view_graph/*.ml \
# 	dgraph/*.mli dgraph/*.ml > .depend
# ocamlc.opt -c -I src -I lib -g -dtypes src/sig.mli
# ocamlc.opt -c -I src -I lib -g -dtypes src/sig_pack.mli
# ocamlc.opt -c -I src -I lib -g -dtypes src/dot_ast.mli
# ocamlc.opt -c -I src -I lib -g -dtypes lib/unionfind.mli
# ocamlopt -w y -g -dtypes -unsafe -inline 9 -I src -I lib -c -I src -I lib -for-pack Graph lib/unionfind.ml
# ocamlc.opt -c -I src -I lib -g -dtypes lib/heap.mli
# ocamlopt -w y -g -dtypes -unsafe -inline 9 -I src -I lib -c -I src -I lib -for-pack Graph lib/heap.ml
# File "lib/heap.ml", line 54, characters 13-25:
# 54 |     let d' = Array.create n' d.(0) in
#                   ^^^^^^^^^^^^
# Error: Unbound value Array.create
# make[2]: *** [Makefile:477: lib/heap.cmx] Error 2
# make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/ott.0.32/ocamlgraph-1.7'
# make[1]: *** [Makefile:230: ../ocamlgraph-1.7/graph.cmxa] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/ott.0.32/src'
# make: *** [Makefile:37: world] Error 2
```