### PR TITLE
ucaml is not compatible with OCaml 5.0 (uses String.uppercase)

### DIFF
--- a/packages/ucaml/ucaml.0.1/opam
+++ b/packages/ucaml/ucaml.0.1/opam
@@ -8,7 +8,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/masateruk/micro-caml"
 synopsis: "Translate OCaml code into C code"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0"}
+]
 extra-files: ["ucaml.install" "md5=25d555ca28a54aded0ee7aba4ab80d83"]
 url {
   src: "https://github.com/masateruk/micro-caml/archive/v0.1.tar.gz"


### PR DESCRIPTION
```
#=== ERROR while compiling ucaml.0.1 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ucaml.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ucaml-8-e2c282.env
# output-file          ~/.opam/log/ucaml-8-e2c282.out
### output ###
# ocamllex  lexer.mll
# 96 states, 4156 transitions, table size 17200 bytes
# ocamlyacc  parser.mly
# 169 shift/reduce conflicts.
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ucaml.0.1'
# ocamldep parser.mli > ._bcdi/parser.di
# ocamldep c.mli > ._bcdi/c.di
# ocamldep closure.mli > ._bcdi/closure.di
# ocamldep assoc.mli > ._bcdi/assoc.di
# ocamldep alpha.mli > ._bcdi/alpha.di
# ocamldep kNormal.mli > ._bcdi/kNormal.di
# ocamldep wrap.mli > ._bcdi/wrap.di
# ocamldep typing.mli > ._bcdi/typing.di
# ocamldep type.mli > ._bcdi/type.di
# ocamldep parser.ml > ._d/parser.d
# ocamldep lexer.ml > ._d/lexer.d
# ocamldep main.ml > ._d/main.d
# ocamldep cFormat.ml > ._d/cFormat.d
# ocamldep optimize.ml > ._d/optimize.d
# ocamldep c.ml > ._d/c.d
# ocamldep cType.ml > ._d/cType.d
# ocamldep closure.ml > ._d/closure.d
# ocamldep assoc.ml > ._d/assoc.d
# ocamldep alpha.ml > ._d/alpha.d
# ocamldep kNormal.ml > ._d/kNormal.d
# ocamldep wrap.ml > ._d/wrap.d
# ocamldep typing.ml > ._d/typing.d
# ocamldep syntax.ml > ._d/syntax.d
# ocamldep env.ml > ._d/env.d
# ocamldep type.ml > ._d/type.d
# ocamldep s.ml > ._d/s.d
# ocamldep m.ml > ._d/m.d
# ocamldep id.ml > ._d/id.d
# ocamldep l.ml > ._d/l.d
# ocamldep d.ml > ._d/d.d
# ocamlc -c -g d.ml
# ocamlc -c -g l.ml
# ocamlc -c -g id.ml
# File "id.ml", line 17, characters 2-18:
# 17 |   String.uppercase (Str.global_replace (Str.regexp "\\([a-z0-9]\\)\\([A-Z]+\\)") "\\1_\\2" s)
#        ^^^^^^^^^^^^^^^^
# Error: Unbound value String.uppercase
# make[1]: *** [OCamlMakefile:1067: id.cmi] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/ucaml.0.1'
# make: *** [OCamlMakefile:823: debug-code] Error 2
```