### PR TITLE
TCSLib is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/TCSLib/TCSLib.0.1/opam
+++ b/packages/TCSLib/TCSLib.0.1/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "Camldiets"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "num"

--- a/packages/TCSLib/TCSLib.0.2/opam
+++ b/packages/TCSLib/TCSLib.0.2/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "TCSLib"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/TCSLib/TCSLib.0.3/opam
+++ b/packages/TCSLib/TCSLib.0.3/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "TCSLib"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   ("extlib" | "extlib-compat")
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling TCSLib.0.3 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/TCSLib.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/TCSLib-8-d8141f.env
# output-file          ~/.opam/log/TCSLib-8-d8141f.out
### output ###
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```