### PR TITLE
tree_layout < 0.2 is not compatible with OCaml 5.0 (uses oasis)

### DIFF
--- a/packages/tree_layout/tree_layout.0.1.0/opam
+++ b/packages/tree_layout/tree_layout.0.1.0/opam
@@ -22,7 +22,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "tree_layout"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "tyxml" {with-test & >= "3.0.0" & < "4.0.0"}
   "ocamlbuild" {build}


### PR DESCRIPTION
```
#=== ERROR while compiling tree_layout.0.1.0 ==================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/tree_layout.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
# exit-code            2
# env-file             ~/.opam/log/tree_layout-8-d9b03b.env
# output-file          ~/.opam/log/tree_layout-8-d9b03b.out
### output ###
# File "./setup.ml", line 318, characters 20-36:
# 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
#                           ^^^^^^^^^^^^^^^^
# Error: Unbound value String.lowercase
```