### PR TITLE
ocaml 5: restrict obandit releases

### DIFF
--- a/packages/obandit/obandit.0.1.38/opam
+++ b/packages/obandit/obandit.0.1.38/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+http://git.freux.fr/cgit/obandit.git"
 bug-reports: "ocaml@freux.fr"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/obandit/obandit.0.1.41/opam
+++ b/packages/obandit/obandit.0.1.41/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+http://git.freux.fr/cgit/obandit.git"
 bug-reports: "ocaml@freux.fr"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/obandit/obandit.0.1.42/opam
+++ b/packages/obandit/obandit.0.1.42/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+http://git.freux.fr/cgit/obandit.git"
 bug-reports: "ocaml@freux.fr"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/opam
+++ b/packages/obandit/obandit.0.2.3.1-5-g40e1b6c/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+https://github.com/freuk/obandit.git"
 bug-reports: "https://github.com/freuk/obandit/issues"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/obandit/obandit.0.2/opam
+++ b/packages/obandit/obandit.0.2/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+http://git.freux.fr/cgit/obandit.git"
 bug-reports: "ocaml@freux.fr"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/obandit/obandit.0.3.4/opam
+++ b/packages/obandit/obandit.0.3.4/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+https://github.com/freuk/obandit.git"
 bug-reports: "https://github.com/freuk/obandit/issues"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling obandit.0.3.4 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/obandit.0.3.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false
    # exit-code            1
    # env-file             ~/.opam/log/obandit-8-6d3720.env
    # output-file          ~/.opam/log/obandit-8-6d3720.out
    ### output ###
    # ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
    # ocamlfind ocamldep -package cmdliner -package batteries -package bytes -modules src/obandit.ml > src/obandit.ml.depends
    # ocamlfind ocamldep -package cmdliner -package batteries -package bytes -modules src/obandit.mli > src/obandit.mli.depends
    # ocamlfind ocamlc -c -g -bin-annot -safe-string -package cmdliner -package batteries -package bytes -I src -I test -o src/obandit.cmi src/obandit.mli
    # ocamlfind ocamlopt -c -g -bin-annot -safe-string -package cmdliner -package batteries -package bytes -I src -I test -o src/obandit.cmx src/obandit.ml
    # + ocamlfind ocamlopt -c -g -bin-annot -safe-string -package cmdliner -package batteries -package bytes -I src -I test -o src/obandit.cmx src/obandit.ml
    # File "src/obandit.ml", line 77, characters 20-38:
    # 77 | let makecmp v x y = Pervasives.compare (v x) (v y)
    #                          ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
