### PR TITLE
goblint-cil, goblint: add OCaml 5.0 upper bounds

### DIFF
--- a/packages/goblint-cil/goblint-cil.1.7.3/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.3/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "num" {build}

--- a/packages/goblint-cil/goblint-cil.1.7.4/opam
+++ b/packages/goblint-cil/goblint-cil.1.7.4/opam
@@ -13,7 +13,7 @@ install: [
   make "install"
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "zarith"

--- a/packages/goblint-cil/goblint-cil.1.8.0/opam
+++ b/packages/goblint-cil/goblint-cil.1.8.0/opam
@@ -21,7 +21,7 @@ license: "BSD-3-Clause"
 homepage: "https://cil-project.github.io/cil/"
 bug-reports: "https://github.com/goblint/cil/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.04.2" & < "5.0"}
   "ocamlfind"
   "zarith"
   "hevea" {with-doc}

--- a/packages/goblint-cil/goblint-cil.1.8.2/opam
+++ b/packages/goblint-cil/goblint-cil.1.8.2/opam
@@ -23,7 +23,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/goblint/cil"
 bug-reports: "https://github.com/goblint/cil/issues"
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0"}
   "ocamlfind"
   "zarith"
   "hevea" {with-doc}

--- a/packages/goblint/goblint.2.0.0/opam
+++ b/packages/goblint/goblint.2.0.0/opam
@@ -18,7 +18,7 @@ homepage: "https://goblint.in.tum.de"
 doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.0"}
   "dune" {>= "2.9.1"}
   "goblint-cil" {>= "2.0.0"}
   "batteries" {>= "3.4.0"}

--- a/packages/goblint/goblint.2.0.1/opam
+++ b/packages/goblint/goblint.2.0.1/opam
@@ -18,7 +18,7 @@ homepage: "https://goblint.in.tum.de"
 doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.0"}
   "dune" {>= "2.9.1"}
   "goblint-cil" {>= "2.0.0"}
   "batteries" {>= "3.4.0"}

--- a/packages/goblint/goblint.2.1.0/opam
+++ b/packages/goblint/goblint.2.1.0/opam
@@ -18,7 +18,7 @@ homepage: "https://goblint.in.tum.de"
 doc: "https://goblint.readthedocs.io/en/latest/"
 bug-reports: "https://github.com/goblint/analyzer/issues"
 depends: [
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.0"}
   "dune" {>= "3.0"}
   "goblint-cil" {>= "2.0.1"}
   "batteries" {>= "3.4.0"}


### PR DESCRIPTION
Based on opam-health-check for 5.0+alpha-repo with a pre-release of #22635 these fail to compile on OCaml 5.0.