### PR TITLE
[new release] coq-lsp (0.1.2+v8.16)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.1.2+v8.16/opam
+++ b/packages/coq-lsp/coq-lsp.0.1.2+v8.16/opam
@@ -1,0 +1,41 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+  "ocaml"        { >= "4.12.0" }
+  "dune"         { >= "3.2"  }
+
+  # Not yet required, install Coq deps instead
+  "coq"            {         >= "8.16.0" & < "8.17" }
+  "coq-serapi"     {         >= "8.16.0" & < "8.17" }
+  "camlp-streams"  {         >= "5.0"               }
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.1.2%2Bv8.16/coq-lsp-0.1.2.v8.16.tbz"
+  checksum: [
+    "sha256=31b83f0908bbabf4079806ce9271a30f7af8fb4e2fd5c81c1ccc3c1e8022f0de"
+    "sha512=de9f48cb643944620183243a55a225b33b3b77d2cc2ea26e38377622ea9036e7205634e880d804dd0ae69ce22d321ce4dfbacc94aebb402d1f124d5be348ebca"
+  ]
+}
+x-commit-hash: "db7e96da8bdcd8022fb2a6c2d8b1cc70d8f9ea31"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

------------------------

 - Send an error to the client if the client and server versions don't
   match (@ejgallego, ejgallego/coq-lsp#126)
 - Parse options -noinit, -indices-matter, and -impredicative-set from
   `_CoqProject` (@artagnon, @ejgallego, ejgallego/coq-lsp#140, ejgallego/coq-lsp#150)
 - Log file `log-lsp.txt` has been removed in favor of `coq-lsp.trace.server`
   (@artagnon, @ejgallego, ejgallego/coq-lsp#130, ejgallego/coq-lsp#148)
 - Added --bt flag to print a backtrace on error (@Alizter, ejgallego/coq-lsp#147)
 - A detailed view of Coq errors is now displayed in the info panel
   (@ejgallego, ejgallego/coq-lsp#128)
 - Coq "Notice" messages, such as the ones generated by `About` or
   `Search` are not shown anymore as diagnostics. Instead, they will
   be shown on the side panel when clicking on the corresponding
   command. The `show_notices_as_diagnostics` option allows to restore
   old behavior (@ejgallego, ejgallego/coq-lsp#128, fixes ejgallego/coq-lsp#125)
 - Print some more info about Coq workspace configuration (@ejgallego, ejgallego/coq-lsp#151)
 - Admit failed `Qed` by default; allow users to configure it
   (@ejgallego, ejgallego/coq-lsp#118, fixes ejgallego/coq-lsp#90)
