### PR TITLE
[new release] coq-lsp (0.1.3+v8.16)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.1.3+v8.16/opam
+++ b/packages/coq-lsp/coq-lsp.0.1.3+v8.16/opam
@@ -1,0 +1,44 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+  "Ali Caglayan <alizter@gmail.com>"
+  "Shachar Itzhaky <shachari@cs.technion.ac.il>"
+  "Ramkumar Ramachandra <r@artagnon.com>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+  "ocaml"        { >= "4.12.0" }
+  "dune"         { >= "3.2"  }
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+
+  # Not yet required, install Coq deps instead
+  "coq"            {         >= "8.16.0" & < "8.17" }
+  "coq-serapi"     {         >= "8.16.0+0.16.2" & < "8.17" }
+  "camlp-streams"  {         >= "5.0"               }
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.1.3%2Bv8.16/coq-lsp-0.1.3.v8.16.tbz"
+  checksum: [
+    "sha256=d6d589ae18453d9251b4250df50e59cfc87254de0e4734e13c5bca06ab14cee5"
+    "sha512=802b4673c7f581976526a3cb4bd824f7574c5b1cc8fcc7759fcd3358cdc3e4cebef3ec908899ad68129190777ccda931dfc1643b45db156ede15acae0382c148"
+  ]
+}
+x-commit-hash: "d71623f60ff13b40a982f4526f6fa607b2b0fa6e"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

----------------------

 - Much improved handling of Coq fatal errors, the server is now
   hardened against them (@ejgallego, ejgallego/coq-lsp#155, ejgallego/coq-lsp#157, ejgallego/coq-lsp#160, fixes ejgallego/coq-lsp#91)
 - `coq-lsp` now follows the LSP specification regarding
   initialization strictly (@ejgallego, ejgallego/coq-lsp#168)
 - New setting for goals to be updated when the selection changes due
   to a command; this makes VsCodeVim cursor tracking work; thanks to
   Cactus (Anton) Golov for detailed bug reporting and testing
   (@ejgallego, @jesyspa, ejgallego/coq-lsp#170, fixes ejgallego/coq-lsp#163)
 - `coq-lsp` will now warn the user when two files have been opened
   simultaneously and the parser may go into a broken state :/
   (@ejgallego, ejgallego/coq-lsp#169)
 - Implement request postponement and cancellation. Thus
   `documentSymbols` will now be postponed until the document is
   ready, (@ejgallego, ejgallego/coq-lsp#141, ejgallego/coq-lsp#146, fixes ejgallego/coq-lsp#124)
 - Protocol and VS Code interfaces now support shelved and given_up
   goals (@ejgallego, ejgallego/coq-lsp#175)
 - Allow to postpone requests to wait for data to become available on
   document points; this is implemented to provide a nicer "show goals
   while I type" experience. Client default has been changed to "show
   goals on mouse, click, typing, and cursor movement) (@ejgallego,
   ejgallego/coq-lsp#177, ejgallego/coq-lsp#179)
 - Store stats per document (@ejgallego, ejgallego/coq-lsp#180, fixes ejgallego/coq-lsp#173)
