### PR TITLE
lua-ml: add a warning message about parallelism problems for OCaml 5.0.0

### DIFF
--- a/packages/lua-ml/lua-ml.0.9.1/opam
+++ b/packages/lua-ml/lua-ml.0.9.1/opam
@@ -22,3 +22,7 @@ url {
     "sha512=5cb56cd96dbfae42835b3f10f275753685575472ace518e351e62e50a01c07a510203be21644fd3429680b926ecd9905d4dca1e101b762c442f7c6dc00b0f0ae"
   ]
 }
+post-messages: [
+ "Lua-ML does build with OCaml 5.0.0, however, it only works with it as long as the code is single-threaded: \
+  trying to execute Lua code in more than one domain may incur in confusing, unpredictable failures." {ocaml:version >= "5.0"}
+]

--- a/packages/lua-ml/lua-ml.0.9.2/opam
+++ b/packages/lua-ml/lua-ml.0.9.2/opam
@@ -21,3 +21,7 @@ url {
     "sha512=0719252c753a81301ff2de1b4de7a60a136afe2d73fc75c332529fed7f0975d44b85cbd2cad1762f8f9985110108b85a8e935222c7cbf430993fbafc2253d6fa"
   ]
 }
+post-messages: [
+ "Lua-ML does build with OCaml 5.0.0, however, it only works with it as long as the code is single-threaded: \
+  trying to execute Lua code in more than one domain may incur in confusing, unpredictable failures." {ocaml:version >= "5.0"}
+]

--- a/packages/lua-ml/lua-ml.0.9.3/opam
+++ b/packages/lua-ml/lua-ml.0.9.3/opam
@@ -36,3 +36,7 @@ url {
     "sha512=74d6881dc6b3a16738fa1a66db903bb2968bb913afc422ed230f279f7f05377b91a1c9cea5364021da5f6ee1f605c2fb25932503b978e9080dd6b9e7e8d36de8"
   ]
 }
+post-messages: [
+ "Lua-ML does build with OCaml 5.0.0, however, it only works with it as long as the code is single-threaded: \
+  trying to execute Lua code in more than one domain may incur in confusing, unpredictable failures." {ocaml:version >= "5.0"}
+]

--- a/packages/lua-ml/lua-ml.0.9.4/opam
+++ b/packages/lua-ml/lua-ml.0.9.4/opam
@@ -38,3 +38,7 @@ url {
     "sha512=3127b73bff078a40825fc5216559e3fe37fb1c4faf0121adc3a06acac6fb77dec82ba150d1f78ac1953266720ea3bedd4f7e2b21ddce1e0250417b36e1327eee"
   ]
 }
+post-messages: [
+ "Lua-ML does build with OCaml 5.0.0, however, it only works with it as long as the code is single-threaded: \
+  trying to execute Lua code in more than one domain may incur in confusing, unpredictable failures." {ocaml:version >= "5.0"}
+]

--- a/packages/lua-ml/lua-ml.0.9/opam
+++ b/packages/lua-ml/lua-ml.0.9/opam
@@ -20,3 +20,8 @@ url {
     "sha512=e8a841dd03256d29eb22868c5cb317db34cfb3de54037605a88812ce4a2d2600de35579af7b627f06c32583510b72e7e02da4bed212658af1edd454a767a1aa7"
   ]
 }
+post-messages: [
+ "Lua-ML does build with OCaml 5.0.0, however, it only works with it as long as the code is single-threaded: \
+  trying to execute Lua code in more than one domain may incur in confusing, unpredictable failures." {ocaml:version >= "5.0"}
+]
+


### PR DESCRIPTION
This PR may be misguided, please close it if it is and let me know.

Lua-ML does build with OCaml 5.0.0. However, it only works with it as long as the code is single-threaded. If someone tries to run Lua code in more than one domain, that will blow up due to hidden mutable state in the interpreter that causes race conditions and random, weird failures.

I wonder if it's better to make the package unavailable for 5.0.0 until those issues are fixed to avoid misleading people into thinking that it's good for multicore (until it's actually good for it).

Or is there another way to mark a package multicore-unsafe?

