### PR TITLE
[new release] merlin, merlin-lib and dot-merlin-reader (4.7.1-500)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.7.1-500/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.7.1-500/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "6.0" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.6"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7.1-500/merlin-4.7.1-500.tbz"
+  checksum: [
+    "sha256=885d7a69796e06b1e7f80ddfc568af3a35cd03670e2ce23d39ea3c8547fa4b27"
+    "sha512=de89c4cea7fe67e0d6f69d51e565a65d846fdf8ab63e4c1e9aafffebe73f7a087f12f828da7352c589cb1d1a127d8e0a2f021a3779cd9799b2e2a4681b8ed011"
+  ]
+}
+x-commit-hash: "f3643eab67b5d2a89c3310282b1b605eadeb1908"

--- a/packages/merlin-lib/merlin-lib.4.7.1-500/opam
+++ b/packages/merlin-lib/merlin-lib.4.7.1-500/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir" {dev}
+  "menhirLib" {dev}
+  "menhirSdk" {dev}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7.1-500/merlin-4.7.1-500.tbz"
+  checksum: [
+    "sha256=885d7a69796e06b1e7f80ddfc568af3a35cd03670e2ce23d39ea3c8547fa4b27"
+    "sha512=de89c4cea7fe67e0d6f69d51e565a65d846fdf8ab63e4c1e9aafffebe73f7a087f12f828da7352c589cb1d1a127d8e0a2f021a3779cd9799b2e2a4681b8ed011"
+  ]
+}
+x-commit-hash: "f3643eab67b5d2a89c3310282b1b605eadeb1908"

--- a/packages/merlin/merlin.4.7.1-500/opam
+++ b/packages/merlin/merlin.4.7.1-500/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.6"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.7.1-500/merlin-4.7.1-500.tbz"
+  checksum: [
+    "sha256=885d7a69796e06b1e7f80ddfc568af3a35cd03670e2ce23d39ea3c8547fa4b27"
+    "sha512=de89c4cea7fe67e0d6f69d51e565a65d846fdf8ab63e4c1e9aafffebe73f7a087f12f828da7352c589cb1d1a127d8e0a2f021a3779cd9799b2e2a4681b8ed011"
+  ]
+}
+x-commit-hash: "f3643eab67b5d2a89c3310282b1b605eadeb1908"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Thu Dec 13 11:49:42 CEST 2022

  + merlin binary
    - Restore compatibility with the compiler's command line by accepting
      the `-safe-string` flag as a no-op instead of rejecting it. (ocaml/merlin#1544,
      fixes ocaml/merlin#1518)
    - Mark some C variables as unused to remove warnings (ocaml/merlin#1541, @antalsz)
