### PR TITLE
old version of irmin-layers needs an old version of mtime

### DIFF
--- a/packages/irmin-layers/irmin-layers.2.3.0/opam
+++ b/packages/irmin-layers/irmin-layers.2.3.0/opam
@@ -16,7 +16,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.03.0"}
   "dune"       {>= "2.7.0"}
-  "mtime"      {>= "1.0.0"}
+  "mtime"      {>= "1.0.0" & < "2.0"}
   "irmin"      {= version}
   "logs"
   "lwt"


### PR DESCRIPTION
Otherwise it fails with:

```
  #=== ERROR while compiling irmin-layers.2.3.0 =================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.12.1 | file:///home/opam/opam-repository
  # path                 ~/.opam/4.12/.opam-switch/build/irmin-layers.2.3.0
  # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p irmin-layers -j 31
  # exit-code            1
  # env-file             ~/.opam/log/irmin-layers-7-666caa.env
  # output-file          ~/.opam/log/irmin-layers-7-666caa.out
  ### output ###
  # (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I src/irmin-layers/.irmin_layers.objs/byte -I /home/opam/.opam/4.12/lib/angstrom -I /home/opam/.opam/4.12/lib/astring -I /home/opam/.opam/4.12/lib/base64 -I /home/opam/.opam/4.12/lib/bheap -I /home/opam/.opam/4.12/lib/bigstringaf -I /home/opam/.opam/4.12/lib/digestif -I /home/opam/.opam/4.12/lib/either -I /home/opam/.opam/4.12/lib/eqaf -I /home/opam/.opam/4.12/lib/fmt -I /home/opam/.opam/4.12/lib/irmin -I /home/opam/.opam/4.12/lib/jsonm -I /home/opam/.opam/4.12/lib/logs -I /home/opam/.opam/4.12/lib/lwt -I /home/opam/.opam/4.12/lib/mtime -I /home/opam/.opam/4.12/lib/mtime/clock/os -I /home/opam/.opam/4.12/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.12/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.12/lib/ocaml-migrate-parsetree -I /home/opam/.opam/4.12/lib/ocaml/compiler-libs -I /home/opam/.opam/4.12/lib/ocamlgraph -I /home/opam/.opam/4.12/lib/ppx_derivers -I /home/opam/.opam/4.12/lib/ppx_irmin -I /home/opam/.opam/4.12/lib/ppx_repr/lib -I /home/opam/.opam/4.12/lib/ppxlib -I /home/opam/.opam/4.12/lib/ppxlib/ast -I /home/opam/.opam/4.12/lib/ppxlib/print_diff -I /home/opam/.opam/4.12/lib/ppxlib/stdppx -I /home/opam/.opam/4.12/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.12/lib/repr -I /home/opam/.opam/4.12/lib/result -I /home/opam/.opam/4.12/lib/sexplib0 -I /home/opam/.opam/4.12/lib/stdlib-shims -I /home/opam/.opam/4.12/lib/stringext -I /home/opam/.opam/4.12/lib/uchar -I /home/opam/.opam/4.12/lib/uri -I /home/opam/.opam/4.12/lib/uutf -intf-suffix .ml -no-alias-deps -open Irmin_layers__ -o src/irmin-layers/.irmin_layers.objs/byte/irmin_layers__Stats.cmo -c -impl src/irmin-layers/stats.pp.ml)
  # File "src/irmin-layers/stats.ml", line 124, characters 13-29:
  # 124 |   let span = Mtime.Span.to_us (Mtime_clock.count timer) in
  #                    ^^^^^^^^^^^^^^^^
  # Error: Unbound value Mtime.Span.to_us
```