### PR TITLE
dns < 6.0.0 is not compatible with OCaml 5.0

### DIFF
--- a/packages/dns/dns.0.10.0/opam
+++ b/packages/dns/dns.0.10.0/opam
@@ -30,7 +30,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.11.0/opam
+++ b/packages/dns/dns.0.11.0/opam
@@ -30,7 +30,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.12.0/opam
+++ b/packages/dns/dns.0.12.0/opam
@@ -30,7 +30,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.13.0/opam
+++ b/packages/dns/dns.0.13.0/opam
@@ -31,7 +31,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "base-bytes"
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}

--- a/packages/dns/dns.0.14.0/opam
+++ b/packages/dns/dns.0.14.0/opam
@@ -31,7 +31,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "base-bytes"
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}

--- a/packages/dns/dns.0.14.1/opam
+++ b/packages/dns/dns.0.14.1/opam
@@ -26,7 +26,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "base-bytes"
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}

--- a/packages/dns/dns.0.15.0/opam
+++ b/packages/dns/dns.0.15.0/opam
@@ -24,7 +24,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "base-bytes"
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}

--- a/packages/dns/dns.0.15.1/opam
+++ b/packages/dns/dns.0.15.1/opam
@@ -44,7 +44,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "base-bytes"
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "2.0.0"}

--- a/packages/dns/dns.0.15.2/opam
+++ b/packages/dns/dns.0.15.2/opam
@@ -46,7 +46,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.15.3/opam
+++ b/packages/dns/dns.0.15.3/opam
@@ -44,7 +44,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.16.0/opam
+++ b/packages/dns/dns.0.16.0/opam
@@ -46,7 +46,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.17.0/opam
+++ b/packages/dns/dns.0.17.0/opam
@@ -47,7 +47,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.18.0/opam
+++ b/packages/dns/dns.0.18.0/opam
@@ -47,7 +47,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.18.1/opam
+++ b/packages/dns/dns.0.18.1/opam
@@ -30,7 +30,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.19.0/opam
+++ b/packages/dns/dns.0.19.0/opam
@@ -47,7 +47,7 @@ install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "dns"]
 
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "lwt" {>= "2.4.7" & < "3.0.0"}

--- a/packages/dns/dns.0.19.1/opam
+++ b/packages/dns/dns.0.19.1/opam
@@ -53,7 +53,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}

--- a/packages/dns/dns.0.20.0/opam
+++ b/packages/dns/dns.0.20.0/opam
@@ -53,7 +53,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}

--- a/packages/dns/dns.0.20.1/opam
+++ b/packages/dns/dns.0.20.1/opam
@@ -55,7 +55,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.8.0"}

