### PR TITLE
molenc is not compatible with OCaml 5.0 (uses Array.create)

### DIFF
--- a/packages/molenc/molenc.0.0.1/opam
+++ b/packages/molenc/molenc.0.0.1/opam
@@ -14,7 +14,7 @@ depends: [
   "parmap"
   "minicli"
   "conf-rdkit"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/molenc/molenc.1.0.0/opam
+++ b/packages/molenc/molenc.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "minicli"
   "conf-rdkit"
   "conf-python-3"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/molenc/molenc.1.1.0/opam
+++ b/packages/molenc/molenc.1.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "minicli"
   "conf-rdkit"
   "conf-python-3"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/molenc/molenc.11.4.0/opam
+++ b/packages/molenc/molenc.11.4.0/opam
@@ -26,7 +26,7 @@ depends: [
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlgraph"
   "owl"
   "parany" {>= "11.0.0"}

--- a/packages/molenc/molenc.15.4.0/opam
+++ b/packages/molenc/molenc.15.4.0/opam
@@ -31,7 +31,7 @@ depends: [
   "dolog" {>= "5.0.0"}
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "ocamlgraph"
   "parany" {>= "11.0.0"}
   "vector3"

--- a/packages/molenc/molenc.16.0.0/opam
+++ b/packages/molenc/molenc.16.0.0/opam
@@ -33,7 +33,7 @@ depends: [
   "dolog" {>= "5.0.0"}
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "ocamlgraph"
   "parany" {>= "11.0.0"}
   "vector3"

--- a/packages/molenc/molenc.16.13.0/opam
+++ b/packages/molenc/molenc.16.13.0/opam
@@ -39,7 +39,7 @@ depends: [
   "dune" {>= "1.11"}
   "line_oriented"
   "minicli" {>= "5.0.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "ocamlgraph"
   "parany" {>= "12.1.1"}
   "vector3"

--- a/packages/molenc/molenc.16.2.0/opam
+++ b/packages/molenc/molenc.16.2.0/opam
@@ -33,7 +33,7 @@ depends: [
   "dolog" {>= "5.0.0"}
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "ocamlgraph"
   "parany" {>= "12.1.1"}
   "vector3"

--- a/packages/molenc/molenc.16.5.0/opam
+++ b/packages/molenc/molenc.16.5.0/opam
@@ -33,7 +33,7 @@ depends: [
   "dolog" {>= "5.0.0"}
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "ocamlgraph"
   "parany" {>= "12.1.1"}
   "vector3"

--- a/packages/molenc/molenc.16.7.0/opam
+++ b/packages/molenc/molenc.16.7.0/opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "1.11"}
   "line_oriented"
   "minicli" {>= "5.0.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "ocamlgraph"
   "parany" {>= "12.1.1"}
   "vector3"

--- a/packages/molenc/molenc.2.0.0/opam
+++ b/packages/molenc/molenc.2.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "minicli"
   "conf-rdkit"
   "conf-python-3"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/molenc/molenc.4.0.2/opam
+++ b/packages/molenc/molenc.4.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "minicli"
   "conf-rdkit"
   "conf-python-3"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"
 description: """Chemical fingerprints are lossy encodings of molecules.

--- a/packages/molenc/molenc.5.0.0/opam
+++ b/packages/molenc/molenc.5.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "minicli" {>= "5.0.0"}
   "conf-rdkit"
   "conf-python-3"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "parmap" {>= "0.9.8"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"

--- a/packages/molenc/molenc.5.0.1/opam
+++ b/packages/molenc/molenc.5.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
   "minicli"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
   "parmap"
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"

--- a/packages/molenc/molenc.7.0.1/opam
+++ b/packages/molenc/molenc.7.0.1/opam
@@ -24,7 +24,7 @@ depends: [
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
   "minicli"
-  "ocaml"
+  "ocaml" {< "5.0"}
   "parany" {>= "9.0.0" & < "11.0.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"

--- a/packages/molenc/molenc.8.0.2/opam
+++ b/packages/molenc/molenc.8.0.2/opam
@@ -24,7 +24,7 @@ depends: [
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
   "minicli"
-  "ocaml"
+  "ocaml" {< "5.0"}
   "parany" {>= "9.0.0" & < "11.0.0"}
 ]
 synopsis: "Molecular encoder/featurizer using rdkit and OCaml"


### PR DESCRIPTION
```
#=== ERROR while compiling molenc.16.13.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/molenc.16.13.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p molenc -j 31
# exit-code            1
# env-file             ~/.opam/log/molenc-8-820872.env
# output-file          ~/.opam/log/molenc-8-820872.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.molenc.objs/byte -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/bst -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -I /home/opam/.opam/5.0/lib/pyml -I /home/opam/.opam/5.0/lib/stdcompat -I /home/opam/.opam/5.0/lib/vector3 -no-alias-deps -open Molenc -o src/.molenc.objs/byte/molenc__Sdf_3D.cmo -c -impl src/sdf_3D.ml)
# File "src/sdf_3D.ml", line 276, characters 14-22:
# 276 |   let bonds = A.create num_atoms [] in
#                     ^^^^^^^^
# Error: Unbound value A.create
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.molenc.objs/byte -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/bst -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -I /home/opam/.opam/5.0/lib/pyml -I /home/opam/.opam/5.0/lib/stdcompat -I /home/opam/.opam/5.0/lib/vector3 -no-alias-deps -open Molenc -o src/.molenc.objs/byte/molenc__Bloom.cmo -c -impl src/bloom.ml)
# File "src/bloom.ml", line 53, characters 12-20:
# 53 |   let res = A.create m 0 in (* dense output vector *)
#                  ^^^^^^^^
# Error: Unbound value A.create
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.molenc.objs/byte -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/bst -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -I /home/opam/.opam/5.0/lib/pyml -I /home/opam/.opam/5.0/lib/stdcompat -I /home/opam/.opam/5.0/lib/vector3 -no-alias-deps -open Molenc -o src/.molenc.objs/byte/molenc__WMH.cmo -c -impl src/WMH.ml)
# File "src/WMH.ml", line 73, characters 12-20:
# 73 |   let res = A.create total 0 in
#                  ^^^^^^^^
# Error: Unbound value A.create
```
cc @UnixJunkie 