### PR TITLE
syndc < 1.6 is not compatible with OCaml 5

### DIFF
--- a/packages/syndic/syndic.1.2/opam
+++ b/packages/syndic/syndic.1.2/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "calendar" {>= "2.03.2"}
   "ocamlfind" {build}
   "uri" {>= "1.3.1"}

--- a/packages/syndic/syndic.1.3.1/opam
+++ b/packages/syndic/syndic.1.3.1/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "calendar" {>= "2.03.2"}
   "ocamlfind" {build}
   "uri" {>= "1.3.1"}

--- a/packages/syndic/syndic.1.3/opam
+++ b/packages/syndic/syndic.1.3/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "calendar" {>= "2.03.2"}
   "ocamlfind" {build}
   "uri" {>= "1.3.1"}

--- a/packages/syndic/syndic.1.4/opam
+++ b/packages/syndic/syndic.1.4/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "calendar" {>= "2.03.2"}
   "cohttp" {<"0.99.0" & with-test}
   "lwt" {with-test}

--- a/packages/syndic/syndic.1.5.1/opam
+++ b/packages/syndic/syndic.1.5.1/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {<"0.99.0" & with-test}
   "lwt" {with-test}
   "ocamlbuild" {build}

--- a/packages/syndic/syndic.1.5.2/opam
+++ b/packages/syndic/syndic.1.5.2/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {<"0.99.0" & with-test}
   "lwt" {with-test}
   "ocamlbuild" {build}

--- a/packages/syndic/syndic.1.5.3/opam
+++ b/packages/syndic/syndic.1.5.3/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "syndic"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {<"0.99.0" & with-test}
   "lwt" {with-test}
   "ocamlbuild" {build}

--- a/packages/syndic/syndic.1.5/opam
+++ b/packages/syndic/syndic.1.5/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "syndic"]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "ssl" {with-test}
   "tls" {with-test}
   "cohttp" {<"0.99.0" & with-test}


### PR DESCRIPTION
It uses `String.lowercases` which is not available in OCaml 5 anymore.

/cc @dinosaure 