### PR TITLE
releases lwt-parallel.1.0.0

### DIFF
--- a/packages/lwt-parallel/lwt-parallel.1.0.0/opam
+++ b/packages/lwt-parallel/lwt-parallel.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "Ivan Gotovchits <ivg@ieee.org>"
+homepage: "https://github.com/ivg/parallel"
+bug-reports: "https://github.com/ivg/lwt-parallel/issues"
+dev-repo: "git+https://github.com/ivg/lwt-parallel.git"
+license: "MIT"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+
+depends: [
+  "base-unix"
+  "dune" {>= "1.6"}
+  "fmt"
+  "logs"
+  "lwt"   {>= "2.7.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+synopsis: "Lwt-enabled Parallel Processing Library"
+
+tags: ["lwt" "parallel" "fork"]
+url {
+  src: "https://github.com/ivg/lwt-parallel/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: "md5=86c30d030d7a9f04c6380c5e9dcedee0"
+}


### PR DESCRIPTION
The [lwt-parallel][1] library allows running lwt computations in different OS processes. In general, Lwt and Unix fork do not play nicely but this library makes it possible. See the README and implementation for more details. The library works on Unix systems, such as GNU/Linux and macOS.

The bumped to 1.0.0 version indicates the stability of the interface, i.e., we do not plan to break it without chaning the major number. It also indicates that the library is ready to use and is supported.

The 1.0.0 release includes some new features, such as an explicit notation for process snapshots (and support for running multiple snapshots in parallel). It is also now possible to specify custom serialization protocols for data that is passed between processes.

[1]: https://github.com/ivg/lwt-parallel