### PR TITLE
ocaml 5: restrict mm releases

### DIFF
--- a/packages/mm/mm.0.3.1/opam
+++ b/packages/mm/mm.0.3.1/opam
@@ -10,7 +10,7 @@ install: [
   [make "install"]
 ]
 remove: ["ocamlfind" "remove" "mm"]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind"]
 depopts: [
   "alsa"
   "ao"

--- a/packages/mm/mm.0.4.0/opam
+++ b/packages/mm/mm.0.4.0/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "mm"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 depopts: [

--- a/packages/mm/mm.0.4.1/opam
+++ b/packages/mm/mm.0.4.1/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "mm"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 depopts: [

--- a/packages/mm/mm.0.5.0/opam
+++ b/packages/mm/mm.0.5.0/opam
@@ -12,7 +12,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 depopts: [

--- a/packages/mm/mm.0.5.1/opam
+++ b/packages/mm/mm.0.5.1/opam
@@ -12,7 +12,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 depopts: [


### PR DESCRIPTION
They rely on string assignment syntax:

    #=== ERROR while compiling mm.0.5.1 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mm.0.5.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/mm-8-b2184d.env
    # output-file          ~/.opam/log/mm-8-b2184d.out
    ### output ###
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/mm.0.5.1/src'
    # make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/mm.0.5.1/src'
    # ocamldep.opt synth.mli > ._bcdi/synth.di
    # ocamldep.opt MIDI.mli > ._bcdi/MIDI.di
    # ocamldep.opt video.mli > ._bcdi/video.di
    # ocamldep.opt image.mli > ._bcdi/image.di
    # ocamldep.opt audio.mli > ._bcdi/audio.di
    # ocamldep.opt ringbuffer.mli > ._bcdi/ringbuffer.di
    # ocamldep.opt synth.ml > ._d/synth.d
    # ocamldep.opt MIDI.ml > ._d/MIDI.d
    # File "MIDI.ml", line 107, characters 8-39:
    # 107 |         s.[0] <- coi (0x8 lsl 4 + chan);
    #               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    # Error: Syntax error: strings are immutable, there is no assignment syntax for them.
