### PR TITLE
Constrain DKML to < ocaml.5.0.0~

### DIFF
--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~alpha0~20221104/opam
@@ -21,6 +21,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-opam"
 bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
 depends: [
+  "ocaml" {>= "4.12.1~" & <= "5.0.0~"}
   "dune" {>= "2.9"}
   "dkml-install" {>= "0.2.0"}
   "cmdliner" {>= "1.0.4"}

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~dkml20220801/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~dkml20220801/opam
@@ -8,6 +8,7 @@ authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
 license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-opam"
 bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+available: os = "win32" | os = "linux" # later versions support macOS + cross-compiling
 depends: [
   "ocaml"                   {>= "4.12.1~" & <= "5.0.0~"}
   "dkml-install"            {>= "0.2.0"}

--- a/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~dkml20220801/opam
+++ b/packages/dkml-component-staging-opam32/dkml-component-staging-opam32.2.2.0~dkml20220801/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-opam"
 bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
 depends: [
+  "ocaml"                   {>= "4.12.1~" & <= "5.0.0~"}
   "dkml-install"            {>= "0.2.0"}
   "dune"                    {>= "2.9"}
   "diskuvbox"               {>= "0.1.0" & build}

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~alpha0~20221104/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~alpha0~20221104/opam
@@ -24,6 +24,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-opam"
 bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
 depends: [
+  "ocaml" {>= "4.12.1~" & <= "5.0.0~"}
   "dune" {>= "2.9"}
   "dkml-install" {>= "0.2.0"}
   "cmdliner" {>= "1.0.4"}

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~dkml20220801/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~dkml20220801/opam
@@ -8,6 +8,7 @@ authors: ["Diskuv, Inc. <opensource+diskuv-ocaml@support.diskuv.com>"]
 license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-opam"
 bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
+available: os = "win32" | os = "linux" # later versions support macOS + cross-compiling
 depends: [
   "ocaml"                   {>= "4.12.1~" & <= "5.0.0~"}
   "dkml-install"            {>= "0.2.0"}

--- a/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~dkml20220801/opam
+++ b/packages/dkml-component-staging-opam64/dkml-component-staging-opam64.2.2.0~dkml20220801/opam
@@ -9,6 +9,7 @@ license: "Apache-2.0"
 homepage: "https://github.com/diskuv/dkml-component-opam"
 bug-reports: "https://github.com/diskuv/dkml-component-opam/issues"
 depends: [
+  "ocaml"                   {>= "4.12.1~" & <= "5.0.0~"}
   "dkml-install"            {>= "0.2.0"}
   "dune"                    {>= "2.9"}
   "diskuvbox"               {>= "0.1.0" & build}


### PR DESCRIPTION
Nothing in DKML is ready for 5.0.0, especially since the MSVC and Android ARM32 ports of OCaml 5.0.0 are not available and none of the cross-compiling bits have been ported.

Fixes revdeps in #22805 