### PR TITLE
links < 0.9.7 is not compatible with OCaml 5.0

### DIFF
--- a/packages/links/links.0.9.3/opam
+++ b/packages/links/links.0.9.3/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "1.10.0"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}

--- a/packages/links/links.0.9.4/opam
+++ b/packages/links/links.0.9.4/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "1.10.0"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}

--- a/packages/links/links.0.9.5/opam
+++ b/packages/links/links.0.9.5/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.7"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}

--- a/packages/links/links.0.9.6/opam
+++ b/packages/links/links.0.9.6/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "dune" {>= "2.7"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.3"}


### PR DESCRIPTION
Uses Format.pp_set_formatter_tag_functions
```
#=== ERROR while compiling links.0.9.6 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/links.0.9.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p links -j 255
# exit-code            1
# env-file             ~/.opam/log/links-9-bdc962.env
# output-file          ~/.opam/log/links-9-bdc962.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I lens/.links_lens.objs/byte -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Links_lens__ -o lens/.links_lens.objs/byte/links_lens__Statistics.cmo -c -impl lens/statistics.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I lens/.links_lens.objs/byte -I lens/.links_lens.objs/native -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Links_lens__ -o lens/.links_lens.objs/native/links_lens__Statistics.cmx -c -impl lens/statistics.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I lens/.links_lens.objs/byte -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Links_lens__ -o lens/.links_lens.objs/byte/links_lens__Database.cmo -c -impl lens/database.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The str subdirectory has been
# automatically added to the search path, but you should add -I +str to the
# command-line to silence this alert (e.g. by adding str to the list of
# libraries in your dune file, or adding use_str to your _tags file for
# ocamlbuild, or using -package str for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I core/.links_core.objs/byte -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/byte/links_core__Debug.cmo -c -impl core/debug.pp.ml)
# File "core/debug.ml", line 25, characters 12-26:
# 25 | let f fmt = Printf.kprintf print fmt
#                  ^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I core/.links_core.objs/byte -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -no-alias-deps -open Links_core -o core/.links_core.objs/byte/links_core__Errors.cmi -c -intf core/errors.pp.mli)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I core/.links_core.objs/byte -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/byte/links_core__DatabaseDriver.cmo -c -impl core/databaseDriver.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I core/.links_core.objs/byte -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/byte/links_core__Errors.cmo -c -impl core/errors.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I lens/.links_lens.objs/byte -I lens/.links_lens.objs/native -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -open Links_lens__ -o lens/.links_lens.objs/native/links_lens__Database.cmx -c -impl lens/database.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The str subdirectory has been
# automatically added to the search path, but you should add -I +str to the
# command-line to silence this alert (e.g. by adding str to the list of
# libraries in your dune file, or adding use_str to your _tags file for
# ocamlbuild, or using -package str for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -bin-annot -I core/.links_core.objs/byte -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/byte/links_core__QueryLang.cmo -c -impl core/queryLang.pp.ml)
# File "core/query/queryLang.ml", line 29, characters 4-18:
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I core/.links_core.objs/byte -I core/.links_core.objs/native -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -I lens/.links_lens.objs/native -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/native/links_core__Debug.cmx -c -impl core/debug.pp.ml)
# File "core/debug.ml", line 25, characters 12-26:
# 25 | let f fmt = Printf.kprintf print fmt
#                  ^^^^^^^^^^^^^^
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I core/.links_core.objs/byte -I core/.links_core.objs/native -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -I lens/.links_lens.objs/native -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/native/links_core__Errors.cmx -c -impl core/errors.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I core/.links_core.objs/byte -I core/.links_core.objs/native -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -I lens/.links_lens.objs/native -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/native/links_core__DatabaseDriver.cmx -c -impl core/databaseDriver.pp.ml)
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The dynlink subdirectory has
# been automatically added to the search path, but you should add -I +dynlink
# to the command-line to silence this alert (e.g. by adding dynlink to the list
# of libraries in your dune file, or adding use_dynlink to your _tags file for
# ocamlbuild, or using -package dynlink for ocamlfind).
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I core/.links_core.objs/byte -I core/.links_core.objs/native -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cohttp -I /home/opam/.opam/5.0/lib/cohttp-lwt -I /home/opam/.opam/5.0/lib/cohttp-lwt-unix -I /home/opam/.opam/5.0/lib/conduit-lwt-unix -I /home/opam/.opam/5.0/lib/findlib -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/safepass -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/websocket -I /home/opam/.opam/5.0/lib/websocket-lwt-unix/cohttp -I /home/opam/.opam/5.0/lib/yojson -I lens/.links_lens.objs/byte -I lens/.links_lens.objs/native -intf-suffix .ml -no-alias-deps -open Links_core -o core/.links_core.objs/native/links_core__QueryLang.cmx -c -impl core/queryLang.pp.ml)
# File "core/query/queryLang.ml", line 29, characters 4-18:
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -strict-formats -strict-sequence -safe-string -bin-annot -w +A-4-42-44-45-48-60-67-70 -g -O3 -I bin/.links.eobjs/byte -I bin/.links.eobjs/native -I /home/opam/.opam/5.0/lib/ANSITerminal -I /home/opam/.opam/5.0/lib/linenoise -I /home/opam/.opam/5.0/lib/ocaml/dynlink -I /home/opam/.opam/5.0/lib/ocaml/threads -I core/.links_core.objs/byte -I core/.links_core.objs/native -intf-suffix .ml -no-alias-deps -open Dune__exe -o bin/.links.eobjs/native/dune__exe__Repl.cmx -c -impl bin/repl.ml)
# File "bin/repl.ml", line 64, characters 33-63:
# 64 |     begin [@alert "-deprecated"] pp_set_formatter_tag_functions
#                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value pp_set_formatter_tag_functions
# Hint: Did you mean pp_set_formatter_stag_functions?
```