### PR TITLE
Some versions of bisect_ppx are imcompatible with ocaml5

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.6.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.6.0/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.7.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.0/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.7.1/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.7.1/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}

--- a/packages/bisect_ppx/bisect_ppx.2.8.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.0/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "cmdliner" {>= "1.0.0"}
   "dune" {>= "2.7.0"}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ppxlib" {>= "0.21.0" & < "0.26.0"}
 
   "ocamlformat" {with-test & = "0.16.0"}


### PR DESCRIPTION
```
#=== ERROR while compiling bisect_ppx.2.6.0 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/bisect_ppx.2.6.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bisect_ppx -j 71
# exit-code            1
# env-file             ~/.opam/log/bisect_ppx-7-a0b677.env
# output-file          ~/.opam/log/bisect_ppx-7-a0b677.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/runtime/native/.bisect.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I src/common/.bisect_common.objs/byte -intf-suffix .ml -no-alias-deps -open Bisect -o src/runtime/native/.bisect.objs/byte/bisect__Runtime.cmo -c -impl src/runtime/native/runtime.ml)
# File "src/runtime/native/runtime.ml", line 37, characters 11-27:
# 37 |     match (String.uppercase [@ocaml.warning "-3"]) fname with
#                 ^^^^^^^^^^^^^^^^
# Error: Unbound value String.uppercase
```