### PR TITLE
[new release] jose (0.8.0)

### DIFF
--- a/packages/jose/jose.0.8.0/opam
+++ b/packages/jose/jose.0.8.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/reason-jose"
+doc: "https://ulrikstrid.github.io/reason-jose"
+bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.8" & >= "1.11"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "0.10.0"}
+  "x509" {>= "0.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "astring"
+  "yojson" {>= "1.6.0"}
+  "zarith"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/reason-jose/releases/download/v0.8.0/jose-v0.8.0.tbz"
+  checksum: [
+    "sha256=3f4ab61831be6708add6623341a033caebe1ce9cb08a8ecbd63b65fe62510a4f"
+    "sha512=90cb8d9c33c2ca44e12908a6ebc1e394e052a39cc9e1a99f7598659ce49029c034a1e5390647ab7521a971253a310fb50d1c5110fe9b4282907c5eb1bd7fcdef"
+  ]
+}
+x-commit-hash: "3b74d6e3c3dff0f601bdbc78c108d84077c0a629"

--- a/packages/oidc/oidc.0.1.0/opam
+++ b/packages/oidc/oidc.0.1.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ulrikstrid/ocaml-oidc/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.5"}
-  "jose" {>= "0.5.1"}
+  "jose" {>= "0.5.1" & <= "0.7.0"}
   "uri"
   "uunf"
   "uutf"

--- a/packages/oidc/oidc.0.1.1/opam
+++ b/packages/oidc/oidc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ulrikstrid/ocaml-oidc/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.5"}
-  "jose" {>= "0.5.1"}
+  "jose" {>= "0.5.1" & <= "0.7.0"}
   "uri"
   "yojson"
   "logs"


### PR DESCRIPTION
CHANGES:

- Make `use` and `alg` optional
- Correct thumbprint generation on all algs
- Add getters for claims
- Thumbprint is now a Cstruct.t instead of string which is less ambigious
- Make `header` argument optional when signing which simplifies the normal usecase

https://github.com/ulrikstrid/reason-jose/issues/54