### PR TITLE
Package bls12-381.6.0.1

### DIFF
--- a/packages/bls12-381/bls12-381.6.0.1/opam
+++ b/packages/bls12-381/bls12-381.6.0.1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: """\
+Implementation of BLS12-381 and some cryptographic primitives built
+on top of it"""
+maintainer: "Danny Willems <be.danny.willems@gmail.com>"
+authors: "Danny Willems <be.danny.willems@gmail.com>"
+license: "MIT"
+homepage:
+  "https://nomadic-labs.gitlab.io/cryptography/ocaml-bls12-381/bls12-381/"
+bug-reports:
+  "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "ff-sig" {>= "0.6.1" & < "0.7.0"}
+  "zarith" {>= "1.10" & < "2.0"}
+  "zarith_stubs_js" {with-test}
+  "hex" {>= "1.3.0"}
+  "alcotest" {with-test}
+  "integers"
+  "integers_stubs_js" {with-test}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0"}
+  "odoc" {with-doc}
+]
+conflicts: ["ocaml-option-bytecode-only"]
+available: arch != "arm32" & arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/archive/6.0.1/ocaml-bls12-381-6.0.1.tar.gz"
+  checksum: [
+    "md5=6888479cbebb02f68b137d4bcc3a6488"
+    "sha512=f5395e1461cb5edba0e7072ca90c64bed50ae45b53fe76f4f071043f1b56f3967495c939757abe5307aa9d84b4bf33bd98e5a4c465016a42da4b4570d4503234"
+  ]
+}
+x-ci-accept-failures: ["centos-7" "oraclelinux-7"]


### PR DESCRIPTION
### `bls12-381.6.0.1`
Implementation of BLS12-381 and some cryptographic primitives built
on top of it



---
* Homepage: https://nomadic-labs.gitlab.io/cryptography/ocaml-bls12-381/bls12-381/
* Source repo: git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git
* Bug tracker: https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/issues

---
:camel: Pull-request generated by opam-publish v2.2.0