### PR TITLE
Mark kind2 packages as not compatible with ocaml5

### DIFF
--- a/packages/kind2/kind2.1.3.0/opam
+++ b/packages/kind2/kind2.1.3.0/opam
@@ -10,7 +10,7 @@ homepage: "https://kind2-mc.github.io/kind2"
 doc: "https://kind.cs.uiowa.edu/kind2_user_doc"
 bug-reports: "https://github.com/kind2-mc/kind2/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "dune" {>= "2.0"}
   "dune-build-info"
   "menhir" {< "20211215"}

--- a/packages/kind2/kind2.1.3.1/opam
+++ b/packages/kind2/kind2.1.3.1/opam
@@ -10,7 +10,7 @@ homepage: "https://kind2-mc.github.io/kind2"
 doc: "https://kind.cs.uiowa.edu/kind2_user_doc"
 bug-reports: "https://github.com/kind2-mc/kind2/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "dune" {>= "2.0"}
   "dune-build-info"
   "menhir" {< "20211215"}

--- a/packages/kind2/kind2.1.4.0/opam
+++ b/packages/kind2/kind2.1.4.0/opam
@@ -15,7 +15,7 @@ homepage: "https://kind2-mc.github.io/kind2"
 doc: "https://kind.cs.uiowa.edu/kind2_user_doc"
 bug-reports: "https://github.com/kind2-mc/kind2/issues"
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0"}
   "dune" {>= "2.0"}
   "dune-build-info"
   "menhir" {< "20211215"}


### PR DESCRIPTION
```
#=== ERROR while compiling kind2.1.3.0 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/kind2.1.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p kind2 -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/kind2-7-f6bb1f.env
# output-file          ~/.opam/log/kind2-7-f6bb1f.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.kind2dev.objs/byte -I src/.kind2dev.objs/native -I /home/opam/.opam/5.0/lib/dune-build-info -I /home/opam/.opam/5.0/lib/menhirLib -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdint -I /home/opam/.opam/5.0/lib/yojson -I /home/opam/.opam/5.0/lib/zmq -intf-suffix .ml -no-alias-deps -o src/.kind2dev.objs/native/pretty.cmx -c -impl src/utils/pretty.ml)
# File "src/utils/pretty.ml", line 240, characters 15-52:
# 240 |   let old_fs = Format.pp_get_formatter_tag_functions formatter () in
#                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Format.pp_get_formatter_tag_functions
# Hint: Did you mean pp_get_formatter_stag_functions?
```

From https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a27a671c76fba1d3b86d71f6a87f5e881186ce00