### PR TITLE
ocaml5: restrict mixture releases

### DIFF
--- a/packages/mixture/mixture.0.2.0/opam
+++ b/packages/mixture/mixture.0.2.0/opam
@@ -20,7 +20,7 @@ remove: [
   ["rm" "-rf" "%{share}%/doc/mixture"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
   "conf-bmake"

--- a/packages/mixture/mixture.0.2.1/opam
+++ b/packages/mixture/mixture.0.2.1/opam
@@ -20,7 +20,7 @@ remove: [
   ["rm" "-rf" "%{share}%/doc/mixture"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
   "conf-bmake"

--- a/packages/mixture/mixture.1.0.0/opam
+++ b/packages/mixture/mixture.1.0.0/opam
@@ -20,7 +20,7 @@ remove: [
   ["rm" "-rf" "%{share}%/doc/mixture"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1" & != "4.02.1"}
+  "ocaml" {>= "4.00.1" & != "4.02.1" & < "5.0.0"}
   "broken" {>= "0.4.2"}
   "bsdowl" {>= "3.0.0"}
   "conf-bmake"


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling mixture.1.0.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mixture.1.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build /usr/bin/bmake -I/home/opam/.opam/5.0/share/bsdowl all
    # exit-code            1
    # env-file             ~/.opam/log/mixture-8-4cb250.env
    # output-file          ~/.opam/log/mixture-8-4cb250.out
    ### output ###
    ...
    # ocamlfind ocamlopt -c -package "broken" -I /home/opam/.opam/5.0/.opam-switch/build/mixture.1.0.0/src -I /home/opam/.opam/5.0/.opam-switch/build/mixture.1.0.0/src -o mixture_Monad.cmx mixture_Monad.ml
    # File "mixture_Monad.ml", line 132, characters 11-28:
    # 132 |     Infix.(Pervasives.ignore <$> m)
    #                  ^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
