### PR TITLE
Package geoml.0.1.1

### DIFF
--- a/packages/geoml/geoml.0.1.1/opam
+++ b/packages/geoml/geoml.0.1.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@epita.fr>"
+authors: [
+  "Ghiles Ziat"
+  "Rémy Besognet El Sibaïe"
+]
+homepage: "https://github.com/ghilesZ/geoml"
+bug-reports: "https://github.com/ghilesZ/geoml/issues"
+dev-repo: "git+https://github.com/ghilesZ/geoml"
+license: "MIT"
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "build" "@runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "2.4"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+]
+
+synopsis: "Geoml: 2D Geometry library for OCaml"
+description: "Geoml is a 2D geometry for OCaml that provides basic euclidean geometry types (point, line, circle ...) and useful operations over those types. Computations are made using floatting point precision"
+url {
+  src: "https://github.com/ghilesZ/geoml/archive/0.1.1.tar.gz"
+  checksum: [
+    "md5=37ca15d64a035762d12c4bd7064a1841"
+    "sha512=109d7597bd2a8d6628b4c0ee40cd94066fe09ce565bb35fe10683e5f701c1d058daaec79702b4f5f8ed68eeed444c363ca6070f854bbdfb6d0cd997db0f21408"
+  ]
+}


### PR DESCRIPTION
### `geoml.0.1.1`
Geoml: 2D Geometry library for OCaml
Geoml is a 2D geometry for OCaml that provides basic euclidean geometry types (point, line, circle ...) and useful operations over those types. Computations are made using floatting point precision



---
* Homepage: https://github.com/ghilesZ/geoml
* Source repo: git+https://github.com/ghilesZ/geoml
* Bug tracker: https://github.com/ghilesZ/geoml/issues

---
:camel: Pull-request generated by opam-publish v2.1.0