### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.7)

### DIFF
--- a/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.0.0~alpha0/opam
@@ -20,7 +20,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "2.9"}
   "base-domains"
-  "eio" {>= "0.6"}
+  "eio" {>= "0.6" & < "0.7"}
   "eio_main" {with-test}
   "mdx" {with-test}
   "uri" {with-test}

--- a/packages/eio/eio.0.7/opam
+++ b/packages/eio/eio.0.7/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "astring" {>= "0.8.5" & with-test}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "1.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-base-compiler" {< "5.0.0~beta1"}
+  "ocaml-variants" {< "5.0.0~beta1"}
+  "ocaml-system" {< "5.0.0~beta1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.7/eio-0.7.tbz"
+  checksum: [
+    "sha256=675e67f343ccf37b965d15d1ee1c639d7a06431e8f08e95559133419f3488ee1"
+    "sha512=3d1bd0e5e0aa79d8858d83944d734a0efc325ed66a12a1506c3b36281db56c0216e6cb90a46e6021db1ea34cdd2567ebabe0bd687d9989495bb7cf6099e90ba7"
+  ]
+}
+x-commit-hash: "aa91a7bf813b9ab2eddeae35c17bc7439f2c0836"

--- a/packages/eio_linux/eio_linux.0.7/opam
+++ b/packages/eio_linux/eio_linux.0.7/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.4"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.7/eio-0.7.tbz"
+  checksum: [
+    "sha256=675e67f343ccf37b965d15d1ee1c639d7a06431e8f08e95559133419f3488ee1"
+    "sha512=3d1bd0e5e0aa79d8858d83944d734a0efc325ed66a12a1506c3b36281db56c0216e6cb90a46e6021db1ea34cdd2567ebabe0bd687d9989495bb7cf6099e90ba7"
+  ]
+}
+x-commit-hash: "aa91a7bf813b9ab2eddeae35c17bc7439f2c0836"

--- a/packages/eio_luv/eio_luv.0.7/opam
+++ b/packages/eio_luv/eio_luv.0.7/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.7/eio-0.7.tbz"
+  checksum: [
+    "sha256=675e67f343ccf37b965d15d1ee1c639d7a06431e8f08e95559133419f3488ee1"
+    "sha512=3d1bd0e5e0aa79d8858d83944d734a0efc325ed66a12a1506c3b36281db56c0216e6cb90a46e6021db1ea34cdd2567ebabe0bd687d9989495bb7cf6099e90ba7"
+  ]
+}
+x-commit-hash: "aa91a7bf813b9ab2eddeae35c17bc7439f2c0836"

--- a/packages/eio_main/eio_main.0.7/opam
+++ b/packages/eio_main/eio_main.0.7/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.7/eio-0.7.tbz"
+  checksum: [
+    "sha256=675e67f343ccf37b965d15d1ee1c639d7a06431e8f08e95559133419f3488ee1"
+    "sha512=3d1bd0e5e0aa79d8858d83944d734a0efc325ed66a12a1506c3b36281db56c0216e6cb90a46e6021db1ea34cdd2567ebabe0bd687d9989495bb7cf6099e90ba7"
+  ]
+}
+x-commit-hash: "aa91a7bf813b9ab2eddeae35c17bc7439f2c0836"


### PR DESCRIPTION
Effect-based direct-style IO mainloop for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

API changes:

- Unify IO errors as `Eio.Io` (@talex5 ocaml-multicore/eio#378).
  This makes it easy to catch and log all IO errors if desired.
  The exception payload gives the type and can be used for matching specific errors.
  It also allows attaching extra information to exceptions, and various functions were updated to do this.

- Add `Time.Mono` for monotonic clocks (@bikallem @talex5 ocaml-multicore/eio#338).
  Using the system clock for timeouts, etc can fail if the system time is changed during the wait.

- Allow datagram sockets to be created without a source address (@bikallem @haesbaert ocaml-multicore/eio#360).
  The kernel will allocate an address in this case.
  You can also now control the `reuse_addr` and `reuse_port` options.

- Add `File.stat` and improve `Path.load` (@haesbaert @talex5 ocaml-multicore/eio#339).
  `Path.load` now uses the file size as the initial buffer size.

- Add `Eio_unix.pipe` (@patricoferris ocaml-multicore/eio#350).
  This replaces `Eio_linux.pipe`.

- Avoid short reads from `getrandom(2)` (@haesbaert ocaml-multicore/eio#344).
  Guards against buggy user code that might not handle this correctly.

- Rename `Flow.read` to `Flow.single_read` (@talex5 ocaml-multicore/eio#353).
  This is a low-level function and it is easy to use it incorrectly by ignoring the possibility of short reads.

Bug fixes:

- Eio_luv: Fix non-tail-recursive continue (@talex5 ocaml-multicore/eio#378).
  Affects the `Socket_of_fd` and `Socketpair` effects.

- Eio_linux: UDP sockets were not created close-on-exec (@talex5 ocaml-multicore/eio#360).

- Eio_linux: work around io_uring non-blocking bug (@haesbaert ocaml-multicore/eio#327 ocaml-multicore/eio#355).
  The proper fix should be in Linux 6.1.

- `Eio_mock.Backend`: preserve backtraces from `main` (@talex5 ocaml-multicore/eio#349).

- Don't lose backtrace in `Switch.run_internal` (@talex5 ocaml-multicore/eio#369).

Documentation:

- Use a proper HTTP response in the README example (@talex5 ocaml-multicore/eio#377).

- Document that read_dir excludes "." and ".." (@talex5 ocaml-multicore/eio#379).

- Warn about both operations succeeding in `Fiber.first` (@talex5 ocaml-multicore/eio#358, reported by @iitalics).

- Update README for OCaml 5.0.0~beta2 (@talex5 ocaml-multicore/eio#375).

Backend-specific changes:

- Eio_luv: add low-level process support (@patricoferris ocaml-multicore/eio#359).
  A future release will add Eio_linux support and a cross-platform API for this.

- Expose `Eio_luv.Low_level.Stream.write` (@patricoferris ocaml-multicore/eio#359).

- Expose `Eio_luv.Low_level.get_loop` (@talex5 ocaml-multicore/eio#371).
  This is needed if you want to create resources directly and then use them with Eio_luv.

- `Eio_linux.Low_level.openfile` is gone (@talex5 ocaml-multicore/eio#378).
  It was just left-over test code.
