### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.15.0~5.0preview1)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.15.0~5.0preview1/opam
+++ b/packages/jsonrpc/jsonrpc.1.15.0~5.0preview1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.0%2B5.0preview1/lsp-1.15.0.5.0preview1.tbz"
+  checksum: [
+    "sha256=e988a9de9a3e809ac1005c1eafd8f5825842edb8e92d05199110b682968c102c"
+    "sha512=a581a81b19b2d33e4ccf45d042b889164965bdefdbba06a5af8959052a0b515ede09fc8d75c25d8795777c61c39a299930fe3dbc3d69a561b6065f6629baa0a6"
+  ]
+}
+x-commit-hash: "a2779a1e8fa244a2d2002fc872f8672f6e7ca067"

--- a/packages/lsp/lsp.1.15.0~5.0preview1/opam
+++ b/packages/lsp/lsp.1.15.0~5.0preview1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "menhir" {>= "20211230" & with-test}
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.0%2B5.0preview1/lsp-1.15.0.5.0preview1.tbz"
+  checksum: [
+    "sha256=e988a9de9a3e809ac1005c1eafd8f5825842edb8e92d05199110b682968c102c"
+    "sha512=a581a81b19b2d33e4ccf45d042b889164965bdefdbba06a5af8959052a0b515ede09fc8d75c25d8795777c61c39a299930fe3dbc3d69a561b6065f6629baa0a6"
+  ]
+}
+x-commit-hash: "a2779a1e8fa244a2d2002fc872f8672f6e7ca067"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.13.2~5.0preview/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.13.2~5.0preview/opam
@@ -41,6 +41,7 @@ depends: [
   "odoc" {with-doc}
   "ocaml" {>= "5.0" & < "5.1"}
 ]
+available: false
 dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.15.0~5.0preview1/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.15.0~5.0preview1/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "ocamlc-loc" {>= "3.5.0" & < "3.7.0"}
+  "omd" {>= "1.3.2" & < "2.0.0~alpha1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "5.0" & < "5.1"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.0%2B5.0preview1/lsp-1.15.0.5.0preview1.tbz"
+  checksum: [
+    "sha256=e988a9de9a3e809ac1005c1eafd8f5825842edb8e92d05199110b682968c102c"
+    "sha512=a581a81b19b2d33e4ccf45d042b889164965bdefdbba06a5af8959052a0b515ede09fc8d75c25d8795777c61c39a299930fe3dbc3d69a561b6065f6629baa0a6"
+  ]
+}
+x-commit-hash: "a2779a1e8fa244a2d2002fc872f8672f6e7ca067"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add support for OCaml 5.0

- Semantic highlighting support is enabled by default (ocaml/ocaml-lsp#933)

- Re-enable `ocamlformat-rpc` for formatting code snippets (but not files) (ocaml/ocaml-lsp#920, ocaml/ocaml-lsp#939)

  One needs to have either `ocamlformat` version > 0.21.0 or, otherwise,
  `ocamlformat-rpc` package installed.

- Add custom ocamllsp/hoverExtended request (ocaml/ocaml-lsp#561)

- Support utf-8 position encoding clients (ocaml/ocaml-lsp#919)

- Upgrade to merlin 4.7 and use merlin's `verbosity=smart` by default, which
  allows unwrapping module alias types (ocaml/ocaml-lsp#942)

## Fixes

- Fix document syncing for ranges that span an entire line (ocaml/ocaml-lsp#927)

- Respect the client's completion item resolve and preSelect capabilities
  (ocaml/ocaml-lsp#925, ocaml/ocaml-lsp#936)

- Disable polling for dune's watch mode on Windows and OCaml 4.14.0 (ocaml/ocaml-lsp#935)

- Fix semantic highlighting of "long identifiers," e.g., `Foo.Bar.x` (ocaml/ocaml-lsp#932)
