### PR TITLE
ocaml 5: restrict msat releases

### DIFF
--- a/packages/msat/msat.0.1/opam
+++ b/packages/msat/msat.0.1/opam
@@ -16,7 +16,7 @@ build: [make "lib"]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0.0"}
   "ocamlfind" {build}
   "base-unix"
   "ocamlbuild" {build}

--- a/packages/msat/msat.0.2/opam
+++ b/packages/msat/msat.0.2/opam
@@ -16,7 +16,7 @@ build: [[make "disable_log"] [make "lib"]]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.02.1"}
+  "ocaml" {>= "4.02.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-unix"

--- a/packages/msat/msat.0.3/opam
+++ b/packages/msat/msat.0.3/opam
@@ -19,7 +19,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.4.1/opam
+++ b/packages/msat/msat.0.4.1/opam
@@ -19,7 +19,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.4/opam
+++ b/packages/msat/msat.0.4/opam
@@ -19,7 +19,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.5.1/opam
+++ b/packages/msat/msat.0.5.1/opam
@@ -19,7 +19,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.5/opam
+++ b/packages/msat/msat.0.5/opam
@@ -19,7 +19,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "msat"]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.6.1/opam
+++ b/packages/msat/msat.0.6.1/opam
@@ -20,7 +20,7 @@ build: [
 install: [make "DOCDIR=%{doc}%" "install"]
 remove: [make "DOCDIR=%{doc}%" "uninstall"]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.6/opam
+++ b/packages/msat/msat.0.6/opam
@@ -20,7 +20,7 @@ build: [
 install: [make "DOCDIR=%{msat:doc}%" "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/msat/msat.0.7/opam
+++ b/packages/msat/msat.0.7/opam
@@ -14,7 +14,7 @@ remove: [
     [make "DOCDIR=%{msat:doc}%" "uninstall"]
 ]
 depends: [
-  "ocaml" { >= "4.00.1" }
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "dolmen" {with-test & >= "0.4" & < "0.5" }

--- a/packages/msat/msat.0.8/opam
+++ b/packages/msat/msat.0.8/opam
@@ -8,7 +8,7 @@ tags: ["sat" "smt"]
 homepage: "https://github.com/Gbury/mSAT"
 bug-reports: "https://github.com/Gbury/mSAT/issues/"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "dune"
   "iter" {>= "1.2"}
   "containers" {with-test & >= "2.0" & < "3.0" }


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling msat.0.8 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/msat.0.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build @install -p msat -j 127
    # exit-code            1
    # env-file             ~/.opam/log/msat-8-63a4cf.env
    # output-file          ~/.opam/log/msat-8-63a4cf.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -g -bin-annot -I src/core/.msat.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/iter -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -no-alias-deps -open Msat__ -o src/core/.msat.objs/byte/msat__Heap_intf.cmo -c -impl src/core/Heap_intf.ml)
    # File "src/core/Heap_intf.ml", line 1:
    # Warning 70 [missing-mli]: Cannot find interface file.
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -g -bin-annot -I src/core/.msat.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/iter -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -no-alias-deps -open Msat__ -o src/core/.msat.objs/byte/msat__Solver_intf.cmo -c -impl src/core/Solver_intf.ml)
    # File "src/core/Solver_intf.ml", line 1:
    # Warning 70 [missing-mli]: Cannot find interface file.
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3 -w +a-4-42-44-48-50-58-32-60@8 -color always -safe-string -g -bin-annot -I src/core/.msat.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/iter -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -no-alias-deps -open Msat__ -o src/core/.msat.objs/byte/msat__Internal.cmo -c -impl src/core/Internal.ml)
    # File "src/core/Internal.ml", line 235, characters 31-49:
    # 235 |     let[@inline] compare a b = Pervasives.compare a.aid b.aid
    #                                      ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
