### PR TITLE
[conf-clang-format] add package to test for clang-format

### DIFF
--- a/packages/conf-clang-format/conf-clang-format.1/opam
+++ b/packages/conf-clang-format/conf-clang-format.1/opam
@@ -8,7 +8,8 @@ build: ["clang-format" "--version"]
 depexts: [
   ["clang-format"] {os-family = "debian"}
   ["clang-tools-extra"] {os-family = "fedora"}
-  ["clang15-extra-tools"] {os-distribution = "alpine"}
+  ["clang-extra-tools"] {os-distribution = "alpine" & os-version < "3.17" }
+  ["clang15-extra-tools"] {os-distribution = "alpine" & os-version >= "3.17" }
   ["clang-tools"] {os-family = "suse"}
   ["clang"] {os-distribution = "arch"}
   ["clang-format"] {os-distribution = "homebrew" & os = "macos"}

--- a/packages/conf-clang-format/conf-clang-format.1/opam
+++ b/packages/conf-clang-format/conf-clang-format.1/opam
@@ -1,0 +1,19 @@
+opam-version: "2.0"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://clang.llvm.org/docs/ClangFormat.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: "The Clang Team"
+license: "NCSA"
+build: ["clang-format" "--version"]
+depexts: [
+  ["clang-format"] {os-family = "debian"}
+  ["clang-tools-extra"] {os-family = "fedora"}
+  ["clang15-extra-tools"] {os-distribution = "alpine"}
+  ["clang-tools"] {os-family = "suse"}
+  ["clang"] {os-distribution = "arch"}
+  ["clang-format"] {os-distribution = "homebrew" & os = "macos"}
+]
+synopsis: "Virtual package relying on clang-format"
+description:
+  "This package can only install if the clang-format binary is installed on the system."
+flags: conf


### PR DESCRIPTION
Some distributions do not install clang-format along with clang; others have a specific package that does not depend on the 'clang' package itself. In both cases, it is useful to have a specific package for this command.