### PR TITLE
Add: brr.0.0.4

### DIFF
--- a/packages/brr/brr.0.0.4/opam
+++ b/packages/brr/brr.0.0.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Browser programming toolkit for OCaml"
+description: """\
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* Note based reactive support (optional and experimental).
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on [Note][note]
+and on the `js_of_ocaml` compiler and runtime – but not on its
+libraries or syntax extension.
+
+[note]: https://erratique.ch/software/note
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: https://erratique.ch/software/brr"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The brr programmers"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "js_of_ocaml-compiler" {>= "4.1.0"}
+  "js_of_ocaml-toplevel" {>= "4.1.0"}
+  "note"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.4.tbz"
+  checksum:
+    "sha512=f641c070a4bb27b5127019cfd1dad9bddd309a1144ea6431006b663363b32ba9277f73f940de147b75f89ebf57684c6370601818aefb594f85dab33523401d9b"
+}


### PR DESCRIPTION
* Add: `brr.0.0.4` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.4 2022-12-05 Zagreb

### Changes for upcoming `js_of_ocaml` effect support

The following changes are needed for the upcoming effect support in
`js_of_ocaml`. Thanks to Jérôme Vouillon for his help.

- **Important** Add `Jv.callback`. When the effect support lands it
  will no longer be possible to invoke an OCaml function `f` from
  JavaScript by simply using `(Jv.repr f)` to get a `Jv.t` value as
  was suggested in the cookbook. You have to use `(Jv.callback ~arity
  f)` with `arity` the arity of the function. The recipes of the
  cookbook to deal with callbacks and exposing OCaml functions to
  JavaScript have been updated accordingly.
- `Brr.Ev.listen` no longer returns `unit` but an abstract value of type 
  `Brr.Ev.listener`. If you don't need to unlisten you can simply `ignore` 
  that value. If you do, see next point.
- `Brr.Ev.unlisten` is changed to take a value of type `Brr.Ev.listener`. 
   Previously you had to invoke it with the same arguments you gave to 
   `Brr.Ev.listen` like in JavaScript.

### Additions

- Add `Brr_webmidi`, bindings for Web MIDI.
- `Brr.At`, add support for `accesskey`, `action`, `autocomplete`, 
  `autofocus`, `list`, `method`, `selected`, `style` attributes.
  Make sure MDN doc links do not 404.
- Add `Brr.At.float`.
- Add `Brr.At.{void,is_void,if',if_some}` and deprecate
  `Brr.At.{add_if,add_if_some}`. The new scheme if more convenient 
  and clearer when working with list literals.
- Add `Brr.File.relative_path`.
- Add `Brr_canvas.{C2d,Gl}.get_context` and deprecate 
  `Brr_canvas.{C2d,Gl}.create` whose names are misleading ([#36](https://github.com/dbuenzli/brr/issues/36)).
- Add `Brr_canvas.C2d.{set_transform',transform'}` taking matrix
  components directly.
- Add `Jstr.binary_{of,to}_octets` to convert between OCaml strings
  as sequence of bytes and JavaScript binary strings ([#18](https://github.com/dbuenzli/brr/issues/18) again)

### Breaking changes

- `Brr.El.v`, perform `At.style` attribute merging like we do with
  `At.class`. This is a breaking change if you had `El.v` calls with 
  multiple `style` attributes definition and expected the last one to 
  take over. Note that the `At.style` value is introduced in this version.

### Bug fixes and internal changes

- Fix `Brr_canvas.C2d.transform` it was binding to `resetTransform` 
  instead of `transform` ([#38](https://github.com/dbuenzli/brr/issues/38)).
- Adapt to `js_of_ocaml-toplevel` changes.
- Make the modules' initialisation bits web worker safe.
  We had toplevel code that accessed properties of values that are not
  allowed in workers (e.g. `Brr.El` accessing `document` or `Brr_note`
  accessing mutation observers). These modules may still be linked in
  your web worker code (e.g. if you fork()-like your workers) in which
  case these toplevel initialisation bits would get executed and fail.

---

Use `b0 -- .opam.publish brr.0.0.4` to update the pull request.