### PR TITLE
ocaml 5: restrict ocamlfuse releases

### DIFF
--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs/opam
@@ -12,7 +12,7 @@ install: [
   [make "-C" "lib" "install"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "camlidl"
   "conf-libfuse"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs2/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs2/opam
@@ -12,7 +12,7 @@ install: [
   [make "-C" "lib" "install"]
 ]
 depends: [
-  "ocaml" {>= "3.08.0"}
+  "ocaml" {>= "3.08.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "camlidl"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs3/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs3/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "3.08.0"}
+  "ocaml" {>= "3.08.0" & < "5.0.0"}
   "base-bigarray"
   "base-threads"
   "base-unix"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "3.08.0"}
+  "ocaml" {>= "3.08.0" & < "5.0.0"}
   "base-bigarray"
   "base-threads"
   "base-unix"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs5/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "3.08.0"}
+  "ocaml" {>= "3.08.0" & < "5.0.0"}
   "base-bigarray"
   "base-threads"
   "base-unix"

--- a/packages/ocamlfuse/ocamlfuse.2.7.1-cvs7/opam
+++ b/packages/ocamlfuse/ocamlfuse.2.7.1-cvs7/opam
@@ -9,7 +9,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "base-bigarray"
   "base-threads"
   "base-unix"


### PR DESCRIPTION
They rely on non-prefixed C functions from the runtime.

    #=== ERROR while compiling ocamlfuse.2.7.1-cvs7 ===============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocamlfuse.2.7.1-cvs7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocamlfuse -j 31
    # exit-code            1
    # env-file             ~/.opam/log/ocamlfuse-8-c0bedd.env
    # output-file          ~/.opam/log/ocamlfuse-8-c0bedd.out
    ### output ###
    [...]
    # File "lib/dune", line 6, characters 40-55:
    # 6 |  (c_names Fuse_bindings_stubs Fuse_util Unix_util_stubs)
    #                                             ^^^^^^^^^^^^^^^
    # (cd _build/default/lib && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -I/usr/include/fuse -D_FILE_OFFSET_BITS=64 -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/camlidl -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o Unix_util_stubs.o -c Unix_util_stubs.c)
    # Unix_util_stubs.c: In function 'unix_util_read':
    # Unix_util_stubs.c:56:19: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
    #    56 |   void * c_data = Data_bigarray_val(buf);
    #       |                   ^~~~~~~~~~~~~~~~~
    #       |                   Caml_ba_array_val
    # Unix_util_stubs.c:56:19: warning: initialization of 'void *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    # Unix_util_stubs.c:57:15: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
    #    57 |   int c_dim = Bigarray_val(buf)->dim[0];
    #       |               ^~~~~~~~~~~~
    # Unix_util_stubs.c:57:32: error: invalid type argument of '->' (have 'int')
    #    57 |   int c_dim = Bigarray_val(buf)->dim[0];
    #       |                                ^~
    # Unix_util_stubs.c:59:3: warning: implicit declaration of function 'enter_blocking_section'; did you mean 'caml_enter_blocking_section'? [-Wimplicit-function-declaration]
    #    59 |   enter_blocking_section();
    #       |   ^~~~~~~~~~~~~~~~~~~~~~
    #       |   caml_enter_blocking_section
