### PR TITLE
ocaml 5: restrict qcheck-core releases

### DIFF
--- a/packages/qcheck-core/qcheck-core.0.10/opam
+++ b/packages/qcheck-core/qcheck-core.0.10/opam
@@ -11,7 +11,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "odoc" {with-doc}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
 ]
 conflicts: [
   "ounit" {< "2.0"}

--- a/packages/qcheck-core/qcheck-core.0.11/opam
+++ b/packages/qcheck-core/qcheck-core.0.11/opam
@@ -11,7 +11,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "odoc" {with-doc}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
 ]
 conflicts: [
   "ounit" {< "2.0"}

--- a/packages/qcheck-core/qcheck-core.0.12/opam
+++ b/packages/qcheck-core/qcheck-core.0.12/opam
@@ -18,7 +18,7 @@ depends: [
   "base-bytes"
   "base-unix"
   "odoc" {with-doc}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
 ]
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
 bug-reports: "https://github.com/c-cube/qcheck/issues"

--- a/packages/qcheck-core/qcheck-core.0.9/opam
+++ b/packages/qcheck-core/qcheck-core.0.9/opam
@@ -7,7 +7,7 @@ doc: "http://c-cube.github.io/qcheck/"
 bug-reports: "https://github.com/c-cube/qcheck/issues"
 depends: [
   "dune"
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "base-bytes"
   "base-unix"
   "odoc" {with-doc}


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling qcheck-core.0.12 ===================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/qcheck-core.0.12
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p qcheck-core -j 47
    # exit-code            1
    # env-file             ~/.opam/log/qcheck-core-8-3afe21.env
    # output-file          ~/.opam/log/qcheck-core-8-3afe21.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w +a-4-42-44-48-50-58-32-60@8 -safe-string -g -I src/core/.qcheck_core.objs/byte -I src/core/.qcheck_core.objs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -o src/core/.qcheck_core.objs/native/qCheck.cmx -c -impl src/core/QCheck.ml)
    # File "src/core/QCheck.ml", line 1172, characters 24-42:
    # 1172 |             begin match Pervasives.compare (small instance) (small c_ex'.instance) with
    #                                ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w +a-4-42-44-48-50-58-32-60@8 -safe-string -g -bin-annot -I src/core/.qcheck_core.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -intf-suffix .ml -no-alias-deps -o src/core/.qcheck_core.objs/byte/qCheck.cmo -c -impl src/core/QCheck.ml)
    # File "src/core/QCheck.ml", line 1172, characters 24-42:
    # 1172 |             begin match Pervasives.compare (small instance) (small c_ex'.instance) with
    #                                ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
