### PR TITLE
old versions of mirage-logs do not work with OCaml 5

### DIFF
--- a/packages/mirage-logs/mirage-logs.0.1/opam
+++ b/packages/mirage-logs/mirage-logs.0.1/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "mirage-logs"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "logs" {>= "0.5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/mirage-logs/mirage-logs.0.2/opam
+++ b/packages/mirage-logs/mirage-logs.0.2/opam
@@ -9,7 +9,7 @@ build: [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: ["ocamlfind" "remove" "mirage-logs"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "logs" {>= "0.5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
They fail with:

```
  #=== ERROR while compiling mirage-logs.0.1 ====================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/mirage-logs.0.1
  # command              ~/.opam/opam-init/hooks/sandbox.sh build make PREFIX=/home/opam/.opam/5.0
  # exit-code            2
  # env-file             ~/.opam/log/mirage-logs-7-ed5965.env
  # output-file          ~/.opam/log/mirage-logs-7-ed5965.out
  ### output ###
  # ocaml setup.ml -configure
  # File "./setup.ml", line 318, characters 20-36:
  # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
  #                           ^^^^^^^^^^^^^^^^
  # Error: Unbound value String.lowercase
  # make: *** [Makefile:34: setup.data] Error 2
```