### PR TITLE
eio < 0.6 is not compatible with OCaml >= 5.0.0~beta1

### DIFF
--- a/packages/eio/eio.0.1/opam
+++ b/packages/eio/eio.0.1/opam
@@ -22,6 +22,10 @@ depends: [
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-base-compiler" {>= "5.0.0~beta1"}
+  "ocaml-variants" {>= "5.0.0~beta1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/eio/eio.0.2/opam
+++ b/packages/eio/eio.0.2/opam
@@ -22,6 +22,10 @@ depends: [
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-base-compiler" {>= "5.0.0~beta1"}
+  "ocaml-variants" {>= "5.0.0~beta1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/eio/eio.0.3/opam
+++ b/packages/eio/eio.0.3/opam
@@ -23,6 +23,10 @@ depends: [
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-base-compiler" {>= "5.0.0~beta1"}
+  "ocaml-variants" {>= "5.0.0~beta1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/eio/eio.0.4/opam
+++ b/packages/eio/eio.0.4/opam
@@ -23,6 +23,10 @@ depends: [
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-base-compiler" {>= "5.0.0~beta1"}
+  "ocaml-variants" {>= "5.0.0~beta1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/eio/eio.0.5/opam
+++ b/packages/eio/eio.0.5/opam
@@ -23,6 +23,10 @@ depends: [
   "alcotest" {>= "1.4.0" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "ocaml-base-compiler" {>= "5.0.0~beta1"}
+  "ocaml-variants" {>= "5.0.0~beta1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
Uses Unhandled was moved to the Effect module
```
#=== ERROR while compiling eio.0.5 ============================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/eio.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p eio -j 31 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/eio-7-dda50e.env
# output-file          ~/.opam/log/eio-7-dda50e.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib_eio/core/.eio__core.objs/byte -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/hmap -I /home/opam/.opam/5.0/lib/lwt-dllist -no-alias-deps -open Eio__core__ -o lib_eio/core/.eio__core.objs/byte/eio__core__Debug.cmo -c -impl lib_eio/core/debug.ml)
# File "lib_eio/core/debug.ml", line 32, characters 16-25:
# 32 |     | exception Unhandled -> default_traceln
#                      ^^^^^^^^^
# Error: This variant pattern is expected to have type exn
#        There is no constructor Unhandled within type exn
```