### PR TITLE
New release of Solo5.0.7.5

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.5/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.7.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.5/solo5-v0.7.5.tar.gz"
+  checksum: "sha512=1e8be23e84e54f8fdb364e8d2a20933150930b43f91085b4dd378ed6445718ef38abca98bcfd0a1e68cdbda747bf829551f0b2a31cdcfe13db219e332512ff79"
+}

--- a/packages/solo5/solo5.0.7.5/opam
+++ b/packages/solo5/solo5.0.7.5/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+x-ci-accept-failures: [ "centos-7" ]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.7.5/solo5-v0.7.5.tar.gz"
+  checksum: "sha512=1e8be23e84e54f8fdb364e8d2a20933150930b43f91085b4dd378ed6445718ef38abca98bcfd0a1e68cdbda747bf829551f0b2a31cdcfe13db219e332512ff79"
+}


### PR DESCRIPTION
* Since MirageOS moved from PV mode to PVH on Xen, and thus replacing Mini-OS with solo5, there was an issue in the solo5 code which failed to properly account the already written bytes on the console. This only occurs if the output to be performed does not fit in a single output buffer (2048 bytes on Xen).

  The code in question set the number of bytes written to the last written count `written = output_some(buf)`, instead of increasing the written count `written += output_some(buf)`.

  Thanks to Krzysztof Burghardt, Pierre Alain, Thomas Leonard & Hannes Mehnert
  for the issue, review and proposal. The fix is available here: #538.