### PR TITLE
[new release] lockfree (0.3.0)

### DIFF
--- a/packages/lockfree/lockfree.0.3.0/opam
+++ b/packages/lockfree/lockfree.0.3.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage: "https://github.com/ocaml-multicore/lockfree"
+doc: "https://ocaml-multicore.github.io/lockfree"
+synopsis: "Lock-free data structures for multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
+bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.0"}
+  "qcheck" {with-test & >= "0.18.1"}
+  "qcheck-alcotest" {with-test & >= "0.18.1"}
+  "alcotest" {>= "1.6.0"}
+  "yojson" {>= "2.0.2"}
+  "dscheck" {>= "0.0.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/ocaml-multicore/lockfree/releases/download/0.3.0/lockfree-0.3.0.tbz"
+  checksum: [
+    "sha256=5dd251e688c5b00edb278699e6b875d0d8e8a44d0d8dfa90f4a8ad38b321dc9a"
+    "sha512=f98a9d102450e3713cebce48709c6c4ad30b2101d1b5acf8c394bb6af40b9909858e000fe28924cf6c6996d7de6e036e81e67fe660faa560cb901d40deff3fa1"
+  ]
+}
+x-commit-hash: "bf8f5000a6e802b4a21a6cfbf8ec8aa5208a8612"


### PR DESCRIPTION
Lock-free data structures for multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/lockfree">https://github.com/ocaml-multicore/lockfree</a>
- Documentation: <a href="https://ocaml-multicore.github.io/lockfree">https://ocaml-multicore.github.io/lockfree</a>

##### CHANGES:

--------------------------

* Add Chase-Lev Work-stealing deque `Ws_deque`. (@ctk21)
