### PR TITLE
coccinelle does not compile on OCaml 5.0 (expects to be able to find bigarray)

### DIFF
--- a/packages/coccinelle/coccinelle.1.0.0-rc21/opam
+++ b/packages/coccinelle/coccinelle.1.0.0-rc21/opam
@@ -11,7 +11,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "menhir" {< "20141215"}
   "ocamlfind"

--- a/packages/coccinelle/coccinelle.1.0.0-rc22/opam
+++ b/packages/coccinelle/coccinelle.1.0.0-rc22/opam
@@ -11,7 +11,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "menhir" {< "20141215"}
   "ocamlfind"

--- a/packages/coccinelle/coccinelle.1.0.0-rc24/opam
+++ b/packages/coccinelle/coccinelle.1.0.0-rc24/opam
@@ -11,7 +11,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "menhir" {= "20140422"}
   "ocamlfind"

--- a/packages/coccinelle/coccinelle.1.0.0.1/opam
+++ b/packages/coccinelle/coccinelle.1.0.0.1/opam
@@ -11,7 +11,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "menhir" {= "20140422"}
   "ocamlfind"

--- a/packages/coccinelle/coccinelle.1.0.2/opam
+++ b/packages/coccinelle/coccinelle.1.0.2/opam
@@ -20,7 +20,7 @@ remove: [
   ["rm" "-f"  "%{prefix}%/share/man/man3/Coccilib.3cocci"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "camlp4"
   "menhir" {= "20140422"}
   "ocamlfind"

--- a/packages/coccinelle/coccinelle.1.0.8/opam
+++ b/packages/coccinelle/coccinelle.1.0.8/opam
@@ -15,7 +15,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "menhir" {< "20200525"}
   "ocamlfind"
   "pcre"

--- a/packages/coccinelle/coccinelle.1.0.9/opam
+++ b/packages/coccinelle/coccinelle.1.0.9/opam
@@ -15,7 +15,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "menhir"
   "ocamlfind"
   "pcre"

--- a/packages/coccinelle/coccinelle.1.1.0/opam
+++ b/packages/coccinelle/coccinelle.1.1.0/opam
@@ -15,7 +15,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "menhir" {>= "20181113"}
   "ocamlfind"
   "pcre"

--- a/packages/coccinelle/coccinelle.1.1.1/opam
+++ b/packages/coccinelle/coccinelle.1.1.1/opam
@@ -15,7 +15,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "menhir" {>= "20181113"}
   "ocamlfind"
   "pcre"


### PR DESCRIPTION
cc @evdenis
```
#=== ERROR while compiling coccinelle.1.1.1 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/coccinelle.1.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --enable-opt --enable-ocaml --enable-python --enable-pcre-syntax --enable-pcre --prefix /home/opam/.opam/5.0 --libdir /home/opam/.opam/5.0/lib
# exit-code            1
# env-file             ~/.opam/log/coccinelle-7-f73de1.env
# output-file          ~/.opam/log/coccinelle-7-f73de1.out
### output ###
# configure: configuring coccinelle 1.1.1 in /home/opam/.opam/5.0/.opam-switch/build/coccinelle.1.1.1
# checking for a BSD-compatible install... /usr/bin/install -c
# checking whether build environment is sane... yes
# checking for a thread-safe mkdir -p... /bin/mkdir -p
# checking for gawk... no
# checking for mawk... mawk
# checking whether make sets $(MAKE)... yes
# checking whether make supports nested variables... yes
# configure: determining version suffix
# checking for date... /bin/date
# configure: version suffix set to Thu, 05 Jan 2023 16:01:01 +0000
# configure: this configure program uses pkg-config m4 macros
# configure: this configure program uses ocaml m4 macros (see setup/ocaml.m4)
# configure: this configure program uses custom m4 macros (see setup/cocci.m4)
# configure: some fake substitutions for required but unavailable programs may be used (see setup/fake*)
# configure: verifying basic tools
# checking whether make supports the include directive... yes (GNU style)
# checking for gcc... gcc
# checking whether the C compiler works... yes
# checking for C compiler default output file name... a.out
# checking for suffix of executables... 
# checking whether we are cross compiling... no
# checking for suffix of object files... o
# checking whether we are using the GNU C compiler... yes
# checking whether gcc accepts -g... yes
# checking for gcc option to accept ISO C89... none needed
# checking whether gcc understands -c and -o together... yes
# checking dependency style of gcc... none
# checking how to run the C preprocessor... gcc -E
# checking for bash... /bin/bash
# checking for tar... /bin/tar
# checking for patch... /usr/bin/patch
# checking for echo... /bin/echo
# checking for patchelf... no
# checking for pkg-config... /usr/bin/pkg-config
# checking pkg-config is at least version 0.9.0... yes
# checking for ocamlc... /home/opam/.opam/5.0/bin/ocamlc
# OCaml version is 5.0.0
# OCaml library path is /home/opam/.opam/5.0/lib/ocaml
# checking for ocamlopt... /home/opam/.opam/5.0/bin/ocamlopt
# checking for ocamlc.opt... /home/opam/.opam/5.0/bin/ocamlc.opt
# checking for ocamlopt.opt... /home/opam/.opam/5.0/bin/ocamlopt.opt
# checking for ocaml... /home/opam/.opam/5.0/bin/ocaml
# checking for ocamldep... /home/opam/.opam/5.0/bin/ocamldep
# checking for ocamlmktop... /home/opam/.opam/5.0/bin/ocamlmktop
# checking for ocamlmklib... /home/opam/.opam/5.0/bin/ocamlmklib
# checking for ocamldoc... /home/opam/.opam/5.0/bin/ocamldoc
# checking that the OCaml version is at least 3.12... yes
# checking that the OCaml version is at least 4.02... yes
# checking that the OCaml version is at least 4.03... yes
# checking for ocamllex... /home/opam/.opam/5.0/bin/ocamllex
# checking for ocamllex.opt... /home/opam/.opam/5.0/bin/ocamllex.opt
# checking for ocamlyacc... /home/opam/.opam/5.0/bin/ocamlyacc
# checking for ocamlfind... /home/opam/.opam/5.0/bin/ocamlfind
# checking for ocamlprof... /home/opam/.opam/5.0/bin/ocamlprof
# configure: verifying basic ocaml modules
# configure: coccinelle may use external ocaml libraries in /home/opam/.opam/5.0/.opam-switch/build/coccinelle.1.1.1/bundles
# configure: the following OCaml packages should be provided by your ocaml installation
# checking for OCaml findlib package unix... found
# checking for OCaml findlib package bigarray... not found
# configure: error: package bigarray is required. It should be part of your ocaml installation.
```