### PR TITLE
lz4 < 1.2.0 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/lz4/lz4.1.0.0/opam
+++ b/packages/lz4/lz4.1.0.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "lz4"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build & != "0.9.0"}

--- a/packages/lz4/lz4.1.0.1/opam
+++ b/packages/lz4/lz4.1.0.1/opam
@@ -13,7 +13,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "lz4"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ctypes" {>= "0.4.0" & < "0.6.0"}

--- a/packages/lz4/lz4.1.1.0/opam
+++ b/packages/lz4/lz4.1.1.0/opam
@@ -18,7 +18,7 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "lz4"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ctypes" {>= "0.4.1" & < "0.6.0"}

--- a/packages/lz4/lz4.1.1.1/opam
+++ b/packages/lz4/lz4.1.1.1/opam
@@ -26,7 +26,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "lz4"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "base-bigarray"
   "ocamlfind" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling lz4.1.1.1 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/lz4.1.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/lz4-8-648429.env
# output-file          ~/.opam/log/lz4-8-648429.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```