### PR TITLE
datalog 0.6 is not compatible with ocaml 5

### DIFF
--- a/packages/datalog/datalog.0.6/opam
+++ b/packages/datalog/datalog.0.6/opam
@@ -9,7 +9,7 @@ doc: "https://c-cube.github.io/datalog"
 bug-reports: "https://github.com/c-cube/datalog/issues"
 depends: [
   "dune"
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0"}
   "odoc" {with-doc}
   "mdx" {>= "1.3" & with-test}
 ]


### PR DESCRIPTION
```
#=== ERROR while compiling datalog.0.6 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/datalog.0.6
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p datalog -j 71
# exit-code            1
# env-file             ~/.opam/log/datalog-7-97f55d.env
# output-file          ~/.opam/log/datalog-7-97f55d.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/bottom_up_cli/.datalog_cli.eobjs/byte -I src/bottom_up/.datalog.objs/byte -no-alias-deps -o src/bottom_up_cli/.datalog_cli.eobjs/byte/datalog_cli.cmo -c -impl src/bottom_up_cli/datalog_cli.ml)
# File "src/bottom_up_cli/datalog_cli.ml", line 59, characters 6-24:
# 59 |       Pervasives.compare a b
#            ^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -color always -safe-string -warn-error -a+8 -g -bin-annot -I src/top_down/.datalog_top_down.objs/byte -I src/bottom_up/.datalog.objs/byte -intf-suffix .ml -no-alias-deps -open Datalog_top_down__ -o src/top_down/.datalog_top_down.objs/byte/datalog_top_down.cmo -c -impl src/top_down/Datalog_top_down.ml)
# File "src/top_down/Datalog_top_down.ml", line 1681, characters 10-17:
# 1681 |       let new_var =
#                  ^^^^^^^
# Warning 26 [unused-var]: unused variable new_var.
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -color always -safe-string -warn-error -a+8 -g -I src/top_down/.datalog_top_down.objs/byte -I src/top_down/.datalog_top_down.objs/native -I src/bottom_up/.datalog.objs/byte -I src/bottom_up/.datalog.objs/native -intf-suffix .ml -no-alias-deps -open Datalog_top_down__ -o src/top_down/.datalog_top_down.objs/native/datalog_top_down.cmx -c -impl src/top_down/Datalog_top_down.ml)
# File "src/top_down/Datalog_top_down.ml", line 1681, characters 10-17:
# 1681 |       let new_var =
#                  ^^^^^^^
# Warning 26 [unused-var]: unused variable new_var.
```

Seen on https://github.com/ocaml/opam-repository/pull/22867 revdeps