### PR TITLE
[new release] mdx (2.2.0)

### DIFF
--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -33,6 +33,9 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build & >= "1.1.0"}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "ocaml-version" {>= "2.3.0"}
+  "odoc-parser" {>= "1.0.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/2.2.0/mdx-2.2.0.tbz"
+  checksum: [
+    "sha256=e8ac4af8ae24259d309d8476f7cec70f98819ba44af83591cf303907ac3528f7"
+    "sha512=1cbbeb7889d0931189c7fc22fe90310ae6c49b9f8a56cbd131e6e1a5045383c4d075f4acb9b60501dfe59c66e4f9ac02b5a07ed5fba6fce9d1ce9ea01e59a1c0"
+  ]
+}
+x-commit-hash: "aadf69623e8fa17c85bb8767bf20c24eb22ed133"


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Added

- Report all parsing errors in Markdown files (realworldocaml/mdx#389, @NathanReb)

#### Changed

- Preserve indentation in multiline OCaml blocks in .mli files (realworldocaml/mdx#395, @panglesd)

#### Fixed

- Fixed compatibility with Cmdliner 1.1.0 (realworldocaml/mdx#371, @Leonidas-from-XIV)
- Report errors and exit codes of toplevel directives (realworldocaml/mdx#382, @talex5,
  @Leonidas-from-XIV)
- Fix block locations in error reporting (realworldocaml/mdx#389, @NathanReb)
- Include the content of the line that features the `part-end` MDX directive in
  the output, before that line would've been dropped (realworldocaml/mdx#374, realworldocaml/mdx#387,
  @Leonidas-from-XIV)
- Handle EINTR signal on waitpid call by restarting the syscall. (realworldocaml/mdx#409, @tmcgilchrist)
- Fix parsing of multiline toplevel phrases in .mli files (realworldocaml/mdx#394, realworldocaml/mdx#397,
  @Leonidas-from-XIV)

#### Removed

- Removed warning about missing semicolons added in MDX 1.11.0 and the
  automatic insertion of semicolons in the corrected files introduced in MDX
  2.0.0. (realworldocaml/mdx#398, @Leonidas-from-XIV)
