### PR TITLE
root1d < 0.5 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/root1d/root1d.0.2/opam
+++ b/packages/root1d/root1d.0.2/opam
@@ -8,7 +8,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "root1d"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "oasis" {>= "0.3.0" & < "0.4.7"}
   "ocamlbuild" {build}

--- a/packages/root1d/root1d.0.4/opam
+++ b/packages/root1d/root1d.0.4/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "root1d"]
 ]
 depends: [
-  "ocaml" {>= "4.0.0"}
+  "ocaml" {>= "4.0.0" & < "5.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "benchmark" {with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling root1d.0.4 =========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/root1d.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/root1d-8-0ab40b.env
# output-file          ~/.opam/log/root1d-8-0ab40b.out
### output ###
# File "./setup.ml", line 320, characters 20-36:
# 320 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```