### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-lwt and js_of_ocaml-compiler (5.0.1)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.0.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.0.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04" & < "5.1"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.0.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.0.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.0.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.0.1/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.0.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.0.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.0.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.0.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"

--- a/packages/js_of_ocaml/js_of_ocaml.5.0.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.0.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.04"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.0.1/js_of_ocaml-5.0.1.tbz"
+  checksum: [
+    "sha256=7a210f1ca16a742381947dc67c3d8d9f4c94fbf20738744b1353897985b61069"
+    "sha512=07a973561190686d56bd5d56d9a275e177716ea8b9720f6acc7ddf8618680844a6d0c798447567ea9542d83bab524c165d076f3cce0769a12fc483ef8cd6a733"
+  ]
+}
+x-commit-hash: "66570bae49d9fae4341bc548dde9f944afe3b41a"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Compiler: add support for effect handlers (--enable=effects)
* Compiler: small refactoring in code generation
* Compiler: check build info compatibility when linking js file.
* Misc: fix and update benchmarks
* Misc: upgrade CI
* Toplevel: recover more names when generating code during toplevel evaluation
* Runtime: wrapping exception or not is now controled in the runtime.

## Bug fixes
* Runime: Gc.finalise_last should not be eliminated
* Tyxml: reactive dom needed a fix after ocsigen/js_of_ocaml#1268 (ocsigen/js_of_ocaml#1353)
* Toplevel: Make sure the toplevel uses the correct memory representaion for strings
* Compiler: fix minifier, missing constraint on try-catch blocks.
* Compiler: Miscompilation of code involving references and exceptions (ocsigen/js_of_ocaml#1354, ocsigen/js_of_ocaml#1356)
* Runtime: fix caml_read_file_content
