### PR TITLE
mirage-btrees does not work with OCaml 5

### DIFF
--- a/packages/mirage-btrees/mirage-btrees.0.1.0/opam
+++ b/packages/mirage-btrees/mirage-btrees.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "mirage-btrees"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "bisect_ppx" {>= "1.0.0"}


### PR DESCRIPTION
It fails with:

```
  #=== ERROR while compiling mirage-btrees.0.1.0 ================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.0.0+trunk | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/mirage-btrees.0.1.0
  # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
  # exit-code            2
  # env-file             ~/.opam/log/mirage-btrees-8-771100.env
  # output-file          ~/.opam/log/mirage-btrees-8-771100.out
  ### output ###
  # File "./setup.ml", line 318, characters 20-36:
  # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
  #                           ^^^^^^^^^^^^^^^^
  # Error: Unbound value String.lowercase
```