### PR TITLE
cca is not compatible with mtime >= 2.0 (uses Mtime.Span.to_us)

### DIFF
--- a/packages/cca/cca.0.1/opam
+++ b/packages/cca/cca.0.1/opam
@@ -22,6 +22,7 @@ depends: [
   "pxp"
   "uuidm"
   "volt"
+  "mtime" {< "2.0"}
 ]
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
 synopsis: "A framework for code continuity analysis"

--- a/packages/cca/cca.0.2/opam
+++ b/packages/cca/cca.0.2/opam
@@ -22,6 +22,7 @@ depends: [
   "pxp"
   "uuidm"
   "volt"
+  "mtime" {< "2.0"}
 ]
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
 synopsis: "A framework for code continuity analysis"

--- a/packages/cca/cca.0.4/opam
+++ b/packages/cca/cca.0.4/opam
@@ -22,6 +22,7 @@ depends: [
   "pxp"
   "uuidm"
   "volt"
+  "mtime" {< "2.0"}
 ]
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
 synopsis: "A framework for code continuity analysis"

--- a/packages/cca/cca.0.5/opam
+++ b/packages/cca/cca.0.5/opam
@@ -22,6 +22,7 @@ depends: [
   "pxp"
   "uuidm"
   "volt"
+  "mtime" {< "2.0"}
 ]
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
 synopsis: "A framework for code continuity analysis"

--- a/packages/cca/cca.0.6.2/opam
+++ b/packages/cca/cca.0.6.2/opam
@@ -24,6 +24,7 @@ depends: [
   "pxp"
   "uuidm"
   "volt"
+  "mtime" {< "2.0"}
 ]
 available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
 synopsis: "A framework for differential source code analyses"


### PR DESCRIPTION
```
#=== ERROR while compiling cca.0.6.2 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/cca.0.6.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C src/ast/analyzing production
# exit-code            2
# env-file             ~/.opam/log/cca-7-3b3588.env
# output-file          ~/.opam/log/cca-7-3b3588.out
### output ###
# File "git_diffast.ml", line 61, characters 15-31:
# 61 |       let dt = Mtime.Span.to_us (Mtime_clock.elapsed ()) in
#                     ^^^^^^^^^^^^^^^^
# Error: Unbound value Mtime.Span.to_us
# make: *** [../../rules.mk:105: git_diffast.cmx] Error 2
# make: Leaving directory '/home/opam/.opam/4.14/.opam-switch/build/cca.0.6.2/src/ast/analyzing'
```
cc @codinuum 