### PR TITLE
Remove the url field from conf-netsnmp

### DIFF
--- a/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
+++ b/packages/conf-netsnmp/conf-netsnmp.1.0.0/opam
@@ -24,9 +24,4 @@ description: """
 Virtual package relying on net-snmp system libraries installation.
 This package can only install if the net-snmp lib and development packages
 are installed on the system."""
-url {
-  src:
-    "https://www.github.com/stevebleazard/ocaml-conf-netsnmp/releases/download/v1.0.0/conf-netsnmp-1.0.0.tbz"
-  checksum: "md5=b7182d9bed4e50b2c7fc94b4a1a303d3"
-}
 flags: conf


### PR DESCRIPTION
This is a virtual package, and the presence of the url field causes linting to fail.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>