### PR TITLE
ocaml 5: restrict resource-pooling releases

### DIFF
--- a/packages/resource-pooling/resource-pooling.0.3.2/opam
+++ b/packages/resource-pooling/resource-pooling.0.3.2/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "resource-pooling"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}

--- a/packages/resource-pooling/resource-pooling.0.5.1/opam
+++ b/packages/resource-pooling/resource-pooling.0.5.1/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "resource-pooling"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}

--- a/packages/resource-pooling/resource-pooling.0.5/opam
+++ b/packages/resource-pooling/resource-pooling.0.5/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "resource-pooling"]
 ]
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "lwt" {>= "2.4.7"}
   "lwt_log"
   "ocamlbuild" {build}


### PR DESCRIPTION
Follow-up to #22891. These also rely on `Stream`:

    #=== ERROR while compiling resource-pooling.0.5.1 =============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/resource-pooling.0.5.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/resource-pooling-8-8bbcbb.env
    # output-file          ~/.opam/log/resource-pooling-8-8bbcbb.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
