### PR TITLE
General < 0.3.0: Add missing dependency on cppo

### DIFF
--- a/packages/General/General.0.1.0/opam
+++ b/packages/General/General.0.1.0/opam
@@ -30,6 +30,7 @@ depends: [
   "ocaml" {>= "4.02.2" & < "4.06.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
+  "cppo"
   "cppo_ocamlbuild"
 ]
 synopsis: "Rich functionality for built-in and basic OCaml types"

--- a/packages/General/General.0.2.0/opam
+++ b/packages/General/General.0.2.0/opam
@@ -36,6 +36,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
+  "cppo"
   "cppo_ocamlbuild"
 ]
 synopsis: "Rich functionality for built-in and basic OCaml types"


### PR DESCRIPTION
```
#=== ERROR while compiling General.0.2.0 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.05.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.05/.opam-switch/build/General.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocamlbuild -use-ocamlfind -plugin-tag package(cppo_ocamlbuild) General.cma General.cmxa
# exit-code            10
# env-file             ~/.opam/log/General-9-5c1030.env
# output-file          ~/.opam/log/General-9-5c1030.out
### output ###
# ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package cppo_ocamlbuild myocamlbuild.ml /home/opam/.opam/4.05/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamldep -package num -modules src/General.mli > src/General.mli.depends
# ocamlfind ocamldep -open Pervasives_ -package num -modules src/Concepts/Able.ml > src/Concepts/Able.ml.depends
# ocamlfind ocamldep -open Pervasives_ -package num -modules src/Concepts/Identifiable.ml > src/Concepts/Identifiable.ml.depends
# ocamlfind ocamldep -package num -modules src/Pervasives_.ml > src/Pervasives_.ml.depends
# ocamlfind ocamldep -open Reset -package num -modules src/Foundations/Bool.ml > src/Foundations/Bool.ml.depends
# ocamlfind ocamldep -open Reset -package num -modules src/Foundations/Compare.ml > src/Foundations/Compare.ml.depends
# ocamlfind ocamldep -package num -modules src/Foundations/Reset.ml > src/Foundations/Reset.ml.depends
# cppo -V OCAML:4.05.0 -o src/Foundations/ResetPervasives.ml src/Foundations/ResetPervasives.cppo.ml
# + cppo -V OCAML:4.05.0 -o src/Foundations/ResetPervasives.ml src/Foundations/ResetPervasives.cppo.ml
# /bin/sh: 1: cppo: not found
# Command exited with code 127.
```