### PR TITLE
raygui < 0.6 is not compatible with raylib >= 0.6

### DIFF
--- a/packages/raygui/raygui.0.3.1/opam
+++ b/packages/raygui/raygui.0.3.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune-configurator"
   "ctypes" {>= "0.14"}
   "ppx_cstubs" {>= "0.6"}
-  "raylib" {>= "0.3"}
+  "raylib" {>= "0.3" & < "0.6"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/raygui/raygui.0.3.2/opam
+++ b/packages/raygui/raygui.0.3.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune-configurator"
   "ctypes" {>= "0.14"}
   "ppx_cstubs" {>= "0.6"}
-  "raylib" {>= "0.3"}
+  "raylib" {>= "0.3" & < "0.6"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/raygui/raygui.0.5.1/opam
+++ b/packages/raygui/raygui.0.5.1/opam
@@ -11,7 +11,7 @@ depends: [
   "dune-configurator"
   "ctypes" {>= "0.14"}
   "ppx_cstubs" {>= "0.6"}
-  "raylib" {>= "0.3"}
+  "raylib" {>= "0.3" & < "0.6"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Detected in https://github.com/ocaml/opam-repository/pull/22905