### PR TITLE
bear.0.0.1 not compatible with ocaml5

### DIFF
--- a/packages/bear/bear.0.0.1/opam
+++ b/packages/bear/bear.0.0.1/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "bear"]
 ]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling bear.0.0.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/bear.0.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/bear-6-163c01.env
# output-file          ~/.opam/log/bear-6-163c01.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```