### PR TITLE
ocaml 5: restrict dum releases

### DIFF
--- a/packages/dum/dum.1.0.1/opam
+++ b/packages/dum/dum.1.0.1/opam
@@ -11,7 +11,7 @@ dev-repo: "git+https://github.com/mjambon/dum.git"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 build: make
 remove: [["ocamlfind" "remove" "dum"]]
-depends: ["ocaml" "ocamlfind" "easy-format"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind" "easy-format"]
 install: [make "install"]
 synopsis: "Inspect the runtime representation of arbitrary OCaml values"
 description: """

--- a/packages/dum/dum.1.0.3/opam
+++ b/packages/dum/dum.1.0.3/opam
@@ -12,6 +12,7 @@ license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/mjambon/dum"
 bug-reports: "https://github.com/mjambon/dum/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "easy-format"
 ]


### PR DESCRIPTION
They rely on `Lazy.lazy_is_val`:

    #=== ERROR while compiling dum.1.0.3 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/dum.1.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dum -j 31 @install
    # exit-code            1
    # env-file             ~/.opam/log/dum-9-187a5a.env
    # output-file          ~/.opam/log/dum-9-187a5a.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .dum.objs/byte -I /home/opam/.opam/5.0/lib/easy-format -intf-suffix .ml -no-alias-deps -o .dum.objs/byte/dum.cmo -c -impl dum.ml)
    # File "dum.ml", line 236, characters 9-25:
    # 236 | 	assert (Lazy.lazy_is_val (Obj.obj r));
    #       	        ^^^^^^^^^^^^^^^^
    # Error: Unbound value Lazy.lazy_is_val
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I .dum.objs/byte -I .dum.objs/native -I /home/opam/.opam/5.0/lib/easy-format -intf-suffix .ml -no-alias-deps -o .dum.objs/native/dum.cmx -c -impl dum.ml)
    # File "dum.ml", line 236, characters 9-25:
    # 236 | 	assert (Lazy.lazy_is_val (Obj.obj r));
    #       	        ^^^^^^^^^^^^^^^^
    # Error: Unbound value Lazy.lazy_is_val
