### PR TITLE
[new release] lambdapi (2.3.0)

### DIFF
--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+synopsis: "Proof assistant for the λΠ-calculus modulo rewriting"
+description: """
+This package provides:
+- A lambdapi command for checking .lp or .dk files,
+translating .dk files to .lp files and vice versa,
+or launching an LSP server for editing .lp files.
+- A library of logic definitions and basic definitions and proofs
+on natural numbers and polymorphic lists.
+- A rich Emacs mode based on LSP (available on MELPA too).
+- A basic mode for Vim.
+- OCaml libraries.
+A VSCode extension is also available on the VSCode Marketplace.
+
+Find Lambdapi user manual on https://lambdapi.readthedocs.io/.
+
+Lambdapi provides a rich type system with dependent types.
+In Lambdapi, one can define both type and function symbols
+by using rewriting rules (oriented equations).
+A symbol can be declared associative and commutative.
+Lambdapi supports unicode symbols and infix operators.
+The declaration of symbols and rewriting rules is separated
+so that one can easily define inductive-recursive types.
+
+Lambdapi checks that rules are locally confluent (by checking
+the joinability of critical pairs) and preserve typing.
+Rewrite rules can also be exported to the TRS and XTC formats
+for checking confluence and termination with external tools.
+
+Lambdapi does not come with a pre-defined logic. It is a
+powerful logical framework in which one can easily define
+its own logic and build and check proofs in this logic.
+There exist .lp files defining first or higher-order logic
+and complex type systems like in Coq or Agda.
+
+Lambdapi provides a basic module and package system,
+interactive modes for proving both unification goals
+and typing goals, and tactics for solving them step by step.
+In particular, a rewrite tactic like in SSReflect, and
+a why3 tactic for calling external automated provers through
+the Why3 platform."""
+maintainer: ["dedukti-dev@inria.fr"]
+authors: ["Deducteam"]
+license: "CECILL-2.1"
+homepage: "https://github.com/Deducteam/lambdapi"
+bug-reports: "https://github.com/Deducteam/lambdapi/issues"
+dev-repo: "git+https://github.com/Deducteam/lambdapi.git"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "menhir" {>= "20200624"}
+  "sedlex" {>= "2.2"}
+  "alcotest" {with-test}
+  "dedukti" {with-test & >= "2.7"}
+  "bindlib" {>= "5.0.1"}
+  "timed" {>= "1.0"}
+  "pratter" {>= "2.0.0"}
+  "camlp-streams" {>= "5.0"}
+  "why3" {>= "1.5.0"}
+  "yojson" {>= "1.6.0"}
+  "cmdliner" {>= "1.1.0"}
+  "stdlib-shims" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [make]
+]
+install: [
+  [make "install"]
+]
+url {
+  src:
+    "https://github.com/Deducteam/lambdapi/releases/download/2.3.0/lambdapi-2.3.0.tbz"
+  checksum: [
+    "sha256=93077b0b8aed4a0e4dfd100c2c55f961908cbd8a3b630a4d1f9ccfe109bdf202"
+    "sha512=a98d01a5b6a6d66bdd8f1599e3d06d2c2e8bbc414128f49077367af6e942f344023a0ade1ad43a788cc5d663a53e51aad0719a96ad6cb2df0dd86c62212dd69f"
+  ]
+}
+x-commit-hash: "0b3fda35a09207b2c619573098cbafe5f0b722ae"

