### PR TITLE
Add stb_truetype.0.7

### DIFF
--- a/packages/stb_truetype/stb_truetype.0.7/opam
+++ b/packages/stb_truetype/stb_truetype.0.7/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/stb_truetype"
+bug-reports: "https://github.com/let-def/stb_truetype"
+license: "CC0-1.0+"
+dev-repo: "git+https://github.com/let-def/stb_truetype.git"
+build: [make]
+install: [make "install"]
+remove: ["ocamlfind" "remove" "stb_truetype"]
+depends: [
+  "ocaml" {>= "4.06"}
+  "ocamlfind" {build}
+]
+synopsis: "OCaml bindings to stb_truetype, a public domain font rasterizer"
+description: """
+Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):
+
+  stb_truetype.h: public domain C truetype rasterization library
+
+The OCaml binding is released under CC-0 license.  It has no dependency beside
+working OCaml and C compilers (stb_truetype is self-contained)."""
+flags: light-uninstall
+url {
+  src: "https://github.com/let-def/stb_truetype/archive/v0.7.tar.gz"
+  checksum: "md5=91234b0b6e54f0833fc02bd37db72c19"
+}

--- a/packages/stb_truetype/stb_truetype.0.7/opam
+++ b/packages/stb_truetype/stb_truetype.0.7/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.06"}
   "ocamlfind" {build}
 ]
+conflicts: [ "ocaml-option-bytecode-only" ]
 synopsis: "OCaml bindings to stb_truetype, a public domain font rasterizer"
 description: """
 Stb_truetype is an OCaml binding to stb_truetype from Sean Barrett, [Nothings](http://nothings.org/):


### PR DESCRIPTION
Minor update:
- Use `Unix.mapfile` instead of `Bigarray.*.map_file` (reduce compatibility to OCaml >= 4.06).
- Add glyph manipulation primitives (contributed by @Armael).