### PR TITLE
Add conf-assimp package (checks system for assimp)

### DIFF
--- a/packages/conf-assimp/conf-assimp.1/opam
+++ b/packages/conf-assimp/conf-assimp.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "geoffderosenroll@gmail.com"
+authors: ["Geoff deRosenroll"]
+homepage: "https://github.com/assimp/assimp"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "BSD-3-Clause"
+build: [
+  ["assimp" "--help"] {os != "openbsd"}
+  ["/usr/local/bin/assimp" "--help"] {os = "openbsd"}
+]
+depexts: [
+  ["libassimp-dev"] {os-family = "debian"}
+  ["assimp"] {os-distribution = "arch"}
+  ["assimp-devel"] {os-distribution = "fedora"}
+  ["lib64assimp-devel"] {os-distribution = "mageia"}
+  ["assimp"] {os-distribution = "alpine"}
+  ["assimp"] {os-distribution = "nixos"}
+  ["assimp-5.0.0"] {os = "openbsd"}
+  ["assimp"] {os = "macos" & os-distribution = "homebrew"}
+  ["assimp"] {os = "macos" & os-distribution = "macports"}
+  ["assimp"] {os = "freebsd"}
+  ["assimp"] {os = "win32" & os-distribution = "vcpkg"}
+]
+synopsis: "Check if assimp (Open Asset Import Library) is installed"
+description: """
+This package can only install if the assimp package (Open Asset Import Library)
+is installed on the system."""
+flags: conf

--- a/packages/conf-assimp/conf-assimp.1/opam
+++ b/packages/conf-assimp/conf-assimp.1/opam
@@ -13,7 +13,7 @@ depexts: [
   ["libassimp-dev"] {os-family = "debian"}
   ["assimp"] {os-distribution = "arch"}
   ["assimp-devel"] {os-distribution = "fedora"}
-  ["assimp-devel.x86_64"] {os-distribution = "ol"}
+  ["assimp-devel"] {os-distribution = "ol"}
   ["assimp"] {os-distribution = "suse"}
   ["libassimp-dev"] {os-family = "suse"}
   ["lib64assimp-devel"] {os-distribution = "mageia"}

--- a/packages/conf-assimp/conf-assimp.1/opam
+++ b/packages/conf-assimp/conf-assimp.1/opam
@@ -9,9 +9,13 @@ build: [
   ["/usr/local/bin/assimp" "--help"] {os = "openbsd"}
 ]
 depexts: [
+  ["assimp-utils"] {os-family = "debian"}
   ["libassimp-dev"] {os-family = "debian"}
   ["assimp"] {os-distribution = "arch"}
   ["assimp-devel"] {os-distribution = "fedora"}
+  ["assimp-devel"] {os-distribution = "ol"}
+  ["assimp"] {os-distribution = "opensuse"}
+  ["libassimp-dev"] {os-family = "opensuse"}
   ["lib64assimp-devel"] {os-distribution = "mageia"}
   ["assimp"] {os-distribution = "alpine"}
   ["assimp"] {os-distribution = "nixos"}
@@ -24,5 +28,6 @@ depexts: [
 synopsis: "Check if assimp (Open Asset Import Library) is installed"
 description: """
 This package can only install if the assimp package (Open Asset Import Library)
-is installed on the system."""
+is installed on the system. A check for the presence of the assimp binary in the path
+is performed, but the depexpts list packages required for delevopment as well."""
 flags: conf

--- a/packages/conf-assimp/conf-assimp.1/opam
+++ b/packages/conf-assimp/conf-assimp.1/opam
@@ -13,9 +13,9 @@ depexts: [
   ["libassimp-dev"] {os-family = "debian"}
   ["assimp"] {os-distribution = "arch"}
   ["assimp-devel"] {os-distribution = "fedora"}
-  ["assimp-devel"] {os-distribution = "ol"}
-  ["assimp"] {os-distribution = "opensuse"}
-  ["libassimp-dev"] {os-family = "opensuse"}
+  ["assimp-devel.x86_64"] {os-distribution = "ol"}
+  ["assimp"] {os-distribution = "suse"}
+  ["libassimp-dev"] {os-family = "suse"}
   ["lib64assimp-devel"] {os-distribution = "mageia"}
   ["assimp"] {os-distribution = "alpine"}
   ["assimp"] {os-distribution = "nixos"}

--- a/packages/conf-assimp/conf-assimp.1/opam
+++ b/packages/conf-assimp/conf-assimp.1/opam
@@ -5,21 +5,19 @@ homepage: "https://github.com/assimp/assimp"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "BSD-3-Clause"
 build: [
-  ["assimp" "--help"] {os != "openbsd"}
-  ["/usr/local/bin/assimp" "--help"] {os = "openbsd"}
+  ["assimp" "--help"]
 ]
 depexts: [
-  ["assimp-utils"] {os-family = "debian"}
-  ["libassimp-dev"] {os-family = "debian"}
-  ["assimp"] {os-distribution = "arch"}
+  ["assimp-utils" "libassimp-dev"] {os-family = "debian"}
+  ["assimp-utils" "libassimp-dev"] {os-family = "ubuntu"}
+  ["assimp"] {os-family = "arch"}
   ["assimp-devel"] {os-distribution = "fedora"}
   ["assimp-devel"] {os-distribution = "ol"}
-  ["assimp"] {os-distribution = "suse"}
-  ["libassimp-dev"] {os-family = "suse"}
+  ["assimp" "libassimp-dev"] {os-family = "suse"}
   ["lib64assimp-devel"] {os-distribution = "mageia"}
-  ["assimp"] {os-distribution = "alpine"}
+  ["assimp"] {os-family = "alpine"}
   ["assimp"] {os-distribution = "nixos"}
-  ["assimp-5.0.0"] {os = "openbsd"}
+  ["assimp"] {os = "openbsd"}
   ["assimp"] {os = "macos" & os-distribution = "homebrew"}
   ["assimp"] {os = "macos" & os-distribution = "macports"}
   ["assimp"] {os = "freebsd"}


### PR DESCRIPTION
This is my first time making a `conf` package, so I'm not sure that I've done everything just right. I noticed that there is an `assimp` bindings package, but for my current purposes, I'm trying to make sure the library is installed for linking during compilation of a vendored C++ dependency.