### PR TITLE
bracetax.0.4 not compatible with ocaml5

### DIFF
--- a/packages/bracetax/bracetax.0.4/opam
+++ b/packages/bracetax/bracetax.0.4/opam
@@ -16,7 +16,7 @@ remove: [
   ["rm" "-f" "%{bin}%/brtx" "%{bin}%/brtx.exe"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"


### PR DESCRIPTION
```
#=== ERROR while compiling bracetax.0.4 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/bracetax.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/bracetax-7-ddba8c.env
# output-file          ~/.opam/log/bracetax-7-ddba8c.out
### output ###
# File "./setup.ml", line 575, characters 4-15:
# 575 |     Stream.from next
#           ^^^^^^^^^^^
# Error: Unbound module Stream
```