### PR TITLE
Add constraint `with-test` for ff-pbt in the OPAM definition of bls12-381.6.0.1

### DIFF
--- a/packages/bls12-381/bls12-381.6.0.1/opam
+++ b/packages/bls12-381/bls12-381.6.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "alcotest" {with-test}
   "integers"
   "integers_stubs_js" {with-test}
-  "ff-pbt" {>= "0.6.0" & < "0.7.0"}
+  "ff-pbt" {>= "0.6.0" & < "0.7.0" & with-test}
   "odoc" {with-doc}
 ]
 conflicts: ["ocaml-option-bytecode-only"]


### PR DESCRIPTION
It is fixed here, but not in the release tag at https://gitlab.com/nomadic-labs/crytography/ocaml-bls12-381. There is therefore an inconsistency between the OPAM file definitions. As it is not related to the code, I suggest to leave it like this.

See https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381/-/merge_requests/215 for the fix upstream.