### PR TITLE
Eio: add an upper-bound on mtime

### DIFF
--- a/packages/eio/eio.0.7/opam
+++ b/packages/eio/eio.0.7/opam
@@ -19,7 +19,7 @@ depends: [
   "hmap" {>= "0.8.1"}
   "astring" {>= "0.8.5" & with-test}
   "crowbar" {>= "0.2" & with-test}
-  "mtime" {>= "1.2.0"}
+  "mtime" {>= "1.2.0" & < "2.0.0"}
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
It currently fails to install, with:
```
# File "lib_eio/time.ml", line 91, characters 14-29:
# 91 |       let d = Mtime.Span.to_s d in
#                    ^^^^^^^^^^^^^^^
```
/cc @bikallem 