### PR TITLE
Old versions of Git needs an old version of bigstringaf

### DIFF
--- a/packages/git/git.3.2.0/opam
+++ b/packages/git/git.3.2.0/opam
@@ -20,7 +20,7 @@ depends: [
   "digestif" {>= "0.8.1"}
   "rresult"
   "result"
-  "bigstringaf"
+  "bigstringaf" {< "0.9"}
   "bigarray-compat"
   "optint"
   "decompress" {< "1.3.0"}

--- a/packages/git/git.3.3.0/opam
+++ b/packages/git/git.3.3.0/opam
@@ -21,7 +21,7 @@ depends: [
   "rresult"
   "base64" {>= "3.0.0"}
   "result"
-  "bigstringaf"
+  "bigstringaf" {< "0.9"}
   "bigarray-compat"
   "optint"
   "decompress" {< "1.3.0"}

--- a/packages/git/git.3.3.1/opam
+++ b/packages/git/git.3.3.1/opam
@@ -21,10 +21,10 @@ depends: [
   "rresult"
   "base64" {>= "3.0.0"}
   "result"
-  "bigstringaf"
+  "bigstringaf" {>= "0.8.0" & < "0.9"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.3.2/opam
+++ b/packages/git/git.3.3.2/opam
@@ -21,10 +21,10 @@ depends: [
   "rresult"
   "base64" {>= "3.0.0"}
   "result"
-  "bigstringaf"
+  "bigstringaf" {>= "0.8.0" & < "0.9"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic"

--- a/packages/git/git.3.3.3/opam
+++ b/packages/git/git.3.3.3/opam
@@ -21,10 +21,10 @@ depends: [
   "rresult"
   "base64" {>= "3.0.0"}
   "result"
-  "bigstringaf"
+  "bigstringaf" {>= "0.8.0" & < "0.9"}
   "bigarray-compat"
   "optint"
-  "decompress" {>= "1.3.0"}
+  "decompress" {>= "1.3.0" & < "1.4.3"}
   "logs"
   "lwt"
   "mimic"


### PR DESCRIPTION
Otherwise, the error is:

```
- File "src/loose/loose.ml", line 58, characters 31-56:
- 58 |             Zl.Def.src encoder (Cstruct.to_bigarray src) 0 (Cstruct.len src)
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
- Error: This expression has type
-          Cstruct.buffer =
-            (char, Bigarray_compat.int8_unsigned_elt,
-             Bigarray_compat.c_layout)
-            Bigarray_compat.Array1.t
-        but an expression was expected of type
-          Zl.bigstring =
-            (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout)
-            Bigarray.Array1.t
```