### PR TITLE
geojsone 0.1.0: disable tests on ocaml 5

### DIFF
--- a/packages/geojsone/geojsone.0.1.0/opam
+++ b/packages/geojsone/geojsone.0.1.0/opam
@@ -31,7 +31,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test & ocaml:version < "5.0"}
+    "@runtest" {with-test & eio:version < "0.7"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/geojsone/geojsone.0.1.0/opam
+++ b/packages/geojsone/geojsone.0.1.0/opam
@@ -30,7 +30,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.0"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/geojsone/geojsone.0.1.0/opam
+++ b/packages/geojsone/geojsone.0.1.0/opam
@@ -9,13 +9,13 @@ tags: ["geojson" "geospatial" "geocaml"]
 homepage: "https://github.com/geocaml/ocaml-geojson"
 bug-reports: "https://github.com/geocaml/ocaml-geojson/issues"
 depends: [
-  "ocaml"
   "dune" {>= "2.9"}
   "geojson" {= version}
   "mdx" {with-test}
   "ezjsonm" {with-test}
   "eio_main" {>= "0.6" & with-test}
   "eio" {>= "0.6"}
+  "eio" {with-test & < "0.7"}
   "hex"
   "sexplib0"
   "odoc" {with-doc}
@@ -31,7 +31,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test & eio:version < "0.7"}
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/geojsone/geojsone.0.1.0/opam
+++ b/packages/geojsone/geojsone.0.1.0/opam
@@ -9,6 +9,7 @@ tags: ["geojson" "geospatial" "geocaml"]
 homepage: "https://github.com/geocaml/ocaml-geojson"
 bug-reports: "https://github.com/geocaml/ocaml-geojson/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9"}
   "geojson" {= version}
   "mdx" {with-test}


### PR DESCRIPTION
```
 File "README.md", line 1, characters 0-0:
 /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/README.md _build/default/.mdx/README.md.corrected
 diff --git a/_build/default/README.md b/_build/default/.mdx/README.md.corrected
 index 30e6983..15a70c3 100644
 --- a/_build/default/README.md
 +++ b/_build/default/.mdx/README.md.corrected
 @@ -141,6 +141,9 @@ For reading, we can turn an arbitrary Eio `Flow.t` into a source. A `Flow.t` is
      let got = Eio.Flow.(read flow buff) in
      let t = Cstruct.sub buff 0 got in
      t;;
 +Line 4, characters 25-29:
 +Alert deprecated: Eio.Flow.read
 +Use single_read if you really want this.
  val src_of_flow : #Eio.Flow.source -> unit -> Cstruct.t = <fun>
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>