### PR TITLE
OCaml 4.14.1~rc1: base and variants packages

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/files/ocaml-base-compiler.install
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/files/ocaml-base-compiler.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1~rc1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "First release candidate of OCaml 4.14.1"
+maintainer: "platform@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-options-vanilla" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.1-rc1.tar.gz"
+  checksum: "sha256=c0dc72b35d510524a80d8da82e0054b82d35bea339911136671201ce9943ebf3"
+}
+extra-files: ["ocaml-base-compiler.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]

--- a/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1~rc1+options/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate of OCaml 4.14.1"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
+depends: [
+  "ocaml" {= "4.14.1" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.1-rc1.tar.gz"
+  checksum: "sha256=c0dc72b35d510524a80d8da82e0054b82d35bea339911136671201ce9943ebf3"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]


### PR DESCRIPTION
This PR adds the opam packages for the release candidate for OCaml 4.14.1, which will be released at the same time as OCaml 5.0 as a companion release on compiler LTS branch.

Changes in the release candidate compared to OCaml 4.14.0
--------------------------------------------------------------------------------------

### Compiler user-interface and warnings:

- 11184, 11670: Stop calling ranlib on created / installed libraries
  (Sébastien Hinderer and Xavier Leroy, review by the same)

### Build system:

- 11370, 11373: Don't pass CFLAGS to flexlink during configure.
  (David Allsopp, report by William Hu, review by Xavier Leroy and
   Sébastien Hinderer)

- 11487: Thwart FMA test optimization during configure
  (William Hu, review by David Allsopp and Sébastien Hinderer)

### Bug fixes:

- 10768, 11340: Fix typechecking regression when combining first class
  modules and GADTs.
  (Jacques Garrigue, report by François Thiré, review by Matthew Ryan)

- 11204: Fix regression introduced in 4.14.0 that would trigger Warning 17 when
  calling virtual methods introduced by constraining the self type from within
  the class definition.
  (Nicolás Ojeda Bär, review by Leo White)

- 11263, 11267: caml/{memory,misc}.h: check whether `_MSC_VER` is defined
  before using it to ensure that the headers can always be used in code which
  turns on -Wundef (or equivalent).
  (David Allsopp and Nicolás Ojeda Bär, review by Nicolás Ojeda Bär and
   Sébastien Hinderer)

- 11314, 11416: fix non-informative error message for module inclusion
  (Florian Angeletti, report by Thierry Martinez, review by Gabriel Scherer)

- 11358, 11379: Refactor the initialization of bytecode threading,
  This avoids a "dangling pointer" warning of GCC 12.1.
  (Xavier Leroy, report by Armaël Guéneau, review by Gabriel Scherer)

- 11387, module type with constraints no longer crash the compiler in presence
  of both shadowing warnings and the `-bin-annot` compiler flag.
  (Florian Angeletti, report by Christophe Raffalli, review by Gabriel Scherer)

- 11392, 11392: assertion failure with -rectypes and external definitions
  (Gabriel Scherer, review by Florian Angeletti, report by Dmitrii Kosarev)

- 11417: Fix regression allowing virtual methods in non-virtual classes.
  (Leo White, review by Florian Angeletti)

- 11468: Fix regression from 10186 (OCaml 4.13) detecting IPv6 on Windows for
  mingw-w64 i686 port.
  (David Allsopp, review by Xavier Leroy and Sébastien Hinderer)

- 11489, 11496: More prudent deallocation of alternate signal stack
  (Xavier Leroy, report by @rajdakin, review by Florian Angeletti)

- 11516, 11524: Fix the `deprecated_mutable` attribute.
  (Chris Casinghino, review by Nicolás Ojeda Bär and Florian Angeletti)

- 11194, 11609: Fix inconsistent type variable names in "unbound type var"
  messages
  (Ulysse Gérard and Florian Angeletti, review Florian Angeletti and
   Gabriel Scherer)

- 11622: Prevent stack overflow when printing a constructor or record
  mismatch error involving recursive types.
  (Florian Angeletti, review by Gabriel Scherer)

- 11732: Ensure that types from packed modules are always generalised
  (Stephen Dolan and Leo White, review by Jacques Garrigue)

- 11737: Fix segfault condition in Unix.stat under Windows in the presence of
  multiple threads.
  (Marc Lasson, Nicolás Ojeda Bär, review by Gabriel Scherer and David Allsopp)

- 11776: Extend environment with functor parameters in `strengthen_lazy`.
  (Chris Casinghino and Luke Maurer, review by Gabriel Scherer)

- 11533, 11534: follow synonyms again in #show_module_type
  (this had stopped working in 4.14.0)
  (Gabriel Scherer, review by Jacques Garrigue, report by Yaron Minsky)

- 11768, 11788: Fix crash at start-up of bytecode programs in
  no-naked-pointers mode caused by wrong initialization of caml_global_data
  (Xavier Leroy, report by Etienne Millon, review by Gabriel Scherer)
