### PR TITLE
Package libbinaryen.110.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.110.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.110.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "5.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v110.0.0/libbinaryen-v110.0.0.tar.gz"
+  checksum: [
+    "md5=f526a80b9d0c55718ddde136cc1c89ba"
+    "sha512=83e9607dae591d924655cda4c8653bede4fc37941c529e5c41967f7c45bb89e43f019e997f3335d80f08bbae638a063c643f7ddbf4b62a5627a8f138d15ec3f3"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.110.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [110.0.0](https://github.com/grain-lang/libbinaryen/compare/v109.0.1...v110.0.0) (2023-01-05)


### ⚠ BREAKING CHANGES

* Require dune 3.0 to better support js_of_ocaml
* Require js_of_ocaml 4.1 to ensure optimization fix
* Update binaryen to version_110 ([#72](https://github.com/grain-lang/libbinaryen/issues/72))

### Features

* Update binaryen to version_110 ([#72](https://github.com/grain-lang/libbinaryen/issues/72)) ([008d8ff](https://github.com/grain-lang/libbinaryen/commit/008d8ffa7431a0190b05db9b33a15c52044435c2))


### Miscellaneous Chores

* Require dune 3.0 to better support js_of_ocaml ([008d8ff](https://github.com/grain-lang/libbinaryen/commit/008d8ffa7431a0190b05db9b33a15c52044435c2))
* Require js_of_ocaml 4.1 to ensure optimization fix ([008d8ff](https://github.com/grain-lang/libbinaryen/commit/008d8ffa7431a0190b05db9b33a15c52044435c2))

---
:camel: Pull-request generated by opam-publish v2.0.3