### PR TITLE
Package tdigest.2.1.0

### DIFF
--- a/packages/tdigest/tdigest.2.1.0/opam
+++ b/packages/tdigest/tdigest.2.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+  "Will Welch"
+]
+synopsis: "OCaml implementation of the T-Digest algorithm"
+description: """
+The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.
+
+The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.
+
+Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/tdigest"
+dev-repo: "git://github.com/SGrondin/tdigest"
+doc: "https://github.com/SGrondin/tdigest"
+bug-reports: "https://github.com/SGrondin/tdigest/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "core" { >= "v0.15.0" }
+  # "ocamlformat" { = "0.21.0" } # Development
+  # "ocaml-lsp-server" # Development
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/SGrondin/tdigest/archive/2.1.0.tar.gz"
+  checksum: [
+    "md5=0772efa1b0f164c48c25be0f108dedc6"
+    "sha512=b858b1d300416c2c14db1dffdcd68adc359bf04c6d64c9cde52fdeaa5034de4a61b7be2f5872ee727e17f1bf599f8bf72f1ef251fd0c3777edc14444ed249002"
+  ]
+}


### PR DESCRIPTION
### `tdigest.2.1.0`
OCaml implementation of the T-Digest algorithm
The T-Digest is a data structure and algorithm for constructing an approximate distribution for a collection of real numbers presented as a stream.

The T-Digest can estimate percentiles or quantiles extremely accurately even at the tails, while using a fraction of the space.

Additionally, the T-Digest is concatenable, making it a good fit for distributed systems. The internal state of a T-Digest can be exported as a binary string, and the concatenation of any number of those strings can then be imported to form a new T-Digest.



---
* Homepage: https://github.com/SGrondin/tdigest
* Source repo: git://github.com/SGrondin/tdigest
* Bug tracker: https://github.com/SGrondin/tdigest/issues

---
:camel: Pull-request generated by opam-publish v2.1.0