### PR TITLE
Package libiwasm.1.1.2

### DIFF
--- a/packages/libiwasm/libiwasm.1.1.2/opam
+++ b/packages/libiwasm/libiwasm.1.1.2/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "The iwasm core from wasm-micro-runtime packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libiwasm"
+bug-reports: "https://github.com/grain-lang/libiwasm/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.1.0"}
+  "dune-configurator" {>= "3.1.0"}
+  "ocaml" {>= "4.12"}
+  "ctypes" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest"] {with-test}
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libiwasm.git"
+url {
+  src:
+    "https://github.com/grain-lang/libiwasm/releases/download/v1.1.2/libiwasm-v1.1.2.tar.gz"
+  checksum: [
+    "md5=08a297fb7b192a33444c738898a1eed8"
+    "sha512=9a2969effa0039d57edde55d7599fcd7693daa9eac9375760284d764324bd164556eea03279244f241808479773aec1945c9f2148d17914e12d781470290d712"
+  ]
+}


### PR DESCRIPTION
### `libiwasm.1.1.2`
The iwasm core from wasm-micro-runtime packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libiwasm
* Source repo: git+https://github.com/grain-lang/libiwasm.git
* Bug tracker: https://github.com/grain-lang/libiwasm/issues

---
## 1.1.2 (2022-12-16)


### Features

* Package iwasm core for OCaml & Dune ([4602529](https://github.com/phated/libwamr/commit/460252956076a08ab4909c3fc3d3a14dc30a8811))

---
:camel: Pull-request generated by opam-publish v2.0.3