### PR TITLE
Datakit-client needs an old version of Lwt

### DIFF
--- a/packages/datakit-client/datakit-client.0.12.0/opam
+++ b/packages/datakit-client/datakit-client.0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring"
   "result"  {< "1.5"}
   "fmt"
-  "lwt"
+  "lwt" {< "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 synopsis: "A library to connect to DataKit servers"

--- a/packages/datakit-client/datakit-client.0.12.0/opam
+++ b/packages/datakit-client/datakit-client.0.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"
   "jbuilder" {>= "1.0+beta10"}
   "astring"
-  "result"  {< "1.5"}
+  "result"  {>= "1.1" & < "1.5"}
   "fmt"
   "lwt" {< "5.6"}
   "cstruct" {> "2.2.0"}

--- a/packages/datakit-client/datakit-client.0.12.0/opam
+++ b/packages/datakit-client/datakit-client.0.12.0/opam
@@ -16,7 +16,7 @@ depends: [
   "astring"
   "result"  {>= "1.1" & < "1.5"}
   "fmt"
-  "lwt" {< "5.6"}
+  "lwt" {>= "2.6.0" & < "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 synopsis: "A library to connect to DataKit servers"

--- a/packages/datakit-client/datakit-client.0.12.2/opam
+++ b/packages/datakit-client/datakit-client.0.12.2/opam
@@ -13,7 +13,7 @@ depends: [
   "astring"
   "result"  {< "1.5"}
   "fmt"
-  "lwt"
+  "lwt" {< "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-client/datakit-client.0.12.2/opam
+++ b/packages/datakit-client/datakit-client.0.12.2/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
-  "result"  {< "1.5"}
+  "result"  {>= "1.1" & < "1.5"}
   "fmt"
   "lwt" {< "5.6"}
   "cstruct" {> "2.2.0"}

--- a/packages/datakit-client/datakit-client.0.12.2/opam
+++ b/packages/datakit-client/datakit-client.0.12.2/opam
@@ -13,7 +13,7 @@ depends: [
   "astring"
   "result"  {>= "1.1" & < "1.5"}
   "fmt"
-  "lwt" {< "5.6"}
+  "lwt" {>= "2.6.0" & < "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-client/datakit-client.0.12.3/opam
+++ b/packages/datakit-client/datakit-client.0.12.3/opam
@@ -13,7 +13,7 @@ depends: [
   "astring"
   "result"  {< "1.5"}
   "fmt"
-  "lwt"
+  "lwt" {< "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-client/datakit-client.0.12.3/opam
+++ b/packages/datakit-client/datakit-client.0.12.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "dune"
   "astring"
-  "result"  {< "1.5"}
+  "result"  {>= "1.1" & < "1.5"}
   "fmt"
   "lwt" {< "5.6"}
   "cstruct" {> "2.2.0"}

--- a/packages/datakit-client/datakit-client.0.12.3/opam
+++ b/packages/datakit-client/datakit-client.0.12.3/opam
@@ -13,7 +13,7 @@ depends: [
   "astring"
   "result"  {>= "1.1" & < "1.5"}
   "fmt"
-  "lwt" {< "5.6"}
+  "lwt" {>= "2.6.0" & < "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/datakit-client/datakit-client.1.0.0/opam
+++ b/packages/datakit-client/datakit-client.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "astring"
   "result"  {< "1.5"}
   "fmt"
-  "lwt" {>= "2.6.0"}
+  "lwt" {>= "2.6.0" & < "5.6"}
   "cstruct" {> "2.2.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Otherwise it fails with:

```
 File "api/ocaml/datakit_client.mli", line 141, characters 32-45:
 141 |   type +'a result = ('a, error) Result.result Lwt.t
                                       ^^^^^^^^^^^^^
 Error: Unbound type constructor Result.result
```