### PR TITLE
[why3] add OCaml 5 constraints

### DIFF
--- a/packages/why3/why3.1.3.0/opam
+++ b/packages/why3/why3.1.3.0/opam
@@ -41,7 +41,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20151112"}
   "num"

--- a/packages/why3/why3.1.3.1/opam
+++ b/packages/why3/why3.1.3.1/opam
@@ -41,7 +41,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20151112"}
   "num"

--- a/packages/why3/why3.1.3.2/opam
+++ b/packages/why3/why3.1.3.2/opam
@@ -41,7 +41,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20151112"}
   "num"

--- a/packages/why3/why3.1.3.3/opam
+++ b/packages/why3/why3.1.3.3/opam
@@ -41,7 +41,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20151112"}
   "num"

--- a/packages/why3/why3.1.4.0/opam
+++ b/packages/why3/why3.1.4.0/opam
@@ -42,7 +42,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"

--- a/packages/why3/why3.1.4.1/opam
+++ b/packages/why3/why3.1.4.1/opam
@@ -42,7 +42,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"

--- a/packages/why3/why3.1.5.0/opam
+++ b/packages/why3/why3.1.5.0/opam
@@ -41,7 +41,7 @@ install: [
 
 depends: [
   "conf-autoconf" {build & dev}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}
   "num"


### PR DESCRIPTION
Why3 (all current versions, I believe) is incompatible with OCaml 5 at the compilation level: trying to build it always results in:

```
# File "src/util/pp.mli", line 122, characters 33-51:
# 122 |   ('b,  formatter, unit, string) Pervasives.format4 -> 'b
#                                        ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:2084: src/util/pp.cmi] Error 2
```

However, because only why3.1.5.1 (the latest release) has been explicitly marked as incompatible with OCaml 5, if someone currently tries to install e.g. Frama-C (which uses Why3) on such a switch, opam will try installing an *older* version of Frama-C, including several of its dependencies, and then inevitably fail, either due to this dependency, or another one. Adding these constraints should save time.

We could add such `conflict`s clauses to Frama-C directly, but it seems to me that it is more appropriate to add them directly upstream, to the packages who are themselves incompatible. I don't know if there is currently a policy on adding constraints to "older" package versions; I added to these 3 versions because I believe that should be enough to prevent any incompatible installations from working.