### PR TITLE
pyml 20220905 supports ocaml 5

### DIFF
--- a/packages/pyml/pyml.20220905/opam
+++ b/packages/pyml/pyml.20220905/opam
@@ -23,7 +23,7 @@ synopsis: "OCaml bindings for Python"
 description: "OCaml bindings for Python 2 and Python 3"
 available: arch != "s390x"
 depends: [
-  "ocaml" {>= "3.12.1" & < "5.0"}
+  "ocaml" {>= "3.12.1"}
   "dune" {>= "2.8.0"}
   "ocamlfind" {build}
   "stdcompat" {>= "18"}


### PR DESCRIPTION
This was tested locally, and agrees with the release changelog.
Noitced on https://github.com/ocaml/opam-repository/pull/22841