### PR TITLE
DrawGrammar < 0.2.2 is not compatible with JsOfCairo 2.0

### DIFF
--- a/packages/DrawGrammar/DrawGrammar.0.1.0/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "menhir"
-  "JsOfOCairo"
+  "JsOfOCairo" {< "2.0.0"}
   "cairo2"
   "General" {< "0.4"}
 ]

--- a/packages/DrawGrammar/DrawGrammar.0.2.0/opam
+++ b/packages/DrawGrammar/DrawGrammar.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "menhir"
-  "JsOfOCairo"
+  "JsOfOCairo" {< "2.0.0"}
   "cairo2"
   "General" {>= "0.2" & < "0.4"}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling DrawGrammar.0.2.0 ==================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/DrawGrammar.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build sh -c cd src; ocamlbuild -use-ocamlfind -no-plugin -menhir "menhir --table" draw_grammar.native
# exit-code            10
# env-file             ~/.opam/log/DrawGrammar-8-c06d8e.env
# output-file          ~/.opam/log/DrawGrammar-8-c06d8e.out
### output ###
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules draw_grammar.ml > draw_grammar.ml.depends
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules Drawer.ml > Drawer.ml.depends
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules Grammar.mli > Grammar.mli.depends
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o Grammar.cmi Grammar.mli
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules Parse.ml > Parse.ml.depends
# /home/opam/.opam/4.03/bin/ocamllex.opt -q IsoEbnf_Lexer.mll
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules IsoEbnf_Lexer.ml > IsoEbnf_Lexer.ml.depends
# menhir --table --raw-depend --ocamldep 'ocamlfind ocamldep -modules' IsoEbnf_Parser.mly > IsoEbnf_Parser.mly.depends
# menhir --table --ocamlc 'ocamlfind ocamlc -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-9-44' --infer IsoEbnf_Parser.mly
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules IsoEbnf_Parser.mli > IsoEbnf_Parser.mli.depends
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o IsoEbnf_Parser.cmi IsoEbnf_Parser.mli
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules IsoEbnf_Messages.ml > IsoEbnf_Messages.ml.depends
# /home/opam/.opam/4.03/bin/ocamllex.opt -q OCamlETexEbnf_Lexer.mll
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules OCamlETexEbnf_Lexer.ml > OCamlETexEbnf_Lexer.ml.depends
# menhir --table --raw-depend --ocamldep 'ocamlfind ocamldep -modules' OCamlETexEbnf_Parser.mly > OCamlETexEbnf_Parser.mly.depends
# menhir --table --ocamlc 'ocamlfind ocamlc -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-9-44' --infer OCamlETexEbnf_Parser.mly
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules OCamlETexEbnf_Parser.mli > OCamlETexEbnf_Parser.mli.depends
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o OCamlETexEbnf_Parser.cmi OCamlETexEbnf_Parser.mli
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules OCamlETexEbnf_Messages.ml > OCamlETexEbnf_Messages.ml.depends
# /home/opam/.opam/4.03/bin/ocamllex.opt -q PythonEbnf_Lexer.mll
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules PythonEbnf_Lexer.ml > PythonEbnf_Lexer.ml.depends
# menhir --table --raw-depend --ocamldep 'ocamlfind ocamldep -modules' PythonEbnf_Parser.mly > PythonEbnf_Parser.mly.depends
# menhir --table --ocamlc 'ocamlfind ocamlc -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-9-44' --infer PythonEbnf_Parser.mly
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules PythonEbnf_Parser.mli > PythonEbnf_Parser.mli.depends
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o PythonEbnf_Parser.cmi PythonEbnf_Parser.mli
# ocamlfind ocamldep -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -modules PythonEbnf_Messages.ml > PythonEbnf_Messages.ml.depends
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o IsoEbnf_Lexer.cmo IsoEbnf_Lexer.ml
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o IsoEbnf_Messages.cmo IsoEbnf_Messages.ml
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o OCamlETexEbnf_Lexer.cmo OCamlETexEbnf_Lexer.ml
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o OCamlETexEbnf_Messages.cmo OCamlETexEbnf_Messages.ml
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o PythonEbnf_Lexer.cmo PythonEbnf_Lexer.ml
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o PythonEbnf_Messages.cmo PythonEbnf_Messages.ml
# ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o Drawer.cmo Drawer.ml
# + ocamlfind ocamlc -c -safe-string -strict-formats -strict-sequence -package menhirLib -package cairo2 -package js_of_ocaml.ppx -package js_of_ocaml -package JsOfOCairo -package General -w @A-4-44-48 -o Drawer.cmo Drawer.ml
# File "Drawer.ml", line 66, characters 25-26:
# Error: The function applied to this argument has type float -> float -> unit
# This argument cannot be applied with label ~x
# Command exited with code 2.
```