### PR TITLE
[new release] ppx_deriving_yaml (0.2.1)

### DIFF
--- a/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.1/opam
+++ b/packages/ppx_deriving_yaml/ppx_deriving_yaml.0.2.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Yaml PPX Deriver"
+description:
+  "Deriving conversion functions to and from yaml for your OCaml types."
+maintainer: ["patrick@sirref.org"]
+authors: ["Patrick Ferris"]
+license: "ISC"
+homepage: "https://github.com/patricoferris/ppx_deriving_yaml"
+bug-reports: "https://github.com/patricoferris/ppx_deriving_yaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "alcotest" {with-test}
+  "bos" {with-test}
+  "mdx" {with-test}
+  "ezjsonm" {with-test}
+  "ocaml" {>= "4.08.1"}
+  "ppxlib" {>= "0.14.0"}
+  "ppx_deriving"
+  "yaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/patricoferris/ppx_deriving_yaml.git"
+url {
+  src:
+    "https://github.com/patricoferris/ppx_deriving_yaml/releases/download/v0.2.1/ppx_deriving_yaml-0.2.1.tbz"
+  checksum: [
+    "sha256=def99acbc518eddde3f7a54e43e0f7a18128b73565b3dd45e7579b5d643ff524"
+    "sha512=ddf55de0bdd420a60248ca928bfe03d1c8221188f0592faa925434a30006c7f3a9177d4813dde932ab46fadf80408ecf4d1235811a176c58cc2988cec976cede"
+  ]
+}
+x-commit-hash: "08fb5facaa2a1575fd481a456f60aa0964cb6eda"


### PR DESCRIPTION
Yaml PPX Deriver

- Project page: <a href="https://github.com/patricoferris/ppx_deriving_yaml">https://github.com/patricoferris/ppx_deriving_yaml</a>

##### CHANGES:

 - Support types with recursive definitions (patricoferris/ppx_deriving_yaml#46, @patricoferris)
 - Fix `skip_unknown` flag when unknown fields are not last in the record (patricoferris/ppx_deriving_yaml#43, @code-ghalib)
