### PR TITLE
ocaml 5: restrict mlcuddidl releases

### DIFF
--- a/packages/mlcuddidl/mlcuddidl.3.0.6/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.6/opam
@@ -16,7 +16,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind"  {build}
   "camlidl"
   "ocamlbuild" {build}

--- a/packages/mlcuddidl/mlcuddidl.3.0.7/opam
+++ b/packages/mlcuddidl/mlcuddidl.3.0.7/opam
@@ -14,7 +14,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.04" & < "5.0.0"}
   "ocamlfind"  {build}
   "camlidl"
   "ocamlbuild" {build}


### PR DESCRIPTION
They rely on `Obj.truncate`:

    #=== ERROR while compiling mlcuddidl.3.0.7 ====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mlcuddidl.3.0.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j127
    # exit-code            2
    # env-file             ~/.opam/log/mlcuddidl-8-556d68.env
    # output-file          ~/.opam/log/mlcuddidl-8-556d68.out
    ### output ###
    ...
    # File "weakke.ml", line 123, characters 6-18:
    # 123 |       Obj.truncate (Obj.repr bucket) (prev_len + 1);
    #             ^^^^^^^^^^^^
    # Error: Unbound value Obj.truncate
    # make: *** [Makefile:308: weakke.cmo] Error 2
    # make: *** Waiting for unfinished jobs....
    # File "weakke.ml", line 123, characters 6-18:
    # 123 |       Obj.truncate (Obj.repr bucket) (prev_len + 1);
    #             ^^^^^^^^^^^^
    # Error: Unbound value Obj.truncate
    # make: *** [Makefile:314: weakke.cmx] Error 2
