### PR TITLE
[new release] omd (2.0.0.alpha3)

### DIFF
--- a/packages/omd/omd.2.0.0.alpha3/opam
+++ b/packages/omd/omd.2.0.0.alpha3/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/ocaml/omd/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "stdcompat"
+  "stdcompat" {>= "16"}
   "uutf"
   "uucp"
   "uunf"

--- a/packages/omd/omd.2.0.0.alpha3/opam
+++ b/packages/omd/omd.2.0.0.alpha3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "A Markdown frontend in pure OCaml"
+description: """
+This Markdown library is implemented using only pure OCaml (including
+I/O operations provided by the standard OCaml compiler distribution).
+OMD is meant to be as faithful as possible to the original Markdown.
+Additionally, OMD implements a few Github markdown features, an
+extension mechanism, and some other features. Note that the opam
+package installs both the OMD library and the command line tool `omd`."""
+maintainer: [
+  "Shon Feder <shon.feder@gmail.com>" "Raphael Sousa Santos <@sonologico>"
+]
+authors: [
+  "Philippe Wang <philippe.wang@gmail.com>"
+  "Nicolás Ojeda Bär <n.oje.bar@gmail.com>"
+]
+license: "ISC"
+tags: ["org:ocamllabs" "org:mirage"]
+homepage: "https://github.com/ocaml/omd"
+bug-reports: "https://github.com/ocaml/omd/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "stdcompat"
+  "uutf"
+  "uucp"
+  "uunf"
+  "dune-build-info" {>= "2.7"}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/omd.git"
+url {
+  src:
+    "https://github.com/ocaml/omd/releases/download/2.0.0.alpha3/omd-2.0.0.alpha3.tbz"
+  checksum: [
+    "sha256=278e8e5409954bee919ac853909f97061f954e728cbdb241466c235cb741377c"
+    "sha512=51c1ca573bd8e20e100788db575f3bee3c2ef61f0cf5c83fb5b67e193d2c87a223ae4a5776b1f3fe85f024cddf85bbe3e1f10988c38a88ae7304a282fd81825a"
+  ]
+}
+x-commit-hash: "2c6b1adb5107d452b69527e4494cb3fd171c48fb"


### PR DESCRIPTION
A Markdown frontend in pure OCaml

- Project page: <a href="https://github.com/ocaml/omd">https://github.com/ocaml/omd</a>

##### CHANGES:

- Expose the HTML escape function `htmlentities` (ocaml/omd#295 @cuihtlauac)

- Support generation of identifiers in headers (ocaml/omd#294, @tatchi)

- Support GitHub-Flavoured Markdown tables (ocaml/omd#292, @bobatkey)

- Update parser to support CommonMark Spec 0.30 (ocaml/omd#266, @SquidDev)

- Preserve the order of input files in the HTML output to stdout (ocaml/omd#258,
  @patricoferris)

- Fix all deviations from CommonMark Spec 0.30 (ocaml/omd#284, ocaml/omd#283, ocaml/omd#278, ocaml/omd#277, ocaml/omd#269,
  @tatchi)
