### PR TITLE
ocaml 5: restrict yajl releases

### DIFF
--- a/packages/yajl/yajl.0.7.0/opam
+++ b/packages/yajl/yajl.0.7.0/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "mlin@mlin.net"
 remove: [["ocamlfind" "remove" "yajl"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "conf-ruby" {build}

--- a/packages/yajl/yajl.0.7.1/opam
+++ b/packages/yajl/yajl.0.7.1/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "mlin@mlin.net"
 remove: [["ocamlfind" "remove" "yajl"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/yajl/yajl.0.7.2/opam
+++ b/packages/yajl/yajl.0.7.2/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "mlin@mlin.net"
 remove: [["ocamlfind" "remove" "yajl"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/yajl/yajl.0.7.3/opam
+++ b/packages/yajl/yajl.0.7.3/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 maintainer: "mlin@mlin.net"
 remove: [["ocamlfind" "remove" "yajl"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
They rely on `Stream`:

    #=== ERROR while installing yajl.0.7.3 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/yajl.0.7.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh install make install
    # exit-code            2
    # env-file             ~/.opam/log/yajl-8-bd45e3.env
    # output-file          ~/.opam/log/yajl-8-bd45e3.out
    ### output ###
    ...
    # File "ocaml+twt.ml", line 336, characters 15-29:
    # 336 |   let stream = Stream.of_list lines in
    #                      ^^^^^^^^^^^^^^
    # Error: Unbound module Stream
    # make[1]: *** [Makefile:8: ocaml+twt] Error 2
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/yajl.0.7.3/twt'
    # make: *** [Makefile:48: twt/ocaml+twt] Error 2
