### PR TITLE
containers >= 3.7 does not support bytecode-only mode (uses (modes native))

### DIFF
--- a/packages/containers/containers.3.10/opam
+++ b/packages/containers/containers.3.10/opam
@@ -26,6 +26,9 @@ depopts: [
   "base-unix"
   "base-threads"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "https://c-cube.github.io/ocaml-containers"

--- a/packages/containers/containers.3.7/opam
+++ b/packages/containers/containers.3.7/opam
@@ -26,6 +26,9 @@ depopts: [
   "base-unix"
   "base-threads"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "https://c-cube.github.io/ocaml-containers"

--- a/packages/containers/containers.3.8/opam
+++ b/packages/containers/containers.3.8/opam
@@ -26,6 +26,9 @@ depopts: [
   "base-unix"
   "base-threads"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "https://c-cube.github.io/ocaml-containers"

--- a/packages/containers/containers.3.9/opam
+++ b/packages/containers/containers.3.9/opam
@@ -26,6 +26,9 @@ depopts: [
   "base-unix"
   "base-threads"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
 homepage: "https://github.com/c-cube/ocaml-containers/"
 doc: "https://c-cube.github.io/ocaml-containers"


### PR DESCRIPTION
Fixed upstream in https://github.com/c-cube/ocaml-containers/pull/421
```
#=== ERROR while compiling containers.3.7 =====================================#
# context     2.2.0~alpha~dev | linux/arm64 | ocaml-option-bytecode-only.1 | git+https://github.com/ocaml/opam-repository
# path        ~/.opam/bytecode-only/.opam-switch/build/containers.3.7
# command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p containers -j 9
# exit-code   1
# env-file    ~/.opam/log/containers-67311-a0e1a2.env
# output-file ~/.opam/log/containers-67311-a0e1a2.out
### output ###
# File "src/core/.merlin-conf/_unknown_", line 1, characters 0-0:
# Error: No rule found for src/core/cpp/cpp.exe
```