### PR TITLE
Fix mtime dependency on git-unix.3.10.1

### DIFF
--- a/packages/git-unix/git-unix.3.10.1/opam
+++ b/packages/git-unix/git-unix.3.10.1/opam
@@ -36,7 +36,7 @@ depends: [
   "decompress" {>= "1.4.0"}
   "domain-name" {>= "0.3.0"}
   "ipaddr" {>= "5.0.1"}
-  "mtime" {>= "1.2.0"}
+  "mtime" {>= "1.2.0" & < "2.0.0"}
   "ocamlfind" {>= "1.8.1"}
   "tcpip" {>= "7.0.0"}
   "cstruct" {>= "6.0.0"}


### PR DESCRIPTION
It seems that we missed a constraint on #22622 about the recently release `mtime` package. This PR fix conflicts for `git-unix.3.10.1`.