### PR TITLE
[new release] happy-eyeballs, happy-eyeballs-mirage and happy-eyeballs-lwt (0.4.0) and dnssec, dns, dns-tsig, dns-stub, dns-server, dns-resolver, dns-mirage, dns-client, dns-cli and dns-certify (6.4.1)

### DIFF
--- a/packages/dns-certify/dns-certify.6.4.1/opam
+++ b/packages/dns-certify/dns-certify.6.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.13.0"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-cli/dns-cli.6.4.1/opam
+++ b/packages/dns-cli/dns-cli.6.4.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dnssec" {= version}
+  "dns-tsig" {= version}
+  "dns-client" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.13.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-client/dns-client.6.0.2/opam
+++ b/packages/dns-client/dns-client.6.0.2/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.1.0/opam
+++ b/packages/dns-client/dns-client.6.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.1.1/opam
+++ b/packages/dns-client/dns-client.6.1.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.1.2/opam
+++ b/packages/dns-client/dns-client.6.1.2/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.1.3/opam
+++ b/packages/dns-client/dns-client.6.1.3/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.1.4/opam
+++ b/packages/dns-client/dns-client.6.1.4/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.2.0/opam
+++ b/packages/dns-client/dns-client.6.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.2.1/opam
+++ b/packages/dns-client/dns-client.6.2.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.2.2/opam
+++ b/packages/dns-client/dns-client.6.2.2/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.3.0/opam
+++ b/packages/dns-client/dns-client.6.3.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.4.0/opam
+++ b/packages/dns-client/dns-client.6.4.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.1.0"}
+  "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0"}
   "tls-mirage" {>= "0.15.0"}

--- a/packages/dns-client/dns-client.6.4.1/opam
+++ b/packages/dns-client/dns-client.6.4.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.8"}
+  "logs" {>= "0.6.3"}
+  "dns" {= version}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "happy-eyeballs" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "tls" {>= "0.15.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "x509" {>= "0.16.0"}
+  "ca-certs"
+  "ca-certs-nss"
+]
+synopsis: "DNS resolver API"
+description: """
+A resolver implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-mirage/dns-mirage.6.4.1/opam
+++ b/packages/dns-mirage/dns-mirage.6.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-resolver/dns-resolver.6.4.1/opam
+++ b/packages/dns-resolver/dns-resolver.6.4.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "dnssec" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {with-test}
+  "tls" "tls-mirage"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-server/dns-server.6.4.1/opam
+++ b/packages/dns-server/dns-server.6.4.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-stub/dns-stub.6.4.1/opam
+++ b/packages/dns-stub/dns-stub.6.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns-tsig/dns-tsig.6.4.1/opam
+++ b/packages/dns-tsig/dns-tsig.6.4.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dns/dns.6.4.1/opam
+++ b/packages/dns/dns.6.4.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.4.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+  "base64" {>= "3.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/dnssec/dnssec.6.4.1/opam
+++ b/packages/dnssec/dnssec.6.4.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "alcotest" {with-test}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "domain-name" {>= "0.4.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNSSec support for OCaml-DNS"
+description: """
+DNSSec (DNS security extensions) for OCaml-DNS, including
+signing and verifying of RRSIG records.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v6.4.1/dns-6.4.1.tbz"
+  checksum: [
+    "sha256=a261b47ca6401c673ee04442f1cc8ae3b8de12488166407ed5fcf8ea3e920e7a"
+    "sha512=4f761a25f8bdffb866c02ae91d85b248158d478b4905b6cbc107a24ed8f1ce0c58468e34a32ddc74b2c1bca29fddc50c1591e47927bc19c15b85d909d2496317"
+  ]
+}
+x-commit-hash: "748ada0f9a8799ed8c7b5354d8a4c8cb9dc0953f"

--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.4.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns-client" {>= "6.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.4.0/happy-eyeballs-0.4.0.tbz"
+  checksum: [
+    "sha256=811f6ae09fc39d8273f2862693fc32d7b87817ac316e595b6bf824a2be62d674"
+    "sha512=2f95af7a3e1e899d0423411d028aaaa0179c73c9e632aaf7153a617fcca8630d66cae2802db9ee3b6b0faf9f1d3ed565db9decbae5706ed706632904400bd81b"
+  ]
+}
+x-commit-hash: "e459b09acdaf613ebe346f7e9a753111019629e4"

--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.4.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "happy-eyeballs" {=version}
   "cmdliner" {>= "1.1.0"}
   "duration"
-  "dns-client" {>= "6.0.0"}
+  "dns-client" {>= "6.4.1"}
   "domain-name"
   "ipaddr"
   "fmt"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.4.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.4.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "happy-eyeballs" {=version}
   "duration"
-  "dns-client" {>= "6.2.0"}
+  "dns-client" {>= "6.4.1"}
   "domain-name"
   "ipaddr"
   "fmt"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.4.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "6.2.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.4.0/happy-eyeballs-0.4.0.tbz"
+  checksum: [
+    "sha256=811f6ae09fc39d8273f2862693fc32d7b87817ac316e595b6bf824a2be62d674"
+    "sha512=2f95af7a3e1e899d0423411d028aaaa0179c73c9e632aaf7153a617fcca8630d66cae2802db9ee3b6b0faf9f1d3ed565db9decbae5706ed706632904400bd81b"
+  ]
+}
+x-commit-hash: "e459b09acdaf613ebe346f7e9a753111019629e4"

--- a/packages/happy-eyeballs/happy-eyeballs.0.4.0/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.4.0/happy-eyeballs-0.4.0.tbz"
+  checksum: [
+    "sha256=811f6ae09fc39d8273f2862693fc32d7b87817ac316e595b6bf824a2be62d674"
+    "sha512=2f95af7a3e1e899d0423411d028aaaa0179c73c9e632aaf7153a617fcca8630d66cae2802db9ee3b6b0faf9f1d3ed565db9decbae5706ed706632904400bd81b"
+  ]
+}
+x-commit-hash: "e459b09acdaf613ebe346f7e9a753111019629e4"


### PR DESCRIPTION
Connecting to a remote host via IP version 4 or 6

- Project page: <a href="https://github.com/roburio/happy-eyeballs">https://github.com/roburio/happy-eyeballs</a>
- Documentation: <a href="https://roburio.github.io/happy-eyeballs/">https://roburio.github.io/happy-eyeballs/</a>

##### CHANGES:

* Cancellation of connection attempts (roburio/happy-eyeballs#30 @reynir @hannesm, fixes roburio/happy-eyeballs#27)
* Make the type id abstract (suggested by @reynir in roburio/happy-eyeballs#30)
* Add reason for failures to the variants, improves log output (roburio/happy-eyeballs#30, fixes roburio/happy-eyeballs#7, @hannesm @reynir)
* Remove log messages about DNS resolution success/failure when there is no
  awaiting connection (roburio/happy-eyeballs#30, @hannesm)
* Use the domain name of the fist IP address in connect_ip as identifier (this
  provides more useful information than the hardcoded "host.invalid") (roburio/happy-eyeballs#29, @hannesm)

[new release] dnssec, dns, dns-tsig, dns-stub, dns-server, dns-resolver, dns-mirage, dns-client, dns-cli and dns-certify (6.4.1)
    
CHANGES:
    
* dns-client: adapt to happy eyeballs 0.4.0 (mirage/ocaml-dns#329 @reynir @hannesm)
* dns-resolver: dnssec validation is optional via a labeled parameter ~dnssec
      passed to Dns_resolver.create (mirage/ocaml-dns#325 @hannesm)
* upgrade to dune 2 (mirage/ocaml-dns#327 @reynir)