### PR TITLE
Fix lowerbound for ocamlfind.1.9.5

### DIFF
--- a/packages/ocamlfind/ocamlfind.1.9.5/opam
+++ b/packages/ocamlfind/ocamlfind.1.9.5/opam
@@ -13,7 +13,7 @@ authors: "Gerd Stolpmann <gerd@gerd-stolpmann.de>"
 homepage: "http://projects.camlcity.org/projects/findlib.html"
 bug-reports: "https://github.com/ocaml/ocamlfind/issues"
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.02.0"}
 ]
 depopts: ["graphics"]
 build: [


### PR DESCRIPTION
cf. https://github.com/ocaml/ocamlfind/issues/58

Fixed in 1.9.6 - this PR probably wants merging _after_ 1.9.6 is released to opam-repository, given the recompiles.