### PR TITLE
imagelib is not compatible with ocaml 5

### DIFF
--- a/packages/imagelib/imagelib.20171028/opam
+++ b/packages/imagelib/imagelib.20171028/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "decompress" {= "0.7"}

--- a/packages/imagelib/imagelib.20180522/opam
+++ b/packages/imagelib/imagelib.20180522/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "decompress" {= "0.7"}

--- a/packages/imagelib/imagelib.20200929/opam
+++ b/packages/imagelib/imagelib.20200929/opam
@@ -32,7 +32,7 @@ license: "GPL-3.0-only"
 doc: "https://rlepigre.github.io/ocaml-imagelib"
 
 depends: [
-  "ocaml"        { >= "4.07.0" }
+  "ocaml"        { >= "4.07.0" & < "5.0" }
   "base-unix"
   "dune"         { >= "2.3.0"  }
   "decompress"   { >= "1.2.0" & < "1.3.0" }

--- a/packages/imagelib/imagelib.20210116/opam
+++ b/packages/imagelib/imagelib.20210116/opam
@@ -32,7 +32,7 @@ license: "GPL-3.0-only"
 doc: "https://rlepigre.github.io/ocaml-imagelib"
 
 depends: [
-  "ocaml"        { >= "4.07.0" }
+  "ocaml"        { >= "4.07.0" & < "5.0" }
   "base-unix"
   "dune"         { >= "2.3.0"  }
   "decompress"   { >= "1.2.0" & < "1.3.0" }

--- a/packages/imagelib/imagelib.20210402/opam
+++ b/packages/imagelib/imagelib.20210402/opam
@@ -41,7 +41,7 @@ license: "GPL-3.0-only"
 doc: "https://rlepigre.github.io/ocaml-imagelib"
 
 depends: [
-  "ocaml"        { >= "4.07.0" }
+  "ocaml"        { >= "4.07.0" & < "5.0" }
   "base-unix"
   "dune"         { >= "2.3.0"  }
   "decompress"   { >= "1.3.0" }

--- a/packages/imagelib/imagelib.20210511/opam
+++ b/packages/imagelib/imagelib.20210511/opam
@@ -41,7 +41,7 @@ license: "GPL-3.0-only"
 doc: "https://rlepigre.github.io/ocaml-imagelib"
 
 depends: [
-  "ocaml"        { >= "4.07.0" }
+  "ocaml"        { >= "4.07.0" & < "5.0" }
   "base-unix"
   "dune"         { >= "2.3.0"  }
   "decompress"   { >= "1.3.0" }


### PR DESCRIPTION
it fails with multiple errors about not linking unix.

```
=== ERROR while compiling imagelib.20200929 ==================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/imagelib.20200929
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p imagelib -j 71 @install
 exit-code            1
 env-file             ~/.opam/log/imagelib-7-975662.env
 output-file          ~/.opam/log/imagelib-7-975662.out
output ###
[...]
 (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o app/imagetool.exe /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/optint/optint.cmxa /home/opam/.opam/5.0/lib/checkseum/ocaml/checkseum_ocaml.cmxa /home/opam/.opam/5.0/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.0/lib/decompress/de/de.cmxa /home/opam/.opam/5.0/lib/decompress/zl/zl.cmxa src/imagelib.cmxa unix/imagelib_unix.cmxa app/.imagetool.eobjs/native/dune__exe__Imagetool.cmx)
 File "_none_", line 1:
 Error: No implementations provided for the following modules:
          Unix referenced from app/.imagetool.eobjs/native/dune__exe__Imagetool.cmx
```

Seen on the revdeps of https://github.com/ocaml/opam-repository/pull/22690

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>