### PR TITLE
camltc is not compatible with OCaml 5.0 (uses deprecated C API)

### DIFF
--- a/packages/camltc/camltc.0.9.6/opam
+++ b/packages/camltc/camltc.0.9.6/opam
@@ -18,7 +18,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {> "4.02.2"}
+  "ocaml" {> "4.02.2" & < "5.0"}
   "ocamlfind" {build}
   "ounit"
   "lwt" {>= "3.2.0" & < "4.0.0"}

--- a/packages/camltc/camltc.0.9.7.0/opam
+++ b/packages/camltc/camltc.0.9.7.0/opam
@@ -13,7 +13,7 @@ remove: [
   ["ocamlfind" "remove" "camltc"]
 ]
 depends: [
-  "ocaml" {> "4.02.2"}
+  "ocaml" {> "4.02.2" & < "5.0"}
   "ocamlfind" {build}
   "ounit"
   "lwt" {>= "3.2.0"}

--- a/packages/camltc/camltc.0.9.8/opam
+++ b/packages/camltc/camltc.0.9.8/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {> "4.02.3"}
+  "ocaml" {> "4.02.3" & < "5.0"}
   "dune" {>= "1.1.0"}
   "lwt" {>= "3.2.0"}
   "logs" {>= "0.5.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling linwrap.9.0.0 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/linwrap.9.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p linwrap -j 255
# exit-code            1
# env-file             ~/.opam/log/linwrap-8-29041d.env
# output-file          ~/.opam/log/linwrap-8-29041d.out
### output ###
# File "src/dune", line 3, characters 16-23:
# 3 |   (names        linwrap)
#                     ^^^^^^^
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o src/linwrap.exe /home/opam/.opam/5.0/lib/ocaml/nums.cmxa -I /home/opam/.opam/5.0/lib/ocaml /home/opam/.opam/5.0/lib/camlp-streams/camlp_streams.cmxa /home/opam/.opam/5.0/lib/ocaml/str/str.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/batteries/batteries.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/batteries/batteriesThread.cmxa /home/opam/.opam/5.0/lib/cpm/cpm.cmxa /home/opam/.opam/5.0/lib/dolog/dolog.cmxa /home/opam/.opam/5.0/lib/minicli/minicli.cmxa /home/opam/.opam/5.0/lib/lockfree/lockfree.cmxa /home/opam/.opam/5.0/lib/domainslib/domainslib.cmxa /home/opam/.opam/5.0/lib/parany/parany.cmxa /home/opam/.opam/5.0/lib/extunix/ExtUnix.cmxa -I /home/opam/.opam/5.0/lib/extunix /home/opam/.opam/5.0/lib/dokeysto/dokeysto.cmxa /home/opam/.opam/5.0/lib/logs/logs.cmxa /home/opam/.opam/5.0/lib/lwt/lwt.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.0/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.0/lib/lwt/unix /home/opam/.opam/5.0/lib/logs/logs_lwt.cmxa /home/opam/.opam/5.0/lib/camltc/tc/tc.cmxa -I /home/opam/.opam/5.0/lib/camltc/tc /home/opam/.opam/5.0/lib/camltc/camltc.cmxa -I /home/opam/.opam/5.0/lib/camltc /home/opam/.opam/5.0/lib/dokeysto_camltc/dokeysto_camltc.cmxa src/.linwrap.eobjs/native/utls.cmx src/.linwrap.eobjs/native/gnuplot.cmx src/.linwrap.eobjs/native/perf.cmx src/.linwrap.eobjs/native/linwrap.cmx)
# /usr/bin/ld: /home/opam/.opam/5.0/lib/camltc/libcamltc_stubs.a(otc_wrapper.o): in function `alloc_bdb':
# /home/opam/.opam/5.0/.opam-switch/build/camltc.0.9.8/_build/default/src/otc_wrapper.c:67: undefined reference to `alloc_custom'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/camltc/libcamltc_stubs.a(otc_wrapper.o): in function `alloc_bdbcur':
# /home/opam/.opam/5.0/.opam-switch/build/camltc.0.9.8/_build/default/src/otc_wrapper.c:74: undefined reference to `alloc_custom'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/camltc/libcamltc_stubs.a(otc_wrapper.o): in function `bdb_key_count':
# /home/opam/.opam/5.0/.opam-switch/build/camltc.0.9.8/_build/default/src/otc_wrapper.c:621: undefined reference to `copy_int64'
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```
cc @toolslive 