### PR TITLE
Package ocaml.4.14.0

### DIFF
--- a/packages/ocaml/ocaml.4.14.0/opam
+++ b/packages/ocaml/ocaml.4.14.0/opam
@@ -9,7 +9,8 @@ depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.0~" & < "4.14.1~"} |
   "ocaml-variants" {>= "4.14.0~" & < "4.14.1~"} |
-  "ocaml-system" {>= "4.14.0" & < "4.14.1~"}
+  "ocaml-system" {>= "4.14.0" & < "4.14.1~"} |
+  "dkml-base-compiler" {>= "4.14.0~" & < "4.14.1~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]


### PR DESCRIPTION
### `ocaml.4.14.0`
The OCaml compiler (virtual package)
This package requires a matching implementation of OCaml,
and polls it to initialise specific variables like `ocaml:native-dynlink`



---
* Homepage: https://ocaml.org
* Bug tracker: https://github.com/ocaml/opam-repository/issues

---
:camel: Pull-request generated by opam-publish v2.1.0