### PR TITLE
plplot is not compatible with OCaml 5.0 (uses deprecated C API)

### DIFF
--- a/packages/plplot/plplot.5.11.0-1/opam
+++ b/packages/plplot/plplot.5.11.0-1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "dune" {>= "2.0.0"}
   "dune-configurator"
   "conf-plplot"

--- a/packages/plplot/plplot.5.11.0/opam
+++ b/packages/plplot/plplot.5.11.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "conf-plplot"


### PR DESCRIPTION
```
#=== ERROR while compiling plplot.5.11.0-1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/plplot.5.11.0-1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p plplot -j 31
# exit-code            1
# env-file             ~/.opam/log/plplot-7-b0038b.env
# output-file          ~/.opam/log/plplot-7-b0038b.out
### output ###
# File "src/dune", line 12, characters 39-47:
# 12 |   (names plplot_core_stubs plplot_impl idlalloc)
#                                             ^^^^^^^^
# (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -O2 -I/usr/include/plplot -g -I /home/opam/.opam/5.0/lib/ocaml -o idlalloc.o -c idlalloc.c)
# idlalloc.c: In function 'camlidl_find_enum':
# idlalloc.c:35:3: warning: implicit declaration of function 'invalid_argument'; did you mean 'caml_invalid_argument'? [-Wimplicit-function-declaration]
#    35 |   invalid_argument(errmsg);
#       |   ^~~~~~~~~~~~~~~~
#       |   caml_invalid_argument
# idlalloc.c: In function 'camlidl_alloc_flag_list':
# idlalloc.c:47:19: warning: implicit declaration of function 'alloc_small'; did you mean 'caml_alloc_small'? [-Wimplicit-function-declaration]
#    47 |         value v = alloc_small(2, 0);
#       |                   ^~~~~~~~~~~
#       |                   caml_alloc_small
```
cc @hcarty 