### PR TITLE
[new release] git, git-paf, git-mirage and git-unix (3.10.1)

### DIFF
--- a/packages/git-mirage/git-mirage.3.10.1/opam
+++ b/packages/git-mirage/git-mirage.3.10.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "A package to use ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "mimic"
+  "mimic-happy-eyeballs" {>= "0.0.5"}
+  "base64" {>= "3.5.0"}
+  "git" {= version}
+  "git-paf" {= version}
+  "awa" {>= "0.1.0"}
+  "awa-mirage" {>= "0.1.0"}
+  "dns" {>= "6.1.3"}
+  "dns-client" {>= "6.1.3"}
+  "tls"
+  "tls-mirage"
+  "uri"
+  "hex"
+  "happy-eyeballs-mirage" {>= "0.1.2"}
+  "happy-eyeballs" {>= "0.1.2"}
+  "ca-certs-nss"
+  "mirage-crypto"
+  "ptime"
+  "x509" {>= "0.16.2"}
+  "cstruct"
+  "tcpip" {>= "7.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "5.0.1"}
+  "lwt" {>= "5.3.0"}
+  "mirage-clock" {>= "3.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.1"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "alcotest-lwt" {>= "1.2.3" & with-test}
+  "bigstringaf" {>= "0.9.0" & with-test}
+  "cstruct" {>= "6.0.0" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ke" {>= "0.4" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.10.1/git-3.10.1.tbz"
+  checksum: [
+    "sha256=a65bbaf45229c8972e67c9c9dd09ee7cb9c3123b5cb2801df1ccca1dfcd391df"
+    "sha512=3c049fab53db700faf6fe15c649db7c52eab1547e96eb2a6feeb72a1dbdc208819b82a36845a270f2ab865a5ca8585e9fe1afd9ca4780860300a0a309e5d31f6"
+  ]
+}
+x-commit-hash: "ec1d28267fb8eb269ef896996607264abc48c610"

--- a/packages/git-paf/git-paf.3.10.1/opam
+++ b/packages/git-paf/git-paf.3.10.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A package to use HTTP-based ocaml-git with MirageOS backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "mimic" {>= "0.0.4"}
+  "paf" {>= "0.2.0"}
+  "ca-certs-nss"
+  "fmt"
+  "ipaddr"
+  "logs"
+  "lwt"
+  "mirage-clock"
+  "tcpip" {>= "7.0.0"}
+  "mirage-time"
+  "result"
+  "rresult"
+  "tls" {>= "0.14.0"}
+  "uri"
+  "bigstringaf"
+  "domain-name"
+  "httpaf"
+  "mirage-flow"
+  "tls-mirage"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.10.1/git-3.10.1.tbz"
+  checksum: [
+    "sha256=a65bbaf45229c8972e67c9c9dd09ee7cb9c3123b5cb2801df1ccca1dfcd391df"
+    "sha512=3c049fab53db700faf6fe15c649db7c52eab1547e96eb2a6feeb72a1dbdc208819b82a36845a270f2ab865a5ca8585e9fe1afd9ca4780860300a0a309e5d31f6"
+  ]
+}
+x-commit-hash: "ec1d28267fb8eb269ef896996607264abc48c610"

--- a/packages/git-unix/git-unix.3.10.1/opam
+++ b/packages/git-unix/git-unix.3.10.1/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "Virtual package to install and configure ocaml-git's Unix backend"
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "git" {= version}
+  "git-mirage" {= version}
+  "happy-eyeballs-lwt" {>= "0.1.2"}
+  "rresult"
+  "result"
+  "bigstringaf" {>= "0.9.0"}
+  "fmt" {>= "0.8.7"}
+  "bos"
+  "fpath"
+  "uri" {with-test}
+  "digestif" {>= "1.1.2"}
+  "logs"
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "mirage-clock" {>= "4.1.0"}
+  "mirage-clock-unix" {>= "4.1.0"}
+  "astring" {>= "0.8.5"}
+  "awa" {>= "0.1.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-unix" {>= "5.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "decompress" {>= "1.4.0"}
+  "domain-name" {>= "0.3.0"}
+  "ipaddr" {>= "5.0.1"}
+  "mtime" {>= "1.2.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "tcpip" {>= "7.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "awa-mirage" {>= "0.1.0"}
+  "mirage-flow" {>= "2.0.1"}
+  "ke" {>= "0.4" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "ptime"
+  "mimic"
+  "ca-certs-nss" {>= "3.60"}
+  "tls" {>= "0.14.0"}
+  "tls-mirage" {>= "0.14.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs "--no-buffer"] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.10.1/git-3.10.1.tbz"
+  checksum: [
+    "sha256=a65bbaf45229c8972e67c9c9dd09ee7cb9c3123b5cb2801df1ccca1dfcd391df"
+    "sha512=3c049fab53db700faf6fe15c649db7c52eab1547e96eb2a6feeb72a1dbdc208819b82a36845a270f2ab865a5ca8585e9fe1afd9ca4780860300a0a309e5d31f6"
+  ]
+}
+x-commit-hash: "ec1d28267fb8eb269ef896996607264abc48c610"

--- a/packages/git/git.3.10.1/opam
+++ b/packages/git/git.3.10.1/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Git format and protocol in pure OCaml"
+description: """\
+Support for on-disk and in-memory Git stores. Can read and write all
+the Git objects: the usual blobs, trees, commits and tags but also
+the pack files, pack indexes and the index file (where the staging area
+lives).
+
+All the objects share a consistent API, and convenience functions are
+provided to manipulate the different objects."""
+maintainer: ["thomas@gazagnaire.org" "romain.calascibetta@gmail.com"]
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-git"
+doc: "https://mirage.github.io/ocaml-git/"
+bug-reports: "https://github.com/mirage/ocaml-git/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.8.0"}
+  "digestif" {>= "1.1.2"}
+  "rresult"
+  "base64" {>= "3.0.0"}
+  "result"
+  "bigstringaf" {>= "0.9.0"}
+  "optint"
+  "decompress" {>= "1.4.0"}
+  "logs"
+  "lwt"
+  "mimic" {>= "0.0.6"}
+  "cstruct" {>= "6.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "carton" {>= "0.4.4"}
+  "carton-lwt" {>= "0.4.4"}
+  "carton-git" {>= "0.4.4"}
+  "ke" {>= "0.4"}
+  "fmt" {>= "0.8.7"}
+  "checkseum" {>= "0.3.3"}
+  "ocamlgraph" {>= "1.8.8"}
+  "astring"
+  "fpath"
+  "encore" {>= "0.8"}
+  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest-lwt" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng" {with-test & >= "0.8.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "base-unix" {with-test}
+  "fpath"
+  "hxd" {>= "0.3.2"}
+  "mirage-flow" {>= "2.0.1"}
+  "domain-name" {>= "0.3.0"}
+  "emile" {>= "1.1"}
+  "ipaddr" {>= "5.0.1"}
+  "psq" {>= "0.2.0"}
+  "uri" {>= "4.1.0"}
+  "crowbar" {>= "0.2.1" & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-git.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-git/releases/download/3.10.1/git-3.10.1.tbz"
+  checksum: [
+    "sha256=a65bbaf45229c8972e67c9c9dd09ee7cb9c3123b5cb2801df1ccca1dfcd391df"
+    "sha512=3c049fab53db700faf6fe15c649db7c52eab1547e96eb2a6feeb72a1dbdc208819b82a36845a270f2ab865a5ca8585e9fe1afd9ca4780860300a0a309e5d31f6"
+  ]
+}
+x-commit-hash: "ec1d28267fb8eb269ef896996607264abc48c610"


### PR DESCRIPTION
Git format and protocol in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-git">https://github.com/mirage/ocaml-git</a>
- Documentation: <a href="https://mirage.github.io/ocaml-git/">https://mirage.github.io/ocaml-git/</a>

##### CHANGES:

- Add the NixOS CI to test `ocaml-git` (@Et7f3, mirage/ocaml-git#600, mirage/ocaml-git#473)
- Specify few more headers fields when we fetch/push via HTTP (@reynir, @hannesm, @dinosaure, mirage/ocaml-git#603, mirage/ocaml-git#601)
- Improve the error message about `Smart_git.Endpoint.of_string` (@reynir, @dinosaure, mirage/ocaml-git#605, mirage/ocaml-git#604)
