### PR TITLE
Package javalib.3.2.2

### DIFF
--- a/packages/javalib/javalib.3.2.2/opam
+++ b/packages/javalib/javalib.3.2.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "David Pichardie <david.pichardie@ens-rennes.fr>"
+authors: "Javalib Development team"
+homepage: "https://javalib-team.github.io/javalib/"
+bug-reports: "https://github.com/javalib-team/javalib/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+dev-repo: "git+https://github.com/javalib-team/javalib.git"
+build: [
+  ["./configure.sh" "-s" {ocaml:native-dynlink}]
+  [make]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>= "4.08"}
+  "conf-which" {build}
+  "ocamlfind" {build}
+  "camlzip" {>= "1.11"}
+  "extlib"
+]
+conflicts: [ "ocaml-option-bytecode-only" ]
+    
+synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"
+
+description: """
+Thus it stands for a good starting point for people who want to
+develop static analyses for Java byte-code programs, benefiting from
+the strength of OCaml language.
+"""
+url {
+  src: "https://github.com/javalib-team/javalib/archive/3.2.2.tar.gz"
+  checksum: [
+    "md5=90174a2297d43891ee7ebaaf7d29b87e"
+    "sha512=4796042b9d7929db45cf71a471a30a551b5fc2f27e801759d4911610c355b2a93b7148b3c84bb96844da31f756e2b3eb242f553f99dd5698474fbffaed4f8b98"
+  ]
+}


### PR DESCRIPTION
### `javalib.3.2.2`
Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files
Thus it stands for a good starting point for people who want to
develop static analyses for Java byte-code programs, benefiting from
the strength of OCaml language.



---
* Homepage: https://javalib-team.github.io/javalib/
* Source repo: git+https://github.com/javalib-team/javalib.git
* Bug tracker: https://github.com/javalib-team/javalib/issues

---
:camel: Pull-request generated by opam-publish v2.1.0