--- a/packages/dns/dns.0.4.0/opam
+++ b/packages/dns/dns.0.4.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "cstruct" {>= "0.5.0" & < "0.6.0"}
   "lwt" {< "3.0.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.5.0/opam
+++ b/packages/dns/dns.0.5.0/opam
@@ -29,7 +29,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.0.0"}
+  "ocaml" {>= "4.0.0" & < "5.0"}
   "cstruct" {>= "0.5.1" & < "0.6.0"}
   "ocamlfind"
   "cryptokit"

--- a/packages/dns/dns.0.5.1/opam
+++ b/packages/dns/dns.0.5.1/opam
@@ -19,7 +19,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "cstruct" {>= "0.5.1" & < "0.6.0"}
   "ocamlfind"
   "cryptokit"

--- a/packages/dns/dns.0.6.0/opam
+++ b/packages/dns/dns.0.6.0/opam
@@ -29,7 +29,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0" & < "1.0.0"}
   "ocamlfind"
   "cryptokit"

--- a/packages/dns/dns.0.6.1/opam
+++ b/packages/dns/dns.0.6.1/opam
@@ -28,7 +28,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.1" & < "3.0.0"}
   "cstruct" {>= "0.6.0" & < "1.0.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.6.2/opam
+++ b/packages/dns/dns.0.6.2/opam
@@ -28,7 +28,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.1" & < "3.0.0"}
   "cstruct" {>= "0.6.0" & < "1.0.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.7.0/opam
+++ b/packages/dns/dns.0.7.0/opam
@@ -28,7 +28,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.1" & < "3.0.0"}
   "cstruct" {>= "0.7.1" & < "1.0.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.8.0/opam
+++ b/packages/dns/dns.0.8.0/opam
@@ -27,7 +27,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.8.1/opam
+++ b/packages/dns/dns.0.8.1/opam
@@ -27,7 +27,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.9.0/opam
+++ b/packages/dns/dns.0.9.0/opam
@@ -27,7 +27,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.0.9.1/opam
+++ b/packages/dns/dns.0.9.1/opam
@@ -27,7 +27,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "dns"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0"}
   "lwt" {>= "2.4.3" & < "3.0.0"}
   "cstruct" {>= "1.0.1" & < "1.6.0"}
   "ocamlfind"

--- a/packages/dns/dns.1.0.1/opam
+++ b/packages/dns/dns.1.0.1/opam
@@ -18,7 +18,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "base-bytes"
   "jbuilder" {>= "1.0+beta9"}
   "cstruct" {>= "3.0.2" & < "6.0.0"}

--- a/packages/dns/dns.1.1.0/opam
+++ b/packages/dns/dns.1.1.0/opam
@@ -30,7 +30,7 @@ homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"
   "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"

--- a/packages/dns/dns.1.1.1/opam
+++ b/packages/dns/dns.1.1.1/opam
@@ -30,7 +30,7 @@ homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"
   "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"

--- a/packages/dns/dns.1.1.3/opam
+++ b/packages/dns/dns.1.1.3/opam
@@ -30,7 +30,7 @@ homepage: "https://github.com/mirage/ocaml-dns"
 doc: "https://mirage.github.io/ocaml-dns/"
 bug-reports: "https://github.com/mirage/ocaml-dns/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune" {>= "1.2"}
   "cstruct" {>= "3.0.2" & < "6.0.0"}
   "ppx_cstruct"

--- a/packages/dns/dns.4.0.0/opam
+++ b/packages/dns/dns.4.0.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.1.0/opam
+++ b/packages/dns/dns.4.1.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.2.0/opam
+++ b/packages/dns/dns.4.2.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.3.0/opam
+++ b/packages/dns/dns.4.3.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.3.1/opam
+++ b/packages/dns/dns.4.3.1/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.4.0/opam
+++ b/packages/dns/dns.4.4.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.4.1/opam
+++ b/packages/dns/dns.4.4.1/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.5.0/opam
+++ b/packages/dns/dns.4.5.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.6.0/opam
+++ b/packages/dns/dns.4.6.0/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.6.1/opam
+++ b/packages/dns/dns.4.6.1/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.6.2/opam
+++ b/packages/dns/dns.4.6.2/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}

--- a/packages/dns/dns.4.6.3/opam
+++ b/packages/dns/dns.4.6.3/opam
@@ -9,7 +9,7 @@ license: "BSD-2-Clause"
 
 depends: [
   "dune" {>= "1.2.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "rresult" "astring" "fmt" "logs" "ptime"
   "domain-name" {>= "0.3.0"}
   "gmap" {>= "0.3.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling dns.4.6.3 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/dns.4.6.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dns -j 31
# exit-code            1
# env-file             ~/.opam/log/dns-8-bfb0e7.env
# output-file          ~/.opam/log/dns-8-bfb0e7.out
### output ###
# File "cache/dns_cache.ml", line 98, characters 13-41:
# 98 | module LRU = Lru.M.MakeSeeded(Key)(Entry)
#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: The functor application is ill-typed.
#        These arguments:
#          Key Entry
#        do not match these parameters:
#          functor (K : Hashtbl.SeededHashedType) (V : Lru.Weighted) -> ...
#        1. Modules do not match:
#             Key :
#             sig
#               type t = [ `raw ] Domain_name.t
#               val equal : 'a Domain_name.t -> 'b Domain_name.t -> bool
#               val hash : int -> 'a -> int
#             end
#           is not included in
#             Hashtbl.SeededHashedType
#           The value `seeded_hash' is required but not provided
#           File "hashtbl.mli", line 411, characters 4-36: Expected declaration
#        2. Module Entry matches the expected module type Lru.Weighted
```