### PR TITLE
ocaml 5: restrict qcheck releases

### DIFF
--- a/packages/qcheck/qcheck.0.5.2/opam
+++ b/packages/qcheck/qcheck.0.5.2/opam
@@ -18,7 +18,7 @@ remove: [
     ["ocamlfind" "remove" "qcheck"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "base-bytes"
   "base-unix"

--- a/packages/qcheck/qcheck.0.5.3.1/opam
+++ b/packages/qcheck/qcheck.0.5.3.1/opam
@@ -22,7 +22,7 @@ remove: [
     ["ocamlfind" "remove" "qcheck"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "base-bytes"
   "base-unix"

--- a/packages/qcheck/qcheck.0.5.3/opam
+++ b/packages/qcheck/qcheck.0.5.3/opam
@@ -22,7 +22,7 @@ remove: [
     ["ocamlfind" "remove" "qcheck"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "base-bytes"
   "base-unix"

--- a/packages/qcheck/qcheck.0.6/opam
+++ b/packages/qcheck/qcheck.0.6/opam
@@ -22,7 +22,7 @@ remove: [
     ["ocamlfind" "remove" "qcheck"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "base-bytes"
   "base-unix"

--- a/packages/qcheck/qcheck.0.7/opam
+++ b/packages/qcheck/qcheck.0.7/opam
@@ -17,7 +17,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "qcheck"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "base-bytes"
   "base-unix"


### PR DESCRIPTION
They rely on Stream:

    #=== ERROR while compiling qcheck.0.7 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/qcheck.0.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/qcheck-8-645cff.env
    # output-file          ~/.opam/log/qcheck-8-645cff.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
