### PR TITLE
[new release] OCADml (0.2.0)

### DIFF
--- a/packages/OCADml/OCADml.0.2.0/opam
+++ b/packages/OCADml/OCADml.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.13.0"}
+  "cairo2" {>= "0.6.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.2.0/OCADml-0.2.0.tbz"
+  checksum: [
+    "sha256=f343bf7fcbeccd4dfb748f045a56a8edaa7e30157cf3a10b04c121c351c55873"
+    "sha512=079b5c5af8a1fc811d1cd13144f7aedc40509bd86929495e03f1de355f2a9b22e4313daa668e6c361848742ef9dcf7e144897fe6ae98f0c095c1eaec77ffd243"
+  ]
+}
+x-commit-hash: "3164efdc42799b2c5c4d12b662514947c1d3dfc6"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- Use v4 type for `Plane.t` abstract it and add type conversions
- `Mesh.extrude` altered to return mid-sectionless shape when `~height` is less
  than the combined height of `~caps` (rather than breaking with `nans`)
- Use `Mesh.Cap.t` and sub-variants more consistently for `~caps` specification in
  sweeping functions of `Mesh` (looping restricted using sub-types)
- Add `Mesh.revolve`
