### PR TITLE
2 packages from mpelleau/AbSolute

### DIFF
--- a/packages/absolute/absolute.0.2/opam
+++ b/packages/absolute/absolute.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Marie Pelleau <marie.pelleau@i3s.unice.fr>"
+authors: [
+  "Marie Pelleau <marie.pelleau@i3s.unice.fr>"
+  "Ghiles Ziat <ghiles.ziat@epita.fr>"
+]
+homepage: "https://github.com/mpelleau/AbSolute"
+bug-reports: "https://github.com/mpelleau/AbSolute/issues"
+dev-repo: "git+https://github.com/mpelleau/AbSolute"
+license: " LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.11"}
+  "apron"
+  "apronext" {>= "1.0.2"}
+  "picasso" {>= "0.3.0"}
+  "menhir" {>= "2.0"}
+  "libabsolute"
+  "odoc" {with-doc}
+]
+synopsis: "AbSolute solver"
+description: "AbSolute is a constraint solver based on abstract domains from the theory of abstract interpretation."
+url {
+  src: "https://github.com/mpelleau/AbSolute/archive/0.2.tar.gz"
+  checksum: [
+    "md5=7fa3ddb22997078b47f517ada5f6cb96"
+    "sha512=43aff8a0f05022b90ff89f0b2feacdc829e9e6da9be88f802254aff383823b2d8f3dc4e3a694a9d534493d3e60b8a98de9c45a4690c3275b58a6a9dba476e133"
+  ]
+}

--- a/packages/absolute/absolute.0.2/opam
+++ b/packages/absolute/absolute.0.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mpelleau/AbSolute/issues"
 dev-repo: "git+https://github.com/mpelleau/AbSolute"
 license: " LGPL-3.0-or-later"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
@@ -18,10 +18,11 @@ depends: [
   "apron"
   "apronext" {>= "1.0.2"}
   "picasso" {>= "0.3.0"}
-  "menhir" {>= "2.0"}
+  "menhir" {>= "20180528"}
   "libabsolute"
   "odoc" {with-doc}
 ]
+available: arch != "x86_32" & arch != "arm32"
 synopsis: "AbSolute solver"
 description: "AbSolute is a constraint solver based on abstract domains from the theory of abstract interpretation."
 url {

--- a/packages/libabsolute/libabsolute.0.1/opam
+++ b/packages/libabsolute/libabsolute.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mpelleau/AbSolute/issues"
 dev-repo: "git+https://github.com/mpelleau/AbSolute"
 license: "LGPL-3.0-or-later"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
@@ -18,7 +18,7 @@ depends: [
   "apron"
   "apronext" {>= "1.0.2"}
   "picasso"{>= "0.3.0"}
-  "menhir" {>= "2.0"}
+  "menhir" {>= "20180528"}
 ]
 synopsis: "Libabsolute"
 description: "Libabsolute is a constraint programming library based on abstract domains from the theory of abstract interpretation. It is used and distributed with the AbSolute constraint solver."

--- a/packages/libabsolute/libabsolute.0.1/opam
+++ b/packages/libabsolute/libabsolute.0.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Marie Pelleau <marie.pelleau@i3s.unice.fr>"
+authors: [
+  "Marie Pelleau <marie.pelleau@i3s.unice.fr>"
+  "Ghiles Ziat <ghiles.ziat@lip6.fr>"
+]
+homepage: "https://github.com/mpelleau/AbSolute"
+bug-reports: "https://github.com/mpelleau/AbSolute/issues"
+dev-repo: "git+https://github.com/mpelleau/AbSolute"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.11"}
+  "apron"
+  "apronext" {>= "1.0.2"}
+  "picasso"{>= "0.3.0"}
+  "menhir" {>= "2.0"}
+]
+synopsis: "Libabsolute"
+description: "Libabsolute is a constraint programming library based on abstract domains from the theory of abstract interpretation. It is used and distributed with the AbSolute constraint solver."
+url {
+  src: "https://github.com/mpelleau/AbSolute/archive/0.2.tar.gz"
+  checksum: [
+    "md5=7fa3ddb22997078b47f517ada5f6cb96"
+    "sha512=43aff8a0f05022b90ff89f0b2feacdc829e9e6da9be88f802254aff383823b2d8f3dc4e3a694a9d534493d3e60b8a98de9c45a4690c3275b58a6a9dba476e133"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`absolute.0.2`: AbSolute solver
-`libabsolute.0.1`: Libabsolute



---
* Homepage: https://github.com/mpelleau/AbSolute
* Source repo: git+https://github.com/mpelleau/AbSolute
* Bug tracker: https://github.com/mpelleau/AbSolute/issues

---
:camel: Pull-request generated by opam-publish v2.1.0