### PR TITLE
zenon < 0.8.5 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/zenon/zenon.0.8.4/opam
+++ b/packages/zenon/zenon.0.8.4/opam
@@ -5,7 +5,7 @@ maintainer: "Damien Doligez <damien.doligez@inria.fr>"
 authors: [ "R. Bonichon" "D. Delahaye" "D. Doligez" ]
 bug-reports: "https://github.com/zenon-prover/zenon/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
 ]
 depopts: [
   "coq"


### PR DESCRIPTION
```
#=== ERROR while compiling zenon.0.8.4 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/zenon.0.8.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/zenon-8-d0aaeb.env
# output-file          ~/.opam/log/zenon-8-d0aaeb.out
### output ###
# ocamlc.opt -warn-error ""  -c version.mli
# ocamlc.opt -warn-error ""  -c version.ml
# ocamlc.opt -warn-error ""  -c config.mli
# ocamlc.opt -warn-error ""  -c config.ml
# ocamlc.opt -warn-error ""  -c misc.mli
# ocamlc.opt -warn-error ""  -c misc.ml
# ocamlc.opt -warn-error ""  -c heap.mli
# ocamlc.opt -warn-error ""  -c heap.ml
# ocamlc.opt -warn-error ""  -c globals.mli
# ocamlc.opt -warn-error ""  -c globals.ml
# ocamlc.opt -warn-error ""  -c error.mli
# ocamlc.opt -warn-error ""  -c error.ml
# ocamlc.opt -warn-error ""  -c progress.mli
# ocamlc.opt -warn-error ""  -c progress.ml
# ocamlc.opt -warn-error ""  -c namespace.mli
# ocamlc.opt -warn-error ""  -c namespace.ml
# ocamlc.opt -warn-error ""  -c expr.mli
# ocamlc.opt -warn-error ""  -c expr.ml
# File "expr.ml", line 367, characters 34-52:
# 367 |   | 0 -> if equal x y then 0 else Pervasives.compare x y
#                                         ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# make: *** [Makefile:103: expr.cmo] Error 2
```