### PR TITLE
Add 5.0.0~rc1+tsan switch

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+tsan/files/ocaml-variants.install
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+tsan/files/ocaml-variants.install
@@ -1,0 +1,1 @@
+share_root: ["config.cache" {"ocaml/config.cache"}]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+tsan/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0~rc1+tsan/opam
@@ -1,0 +1,76 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate of OCaml 5.0.0, with ThreadSanitizer instrumentation"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon" "Anmol Sahoo" "Olivier Nicole" "Fabrice Buoro"]
+homepage: "https://github.com/ocaml-multicore/ocaml-tsan"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-tsan/issues"
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-tsan.git#tsan_5.0.0-rc1"
+depends: [
+  "ocaml" {= "5.0.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml-multicore/ocaml-tsan/archive/refs/tags/5.0.0-rc1+tsan.tar.gz"
+  checksum: "sha256=40a31f16e8791bbe8c6e4d3aa9b7660ef530ca9cbe72ad232c33eb54bf17f791"
+}
+extra-files: ["ocaml-variants.install" "md5=3e969b841df1f51ca448e6e6295cb451"]
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-32bit"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+]


### PR DESCRIPTION
This proposes the addition of a switch `5.0.0~rc1+tsan` to install OCaml 5.0.0 rc1 with ThreadSanitizer support. It points to the 5.0.0\~rc1 release of https://github.com/ocaml-multicore/ocaml-tsan.