### PR TITLE
Parany for OCaml-5

### DIFF
--- a/packages/parany/parany.13.0.0/opam
+++ b/packages/parany/parany.13.0.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/UnixJunkie/parany"
 bug-reports: "https://github.com/UnixJunkie/parany/issues"
 dev-repo: "git+https://github.com/UnixJunkie/parany.git"
 depends: [
-  "domainslib"
+  "domainslib" {>= "0.5.0"}
   "dune" {>= "1.6.0"}
   "ocaml" {>= "5.0.0"}
 ]

--- a/packages/parany/parany.13.0.0/opam
+++ b/packages/parany/parany.13.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: "Francois Berenger"
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/UnixJunkie/parany"
+bug-reports: "https://github.com/UnixJunkie/parany/issues"
+dev-repo: "git+https://github.com/UnixJunkie/parany.git"
+depends: [
+  "domainslib"
+  "dune" {>= "1.6.0"}
+  "ocaml" {>= "5.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "src/test.exe"] {with-test}
+  ["./test.sh"] {with-test}
+]
+synopsis: "Parallelize any computation"
+description: """
+Generalized map reduce for parallel computers (not distributed computing).
+Can process in parallel an infinite stream of elements.
+
+Can process a very large file in parallel on a multicore computer;
+provided there is a way to cut your file into independent blocks
+(the 'demux' function).
+The processing function is called 'work'.
+The function gathering the results is called 'mux'.
+The number of processors running your computation in parallel is called
+'nprocs'.
+The chunk size (number of items) processed by one call to the 'work' function
+is called 'csize'.
+
+There is a minimalist Parmap module, if you want to switch
+to/from Parmap easily.
+
+Read the corresponding ocamldoc before using.
+"""
+url {
+  src: "https://github.com/UnixJunkie/parany/archive/v13.0.0.tar.gz"
+  checksum: "md5=721637080520affb02ea2be3c3d0158e"
+}


### PR DESCRIPTION
Slight changes in the interface so major version.

Adapting to this new version should be straightforward. Expect even faster parallel OCaml programs.
Exchanging values between parallel workers is now way faster than what any previous parany version was doing (relying on Marshal).

new file:   packages/parany/parany.13.0.0/opam