### PR TITLE
Mark all versions of llvm as not compatible with OCaml 5.0

### DIFF
--- a/packages/llvm/llvm.3.4/opam
+++ b/packages/llvm/llvm.3.4/opam
@@ -22,6 +22,10 @@ depends: [
   "ocaml"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 install: ["sh" "./compile.sh" "install" "3.4" make prefix lib]
 synopsis: "The official LLVM binding"
 description: "Note: LLVM should be installed first."

--- a/packages/llvm/llvm.3.5/opam
+++ b/packages/llvm/llvm.3.5/opam
@@ -22,6 +22,10 @@ depends: [
   "ocaml"
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 install: ["sh" "./compile.sh" "install" "3.5" make prefix lib]
 synopsis: "The official LLVM binding"
 description: "Note: LLVM should be installed first."

--- a/packages/llvm/llvm.3.6/opam
+++ b/packages/llvm/llvm.3.6/opam
@@ -16,6 +16,10 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 depexts: [
   ["llvm-3.6-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm36"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/llvm/llvm.3.7/opam
+++ b/packages/llvm/llvm.3.7/opam
@@ -17,6 +17,10 @@ depends: [
   "ounit" {with-test}
   "ocamlbuild" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 depexts: [
   ["llvm-3.7-dev"] {os-family = "debian"}
   ["homebrew/versions/llvm37"] {os = "macos" & os-distribution = "homebrew"}

--- a/packages/llvm/llvm.3.8/opam
+++ b/packages/llvm/llvm.3.8/opam
@@ -19,6 +19,10 @@ depends: [
   "conf-llvm" {build & = "3.8"}
   "conf-python-2-7" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 flags: light-uninstall

--- a/packages/llvm/llvm.3.9/opam
+++ b/packages/llvm/llvm.3.9/opam
@@ -33,6 +33,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [

--- a/packages/llvm/llvm.4.0.0/opam
+++ b/packages/llvm/llvm.4.0.0/opam
@@ -25,6 +25,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 synopsis: "The OCaml bindings distributed with LLVM"
 description: "Note: LLVM should be installed first."
 extra-files: [

--- a/packages/llvm/llvm.5.0.0/opam
+++ b/packages/llvm/llvm.5.0.0/opam
@@ -26,6 +26,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 patches: [
   "fix-shared.patch"
 ]

--- a/packages/llvm/llvm.6.0.0/opam
+++ b/packages/llvm/llvm.6.0.0/opam
@@ -26,6 +26,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 patches: [
   "fix-shared.patch"
 ]

--- a/packages/llvm/llvm.7.0.0/opam
+++ b/packages/llvm/llvm.7.0.0/opam
@@ -26,6 +26,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 patches: [
   "fix-shared.patch"
 ]

--- a/packages/llvm/llvm.8.0.0/opam
+++ b/packages/llvm/llvm.8.0.0/opam
@@ -21,6 +21,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 patches: [
   "fix-shared.patch"
 ]

--- a/packages/llvm/llvm.9.0.0/opam
+++ b/packages/llvm/llvm.9.0.0/opam
@@ -21,6 +21,10 @@ depends: [
   "conf-python-2-7" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nnpchecker"
+]
 patches: [
   "fix-shared.patch"
 ]


### PR DESCRIPTION
For some reason only llvm >= 10 was marked as such.

cc @alan-j-hu do you have any updates on your LLVM for OCaml 5.0 work by any chance?