### PR TITLE
optint.0.0.2 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/optint/optint.0.0.2/opam
+++ b/packages/optint/optint.0.0.2/opam
@@ -24,7 +24,7 @@ homepage: "https://github.com/dinosaure/optint"
 doc: "https://dinosaure.github.io/optint/"
 bug-reports: "https://github.com/dinosaure/optint/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"
 ]
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling optint.0.0.2 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/optint.0.0.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p optint -j 47
# exit-code            1
# env-file             ~/.opam/log/optint-8-70f2d2.env
# output-file          ~/.opam/log/optint-8-70f2d2.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.optint.objs/byte -no-alias-deps -open Optint__ -o src/.optint.objs/byte/optint__Int_x64_backend.cmo -c -impl src/int_x64_backend.ml)
# File "src/int_x64_backend.ml", line 14, characters 12-26:
# 14 | let abs x = Pervasives.abs x
#                  ^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```