### PR TITLE
[new release] mirage-kv-mem (3.2.1)

### DIFF
--- a/packages/mirage-kv-mem/mirage-kv-mem.3.2.1/opam
+++ b/packages/mirage-kv-mem/mirage-kv-mem.3.2.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/mirage/mirage-kv-mem"
+doc: "https://mirage.github.io/mirage-kv-mem/"
+bug-reports: "https://github.com/mirage/mirage-kv-mem/issues"
+dev-repo: "git+https://github.com/mirage/mirage-kv-mem.git"
+tags: [ "org:mirage" "org:robur" ]
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "fmt"
+  "ptime"
+  "mirage-clock-unix" {>= "3.0.0"}
+  "optint"
+]
+conflicts: [ "result" {< "1.5"} ]
+
+synopsis: "In-memory key value store for MirageOS"
+description: """
+Implements the mirage-kv interface, but does not provide a persistent data storage.
+Use for testing or amnesia.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv-mem/releases/download/v3.2.1/mirage-kv-mem-3.2.1.tbz"
+  checksum: [
+    "sha256=a9fcc06285bd757de62b9da33c569c8ada0a6e49e333bb3c536993351128191f"
+    "sha512=c0f470429bff5fca4cddad014baa7d0c992f61ef316aad51b4cc7c61f3899ea387f664fdda8bf1bcef004965584c906866cbf49ea8e3a0c998423386c20dec71"
+  ]
+}
+x-commit-hash: "7ea598b93b92f2a70f30f9a9061b1769a387ec79"


### PR DESCRIPTION
In-memory key value store for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-kv-mem">https://github.com/mirage/mirage-kv-mem</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv-mem/">https://mirage.github.io/mirage-kv-mem/</a>

##### CHANGES:

* Adhere to mirage-kv documented allocate semantics (@hannesm)
