### PR TITLE
printbox-text 0.6.1: disable tests on ocaml 5

### DIFF
--- a/packages/printbox-text/printbox-text.0.6.1/opam
+++ b/packages/printbox-text/printbox-text.0.6.1/opam
@@ -4,7 +4,7 @@ maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "Text renderer for printbox, using unicode edges"
 build: [
   ["dune" "build" "@install" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [


### PR DESCRIPTION
They currently fail due to a toplevel module error.

```
=== ERROR while compiling printbox-text.0.6.1 ================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/printbox-text.0.6.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p printbox-text -j 47
 exit-code            1
 env-file             ~/.opam/log/printbox-text-7-1ff747.env
 output-file          ~/.opam/log/printbox-text-7-1ff747.out
 File "README.md", line 1, characters 0-0:
 /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/README.md _build/default/README.md.corrected
 diff --git a/_build/default/README.md b/_build/default/README.md.corrected
 index 57db967..68eed58 100644
 --- a/_build/default/README.md
 +++ b/_build/default/README.md.corrected
 @@ -150,18 +150,11 @@ can be used as a default printer for boxes.

  ```ocaml
  # #install_printer PrintBox_text.pp;;
 +Cannot find type Topdirs.printer_type_new.
  # PrintBox.(frame @@ frame @@ init_grid ~line:3 ~col:2 (fun ~line:i ~col:j -> sprintf "%d.%d" i j));;
 -- : B.t =
 -┌─────────┐
 -│┌───┬───┐│
 -││0.0│0.1││
 -│├───┼───┤│
 -││1.0│1.1││
 -│├───┼───┤│
 -││2.0│2.1││
 -│└───┴───┘│
 -└─────────┘
 +- : B.t = <abstr>
  # #remove_printer PrintBox_text.pp;;
 +Cannot find type Topdirs.printer_type_new.
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>