### PR TITLE
Unparallelise uri.2.1.0

### DIFF
--- a/packages/uri/uri.2.1.0/opam
+++ b/packages/uri/uri.2.1.0/opam
@@ -23,8 +23,8 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "-p" name "-j" "1"]
+  ["dune" "runtest" "-p" name "-j" "1"] {with-test}
 ]
 url {
   src:


### PR DESCRIPTION
This is a known issue with the way uri used to build with dune and means it is not reliable to build in parallel.
```
#=== ERROR while compiling uri.2.1.0 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.09.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.09/.opam-switch/build/uri.2.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p uri -j 31
# exit-code            1
# env-file             ~/.opam/log/uri-8-5e1882.env
# output-file          ~/.opam/log/uri-8-5e1882.out
### output ###
# File "benchmarks/jbuild", line 1, characters 0-0:
# Warning: jbuild files are deprecated, please convert this file to a dune file
# instead.
# Note: You can use "dune upgrade" to convert your project to dune.
#       ocamlc lib/.uri.objs/byte/uri_re.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.09/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.uri.objs/byte -no-alias-deps -o lib/.uri.objs/byte/uri_re.cmo -c -impl lib/.wrapped_compat/Uri_re.ml-gen)
# File "lib/.wrapped_compat/Uri_re.ml-gen", line 1, characters 99-110:
# 1 | [@@@deprecated "Please switch to using Uri.Re instead of Uri_re. Use Uri.Uri_re instead."] include Uri__Uri_re
#                                                                                                        ^^^^^^^^^^^
# Error: Unbound module Uri__Uri_re
#       ocamlc lib/.uri.objs/byte/uri.{cmo,cmt}
# File "lib/uri.ml", line 602, characters 32-38:
# 602 |     try Some (Pct.cast_encoded (Re.get s n))
#                                       ^^^^^^
# Alert deprecated: Re.get
# Use Group.get
# File "lib/uri.ml", line 607, characters 34-40:
# 607 |       let pct = Pct.cast_encoded (Re.get s n) in
#                                         ^^^^^^
# Alert deprecated: Re.get
# Use Group.get
#     ocamlopt lib/.uri.objs/native/uri.{cmx,o}
# File "lib/uri.ml", line 602, characters 32-38:
# 602 |     try Some (Pct.cast_encoded (Re.get s n))
#                                       ^^^^^^
# Alert deprecated: Re.get
# Use Group.get
# File "lib/uri.ml", line 607, characters 34-40:
# 607 |       let pct = Pct.cast_encoded (Re.get s n) in
#                                         ^^^^^^
# Alert deprecated: Re.get
# Use Group.get
```