### PR TITLE
orf is not compatible with OCaml 5.0 (uses Array.create)

### DIFF
--- a/packages/orf/orf.1.0.0/opam
+++ b/packages/orf/orf.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dolog" {>= "4.0.0"}
   "dune" {>= "2.8"}
   "minicli"
-  "ocaml"
+  "ocaml" {< "5.0"}
   "parany" {>= "11.0.0"}
   "line_oriented"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling orf.1.0.0 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/orf.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p orf -j 255
# exit-code            1
# env-file             ~/.opam/log/orf-7-2a97cb.env
# output-file          ~/.opam/log/orf-7-2a97cb.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.orf.objs/byte -I src/.orf.objs/public_cmi -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/cpm -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/line_oriented -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -no-alias-deps -open Orf -o src/.orf.objs/byte/orf__Utls.cmo -c -impl src/utls.ml)
# File "src/utls.ml", line 392, characters 14-22:
# 392 |   let flags = A.create n '0' in
#                     ^^^^^^^^
# Error: Unbound value A.create
```
cc @UnixJunkie 