### PR TITLE
decompress >= 1.3.0's tests are not compatible with OCam 5.0

### DIFF
--- a/packages/decompress/decompress.1.3.0/opam
+++ b/packages/decompress/decompress.1.3.0/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}

--- a/packages/decompress/decompress.1.4.0/opam
+++ b/packages/decompress/decompress.1.4.0/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}

--- a/packages/decompress/decompress.1.4.1/opam
+++ b/packages/decompress/decompress.1.4.1/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}

--- a/packages/decompress/decompress.1.4.2/opam
+++ b/packages/decompress/decompress.1.4.2/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}

--- a/packages/decompress/decompress.1.4.3/opam
+++ b/packages/decompress/decompress.1.4.3/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}

--- a/packages/decompress/decompress.1.5.0/opam
+++ b/packages/decompress/decompress.1.5.0/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}

--- a/packages/decompress/decompress.1.5.1/opam
+++ b/packages/decompress/decompress.1.5.1/opam
@@ -13,7 +13,7 @@ It provides a pure non-blocking interface to inflate and deflate data flow.
 """
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {ocaml:version < "5.0"}
 
 depends: [
   "ocaml"       {>= "4.07.0"}


### PR DESCRIPTION
does not use ocamlc_cflags and is missing -pthread
```
#=== ERROR while compiling decompress.1.4.3 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/decompress.1.4.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p decompress -j 31
# exit-code            1
# env-file             ~/.opam/log/decompress-7-7eb0ff.env
# output-file          ~/.opam/log/decompress-7-7eb0ff.out
### output ###
# (cd _build/default/bindings/stubs && /usr/bin/ar r libdecompress.a decompress.exe.o)
# /usr/bin/ar: creating libdecompress.a
# File "test/bin/bindings.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/4148436792060c737cdfcfedb1cd3652/default/test/bin/bindings.t _build/.sandbox/4148436792060c737cdfcfedb1cd3652/default/test/bin/bindings.t.corrected
# diff --git a/_build/.sandbox/4148436792060c737cdfcfedb1cd3652/default/test/bin/bindings.t b/_build/.sandbox/4148436792060c737cdfcfedb1cd3652/default/test/bin/bindings.t.corrected
# index fcd757c..e1aa589 100644
# --- a/_build/.sandbox/4148436792060c737cdfcfedb1cd3652/default/test/bin/bindings.t
# +++ b/_build/.sandbox/4148436792060c737cdfcfedb1cd3652/default/test/bin/bindings.t.corrected
# @@ -24,6 +24,52 @@ Test reverse bindings
#    > }
#    > EOF
#    $ cc -o a.out main.c -I$(ocamlopt -where) -L../../bindings/stubs -I../../bindings/stubs -ldecompress -lm -ldl
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `install_backup_thread':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1005: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1009: undefined reference to `pthread_create'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1012: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1018: undefined reference to `pthread_detach'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `domain_thread_func':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1086: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `domain_terminate':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1662: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_domain_spawn':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1148: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1151: undefined reference to `pthread_create'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1154: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1178: undefined reference to `pthread_detach'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1182: undefined reference to `pthread_join'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_plat_try_lock':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/caml/platform.h:162: undefined reference to `pthread_mutex_trylock'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/caml/platform.h:162: undefined reference to `pthread_mutex_trylock'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_recommended_domain_count':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/domain.c:1795: undefined reference to `pthread_getaffinity_np'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_plat_try_lock':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/caml/platform.h:162: undefined reference to `pthread_mutex_trylock'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_plat_mutex_init':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/platform.c:50: undefined reference to `pthread_mutexattr_init'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/platform.c:52: undefined reference to `pthread_mutexattr_settype'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/platform.c:57: undefined reference to `pthread_mutexattr_destroy'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/platform.c:57: undefined reference to `pthread_mutexattr_destroy'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_plat_cond_init_aux':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/platform.c:96: undefined reference to `pthread_condattr_setclock'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_execute_signal_exn':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/signals.c:216: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/signals.c:229: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `caml_process_pending_signals_exn':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/signals.c:75: undefined reference to `pthread_sigmask'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `sync_mutex_create':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:40: undefined reference to `pthread_mutexattr_init'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:54: undefined reference to `pthread_mutexattr_destroy'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:42: undefined reference to `pthread_mutexattr_settype'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:54: undefined reference to `pthread_mutexattr_destroy'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:48: undefined reference to `pthread_mutexattr_destroy'
# +  /usr/bin/ld: ../../bindings/stubs/libdecompress.a(decompress.exe.o): in function `sync_mutex_trylock':
# +  /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:77: undefined reference to `pthread_mutex_trylock'
# +  /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ocaml-base-compiler.5.0.0/runtime/sync_posix.h:77: undefined reference to `pthread_mutex_trylock'
# +  collect2: error: ld returned 1 exit status
# +  [1]
#    $ ./a.out
# -  Hello World!
# +  ./a.out: not found
# +  [127]
```
cc @dinosaure 