### PR TITLE
bechamel.0.[12].0 are not compatible with ocaml5

### DIFF
--- a/packages/bechamel/bechamel.0.1.0/opam
+++ b/packages/bechamel/bechamel.0.1.0/opam
@@ -18,7 +18,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.08.0"}
+  "ocaml"      {>= "4.08.0" & < "5.0"}
   "dune"       {>= "2.0.0"}
   "fmt"
   "base-bytes"

--- a/packages/bechamel/bechamel.0.2.0/opam
+++ b/packages/bechamel/bechamel.0.2.0/opam
@@ -17,7 +17,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"      {>= "4.08.0"}
+  "ocaml"      {>= "4.08.0" & < "5.0"}
   "dune"       {>= "2.0.0"}
   "fmt"        {>= "0.9.0"}
   "base-bytes"


### PR DESCRIPTION
```
#=== ERROR while compiling bechamel.0.1.0 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/bechamel.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bechamel -j 127
# exit-code            1
# env-file             ~/.opam/log/bechamel-7-0fa4b7.env
# output-file          ~/.opam/log/bechamel-7-0fa4b7.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.bechamel.objs/byte -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/stdlib-shims -I lib/monotonic_clock/.monotonic_clock.objs/byte -intf-suffix .ml -no-alias-deps -open Bechamel__ -o lib/.bechamel.objs/byte/bechamel__Ext.cmo -c -impl lib/ext.ml)
# File "lib/ext.ml", line 30, characters 9-32:
# 30 |         (Stdlib.Obj.extension_id [%extension_constructor T] [@warning "-3"])
#               ^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Stdlib.Obj.extension_id
```