### PR TITLE
lwt_eio 0.1 disable tests on ocaml 5

### DIFF
--- a/packages/lwt_eio/lwt_eio.0.1/opam
+++ b/packages/lwt_eio/lwt_eio.0.1/opam
@@ -26,7 +26,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.0"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/lwt_eio/lwt_eio.0.1/opam
+++ b/packages/lwt_eio/lwt_eio.0.1/opam
@@ -8,6 +8,7 @@ license: "ISC"
 homepage: "https://github.com/talex5/lwt_eio"
 bug-reports: "https://github.com/talex5/lwt_eio/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9"}
   "eio"
   "lwt"


### PR DESCRIPTION
They currently fail due to deprecation warnings making their way in the mdx output and a toplevel module error.

```
# File "README.md", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/README.md _build/default/.mdx/README.md.corrected
# diff --git a/_build/default/README.md b/_build/default/.mdx/README.md.corrected
# index e211634..eae6988 100644
# --- a/_build/default/README.md
# +++ b/_build/default/.mdx/README.md.corrected
# @@ -259,6 +259,9 @@ Finally, we can convert `sort`'s callback to Eio code and drop the use of `Lwt`
#      process_lines ~src ~dst @@ fun lines ->
#      Fibre.yield ();     (* Simulate async work *)
#      List.sort String.compare lines;;
# +Line 3, characters 5-16:
# +Alert deprecated: module Eio.Std.Fibre
# +Now spelt Fiber
#  val sort : src:#Eio.Flow.source -> dst:#Eio.Flow.sink -> unit = <fun>
#  
#  # Eio_main.run @@ fun env ->
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>