### PR TITLE
Old version of depyt needs an old version of cstruct

### DIFF
--- a/packages/depyt/depyt.0.2.0/opam
+++ b/packages/depyt/depyt.0.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "cstruct" {< "6.1"}
+  "cstruct" {>= "0.6.0" & < "6.1"}
   "fmt"
   "result" {< "1.5"}
   "jsonm"

--- a/packages/depyt/depyt.0.2.0/opam
+++ b/packages/depyt/depyt.0.2.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {>= "1.0+beta10"}
-  "cstruct"
+  "cstruct" {< "6.1"}
   "fmt"
   "result" {< "1.5"}
   "jsonm"


### PR DESCRIPTION
Otherwise it fails with:

```
  File "src/depyt.ml", line 756, characters 15-37:
  756 |     | C buf -> Cstruct.blit_to_string buf pos str 0 len
                       ^^^^^^^^^^^^^^^^^^^^^^
  Error: Unbound value Cstruct.blit_to_string
  Hint: Did you mean blit_from_string?
```