### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.9.0)

### DIFF
--- a/packages/http_async/http_async.0.0.4/opam
+++ b/packages/http_async/http_async.0.0.4/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.5.0"}
+  "shuttle" {>= "0.5.0" & < "0.9.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/http_async/http_async.0.1.0/opam
+++ b/packages/http_async/http_async.0.1.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.6.0"}
+  "shuttle" {>= "0.6.0" & < "0.9.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/http_async/http_async.0.1.1/opam
+++ b/packages/http_async/http_async.0.1.1/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.6.0"}
+  "shuttle" {>= "0.6.0" & < "0.9.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/http_async/http_async.0.2.0/opam
+++ b/packages/http_async/http_async.0.2.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/anuragsoni/http_async/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
-  "shuttle" {>= "0.6.0"}
+  "shuttle" {>= "0.6.0" & < "0.9.0"}
   "ppxlib" {>= "0.23.0"}
   "odoc" {with-doc}
 ]

--- a/packages/shuttle/shuttle.0.9.0/opam
+++ b/packages/shuttle/shuttle.0.9.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.0/shuttle-0.9.0.tbz"
+  checksum: [
+    "sha256=fd61626c46dcbd63449746b55e1b0821119e5215c6b32330f9671fbb306812ef"
+    "sha512=f06946e9271acd8df613385f7b94facb3d807b031c7eb21fac30886db0f45d8615b6eb71132455008b746513de3590d77890518e0c1a2672f1434cd9c1d97f67"
+  ]
+}
+x-commit-hash: "bfc5f14556548fdccc628778afdcaeb06d491a92"

--- a/packages/shuttle_http/shuttle_http.0.9.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.9.0/opam
@@ -12,6 +12,7 @@ bug-reports: "https://github.com/anuragsoni/shuttle/issues"
 depends: [
   "dune" {>= "2.8"}
   "shuttle" {= version}
+  "shuttle_ssl" {= version}
   "re2" {>= "v0.15.0"}
   "ppx_jane" {with-test}
   "core_unix" {with-test}

--- a/packages/shuttle_http/shuttle_http.0.9.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.9.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "re2" {>= "v0.15.0"}
+  "ppx_jane" {with-test}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.0/shuttle-0.9.0.tbz"
+  checksum: [
+    "sha256=fd61626c46dcbd63449746b55e1b0821119e5215c6b32330f9671fbb306812ef"
+    "sha512=f06946e9271acd8df613385f7b94facb3d807b031c7eb21fac30886db0f45d8615b6eb71132455008b746513de3590d77890518e0c1a2672f1434cd9c1d97f67"
+  ]
+}
+x-commit-hash: "bfc5f14556548fdccc628778afdcaeb06d491a92"

--- a/packages/shuttle_ssl/shuttle_ssl.0.9.0/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.9.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.0/shuttle-0.9.0.tbz"
+  checksum: [
+    "sha256=fd61626c46dcbd63449746b55e1b0821119e5215c6b32330f9671fbb306812ef"
+    "sha512=f06946e9271acd8df613385f7b94facb3d807b031c7eb21fac30886db0f45d8615b6eb71132455008b746513de3590d77890518e0c1a2672f1434cd9c1d97f67"
+  ]
+}
+x-commit-hash: "bfc5f14556548fdccc628778afdcaeb06d491a92"


### PR DESCRIPTION
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>
- Documentation: <a href="https://anuragsoni.github.io/shuttle/">https://anuragsoni.github.io/shuttle/</a>

##### CHANGES:

* Forward ssl connection details to shuttle_ssl server handlers
* Remove listen and with_connection from shuttle_ssl. Use upgrade_server_connection and upgrade_client_connection with the regular Connection module provided within Shuttle.
* Allow accessing the underlying buffer capacity for channels
* Add helper method that creates server connections using inet sockets
* Reliably schedule stream cleanup for all streaming server responses without forcing users to use any special functions to create the response
* Add one-shot http client
* Setup tcp server within http server module
