### PR TITLE
Old versions of eio do not work with pre-release versions of OCaml 5

### DIFF
--- a/packages/eio/eio.0.1/opam
+++ b/packages/eio/eio.0.1/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0~beta"}
   "base-domains"
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"

--- a/packages/eio/eio.0.2/opam
+++ b/packages/eio/eio.0.2/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0~beta"}
   "base-domains"
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"

--- a/packages/eio/eio.0.3/opam
+++ b/packages/eio/eio.0.3/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0~beta"}
   "base-domains"
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}

--- a/packages/eio/eio.0.5/opam
+++ b/packages/eio/eio.0.5/opam
@@ -9,7 +9,7 @@ doc: "https://ocaml-multicore.github.io/eio/"
 bug-reports: "https://github.com/ocaml-multicore/eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "5.0.0"}
+  "ocaml" {>= "5.0.0" & < "5.0.0~beta"}
   "bigstringaf" {>= "0.9.0"}
   "cstruct" {>= "6.0.1"}
   "lwt-dllist"


### PR DESCRIPTION
They fail with:

```
  #=== ERROR while compiling eio.0.5 ============================================#
  # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
  # path                 ~/.opam/5.0/.opam-switch/build/eio.0.5
  # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p eio -j 127 --promote-install-files=false @install
  # exit-code            1
  # env-file             ~/.opam/log/eio-7-2301fb.env
  # output-file          ~/.opam/log/eio-7-2301fb.out
  ### output ###
  # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib_eio/core/.eio__core.objs/byte -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/hmap -I /home/opam/.opam/5.0/lib/lwt-dllist -no-alias-deps -open Eio__core__ -o lib_eio/core/.eio__core.objs/byte/eio__core__Debug.cmo -c -impl lib_eio/core/debug.ml)
  # File "lib_eio/core/debug.ml", line 32, characters 16-25:
  # 32 |     | exception Unhandled -> default_traceln
  #                      ^^^^^^^^^
  # Error: This variant pattern is expected to have type exn
  #        There is no constructor Unhandled within type exn
```