### PR TITLE
old versions of asl do not work on OCaml 5

### DIFF
--- a/packages/asl/asl.0.10/opam
+++ b/packages/asl/asl.0.10/opam
@@ -15,7 +15,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "asl"]]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "result"
   "logs"
   "ocamlfind" {build}

--- a/packages/asl/asl.0.9/opam
+++ b/packages/asl/asl.0.9/opam
@@ -15,7 +15,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "asl"]]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "result"
   "logs"
   "ocamlfind" {build}


### PR DESCRIPTION
They fail with:
```
  #=== ERROR while compiling asl.0.10 ===========================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/asl.0.10
  # command              ~/.opam/opam-init/hooks/sandbox.sh build make PREFIX=/home/opam/.opam/5.0
  # exit-code            2
  # env-file             ~/.opam/log/asl-7-b11297.env
  # output-file          ~/.opam/log/asl-7-b11297.out
  ### output ###
  # ocaml setup.ml -configure
  # File "./setup.ml", line 318, characters 20-36:
  # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
  #                           ^^^^^^^^^^^^^^^^
  # Error: Unbound value String.lowercase
  # make: *** [Makefile:34: setup.data] Error 2
```