### PR TITLE
[new release] optint (0.3.0)

### DIFF
--- a/packages/optint/optint.0.3.0/opam
+++ b/packages/optint/optint.0.3.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   [ "romain.calascibetta@gmail.com" ]
+authors:      "Romain Calascibetta"
+license:      "ISC"
+homepage:     "https://github.com/mirage/optint"
+bug-reports:  "https://github.com/mirage/optint/issues"
+dev-repo:     "git+https://github.com/mirage/optint.git"
+doc:          "https://mirage.github.io/optint/"
+synopsis:     "Efficient integer types on 64-bit architectures"
+description: """
+This library provides two new integer types, `Optint.t` and `Int63.t`, which
+guarantee efficient representation on 64-bit architectures and provide a
+best-effort boxed representation on 32-bit architectures.
+
+Implementation depends on target architecture.
+"""
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune"
+  "crowbar" {with-test & >= "0.2"}
+  "monolith" {with-test}
+  "fmt" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/optint/releases/download/v0.3.0/optint-0.3.0.tbz"
+  checksum: [
+    "sha256=295cff2c134b0385b13ba81d5005d9f841ba40d4a502aed10c997f239ef1147b"
+    "sha512=15ec97a076584e8ea28c589f1db3b9a0dd6fd5a7950528a1d136761cc13bca0e6e7bf6e0f87c73578a37393c213a7a0f3e7beaabd924e176459b29af52b8dd11"
+  ]
+}
+x-commit-hash: "66d321700e7c8c6cbcd3cd7c391e35d4943eac4b"


### PR DESCRIPTION
Efficient integer types on 64-bit architectures

- Project page: <a href="https://github.com/mirage/optint">https://github.com/mirage/optint</a>
- Documentation: <a href="https://mirage.github.io/optint/">https://mirage.github.io/optint/</a>

##### CHANGES:

- Add infix operators for bitwise operations (@reynir, mirage/optint#23)
- Add a deprecation about old infix operators
  They will be removed at the next minor release
