### PR TITLE
memtrace-mirage do not work on OCaml 5

### DIFF
--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.1/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.1/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/hannesm/memtrace-mirage"
 bug-reports: "https://github.com/hannesm/memtrace-mirage/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.0"}
   "mirage-flow" {>= "3.0.0"}
   "mirage-clock" {>= "4.0.0"}
   "ptime" {>= "1.0.0"}

--- a/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.2/opam
+++ b/packages/memtrace-mirage/memtrace-mirage.0.2.1.2.2/opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/hannesm/memtrace-mirage"
 bug-reports: "https://github.com/hannesm/memtrace-mirage/issues"
 depends: [
   "dune" {>= "2.3"}
-  "ocaml" {>= "4.11.0"}
+  "ocaml" {>= "4.11.0" & < "5.0"}
   "mirage-flow" {>= "3.0.0"}
   "mirage-clock" {>= "4.0.0"}
   "ptime" {>= "1.0.0"}


### PR DESCRIPTION
It fails with:

```
  #=== ERROR while compiling memtrace-mirage.0.2.1.2.2 ==========================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/memtrace-mirage.0.2.1.2.2
  # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p memtrace-mirage -j 47 @install
  # exit-code            1
  # env-file             ~/.opam/log/memtrace-mirage-8-18ec84.env
  # output-file          ~/.opam/log/memtrace-mirage-8-18ec84.out
  ### output ###
  # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.memtrace.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/mirage-clock -I /home/opam/.opam/5.0/lib/mirage-flow -I /home/opam/.opam/5.0/lib/ptime -intf-suffix .ml -no-alias-deps -open Memtrace__ -o src/.memtrace.objs/byte/memtrace__Trace.cmo -c -impl src/trace.ml)
  # File "src/trace.ml", lines 524-530, characters 16-4:
  # 524 | ................Hashtbl.MakeSeeded (struct
  # 525 |   type t = int
  # 526 |   let hash _seed (id : t) =
  # 527 |     let h = id * 189696287 in
  # 528 |     h lxor (h lsr 23)
  # 529 |   let equal (a : t) (b : t) = a = b
  # 530 | end)
  # Error: Modules do not match:
  #        sig
  #          type t = int
  #          val hash : 'a -> t -> int
  #          val equal : t -> t -> bool
  #        end
  #      is not included in Hashtbl.SeededHashedType
  #      The value `seeded_hash' is required but not provided
  #      File "hashtbl.mli", line 411, characters 4-36: Expected declaration
```

And is due to the Hashtbl signature changes in OCaml 5.