### PR TITLE
ocaml 5: restrict dolog releases

### DIFF
--- a/packages/dolog/dolog.1.1/opam
+++ b/packages/dolog/dolog.1.1/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "dolog"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "base-unix"
   "ocamlbuild" {build}

--- a/packages/dolog/dolog.2.0/opam
+++ b/packages/dolog/dolog.2.0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "dolog"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "base-unix"
   "ocamlbuild" {build}

--- a/packages/dolog/dolog.3.0/opam
+++ b/packages/dolog/dolog.3.0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "dolog"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "base-unix"
   "ocamlbuild" {build}


### PR DESCRIPTION
They rely on `String.lowercase`:

    #=== ERROR while compiling dolog.3.0 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/dolog.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/dolog-9-f97e32.env
    # output-file          ~/.opam/log/dolog-9-f97e32.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
