### PR TITLE
vector3 0.2.1 is not compatible with ocaml5

### DIFF
--- a/packages/vector3/vector3.0.2.1/opam
+++ b/packages/vector3/vector3.0.2.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "vector3"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling vector3.0.2.1 ======================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/vector3.0.2.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
 exit-code            2
 env-file             ~/.opam/log/vector3-7-a1b26d.env
 output-file          ~/.opam/log/vector3-7-a1b26d.out
 File "./setup.ml", line 1404, characters 23-41:
 1404 |          let compare = Pervasives.compare
                               ^^^^^^^^^^^^^^^^^^
 Error: Unbound module Pervasives
```
Seen on https://github.com/ocaml/opam-repository/pull/22767

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>