### PR TITLE
Remove upper bound of brr on  jsoo 

### DIFF
--- a/packages/brr/brr.0.0.3/opam
+++ b/packages/brr/brr.0.0.3/opam
@@ -11,8 +11,9 @@ tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
 depends: ["ocaml" {>= "4.08.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
+          "js_of_ocaml" {>= "4.0.0"}
           "js_of_ocaml-compiler" {>= "4.0.0"}
-          "js_of_ocaml-toplevel" {>= "4.0.0" & < "4.1.0"}
+          "js_of_ocaml-toplevel" {>= "4.0.0"}
           "note"]
 build: [["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]]
 url {
@@ -24,7 +25,7 @@ Brr is a toolkit for programming browsers in OCaml with the
 
 * Interfaces to a selection of browser APIs.
 * Note based reactive support (optional and experimental).
-* An OCaml console developer tool for live interaction 
+* An OCaml console developer tool for live interaction
   with programs running in web pages.
 * A JavaScript FFI for idiomatic OCaml programming.
 


### PR DESCRIPTION
This is a test. It was introduced here https://github.com/ocaml/opam-repository/pull/22503 by @hhugo but I don't think that's necessary (at least things seem to compile file on my side).