### PR TITLE
assertions.0.1 not compatible with ocaml5

### DIFF
--- a/packages/assertions/assertions.0.1/opam
+++ b/packages/assertions/assertions.0.1/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "assertions"]
 depends: [
-  "ocaml"
+  "ocaml" {<"5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling assertions.0.1 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/assertions.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure
# exit-code            2
# env-file             ~/.opam/log/assertions-7-4b45ea.env
# output-file          ~/.opam/log/assertions-7-4b45ea.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```