### PR TITLE
torch: do not build 0.2/4/5 on OCaml 5+ due to use of Pervasives

### DIFF
--- a/packages/torch/torch.0.2/opam
+++ b/packages/torch/torch.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune-configurator"
   "libtorch" {< "1.1.0"}
   "npy"
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0"}
   "ocaml-compiler-libs"
   "ppx_custom_printf"
   "ppx_expect"

--- a/packages/torch/torch.0.4/opam
+++ b/packages/torch/torch.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "dune-configurator"
   "libtorch" {= "1.1.0"}
   "npy"
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0"}
   "ocaml-compiler-libs"
   "ppx_custom_printf"
   "ppx_expect"

--- a/packages/torch/torch.0.5/opam
+++ b/packages/torch/torch.0.5/opam
@@ -16,7 +16,7 @@ depends: [
   "dune-configurator"
   "libtorch" {= "1.1.0"}
   "npy"
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0"}
   "ocaml-compiler-libs"
   "ppx_custom_printf"
   "ppx_expect"


### PR DESCRIPTION
spotted in revdeps for #22717