### PR TITLE
ocaml 5: restrict lacaml releases

### DIFF
--- a/packages/lacaml/lacaml.7.2.1/opam
+++ b/packages/lacaml/lacaml.7.2.1/opam
@@ -24,7 +24,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5"}

--- a/packages/lacaml/lacaml.7.2.2/opam
+++ b/packages/lacaml/lacaml.7.2.2/opam
@@ -24,7 +24,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {>= "1.5"}

--- a/packages/lacaml/lacaml.7.2.6/opam
+++ b/packages/lacaml/lacaml.7.2.6/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}

--- a/packages/lacaml/lacaml.8.0.4/opam
+++ b/packages/lacaml/lacaml.8.0.4/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}

--- a/packages/lacaml/lacaml.8.0.5/opam
+++ b/packages/lacaml/lacaml.8.0.5/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}

--- a/packages/lacaml/lacaml.8.0.6/opam
+++ b/packages/lacaml/lacaml.8.0.6/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}

--- a/packages/lacaml/lacaml.8.0.7/opam
+++ b/packages/lacaml/lacaml.8.0.7/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}

--- a/packages/lacaml/lacaml.8.1.1/opam
+++ b/packages/lacaml/lacaml.8.1.1/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlfind" {build & >= "1.5"}


### PR DESCRIPTION
They rely on `String.lowercase`:

    #=== ERROR while compiling lacaml.8.1.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lacaml.8.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/lacaml-8-61ee8f.env
    # output-file          ~/.opam/log/lacaml-8-61ee8f.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
