### PR TITLE
odnnr is not compatible with parany >= 13

### DIFF
--- a/packages/odnnr/odnnr.2.0.0/opam
+++ b/packages/odnnr/odnnr.2.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "batteries"
   "minicli" {>= "5.0.0"}
-  "parany" {>= "11.0.0"}
+  "parany" {>= "11.0.0" & < "13.0.0"}
   "cpm"
   "conf-gnuplot"
 ]


### PR DESCRIPTION
expects Parany.Parmap.parmap to have ~core_pin
```
#=== ERROR while compiling odnnr.2.0.0 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/odnnr.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p odnnr -j 255
# exit-code            1
# env-file             ~/.opam/log/odnnr-8-9645b5.env
# output-file          ~/.opam/log/odnnr-8-9645b5.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.model.eobjs/byte -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/cpm -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/minicli -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -I src/.odnnr.objs/byte -no-alias-deps -o src/.model.eobjs/byte/model.cmo -c -impl src/model.ml)
# File "src/model.ml", line 268, characters 29-37:
# 268 |               Parmap.parmap ~core_pin ncores (fun (train_fn, test_fn) ->
#                                    ^^^^^^^^
# Error: The function applied to this argument has type
#          ?preserve:bool -> ?csize:int -> 'a list
# This argument cannot be applied with label ~core_pin
```
cc @UnixJunkie 