### PR TITLE
[new release] mirage-kv (6.0.1)

### DIFF
--- a/packages/mirage-kv/mirage-kv.6.0.0/opam
+++ b/packages/mirage-kv/mirage-kv.6.0.0/opam
@@ -36,3 +36,4 @@ url {
   ]
 }
 x-commit-hash: "297015e2b22524f648ffdc87443fcd0f3ab59b23"
+available: false

--- a/packages/mirage-kv/mirage-kv.6.0.1/opam
+++ b/packages/mirage-kv/mirage-kv.6.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "optint" {>= "0.2.0"}
+  "ptime" {>= "1.0.0"}
+  "alcotest" {with-test}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v6.0.1/mirage-kv-6.0.1.tbz"
+  checksum: [
+    "sha256=86e5f5ae8ddca2b206c0612b6ebf9ef489e6ed9cb46c8a69781b26ea59107ae1"
+    "sha512=a78e61be3e2d1f8a481e54b0f23883243f6f6851fe91de94a21faf29acc8c927188a65a443d850571833322b2e6c217e5ea67caa2277ef4b46f6b9428301c5c3"
+  ]
+}
+x-commit-hash: "b01b94a35ba9ec5346eaac30c4c469bab35535dd"


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Specify in RO.list that the returned list consists of keys being absolute, and
  kinds (mirage/mirage-kv#38 mirage/mirage-kv#39 @reynir @hannesm)
* BREAKING: Before 6.0.0, the return type of RO.list consisted of a string and
  kind list, where the string was relative. Now it is absolute.
