### PR TITLE
BetterErrors is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/BetterErrors/BetterErrors.0.0.1/opam
+++ b/packages/BetterErrors/BetterErrors.0.0.1/opam
@@ -14,7 +14,7 @@ build: [
   "native-dynlink=%{ocaml:native-dynlink}%"
 ]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ANSITerminal" {>= "0.6.5"}


### PR DESCRIPTION
cc @chenglou 
```
#=== ERROR while compiling BetterErrors.0.0.1 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/BetterErrors.0.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/build.ml native=true native-dynlink=true
# exit-code            10
# env-file             ~/.opam/log/BetterErrors-8-94c6ee.env
# output-file          ~/.opam/log/BetterErrors-8-94c6ee.out
### output ###
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/betterErrorsShell.ml > src/betterErrorsShell.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/betterErrorsMain.ml > src/betterErrorsMain.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/betterErrorsParseError.ml > src/betterErrorsParseError.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/betterErrorsTypes.ml > src/betterErrorsTypes.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/Atom.ml > src/Atom.ml.depends
# ocamlfind ocamlc -c -package 're.pcre ANSITerminal' -w @5@8@10@11@12@14@23-24@26@29@40 -I src -o src/Atom.cmo src/Atom.ml
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/helpers.ml > src/helpers.ml.depends
# ocamlfind ocamlc -c -package 're.pcre ANSITerminal' -w @5@8@10@11@12@14@23-24@26@29@40 -I src -o src/betterErrorsTypes.cmo src/betterErrorsTypes.ml
# ocamlfind ocamlc -c -package 're.pcre ANSITerminal' -w @5@8@10@11@12@14@23-24@26@29@40 -I src -o src/helpers.cmo src/helpers.ml
# + ocamlfind ocamlc -c -package 're.pcre ANSITerminal' -w @5@8@10@11@12@14@23-24@26@29@40 -I src -o src/helpers.cmo src/helpers.ml
# File "src/helpers.ml", line 122, characters 12-26:
# 122 |   let rex = Re_pcre.regexp pat in
#                   ^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 123, characters 2-23:
# 123 |   Re_pcre.get_substring (Re_pcre.exec ~rex str) n
#         ^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 123, characters 25-37:
# 123 |   Re_pcre.get_substring (Re_pcre.exec ~rex str) n
#                                ^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 128, characters 12-26:
# 128 |   let rex = Re_pcre.regexp pat in
#                   ^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 129, characters 12-33:
# 129 |   try Some (Re_pcre.get_substring (Re_pcre.exec ~rex str) 1)
#                   ^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 129, characters 35-47:
# 129 |   try Some (Re_pcre.get_substring (Re_pcre.exec ~rex str) 1)
#                                          ^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 133, characters 12-26:
# 133 |   let rex = Re_pcre.regexp pat in
#                   ^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 134, characters 12-33:
# 134 |   try Some (Re_pcre.get_substring (Re_pcre.exec ~rex str) n)
#                   ^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 134, characters 35-47:
# 134 |   try Some (Re_pcre.get_substring (Re_pcre.exec ~rex str) n)
#                                          ^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 138, characters 12-26:
# 138 |   let rex = Re_pcre.regexp pat in
#                   ^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 139, characters 12-24:
# 139 |   try Some (Re_pcre.exec ~rex str)
#                   ^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 143, characters 12-33:
# 143 |   try Some (Re_pcre.get_substring result n)
#                   ^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 147, characters 12-26:
# 147 |   let rex = Re_pcre.regexp sep in
#                   ^^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# File "src/helpers.ml", line 148, characters 2-15:
# 148 |   Re_pcre.split ~rex str
#         ^^^^^^^^^^^^^
# Alert deprecated: module Re_pcre
# Use Re.Pcre
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/parseWarning.ml > src/parseWarning.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/terminalReporter.ml > src/terminalReporter.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/reportError.ml > src/reportError.ml.depends
# ocamlfind ocamldep -package 're.pcre ANSITerminal' -modules src/reportWarning.ml > src/reportWarning.ml.depends
# ocamlfind ocamlc -c -package 're.pcre ANSITerminal' -w @5@8@10@11@12@14@23-24@26@29@40 -I src -o src/reportError.cmo src/reportError.ml
# + ocamlfind ocamlc -c -package 're.pcre ANSITerminal' -w @5@8@10@11@12@14@23-24@26@29@40 -I src -o src/reportError.cmo src/reportError.ml
# File "src/reportError.ml", line 71, characters 20-36:
# 71 |       let pckName = String.lowercase unboundModule in
#                          ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
# Command exited with code 2.
```