### PR TITLE
Restore ocaml-variants.5.0.0+trunk and ocaml-variants.4.14.1+trunk

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.14.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+trunk/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "4.14.1 obsolete development package"
+description: "Replaced with ocaml-variants.4.14.2+trunk"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+flags: [ compiler avoid-version ]
+available: false

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+trunk/opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "5.0.0 obsolete development package"
+description: "Replaced with ocaml-variants.5.0.1+trunk"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#trunk"
+flags: [ compiler avoid-version ]
+available: false


### PR DESCRIPTION
The version numbering requirements of the `ocaml` package mean that the `+trunk` development variant becomes obsolete as soon as a release is made - i.e. once 5.0.0 and 4.14.1 were released, the `+trunk` packages need to be `ocaml-variants.5.0.1+trunk` and `ocaml-variants.4.14.2+trunk`. This was done in #22724, but the renaming is causing problems on some platforms because of the way `opam update` works internally. There's work in progress on the opam side, with linked issues at https://github.com/ocaml/opam/pull/5400. There's also failures like https://github.com/ocaml/opam/issues/5408. On top of that, fairly soon, the aim is to be able to get "trunk" OCaml via a pin, rather than a specific package. So in future this problem hopefully disappears.

In the meantime, I think it may help just to restore dummy versions of the old packages (and potentially do this for any new OCaml releases)?

cc @Octachron (and, tautologically, @kit-ty-kate!)