### PR TITLE
OCaml 5 manual package

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.0.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.0.0/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "http://caml.inria.fr/pub/docs/manual-ocaml/"
+license: "CC-BY-SA-4.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install:
+[
+ [ "cp" "-R" "." _:doc ] {os != "win32"}
+ [ "robocopy" "/E" "." _:doc ] {os = "win32"}
+]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {>= "5.0.0" & < "5.1.0"}
+]
+url {
+  src: "http://caml.inria.fr/distrib/ocaml-5.0/ocaml-5.0-refman-html.tar.gz"
+  checksum: "sha256=ea5cedafd31ee7ce06c6a19c5edc6ff0ab36bec0d60bd374be201e8ae94434a1"
+}


### PR DESCRIPTION
This PR adds the OCaml manual package for 5.0.0 now that I found the time to generate the manual and opam file.