### PR TITLE
spreadsheet is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/spreadsheet/spreadsheet.0.1/opam
+++ b/packages/spreadsheet/spreadsheet.0.1/opam
@@ -13,7 +13,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "spreadsheet"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling spreadsheet.0.1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/spreadsheet.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure
# exit-code            2
# env-file             ~/.opam/log/spreadsheet-8-ca4758.env
# output-file          ~/.opam/log/spreadsheet-8-ca4758.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```