### PR TITLE
ocaml5: restrict posix-time releases

### DIFF
--- a/packages/posix-time/posix-time.0.3.0-0/opam
+++ b/packages/posix-time/posix-time.0.3.0-0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "posix-time"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}
 ]

--- a/packages/posix-time/posix-time.0.5.1-0/opam
+++ b/packages/posix-time/posix-time.0.5.1-0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "posix-time"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}
 ]

--- a/packages/posix-time/posix-time.0.5.2-0/opam
+++ b/packages/posix-time/posix-time.0.5.2-0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "posix-time"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}
 ]

--- a/packages/posix-time/posix-time.0.5.3-0/opam
+++ b/packages/posix-time/posix-time.0.5.3-0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "posix-time"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
They rely on `String.lowercase`:

    #=== ERROR while compiling posix-time.0.5.3-0 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/posix-time.0.5.3-0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/posix-time-8-77867c.env
    # output-file          ~/.opam/log/posix-time-8-77867c.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
