### PR TITLE
[new release] shuttle_ssl and shuttle (0.7.0)

### DIFF
--- a/packages/shuttle/shuttle.0.7.0/opam
+++ b/packages/shuttle/shuttle.0.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.7.0/shuttle-0.7.0.tbz"
+  checksum: [
+    "sha256=6671459bc5b8804fa5d7ef3f0d7ef81a863f0053b833dfdbc8d7b1c289a9ce46"
+    "sha512=527ffc9131c6006af7e0b7a29b37e9e27e808926411b05c17b73f0ff7db08c6f3fb02739023237c97aa8f7fb7184a6f75c3fb21a801b2f96fe2752c62d372675"
+  ]
+}
+x-commit-hash: "3a253dc1ce4136dff508148b64692777365e1692"

--- a/packages/shuttle_ssl/shuttle_ssl.0.7.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.7.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.7.0/shuttle-0.7.0.tbz"
+  checksum: [
+    "sha256=6671459bc5b8804fa5d7ef3f0d7ef81a863f0053b833dfdbc8d7b1c289a9ce46"
+    "sha512=527ffc9131c6006af7e0b7a29b37e9e27e808926411b05c17b73f0ff7db08c6f3fb02739023237c97aa8f7fb7184a6f75c3fb21a801b2f96fe2752c62d372675"
+  ]
+}
+x-commit-hash: "3a253dc1ce4136dff508148b64692777365e1692"


### PR DESCRIPTION
Async_ssl support for shuttle

- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>
- Documentation: <a href="https://anuragsoni.github.io/shuttle/">https://anuragsoni.github.io/shuttle/</a>

##### CHANGES:

* Remove support for blocking file descriptors
* Output_channel accepts an optional user-provided Async Time_source
* Input_channel accepts an optional user-provided Async Time_source
* Support timeouts for Input_channel.refill
* Remove `read`, `read_line`, `lines` from Input_channel
