### PR TITLE
coq-native currently conflicts with OCaml 5.0

### DIFF
--- a/packages/coq-native/coq-native.1/opam
+++ b/packages/coq-native/coq-native.1/opam
@@ -5,6 +5,8 @@ homepage: "https://coq.inria.fr/"
 bug-reports: "https://github.com/coq/coq/issues"
 conflicts: [
   "coq" {< "8.5"}
+  "base-nnp"
+  "ocaml-option-nnpchecker"
 ]
 synopsis: "Package flag enabling coq's native-compiler flag"
 description: """


### PR DESCRIPTION
cc: @ejgallego @erikmd 