### PR TITLE
camlp5 8.00.04: does not handle not having ocamlopt

### DIFF
--- a/packages/camlp5/camlp5.8.00.04/opam
+++ b/packages/camlp5/camlp5.8.00.04/opam
@@ -54,7 +54,9 @@ build: [
   }
 ]
 install: [make "install"]
-
+conflicts: [
+   "ocaml-option-bytecode-only"
+]
 post-messages:
   "To use mkcamlp5 and mkcamlp5.opt properly you will require Perl module which contains 'IPC/System/Simple.pm'. We currently don't know the right way to specify this dependecy on BSD and MacOS systems. You can use https://github.com/camlp5/camlp5/issues/66 for discussion." { os = "macos" | os = "freebsd" | os = "openbsd" }
 


### PR DESCRIPTION
Fails  with 
```
# cd ./5.0.0/utils; make OCAMLN=ocaml opt; cd ../..
# make[3]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlp5.8.00.04/ocaml_stuff/5.0.0/utils'
# ocamlopt  -c pconfig.ml
# make[3]: ocamlopt: No such file or directory
# make[3]: *** [Makefile:25: pconfig.cmx] Error 127
# make[3]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlp5.8.00.04/ocaml_stuff/5.0.0/utils'
# make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlp5.8.00.04/ocaml_stuff'
# make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlp5.8.00.04/lib'
# ocamlrun ../boot/camlp5r -nolib -I ../boot -mode S -o ploc.ppo ploc.ml
# ocamlrun ../boot/camlp5r -nolib -I ../boot pa_macro.cmo -mode S -o versdep.ppo versdep.ml
# ocamlrun ../boot/camlp5r -nolib -I ../boot -mode S -o fstream.ppo fstream.ml
# ocamlrun ../boot/camlp5r -nolib -I ../boot -mode S -o extfun.ppo extfun.ml
# ocamlfind ocamlopt -package compiler-libs,camlp-streams -g -warn-error +A-11 -c -impl extfun.ppo
# ocamlfind ocamlopt -package compiler-libs,camlp-streams -g -warn-error +A-11 -c -impl fstream.ppo
# ocamlfind: Not supported in your configuration: ocamlopt
# ocamlfind: Not supported in your configuration: ocamlopt
# make[2]: *** [../config/Makefile:31: fstream.cmx] Error 2
# make[2]: *** Waiting for unfinished jobs....
# make[2]: *** [../config/Makefile:31: extfun.cmx] Error 2
# ocamlfind ocamlopt -package compiler-libs,camlp-streams -g -warn-error +A-11 -c -impl ploc.ppo
# ocamlfind: Not supported in your configuration: ocamlopt
# make[2]: *** [../config/Makefile:31: ploc.cmx] Error 2
# ocamlfind ocamlopt -package compiler-libs,camlp-streams -g -warn-error +A-11 -c -impl versdep.ppo
# ocamlfind: Not supported in your configuration: ocamlopt
# make[2]: *** [../config/Makefile:31: versdep.cmx] Error 2
# make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlp5.8.00.04/lib'
# make[1]: *** [Makefile:25: opt] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlp5.8.00.04'
# make: *** [Makefile:162: world.opt] Error 2
```