### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.8.0)

### DIFF
--- a/packages/shuttle/shuttle.0.8.0/opam
+++ b/packages/shuttle/shuttle.0.8.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.0/shuttle-0.8.0.tbz"
+  checksum: [
+    "sha256=6631c8b9ca190d680fa8695639646e19adba45507de638776e8fea596af83820"
+    "sha512=f49d5679cd4e79784ae8181e4904932f426181bdf39faf89c3579cd256753ecf3dd6f788b7f09e3d4d7c715e1dd30a73cdfe2c5e1c0cea364751607f2a7c1c88"
+  ]
+}
+x-commit-hash: "a36b8e6a66bd5c36cfda21b22c1f48f55a5c73f5"

--- a/packages/shuttle_http/shuttle_http.0.8.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.0/shuttle-0.8.0.tbz"
+  checksum: [
+    "sha256=6631c8b9ca190d680fa8695639646e19adba45507de638776e8fea596af83820"
+    "sha512=f49d5679cd4e79784ae8181e4904932f426181bdf39faf89c3579cd256753ecf3dd6f788b7f09e3d4d7c715e1dd30a73cdfe2c5e1c0cea364751607f2a7c1c88"
+  ]
+}
+x-commit-hash: "a36b8e6a66bd5c36cfda21b22c1f48f55a5c73f5"

--- a/packages/shuttle_ssl/shuttle_ssl.0.8.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.8.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.0/shuttle-0.8.0.tbz"
+  checksum: [
+    "sha256=6631c8b9ca190d680fa8695639646e19adba45507de638776e8fea596af83820"
+    "sha512=f49d5679cd4e79784ae8181e4904932f426181bdf39faf89c3579cd256753ecf3dd6f788b7f09e3d4d7c715e1dd30a73cdfe2c5e1c0cea364751607f2a7c1c88"
+  ]
+}
+x-commit-hash: "a36b8e6a66bd5c36cfda21b22c1f48f55a5c73f5"


### PR DESCRIPTION
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>
- Documentation: <a href="https://anuragsoni.github.io/shuttle/">https://anuragsoni.github.io/shuttle/</a>

##### CHANGES:

* Revive the http codec as a new shuttle_http package
