### PR TITLE
GuaCaml.0.02 is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/GuaCaml/GuaCaml.0.02/opam
+++ b/packages/GuaCaml/GuaCaml.0.02/opam
@@ -6,7 +6,7 @@ license: "LGPL-3.0-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://gitlab.com/boreal-ldd/guacaml"
 bug-reports: "https://gitlab.com/boreal-ldd/guacaml"
 depends: [
-	"ocaml" {>= "4.08"}
+	"ocaml" {>= "4.08" & < "5.0"}
 	"ocamlbuild" {build}
 	"ocamlfind" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling GuaCaml.0.02 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/GuaCaml.0.02
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/GuaCaml-8-6ab427.env
# output-file          ~/.opam/log/GuaCaml-8-6ab427.out
### output ###
# ocamlbuild -r -j 256 -use-ocamlfind \
# 	GuaCaml.cma \
# 	GuaCaml.cmi \
# 	GuaCaml.cmx \
# 	GuaCaml.cmxa \
# 	GuaCaml.cmxs
# ocamlfind ocamldep -package unix -modules src/AB.ml > src/AB.ml.depends
# ocamlfind ocamldep -package unix -modules src/bTools.mli > src/bTools.mli.depends
# ocamlfind ocamldep -package unix -modules src/io.mli > src/io.mli.depends
# ocamlfind ocamldep -package unix -modules src/o3.ml > src/o3.ml.depends
# ocamlfind ocamldep -package unix -modules src/extra.ml > src/extra.ml.depends
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/extra.cmo src/extra.ml
# ocamlfind ocamldep -package unix -modules src/poly.ml > src/poly.ml.depends
# ocamlfind ocamldep -package unix -modules src/tree.ml > src/tree.ml.depends
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/io.cmi src/io.mli
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/o3.cmo src/o3.ml
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/poly.cmo src/poly.ml
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/tree.cmo src/tree.ml
# ocamlfind ocamldep -package unix -modules src/myList.mli > src/myList.mli.depends
# ocamlfind ocamldep -package unix -modules src/sTools.mli > src/sTools.mli.depends
# ocamlfind ocamldep -package unix -modules src/tools.ml > src/tools.ml.depends
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/bTools.cmi src/bTools.mli
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/myList.cmi src/myList.mli
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/sTools.cmi src/sTools.mli
# ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/tools.cmo src/tools.ml
# + ocamlfind ocamlc -c -annot -bin-annot -for-pack GuaCaml -package unix -I src -o src/tools.cmo src/tools.ml
# File "src/tools.ml", line 389, characters 17-28:
# 389 |       let char = Stream.next stream in
#                        ^^^^^^^^^^^
# Error: Unbound module Stream
# Command exited with code 2.
# make: *** [makefile:14: all] Error 10
```