### PR TITLE
headache 1.06: simplify install

### DIFF
--- a/packages/headache/headache.1.06/opam
+++ b/packages/headache/headache.1.06/opam
@@ -24,18 +24,19 @@ bug-reports: "https://github.com/Frama-C/headache/issues"
 dev-repo: "git+https://github.com/Frama-C/headache.git"
 
 depends: [
+  "ocaml"
   "camomile"
   "dune" {>= "1.6"}
+  "odoc" {with-doc}
 ]
 
 build: [
-  [ "dune" "build" "-p" "headache" ]
+  [ 
+    "dune" "build" "-p" headache "-j" jobs
+    "@doc" {with-doc}
+  ]
 ]
 
-install:  [
-  [make "INSTALLDIR=%{prefix}%/bin" "install"]
-  [make "DOC_INSTALLDIR=%{prefix}%/doc/headache" "install-doc"] {with-doc}
-]
 url {
   src: "https://github.com/Frama-C/headache/archive/v1.06.tar.gz"
   checksum: [

--- a/packages/headache/headache.1.06/opam
+++ b/packages/headache/headache.1.06/opam
@@ -32,7 +32,7 @@ depends: [
 
 build: [
   [ 
-    "dune" "build" "-p" headache "-j" jobs
+    "dune" "build" "-p" name "-j" jobs
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
since it is now using dune.

See discussion in https://github.com/ocaml/opam-repository/pull/22629

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>