### PR TITLE
num is does not handle not having ocamlopt

### DIFF
--- a/packages/num/num.1.0/opam
+++ b/packages/num/num.1.0/opam
@@ -31,7 +31,10 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocamlfind" {build & >= "1.7.3"}
 ]
-conflicts: [ "base-num" ]
+conflicts: [
+  "base-num"
+  "ocaml-option-bytecode-only"
+]
 patches: [ "findlib-install.patch" "installation-warning.patch" ]
 synopsis:
   "The legacy Num library for arbitrary-precision integer and rational arithmetic"

--- a/packages/num/num.1.1/opam
+++ b/packages/num/num.1.1/opam
@@ -31,7 +31,10 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocamlfind" {build & >= "1.7.3"}
 ]
-conflicts: [ "base-num" ]
+conflicts: [
+  "base-num"
+  "ocaml-option-bytecode-only"
+]
 patches: [ "findlib-install.patch" "installation-warning.patch" ]
 synopsis:
   "The legacy Num library for arbitrary-precision integer and rational arithmetic"

--- a/packages/num/num.1.2/opam
+++ b/packages/num/num.1.2/opam
@@ -26,7 +26,10 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocamlfind" {build & >= "1.7.3"}
 ]
-conflicts: [ "base-num" ]
+conflicts: [
+  "base-num"
+  "ocaml-option-bytecode-only"
+]
 patches: [ "installation-warning.patch" ]
 synopsis:
   "The legacy Num library for arbitrary-precision integer and rational arithmetic"

--- a/packages/num/num.1.3/opam
+++ b/packages/num/num.1.3/opam
@@ -25,7 +25,10 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocamlfind" {build & >= "1.7.3"}
 ]
-conflicts: [ "base-num" ]
+conflicts: [
+  "base-num"
+  "ocaml-option-bytecode-only"
+]
 patches: [ "installation-warning.patch" ]
 synopsis:
   "The legacy Num library for arbitrary-precision integer and rational arithmetic"

--- a/packages/num/num.1.4/opam
+++ b/packages/num/num.1.4/opam
@@ -10,7 +10,10 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "ocamlfind" {build & >= "1.7.3"}
 ]
-conflicts: ["base-num"]
+conflicts: [
+  "base-num"
+  "ocaml-option-bytecode-only"
+]
 build: make
 install: [
   ["ocamlfind" "remove" "num"]


### PR DESCRIPTION
```
#=== ERROR while compiling num.1.4 ============================================#
# context              2.2.0~alpha~dev | linux/arm32 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/num.1.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/num-7-813787.env
# output-file          ~/.opam/log/num-7-813787.out
### output ###
# make -C src all
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/num.1.4/src'
# ocamlc -ccopt -DBNG_ARCH_generic -c bng.c
# ocamlc -ccopt -DBNG_ARCH_generic -c nat_stubs.c
# ocamlmklib -oc nums bng.o nat_stubs.o
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c int_misc.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c int_misc.ml
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c nat.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c nat.ml
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c big_int.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c big_int.ml
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c arith_flags.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c arith_flags.ml
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c ratio.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c ratio.ml
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c num.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c num.ml
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c arith_status.mli
# ocamlc -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c arith_status.ml
# ocamlmklib -o nums -oc nums -linkall int_misc.cmo nat.cmo big_int.cmo arith_flags.cmo ratio.cmo num.cmo arith_status.cmo
# ocamlopt -w +a-4-9-41-42-44-45-48 -warn-error A -bin-annot -g -safe-string -strict-sequence -strict-formats -c int_misc.ml
# make[1]: ocamlopt: No such file or directory
# make[1]: *** [Makefile:66: int_misc.cmx] Error 127
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/num.1.4/src'
# make: *** [Makefile:2: all] Error 2
```