### PR TITLE
fd-send-recv is not compatible with OCaml 5.0 (uses long deprecated C API)

### DIFF
--- a/packages/fd-send-recv/fd-send-recv.1.0.5/opam
+++ b/packages/fd-send-recv/fd-send-recv.1.0.5/opam
@@ -19,7 +19,7 @@ build: [
   ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.06"}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta10"}
 ]
 synopsis:

--- a/packages/fd-send-recv/fd-send-recv.2.0.1/opam
+++ b/packages/fd-send-recv/fd-send-recv.2.0.1/opam
@@ -20,7 +20,7 @@ build: [
   ["dune" "build" "@doc" "-p" name] {with-doc}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "dune" {>= "1.4"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling fd-send-recv.2.0.1 =================================#
# context              2.1.3 | macos/x86_64 | ocaml-base-compiler.5.0.0~beta2 | file:///Users/mac1000/opam-repository
# path                 ~/.opam/5.0.0~beta2/.opam-switch/build/fd-send-recv.2.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p fd-send-recv -j 11
# exit-code            1
# env-file             ~/.opam/log/fd-send-recv-10480-20798a.env
# output-file          ~/.opam/log/fd-send-recv-10480-20798a.out
### output ###
# File "lib/dune", line 4, characters 11-29:
# 4 |   (c_names fd_send_recv_stubs)
#                ^^^^^^^^^^^^^^^^^^
# (cd _build/default/lib && /usr/bin/cc -O2 -fno-strict-aliasing -fwrapv -pthread -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -g -I /Users/mac1000/.opam/5.0.0~beta2/lib/ocaml -I /Users/mac1000/.opam/5.0.0~beta2/lib/ocaml/unix -o fd_send_recv_stubs.o -c fd_send_recv_stubs.c)
# fd_send_recv_stubs.c:42:7: warning: assigning to 'value *' (aka 'long *') from 'const value *' (aka 'const long *') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
#                 exn = caml_named_value("fd_send_recv.unix_error");
#                     ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
# fd_send_recv_stubs.c:67:14: error: implicit declaration of function 'convert_flag_list' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
#   cv_flags = convert_flag_list(flags,msg_flag_table);
#              ^
# fd_send_recv_stubs.c:67:14: note: did you mean 'caml_convert_flag_list'?
# /Users/mac1000/.opam/5.0.0~beta2/lib/ocaml/caml/alloc.h:72:16: note: 'caml_convert_flag_list' declared here
# CAMLextern int caml_convert_flag_list (value, const int *);
#                ^
# fd_send_recv_stubs.c:128:14: error: implicit declaration of function 'convert_flag_list' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
#   cv_flags = convert_flag_list(flags,msg_flag_table);
#              ^
# fd_send_recv_stubs.c:163:7: error: implicit declaration of function 'failwith' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
#       failwith("Failed to receive an fd!");
#       ^
# fd_send_recv_stubs.c:174:8: error: implicit declaration of function 'alloc_small' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
#   addr=alloc_small(1,0); /* Unix.sockaddr; must be an ADDR_UNIX of string */
#        ^
# fd_send_recv_stubs.c:178:21: error: implicit declaration of function 'copy_string' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
#     Field(addr,0) = copy_string(unix_socket_name.sun_path);
#                     ^
# fd_send_recv_stubs.c:180:21: error: implicit declaration of function 'copy_string' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
#     Field(addr,0) = copy_string("nothing");
#                     ^
# 1 warning and 6 errors generated.
```