### PR TITLE
rawlink < 1.2 is not compatible with OCaml 5.0 (uses deprecated C API)

### DIFF
--- a/packages/rawlink/rawlink.0.6/opam
+++ b/packages/rawlink/rawlink.0.6/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/haesbaert/rawlink.git"
 doc: "https://haesbaert.github.io/rawlink/api"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "topkg" {build}
   "lwt" {>= "2.4.7" & < "4.0.0"}

--- a/packages/rawlink/rawlink.0.7/opam
+++ b/packages/rawlink/rawlink.0.7/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/haesbaert/rawlink.git"
 doc: "https://haesbaert.github.io/rawlink/api"
 build: [ "ocaml" "pkg/pkg.ml" "build" "--pinned" "%{pinned}%" ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "topkg" {build}
   "lwt" {>= "2.4.7" & < "4.0.0"}

--- a/packages/rawlink/rawlink.1.0/opam
+++ b/packages/rawlink/rawlink.1.0/opam
@@ -10,7 +10,7 @@ build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ] ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"
   "lwt" {>= "2.4.7"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling charrua-unix.1.3.0 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/charrua-unix.1.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p charrua-unix -j 255
# exit-code            1
# env-file             ~/.opam/log/charrua-unix-7-b4c78d.env
# output-file          ~/.opam/log/charrua-unix-7-b4c78d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I unix/.charruad.eobjs/byte -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/charrua -I /home/opam/.opam/5.0/lib/charrua-server -I /home/opam/.opam/5.0/lib/cmdliner -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/cstruct-lwt -I /home/opam/.opam/5.0/lib/cstruct-unix -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/duration -I /home/opam/.opam/5.0/lib/ethernet -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/ipaddr -I /home/opam/.opam/5.0/lib/ipaddr-sexp -I /home/opam/.opam/5.0/lib/logs -I /home/opam/.opam/5.0/lib/lru -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/macaddr -I /home/opam/.opam/5.0/lib/macaddr-sexp -I /home/opam/.opam/5.0/lib/mirage-clock -I /home/opam/.opam/5.0/lib/mirage-flow -I /home/opam/.opam/5.0/lib/mirage-net -I /home/opam/.opam/5.0/lib/mirage-profile -I /home/opam/.opam/5.0/lib/mirage-protocols -I /home/opam/.opam/5.0/lib/mirage-random -I /home/opam/.opam/5.0/lib/mtime -I /home/opam/.opam/5.0/lib/mtime/clock/os -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/psq -I /home/opam/.opam/5.0/lib/randomconv -I /home/opam/.opam/5.0/lib/rawlink -I /home/opam/.opam/5.0/lib/rawlink/lwt -I /home/opam/.opam/5.0/lib/rresult -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdlib-shims -I /home/opam/.opam/5.0/lib/tcpip -I /home/opam/.opam/5.0/lib/tcpip/ipv4 -I /home/opam/.opam/5.0/lib/tcpip/udp -I /home/opam/.opam/5.0/lib/tcpip/unix -I /home/opam/.opam/5.0/lib/tuntap -no-alias-deps -o unix/.charruad.eobjs/byte/charruad.cmo -c -impl unix/charruad.ml)
# File "unix/charruad.ml", line 93, characters 42-53:
# 93 |   let t = match Dhcp_wire.pkt_of_buf buf (Cstruct.len buf) with
#                                                ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "unix/charruad.ml", line 185, characters 8-12:
# 185 |   Term.(pure charruad $ configfile $ verbosity $ daemonize),
#               ^^^^
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "unix/charruad.ml", line 186, characters 2-11:
# 186 |   Term.info "charruad" ~version:"0.1" ~doc:"Charrua DHCPD"
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "unix/charruad.ml", line 187, characters 15-24:
# 187 | let () = match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0
#                      ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.eval
# Use Cmd.v and one of Cmd.eval* instead.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I unix/.charruad.eobjs/byte -I unix/.charruad.eobjs/native -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/charrua -I /home/opam/.opam/5.0/lib/charrua-server -I /home/opam/.opam/5.0/lib/cmdliner -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/cstruct-lwt -I /home/opam/.opam/5.0/lib/cstruct-unix -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/duration -I /home/opam/.opam/5.0/lib/ethernet -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/ipaddr -I /home/opam/.opam/5.0/lib/ipaddr-sexp -I /home/opam/.opam/5.0/lib/logs -I /home/opam/.opam/5.0/lib/lru -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/lwt_log -I /home/opam/.opam/5.0/lib/lwt_log/core -I /home/opam/.opam/5.0/lib/macaddr -I /home/opam/.opam/5.0/lib/macaddr-sexp -I /home/opam/.opam/5.0/lib/mirage-clock -I /home/opam/.opam/5.0/lib/mirage-flow -I /home/opam/.opam/5.0/lib/mirage-net -I /home/opam/.opam/5.0/lib/mirage-profile -I /home/opam/.opam/5.0/lib/mirage-protocols -I /home/opam/.opam/5.0/lib/mirage-random -I /home/opam/.opam/5.0/lib/mtime -I /home/opam/.opam/5.0/lib/mtime/clock/os -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/psq -I /home/opam/.opam/5.0/lib/randomconv -I /home/opam/.opam/5.0/lib/rawlink -I /home/opam/.opam/5.0/lib/rawlink/lwt -I /home/opam/.opam/5.0/lib/rresult -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdlib-shims -I /home/opam/.opam/5.0/lib/tcpip -I /home/opam/.opam/5.0/lib/tcpip/ipv4 -I /home/opam/.opam/5.0/lib/tcpip/udp -I /home/opam/.opam/5.0/lib/tcpip/unix -I /home/opam/.opam/5.0/lib/tuntap -intf-suffix .ml -no-alias-deps -o unix/.charruad.eobjs/native/charruad.cmx -c -impl unix/charruad.ml)
# File "unix/charruad.ml", line 93, characters 42-53:
# 93 |   let t = match Dhcp_wire.pkt_of_buf buf (Cstruct.len buf) with
#                                                ^^^^^^^^^^^
# Alert deprecated: Cstruct.len
# len is deprecated, you should use length instead.
# File "unix/charruad.ml", line 185, characters 8-12:
# 185 |   Term.(pure charruad $ configfile $ verbosity $ daemonize),
#               ^^^^
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "unix/charruad.ml", line 186, characters 2-11:
# 186 |   Term.info "charruad" ~version:"0.1" ~doc:"Charrua DHCPD"
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "unix/charruad.ml", line 187, characters 15-24:
# 187 | let () = match Term.eval cmd with `Error _ -> exit 1 | _ -> exit 0
#                      ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.eval
# Use Cmd.v and one of Cmd.eval* instead.
# File "unix/dune", line 2, characters 7-15:
# 2 |  (name charruad)
#            ^^^^^^^^
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o unix/charruad.exe /home/opam/.opam/5.0/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.0/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.0/lib/cstruct /home/opam/.opam/5.0/lib/macaddr/macaddr.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/lwt/lwt.cmxa /home/opam/.opam/5.0/lib/mirage-net/mirage_net.cmxa /home/opam/.opam/5.0/lib/mirage-flow/mirage_flow.cmxa /home/opam/.opam/5.0/lib/duration/duration.cmxa /home/opam/.opam/5.0/lib/domain-name/domain_name.cmxa /home/opam/.opam/5.0/lib/ipaddr/ipaddr.cmxa /home/opam/.opam/5.0/lib/mirage-protocols/mirage_protocols.cmxa /home/opam/.opam/5.0/lib/logs/logs.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/mirage-profile/mirage_profile.cmxa /home/opam/.opam/5.0/lib/ethernet/ethernet.cmxa /home/opam/.opam/5.0/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.0/lib/base/caml/caml.cmxa /home/opam/.opam/5.0/lib/parsexp/parsexp.cmxa /home/opam/.opam/5.0/lib/sexplib/sexplib.cmxa /home/opam/.opam/5.0/lib/psq/psq.cmxa /home/opam/.opam/5.0/lib/lru/lru.cmxa /home/opam/.opam/5.0/lib/mirage-clock/mirage_clock.cmxa /home/opam/.opam/5.0/lib/mirage-random/mirage_random.cmxa /home/opam/.opam/5.0/lib/randomconv/randomconv.cmxa /home/opam/.opam/5.0/lib/tcpip/tcpip.cmxa -I /home/opam/.opam/5.0/lib/tcpip /home/opam/.opam/5.0/lib/tcpip/udp/tcpip_udpv4.cmxa /home/opam/.opam/5.0/lib/tcpip/ipv4/tcpip_ipv4.cmxa /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/5.0/lib/ipaddr-sexp/ipaddr_sexp.cmxa /home/opam/.opam/5.0/lib/macaddr-sexp/macaddr_sexp.cmxa /home/opam/.opam/5.0/lib/rresult/rresult.cmxa /home/opam/.opam/5.0/lib/charrua/dhcp_wire.cmxa /home/opam/.opam/5.0/lib/charrua-server/dhcp_server.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.0/lib/lwt/unix /home/opam/.opam/5.0/lib/cstruct-lwt/cstruct_lwt.cmxa /home/opam/.opam/5.0/lib/cstruct-unix/cstruct_unix.cmxa /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/tuntap/tuntap.cmxa -I /home/opam/.opam/5.0/lib/tuntap /home/opam/.opam/5.0/lib/rawlink/rawlink.cmxa -I /home/opam/.opam/5.0/lib/rawlink /home/opam/.opam/5.0/lib/rawlink/lwt/lwt_rawlink.cmxa /home/opam/.opam/5.0/lib/mtime/mtime.cmxa /home/opam/.opam/5.0/lib/mtime/clock/os/mtime_clock.cmxa -I /home/opam/.opam/5.0/lib/mtime/clock/os /home/opam/.opam/5.0/lib/tcpip/unix/tcpip_unix.cmxa /home/opam/.opam/5.0/lib/lwt_log/core/lwt_log_core.cmxa /home/opam/.opam/5.0/lib/lwt_log/lwt_log.cmxa unix/.charruad.eobjs/native/charruad.cmx)
# /usr/bin/ld: /home/opam/.opam/5.0/lib/rawlink/librawlink_stubs.a(rawlink_stubs.o): in function `af_packet_open':
# /home/opam/.opam/5.0/.opam-switch/build/rawlink.1.0/_build/default/lib/rawlink_stubs.c:214: undefined reference to `enter_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/rawlink.1.0/_build/default/lib/rawlink_stubs.c:216: undefined reference to `leave_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/lib/rawlink/librawlink_stubs.a(rawlink_stubs.o): in function `af_packet_setif':
# /home/opam/.opam/5.0/.opam-switch/build/rawlink.1.0/_build/default/lib/rawlink_stubs.c:241: undefined reference to `enter_blocking_section'
# /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/rawlink.1.0/_build/default/lib/rawlink_stubs.c:243: undefined reference to `leave_blocking_section'
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```