### PR TITLE
ocaml 5: restrict owl-base releases

### DIFF
--- a/packages/owl-base/owl-base.0.4.0/opam
+++ b/packages/owl-base/owl-base.0.4.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0.0"}
   "alcotest" {with-test}
   "base-bigarray"
   "dune"

--- a/packages/owl-base/owl-base.0.5.0/opam
+++ b/packages/owl-base/owl-base.0.5.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0.0"}
   "base-bigarray"
   "dune"
   "dune-configurator"

--- a/packages/owl-base/owl-base.0.6.0/opam
+++ b/packages/owl-base/owl-base.0.6.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0.0"}
   "base-bigarray"
   "dune" {>= "1.7"}
   "dune-configurator"


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling owl-base.0.6.0 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/owl-base.0.6.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p owl-base -j 127
    # exit-code            1
    # env-file             ~/.opam/log/owl-base-8-253801.env
    # output-file          ~/.opam/log/owl-base-8-253801.out
    ### output ###
    ...
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I src/base/.owl_base.objs/byte -intf-suffix .ml -no-alias-deps -o src/base/.owl_base.objs/byte/owl_base_complex.cmo -c -impl src/base/owl_base_complex.ml)
    # File "src/base/maths/owl_base_complex.ml", line 32, characters 2-12:
    # Error: Unbound module Pervasives
