### PR TITLE
Correct the OCaml 5 bytecode no-flat-float-array packages

### DIFF
--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1+bytecode-only/opam
@@ -3,7 +3,7 @@ synopsis: "Ensure that OCaml is compiled with no-flat-float-array, and no other 
 depends: [
   "ocaml-option-no-flat-float-array"
   "ocaml-option-bytecode-only"
-  "ocaml-variants" {post & (>= "5.00.0~~" & arch != "x86_64" & arch != "arm64")}
+  "ocaml-variants" {post & >= "5.0.0~~"}
 ]
 conflicts: [
   "ocaml-option-32bit"
@@ -19,3 +19,4 @@ conflicts: [
 ]
 maintainer: "platform@lists.ocaml.org"
 flags: compiler
+available: arch != "x86_64" & arch != "arm64"

--- a/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
+++ b/packages/ocaml-options-only-no-flat-float-array/ocaml-options-only-no-flat-float-array.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Ensure that OCaml is compiled with no-flat-float-array, and no other custom options"
 depends: [
   "ocaml-option-no-flat-float-array"
-  "ocaml-variants" {post & (< "5.00.0~~" | arch = "x86_64" | arch = "arm64")}
+  "ocaml-variants" {post & < "5.0.0~~" & arch != "x86_64" & arch != "arm64"}
 ]
 conflicts: [
   "ocaml-option-32bit"


### PR DESCRIPTION
Corrects the previous PR, which didn't encode the version/architecture constraints correctly