### PR TITLE
ocaml 5: restrict csv releases

### DIFF
--- a/packages/csv/csv.1.4.1/opam
+++ b/packages/csv/csv.1.4.1/opam
@@ -20,7 +20,7 @@ remove: [
   ["ocaml" "%{etc}%/csv/_oasis_remove_.ml" "%{etc}%/csv"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}

--- a/packages/csv/csv.1.4.2/opam
+++ b/packages/csv/csv.1.4.2/opam
@@ -20,7 +20,7 @@ remove: [
   ["ocaml" "%{etc}%/csv/_oasis_remove_.ml" "%{etc}%/csv"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}

--- a/packages/csv/csv.1.4/opam
+++ b/packages/csv/csv.1.4/opam
@@ -20,7 +20,7 @@ remove: [
   ["ocamlfind" "remove" "csv"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}
   "ocamlbuild" {build}

--- a/packages/csv/csv.1.5/opam
+++ b/packages/csv/csv.1.5/opam
@@ -20,7 +20,7 @@ remove: [
   ["ocaml" "%{etc}%/csv/_oasis_remove_.ml" "%{etc}%/csv"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.5"}

--- a/packages/csv/csv.1.6/opam
+++ b/packages/csv/csv.1.6/opam
@@ -21,7 +21,7 @@ remove: [
   ["ocaml" "%{etc}%/csv/setup.ml" "-C" "%{etc}%/csv" "-uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "base-bytes"
   "ocamlbuild" {build}
   "ocamlfind" {build & >= "1.5"}


### PR DESCRIPTION
They rely on `String.lowercase`:

    #=== ERROR while compiling csv.1.4 ============================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/csv.1.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/csv-8-1d4adf.env
    # output-file          ~/.opam/log/csv-8-1d4adf.out
    ### output ###
    # File "./setup.ml", line 316, characters 20-36:
    # 316 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
