### PR TITLE
diy is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/diy/diy.5.01/opam
+++ b/packages/diy/diy.5.01/opam
@@ -5,7 +5,6 @@ homepage: "http://diy.inria.fr/"
 dev-repo: "git+https://github.com/herd/herdtools7.git"
 bug-reports: "https://github.com/herd/herdtools7/issues"
 license: "LGPL-2.0-or-later"
-available: ["ocaml-version" >= "3.12"]
 build: [
   ["sed" "-i" "-e" "s#^PREFIX=.*$#PREFIX=%{prefix}%#" "Makefile"]
   [make "-j" jobs]
@@ -23,7 +22,7 @@ remove: [
   ["rm" "-fr" "%{prefix}%/lib/litmus"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlbuild" {build}
 ]
 synopsis: "Tool suite for testing shared memory models"


### PR DESCRIPTION
```
#=== ERROR while compiling diy.5.01 ===========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/diy.5.01
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -j 255
# exit-code            2
# env-file             ~/.opam/log/diy-8-cab77e.env
# output-file          ~/.opam/log/diy-8-cab77e.out
### output ###
# for d in litmus gen ; \
# do ( cd $d && make -j255 --jobserver-auth=3,4 PREFIX=/home/opam/.opam/5.0 all ) ; done
# make[1]: warning: -j255 forced in submake: resetting jobserver mode.
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/diy.5.01/litmus'
# ocamlbuild -classic-display litmus.native mcycles.native
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules litmus.ml > litmus.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules config.ml > config.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules globals.mli > globals.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules misc.mli > misc.mli.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -dtypes -o misc.cmi misc.mli
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules myName.mli > myName.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules mySys.mli > mySys.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules tar.mli > tar.mli.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules top.ml > top.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ARMArch.ml > ARMArch.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules ARMBase.ml > ARMBase.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules pseudo.ml > pseudo.ml.depends
# /home/opam/.opam/5.0/bin/ocamldep.opt -modules symbConstant.ml > symbConstant.ml.depends
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -dtypes -o pseudo.cmo pseudo.ml
# /home/opam/.opam/5.0/bin/ocamlc.opt -c -dtypes -o symbConstant.cmo symbConstant.ml
# + /home/opam/.opam/5.0/bin/ocamlc.opt -c -dtypes -o symbConstant.cmo symbConstant.ml
# File "symbConstant.ml", line 29, characters 30-48:
# 29 | | Concrete i1, Concrete i2 -> Pervasives.compare i1 i2
#                                    ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
```