### PR TITLE
ocaml 5: restrict pratter releases

### DIFF
--- a/packages/pratter/pratter.0.1.1/opam
+++ b/packages/pratter/pratter.0.1.1/opam
@@ -12,7 +12,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/gabrielhdt/pratter"
 bug-reports: "https://github.com/gabrielhdt/pratter/issues"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.0.0"}
   "dune" {>= "2.7"}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/pratter/pratter.1.0/opam
+++ b/packages/pratter/pratter.1.0/opam
@@ -12,8 +12,8 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/gabrielhdt/pratter"
 bug-reports: "https://github.com/gabrielhdt/pratter/issues"
 depends: [
-  "ocaml" {>= "4.05"}
-  "ocaml" {with-test & >= "4.07"}
+  "ocaml" {>= "4.05" & < "5.0.0"}
+  "ocaml" {with-test & >= "4.07" & < "5.0.0"}
   "dune" {>= "2.7"}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/pratter/pratter.1.1/opam
+++ b/packages/pratter/pratter.1.1/opam
@@ -12,7 +12,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/gabrielhdt/pratter"
 bug-reports: "https://github.com/gabrielhdt/pratter/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "dune" {>= "2.7"}
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/packages/pratter/pratter.1.2/opam
+++ b/packages/pratter/pratter.1.2/opam
@@ -12,7 +12,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/gabrielhdt/pratter"
 bug-reports: "https://github.com/gabrielhdt/pratter/issues"
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "dune" {>= "2.7"}
   "alcotest" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
They rely on `Stream`:

    #=== ERROR while compiling pratter.1.2 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/pratter.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pratter -j 47 @install
    # exit-code            1
    # env-file             ~/.opam/log/pratter-8-82969e.env
    # output-file          ~/.opam/log/pratter-8-82969e.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I .pratter.objs/byte -no-alias-deps -o .pratter.objs/byte/pratter.cmo -c -impl pratter.ml)
    # File "pratter.ml", line 93, characters 36-44:
    # 93 |     let rec nud : table -> Sup.term Stream.t -> Sup.term -> Sup.term =
    #                                          ^^^^^^^^
    # Error: Unbound module Stream
