### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.8.1)

### DIFF
--- a/packages/shuttle/shuttle.0.8.1/opam
+++ b/packages/shuttle/shuttle.0.8.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.1/shuttle-0.8.1.tbz"
+  checksum: [
+    "sha256=ab88edfe835c8c6a1f8c68d16ec1ebd7849c804b95bfb89dc16d68ad1051f5ca"
+    "sha512=2c93198cbeea1a815046ef8eef67e41c4e0ff3eaab9fe0c820bf74ab94ff3a6a42ff6f006dc06feceb8302e12157c08a2900352a5ba888283f10b304acfc7b95"
+  ]
+}
+x-commit-hash: "9f4bdd0e053fc5d325488fbcbdd5a142f60703be"

--- a/packages/shuttle_http/shuttle_http.0.8.1/opam
+++ b/packages/shuttle_http/shuttle_http.0.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "ppx_jane" {with-test}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.1/shuttle-0.8.1.tbz"
+  checksum: [
+    "sha256=ab88edfe835c8c6a1f8c68d16ec1ebd7849c804b95bfb89dc16d68ad1051f5ca"
+    "sha512=2c93198cbeea1a815046ef8eef67e41c4e0ff3eaab9fe0c820bf74ab94ff3a6a42ff6f006dc06feceb8302e12157c08a2900352a5ba888283f10b304acfc7b95"
+  ]
+}
+x-commit-hash: "9f4bdd0e053fc5d325488fbcbdd5a142f60703be"

--- a/packages/shuttle_ssl/shuttle_ssl.0.8.1/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.1/shuttle-0.8.1.tbz"
+  checksum: [
+    "sha256=ab88edfe835c8c6a1f8c68d16ec1ebd7849c804b95bfb89dc16d68ad1051f5ca"
+    "sha512=2c93198cbeea1a815046ef8eef67e41c4e0ff3eaab9fe0c820bf74ab94ff3a6a42ff6f006dc06feceb8302e12157c08a2900352a5ba888283f10b304acfc7b95"
+  ]
+}
+x-commit-hash: "9f4bdd0e053fc5d325488fbcbdd5a142f60703be"


### PR DESCRIPTION
##### CHANGES:

* Http codec supports a timeout for reading Request headers

**Bugfixes**

* Fix a bug in the http request parser that could cause unhandled exception when attempting to parse certain malformed payloads.
