### PR TITLE
[new release] git-kv (0.0.3)

### DIFF
--- a/packages/git-kv/git-kv.0.0.3/opam
+++ b/packages/git-kv/git-kv.0.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/roburio/git-kv"
+dev-repo: "git+https://github.com/roburio/git-kv.git"
+bug-reports: "https://github.com/roburio/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.9.0"}
+  "git"               {>= "3.10.0"}
+  "mirage-kv"         {>= "6.0.0"}
+  "carton"            {>= "0.6.0"}
+  "fmt"               {>= "0.8.7"}
+  "mirage-clock"      {>= "2.0.0"}
+  "ptime"
+  "hxd"               {with-test}
+  "conf-git"          {with-test}
+  "mirage-clock-unix" {with-test}
+  "git-unix"          {>= "3.10.0" & with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/roburio/git-kv/releases/download/v0.0.3/git-kv-0.0.3.tbz"
+  checksum: [
+    "sha256=f94fdbacefab6cd0f53fae7ce3bcfe792b85954324a3da22a5e1c996a25bee36"
+    "sha512=454ab1f126aa6da864e41b94aae9cf0ef25d146286d1870a014d1ea7dda7b18ed4574df48ffc9f8df442b70d3361a2bafbcfeebb1e90284cbb8d9af8cba08203"
+  ]
+}
+x-commit-hash: "73bdcba54b6ec5bef97186fae193d47135543ac3"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/roburio/git-kv">https://github.com/roburio/git-kv</a>

##### CHANGES:

- Allow author, author_email, and message being specified in `change_and_push`
  (roburio/git-kv#28 @hannes)
