### PR TITLE
5.1 trunk supports frame pointers again

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -70,13 +70,13 @@ post-messages: [
    to force a sequential build instead."
   {failure & jobs > 1 & os != "cygwin" & opam-version >= "2.0.5"}
 ]
-conflicts: [ "ocaml-option-fp" ]
 depopts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
   "ocaml-option-bytecode-only"
   "ocaml-option-no-flat-float-array"
   "ocaml-option-flambda"
+  "ocaml-option-fp"
   "ocaml-option-musl"
   "ocaml-option-leak-sanitizer"
   "ocaml-option-address-sanitizer"


### PR DESCRIPTION
See https://github.com/ocaml/ocaml/pull/11144

(the ocaml-option-fp package already has a `arch = "x86_64"` constraint, so I don't think any other architecture constraints are necessary).