### PR TITLE
Package headache.1.06

### DIFF
--- a/packages/headache/headache.1.06/opam
+++ b/packages/headache/headache.1.06/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 
-license: "GNU Library General Public License"
+license: "LGPL-2.0-only"
 
 synopsis: "Automatic generation of files headers"
 description: """

--- a/packages/headache/headache.1.06/opam
+++ b/packages/headache/headache.1.06/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+license: "GNU Library General Public License"
+
+synopsis: "Automatic generation of files headers"
+description: """
+Lightweight tool for managing headers in source code files. It can
+update in any source code files (OCaml, C, XML et al).
+"""
+
+authors: [
+  "Vincent Simonet"
+  # contributors
+  "Patrick Baudin"
+  "Mehdi Dogguy"
+  "François Pottier"
+  "Virgile Prevosto"
+  "Ralf Treinen"
+]
+
+maintainer: "Patrick Baudin"
+homepage: "https://github.com/Frama-C/headache/"
+bug-reports: "https://github.com/Frama-C/headache/issues"
+dev-repo: "git+https://github.com/Frama-C/headache.git"
+
+depends: [
+  "camomile"
+  "dune" {>= "1.6"}
+]
+
+build: [
+  [ "dune" "build" "-p" "headache" ]
+]
+
+install:  [
+  [make "INSTALLDIR=%{prefix}%/bin" "install"]
+  [make "DOC_INSTALLDIR=%{prefix}%/doc/headache" "install-doc"] {with-doc}
+]
+url {
+  src: "https://github.com/Frama-C/headache/archive/v1.06.tar.gz"
+  checksum: [
+    "md5=8eb8aaf47e8d4af296828bf8d29c19ea"
+    "sha512=5a49171845dc04ca51c5fe0bb1fb8f45a1946321ca1c591371aaaee4e765c02ddd1b95cb527edaa7fe8072cc8a1c1e05f1f20cb8e6da0057c0de2c6917a00f50"
+  ]
+}


### PR DESCRIPTION
### `headache.1.06`
Automatic generation of files headers
Lightweight tool for managing headers in source code files. It can
update in any source code files (OCaml, C, XML et al).



---
* Homepage: https://github.com/Frama-C/headache/
* Source repo: git+https://github.com/Frama-C/headache.git
* Bug tracker: https://github.com/Frama-C/headache/issues

---
:camel: Pull-request generated by opam-publish v2.1.0