### PR TITLE
Package algaeff.0.2.1

### DIFF
--- a/packages/algaeff/algaeff.0.2.1/opam
+++ b/packages/algaeff/algaeff.0.2.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Reusable Effects-Based Components"
+description: """
+This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.
+"""
+maintainer: "favonia <favonia@gmail.com>"
+authors: "The RedPRL Development Team"
+license: "Apache-2.0"
+homepage: "https://github.com/RedPRL/algaeff"
+bug-reports: "https://github.com/RedPRL/algaeff/issues"
+dev-repo: "git+https://github.com/RedPRL/algaeff.git"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "5.0"}
+  "alcotest" {>= "1.5" & with-test}
+  "qcheck-core" {>= "0.18" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@runtest"] {with-test}
+  ["dune" "build" "-p" name "-j" jobs "@doc"] {with-doc}
+]
+url {
+  src: "https://github.com/RedPRL/algaeff/archive/refs/tags/0.2.1.tar.gz"
+  checksum: [
+    "md5=585035e148aa566c00f38000768e06c8"
+    "sha512=a79ae50ea35574330dafdc06dd261789b0606f913031206f1b38535b85da331b98a6f8d4c598a97af91f66f07c58e52952b40adebcb0328c47d8506acc5af913"
+  ]
+}


### PR DESCRIPTION
### `algaeff.0.2.1`
Reusable Effects-Based Components
This OCaml library collects reusable effects-based components we have identified while developing our proof assistants based on algebraic effects.



---
* Homepage: https://github.com/RedPRL/algaeff
* Source repo: git+https://github.com/RedPRL/algaeff.git
* Bug tracker: https://github.com/RedPRL/algaeff/issues

---
:camel: Pull-request generated by opam-publish v2.2.0