### PR TITLE
ocaml 5: restrict bimage-display releases

### DIFF
--- a/packages/bimage-display/bimage-display.0.3.0/opam
+++ b/packages/bimage-display/bimage-display.0.3.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0"}
+    "ocaml" {>= "4.08.0" & < "5.0.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "glfw-ocaml"

--- a/packages/bimage-display/bimage-display.0.3.1/opam
+++ b/packages/bimage-display/bimage-display.0.3.1/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0"}
+    "ocaml" {>= "4.08.0" & < "5.0.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "glfw-ocaml"

--- a/packages/bimage-display/bimage-display.0.4.0/opam
+++ b/packages/bimage-display/bimage-display.0.4.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0"}
+    "ocaml" {>= "4.08.0" & < "5.0.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "glfw-ocaml"

--- a/packages/bimage-display/bimage-display.0.5.0/opam
+++ b/packages/bimage-display/bimage-display.0.5.0/opam
@@ -10,7 +10,7 @@ tags: ["image processing"]
 
 depends:
 [
-    "ocaml" {>= "4.08.0"}
+    "ocaml" {>= "4.08.0" & < "5.0.0"}
     "dune" {>= "2.0"}
     "bimage" {= version}
     "glfw-ocaml" {>= "3.3.0"}


### PR DESCRIPTION
They rely on `BIGARRAY_KIND_MASK`:

    #=== ERROR while compiling bimage-display.0.5.0 ===============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/bimage-display.0.5.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p bimage-display -j 31
    # exit-code            1
    # env-file             ~/.opam/log/bimage-display-9-70a3f1.env
    # output-file          ~/.opam/log/bimage-display-9-70a3f1.out
    ### output ###
    # File "display/dune", line 6, characters 9-15:
    # 6 |   (names window))
    #              ^^^^^^
    # (cd _build/default/display && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/bimage -I /home/opam/.opam/5.0/lib/glfw-ocaml -o window.o -c window.c)
    # window.c: In function 'bimage_create_texture':
    # window.c:31:44: error: 'BIGARRAY_KIND_MASK' undeclared (first use in this function)
    #    31 |   switch (Caml_ba_array_val(data)->flags & BIGARRAY_KIND_MASK) {
    #       |                                            ^~~~~~~~~~~~~~~~~~
    # window.c:31:44: note: each undeclared identifier is reported only once for each function it appears in
