### PR TITLE
ocaml 5: restrict dtools releases

### DIFF
--- a/packages/dtools/dtools.0.3.0/opam
+++ b/packages/dtools/dtools.0.3.0/opam
@@ -8,7 +8,7 @@ build: [
   [make]
 ]
 remove: [["ocamlfind" "remove" "dtools"]]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind"]
 install: [make "install"]
 synopsis: "Library providing various helper functions to make daemons"
 description: """

--- a/packages/dtools/dtools.0.3.2/opam
+++ b/packages/dtools/dtools.0.3.2/opam
@@ -10,7 +10,7 @@ install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "dtools"]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind"]
 bug-reports: "https://github.com/savonet/ocaml-dtools/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 synopsis: "Library providing various helper functions to make daemons"

--- a/packages/dtools/dtools.0.3.3/opam
+++ b/packages/dtools/dtools.0.3.3/opam
@@ -10,7 +10,7 @@ install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "dtools"]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind"]
 bug-reports: "https://github.com/savonet/ocaml-dtools/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 synopsis: "Library providing various helper functions to make daemons"

--- a/packages/dtools/dtools.0.3.4/opam
+++ b/packages/dtools/dtools.0.3.4/opam
@@ -10,7 +10,7 @@ install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "dtools"]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind"]
 bug-reports: "https://github.com/savonet/ocaml-dtools/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-dtools.git"
 synopsis: "Library providing various helper functions to make daemons"

--- a/packages/dtools/dtools.0.4.0/opam
+++ b/packages/dtools/dtools.0.4.0/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "dtools"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 bug-reports: "https://github.com/savonet/ocaml-dtools/issues"

--- a/packages/dtools/dtools.0.4.1/opam
+++ b/packages/dtools/dtools.0.4.1/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "dtools"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 bug-reports: "https://github.com/savonet/ocaml-dtools/issues"


### PR DESCRIPTION
They use `Pervasives`:

    #=== ERROR while compiling dtools.0.4.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/dtools.0.4.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/dtools-8-2deabb.env
    # output-file          ~/.opam/log/dtools-8-2deabb.out
    ### output ###
    [...]
    # File "dtools.ml", line 362, characters 13-27:
    # 362 |     let nb = Pervasives.ref 0 in
    #                    ^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
