### PR TITLE
[new release] git-kv (0.0.2)

### DIFF
--- a/packages/git-kv/git-kv.0.0.2/opam
+++ b/packages/git-kv/git-kv.0.0.2/opam
@@ -25,6 +25,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 url {
   src:

--- a/packages/git-kv/git-kv.0.0.2/opam
+++ b/packages/git-kv/git-kv.0.0.2/opam
@@ -9,7 +9,7 @@ synopsis: "A Mirage_kv implementation using git"
 
 depends: [
   "ocaml"             {>= "4.08.0"}
-  "dune"              {>= "2.0.0"}
+  "dune"              {>= "2.9.0"}
   "git"               {>= "3.10.0"}
   "mirage-kv"         {>= "6.0.0"}
   "carton"            {>= "0.6.0"}

--- a/packages/git-kv/git-kv.0.0.2/opam
+++ b/packages/git-kv/git-kv.0.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "mirage-kv"         {>= "6.0.0"}
   "carton"            {>= "0.6.0"}
   "fmt"               {>= "0.8.7"}
-  "mirage-clock"
+  "mirage-clock"      {>= "2.0.0"}
   "ptime"
   "hxd"               {with-test}
   "conf-git"          {with-test}

--- a/packages/git-kv/git-kv.0.0.2/opam
+++ b/packages/git-kv/git-kv.0.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/roburio/git-kv"
+dev-repo: "git+https://github.com/roburio/git-kv.git"
+bug-reports: "https://github.com/roburio/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.0.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.6.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/roburio/git-kv/releases/download/v0.0.2/git-kv-0.0.2.tbz"
+  checksum: [
+    "sha256=edb6ab6bf3ce1bd7addca4e60fb84c079e72df9fdd028f1d0432aaa17605ee88"
+    "sha512=b26c017e759f4fd55c9b444850daaeaf54acdf26730afb30a3fbfcd7a1c1c1edd283c3d54351a54afa0e2c0c6bb2dc61cecd1fe59a1bcd697e93e2373edaad1e"
+  ]
+}
+x-commit-hash: "3a721fd4cd0fa01e3302e8847aafc73bdc5522f3"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/roburio/git-kv">https://github.com/roburio/git-kv</a>

##### CHANGES:

- Use Stdlib.Result and Fmt instead of Rresult (roburio/git-kv#24 @hannes)
- Use Git.Reference.main (available since git 3.10.0, roburio/git-kv#24 @hannes)
- change_and_push may return errors, report them (roburio/git-kv#24 @hannes)
- delete unix transitive dependencies from tests (roburio/git-kv#25 @dinosaure)
- update to mirage-kv 6.0.0 (roburio/git-kv#27 @hannes)
