### PR TITLE
ocaml 5: restrict touist releases

### DIFF
--- a/packages/touist/touist.3.0.0/opam
+++ b/packages/touist/touist.3.0.0/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocaml" "%{etc}%/touist/setup.ml" "-C" "%{etc}%/touist" "-uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "fileutils" {build & >= "0.4.0"}
   "menhir" {build & >= "20150118"}
   "minisat" {build}

--- a/packages/touist/touist.3.1.0/opam
+++ b/packages/touist/touist.3.1.0/opam
@@ -31,7 +31,7 @@ remove: [
   "ocaml" "%{etc}%/touist/setup.ml" "-C" "%{etc}%/touist" "-uninstall"
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "fileutils" {build & >= "0.4.0"}

--- a/packages/touist/touist.3.2.0/opam
+++ b/packages/touist/touist.3.2.0/opam
@@ -33,7 +33,7 @@ remove: [
   "ocaml" "%{etc}%/touist/setup.ml" "-C" "%{etc}%/touist" "-uninstall"
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "cppo" {build}
   "cppo_ocamlbuild" {build}
   "fileutils" {build & >= "0.4.0"}

--- a/packages/touist/touist.3.2.1/opam
+++ b/packages/touist/touist.3.2.1/opam
@@ -33,7 +33,7 @@ remove: [
   "ocaml" "%{etc}%/touist/setup.ml" "-C" "%{etc}%/touist" "-uninstall"
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "cppo" {build & >= "0.9.4"}
   "cppo_ocamlbuild" {build}
   "fileutils" {build & >= "0.4.0"}


### PR DESCRIPTION
These releases use `Stream`:

    #=== ERROR while compiling touist.3.0.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/touist.3.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/touist-8-28d1c9.env
    # output-file          ~/.opam/log/touist-8-28d1c9.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream

    #=== ERROR while compiling touist.3.1.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/touist.3.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-yices2
    # exit-code            2
    # env-file             ~/.opam/log/touist-8-b0029a.env
    # output-file          ~/.opam/log/touist-8-b0029a.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream

    - File "./setup.ml", line 575, characters 4-15:
    - 575 |     Stream.from next
    -           ^^^^^^^^^^^
    - Error: Unbound module Stream

    #=== ERROR while compiling touist.3.2.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/touist.3.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-yices2 --disable-qbf
    # exit-code            2
    # env-file             ~/.opam/log/touist-9-b92879.env
    # output-file          ~/.opam/log/touist-9-b92879.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream

    - File "./setup.ml", line 575, characters 4-15:
    - 575 |     Stream.from next
    -           ^^^^^^^^^^^
    - Error: Unbound module Stream

    #=== ERROR while compiling touist.3.2.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/touist.3.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-yices2 --disable-qbf
    # exit-code            2
    # env-file             ~/.opam/log/touist-8-8c841d.env
    # output-file          ~/.opam/log/touist-8-8c841d.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
