### PR TITLE
beluga.1.0 not compatible with ocaml5

### DIFF
--- a/packages/beluga/beluga.1.0/opam
+++ b/packages/beluga/beluga.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "extlib"
   "gen"
   "linenoise"
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "sedlex"
 ]
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
```
#=== ERROR while compiling beluga.1.0 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/beluga.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p beluga -j 47
# exit-code            1
# env-file             ~/.opam/log/beluga-7-baf398.env
# output-file          ~/.opam/log/beluga-7-baf398.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/core/.beluga.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/extlib -I /home/opam/.opam/5.0/lib/gen -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/sedlex -I /home/opam/.opam/5.0/lib/seq -I src/support/.support.objs/byte -no-alias-deps -open Beluga -o src/core/.beluga.objs/byte/beluga__Gensym.cmi -c -intf src/core/gensym.pp.mli)
# File "src/core/gensym.mli", line 1, characters 44-52:
# 1 | val create_symbols : string array -> string Stream.t
#                                                 ^^^^^^^^
# Error: Unbound module Stream
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/core/.beluga.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/extlib -I /home/opam/.opam/5.0/lib/gen -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/sedlex -I /home/opam/.opam/5.0/lib/seq -I src/support/.support.objs/byte -no-alias-deps -open Beluga -o src/core/.beluga.objs/byte/beluga__LinkStream.cmi -c -intf src/core/linkStream.pp.mli)
# File "src/core/linkStream.mli", line 41, characters 19-27:
# 41 | val of_stream : 'a Stream.t -> 'a t
#                         ^^^^^^^^
# Error: Unbound module Stream
```