### PR TITLE
[new release] mirage-kv (6.0.0)

### DIFF
--- a/packages/caldav/caldav.0.1.0/opam
+++ b/packages/caldav/caldav.0.1.0/opam
@@ -29,7 +29,7 @@ depends: [
   "tcpip" {with-test & >= "3.7.0"}
   "mirage-clock-unix" {with-test & >= "2.0.0"}
   "mirage-kv-mem" {with-test & >= "2.0.0"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "6.0.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "ppx_deriving" {>= "4.3"}

--- a/packages/caldav/caldav.0.1.1/opam
+++ b/packages/caldav/caldav.0.1.1/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-clock-unix" {with-test & >= "2.0.0"}
   "mirage-kv-mem" {with-test & >= "2.0.0"}
   "fmt" {>= "0.8.7"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "6.0.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "ppx_deriving" {>= "4.3"}

--- a/packages/caldav/caldav.0.2.0/opam
+++ b/packages/caldav/caldav.0.2.0/opam
@@ -30,7 +30,7 @@ depends: [
   "mirage-clock-unix" {with-test & >= "2.0.0"}
   "mirage-kv-mem" {with-test & >= "2.0.0"}
   "fmt" {>= "0.8.7"}
-  "mirage-kv" {>= "3.0.0"}
+  "mirage-kv" {>= "3.0.0" & < "6.0.0"}
   "mirage-clock" {>= "2.0.0"}
   "mirage-random" {>= "2.0.0"}
   "ppx_deriving" {>= "4.3"}

--- a/packages/git-kv/git-kv.0.0.1/opam
+++ b/packages/git-kv/git-kv.0.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"             {>= "4.08.0"}
   "dune"              {>= "2.9.0"}
   "git"               {>= "3.9.0"}
-  "mirage-kv"         {>= "4.0.0"}
+  "mirage-kv"         {>= "4.0.0" & < "6.0.0"}
   "git-unix"          {>= "3.10.0"}
   "carton"            {>= "0.6.0"}
   "mirage-clock-unix"

--- a/packages/mirage-kv-mem/mirage-kv-mem.3.1.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.3.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "alcotest" {with-test}
   "ppx_deriving" {with-test}
   "mirage-clock" {>= "3.0.0"}
-  "mirage-kv" {>= "5.0.0"}
+  "mirage-kv" {>= "5.0.0" & < "6.0.0"}
   "fmt"
   "ptime"
   "mirage-clock-unix" {>= "3.0.0"}

--- a/packages/mirage-kv/mirage-kv.6.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.6.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "optint" {>= "0.2.0"}
+  "ptime" {>= "1.0.0"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v6.0.0/mirage-kv-6.0.0.tbz"
+  checksum: [
+    "sha256=217cb9150e619d5649959b9b3c061a21dc3ad17512eed8c34716b22cb5113f3a"
+    "sha512=5b7fa67f0e3973ed35892e4d3fd9ae08343d24befd8cb40d9b81f3ee556449ebe566fad64f4f50436ef1b44cb9dc497c42cac2348a3c5f459685a9edb2739532"
+  ]
+}
+x-commit-hash: "297015e2b22524f648ffdc87443fcd0f3ab59b23"

--- a/packages/tar-mirage/tar-mirage.2.2.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "5.6.0"}
   "mirage-block" {>= "2.0.0"}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-kv" {>= "5.0.0"}
+  "mirage-kv" {>= "5.0.0" & < "6.0.0"}
   "ptime"
   "tar" {= version}
   "mirage-block-unix" {with-test & >= "2.5.0"}

--- a/packages/tar-mirage/tar-mirage.2.2.1/opam
+++ b/packages/tar-mirage/tar-mirage.2.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "5.6.0"}
   "mirage-block" {>= "2.0.0"}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-kv" {>= "5.0.0"}
+  "mirage-kv" {>= "5.0.0" & < "6.0.0"}
   "ptime"
   "tar" {= version}
   "mirage-block-unix" {with-test & >= "2.5.0"}

--- a/packages/tar-mirage/tar-mirage.2.2.2/opam
+++ b/packages/tar-mirage/tar-mirage.2.2.2/opam
@@ -19,7 +19,7 @@ depends: [
   "lwt" {>= "5.6.0"}
   "mirage-block" {>= "2.0.0"}
   "mirage-clock" {>= "4.0.0"}
-  "mirage-kv" {>= "5.0.0"}
+  "mirage-kv" {>= "5.0.0" & < "6.0.0"}
   "ptime"
   "tar" {= version}
   "mirage-block-unix" {with-test & >= "2.5.0"}


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Use ptime directly for RO.last_modified, instead of the int * int64 pair
  (mirage/mirage-kv#34)
* Add RW.allocate to allocate a key and fill it with zero bytes (mirage/mirage-kv#34)
* RO.list: return Key.t instead of string (mirage/mirage-kv#37, fixes mirage/mirage-kv#33)
* Introduce a custom error for RW.rename with a source which is a prefix of
  destination (mirage/mirage-kv#37, fixes mirage/mirage-kv#31)
* Use Optint.Int63.t for RO.size, RO.get_partial, RO.set_partial (mirage/mirage-kv#37, fixes mirage/mirage-kv#32)
* Remove RW.batch (mirage/mirage-kv#37, fixes mirage/mirage-kv#29 mirage/mirage-kv#36, discussed at the MirageOS meeting in
  November, and on the mirageos-devel mailing list in January 2022)
* Key.pp: escape the entire string, not individual fragments (mirage/mirage-kv#35)
