### PR TITLE
Release jose v0.8.1

### DIFF
--- a/packages/jose/jose.0.8.1/opam
+++ b/packages/jose/jose.0.8.1/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "base64" {>= "3.0.0"}
-  "dune" {>= "2.8" & >= "1.11"}
+  "dune" {>= "2.8"}
   "eqaf" {>= "0.7"}
   "mirage-crypto" {>= "0.10.0"}
   "x509" {>= "0.13.0"}

--- a/packages/jose/jose.0.8.1/opam
+++ b/packages/jose/jose.0.8.1/opam
@@ -10,7 +10,7 @@ doc: "https://ulrikstrid.github.io/reason-jose"
 bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "base64" {>= "3.0.0"}
+  "base64" {>= "3.3.0"}
   "dune" {>= "2.8"}
   "eqaf" {>= "0.7"}
   "mirage-crypto" {>= "0.10.0"}

--- a/packages/jose/jose.0.8.1/opam
+++ b/packages/jose/jose.0.8.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/reason-jose"
+doc: "https://ulrikstrid.github.io/reason-jose"
+bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.0.0"}
+  "dune" {>= "2.8" & >= "1.11"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "0.10.0"}
+  "x509" {>= "0.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "astring"
+  "yojson" {>= "1.6.0"}
+  "zarith"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/reason-jose/releases/download/v0.8.1/jose-v0.8.1.tbz"
+  checksum: [
+    "sha256=fceff4d21742198270db87a3a213839b748afb78eb93372a14d0c81ffe2d0ddf"
+    "sha512=d824829189cca85c8be2d5f595ee41382ca5fc7b00e3117b7f46f2a750885e50dd2a3885eb5875e742bf85413b1e2731fb14e7d58915cfa0a80db1e39d1031a0"
+  ]
+}
+x-commit-hash: "9acb825a3d5332ff911eb390d3268e2d49185ed7"

--- a/packages/oidc/oidc.0.1.0/opam
+++ b/packages/oidc/oidc.0.1.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ulrikstrid/ocaml-oidc/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.5"}
-  "jose" {>= "0.5.1" & <= "0.7.0"}
+  "jose" {>= "0.5.1" & < "0.8.0"}
   "uri"
   "uunf"
   "uutf"

--- a/packages/oidc/oidc.0.1.0/opam
+++ b/packages/oidc/oidc.0.1.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ulrikstrid/ocaml-oidc/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.5"}
-  "jose" {>= "0.5.1"}
+  "jose" {>= "0.5.1" & <= "0.7.0"}
   "uri"
   "uunf"
   "uutf"

--- a/packages/oidc/oidc.0.1.1/opam
+++ b/packages/oidc/oidc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ulrikstrid/ocaml-oidc/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.5"}
-  "jose" {>= "0.5.1"}
+  "jose" {>= "0.5.1" & <= "0.7.0"}
   "uri"
   "yojson"
   "logs"

--- a/packages/oidc/oidc.0.1.1/opam
+++ b/packages/oidc/oidc.0.1.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ulrikstrid/ocaml-oidc/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.5"}
-  "jose" {>= "0.5.1" & <= "0.7.0"}
+  "jose" {>= "0.5.1" & < "0.8.0"}
   "uri"
   "yojson"
   "logs"


### PR DESCRIPTION
CHANGES:

0.8.0 (unreleased)
- Make `use` and `alg` optional
- Correct thumbprint generation on all algs
- Add getters for claims
- Thumbprint is now a Cstruct.t instead of string which is less ambigious
- Make `header` argument optional when signing which simplifies the normal usecase

0.8.1
- Remove usage of Result.get_ok to maintain compatibility with older OCaml versions

https://github.com/ulrikstrid/reason-jose/issues/54