### PR TITLE
tezos-stdlib-unix 15.1: add upper bound on mtime

### DIFF
--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.15.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.15.1/opam
@@ -18,7 +18,7 @@ depends: [
   "re" { >= "1.7.2" }
   "ezjsonm" { >= "1.1.0" }
   "ptime" { >= "1.0.0" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "lwt_log"
   "conf-libev"
   "uri" { >= "2.2.0" }


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling tezos-stdlib-unix.15.1 =============================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.0 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/tezos-stdlib-unix.15.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tezos-stdlib-unix -j 127
 exit-code            1
 env-file             ~/.opam/log/tezos-stdlib-unix-7-7790f5.env
 output-file          ~/.opam/log/tezos-stdlib-unix-7-7790f5.out
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -open Tezos_error_monad -open Tezos_error_monad.TzLwtreslib -open Tezos_event_logging -open Tezos_stdlib -open Data_encoding -g -bin-annot -I src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/data-encoding -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/either -I /home/opam/.opam/4.14/lib/ezjsonm -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/json-data-encoding -I /home/opam/.opam/4.14/lib/json-data-encoding-bson -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-canceler -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/ringo -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tezos-error-monad -I /home/opam/.opam/4.14/lib/tezos-event-logging -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/structs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/structs -I /home/opam/.opam/4.14/lib/tezos-stdlib -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zarith -I /home/opam/.opam/4.14/lib/zarith_stubs_js -intf-suffix .ml -no-alias-deps -open Tezos_stdlib_unix -o src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte/tezos_stdlib_unix__Moving_average.cmo -c -impl src/lib_stdlib_unix/moving_average.ml)
 File "src/lib_stdlib_unix/moving_average.ml", line 56, characters 43-48:
 56 |     let elapsed = int_of_float Mtime.Span.(to_ms now -. to_ms time_at_entry) in
                                                 ^^^^^
 Error: Unbound value to_ms
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -open Tezos_error_monad -open Tezos_error_monad.TzLwtreslib -open Tezos_event_logging -open Tezos_stdlib -open Data_encoding -g -O3 -I src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte -I src/lib_stdlib_unix/.tezos_stdlib_unix.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/data-encoding -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/either -I /home/opam/.opam/4.14/lib/ezjsonm -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/json-data-encoding -I /home/opam/.opam/4.14/lib/json-data-encoding-bson -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-canceler -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mtime -I /home/opam/.opam/4.14/lib/mtime/clock/os -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/ringo -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tezos-error-monad -I /home/opam/.opam/4.14/lib/tezos-event-logging -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/bare/structs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/functor-outputs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/sigs -I /home/opam/.opam/4.14/lib/tezos-lwt-result-stdlib/traced/structs -I /home/opam/.opam/4.14/lib/tezos-stdlib -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/zarith -I /home/opam/.opam/4.14/lib/zarith_stubs_js -intf-suffix .ml -no-alias-deps -open Tezos_stdlib_unix -o src/lib_stdlib_unix/.tezos_stdlib_unix.objs/native/tezos_stdlib_unix__Moving_average.cmx -c -impl src/lib_stdlib_unix/moving_average.ml)
 File "src/lib_stdlib_unix/moving_average.ml", line 56, characters 43-48:
 56 |     let elapsed = int_of_float Mtime.Span.(to_ms now -. to_ms time_at_entry) in
                                                 ^^^^^
 Error: Unbound value to_ms
```

Seen on `https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/9ed28b36b743cc7e0143d6f71ccde958a26a60cd/variant/compilers,4.14,batteries.3.6.0,revdeps,tezos-base-test-helpers.15.1`
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>