### PR TITLE
old versions of mirage-fs does not work with OCaml

### DIFF
--- a/packages/mirage-fs/mirage-fs.0.3.0/opam
+++ b/packages/mirage-fs/mirage-fs.0.3.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 build: [[make "all"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-fs/mirage-fs.0.4.0/opam
+++ b/packages/mirage-fs/mirage-fs.0.4.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 build: [[make "all"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0"}
   "ocamlbuild" {build}
 ]

--- a/packages/mirage-fs/mirage-fs.0.5.0/opam
+++ b/packages/mirage-fs/mirage-fs.0.5.0/opam
@@ -6,7 +6,7 @@ tags: [
 ]
 build: [[make "all"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "cstruct" {>= "0.6.0"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
They use `copy_string` instead of `caml_copy_string` in the C stubs.