### PR TITLE
Add dkml-base-compiler to ocaml.4.14.1 & ocaml.5.0.0

### DIFF
--- a/packages/ocaml/ocaml.4.14.1/opam
+++ b/packages/ocaml/ocaml.4.14.1/opam
@@ -9,7 +9,8 @@ depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.1~" & < "4.14.2~"} |
   "ocaml-variants" {>= "4.14.1~" & < "4.14.2~"} |
-  "ocaml-system" {>= "4.14.1" & < "4.14.2~"}
+  "ocaml-system" {>= "4.14.1" & < "4.14.2~"} |
+  "dkml-base-compiler" {>= "4.14.1~" & < "4.14.2~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -9,7 +9,8 @@ depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.0.0~" & < "5.0.1~" } |
   "ocaml-variants" {>= "5.0.0~" & < "5.0.1~"} |
-  "ocaml-system" {>= "5.0.0" & < "5.0.1~"}
+  "ocaml-system" {>= "5.0.0" & < "5.0.1~"} |
+  "dkml-base-compiler" {>= "5.0.0~" & < "5.0.1~"}
 ]
 setenv: [
   [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]


### PR DESCRIPTION
Also apropos https://github.com/ocaml/opam-repository/pull/22719#discussion_r1062400286, this adds `dkml-base-compiler` to the latest releases in 4.14 and 5.0.

Unlike #22901, this is higher impact, as it means `opam update` for users will trigger a rebuild of all installed packages (apart from the compiler itself).