### PR TITLE
[new release] ansi (0.6.0)

### DIFF
--- a/packages/ansi/ansi.0.6.0/opam
+++ b/packages/ansi/ansi.0.6.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "ANSI escape sequence parser"
+description:
+  "This package provides a basic ANSI escape parser, allowing the OCurrent web UI to show logs in colour."
+maintainer: ["Antonin Décimo <antonin@tarides.com>" "<talex5@gmail.com>"]
+authors: ["Antonin Décimo <antonin@tarides.com>" "talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ansi"
+bug-reports: "https://github.com/ocurrent/ansi/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.10.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "tyxml"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ansi.git"
+url {
+  src:
+    "https://github.com/ocurrent/ansi/releases/download/0.6.0/ansi-0.6.0.tbz"
+  checksum: [
+    "sha256=360c63014f0d2ea2e840498defa00e0ec982d7cee76438e86ee5f23f0d3597aa"
+    "sha512=c986201c699261e860c934a5440dff7f70e47bf2442c388eecd7f699d1310dffcde0659844b0d508673430cd36b0ee8266599e36e79eb6ad4a0bdbfcecf2a059"
+  ]
+}
+x-commit-hash: "b0e91b2834b48e70b5d662de8eb133510564a7e2"


### PR DESCRIPTION
ANSI escape sequence parser

- Project page: <a href="https://github.com/ocurrent/ansi">https://github.com/ocurrent/ansi</a>

##### CHANGES:

* Support OSC hyperlinks. (ocurrent/ansi#13, @MisterDA)
  https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda

* Support italic and underline escape sequences with `.italic` and
  `.underline` CSS classes. (ocurrent/ansi#11, @MisterDA)

* Fix range of intermediate bytes. (ocurrent/ansi#8, @MisterDA)

* Add `Ansi.strip` to strip ANSI escape sequences part of a string.
  Support stripping OSC sequences.
  (ocurrent/ansi#7, ocurrent/ansi#9, ocurrent/ansi#12, @MisterDA)

* Support 8-bit colour palette, bright colours. (ocurrent/ansi#6, @MisterDA)

* Expose default foreground and background colors with `.fg-default`
  and `.bg-default` CSS classes. (ocurrent/ansi#6, ocurrent/ansi#10, MisterDA)

* Fix bold/bright confusion, expose `.bold` CSS class. (ocurrent/ansi#6, ocurrent/ansi#10 @MisterDA)

* Expose alternative 16-colours colorschemes (xterm dark, solarized
  light and dark). (ocurrent/ansi#6, @MisterDA)
