### PR TITLE
ocaml 5: restrict expect.0.0.6

### DIFF
--- a/packages/expect/expect.0.0.6/opam
+++ b/packages/expect/expect.0.0.6/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "expect"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "batteries"
   "ounit"


### PR DESCRIPTION
It uses `Stream`:

    #=== ERROR while compiling expect.0.0.6 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/expect.0.0.6
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/expect-8-7f9635.env
    # output-file          ~/.opam/log/expect-8-7f9635.out
    ### output ###
    # File "./setup.ml", line 596, characters 4-15:
    # 596 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
