### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.8.0)

### DIFF
--- a/packages/shuttle/shuttle.0.8.0/opam
+++ b/packages/shuttle/shuttle.0.8.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.0/shuttle-0.8.0.tbz"
+  checksum: [
+    "sha256=ca742c54ba593759e7d112b76d77f97c9fd279a3c4dbb69d54681e0941d1cff3"
+    "sha512=ecad64f99e9801a56c8e923b736086b693f2e302cb105ed6963a01fdb58503dc37b16d5e6d0c1e3f6851cd2598d4ba9543deb7a4e27904423386ee308fb65431"
+  ]
+}
+x-commit-hash: "873c66738acd4161b3bd73486b5f039db9ca72be"

--- a/packages/shuttle_http/shuttle_http.0.8.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.8.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "ppx_jane" {with-test}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.0/shuttle-0.8.0.tbz"
+  checksum: [
+    "sha256=ca742c54ba593759e7d112b76d77f97c9fd279a3c4dbb69d54681e0941d1cff3"
+    "sha512=ecad64f99e9801a56c8e923b736086b693f2e302cb105ed6963a01fdb58503dc37b16d5e6d0c1e3f6851cd2598d4ba9543deb7a4e27904423386ee308fb65431"
+  ]
+}
+x-commit-hash: "873c66738acd4161b3bd73486b5f039db9ca72be"

--- a/packages/shuttle_http/shuttle_http.0.8.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.8.0/opam
@@ -40,3 +40,4 @@ url {
   ]
 }
 x-commit-hash: "873c66738acd4161b3bd73486b5f039db9ca72be"
+available: [ arch = "x86_64" | arch = "arm64" ]

--- a/packages/shuttle_ssl/shuttle_ssl.0.8.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.8.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.8.0/shuttle-0.8.0.tbz"
+  checksum: [
+    "sha256=ca742c54ba593759e7d112b76d77f97c9fd279a3c4dbb69d54681e0941d1cff3"
+    "sha512=ecad64f99e9801a56c8e923b736086b693f2e302cb105ed6963a01fdb58503dc37b16d5e6d0c1e3f6851cd2598d4ba9543deb7a4e27904423386ee308fb65431"
+  ]
+}
+x-commit-hash: "873c66738acd4161b3bd73486b5f039db9ca72be"


### PR DESCRIPTION
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>
- Documentation: <a href="https://anuragsoni.github.io/shuttle/">https://anuragsoni.github.io/shuttle/</a>

##### CHANGES:

* Revive the http codec as a new shuttle_http package
  - Http codec supports a timeout for reading Request headers
  - Server module reports a deferred that resolves when the server context closes. This can be usedul to register cleanup actions that should run when a server connection is torn down.
  - Using the utility methods within the Server module to create responses ensures that streams are torn down if the server connection is closed before a stream was fully consumed.
