### PR TITLE
webmachine < 0.5.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/webmachine/webmachine.0.1.0/opam
+++ b/packages/webmachine/webmachine.0.1.0/opam
@@ -21,7 +21,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "ounit" {with-test}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.1.1/opam
+++ b/packages/webmachine/webmachine.0.1.1/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "1.0.2"}

--- a/packages/webmachine/webmachine.0.1.2/opam
+++ b/packages/webmachine/webmachine.0.1.2/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "1.0.2"}

--- a/packages/webmachine/webmachine.0.2.0/opam
+++ b/packages/webmachine/webmachine.0.2.0/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {< "0.2.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.2.1/opam
+++ b/packages/webmachine/webmachine.0.2.1/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {= "0.2.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.2.2/opam
+++ b/packages/webmachine/webmachine.0.2.2/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {= "0.2.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.2.3/opam
+++ b/packages/webmachine/webmachine.0.2.3/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.2.4/opam
+++ b/packages/webmachine/webmachine.0.2.4/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.3.0/opam
+++ b/packages/webmachine/webmachine.0.3.0/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.3.1/opam
+++ b/packages/webmachine/webmachine.0.3.1/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.3.2/opam
+++ b/packages/webmachine/webmachine.0.3.2/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "webmachine"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0"}
   "cohttp" {>= "0.12.0" & < "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "ocamlfind" {build}

--- a/packages/webmachine/webmachine.0.4.0/opam
+++ b/packages/webmachine/webmachine.0.4.0/opam
@@ -16,7 +16,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "webmachine"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0"}
   "calendar" {>= "2.03.2"}
   "cohttp" {>= "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling webmachine.0.4.0 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/webmachine.0.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/webmachine-7-300f57.env
# output-file          ~/.opam/log/webmachine-7-300f57.out
### output ###
# File "./setup.ml", line 1404, characters 23-41:
# 1404 |          let compare = Pervasives.compare
#                               ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```