### PR TITLE
fasmifra is not compatible with parany >= 13

### DIFF
--- a/packages/fasmifra/fasmifra.1.0.0/opam
+++ b/packages/fasmifra/fasmifra.1.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
   "ocaml"
-  "parany" {>= "12.0.0"}
+  "parany" {>= "12.0.0" & < "13.0.0"}
   "line_oriented" {>= "1.0.0"}
   "conf-rdkit" {>= "1"}
   "conf-python-3" {>= "1.0.0"}

--- a/packages/fasmifra/fasmifra.1.1.0/opam
+++ b/packages/fasmifra/fasmifra.1.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.11"}
   "minicli" {>= "5.0.0"}
   "ocaml"
-  "parany" {>= "12.0.0"}
+  "parany" {>= "12.0.0" & < "13.0.0"}
   "line_oriented" {>= "1.0.0"}
   "conf-rdkit" {>= "1"}
   "conf-python-3" {>= "1.0.0"}


### PR DESCRIPTION
Expects Parany.run to have ~init
```
#=== ERROR while compiling fasmifra.1.1.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/fasmifra.1.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p fasmifra -j 47
# exit-code            1
# env-file             ~/.opam/log/fasmifra-8-72e27a.env
# output-file          ~/.opam/log/fasmifra-8-72e27a.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.fasmifra.eobjs/byte -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/line_oriented -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/minicli -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -no-alias-deps -o src/.fasmifra.eobjs/byte/fasmifra.cmo -c -impl src/fasmifra.ml)
# File "src/fasmifra.ml", line 468, characters 18-28:
# 468 |             ~init:(init rng)
#                         ^^^^^^^^^^
# Error: The function applied to this argument has type ?preserve:bool -> unit
# This argument cannot be applied with label ~init
```
cc @UnixJunkie 