### PR TITLE
old version of aws do not work with OCaml 5

### DIFF
--- a/packages/aws/aws.1.0.0/opam
+++ b/packages/aws/aws.1.0.0/opam
@@ -34,7 +34,7 @@ remove: [
   ["ocamlfind" "remove" "aws"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "calendar" {>= "2.00"}
   "ezxmlm"
   "nocrypto"

--- a/packages/aws/aws.1.0.1/opam
+++ b/packages/aws/aws.1.0.1/opam
@@ -34,7 +34,7 @@ remove: [
   ["ocamlfind" "remove" "aws"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "calendar" {>= "2.00"}
   "ezxmlm"
   "nocrypto"

--- a/packages/aws/aws.1.0.2/opam
+++ b/packages/aws/aws.1.0.2/opam
@@ -34,7 +34,7 @@ remove: [
   ["ocamlfind" "remove" "aws"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "calendar" {>= "2.00"}
   "ezxmlm"
   "nocrypto"


### PR DESCRIPTION
They fail with:

```
  #=== ERROR while compiling aws.1.0.2 ==========================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/aws.1.0.2
  # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-lwt --disable-async
  # exit-code            2
  # env-file             ~/.opam/log/aws-7-fe97aa.env
  # output-file          ~/.opam/log/aws-7-fe97aa.out
  ### output ###
  # File "./setup.ml", line 318, characters 20-36:
  # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
  #                           ^^^^^^^^^^^^^^^^
  # Error: Unbound value String.lowercase
```