### PR TITLE
[new release] interval_intel, interval_crlibm, interval_base and interval (1.6)

### DIFF
--- a/packages/interval/interval.1.6/opam
+++ b/packages/interval/interval.1.6/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0-only"
+tags: ["interval" "science"]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "interval_base" {= version}
+  "interval_intel" {= version}
+  "interval_crlibm" {= version}
+]
+synopsis: "An interval arithmetic library for OCaml (meta package)"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.6/interval-1.6.tbz"
+  checksum: [
+    "sha256=a2807d7860a9f965a3f91b40de17b98321e5c3f7da9e69dccf3dc20f1ac77e96"
+    "sha512=76196b171a41ce1374cae946b7c7a1dea6d614db61743ead14d628a12dce30a0dbd82db1960ad17b58f1f65a6f3fc61aaa5eac42face474baf840efb670feee8"
+  ]
+}
+x-commit-hash: "857f185c3b95f9824b21c5ef1c7340ba942ed527"

--- a/packages/interval_base/interval_base.1.6/opam
+++ b/packages/interval_base/interval_base.1.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0-only"
+tags: ["interval" "science"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.09"}
+  "dune"  {>= "2.4"}
+  "dune-configurator"
+]
+synopsis: "An interval library for OCaml (base package)"
+description: "
+This library define basic interval operations.  It is supported on
+all platforms.
+"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.6/interval-1.6.tbz"
+  checksum: [
+    "sha256=a2807d7860a9f965a3f91b40de17b98321e5c3f7da9e69dccf3dc20f1ac77e96"
+    "sha512=76196b171a41ce1374cae946b7c7a1dea6d614db61743ead14d628a12dce30a0dbd82db1960ad17b58f1f65a6f3fc61aaa5eac42face474baf840efb670feee8"
+  ]
+}
+x-commit-hash: "857f185c3b95f9824b21c5ef1c7340ba942ed527"

--- a/packages/interval_crlibm/interval_crlibm.1.6/opam
+++ b/packages/interval_crlibm/interval_crlibm.1.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0-only"
+tags: ["interval" "science"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "interval_base" {= version}
+  "dune"
+  "crlibm" { >= "0.5" }
+]
+synopsis: "An interval library for OCaml (crlibm version)"
+description: "
+This library uses assembly code to compute all operations with proper
+roundings, and currently ONLY works on intel processors.
+
+This package uses CRlibm (a proved correctly rounded mathematical
+library) to provide enclosures of transcendental functions.  It may be
+slower than the version using the implementation in the CPU but
+the bounds are proved correct.  It also provides *pi versions of the
+trigonometric functions and their inverse.
+"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.6/interval-1.6.tbz"
+  checksum: [
+    "sha256=a2807d7860a9f965a3f91b40de17b98321e5c3f7da9e69dccf3dc20f1ac77e96"
+    "sha512=76196b171a41ce1374cae946b7c7a1dea6d614db61743ead14d628a12dce30a0dbd82db1960ad17b58f1f65a6f3fc61aaa5eac42face474baf840efb670feee8"
+  ]
+}
+x-commit-hash: "857f185c3b95f9824b21c5ef1c7340ba942ed527"

--- a/packages/interval_intel/interval_intel.1.6/opam
+++ b/packages/interval_intel/interval_intel.1.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Jean-Marc Alliot <jean-marc.alliot@irit.fr>"
+          "Jean-Baptiste Gotteland <gottelan@recherche.enac.fr>"
+          "Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
+homepage: "https://github.com/Chris00/ocaml-interval"
+dev-repo: "git+https://github.com/Chris00/ocaml-interval.git"
+bug-reports: "https://github.com/Chris00/ocaml-interval/issues"
+doc: "https://Chris00.github.io/ocaml-interval/doc"
+license: "LGPL-3.0-only"
+tags: ["interval" "science"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc"] {with-doc}
+]
+depends: [
+  "interval_base" {= version}
+  "dune"
+]
+available: [ arch = "x86_64" ]
+synopsis: "An interval library for OCaml"
+description: "
+This library uses assembly code to compute all operations with proper
+roundings, and currently ONLY works on intel processors.  It supports
+Linux, Windows and MacOS, with gcc and clang.  Unfortunately, the Intel
+processor does not properly round trigonometric functions so this library
+cannot be used whenever proved correct enclosures are needed.
+
+More information is given in the paper presented in the OCaml meeting
+2012: http://www.alliot.fr/papers/oud2012.pdf
+"
+url {
+  src:
+    "https://github.com/Chris00/ocaml-interval/releases/download/1.6/interval-1.6.tbz"
+  checksum: [
+    "sha256=a2807d7860a9f965a3f91b40de17b98321e5c3f7da9e69dccf3dc20f1ac77e96"
+    "sha512=76196b171a41ce1374cae946b7c7a1dea6d614db61743ead14d628a12dce30a0dbd82db1960ad17b58f1f65a6f3fc61aaa5eac42face474baf840efb670feee8"
+  ]
+}
+x-commit-hash: "857f185c3b95f9824b21c5ef1c7340ba942ed527"


### PR DESCRIPTION
An interval library for OCaml

- Project page: <a href="https://github.com/Chris00/ocaml-interval">https://github.com/Chris00/ocaml-interval</a>
- Documentation: <a href="https://Chris00.github.io/ocaml-interval/doc">https://Chris00.github.io/ocaml-interval/doc</a>

##### CHANGES:

- Use the standard `inf` and `sup` for the bounds of the interval.
- Prefer `..._up` and `..._dw` to mark the rounding of functions and
  `RoundUp` and `RoundDown` for the modules.  Crlibm was updated
  accordingly.
- Rename `Interval` as `Interval_base` as it conflicted with the
  `Interval` module in compiler libs (provoking a collision when this
  library was used in the REPL).
- Add functions `mag` (magnitude) and `mig` (mignitude), `mid`
  (midpoint), `singleton` (creation of intervals containing a single
  value), `is_singleton`, `diam` (diameter), `belong` (x ∈ I), `floor`,
  `ceil` and `hypot`.
- Renamed `Interval_*.t` as `Interval_*.interval` as to not import the
  short type `t` into the namespace (but still have access to the
  record fields).
- Add functions `RoundDown.dist` and `RoundUp.dist` (downward/upward
  rounded distance).
- Use Dune 2.0.
