### PR TITLE
torch 0.{4-13} requires ctypes >= 0.11

### DIFF
--- a/packages/torch/torch.0.10/opam
+++ b/packages/torch/torch.0.10/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.11/opam
+++ b/packages/torch/torch.0.11/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.12/opam
+++ b/packages/torch/torch.0.12/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.4/opam
+++ b/packages/torch/torch.0.4/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.5/opam
+++ b/packages/torch/torch.0.5/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.7/opam
+++ b/packages/torch/torch.0.7/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.8/opam
+++ b/packages/torch/torch.0.8/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"

--- a/packages/torch/torch.0.9/opam
+++ b/packages/torch/torch.0.9/opam
@@ -10,7 +10,7 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "base" {>= "v0.11.0"}
   "cmdliner"
-  "ctypes" {>= "0.5"}
+  "ctypes" {>= "0.11"}
   "ctypes-foreign"
   "dune" {>= "1.3.0"}
   "dune-configurator"


### PR DESCRIPTION
They use Ctypes.is_null.
Failure:
```
# (cd _build/default && /home/opam/.opam/4.06/bin/ocamlc.opt -w -40 -g -bin-annot -I src/wrapper/.torch_core.objs/byte -I /home/opam/.opam/4.06/lib/bytes -I /home/opam/.opam/4.06/lib/ctypes -I /home/opam/.opam/4.06/lib/ocaml/threads -no-alias-deps -open Torch_core -o src/wrapper/.torch_core.objs/byte/torch_core__Wrapper_generated.cmo -c -impl src/wrapper/wrapper_generated.ml)
# File "src/wrapper/wrapper_generated.ml", line 11, characters 7-14:
# Error: Unbound value is_null
# Hint: Did you mean null?
```
Seen on https://github.com/ocaml/opam-repository/pull/22824

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>