### PR TITLE
travis-opam is not available on OCaml 5

### DIFF
--- a/packages/travis-opam/travis-opam.1.0.0/opam
+++ b/packages/travis-opam/travis-opam.1.0.0/opam
@@ -10,13 +10,13 @@ authors: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build}
 ]
 build: [make]
 synopsis: "Travis CI (Continuous Integration) helpers"
 description: """
-This package installs a set of helper tools that integrate your 
+This package installs a set of helper tools that integrate your
 OCaml project with the Travis CI (http://travis-ci.org) online
 continuous integration system.
 

--- a/packages/travis-opam/travis-opam.1.0.2/opam
+++ b/packages/travis-opam/travis-opam.1.0.2/opam
@@ -11,13 +11,13 @@ authors: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build}
 ]
 build: [make]
 synopsis: "Travis CI (Continuous Integration) helpers"
 description: """
-This package installs a set of helper tools that integrate your 
+This package installs a set of helper tools that integrate your
 OCaml project with the Travis CI (http://travis-ci.org) online
 continuous integration system.
 

--- a/packages/travis-opam/travis-opam.1.0.3/opam
+++ b/packages/travis-opam/travis-opam.1.0.3/opam
@@ -11,13 +11,13 @@ authors: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build}
 ]
 build: [make]
 synopsis: "Travis CI (Continuous Integration) helpers"
 description: """
-This package installs a set of helper tools that integrate your 
+This package installs a set of helper tools that integrate your
 OCaml project with the Travis CI (http://travis-ci.org) online
 continuous integration system.
 

--- a/packages/travis-opam/travis-opam.1.1.0/opam
+++ b/packages/travis-opam/travis-opam.1.1.0/opam
@@ -10,7 +10,7 @@ authors: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlbuild" {build}
 ]
 depexts: [
@@ -25,7 +25,7 @@ depexts: [
 build: [make]
 synopsis: "Travis CI (Continuous Integration) helpers"
 description: """
-This package installs a set of helper tools that integrate your 
+This package installs a set of helper tools that integrate your
 OCaml project with the Travis CI (http://travis-ci.org) online
 continuous integration system.
 

--- a/packages/travis-opam/travis-opam.1.2.0/opam
+++ b/packages/travis-opam/travis-opam.1.2.0/opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "jsonm" {build}
 ]

--- a/packages/travis-opam/travis-opam.1.3.0/opam
+++ b/packages/travis-opam/travis-opam.1.3.0/opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "jsonm" {build}
 ]

--- a/packages/travis-opam/travis-opam.1.4.0/opam
+++ b/packages/travis-opam/travis-opam.1.4.0/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocaml/ocaml-ci-scripts"
 doc: "https://ocaml.github.io/ocaml-ci-scripts/"
 bug-reports: "https://github.com/ocaml/ocaml-ci-scripts/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "jsonm" {build}
 ]

--- a/packages/travis-opam/travis-opam.1.5.0/opam
+++ b/packages/travis-opam/travis-opam.1.5.0/opam
@@ -12,7 +12,7 @@ doc: "https://ocaml.github.io/ocaml-ci-scripts/"
 bug-reports: "https://github.com/ocaml/ocaml-ci-scripts/issues"
 depends: [
   "dune"
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jsonm" {build}
   "opam-file-format" {build}
 ]


### PR DESCRIPTION
It uses `String.lowercase`.