### PR TITLE
js_of_ocaml >= 3.7.0 does not support bytecode-only compilers

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.10.0/opam
@@ -27,6 +27,7 @@ conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.11.0/opam
@@ -28,6 +28,7 @@ conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.0/opam
@@ -29,6 +29,7 @@ conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 x-commit-hash: "d50221f1cf19f7637dfca7407762a85dcd420f46"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.7.1/opam
@@ -29,6 +29,7 @@ conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 x-commit-hash: "888697ba6c17051c50839e35d882a8c58fdc69f5"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.8.0/opam
@@ -29,6 +29,7 @@ conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 x-commit-hash: "09d5731241917577e9c16b6a0063c23baae00df8"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.0/opam
@@ -29,6 +29,7 @@ conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 x-commit-hash: "95bc95d31122bae5764022f878d8a6dd95ceb169"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.3.9.1/opam
@@ -29,6 +29,7 @@ conflicts: [
   "ocamlfind"   {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 x-commit-hash: "c97f2543ff7bfa6c8fe683cca7beec884b38f918"
 url {

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.0.0/opam
@@ -28,6 +28,7 @@ conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "base-domains"
+  "ocaml-option-bytecode-only"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.4.1.0/opam
@@ -28,6 +28,7 @@ conflicts: [
   "ocamlfind" {< "1.5.1"}
   "js_of_ocaml" {< "3.0"}
   "ocaml-variants" {= "4.12.0+domains" | = "4.12.0+domains+effects"}
+  "ocaml-option-bytecode-only"
 ]
 dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
 build: [


### PR DESCRIPTION
```
#=== ERROR while compiling js_of_ocaml-compiler.4.1.0 =========================#
# context              2.2.0~alpha~dev | linux/x86_32 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/js_of_ocaml-compiler.4.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p js_of_ocaml-compiler -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/js_of_ocaml-compiler-7-513434.env
# output-file          ~/.opam/log/js_of_ocaml-compiler-7-513434.out
### output ###
# (cd tools/version && /home/opam/.opam/5.0/bin/ocaml -I +compiler-libs /home/opam/.opam/5.0/.opam-switch/build/js_of_ocaml-compiler.4.1.0/_build/.dune/default/tools/version/dune.ml)
# fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
# File "compiler/bin-js_of_ocaml/dune", line 2, characters 7-18:
# 2 |  (name js_of_ocaml)
#            ^^^^^^^^^^^
# Error: No rule found for compiler/bin-js_of_ocaml/js_of_ocaml.exe
```
Fixed upstream in https://github.com/ocsigen/js_of_ocaml/pull/1363