### PR TITLE
ANSITerminal.0.7 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.7/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.7/opam
@@ -20,7 +20,7 @@ remove: [
   ["ocamlfind" "remove" "ANSITerminal"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "base-unix"
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling ANSITerminal.0.7 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ANSITerminal.0.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/ANSITerminal-8-6113c1.env
# output-file          ~/.opam/log/ANSITerminal-8-6113c1.out
### output ###
# File "./setup.ml", line 1402, characters 23-41:
# 1402 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```