### PR TITLE
some versions of camlimages are not compatible with ocaml5

### DIFF
--- a/packages/camlimages/camlimages.5.0.3/opam
+++ b/packages/camlimages/camlimages.5.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "cppo" {build}
   "dune" {>= "1.11"}
   "dune-configurator" {build & >= "2.0.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "ocamlfind" {build}
   "stdio"
 ]

--- a/packages/camlimages/camlimages.5.0.4-1/opam
+++ b/packages/camlimages/camlimages.5.0.4-1/opam
@@ -12,7 +12,7 @@ depends: [
   "cppo" {build}
   "dune" {>= "1.11"}
   "dune-configurator" {build & >= "2.0.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "ocamlfind" {build}
   "stdio"
 ]

--- a/packages/camlimages/camlimages.5.0.4/opam
+++ b/packages/camlimages/camlimages.5.0.4/opam
@@ -12,7 +12,7 @@ depends: [
   "cppo" {build}
   "dune" {>= "1.11"}
   "dune-configurator" {build & >= "2.0.0"}
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0"}
   "ocamlfind" {build}
   "stdio"
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling camlimages.5.0.3 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/camlimages.5.0.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p camlimages -j 255
# exit-code            1
# env-file             ~/.opam/log/camlimages-7-ef7aad.env
# output-file          ~/.opam/log/camlimages-7-ef7aad.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -3 -g -bin-annot -I core/.camlimages.objs/byte -no-alias-deps -o core/.camlimages.objs/byte/units.cmo -c -impl core/units.ml)
# File "core/units.ml", line 33, characters 19-35:
# 33 |       (List.assoc (String.lowercase unit) units) *. float_of_string digit
#                         ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```