### PR TITLE
[new release] ocaml-lsp-server, lsp and jsonrpc (1.15.0-5.0)

### DIFF
--- a/packages/jsonrpc/jsonrpc.1.15.0-5.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.15.0-5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.0-5.0/lsp-1.15.0-5.0.tbz"
+  checksum: [
+    "sha256=f2ff50716258ae35142bce935387fcc6b5541113d0df59ff15b106bb409c5d90"
+    "sha512=34e7f23c48a506ae8497e040945e16e4bc78d88e210eaf9659a97ea41731708a2d9457deeda270985dfd9f4170f82cf5f91c7cdf6639fbe18f11cbaa8de5a6fa"
+  ]
+}
+x-commit-hash: "176d387926dfb0a0b2b0196395ad38000395c049"

--- a/packages/lsp/lsp.1.15.0-5.0/opam
+++ b/packages/lsp/lsp.1.15.0-5.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.12"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["ocaml" "unix.cma" "unvendor.ml"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.0-5.0/lsp-1.15.0-5.0.tbz"
+  checksum: [
+    "sha256=f2ff50716258ae35142bce935387fcc6b5541113d0df59ff15b106bb409c5d90"
+    "sha512=34e7f23c48a506ae8497e040945e16e4bc78d88e210eaf9659a97ea41731708a2d9457deeda270985dfd9f4170f82cf5f91c7cdf6639fbe18f11cbaa8de5a6fa"
+  ]
+}
+x-commit-hash: "176d387926dfb0a0b2b0196395ad38000395c049"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.15.0-5.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.15.0-5.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "ppx_expect" {>= "v0.15.0" & with-test}
+  "ocamlformat" {with-test & = "0.24.1"}
+  "ocamlc-loc" {>= "3.5.0" & < "3.7.0"}
+  "omd" {>= "1.3.2" & < "2.0.0~alpha1"}
+  "octavius" {>= "1.2.2"}
+  "uutf" {>= "1.0.2"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "ocaml" {>= "5.0" & < "5.1"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "ocaml-lsp-server.install"
+    "--release"
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.15.0-5.0/lsp-1.15.0-5.0.tbz"
+  checksum: [
+    "sha256=f2ff50716258ae35142bce935387fcc6b5541113d0df59ff15b106bb409c5d90"
+    "sha512=34e7f23c48a506ae8497e040945e16e4bc78d88e210eaf9659a97ea41731708a2d9457deeda270985dfd9f4170f82cf5f91c7cdf6639fbe18f11cbaa8de5a6fa"
+  ]
+}
+x-commit-hash: "176d387926dfb0a0b2b0196395ad38000395c049"


### PR DESCRIPTION
LSP Server for OCaml

- Project page: <a href="https://github.com/ocaml/ocaml-lsp">https://github.com/ocaml/ocaml-lsp</a>

##### CHANGES:

## Features

- Add support for OCaml 5.0

- Enable [semantic highlighting](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens)
  support by default (ocaml/ocaml-lsp#933)

- Support connecting over pipes and socket. Pipes on Windows aren't yet
  supported (ocaml/ocaml-lsp#946)

  [More](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#implementationConsiderations)
  about communication channels in LSP specification.

- Re-enable `ocamlformat-rpc` for formatting code snippets (but not files and
  not on Windows) (ocaml/ocaml-lsp#920, ocaml/ocaml-lsp#939)

  One needs to have installed either `ocamlformat` package version > 0.21.0 or,
  otherwise, `ocamlformat-rpc` package. Note that previously `ocamlformat-rpc`
  came in a standalone OPAM package, but since `ocamlformat` version > 0.21.0,
  it comes within `ocamlformat` package.

- Add custom
  [`ocamllsp/hoverExtended`](https://github.com/ocaml/ocaml-lsp/blob/e165f6a3962c356adc7364b9ca71788e93489dd0/ocaml-lsp-server/docs/ocamllsp/hoverExtended-spec.md#L1)
  request (ocaml/ocaml-lsp#561)

- Support utf-8 position encoding clients (ocaml/ocaml-lsp#919)

  [More](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position) about position encoding in LSP specification.

- Show unwrapped module alias types on hovering over module names. This is due
  to upgrading to merlin 4.7 and using merlin's `verbosity=smart` by default
  (ocaml/ocaml-lsp#942)

## Fixes

- Respect the client's completion item resolve and preSelect capabilities
  (ocaml/ocaml-lsp#925, ocaml/ocaml-lsp#936)

- Disable polling for dune's watch mode on Windows and OCaml 4.14.0 (ocaml/ocaml-lsp#935)

- Fix semantic highlighting of "long identifiers," e.g., `Foo.Bar.x` (ocaml/ocaml-lsp#932)

- Fix syncing of document contents:

  - For ranges that span an entire line (ocaml/ocaml-lsp#927)
  - Previously, whole line edits would incorrectly eat the newline characters (ocaml/ocaml-lsp#971)
