### PR TITLE
ocaml 5: restrict herdtools7 releases

### DIFF
--- a/packages/herdtools7/herdtools7.7.42-beta.3/opam
+++ b/packages/herdtools7/herdtools7.7.42-beta.3/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "This is herdtools7, a tool suite to test weak memory models."

--- a/packages/herdtools7/herdtools7.7.42/opam
+++ b/packages/herdtools7/herdtools7.7.42/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "This is herdtools7, a tool suite to test weak memory models."

--- a/packages/herdtools7/herdtools7.7.43/opam
+++ b/packages/herdtools7/herdtools7.7.43/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis:

--- a/packages/herdtools7/herdtools7.7.44/opam
+++ b/packages/herdtools7/herdtools7.7.44/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.45/opam
+++ b/packages/herdtools7/herdtools7.7.45/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.46/opam
+++ b/packages/herdtools7/herdtools7.7.46/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.47/opam
+++ b/packages/herdtools7/herdtools7.7.47/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.48/opam
+++ b/packages/herdtools7/herdtools7.7.48/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.49/opam
+++ b/packages/herdtools7/herdtools7.7.49/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.50/opam
+++ b/packages/herdtools7/herdtools7.7.50/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.51/opam
+++ b/packages/herdtools7/herdtools7.7.51/opam
@@ -13,7 +13,7 @@ build: ["./build.sh" "%{prefix}%"]
 install: ["./install.sh" "%{prefix}%"]
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "herdtools7, a tool suite for shared memory models."

--- a/packages/herdtools7/herdtools7.7.52/opam
+++ b/packages/herdtools7/herdtools7.7.52/opam
@@ -16,7 +16,7 @@ install: ["./install.sh" "%{prefix}%"]
 # @todo Add "build-test" field
 remove: ["./uninstall.sh" "%{prefix}%"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
 ]
 url {


### PR DESCRIPTION
They use `Pervasives`:

    #=== ERROR while compiling herdtools7.7.52 ====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/herdtools7.7.52
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./build.sh /home/opam/.opam/5.0
    # exit-code            10
    # env-file             ~/.opam/log/herdtools7-8-85ebfa.env
    # output-file          ~/.opam/log/herdtools7-8-85ebfa.out
    ### output ###
    [...]
    # File "lib/Archs.ml", line 108, characters 14-32:
    # 108 | let compare = Pervasives.compare
    #                     ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # Command exited with code 2.
