### PR TITLE
ocaml 5: restrict resource-pooling releases

### DIFF
--- a/packages/resource-pooling/resource-pooling.0.5.2/opam
+++ b/packages/resource-pooling/resource-pooling.0.5.2/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "resource-pooling"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}

--- a/packages/resource-pooling/resource-pooling.0.6/opam
+++ b/packages/resource-pooling/resource-pooling.0.6/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "resource-pooling"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}

--- a/packages/resource-pooling/resource-pooling.0.7/opam
+++ b/packages/resource-pooling/resource-pooling.0.7/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "resource-pooling"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}

--- a/packages/resource-pooling/resource-pooling.0.8/opam
+++ b/packages/resource-pooling/resource-pooling.0.8/opam
@@ -13,7 +13,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}


### PR DESCRIPTION
They rely on Stream:

    #=== ERROR while compiling resource-pooling.0.8 ===============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/resource-pooling.0.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/resource-pooling-8-c4513c.env
    # output-file          ~/.opam/log/resource-pooling-8-c4513c.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
