### PR TITLE
js_of_ocaml.2.8.4 is not compatible with yojson 2.0.0

### DIFF
--- a/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.2.8.4/opam
@@ -20,7 +20,7 @@ depends: [
   "base-no-ppx" | "ppx_tools"
   "ocamlbuild"
   "uchar"
-  "yojson"
+  "yojson" {< "2.0.0"}
 ]
 depopts: [
   "deriving"


### PR DESCRIPTION
```
#=== ERROR while compiling js_of_ocaml.2.8.4 ==================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.04.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.04/.opam-switch/build/js_of_ocaml.2.8.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make build WITH_ASYNC=NO WITH_PPX_DRIVER=NO
# exit-code            2
# env-file             ~/.opam/log/js_of_ocaml-8-660a04.env
# output-file          ~/.opam/log/js_of_ocaml-8-660a04.out
### output ###
# make -C compiler all compilerlib
# make[1]: Entering directory '/home/opam/.opam/4.04/.opam-switch/build/js_of_ocaml.2.8.4/compiler'
# echo "let s = \"2.8.4\"" > compiler_version.ml.tmp
# echo "let git_version = \"\"" >> compiler_version.ml.tmp
# if cmp -s compiler_version.ml.tmp compiler_version.ml; then rm compiler_version.ml.tmp; else mv compiler_version.ml.tmp compiler_version.ml; fi
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c compiler_version.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c compiler_version.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# cppo util.cppo.ml -o util.ml -V OCAML:`ocamlc -version`
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c util.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c util.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c pretty_print.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c pretty_print.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c option.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c option.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c reserved.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c reserved.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c varPrinter.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c varPrinter.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c dgraph.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c dgraph.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c parse_info.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c parse_info.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c code.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c code.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c javascript.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c javascript.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c vlq64.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlopt -g -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -for-pack Compiler -g -c vlq64.ml
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# ocamlfind ocamlc -g  -w +A-4-7-9-37-38-41-44-45-58 -I +compiler-libs -safe-string -package cmdliner -package base64 -package yojson -package findlib -c source_map.mli
# findlib: [WARNING] Interface topdirs.cmi occurs in several directories: /home/opam/.opam/4.04/lib/ocaml, /home/opam/.opam/4.04/lib/ocaml/compiler-libs
# File "source_map.mli", line 41, characters 16-33:
# Error: Unbound type constructor Yojson.Basic.json
# make[1]: *** [Makefile:127: source_map.cmi] Error 2
# make[1]: Leaving directory '/home/opam/.opam/4.04/.opam-switch/build/js_of_ocaml.2.8.4/compiler'
# make: *** [Makefile:13: compiler] Error 2
```