### PR TITLE
piaf is not compatible with OCaml 5.0

### DIFF
--- a/packages/piaf/piaf.0.1.0/opam
+++ b/packages/piaf/piaf.0.1.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "2.5"}
   "angstrom"
   "faraday" {>= "0.8.1"}


### PR DESCRIPTION
uses Hashtbl.MakeSeeded without seeded_hash
```

#=== ERROR while compiling piaf.0.1.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/piaf.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p piaf -j 47
# exit-code            1
# env-file             ~/.opam/log/piaf-8-f3a9c6.env
# output-file          ~/.opam/log/piaf-8-f3a9c6.out
### output ###
[...]
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I vendor/ocaml-h2/lib/.h2.objs/byte -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/faraday -I /home/opam/.opam/5.0/lib/psq -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I vendor/httpaf/lib/.httpaf.objs/byte -I vendor/ocaml-h2/hpack/src/.hpack.objs/byte -no-alias-deps -open H2__ -o vendor/ocaml-h2/lib/.h2.objs/byte/h2__Scheduler.cmo -c -impl vendor/ocaml-h2/lib/scheduler.ml)
# File "vendor/ocaml-h2/lib/scheduler.ml", lines 34-40, characters 10-6:
# 34 | ..........Hashtbl.MakeSeeded (struct
# 35 |     type t = Stream_identifier.t
# 36 | 
# 37 |     let equal = Stream_identifier.( === )
# 38 | 
# 39 |     let hash i k = Hashtbl.seeded_hash i k
# 40 |   end)
# Error: Modules do not match:
#        sig
#          type t = H2__.Stream_identifier.t
#          val equal : Int32.t -> Int32.t -> bool
#          val hash : int -> 'a -> int
#        end
#      is not included in Hashtbl.SeededHashedType
#      The value `seeded_hash' is required but not provided
#      File "hashtbl.mli", line 411, characters 4-36: Expected declaration
```
cc @anmonteiro 