### PR TITLE
0install < 2.15.1 isn't compatible with yojson 2.0

### DIFF
--- a/packages/0install/0install.2.10/opam
+++ b/packages/0install/0install.2.10/opam
@@ -14,7 +14,7 @@ depends: [
   "ounit"
   "react"
   "lwt" {< "3.0.0"}
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ocurl"
   "sha" {>= "1.9"}
   "camlp4"

--- a/packages/0install/0install.2.10/opam
+++ b/packages/0install/0install.2.10/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit"
   "react"

--- a/packages/0install/0install.2.11/opam
+++ b/packages/0install/0install.2.11/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit"
   "react"

--- a/packages/0install/0install.2.11/opam
+++ b/packages/0install/0install.2.11/opam
@@ -14,7 +14,7 @@ depends: [
   "ounit"
   "react"
   "lwt" {< "3.0.0"}
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ocurl"
   "sha" {>= "1.9"}
   "camlp4" {build}

--- a/packages/0install/0install.2.12.1/opam
+++ b/packages/0install/0install.2.12.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ounit" {with-test}
   "lwt" {< "3.0.0"}
   "lwt_react"
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}
   "ocamlbuild" {build}

--- a/packages/0install/0install.2.12.1/opam
+++ b/packages/0install/0install.2.12.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit" {with-test}
   "lwt" {< "3.0.0"}

--- a/packages/0install/0install.2.12.3/opam
+++ b/packages/0install/0install.2.12.3/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.07"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit" {with-test}
   "lwt_react"

--- a/packages/0install/0install.2.12/opam
+++ b/packages/0install/0install.2.12/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit"
   "react"

--- a/packages/0install/0install.2.12/opam
+++ b/packages/0install/0install.2.12/opam
@@ -14,7 +14,7 @@ depends: [
   "ounit"
   "react"
   "lwt" {< "3.0.0"}
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ocurl"
   "sha" {>= "1.9"}
   "camlp4" {build}

--- a/packages/0install/0install.2.14.1/opam
+++ b/packages/0install/0install.2.14.1/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit" {with-test}
   "lwt" {< "5.0.0"}

--- a/packages/0install/0install.2.14.1/opam
+++ b/packages/0install/0install.2.14.1/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}
-  "dune" {< "2.0"}
+  "dune" {>= "1.4" & < "2.0"}
   "cppo" {build}
 ]
 depopts: ["obus" "lablgtk" "lwt_glib"]

--- a/packages/0install/0install.2.14/opam
+++ b/packages/0install/0install.2.14/opam
@@ -10,7 +10,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.03.0" & < "4.08.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit" {with-test}
   "lwt" {< "5.0.0"}

--- a/packages/0install/0install.2.14/opam
+++ b/packages/0install/0install.2.14/opam
@@ -17,7 +17,7 @@ depends: [
   "lwt_react"
   "ocurl" {>= "0.7.9"}
   "sha" {>= "1.9"}
-  "dune" {< "2.0"}
+  "dune" {>= "1.4" & < "2.0"}
   "cppo" {build}
 ]
 depopts: ["obus" "lablgtk" "lwt_glib"]

--- a/packages/0install/0install.2.6.2/opam
+++ b/packages/0install/0install.2.6.2/opam
@@ -7,7 +7,7 @@ build: [
 patches: [ "gui_gtk_dir.patch" ]
 depends: [
   "ocaml"
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit"
   "react"

--- a/packages/0install/0install.2.6.2/opam
+++ b/packages/0install/0install.2.6.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ounit"
   "react"
   "lwt" {< "3.0.0"}
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ssl"
   "ocurl"
   "ocamlbuild" {build & <= "0.9.3"}

--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -7,7 +7,7 @@ build: [
 patches: [ "gui_gtk_dir.patch" ]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.02"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit"
   "react"

--- a/packages/0install/0install.2.8/opam
+++ b/packages/0install/0install.2.8/opam
@@ -12,7 +12,7 @@ depends: [
   "ounit"
   "react"
   "lwt" {<= "2.4.6"}
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ocurl"
   "sha" {>= "1.9"}
   "ocamlbuild" {build & <= "0.9.3"}

--- a/packages/0install/0install.2.9.1/opam
+++ b/packages/0install/0install.2.9.1/opam
@@ -9,7 +9,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.00.0" & < "4.06.0"}
-  "yojson"
+  "yojson" {< "2.0.0"}
   "xmlm"
   "ounit"
   "react"

--- a/packages/0install/0install.2.9.1/opam
+++ b/packages/0install/0install.2.9.1/opam
@@ -14,7 +14,7 @@ depends: [
   "ounit"
   "react"
   "lwt" {< "3.0.0"}
-  "extlib"
+  "extlib" {< "1.7.8"}
   "ocurl"
   "sha" {>= "1.9"}
   "ocamlbuild" {build & <= "0.9.3"}


### PR DESCRIPTION
```
#=== ERROR while compiling 0install.2.14.1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.11.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.11/.opam-switch/build/0install.2.14.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/0install-8-fbba3c.env
# output-file          ~/.opam/log/0install-8-fbba3c.out
### output ###
# dune build --root=. --profile=release @install
#        ocaml (internal)
# ocamlfind: Package `lablgtk2' not found
# (will skip building the GTK plugin)
# File "ocaml/support/json.ml", line 3, characters 9-26:
# 3 | type t = Yojson.Basic.json
#              ^^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Basic.json
# make: *** [Makefile:44: all] Error 1
```