### PR TITLE
[new release] caldav (0.2.1)

### DIFF
--- a/packages/caldav/caldav.0.2.1/opam
+++ b/packages/caldav/caldav.0.2.1/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+maintainer: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+authors: [
+  "Stefanie Schirmer @linse"
+  "Hannes Mehnert"
+]
+homepage: "https://github.com/roburio/caldav"
+bug-reports: "https://github.com/roburio/caldav/issues"
+dev-repo: "git+https://github.com/roburio/caldav.git"
+tags: ["org:mirage" "org:robur"]
+doc: "https://roburio.github.io/caldav/"
+license: "ISC"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.3"}
+  "alcotest" {with-test & >= "0.8.5"}
+  "ounit" {with-test & >= "2.0.0"}
+  "mirage-random-test" {with-test}
+  "tcpip" {with-test & >= "3.7.0"}
+  "mirage-clock-unix" {with-test & >= "2.0.0"}
+  "mirage-kv-mem" {with-test & >= "2.0.0"}
+  "fmt" {>= "0.8.7"}
+  "mirage-kv" {>= "6.0.0"}
+  "mirage-clock" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "ppx_deriving" {>= "4.3"}
+  "lwt" {>= "4.0"}
+  "ptime" {>= "0.8.5"}
+  "cohttp" {>= "2.0.0"}
+  "cohttp-lwt" {>= "2.0.0"}
+  "cohttp-lwt-unix" {with-test & >= "2.0.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+  "base64" {>= "3.0.0"}
+  "xmlm" {>= "1.3.0"}
+  "tyxml" {>= "4.3.0"}
+  "icalendar" {>= "0.1.2"}
+  "sexplib" {>= "v0.12.0"}
+  "ppx_sexp_conv" {>= "v0.12.0"}
+  "logs" {>= "0.6.3"}
+  "hex" {>= "1.4.0"}
+  "metrics"
+  "re" {>= "1.7.2"}
+  #from webmachine
+  "dispatch" {>= "0.5.0"}
+  "uri" {>= "4.0.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "A CalDAV server"
+description: """
+A CalDAV server (RFC 4791). Supports everything from the roburio/icalendar
+library. Also includes a partial WebDAV implementation.
+"""
+url {
+  src:
+    "https://github.com/roburio/caldav/releases/download/v0.2.1/caldav-0.2.1.tbz"
+  checksum: [
+    "sha256=5cc85adbf892ea676e67a2451d12cabd930fba45f534bced7e7b00e2d282ddba"
+    "sha512=d92055d772b6f5cfeba7c4ed4496fdafac90bb67335fc14aee4413404156196a843eb0643e5dc2302ea1c51f4036ea74db1757127d059de304c96c4ed2127d84"
+  ]
+}
+x-commit-hash: "e5a1725ae4c9dcbc5abe91ff05e75f8aada3c709"

--- a/packages/caldav/caldav.0.2.1/opam
+++ b/packages/caldav/caldav.0.2.1/opam
@@ -17,7 +17,7 @@ license: "ISC"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"} # Local network access is forbidden in the macos sandbox
 ]
 
 depends: [


### PR DESCRIPTION
A CalDAV server

- Project page: <a href="https://github.com/roburio/caldav">https://github.com/roburio/caldav</a>
- Documentation: <a href="https://roburio.github.io/caldav/">https://roburio.github.io/caldav/</a>

##### CHANGES:

* Use Mirage-kv 6.0.0 API (roburio/caldav#32 @hannesm)
* Log more write errors (roburio/caldav#32 @hannesm)
* Refine Webdav_fs.batch to return a ('a, [> `Msg of string ]) result io, so
  it can fail (roburio/caldav#32 @hannesm)
* unikernel: use git-kv instead of irmin-mirage-git (roburio/caldav#32 @hannesm)
