### PR TITLE
Package opam-file-format.2.1.5

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.5/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: [
+  "ocaml"
+  "alcotest" {with-test}
+]
+depopts: ["dune"]
+conflicts: [
+  "dune" {< "1.3.0"}
+]
+build: [
+  [make "byte" {!ocaml:native} "all" {ocaml:native}] {!dune:installed}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+    {dune:installed}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:installed}
+]
+install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src:
+    "https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=46dadff2565d8371cdc606d33d408fc4"
+    "sha512=9bb9daa31877e1555b75c6d91566bceee175397f37bf8359ffce3cac16a72f48543d6ff5a03e8bf42aef6e1e499b3a2ce6054b00356a937214848b6b87c2315f"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.1.5`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.1.0