### PR TITLE
dream-httpaf is not compatible with ocaml5:

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha1/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha1/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt"
   "lwt_ppx" {>= "1.2.2"}
   "lwt_ssl"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
 
   # Currently vendored.


### PR DESCRIPTION
```
=== ERROR while compiling dream-httpaf.1.0.0~alpha1 ==========================#
 context              2.1.4 | linux/x86_64 |  | https://opam.ocaml.org#40323065
 path                 /tmp/myswitch/.opam-switch/build/dream-httpaf.1.0.0~alpha1
 command              /tmp/myswitch/bin/dune build -p dream-httpaf -j 7
 exit-code            1
 env-file             /tmp/opam-xxx-12791/dream-httpaf-12791-f3edef.env
 output-file          /tmp/opam-xxx-12791/dream-httpaf-12791-f3edef.out
=## output ###
 (cd _build/default && /tmp/myswitch/bin/ocamlc.opt -w -40 -g -bin-annot -I src/vendor/h2/lib/.h2.objs/byte -I /tmp/myswitch/lib/angstrom -I /tmp/myswitch/lib/base64 -I /tmp/myswitch/lib/bigstringaf -I /tmp/myswitch/lib/bytes -I /tmp/myswitch/lib/faraday -I /tmp/myswitch/lib/psq -I /tmp/myswitch/lib/result -I /tmp/myswitch/lib/seq -I src/vendor/h2/hpack/src/.hpack.objs/byte -I src/vendor/httpaf/lib/.httpaf.objs/byte -no-alias-deps -open H2__ -o src/vendor/h2/lib/.h2.objs/byte/h2__Scheduler.cmo -c -impl src/vendor/h2/lib/scheduler.ml)
 File "src/vendor/h2/lib/scheduler.ml", lines 34-40, characters 10-6:
 34 | ..........Hashtbl.MakeSeeded (struct
 35 |     type t = Stream_identifier.t
 36 |
 37 |     let equal = Stream_identifier.( === )
 38 |
 39 |     let hash i k = Hashtbl.seeded_hash i k
 40 |   end)
 Error: Modules do not match:
        sig
          type t = H2__.Stream_identifier.t
          val equal : Int32.t -> Int32.t -> bool
          val hash : int -> 'a -> int
        end
      is not included in Hashtbl.SeededHashedType
      The value `seeded_hash' is required but not provided
      File "hashtbl.mli", line 411, characters 4-36: Expected declaration
```