### PR TITLE
ocaml 5: restrict parmap releases

### DIFF
--- a/packages/parmap/parmap.1.0-rc11/opam
+++ b/packages/parmap/parmap.1.0-rc11/opam
@@ -12,7 +12,7 @@ install: [
   [make "install" "DESTDIR=%{prefix}%" "OCAMLLIBDIR=lib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/parmap/parmap.1.1.1/opam
+++ b/packages/parmap/parmap.1.1.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune-configurator"
   "base-bigarray"
   "base-unix"
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
 ]
 url {
   src:

--- a/packages/parmap/parmap.1.2.1/opam
+++ b/packages/parmap/parmap.1.2.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune-configurator"
   "base-bigarray"
   "base-unix"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
 ]
 x-commit-hash: "36089bc12f3560faffeeb66d3f38594978561c70"
 url {

--- a/packages/parmap/parmap.1.2.3/opam
+++ b/packages/parmap/parmap.1.2.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator"
   "base-bigarray"
   "base-unix"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/parmap/parmap.1.2.4/opam
+++ b/packages/parmap/parmap.1.2.4/opam
@@ -18,7 +18,7 @@ depends: [
   "dune-configurator"
   "base-bigarray"
   "base-unix"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "odoc" {with-doc}
 ]
 conflicts: [

--- a/packages/parmap/parmap.1.2/opam
+++ b/packages/parmap/parmap.1.2/opam
@@ -25,7 +25,7 @@ depends: [
   "dune-configurator"
   "base-bigarray"
   "base-unix"
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
 ]
 url {
   src:


### PR DESCRIPTION
They rely on `BIGARRAY_*` constants:

    #=== ERROR while compiling parmap.1.2.4 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/parmap.1.2.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p parmap -j 127 @install
    # exit-code            1
    # env-file             ~/.opam/log/parmap-8-c00d7a.env
    # output-file          ~/.opam/log/parmap-8-c00d7a.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.parmap.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -o src/.parmap.objs/byte/parmap_utils.cmo -c -impl src/parmap_utils.ml)
    # File "src/parmap_utils.ml", line 3, characters 2-16:
    # 3 |   Printf.kprintf (fun s -> Format.eprintf "[Parmap]: %s@.%!" s) fmt
    #       ^^^^^^^^^^^^^^
    # Alert deprecated: Stdlib.Printf.kprintf
    # Use Printf.ksprintf instead.
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.parmap.objs/byte -I src/.parmap.objs/native -I /home/opam/.opam/5.0/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -o src/.parmap.objs/native/parmap_utils.cmx -c -impl src/parmap_utils.ml)
    # File "src/parmap_utils.ml", line 3, characters 2-16:
    # 3 |   Printf.kprintf (fun s -> Format.eprintf "[Parmap]: %s@.%!" s) fmt
    #       ^^^^^^^^^^^^^^
    # Alert deprecated: Stdlib.Printf.kprintf
    # Use Printf.ksprintf instead.
    # File "src/dune", line 6, characters 36-51:
    # 6 |  (foreign_stubs (language c) (names bytearray_stubs setcore_stubs)))
    #                                         ^^^^^^^^^^^^^^^
    # (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/unix -o bytearray_stubs.o -c bytearray_stubs.c)
    # bytearray_stubs.c: In function 'ml_marshal_to_bigarray':
    # bytearray_stubs.c:16:3: warning: implicit declaration of function 'output_value_to_malloc'; did you mean 'caml_output_value_to_malloc'? [-Wimplicit-function-declaration]
    #    16 |   output_value_to_malloc(v, flags, &buf, &len);
    #       |   ^~~~~~~~~~~~~~~~~~~~~~
    #       |   caml_output_value_to_malloc
    # bytearray_stubs.c:17:10: warning: implicit declaration of function 'alloc_bigarray' [-Wimplicit-function-declaration]
    #    17 |   return alloc_bigarray(BIGARRAY_UINT8 | BIGARRAY_C_LAYOUT | BIGARRAY_MANAGED,
    #       |          ^~~~~~~~~~~~~~
    # bytearray_stubs.c:17:25: error: 'BIGARRAY_UINT8' undeclared (first use in this function)
