### PR TITLE
icalendar.0.1.{0-2} requires dune >= 1.3

### DIFF
--- a/packages/icalendar/icalendar.0.1.0/opam
+++ b/packages/icalendar/icalendar.0.1.0/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"
+  "dune" {>= "1.3"}
   "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom" {< "0.14.0"}

--- a/packages/icalendar/icalendar.0.1.1/opam
+++ b/packages/icalendar/icalendar.0.1.1/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"
+  "dune" {>= "1.3"}
   "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom" {< "0.14.0"}

--- a/packages/icalendar/icalendar.0.1.2/opam
+++ b/packages/icalendar/icalendar.0.1.2/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune"
+  "dune" {>= "1.3"}
   "alcotest" {with-test & < "1.0.0"}
   "fmt"
   "angstrom" {< "0.14.0"}


### PR DESCRIPTION
Specified in the dune-project file. Seen on https://github.com/ocaml/opam-repository/pull/22823

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>