### PR TITLE
[new release] current_web, current_slack, current_rpc, current_gitlab, current_github, current_git, current_examples, current_docker and current (0.6.3)

### DIFF
--- a/packages/current/current.0.6.3/opam
+++ b/packages/current/current.0.6.3/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "current_incr" {>= "0.5"}
+  "fmt" {>= "0.8.9"}
+  "bos"
+  "ppx_deriving"
+  "lwt" {>= "5.6.1"}
+  "cmdliner" {>= "1.1.0"}
+  "sqlite3"
+  "duration"
+  "prometheus"
+  "dune" {>= "3.3"}
+  "re" {>= "1.9.0"}
+  "lwt-dllist"
+  "alcotest" {>= "1.2.0" & with-test}
+  "alcotest-lwt" {>= "1.2.0" & with-test}
+  "astring" {>= "0.8.5"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "prometheus-app" {with-test & >= "1.2"}
+  "conf-libev" {os != "win32"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_docker/current_docker.0.6.3/opam
+++ b/packages/current_docker/current_docker.0.6.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "ppx_deriving"
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "3.3"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_examples/current_examples.0.6.3/opam
+++ b/packages/current_examples/current_examples.0.6.3/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.6.1"}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "current" {= version}
+  "current_web" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_gitlab" {= version}
+  "current_docker" {= version}
+  "current_rpc" {= version}
+  "capnp-rpc-unix" {>= "0.5"}
+  "dune" {>= "3.3"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.8.0"}
+  "capnp-rpc-net" {>= "0.8.0"}
+  "dockerfile" {>= "7.0.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "routes" {>= "2.0.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "prometheus-app" {>= "1.2"}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_git/current_git.0.6.3/opam
+++ b/packages/current_git/current_git.0.6.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "conf-git"
+  "fmt" {>= "0.8.9"}
+  "ppx_deriving"
+  "lwt" {>= "5.6.1"}
+  "irmin-watcher"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "yojson"
+  "dune" {>= "3.3"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "result" {>= "1.5"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mdx" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_github/current_github.0.6.3/opam
+++ b/packages/current_github/current_github.0.6.3/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.6.1"}
+  "duration"
+  "ptime"
+  "yojson"
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "hex" {>= "1.4.0"}
+  "x509" {>= "0.10.0"}
+  "tls" {>= "0.11.0"}
+  "dune" {>= "3.3"}
+  "github-unix" {>= "4.4.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_gitlab/current_gitlab.0.6.3/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "GitLab plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitLab.
+It can monitor and clone remote GitLab repositories, and can
+push GitLab status messages to show the results of testing
+PRs and branches."""
+maintainer: "timmcgil@gmail.com"
+authors: "timmcgil@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "lwt" {>= "5.6.1"}
+  "yojson"
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "dune" {>= "3.3"}
+  "gitlab-unix" {>= "0.1.4"}
+  "cmdliner" {>= "1.1.0"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_rpc/current_rpc.0.6.3/opam
+++ b/packages/current_rpc/current_rpc.0.6.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "0.8.0"}
+  "capnp-rpc-lwt" {>= "0.4"}
+  "fpath"
+  "dune" {>= "3.3"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_slack/current_slack.0.6.3/opam
+++ b/packages/current_slack/current_slack.0.6.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "fmt" {>= "0.8.9"}
+  "yojson"
+  "lwt" {>= "5.6.1"}
+  "tls" {>= "0.12.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "dune" {>= "3.3"}
+  "logs" {>= "0.7.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"

--- a/packages/current_web/current_web.0.6.3/opam
+++ b/packages/current_web/current_web.0.6.3/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """\
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: "talex5@gmail.com"
+authors: "talex5@gmail.com"
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "crunch" {>= "3.3.0" & build}
+  "current" {= version}
+  "ansi" {>= "0.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "base64"
+  "session"
+  "session-cohttp-lwt"
+  "mirage-crypto" {>= "0.8.7"}
+  "mirage-crypto-rng"
+  "fmt" {>= "0.8.9"}
+  "bos"
+  "lwt" {>= "5.6.1"}
+  "multipart_form-lwt" {>= "0.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "prometheus" {>= "0.7"}
+  "prometheus-app" {>= "1.2"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "tyxml" {>= "4.4.0"}
+  "csv" {>= "2.4"}
+  "routes" {>= "2.0.0"}
+  "dune" {>= "3.3"}
+  "conf-graphviz"
+  "astring" {>= "0.8.5"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "cstruct" {>= "5.2.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.3/current-0.6.3.tbz"
+  checksum: [
+    "sha256=95cd938b03ca79db502ab48db002664d91eba12f638cf31bfffb8d795a7e5457"
+    "sha512=42cb909ab70446dfd82049e36cf307954a3f09d7d4db7bb48b66b3fa0304ae6a052044cfb8ecd6a04c2cc8bfea483c14a8c9b39bc9eb1b1b3d17657418df5ffa"
+  ]
+}
+x-commit-hash: "72dc45330af37cd626a3f2a1cc87e198de343229"


### PR DESCRIPTION
Test web UI for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>

##### CHANGES:

Web UI:

- Make line numbers clickable in logs (@MisterDA, ocurrent/ocurrent#352, ocurrent/ocurrent#356)
- Make the background of rendered graphiz transparent (@MisterDA, ocurrent/ocurrent#362)
- Disable uneeded tooltips on diagrams nodes (@MisterDA, ocurrent/ocurrent#382)

API:

- Add collapse_list to control rendering of ocurrent pipeline (@TheLortex @tmcgilchrist, ocurrent/ocurrent#314)
- Added ref_title accessor for commits (@benmandrew, ocurrent/ocurrent#383)

Plugins:

- GitHub: Add support for rebuilding a commit. (@novemberkilo, ocurrent/ocurrent#361)
- GitHub: Refactor and add support for check-suite events to allow rebuild webooks from GitHub. (@novemberkilo, ocurrent/ocurrent#364)
- GitHub: Remove the role check for webhooks. (@novemberkilo, ocurrent/ocurrent#366)
- GitHub: More explicitly set details_url in CheckRunStatus. (@tmcgilchrist, ocurrent/ocurrent#369)

- GitLab: use set_status name (= context) in the web interface (@tmcgilchrist, ocurrent/ocurrent#350)
- GitLab: More information from current_gitlab plugin (@maiste, ocurrent/ocurrent#389)

- Git: Make the output of git fetch quiet (@kit-ty-kate, ocurrent/ocurrent#371)

- Docker: Add pull argument to docker compose (@patrickoferris, ocurrent/ocurrent#358)
- Docker: Docker compose cli v2. Required to support AWS ECS. (@mtelvers @tmcgilchrist, ocurrent/ocurrent#373)
- Docker: Add build context parameter to docker build (@patricoferris, ocurrent/ocurrent#363)

Other:
- Fix infinite loop in test (@maiste, @art-w, @MisterDA ocurrent/ocurrent#386)
- Dune 3 fixes (@MisterDA, ocurrent/ocurrent#367)
- Fix some overuse of memory and concurrent fd open when too many jobs are queued (@kit-ty-kate, ocurrent/ocurrent#372)
- Pull in crunch.3.3.0 for Windows fixes (@MisterDA, ocurrent/ocurrent#370)
- Allow users to provide a command printer (@patricoferris, ocurrent/ocurrent#359)
- Update to routes 2.0 (@anuragsoni, ocurrent/ocurrent#381)
- Misc. patches: don't use List.length for comparisons, use Unicode ellipsis (@MisterDA, ocurrent/ocurrent#391)
