### PR TITLE
[new release] paf, paf-le and paf-cohttp (0.4.0)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.4.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.4.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.4.0/paf-0.4.0.tbz"
+  checksum: [
+    "sha256=bb1f1f9385c376287851af4d18e2554ae3ec78904fbfafba343fdeb07ae5b901"
+    "sha512=b8c20b8a757ed6476d963e8548f7795edddf735ab54b7b6e4e0a90d411e757c5edecd23aba800cd4d6418fc87818fd79dc51eb9a8e9fbfc4fafd2e8e66d36e1a"
+  ]
+}
+x-commit-hash: "a2d10eaa3c7f4813772070f2a0dcfc1550dc5612"

--- a/packages/paf-le/paf-le.0.4.0/opam
+++ b/packages/paf-le/paf-le.0.4.0/opam
@@ -15,7 +15,7 @@ depends: [
   "emile" {>= "1.1"}
   "httpaf"
   "letsencrypt" {>= "0.4.0"}
-  "mirage-time"
+  "mirage-time" {>= "0.3.0"}
   "mirage-random"
   "mirage-clock"
   "tls-mirage"

--- a/packages/paf-le/paf-le.0.4.0/opam
+++ b/packages/paf-le/paf-le.0.4.0/opam
@@ -21,7 +21,7 @@ depends: [
   "tls-mirage"
   "tcpip" {>= "7.0.0"}
   "x509" {>= "0.13.0"}
-  "dns-client"
+  "dns-client" {>= "6.4.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]

--- a/packages/paf-le/paf-le.0.4.0/opam
+++ b/packages/paf-le/paf-le.0.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "duration"
+  "emile" {>= "1.1"}
+  "httpaf"
+  "letsencrypt" {>= "0.4.0"}
+  "mirage-time"
+  "mirage-random"
+  "mirage-clock"
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "x509" {>= "0.13.0"}
+  "dns-client"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.4.0/paf-0.4.0.tbz"
+  checksum: [
+    "sha256=bb1f1f9385c376287851af4d18e2554ae3ec78904fbfafba343fdeb07ae5b901"
+    "sha512=b8c20b8a757ed6476d963e8548f7795edddf735ab54b7b6e4e0a90d411e757c5edecd23aba800cd4d6418fc87818fd79dc51eb9a8e9fbfc4fafd2e8e66d36e1a"
+  ]
+}
+x-commit-hash: "a2d10eaa3c7f4813772070f2a0dcfc1550dc5612"

--- a/packages/paf/paf.0.4.0/opam
+++ b/packages/paf/paf.0.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic" {>= "0.0.5"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.9.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.4.0/paf-0.4.0.tbz"
+  checksum: [
+    "sha256=bb1f1f9385c376287851af4d18e2554ae3ec78904fbfafba343fdeb07ae5b901"
+    "sha512=b8c20b8a757ed6476d963e8548f7795edddf735ab54b7b6e4e0a90d411e757c5edecd23aba800cd4d6418fc87818fd79dc51eb9a8e9fbfc4fafd2e8e66d36e1a"
+  ]
+}
+x-commit-hash: "a2d10eaa3c7f4813772070f2a0dcfc1550dc5612"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Fix memory leak about functor application (@dinosaure, dinosaure/paf-le-chien#78)
- Add a new sub-package `le.mirage` to facilite obtaining a let's encrypt certificate
  and expose few functions to handle Let's encrypt certificates (@kit-ty-kate, @dinosaure, @hannesm, dinosaure/paf-le-chien#75)
