### PR TITLE
Change spotlib's depopt from "curl" to "ocurl"

### DIFF
--- a/packages/spotlib/spotlib.4.0.3/opam
+++ b/packages/spotlib/spotlib.4.0.3/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
 ]
 depopts: [
-  "curl"
+  "ocurl"
 ]
 synopsis: "Useful functions for OCaml programming used by @camlspotter"
 description: """

--- a/packages/spotlib/spotlib.4.1.0/opam
+++ b/packages/spotlib/spotlib.4.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ppx_test" {>= "1.7.0"}
 ]
 depopts: [
-  "curl"
+  "ocurl"
 ]
 synopsis: "Useful functions for OCaml programming used by @camlspotter"
 description: """

--- a/packages/spotlib/spotlib.4.2.0/opam
+++ b/packages/spotlib/spotlib.4.2.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ppx_test" {>= "1.8.0"}
 ]
 depopts: [
-  "curl"
+  "ocurl"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/camlspotter/spotlib"

--- a/packages/spotlib/spotlib.4.3.0/opam
+++ b/packages/spotlib/spotlib.4.3.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ppx_test" {>= "1.8.0"}
 ]
 depopts: [
-  "curl"
+  "ocurl"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/camlspotter/spotlib"


### PR DESCRIPTION
There is no opam package named "curl" but there is one named "ocurl" which contains a library named "curl".

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>

Tested by initializing opam with a repo that includes this change, then
```
$ opam install spotlib
...
$ opam install ocurl
The following actions will be performed:
  ∗ install   ocamlfind    1.9.5 [required by ocurl]
  ∗ install   conf-libcurl 2     [required by ocurl]
  ∗ install   ocurl        0.9.2
  ↻ recompile spotlib      4.3.0 [uses ocurl]
===== ∗ 3   ↻ 1 =====
```

Now spotlib is recompiled to use ocurl, which didn't happen prior to this change.