### PR TITLE
dune should not be tagged build

### DIFF
--- a/packages/cowabloga/cowabloga.0.5.0/opam
+++ b/packages/cowabloga/cowabloga.0.5.0/opam
@@ -14,7 +14,7 @@ depends: [
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.0.1"}
   "magic-mime"
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cohttp" {with-test & >= "0.5.0"}
   "cohttp-lwt-unix" {with-test}
 ]

--- a/packages/jupyter-archimedes/jupyter-archimedes.2.7.2/opam
+++ b/packages/jupyter-archimedes/jupyter-archimedes.2.7.2/opam
@@ -15,7 +15,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build & >= "1.0.0"}
+  "dune" {>= "1.0.0"}
   "jupyter" {>= "2.7.2" & <= "2.7.8"}
   "cairo2" {>= "0.6.0"}
   "archimedes" {>= "0.4.19"}

--- a/packages/jupyter/jupyter.2.7.5/opam
+++ b/packages/jupyter/jupyter.2.7.5/opam
@@ -29,7 +29,7 @@ depends: [
   "yojson" {>= "1.6.0"}
   "ppx_deriving_yojson" {>= "3.6.0"}
   "cryptokit" {>= "1.12"}
-  "dune" {build & >= "1.0.0"}
+  "dune" {>= "1.0.0"}
 ]
 depopts: [
   "merlin"

--- a/packages/jupyter/jupyter.2.7.6/opam
+++ b/packages/jupyter/jupyter.2.7.6/opam
@@ -29,7 +29,7 @@ depends: [
   "yojson" {>="1.6.0"}
   "ppx_deriving_yojson" {>= "3.6.0"}
   "cryptokit" {>= "1.12"}
-  "dune" {build & >= "1.0.0"}
+  "dune" {>= "1.0.0"}
   "ounit2" {with-test & >= "2.0.0"}
   "ocp-indent" {with-test & >= "1.7.0"}
 ]

--- a/packages/psq/psq.0.2.1/opam
+++ b/packages/psq/psq.0.2.1/opam
@@ -12,7 +12,7 @@ build: [ [ "dune" "subst" ] {dev}
          [ "dune" "runtest" "-p" name ] {with-test & ocaml:version >= "4.07.0"} ]
 depends: [
   "ocaml" {>="4.03.0"}
-  "dune" {build & >= "1.7"}
+  "dune" {>= "1.7"}
   "seq"
   "qcheck-core"     {with-test}
   "qcheck-alcotest" {with-test}

--- a/packages/timed/timed.1.1/opam
+++ b/packages/timed/timed.1.1/opam
@@ -26,7 +26,7 @@ bug-reports: "https://github.com/rlepigre/ocaml-timed/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "odoc" {with-doc}
-  "dune" {>= "2.7" & build}
+  "dune" {>= "2.7"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
These should be the only remaining packages with this problem.
Failure observed for psq [here](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/597d1a0ed1622deae17d497589795df10644d795/variant/compilers,4.14,index.1.5.0,revdeps,tezos-client-base-unix.11.0), part of revdeps in PR [#22598](https://github.com/ocaml/opam-repository/pull/22598)

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>