### PR TITLE
Package ulex-camlp5.1.3

### DIFF
--- a/packages/ulex-camlp5/ulex-camlp5.1.3/opam
+++ b/packages/ulex-camlp5/ulex-camlp5.1.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "claudio.sacerdoticoen@unibo.it"
+authors: ["Alain.Frisch@inria.fr"]
+license: "MIT"
+homepage: "https://github.com/whitequark/ulex"
+dev-repo: "git+https://github.com/whitequark/ulex.git"
+bug-reports: "https://github.com/whitequark/ulex/issues"
+synopsis: "A lexer generator for Unicode (backported to camlp5)"
+build: [
+  [make]
+  [make "all.opt"]
+]
+install: [make "install"]
+remove: [["ocamlfind" "remove" "ulex-camlp5"]]
+flags: light-uninstall
+depends: [
+  "ocaml" {>="5.0.0"} 
+  "ocamlfind" {build}
+  "camlp5" {>= "8.00.04"}
+  "camlp-streams"
+  "ocamlbuild" {build}
+]
+url {
+  src:
+    "https://github.com/sacerdot/ulex/archive/refs/tags/v1.3-camlp5.tar.gz"
+  checksum: [
+    "md5=32033b89d244886d227801437f4b68fa"
+    "sha512=1087e554cc5e5841d42756904da60180a99a4b1d0c7df519b039bc891b0a9f28d547320b34732cefe5683323a5f6c547025dd925cebca14342f9d985d586fe12"
+  ]
+}

--- a/packages/ulex-camlp5/ulex-camlp5.1.3/opam
+++ b/packages/ulex-camlp5/ulex-camlp5.1.3/opam
@@ -11,8 +11,6 @@ build: [
   [make "all.opt"]
 ]
 install: [make "install"]
-remove: [["ocamlfind" "remove" "ulex-camlp5"]]
-flags: light-uninstall
 depends: [
   "ocaml" {>="5.0.0"} 
   "ocamlfind" {build}


### PR DESCRIPTION
Porting to ocaml 5.

NOTE: the package depends on camlp5 that fails to build in CI on some opam architectures, even if the camlp5 package has been accepted before. Please, force it somehow.