### PR TITLE
rankers is not compatible with parany >= 13 (Parany.run doesn't have ~core_pin anymore)

### DIFF
--- a/packages/rankers/rankers.2.0.7/opam
+++ b/packages/rankers/rankers.2.0.7/opam
@@ -17,7 +17,7 @@ depends: [
   "minicli" {>= "5.0.0"}
   "molenc"
   "nlopt-ocaml"
-  "parany" {>= "11.0.0"}
+  "parany" {>= "11.0.0" & < "13.0.0"}
 ]
 synopsis: "Vanishing Ranking Kernels (VRK)"
 description: """


### PR DESCRIPTION
Will be fixed in https://github.com/ocaml/opam-repository/pull/22841 I suppose
```
#=== ERROR while compiling rankers.2.0.7 ======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/rankers.2.0.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p rankers -j 255
# exit-code            1
# env-file             ~/.opam/log/rankers-7-e8a687.env
# output-file          ~/.opam/log/rankers-7-e8a687.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -g -bin-annot -I src/.bwmine.eobjs/byte -I /home/opam/.opam/5.0/lib/batteries -I /home/opam/.opam/5.0/lib/bst -I /home/opam/.opam/5.0/lib/camlp-streams -I /home/opam/.opam/5.0/lib/cpm -I /home/opam/.opam/5.0/lib/dolog -I /home/opam/.opam/5.0/lib/domainslib -I /home/opam/.opam/5.0/lib/lockfree -I /home/opam/.opam/5.0/lib/minicli -I /home/opam/.opam/5.0/lib/molenc -I /home/opam/.opam/5.0/lib/nlopt -I /home/opam/.opam/5.0/lib/num -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/parany -I /home/opam/.opam/5.0/lib/pyml -I /home/opam/.opam/5.0/lib/stdcompat -I /home/opam/.opam/5.0/lib/vector3 -no-alias-deps -o src/.bwmine.eobjs/byte/myList.cmo -c -impl src/myList.ml)
# File "src/myList.ml", line 83, characters 25-34:
# 83 |     Parany.run ~core_pin:pin_cores ~csize ncores
#                               ^^^^^^^^^
# Error: The function applied to this argument has type ?preserve:bool -> unit
# This argument cannot be applied with label ~core_pin
```