### PR TITLE
Package otoml.1.0.4

### DIFF
--- a/packages/otoml/otoml.1.0.4/opam
+++ b/packages/otoml/otoml.1.0.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)"
+description: """\
+OTOML is a library for parsing, manipulating, and pretty-printing TOML files.
+
+* Fully 1.0.0-compliant.
+* No extra dependencies: default implementation uses native numbers and represents dates as strings.
+* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
+* Informative parse error reporting.
+* Pretty-printer offers flexible indentation options."""
+maintainer: "daniil+opam@baturin.org"
+authors: "Daniil Baturin <daniil+otoml@baturin.org>"
+license: "MIT"
+homepage: "https://github.com/dmbaturin/otoml"
+bug-reports: "https://github.com/dmbaturin/otoml/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "menhir"
+  "menhirLib" {>= "20200525"}
+  "dune" {>= "2.0.0"}
+  "uutf" {>= "1.0.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git+https://github.com/dmbaturin/otoml.git"
+url {
+  src: "https://github.com/dmbaturin/otoml/archive/refs/tags/1.0.4.tar.gz"
+  checksum: [
+    "md5=1c502a7db858e7aea5847836eacf6f66"
+    "sha512=7e837fae680b3453422fca23ecd2f72f4993c49b6864fce75df737b41127e569381f3c30e800dc7258ab972050551523b7b3f299d7e6b15cc505d69fcd79e137"
+  ]
+}


### PR DESCRIPTION
### `otoml.1.0.4`
TOML parsing, manipulation, and pretty-printing library (1.0.0-compliant)
OTOML is a library for parsing, manipulating, and pretty-printing TOML files.

* Fully 1.0.0-compliant.
* No extra dependencies: default implementation uses native numbers and represents dates as strings.
* Provides a functor for building alternative implementations: plug your own bignum and calendar libraries if required.
* Informative parse error reporting.
* Pretty-printer offers flexible indentation options.



---
* Homepage: https://github.com/dmbaturin/otoml
* Source repo: git+https://github.com/dmbaturin/otoml.git
* Bug tracker: https://github.com/dmbaturin/otoml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0