### PR TITLE
icalendar: restrict 0.1.[0|1|2] to <ocaml 5 due to Pervasives usage

### DIFF
--- a/packages/icalendar/icalendar.0.1.0/opam
+++ b/packages/icalendar/icalendar.0.1.0/opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0.0"}
   "dune"
   "alcotest" {with-test & < "1.0.0"}
   "fmt"

--- a/packages/icalendar/icalendar.0.1.1/opam
+++ b/packages/icalendar/icalendar.0.1.1/opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0.0"}
   "dune"
   "alcotest" {with-test & < "1.0.0"}
   "fmt"

--- a/packages/icalendar/icalendar.0.1.2/opam
+++ b/packages/icalendar/icalendar.0.1.2/opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0.0"}
   "dune"
   "alcotest" {with-test & < "1.0.0"}
   "fmt"


### PR DESCRIPTION
spotted in revdeps for #22717