### PR TITLE
Fix missing patch for ocaml-base-compiler 4.01.0

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/files/fix-clang-build.patch
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/files/fix-clang-build.patch
@@ -1,0 +1,20 @@
+diff --git a/configure b/configure
+index d45e88f..25d872b 100755
+--- a/configure
++++ b/configure
+@@ -322,7 +322,14 @@ case "$bytecc,$target" in
+     bytecccompopts="-fno-defer-pop $gcc_warnings -DSHRINKED_GNUC"
+     mathlib="";;
+   *,*-*-darwin*)
+-    bytecccompopts="-fno-defer-pop $gcc_warnings"
++    # On recent version of OSX, gcc is a symlink to clang
++    if $bytecc --version | grep -q clang; then
++        # -fno-defer-pop is not supported by clang, and make recent
++        # versions of clang to fail
++        bytecccompopts="$gcc_warnings"
++    else
++        bytecccompopts="-fno-defer-pop $gcc_warnings"
++    fi
+     mathlib=""
+     mkexe="$mkexe -Wl,-no_compact_unwind"
+     # Tell gcc that we can use 32-bit code addresses for threaded code

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -41,7 +41,7 @@ build: [
 ]
 install: [make "install"]
 patches: [
-  "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
+  "fix-clang-build.patch"
   "fix-gcc10.patch"
   "alt-signal-stack.patch"
 ]
@@ -49,12 +49,10 @@ url {
   src: "http://caml.inria.fr/pub/distrib/ocaml-4.01/ocaml-4.01.0.tar.gz"
   checksum: "md5=04dfdd7da189462a4f10ec6530359cef"
 }
-extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
-  src:
-    "https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff"
-  checksum: "md5=faccda3b3ab092fa9ac7d5d4d8beb004"
-}
-extra-files: ["fix-gcc10.patch" "md5=a5ee5f90499987223ca8c13896fa2c4c"]
+extra-files: [
+  ["fix-gcc10.patch" "md5=a5ee5f90499987223ca8c13896fa2c4c"]
+  ["fix-clang-build.patch" "md5=a8c6dd8e547a7b766138f7ca3eb1cbfd"]
+]
 available: arch != "arm64" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
   src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"


### PR DESCRIPTION
A patch on the URL [1] seems to return 404, as the account of jeremiedimino has been removed from GitHub. This means that ocaml-base-compiler.4.01.0 is failing, and so do all the packages which still depend on it (a transitive total of 29 packages, if my counting is correct).

https://github.com/Niols helped me locate the missing commits on Software Heritage's website [2]. There doesn't seem to be an easy way to just download the total diff from there, so instead we put the diff here directly.

The md5 checksum appears to be different. I'm not sure why that is. Potentially, the format of the diff is different.

It seems that the ocaml-base-compiler.4.01.0 now builds on both Linux and macOS.

[1]: https://github.com/jeremiedimino/ocaml/compare/bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff
[2]: https://archive.softwareheritage.org/browse/revision/f2fd13b96528323270c35c4a221032beb7c4e91f
