### PR TITLE
ocaml 5: restrict not-ocamlfind releases

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.05/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.05/opam
@@ -9,6 +9,7 @@ authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/not-ocamlfind"
 bug-reports: "Chet Murthy <chetsky@gmail.com>"
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.8.0"}
   "conf-m4" {build}
   "fmt" {>= "0.8.8"}

--- a/packages/not-ocamlfind/not-ocamlfind.0.07.01/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07.01/opam
@@ -9,6 +9,7 @@ authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/not-ocamlfind"
 bug-reports: "Chet Murthy <chetsky@gmail.com>"
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.8.0"}
   "conf-m4" {build}
   "fmt" {>= "0.8.8"}

--- a/packages/not-ocamlfind/not-ocamlfind.0.07.02/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.07.02/opam
@@ -9,6 +9,7 @@ authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/not-ocamlfind"
 bug-reports: "Chet Murthy <chetsky@gmail.com>"
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.8.0"}
   "conf-m4" {build}
   "fmt" {>= "0.8.8"}

--- a/packages/not-ocamlfind/not-ocamlfind.0.08/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.08/opam
@@ -10,6 +10,7 @@ authors: "Chet Murthy <chetsky@gmail.com>"
 homepage: "https://github.com/chetmurthy/not-ocamlfind"
 bug-reports: "Chet Murthy <chetsky@gmail.com>"
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.8.0"}
   "conf-m4" {build}
   "fmt" {>= "0.8.8"}


### PR DESCRIPTION
They rely on `Stream`:

    #=== ERROR while compiling not-ocamlfind.0.08 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/not-ocamlfind.0.08
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make all
    # exit-code            2
    # env-file             ~/.opam/log/not-ocamlfind-9-a4d2fd.env
    # output-file          ~/.opam/log/not-ocamlfind-9-a4d2fd.out
    ### output ###
    ...
    # ocamlc -I +compiler-libs -opaque -g -c fl_metascanner.ml
    # File "fl_metascanner.ml", line 41, characters 13-25:
    # 41 |           in Stream.lsing (fun _ -> (line, pos, Eof))
    #                   ^^^^^^^^^^^^
    # Error: Unbound module Stream
    # make[2]: *** [Makefile:172: fl_metascanner.cmo] Error 2
    # make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/not-ocamlfind.0.08/local-packages/ocamlfind/src/findlib'
    # make[1]: *** [Makefile:13: all] Error 2
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/not-ocamlfind.0.08/local-packages/ocamlfind'
    # make: *** [Makefile:10: not-ocamlfind] Error 2
