### PR TITLE
mock is not compatible with ocaml 5

### DIFF
--- a/packages/mock/mock.0.1.0/opam
+++ b/packages/mock/mock.0.1.0/opam
@@ -11,7 +11,7 @@ build: [
   [ "jbuilder" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "jbuilder" {>= "1.0+beta10"}
 ]
 synopsis: "Configurable functions to test impure code"

--- a/packages/mock/mock.0.1.1/opam
+++ b/packages/mock/mock.0.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "dune"
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.04.0" & < "5.0"}
 ]
 synopsis: "Configurable functions to test impure code"
 description: """


### PR DESCRIPTION
Uses pervasives explicitly:
```
#=== ERROR while compiling mock.0.1.1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/mock.0.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mock -j 127
# exit-code            1
# env-file             ~/.opam/log/mock-7-2a63a0.env
# output-file          ~/.opam/log/mock-7-2a63a0.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.mock.objs/byte -intf-suffix .ml -no-alias-deps -o src/.mock.objs/byte/mock.cmo -c -impl src/mock.ml)
# File "src/mock.ml", line 15, characters 15-31:
# 15 |   | Raise e -> Pervasives.raise e
#                     ^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.mock.objs/byte -I src/.mock.objs/native -intf-suffix .ml -no-alias-deps -o src/.mock.objs/native/mock.cmx -c -impl src/mock.ml)
# File "src/mock.ml", line 15, characters 15-31:
# 15 |   | Raise e -> Pervasives.raise e
#                     ^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```

Seen on the revdeps on #22690.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>