### PR TITLE
ocaml-initfiles is not compatible with OCaml 5.0 (uses String.lowercase)

### DIFF
--- a/packages/ocaml-inifiles/ocaml-inifiles.1.2/opam
+++ b/packages/ocaml-inifiles/ocaml-inifiles.1.2/opam
@@ -5,7 +5,11 @@ build: [
   [make "opt"]
 ]
 remove: [["ocamlfind" "remove" "inifiles"]]
-depends: ["ocaml" "ocamlfind" "pcre"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+  "pcre"
+]
 patches: ["ocaml-inifiles.diff"]
 install: [make "install"]
 synopsis: "An ini file parser"


### PR DESCRIPTION
```
#=== ERROR while compiling ocaml-inifiles.1.2 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocaml-inifiles.1.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/ocaml-inifiles-7-180dd1.env
# output-file          ~/.opam/log/ocaml-inifiles-7-180dd1.out
### output ###
# ocamllex inilexer.mll
# 27 states, 1999 transitions, table size 8158 bytes
# 7979 additional bytes used for bindings
# ocamlyacc  parseini.mly
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ocaml-inifiles.1.2'
# making ._bcdi/parseini.di from parseini.mli
# making ._bcdi/inifiles.di from inifiles.mli
# making ._d/parseini.d from parseini.ml
# making ._d/inilexer.d from inilexer.ml
# making ._d/inifiles.d from inifiles.ml
# ocamlfind ocamlc -package pcre -c -g parseini.mli
# ocamlfind ocamlc -package pcre -c -g parseini.ml
# ocamlfind ocamlc -package pcre -c -g inilexer.ml
# ocamlfind ocamlc -package pcre -c -g inifiles.mli
# ocamlfind ocamlc -package pcre -c -g inifiles.ml
# File "inifiles.ml", line 53, characters 20-36:
# 53 |     String.compare (String.lowercase x) (String.lowercase y)
#                          ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
# make[1]: *** [OCamlMakefile:935: inifiles.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/ocaml-inifiles.1.2'
# make: *** [OCamlMakefile:753: debug-code-library] Error 2
```