### PR TITLE
afl-persistent >= 1.1 does not handle not having ocamlopt

### DIFF
--- a/packages/afl-persistent/afl-persistent.1.1/opam
+++ b/packages/afl-persistent/afl-persistent.1.1/opam
@@ -13,6 +13,9 @@ depends: [
   "topkg" {build & >= "0.7.6"}
   "base-unix"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 synopsis: "use afl-fuzz in persistent mode"
 description: """
 afl-fuzz normally works by repeatedly fork()ing the program being

--- a/packages/afl-persistent/afl-persistent.1.2/opam
+++ b/packages/afl-persistent/afl-persistent.1.2/opam
@@ -11,6 +11,9 @@ depends: [
   "ocamlfind"
   "base-unix"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 post-messages: [
 "afl-persistent is installed, but since AFL instrumentation is not available
 with this OCaml compiler, instrumented fuzzing with afl-fuzz won't work.

--- a/packages/afl-persistent/afl-persistent.1.3/opam
+++ b/packages/afl-persistent/afl-persistent.1.3/opam
@@ -10,6 +10,9 @@ depends: [
   "ocaml" {>= "4.00"}
   "base-unix"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 post-messages: [
 "afl-persistent is installed, but since AFL instrumentation is not available
 with this OCaml compiler, instrumented fuzzing with afl-fuzz won't work.


### PR DESCRIPTION
```
#=== ERROR while compiling afl-persistent.1.3 =================================#
# context              2.2.0~alpha~dev | linux/arm32 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/afl-persistent.1.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./build.sh
# exit-code            127
# env-file             ~/.opam/log/afl-persistent-7-9b2171.env
# output-file          ~/.opam/log/afl-persistent-7-9b2171.out
### output ###
# + dirname ./build.sh
# + cd .
# + rm -rf _build/
# + rm -f afl-persistent.config
# + mkdir _build
# + cd _build
# + ocamlc=ocamlc -g -bin-annot
# + ocamlopt=ocamlopt -g -bin-annot
# + echo print_string "hello"
# + ocamlopt -dcmm -c afl_check.ml
# + grep -q caml_afl
# + afl_always=false
# + ocamlopt -afl-instrument afl_check.ml -o test
# + [  = hello ]
# + ocamlopt -version
# ./build.sh: 23: ocamlopt: not found
# + [  = 4.04.0+afl ]
# + afl_available=false
# + cat
# + cp ../aflPersistent.mli .
# + [ false = true ]
# + cp ../aflPersistent-stub.ml aflPersistent.ml
# + ocamlc -g -bin-annot -c aflPersistent.mli
# + ocamlc -g -bin-annot -c aflPersistent.ml
# + ocamlc -g -bin-annot -a aflPersistent.cmo -o afl-persistent.cma
# + ocamlopt -g -bin-annot -c aflPersistent.ml
# ./build.sh: 50: ocamlopt: not found
```