### PR TITLE
mirage-fs-lwt needs the right version of mirage-kv

### DIFF
--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.04.2"}
   "dune"
   "mirage-fs" {>= "1.0.0" & < "3.0.0"}
+  "mirage-kv" {>= "1.1.0"}
   "mirage-kv-lwt" {< "2.0.0"}
   "lwt"
   "cstruct" {>= "1.9.0"}

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.1.0"}
   "mirage-kv-lwt" {< "2.0.0"}
-  "lwt"
+  "lwt" {>= "2.4.7"}
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"
 ]

--- a/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
+++ b/packages/mirage-fs-lwt/mirage-fs-lwt.1.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-fs" {>= "1.0.0" & < "3.0.0"}
   "mirage-kv" {>= "1.1.0"}
   "mirage-kv-lwt" {< "2.0.0"}
-  "lwt" {>= "2.4.7"}
+  "lwt" {>= "2.6.0"}
   "cstruct" {>= "1.9.0"}
   "cstruct-lwt"
 ]


### PR DESCRIPTION
Otherwise it fails with:

```
  #=== ERROR while compiling mirage-fs-lwt.1.2.0 ==============================#
  # context     2.1.3 | macos/arm64 | ocaml.4.14.0 | https://opam.ocaml.org#789990a7
  # path        ~/git/mirage-fs/_opam/.opam-switch/build/mirage-fs-lwt.1.2.0
  # command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mirage-fs-lwt -j 9
  # exit-code   1
  # env-file    ~/.opam/log/mirage-fs-lwt-59934-a1bb9e.env
  # output-file ~/.opam/log/mirage-fs-lwt-59934-a1bb9e.out
  ### output ###
  # Error: The implementation lwt/mirage_fs_lwt.ml
  # [...]
  #            (page_aligned_buffer list, error) Result.result Lwt.t
  #        Type
  #          (FS.page_aligned_buffer list,
  #           [> `FS of FS.error | `Unknown_key of string ])
  #          result
  #        is not compatible with type
  #          (page_aligned_buffer list, error) Result.result
  #        File "src/mirage_kv.mli", lines 46-47, characters 2-47:
  #          Expected declaration
  #        File "lwt/mirage_fs_lwt.ml", line 44, characters 6-10:
  #          Actual declaration
```