### PR TITLE
[new release] albatross (1.5.4)

### DIFF
--- a/packages/albatross/albatross.1.5.4/opam
+++ b/packages/albatross/albatross.1.5.4/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos"
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.13.1"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.2.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v1.5.4/albatross-1.5.4.tbz"
+  checksum: [
+    "sha256=01201cb598b91cc50b04860cf2dda7416923e89ca23bfbb9ab310a7def9d7c63"
+    "sha512=2c4f9ae7addf46bf2695f4d9f24961b9a83d1fefa96abbf3259b5dc56cf6ebdaeb42f3e29f926ab0e28fb217c12f510c96e3e96efe59c82f061d77fb7ac64ce2"
+  ]
+}
+x-commit-hash: "c5104fac067f63000da255a7ab24004a88fc3bef"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

- Improve error messages when socket binding fails, and when albatross-console
  is not running (roburio/albatross#139, inspired by roburio/albatross#137, @hannesm @samoht)
- Debian packages: add gmp and libnl package dependencies (roburio/albatross#141 roburio/albatross#142 @reynir
  @hannesm)
- albatross-tls-endpoint: use Unix.inet6_addr_any, also add a command line
  argument to specify the listening address (roburio/albatross#144 roburio/albatross#145 @reynir @hannesm,
  reported in roburio/albatross#143 by @palainp)
- command line: allow multiple ":" in the hostname (to support IPv6 addresses)
  (roburio/albatross#146 @hannesm)
