### PR TITLE
pgocaml is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/pgocaml/pgocaml.1.6/opam
+++ b/packages/pgocaml/pgocaml.1.6/opam
@@ -12,7 +12,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "extlib" {= "1.5.3"}
   "pcre"

--- a/packages/pgocaml/pgocaml.2.2/opam
+++ b/packages/pgocaml/pgocaml.2.2/opam
@@ -13,7 +13,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "base-bytes"
   "pcre"

--- a/packages/pgocaml/pgocaml.2.3/opam
+++ b/packages/pgocaml/pgocaml.2.3/opam
@@ -13,7 +13,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "base-bytes"
   "calendar" {>= "2.00"}
   "csv"

--- a/packages/pgocaml/pgocaml.3.0/opam
+++ b/packages/pgocaml/pgocaml.3.0/opam
@@ -15,7 +15,7 @@ build: [
 install: [[make "install"]]
 remove: [["ocamlfind" "remove" "pgocaml"]]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "base-bytes"
   "calendar" {>= "2.00"}
   "csv"

--- a/packages/pgocaml/pgocaml.4.0/opam
+++ b/packages/pgocaml/pgocaml.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "csv"
   "dune" {>= "1.10"}
   "hex"
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "re"
 ]
 url {

--- a/packages/pgocaml/pgocaml.4.2.2/opam
+++ b/packages/pgocaml/pgocaml.4.2.2/opam
@@ -19,7 +19,7 @@ depends: [
   "csv"
   "dune" {>= "1.10"}
   "hex"
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "ppx_sexp_conv"
   "re"
   "ppx_deriving" {>= "4.0"}

--- a/packages/pgocaml/pgocaml.4.2/opam
+++ b/packages/pgocaml/pgocaml.4.2/opam
@@ -19,7 +19,7 @@ depends: [
   "csv"
   "dune" {>= "1.10"}
   "hex"
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "ppx_sexp_conv"
   "re"
   "ppx_deriving" {>= "4.0"}

--- a/packages/pgocaml/pgocaml.4.3.0/opam
+++ b/packages/pgocaml/pgocaml.4.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "csv"
   "dune" {>= "1.10"}
   "hex"
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "ppx_sexp_conv"
   "re" {>= "1.5.0"}
   "ppx_deriving" {>= "4.2"}


### PR DESCRIPTION
```
#=== ERROR while compiling pgocaml.4.3.0 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/pgocaml.4.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pgocaml -j 127
# exit-code            1
# env-file             ~/.opam/log/pgocaml-7-07bb95.env
# output-file          ~/.opam/log/pgocaml-7-07bb95.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.PGOCaml.objs/byte -I src/.PGOCaml.objs/native -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/csv -I /home/opam/.opam/5.0/lib/hex -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/rresult -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -o src/.PGOCaml.objs/native/pGOCaml_generic.cmx -c -impl src/PGOCaml_generic.pp.ml)
# File "src/PGOCaml_generic.ml", line 1813, characters 34-45:
# 1813 |     if List.exists (fun c -> c <> Stream.next stream) target
#                                          ^^^^^^^^^^^
# Error: Unbound module Stream
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.PGOCaml.objs/byte -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/calendar -I /home/opam/.opam/5.0/lib/cstruct -I /home/opam/.opam/5.0/lib/csv -I /home/opam/.opam/5.0/lib/hex -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_deriving/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/rresult -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -o src/.PGOCaml.objs/byte/pGOCaml_generic.cmo -c -impl src/PGOCaml_generic.pp.ml)
# File "src/PGOCaml_generic.ml", line 1813, characters 34-45:
# 1813 |     if List.exists (fun c -> c <> Stream.next stream) target
#                                          ^^^^^^^^^^^
# Error: Unbound module Stream
```