### PR TITLE
bitcoin doesn't work on OCaml 5

### DIFF
--- a/packages/bitcoin/bitcoin.2.0/opam
+++ b/packages/bitcoin/bitcoin.2.0/opam
@@ -19,7 +19,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "bitcoin"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "yojson" {< "2.0.0"}
   "cryptokit"
   "ocamlbuild" {build}


### PR DESCRIPTION
It fails with:

```
  #=== ERROR while compiling bitcoin.2.0 ========================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/bitcoin.2.0
  # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0 --docdir /home/opam/.opam/5.0/doc/bitcoin --disable-ocsigen --disable-ocamlnet --disable-cohttp --disable-ocurl
  # exit-code            2
  # env-file             ~/.opam/log/bitcoin-7-a1d24e.env
  # output-file          ~/.opam/log/bitcoin-7-a1d24e.out
  ### output ###
  # File "./setup.ml", line 318, characters 20-36:
  # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
  #                           ^^^^^^^^^^^^^^^^
  # Error: Unbound value String.lowercase
```