### PR TITLE
[new release] odoc (2.2.0)

### DIFF
--- a/packages/odoc/odoc.2.2.0/opam
+++ b/packages/odoc/odoc.2.2.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+homepage: "http://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+authors: [
+  "Thomas Refis <trefis@janestreet.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Leo White <leo@lpw25.net>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+]
+maintainer: "Jon Ludlam <jon@recoil.org>"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml documentation generator"
+description: """
+Odoc is a documentation generator for OCaml. It reads doc comments,
+delimited with `(** ... *)`, and outputs HTML. 
+"""
+
+depends: [
+  "odoc-parser" {>= "2.0.0"}
+  "astring"
+  "cmdliner" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.0.2"}
+  "fpath"
+  "ocaml" {>= "4.02.0"}
+  "result"
+  "tyxml" {>= "4.3.0"}
+  "fmt"
+
+  "ocamlfind" {with-test}
+  "yojson" {< "2.0.0" & with-test}
+  ("ocaml" {< "4.04.1" & with-test} | "sexplib0" {with-test})
+  "conf-jq" {with-test}
+
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+  "crunch" {with-test}
+
+  ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
+  ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/2.2.0/odoc-2.2.0.tbz"
+  checksum: [
+    "sha256=6818c971fc0c3eed9d3d143389f80739b1618af70b9fdb443b35bd7f0121740c"
+    "sha512=9f8fc2ee6b25629474e8aa69dd460becab9277261578af0f7b97f7f779cc5f1056d1b5f14ab583b9b94ea097e5df2d6e35040f2a4887021209705486f9d44a22"
+  ]
+}
+x-commit-hash: "103dac4c370aa2ad5aca7ba54f02f8e06adb941b"


### PR DESCRIPTION
CHANGES:

Additions
- New unstable option `--as-json` for the HTML renderer that emits HTML fragments (preamble, content) together with metadata (table of contents, breadcrumbs, whether katex is used) in JSON format. (@sabine, ocaml/odoc#908)
- New maths support via `{m ... }` and `{math ... }` tags. (@giltho, @gpetiot, ocaml/odoc#886)
- Various optimisations (@jonludlam, ocaml/odoc#870, ocaml/odoc#883)
- Better handling of alerts and deprecation notices. (@panglesd, ocaml/odoc#828)
- Handle language tags on code blocks (@julow, ocaml/odoc#848)

Bugfixes
- Shadowing issues (@jonludlam, ocaml/odoc#853)
- Layout fixes and improvements (@panglesd, ocaml/odoc#832, ocaml/odoc#839, ocaml/odoc#847)
- Handle comments on class constraints and inherit (@julow, ocaml/odoc#844)
- Disable the missing root warning (@jonludlam, ocaml/odoc#881)