### PR TITLE
atd 1.x is not compatible with ocaml 5

### DIFF
--- a/packages/atd/atd.1.0.2/opam
+++ b/packages/atd/atd.1.0.2/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/MyLifeLabs/atd"
 build: make
 remove: [["ocamlfind" "remove" "atd"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "menhir" {< "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.0.3/opam
+++ b/packages/atd/atd.1.0.3/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/mjambon/atd"
 build: make
 remove: [["ocamlfind" "remove" "atd"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "menhir" {< "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.1.0/opam
+++ b/packages/atd/atd.1.1.0/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/mjambon/atd"
 build: make
 remove: [["ocamlfind" "remove" "atd"]]
 depends: [
-  "ocaml"
+  "ocaml"  {< "5.0"}
   "ocamlfind"
   "menhir" {< "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.1.1/opam
+++ b/packages/atd/atd.1.1.1/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/mjambon/atd"
 build: make
 remove: [["ocamlfind" "remove" "atd"]]
 depends: [
-  "ocaml"
+  "ocaml"  {< "5.0"}
   "ocamlfind"
   "menhir" {< "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.1.2/opam
+++ b/packages/atd/atd.1.1.2/opam
@@ -4,7 +4,7 @@ homepage: "https://github.com/mjambon/atd"
 build: make
 remove: [["ocamlfind" "remove" "atd"]]
 depends: [
-  "ocaml"
+  "ocaml"  {< "5.0"}
   "ocamlfind"
   "menhir" {< "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.12.0/opam
+++ b/packages/atd/atd.1.12.0/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "menhir" {build & < "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.2.0/opam
+++ b/packages/atd/atd.1.2.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/mjambon/atd.git"
 build: [ [make] ]
 remove: [["ocamlfind" "remove" "atd"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "menhir" {< "20211215"}
   "easy-format"

--- a/packages/atd/atd.1.2.1/opam
+++ b/packages/atd/atd.1.2.1/opam
@@ -10,7 +10,7 @@ build: [
   ["jbuilder" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml"  {< "5.0"}
   "jbuilder" {>= "1.0+beta7"}
   "menhir" {< "20211215"}
   "easy-format"


### PR DESCRIPTION
Explicitly uses the Pervasives module.

Seen in the revdeps of https://github.com/ocaml/opam-repository/pull/22690

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>