### PR TITLE
Remove the url field from conf-gobject-introspection

### DIFF
--- a/packages/conf-gobject-introspection/conf-gobject-introspection.1.0/opam
+++ b/packages/conf-gobject-introspection/conf-gobject-introspection.1.0/opam
@@ -28,11 +28,3 @@ and retry"""
 synopsis: "Virtual package relying on a system gobject-introspection installation"
 depends: ["conf-pkg-config" {build}]
 flags: conf
-url {
-  src:
-    "https://github.com/cedlemo/conf-gobject-introspection/archive/1.0.tar.gz"
-  checksum: [
-    "md5=9d9b95994aa167f9362fcb22ef63336b"
-    "sha512=532ffac7e3c62695ff97db675fbbcb435285003e30863f1028987b07128d075f692d8353f6c74da23a2e4f104454d34518a79211daedf3248a4f074ffdfa0caf"
-  ]
-}


### PR DESCRIPTION
This is a virtual package, and the presence of the url field causes linting to fail.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>