### PR TITLE
Old versions of irmin needs an old version of cstruct

### DIFF
--- a/packages/irmin/irmin.1.3.2/opam
+++ b/packages/irmin/irmin.1.3.2/opam
@@ -18,7 +18,7 @@ depends: [
   "result"  {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.1"}
   "jsonm" {>= "1.0.0"}
   "lwt" {>= "2.4.7"}
   "ocamlgraph"

--- a/packages/irmin/irmin.1.4.0/opam
+++ b/packages/irmin/irmin.1.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "result" {< "1.5"}
   "fmt" {>= "0.8.0"}
   "uri" {>= "1.3.12"}
-  "cstruct" {>= "1.6.0"}
+  "cstruct" {>= "1.6.0" & < "6.1"}
   "jsonm" {>= "1.0.0"}
   "lwt" {>= "2.4.7"}
   "ocamlgraph"


### PR DESCRIPTION
Otherwise they fail with:

```
  #=== ERROR while compiling irmin.1.4.0 ========================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.12.1 | file:///home/opam/opam-repository
  # path                 ~/.opam/4.12/.opam-switch/build/irmin.1.4.0
  # command              ~/.opam/opam-init/hooks/sandbox.sh build jbuilder build -p irmin -j 47
  # exit-code            1
  # env-file             ~/.opam/log/irmin-8-7b617e.env
  # output-file          ~/.opam/log/irmin-8-7b617e.out
  ### output ###
  [..]
  # File "src/irmin/type.ml", line 702, characters 28-39:
  # 702 |   let cstruct s = (int 0) + Cstruct.len s
  #                                   ^^^^^^^^^^^
  # Error: Unbound value Cstruct.len
```