### PR TITLE
dose3.6.1 requires parmap >= 0.9.8 (uses Parmap.L)

### DIFF
--- a/packages/dose3/dose3.6.1/opam
+++ b/packages/dose3/dose3.6.1/opam
@@ -48,7 +48,7 @@ depends: [
   "cudf" {>= "0.7"}
   "ocamlgraph" {>= "2.0.0"}
   "re" {>= "1.2.2"}
-  "parmap"
+  "parmap" {>= "0.9.8"}
   "stdlib-shims"
   "ounit" {with-test}
   "conf-python-3" {with-test}

--- a/packages/dose3/dose3.6.1/opam
+++ b/packages/dose3/dose3.6.1/opam
@@ -47,7 +47,7 @@ depends: [
   "camlzip" {>= "1.08"}
   "cudf" {>= "0.7"}
   "ocamlgraph" {>= "2.0.0"}
-  "re" {>= "1.2.2"}
+  "re" {>= "1.7.2"}
   "parmap" {>= "0.9.8"}
   "stdlib-shims"
   "ounit" {with-test}

--- a/packages/dose3/dose3.6.1/opam
+++ b/packages/dose3/dose3.6.1/opam
@@ -48,7 +48,7 @@ depends: [
   "cudf" {>= "0.7"}
   "ocamlgraph" {>= "2.0.0"}
   "re" {>= "1.7.2"}
-  "parmap" {>= "0.9.8"}
+  "parmap" {>= "1.0-rc8"}
   "stdlib-shims"
   "ounit" {with-test}
   "conf-python-3" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling dose3.6.1 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/dose3.6.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dose3 -j 47 @install
# exit-code            1
# env-file             ~/.opam/log/dose3-7-3835a3.env
# output-file          ~/.opam/log/dose3-7-3835a3.out
### output ###
#        ocaml src/common/gitVersionInfo.ml
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
#    ocamlyacc src/pef/packages_parser.{ml,mli}
# 2 rules never reduced
# 13 reduce/reduce conflicts.
#    ocamlyacc src/npm/npm_parser.{ml,mli}
# 1 rule never reduced
# 4 reduce/reduce conflicts.
#       ocamlc src/applications/.challenged.eobjs/byte/dune__exe__Challenged.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlc.opt -w -40 -g -bin-annot -I src/applications/.challenged.eobjs/byte -I /home/opam/.opam/4.03/lib/base64 -I /home/opam/.opam/4.03/lib/bytes -I /home/opam/.opam/4.03/lib/bz2 -I /home/opam/.opam/4.03/lib/cudf -I /home/opam/.opam/4.03/lib/extlib -I /home/opam/.opam/4.03/lib/ocamlgraph -I /home/opam/.opam/4.03/lib/parmap -I /home/opam/.opam/4.03/lib/re -I /home/opam/.opam/4.03/lib/re/pcre -I /home/opam/.opam/4.03/lib/seq -I /home/opam/.opam/4.03/lib/stdlib-shims -I /home/opam/.opam/4.03/lib/zip -I src/algo/.dose_algo.objs/byte -I src/algo/.dose_algo.objs/native -I src/common/.dose_common.objs/byte -I src/common/.dose_common.objs/native -I src/deb/.dose_debian.objs/byte -I src/deb/.dose_debian.objs/native -I src/doseparse/.dose_doseparse.objs/byte -I src/doseparse/.dose_doseparse.objs/native -I src/npm/.dose_npm.objs/byte -I src/npm/.dose_npm.objs/native -I src/opam2/.dose_opam2.objs/byte -I src/opam2/.dose_opam2.objs/native -I src/opencsw/.dose_opencsw.objs/byte -I src/opencsw/.dose_opencsw.objs/native -I src/pef/.dose_pef.objs/byte -I src/pef/.dose_pef.objs/native -I src/versioning/.dose_versioning.objs/byte -I src/versioning/.dose_versioning.objs/native -no-alias-deps -o src/applications/.challenged.eobjs/byte/dune__exe__Challenged.cmo -c -impl src/applications/challenged.ml)
# File "src/applications/challenged.ml", line 276, characters 41-49:
# Error: Unbound constructor Parmap.L
```