### PR TITLE
[new release] mirage-kv-mem (3.2.0)

### DIFF
--- a/packages/mirage-kv-mem/mirage-kv-mem.3.2.0/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.3.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/mirage/mirage-kv-mem"
+doc: "https://mirage.github.io/mirage-kv-mem/"
+bug-reports: "https://github.com/mirage/mirage-kv-mem/issues"
+dev-repo: "git+https://github.com/mirage/mirage-kv-mem.git"
+tags: [ "org:mirage" "org:robur" ]
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "fmt"
+  "ptime"
+  "mirage-clock-unix" {>= "3.0.0"}
+  "optint"
+]
+conflicts: [ "result" {< "1.5"} ]
+
+synopsis: "In-memory key value store for MirageOS"
+description: """
+Implements the mirage-kv interface, but does not provide a persistent data storage.
+Use for testing or amnesia.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-mem/releases/download/v3.2.0/mirage-kv-mem-3.2.0.tbz"
+  checksum: [
+    "sha256=b7f521cb3410e193c3c775021cca7a044018c41e41bc557ced14a16e63ccfd86"
+    "sha512=09afa1a93f8a56eb64300cd1c878044607b43858bdca60f35bad3dc3a3c0f003a06cc8ee7be032a33f5adbce374450ba25d588976fdb0fcd52e0c8bab3fcd5fc"
+  ]
+}
+x-commit-hash: "d9a86e681321ecdd4dce648ef00cb0e58cc2926c"


### PR DESCRIPTION
In-memory key value store for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-kv-mem">https://github.com/mirage/mirage-kv-mem</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-mem/">https://mirage.github.io/mirage-kv-mem/</a>

##### CHANGES:

* upgrade to mirage-kv 6.0.0 interface (mirage/mirage-kv-mem#5 @hannesm)
