### PR TITLE
ocaml 5: restrict postgresql releases

### DIFF
--- a/packages/postgresql/postgresql.3.2.1/opam
+++ b/packages/postgresql/postgresql.3.2.1/opam
@@ -34,7 +34,7 @@ remove: [
   ["ocamlfind" "remove" "postgresql"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "base-threads"

--- a/packages/postgresql/postgresql.4.0.0/opam
+++ b/packages/postgresql/postgresql.4.0.0/opam
@@ -34,7 +34,7 @@ remove: [
   ["ocamlfind" "remove" "postgresql"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "base-threads"

--- a/packages/postgresql/postgresql.4.0.1/opam
+++ b/packages/postgresql/postgresql.4.0.1/opam
@@ -34,7 +34,7 @@ remove: [
   ["ocamlfind" "remove" "postgresql"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "base-threads"


### PR DESCRIPTION
They rely on `String.lowercase`:

    #=== ERROR while compiling postgresql.4.0.1 ===================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/postgresql.4.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-lablgtk2
    # exit-code            2
    # env-file             ~/.opam/log/postgresql-8-5f4b5c.env
    # output-file          ~/.opam/log/postgresql-8-5f4b5c.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