--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -52,7 +52,7 @@ depends: [
   "sedlex" {>= "2.2"}
   "alcotest" {with-test}
   "dedukti" {with-test & >= "2.7"}
-  "bindlib" {>= "5.0.1"}
+  "bindlib" {>= "6.0.0"}
   "timed" {>= "1.0"}
   "pratter" {>= "2.0.0"}
   "camlp-streams" {>= "5.0"}

--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -61,7 +61,6 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
-  "conf-emacs" {>= "1"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -72,10 +71,12 @@ install: [
 ]
 url {
   src:
-    "https://github.com/Deducteam/lambdapi/releases/download/2.3.0/lambdapi-2.3.0.tbz"
+    "https://github.com/Deducteam/lambdapi/releases/download/2.3.0/lambdapi-2.3.
+0.tbz"
   checksum: [
-    "sha256=93077b0b8aed4a0e4dfd100c2c55f961908cbd8a3b630a4d1f9ccfe109bdf202"
-    "sha512=a98d01a5b6a6d66bdd8f1599e3d06d2c2e8bbc414128f49077367af6e942f344023a0ade1ad43a788cc5d663a53e51aad0719a96ad6cb2df0dd86c62212dd69f"
+    "sha256=3c2328a8f35d06707d550140756d6104a92f0e4e67b40c87774ff3a206293dd1"
+    "sha512=1f74ee2dcba99e40a2ea6c1914c9ec133a0ffcdbdf001a2d6405a0b22ceb8b239226
+2ab4a1dd82fd0b77fe110c4d77b29fa87df06cb0424b16a9a45bd61475ea"
   ]
 }
-x-commit-hash: "0b3fda35a09207b2c619573098cbafe5f0b722ae"
+x-commit-hash: "3160358b24ad2e70641f7d4e0e43672cdd8a1bb1"

--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -61,7 +61,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
-  "conf-emacs" {>= "1.0"}
+  "conf-emacs" {>= "1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -61,6 +61,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "stdlib-shims" {>= "0.1.0"}
   "odoc" {with-doc}
+  "conf-emacs" {>= "1.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/lambdapi/lambdapi.2.3.0/opam
+++ b/packages/lambdapi/lambdapi.2.3.0/opam
@@ -71,12 +71,10 @@ install: [
 ]
 url {
   src:
-    "https://github.com/Deducteam/lambdapi/releases/download/2.3.0/lambdapi-2.3.
-0.tbz"
+    "https://github.com/Deducteam/lambdapi/releases/download/2.3.0/lambdapi-2.3.0.tbz"
   checksum: [
-    "sha256=3c2328a8f35d06707d550140756d6104a92f0e4e67b40c87774ff3a206293dd1"
-    "sha512=1f74ee2dcba99e40a2ea6c1914c9ec133a0ffcdbdf001a2d6405a0b22ceb8b239226
-2ab4a1dd82fd0b77fe110c4d77b29fa87df06cb0424b16a9a45bd61475ea"
+    "sha256=9b13c3121ef87cf4d3311a8a1db43db4be7f0e5e2a702fdaff04a3b3c432cb31"
+    "sha512=81e0760ca77cb862a5bdb8927aa37faf7141c4e2484a8163dad0a3eaa21cc691acb5f72279c78588c085f53dde4bd35186346378feac0ab55ac06a679cf2e60f"
   ]
 }
-x-commit-hash: "3160358b24ad2e70641f7d4e0e43672cdd8a1bb1"
+x-commit-hash: "4939b93c2721c8aa4dc88a7b8190dd43e3badfdc"


### PR DESCRIPTION
Proof assistant for the λΠ-calculus modulo rewriting

- Project page: <a href="https://github.com/Deducteam/lambdapi">https://github.com/Deducteam/lambdapi</a>

##### CHANGES:

### Added

- Export to Coq.
- (API) the rewrite engine can match on the constant `TYPE`.
- Automatic coercion insertion mechanism.
  For example, the command `coerce_rule coerce Int Float $x ↪ FloatOfInt $x;`
  can be used to instruct Lambdapi to automatically coerce integers to floats
  using the function `FloatOfInt`.

### Fixed

- Generation of metavariables through the rewriting engine.
- Application of pattern variables in rewrite rules RHS in the Dedukti
  export.
- Dedukti export: invalid Dedukti module name were not brace-quoted,
  for instance, `#REQUIRE module-name.` could be exported, while `module-name`
  is not recognised by Dedukti2. It is now exported as `#REQUIRE {|module-name|}`,
  and symbols are exported as `{|module-name|}.foo`.
- HRS and XTC exports.
