### PR TITLE
coq-of-ocaml: update the urls of the repo

### DIFF
--- a/packages/coq-of-ocaml/coq-of-ocaml.2.2.1/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.2.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/clarus/coq-of-ocaml"
-dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
-bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -34,7 +34,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/clarus/coq-of-ocaml/archive/2.2.1.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/archive/2.2.1.tar.gz"
   checksum: [
     "sha256=3185fe93e13ce05f409307f04f30de4cbbbdd644b85570f2ef629780b57af174"
     "sha512=835ca0b5f464c602317dedf55c15ca7e4d0f99c88fdda925a595632fe8dc63f6c15e6f4a5578bd211d9fab4fae44d7e61235af786e30f8bb1b2454f55faa6269"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.3.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.3.0/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/clarus/coq-of-ocaml"
-dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
-bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -34,7 +34,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/clarus/coq-of-ocaml/archive/2.3.0.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/archive/2.3.0.tar.gz"
   checksum: [
     "sha256=889046cbfdc479b02aa9a97bcb6284df7539eba60e0f37f03c365e658445395d"
     "sha512=eec30792f4ab93a4ce9f8b94880c6e44bd7bc11424e24258c20e06e414af10fc108435543976e9c962ed7bbf17384cfe3bcf9114c90aeb57f3e1e188716537fe"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.4.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.4.0/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/clarus/coq-of-ocaml"
-dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
-bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -34,7 +34,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/clarus/coq-of-ocaml/archive/2.4.0.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/archive/2.4.0.tar.gz"
   checksum: [
     "sha256=c7996fa56404815f4b87395c910a1cfb4a60ad05fd03ea26604e5ef1f4d345bc"
     "sha512=a92cb1c0c505dcfd58084e4000d90e9816ea3abfd9f9778662306fb7818af3bbfca757822acda4e4ba907b24c81ab703db3b324373c13fa9209f491a3ef4ca8d"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.4.1/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.4.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/clarus/coq-of-ocaml"
-dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
-bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -35,7 +35,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/clarus/coq-of-ocaml/archive/2.4.1.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/archive/2.4.1.tar.gz"
   checksum: [
     "sha256=5856656d5542475e7eaf9e82a8348d85754f5c1ef1c56240ca97234793fb68ff"
     "sha512=44530bce7d40c8a27459db17c504b2a14d9c37fdbb0658df70bcf376df4309bd88222b89a069d8534c09eb40f1394dabda2bade9e44a9fde5a49b01fc9325d35"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.0/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.0/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/clarus/coq-of-ocaml"
-dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
-bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -36,7 +36,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/clarus/coq-of-ocaml/archive/2.5.0.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/archive/2.5.0.tar.gz"
   checksum: [
     "sha256=d58dc0f9223fdf228f995ddc020c9e54499d8d8adf579f07ab900ba88f2967d4"
     "sha512=ed60c61e3c534c4e4b81262a54e0a5896d25070251ed8c7ea68f6f1e4c9374d5f61c35f5093881d061517213973f77d3ba9ab0ea178343164eb1588b928fbe80"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.1/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.1/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/clarus/coq-of-ocaml"
-dev-repo: "git+https://github.com/clarus/coq-of-ocaml.git"
-bug-reports: "https://github.com/clarus/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -36,7 +36,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/clarus/coq-of-ocaml/releases/download/2.5.1/coq-of-ocaml-full.2.5.1.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/releases/download/2.5.1/coq-of-ocaml-full.2.5.1.tar.gz"
   checksum: [
     "sha256=809eaf4d5d21f6169aefc8c1fe4eb366dc44cfbda26ea3671087cc455e4409c5"
     "sha512=252f941e20fd7b0ede673fab647c8a60a28777d3de14ebaea38099efb9964ce1f717f8c516b6e48b322ed4cecf86578abdee62e7b48d044f805bf830986a00b8"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.12/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.12/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/foobar-land/coq-of-ocaml"
-dev-repo: "git+https://github.com/foobar-land/coq-of-ocaml.git"
-bug-reports: "https://github.com/foobar-land/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -36,7 +36,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/foobar-land/coq-of-ocaml/releases/download/2.5.2/coq-of-ocaml-full.2.5.2.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/releases/download/2.5.2/coq-of-ocaml-full.2.5.2.tar.gz"
   checksum: [
     "sha256=55564be48ccbdb5b7bcaced6480365e099b8bd7193454b613a4398fd033247ac"
     "sha512=712c9d594f6f045c127dd9883315286ad83268f7e627771b17437e167d5bbfd221fa79d071b1e77e04e80d219b820dfef14eb0494433e778c9ecfd52d131e665"

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.13/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.2+4.13/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer: "dev@clarus.me"
-homepage: "https://github.com/foobar-land/coq-of-ocaml"
-dev-repo: "git+https://github.com/foobar-land/coq-of-ocaml.git"
-bug-reports: "https://github.com/foobar-land/coq-of-ocaml/issues"
+homepage: "https://github.com/formal-land/coq-of-ocaml"
+dev-repo: "git+https://github.com/formal-land/coq-of-ocaml.git"
+bug-reports: "https://github.com/formal-land/coq-of-ocaml/issues"
 authors: ["Guillaume Claret"]
 license: "MIT"
 build: [
@@ -36,7 +36,7 @@ tags: [
 synopsis: "Compile a subset of OCaml to Coq"
 
 url {
-  src: "https://github.com/foobar-land/coq-of-ocaml/releases/download/2.5.2/coq-of-ocaml-full.2.5.2+4.13.tar.gz"
+  src: "https://github.com/formal-land/coq-of-ocaml/releases/download/2.5.2/coq-of-ocaml-full.2.5.2+4.13.tar.gz"
   checksum: [
     "sha256=9dfde155240061a70b803715609246d360605d887035070b160190e21f672dbd"
     "sha512=259a034fdff6cc0ca4af935eb07ec4dac7916a199452bec2bccbf5b6e26f6dfbcbd33ba53dfe63d0fc64a9c04763129e76ff6d04ebd53bb24e378b96457651ec"


### PR DESCRIPTION
Update the urls to the GitHub repository of `coq-of-ocaml`. Hopefully this does not break anything as GitHub was already doing redirects.