### PR TITLE
Add dkml-base-compiler to 4.14 & 5.x trunk packages

### DIFF
--- a/packages/ocaml/ocaml.4.14.2/opam
+++ b/packages/ocaml/ocaml.4.14.2/opam
@@ -9,7 +9,8 @@ depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.2~" & < "4.14.3~"} |
   "ocaml-variants" {>= "4.14.2~" & < "4.14.3~"} |
-  "ocaml-system" {>= "4.14.2" & < "4.14.3~"}
+  "ocaml-system" {>= "4.14.2" & < "4.14.3~"} |
+  "dkml-base-compiler" {>= "4.14.2~" & < "4.14.3~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]

--- a/packages/ocaml/ocaml.5.0.1/opam
+++ b/packages/ocaml/ocaml.5.0.1/opam
@@ -9,7 +9,8 @@ depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.0.1~" & < "5.0.2~" } |
   "ocaml-variants" {>= "5.0.1~" & < "5.0.2~"} |
-  "ocaml-system" {>= "5.0.1" & < "5.0.2~"}
+  "ocaml-system" {>= "5.0.1" & < "5.0.2~"} |
+  "dkml-base-compiler" {>= "5.0.1~" & < "5.0.2~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]

--- a/packages/ocaml/ocaml.5.1.0/opam
+++ b/packages/ocaml/ocaml.5.1.0/opam
@@ -9,7 +9,8 @@ depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {= "5.1.0"} |
   "ocaml-variants" {>= "5.1.0" & < "5.1.1~"} |
-  "ocaml-system" {>= "5.1.0" & < "5.1.1~"}
+  "ocaml-system" {>= "5.1.0" & < "5.1.1~"} |
+  "dkml-base-compiler" {>= "5.1.0~" & < "5.1.1~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]


### PR DESCRIPTION
Apropos https://github.com/ocaml/opam-repository/pull/22719#discussion_r1062400286, this adds `dkml-base-compiler` to the "trunk" `ocaml` packages for 4.14 and 5.x (i.e. the unreleased versions: 4.14.2, 5.0.1 and 5.1.0).

This PR is low-impact as it only triggers for development builds (and the compiler itself is not recompiled as a result of changes in the `ocaml` package).