### PR TITLE
dream < 1.0.0~alpha4 is not compatible with OCaml 5.0 (uses Stream)

### DIFF
--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -67,7 +67,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
   "multipart-form-data" {>= "0.3.0" & < "0.4.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "opam-installer" {build}
   "uri" {>= "4.0.0"}
   "yojson"  # ...

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -68,7 +68,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
   "multipart_form" {>= "0.3.0" & < "0.4.0"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "uri" {>= "4.2.0"}
   "yojson"  # ...
 

--- a/packages/dream/dream.1.0.0~alpha3/opam
+++ b/packages/dream/dream.1.0.0~alpha3/opam
@@ -69,7 +69,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
   "multipart_form" {>= "0.4.0"}
   "multipart_form-lwt"
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ptime" {>= "0.8.1"}  # Ptime.v.
   "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
   "uri" {>= "4.2.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling dream.1.0.0~alpha2 =================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/dream.1.0.0~alpha2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dream -j 127
# exit-code            1
# env-file             ~/.opam/log/dream-8-93e7f4.env
# output-file          ~/.opam/log/dream-8-93e7f4.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/eml/.eml.objs/byte -no-alias-deps -o src/eml/.eml.objs/byte/eml.cmo -c -impl src/eml/eml.ml)
# File "src/eml/eml.ml", line 39, characters 4-15:
# 39 |     Stream.from begin fun _index ->
#          ^^^^^^^^^^^
# Error: Unbound module Stream
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/vendor/h2/lib/.h2.objs/byte -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/faraday -I /home/opam/.opam/5.0/lib/psq -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I src/vendor/h2/hpack/src/.hpack.objs/byte -I src/vendor/httpaf/lib/.httpaf.objs/byte -no-alias-deps -open H2__ -o src/vendor/h2/lib/.h2.objs/byte/h2__Scheduler.cmo -c -impl src/vendor/h2/lib/scheduler.ml)
# File "src/vendor/h2/lib/scheduler.ml", lines 34-40, characters 10-6:
# 34 | ..........Hashtbl.MakeSeeded (struct
# 35 |     type t = Stream_identifier.t
# 36 | 
# 37 |     let equal = Stream_identifier.( === )
# 38 | 
# 39 |     let hash i k = Hashtbl.seeded_hash i k
# 40 |   end)
# Error: Modules do not match:
#        sig
#          type t = H2__.Stream_identifier.t
#          val equal : Int32.t -> Int32.t -> bool
#          val hash : int -> 'a -> int
#        end
#      is not included in Hashtbl.SeededHashedType
#      The value `seeded_hash' is required but not provided
#      File "hashtbl.mli", line 411, characters 4-36: Expected declaration