### PR TITLE
z3 < 4.8.14 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/z3/z3.4.6/opam
+++ b/packages/z3/z3.4.6/opam
@@ -16,7 +16,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "z3"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "num"
   "conf-gmp"

--- a/packages/z3/z3.4.7.1/opam
+++ b/packages/z3/z3.4.7.1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "z3"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "num"
   "conf-gmp"

--- a/packages/z3/z3.4.8.1/opam
+++ b/packages/z3/z3.4.8.1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "z3"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "num"
   "conf-gmp"

--- a/packages/z3/z3.4.8.11/opam
+++ b/packages/z3/z3.4.8.11/opam
@@ -16,7 +16,7 @@ install: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"

--- a/packages/z3/z3.4.8.4/opam
+++ b/packages/z3/z3.4.8.4/opam
@@ -19,7 +19,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "z3"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "num"
   "conf-gmp"

--- a/packages/z3/z3.4.8.5/opam
+++ b/packages/z3/z3.4.8.5/opam
@@ -16,7 +16,7 @@ install: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "num"
   "conf-gmp"

--- a/packages/z3/z3.4.8.6/opam
+++ b/packages/z3/z3.4.8.6/opam
@@ -13,7 +13,7 @@ install: [
   [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "num"
   "conf-gmp"

--- a/packages/z3/z3.4.8.7/opam
+++ b/packages/z3/z3.4.8.7/opam
@@ -13,7 +13,7 @@ install: [
   [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"

--- a/packages/z3/z3.4.8.8-1/opam
+++ b/packages/z3/z3.4.8.8-1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"

--- a/packages/z3/z3.4.8.8/opam
+++ b/packages/z3/z3.4.8.8/opam
@@ -13,7 +13,7 @@ install: [
   [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"

--- a/packages/z3/z3.4.8.9-1/opam
+++ b/packages/z3/z3.4.8.9-1/opam
@@ -16,7 +16,7 @@ install: [
 ]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"

--- a/packages/z3/z3.4.8.9/opam
+++ b/packages/z3/z3.4.8.9/opam
@@ -13,7 +13,7 @@ install: [
   [ "sh" "-c" "ocamlfind install z3 build/api/ml/META -nodll build/libz3* build/api/ml/*" ]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "zarith"
   "conf-gmp"


### PR DESCRIPTION
```
#=== ERROR while compiling z3.4.8.9-1 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/z3.4.8.9-1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C build -j 31
# exit-code            2
# env-file             ~/.opam/log/z3-8-2687f3.env
# output-file          ~/.opam/log/z3-8-2687f3.out
### output ###
# cp ../src/api/ml/z3.mli api/ml/z3.mli
# src/util/warning.cpp
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3.cmi -c api/ml/z3.mli
# ocamlfind ocamlc -package zarith  -I api/ml -o api/ml/z3.cmo -c ../src/api/ml/z3.ml
# File "../src/api/ml/z3.ml", line 206, characters 16-34:
# 206 |   let compare = Pervasives.compare
#                       ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:4806: api/ml/z3.cmo] Error 2
# make: *** Waiting for unfinished jobs....
# make: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/z3.4.8.9-1/build'
```