### PR TITLE
[new release] http-date (0.1)

### DIFF
--- a/packages/http-date/http-date.0.1/opam
+++ b/packages/http-date/http-date.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "HTTP Datetime encoder/decoder"
+description: "RFC 9110 compliant HTTP datetime decoder and encoder"
+maintainer: ["Bikal Lem"]
+authors: ["Bikal Lem"]
+license: "MPL-2.0"
+homepage: "https://github.com/bikallem/http-date"
+bug-reports: "https://github.com/bikallem/http-date/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.6" & >= "2.6"}
+  "mdx" {>= "2.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/bikallem/http-date.git"
+url {
+  src:
+    "https://github.com/bikallem/http-date/releases/download/0.1/http-date-0.1.tbz"
+  checksum: [
+    "sha256=b2136690892a0e5a98cb09c5570f585ebb97f4ca643c1b1ced4e60bd1c814d0c"
+    "sha512=061baa90d41a76b1dc3ceaf4fd70fe460899c44dc59789bf91a4b4a1b730846b718f69dd6e5168afe9b89ed0353e05dfe19227fb41c21d6bbe38aac5aa48f1fd"
+  ]
+}
+x-commit-hash: "58f0513b2f98165cf36648fcf63c33b27ec4529e"


### PR DESCRIPTION
CHANGES:

- Initial release supporting decoding/encoding in IMF, RFC 850 and asctime format.