### PR TITLE
Fix camlp5 revdeps (incompatibility with ocaml 5)

### DIFF
--- a/packages/elpi/elpi.1.15.2/opam
+++ b/packages/elpi/elpi.1.15.2/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.0" }
   "stdlib-shims"
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }

--- a/packages/elpi/elpi.1.16.1/opam
+++ b/packages/elpi/elpi.1.16.1/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.07.0" }
+  "ocaml" {>= "4.07.0" & < "5.0" }
   "stdlib-shims"
   "ppxlib" {>= "0.12.0" }
   "menhir" {>= "20211230" }

--- a/packages/gsl/gsl.1.24.3/opam
+++ b/packages/gsl/gsl.1.24.3/opam
@@ -22,7 +22,7 @@ most frequently used functions for scientific computation including algorithms
 for optimization, differential equations, statistics, random number generation,
 linear algebra, etc."""
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "1.10"}
   "dune-configurator"
   "conf-gsl" {build}

--- a/packages/ledit/ledit.2.05/opam
+++ b/packages/ledit/ledit.2.05/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/chetmurthy/ledit.git"
 
 build: [ make "all" ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "camlp5" {> "7.99"}
 ]
 synopsis: "Line editor, a la rlwrap"

--- a/packages/ostap/ostap.0.5/opam
+++ b/packages/ostap/ostap.0.5/opam
@@ -19,6 +19,7 @@ depends: [
   "camlp5"     { >= "8" | = "8.00~alpha04" | = "8.00~alpha05"  }
   "re"
   "GT"
+  "ocaml" {< "5.0"}
 ]
 
 url {


### PR DESCRIPTION
Seen on https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/83935adb2608cc82de5d55111879b59583f8ea68