### PR TITLE
ocaml 5: restrict lacaml releases

### DIFF
--- a/packages/lacaml/lacaml.9.0.0/opam
+++ b/packages/lacaml/lacaml.9.0.0/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/lacaml/lacaml.9.1.0/opam
+++ b/packages/lacaml/lacaml.9.1.0/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/lacaml/lacaml.9.1.1/opam
+++ b/packages/lacaml/lacaml.9.1.1/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/lacaml/lacaml.9.2.2/opam
+++ b/packages/lacaml/lacaml.9.2.2/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/lacaml/lacaml.9.2.3/opam
+++ b/packages/lacaml/lacaml.9.2.3/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/lacaml/lacaml.9.3.1/opam
+++ b/packages/lacaml/lacaml.9.3.1/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}

--- a/packages/lacaml/lacaml.9.3.2/opam
+++ b/packages/lacaml/lacaml.9.3.2/opam
@@ -27,7 +27,7 @@ remove: [
   ["ocamlfind" "remove" "lacaml"]
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}


### PR DESCRIPTION
(Follow-up to #22914)

9.0.0, 9.1.0 and 9.1.1 rely on `Pervasives`:

    #=== ERROR while compiling lacaml.9.1.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lacaml.9.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/lacaml-9-0a192a.env
    # output-file          ~/.opam/log/lacaml-9-0a192a.out
    ### output ###
    # File "./setup.ml", line 1404, characters 23-41:
    # 1404 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives

9.2.2, 9.2.3, 9.3.1 and 9.3.2 rely on `Stream`:

    #=== ERROR while compiling lacaml.9.3.2 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lacaml.9.3.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/lacaml-9-67f80d.env
    # output-file          ~/.opam/log/lacaml-9-67f80d.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
