### PR TITLE
Package ppx_deriving_jsoo.0.3

### DIFF
--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.3/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Ppx deriver for Js_of_ocaml"
+maintainer: "contact@origin-labs.com"
+authors: "Maxime Levillain <maxime.levillain@origin-labs.com"
+license: "LGPL-2.1-or-later"
+homepage: "https://gitlab.com/o-labs/ppx_deriving_jsoo"
+bug-reports: "https://gitlab.com/o-labs/ppx_deriving_jsoo/-/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "ppxlib" {>= "0.18.0"}
+]
+depopts: ["ezjs_min"]
+conflicts: [
+  "ezjs_min" {< "0.2.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/o-labs/ppx_deriving_jsoo"
+url {
+  src:
+    "https://gitlab.com/o-labs/ppx_deriving_jsoo/-/archive/0.3/ppx_deriving_jsoo-0.3.tar.gz"
+  checksum: [
+    "md5=fe7cc6e9871ec6eb9f4db51360f0b5b0"
+    "sha512=f7bd3b4839a383959c2cb96632cc5fb9e60b7c2655aea34d535fe2b5c1af290125c895541a063f75cad0acad7d808a61535c7a5e974a4c4fb05526979f886a20"
+  ]
+}

--- a/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.3/opam
+++ b/packages/ppx_deriving_jsoo/ppx_deriving_jsoo.0.3/opam
@@ -15,7 +15,7 @@ conflicts: [
   "ezjs_min" {< "0.2.1"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
### `ppx_deriving_jsoo.0.3`
Ppx deriver for Js_of_ocaml



---
* Homepage: https://gitlab.com/o-labs/ppx_deriving_jsoo
* Source repo: git://gitlab.com/o-labs/ppx_deriving_jsoo
* Bug tracker: https://gitlab.com/o-labs/ppx_deriving_jsoo/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0