### PR TITLE
Sawja uses Pervasives which is incompatible with ocaml5

### DIFF
--- a/packages/sawja/sawja.1.4/opam
+++ b/packages/sawja/sawja.1.4/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "sawja"]]
 depends: [
-  "ocaml"
+  "ocaml" { < "5.0.0" }
   "ocamlfind"
   "javalib" {= "2.2.2"}
 ]

--- a/packages/sawja/sawja.1.4/opam
+++ b/packages/sawja/sawja.1.4/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "sawja"]]
 depends: [
-  "ocaml" { < "5.0.0" }
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "javalib" {= "2.2.2"}
 ]

--- a/packages/sawja/sawja.1.5.1/opam
+++ b/packages/sawja/sawja.1.5.1/opam
@@ -11,7 +11,7 @@ remove: [
   ["ocamlfind" "remove" "sawja"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" { < "5.0.0" }
   "ocamlfind"
   "javalib" {= "2.3.1"}
 ]

--- a/packages/sawja/sawja.1.5.10/opam
+++ b/packages/sawja/sawja.1.5.10/opam
@@ -13,7 +13,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0.0"}
   "ocamlfind" {build}
   "javalib" {>= "3.2.1" & < "3.3"}
 ]

--- a/packages/sawja/sawja.1.5.11/opam
+++ b/packages/sawja/sawja.1.5.11/opam
@@ -16,7 +16,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0.0"}
   "ocamlfind" {build}
   "javalib" {>= "3.2.1" & < "3.3"}
 ]

--- a/packages/sawja/sawja.1.5.3/opam
+++ b/packages/sawja/sawja.1.5.3/opam
@@ -13,7 +13,7 @@ install: [
 ]
 homepage: "http://sawja.inria.fr"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "conf-perl" {build}
   "javalib" {>= "2.3.4" & <= "2.3.5"}

--- a/packages/sawja/sawja.1.5.4/opam
+++ b/packages/sawja/sawja.1.5.4/opam
@@ -13,7 +13,7 @@ install: [
 ]
 homepage: "http://sawja.inria.fr"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "javalib" {= "2.3.5"}
 ]

--- a/packages/sawja/sawja.1.5.5/opam
+++ b/packages/sawja/sawja.1.5.5/opam
@@ -14,7 +14,7 @@ install: [
 ]
 homepage: "http://sawja.inria.fr"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "javalib" {= "2.3.6"}
 ]

--- a/packages/sawja/sawja.1.5.6/opam
+++ b/packages/sawja/sawja.1.5.6/opam
@@ -14,7 +14,7 @@ install: [
 ]
 homepage: "http://sawja.inria.fr"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "javalib" {>= "3.0" & <= "3.1"}
 ]

--- a/packages/sawja/sawja.1.5.7/opam
+++ b/packages/sawja/sawja.1.5.7/opam
@@ -10,7 +10,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "conf-which" {build}
   "conf-perl" {build}

--- a/packages/sawja/sawja.1.5.8/opam
+++ b/packages/sawja/sawja.1.5.8/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.07"}
+  "ocaml" {>= "4.07" & < "5.0.0"}
   "ocamlfind" {build}
   "conf-which" {build}
   "javalib" {>= "3.2.1" & < "3.3"}

--- a/packages/sawja/sawja.1.5/opam
+++ b/packages/sawja/sawja.1.5/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "sawja"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "conf-perl" {build}
   "javalib" {>= "2.3" & < "2.3.2"}


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/22850 the CI fails some revdeps with

```
#=== ERROR while compiling sawja.1.5.8 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/sawja.1.5.8
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/sawja-7-de326a.env
# output-file          ~/.opam/log/sawja-7-de326a.out
### output ###
# make -C src
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/sawja.1.5.8/src'
# ocamlyacc heap_parser/parse_heap.mly
# cp classDomainPtrees.ml classDomain.ml
# rm -f safe.ml
# for i in safe_domain.ml safe_var.ml safe_state.ml safe_constraints.ml safe_solver.ml; do \
#   echo `basename $i .ml` | \
#     awk 'BEGIN{ORS="";OFS="";}{print "module " toupper(substr($0,6,1)) substr($0,7,length($0)-6) "= struct\n";}' >> safe.ml;\
#   echo "# 1 \""$i"\"" >> safe.ml;\
#   cat $i >> safe.ml;\
#   echo " end">> safe.ml;\
# done
# ocamllex heap_parser/lex_heap.mll	
# 82 states, 4559 transitions, table size 18728 bytes
# /home/opam/.opam/5.0/bin/ocamlfind ocamldep -I dataflow_analyses/ iter.mli iter2.mli wlist.mli jProgram.mli classDomain.mli jNativeStubs.mli jsrInline.mli jControlFlow.mli jPrintUtil.mli jPrintHtml.mli jPrintPlugin.mli argPlugin.mli jCodePP.mli jBir.mli jBirPP.mli a3Bir.mli a3BirPP.mli jBirSSA.mli jBirSSAPP.mli a3BirSSA.mli a3BirSSAPP.mli dataflow_analyses/live_bir.mli dataflow_analyses/live_a3bir.mli safe.mli reachableMethods.mli jUtil.mli jType.mli nexir.mli heap_parser//parserType.mli heap_parser/parse_heap.mli heap_parser/heapParser.mli jCRA.mli XTA.mli jRTA.mli jRTAWithHeap.mli jRRTA.mli jCFAOptions.mli jCFADom.mli jCFAPrinter.mli jCFA.mli dataflow_analyses/reachDef.mli dataflow_analyses/availableExpr.mli jUtil.ml iter.ml iter2.ml wlist.ml jProgram.ml classDomain.ml jsrInline.ml jControlFlow.ml jPrintUtil.ml jPrintHtml.ml jPrintPlugin.ml argPlugin.ml jCodePP.ml cmn.ml bir.ml birA3.ml jBir.ml jBirPP.ml a3Bir.ml a3BirPP.ml dataflow_analyses/live_bir.ml dataflow_analyses/live_a3bir.ml jBirSSA.ml jBirSSAPP.ml a3BirSSA.ml a3BirSSAPP.ml safe.ml reachableMethods.ml jNativeStubs.ml jType.ml nexir.ml heap_parser//parserType.ml heap_parser//parse_heap.ml heap_parser/lex_heap.ml heap_parser/heapParser.ml jCRA.ml jRTA.ml jRTAWithHeap.ml jRRTA.ml XTA.ml jCFAOptions.ml jCFADom.ml jCFAPrinter.ml jCFA.ml dataflow_analyses/reachDef.ml dataflow_analyses/availableExpr.ml dataflow_analyses/availableExprSSA.ml > .depend
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -g -w Aer -annot -package javalib -I dataflow_analyses/ -I heap_parser/ -c iter.mli
```

```
# File "jCFADom.mli", line 146, characters 48-62:
# 146 |   val join_ad : ?do_join:bool -> ?modifies:bool Pervasives.ref ->
#                                                       ^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make[1]: *** [Makefile:133: jCFADom.cmi] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/sawja.1.5.8/src'
# make: *** [Makefile:25: sawja] Error 2
```