### PR TITLE
binaryen_dsl 0.7 needs upper bound on libbbinaryen

### DIFF
--- a/packages/binaryen_dsl/binaryen_dsl.0.7/opam
+++ b/packages/binaryen_dsl/binaryen_dsl.0.7/opam
@@ -16,7 +16,7 @@ depends: [
   "core" {< "v0.15"}
   "dune" {>= "2.8"}
   "ctypes" {>= "0.14.0"}
-  "libbinaryen"
+  "libbinaryen" {< "102"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Seen on `https://github.com/ocaml/opam-repository/pull/22863` Fails with C binding issues
```
#=== ERROR while compiling binaryen_dsl.0.7 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/binaryen_dsl.0.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p binaryen_dsl -j 31
# exit-code            1
# env-file             ~/.opam/log/binaryen_dsl-7-5a0aef.env
# output-file          ~/.opam/log/binaryen_dsl-7-5a0aef.out
### output ###
# (cd _build/default && stub_gen/stub_gen.exe -c)
# gen C
# File "dune", line 7, characters 9-10:
# 7 |   (names b)
#              ^
[...]
# b.c:339:17: error: too few arguments to function 'BinaryenMemoryCopy'
#   339 |    void* x249 = BinaryenMemoryCopy(x245, x246, x247, x248);
#       |                 ^~~~~~~~~~~~~~~~~~
[...]
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>