### PR TITLE
pa_comprehension 0.4: fix bad checksum

### DIFF
--- a/packages/pa_comprehension/pa_comprehension.0.4/opam
+++ b/packages/pa_comprehension/pa_comprehension.0.4/opam
@@ -6,7 +6,6 @@ build: [
   ["ocaml" "setup.ml" "-configure"]
   ["ocaml" "setup.ml" "-build"]
 ]
-remove: [["ocamlfind" "remove" "pa_comprehension"]]
 depends: [
   "ocaml"
   "ocamlfind"
@@ -19,6 +18,6 @@ install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Syntax extension for comprehension expressions"
 flags: light-uninstall
 url {
-  src: "https://github.com/cakeplus/pa_comprehension/archive/0.4.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/pa_comprehension.0.4.tar.gz"
   checksum: "md5=d1e6dc22c129d4a5cbc6fd848724be25"
 }

--- a/packages/pa_comprehension/pa_comprehension.0.4/opam
+++ b/packages/pa_comprehension/pa_comprehension.0.4/opam
@@ -16,7 +16,6 @@ depends: [
 dev-repo: "git+https://github.com/cakeplus/pa_comprehension"
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "Syntax extension for comprehension expressions"
-flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-source-archives/raw/main/pa_comprehension.0.4.tar.gz"
   checksum: "md5=d1e6dc22c129d4a5cbc6fd848724be25"


### PR DESCRIPTION
```
#=== ERROR while fetching sources for pa_comprehension.0.4 ====================#
OpamSolution.Fetch_fail("https://github.com/cakeplus/pa_comprehension/archive/0.4.tar.gz (Bad checksum, expected md5=d1e6dc22c129d4a5cbc6fd848724be25)")
```
Seen on https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/9ed28b36b743cc7e0143d6f71ccde958a26a60cd/variant/compilers,4.14,batteries.3.6.0,revdeps,pa_comprehension.0.4

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>