### PR TITLE
hevea 2.36

### DIFF
--- a/packages/hevea/hevea.2.36/opam
+++ b/packages/hevea/hevea.2.36/opam
@@ -5,7 +5,7 @@ homepage: "http://hevea.inria.fr/"
 bug-reports: "http://github.com/herd/hevea/issues/"
 doc: "http://hevea.inria.fr/doc/index.html"
 dev-repo: "git+https://github.com/maranget/hevea.git"
-license: ["QPL-1.0 WITH OCaml-LGPL-linking-exception" "LGPL-2.0-only"]
+license: ["QPL-1.0 WITH OCaml-LGPL-linking-exception"]
 build: [make "PREFIX=%{prefix}%"]
 install: [make "PREFIX=%{prefix}%" "install"]
 post-messages: [

--- a/packages/hevea/hevea.2.36/opam
+++ b/packages/hevea/hevea.2.36/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: "Luc Maranget"
+homepage: "http://hevea.inria.fr/"
+bug-reports: "http://github.com/herd/hevea/issues/"
+doc: "http://hevea.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/maranget/hevea.git"
+license: ["QPL-1.0 WITH OCaml-LGPL-linking-exception" "LGPL-2.0-only"]
+build: [make "PREFIX=%{prefix}%"]
+install: [make "PREFIX=%{prefix}%" "install"]
+post-messages: [
+  "The file 'hevea.sty' has been installed in %{lib}%/hevea but latex won't see it by itself" {success}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlbuild" {build}
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+synopsis: "A quite complete and fast LATEX to HTML translator"
+url {
+  src: "https://github.com/maranget/hevea/archive/v2.36.tar.gz"
+  checksum: "sha256=9848359f935af24b6f962b2ed5d5ac32614bffeb37da374b0960cc0f58e69f0c"
+}


### PR DESCRIPTION
This version is the first to implement support for OCaml 5.

cc @maranget @Octachron (nothing to do on your side)