### PR TITLE
Avoid 4.12.0+domains* packages whenever possible

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains+effects/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml-option-nnp"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [compiler avoid-version]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+domains/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-option-nnp"
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [compiler avoid-version]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [


### PR DESCRIPTION
For some reason they were never tagged with `avoid-version`.

This avoid issues where opam will choose those versions above other (more recent) ones when downgrading from ocaml 5.0.0 because the packages installed are the most similar