### PR TITLE
preface.1.0.0: disable tests with ocaml 5

### DIFF
--- a/packages/preface/preface.1.0.0/opam
+++ b/packages/preface/preface.1.0.0/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/xvw/preface/issues"
 build: [
   [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name ] {with-test & !base-effects:installed}
+  [ "dune" "runtest" "-p" name ] {with-test & !base-effects:installed & ocaml:version < "5.0"}
   [ "dune" "build" "@doc" "-p" name ] {with-doc}
 ]
 


### PR DESCRIPTION
They currently fail due to deprecation warnings making their way in the mdx output and a toplevel module error.

```
=== ERROR while compiling preface.1.0.0 ======================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/preface.1.0.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p preface
 exit-code            1
 env-file             ~/.opam/log/preface-7-76d8d1.env
 output-file          ~/.opam/log/preface-7-76d8d1.out
 File "guides/error_handling.md", line 1, characters 0-0:
 /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/guides/error_handling.md _build/default/guides/.mdx/error_handling.md.corrected
 diff --git a/_build/default/guides/error_handling.md b/_build/default/guides/.mdx/error_handling.md.corrected
 index 4df0ee4..8377418 100644
 --- a/_build/default/guides/error_handling.md
 +++ b/_build/default/guides/.mdx/error_handling.md.corrected
 @@ -1,6 +1,7 @@
  # #require "preface" ;;
  # #install_printer Preface.Nonempty_list.pp ;;
 +Cannot find type Topdirs.printer_type_new.
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>