### PR TITLE
[new release] fd-send-recv (v2.0.2)

### DIFF
--- a/packages/fd-send-recv/fd-send-recv.2.0.2/opam
+++ b/packages/fd-send-recv/fd-send-recv.2.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "xen-api@lists.xensource.com"
+authors: [
+  "David Scott"
+  "David Sheets"
+  "Euan Harris"
+  "Vincent Bernardoff"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/ocaml-fd-send-recv"
+bug-reports: "https://github.com/xapi-project/ocaml-fd-send-recv/issues"
+dev-repo: "git+https://github.com/xapi-project/ocaml-fd-send-recv.git"
+doc: "https://github.com/xapi-project/ocaml-fd-send-recv/blob/master/lib/fd_send_recv.mli"
+tags: [
+  "org:mirage"
+  "org:xapi-project"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+]
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "1.4"}
+  "odoc" {with-doc}
+]
+synopsis:
+  "Bindings for sendmsg/recvmsg that allow Unix.file_descrs to be sent and received over Unix domain sockets"
+url {
+  src:
+    "https://github.com/xapi-project/ocaml-fd-send-recv/archive/v2.0.2.tar.gz"
+  checksum: "sha256=25f5e8bca7d8c7b71671ed304f8a70f779a5aed1f807c660379baeda2f622fc9"
+}


### PR DESCRIPTION
CHANGES:

- OCaml 5 compatibility

Signed-off-by: Pau Ruiz Safont <pau.ruizsafont@cloud.com>