### PR TITLE
update pa_ppx_{hashcons,q_ast,unique} for ocaml 5.0.0

### DIFF
--- a/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.09/opam
+++ b/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.09/opam
@@ -1,0 +1,42 @@
+synopsis: "A PPX Rewriter for Hashconsing"
+description:
+"""
+This is a PPX Rewriter for generating hashconsing implementations
+of ASTs, mechanizing the ideas and code of Jean-Christophe Filliatre
+and Sylvain Conchon.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_hashcons"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_hashcons/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_hashcons.git"
+doc: "https://github.com/camlp5/pa_ppx_hashcons/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+  "hashcons"
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_hashcons/archive/refs/tags/0.09.tar.gz"
+  checksum: [
+    "sha512=d215d7de789ff238d127f2798a13ee7d5020048bb241e42105f94c87760fbc5e1bcb48f2fabfef1fa427eee2e2595118ae18881a9934bd68fd10b5c3769ae7eb"
+  ]
+}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.09/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.09/opam
@@ -1,0 +1,43 @@
+synopsis: "A PPX Rewriter for automating generation of data-conversion code for use with Camlp5's Q_ast"
+description:
+"""
+This is a PPX Rewriter for generating data-conversion code that is otherwise
+hand-written, when using Camlp5's Q_ast.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_q_ast"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_q_ast/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_q_ast.git"
+doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "conf-diffutils" { with-test }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00.04" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "pa_ppx_hashcons"      { >= "0.08" }
+  "pa_ppx_unique"      { >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/0.09.tar.gz"
+  checksum: [
+    "sha512=a7f8119130ef8583edbd273c4db3c076009112794d3cc508f78a438e936d05aabfbffeae694559d0d8a1a2da7bc755090edffe7af4300c2f4959094b192379ee"
+  ]
+}

--- a/packages/pa_ppx_unique/pa_ppx_unique.0.09/opam
+++ b/packages/pa_ppx_unique/pa_ppx_unique.0.09/opam
@@ -1,0 +1,39 @@
+synopsis: "A PPX Rewriter for Uniqifying ASTs"
+description:
+"""
+This is a PPX Rewriter for uniqifying ASTs: inserting unique IDs
+systematically throughout an AST.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_unique"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_unique/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_unique.git"
+doc: "https://github.com/camlp5/pa_ppx_unique/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "conf-perl"
+  "conf-perl-ipc-system-simple"
+  "conf-perl-string-shellquote"
+  "camlp5"      { >= "8.00" }
+  "pa_ppx"      { >= "0.08" }
+  "pa_ppx_migrate"      { with-test & >= "0.08" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_unique/archive/refs/tags/0.09.tar.gz"
+  checksum: [
+    "sha512=8dac960b0fc666d32f64c5d87df6d78c5d21a2fced71b1aefcd92561caf7bd0a83967713169ddc760c95a7e92c3193993ab9517d35ec43587df6ef09505dbf50"
+  ]
+}


### PR DESCRIPTION
minor changes to make these work with ocaml 5.0.0