### PR TITLE
camlbz2 is not compatible with ocaml 5

### DIFF
--- a/packages/camlbz2/camlbz2.0.6.0/opam
+++ b/packages/camlbz2/camlbz2.0.6.0/opam
@@ -13,7 +13,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "conf-libbz2"
 ]

--- a/packages/camlbz2/camlbz2.0.7.0/opam
+++ b/packages/camlbz2/camlbz2.0.7.0/opam
@@ -15,7 +15,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "conf-autoconf"
   "conf-aclocal"


### PR DESCRIPTION
Explicitly uses Pervasives:
```
File "bz2.ml", line 31, characters 52-73:
31 | external open_in : ?small:bool -> ?unused:string -> Pervasives.in_channel ->
```
Seen on https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/91f7250035002fc1fc13e67e52a9b61a8b9485c7/variant/compilers,5.0,dose3.6.1 (part of #22674)

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>