### PR TITLE
ocaml 5: restrict offheap releases

### DIFF
--- a/packages/offheap/offheap.0.1.0/opam
+++ b/packages/offheap/offheap.0.1.0/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/nandor/offheap"
 license: "MIT"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0.0"}
   "dune"
 ]
 synopsis: "Copies OCaml objects out of the OCaml heap"

--- a/packages/offheap/offheap.0.1.1/opam
+++ b/packages/offheap/offheap.0.1.1/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/nandor/offheap"
 license: "MIT"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0.0"}
   "dune"
 ]
 synopsis: "Copies OCaml objects out of the OCaml heap"

--- a/packages/offheap/offheap.0.1.2/opam
+++ b/packages/offheap/offheap.0.1.2/opam
@@ -8,7 +8,6 @@ improved as the traversal of large live objects does not slow the GC down.
 """
 
 maintainer: "Nandor Licker <n@ndor.email>"
-author: "Nandor Licker <n@ndor.email>"
 homepage: "https://github.com/nandor/offheap"
 bug-reports: "https://github.com/nandor/offheap/issues"
 dev-repo: "git+https://github.com/nandor/offheap"
@@ -17,7 +16,7 @@ license: "MIT"
 build: [ "dune" "build" "-p" name "-j" jobs ]
 
 depends: [
-  "ocaml" { >= "4.07" }
+  "ocaml" {>= "4.07" & < "5.0.0"}
   "dune"
 ]
 
@@ -25,3 +24,4 @@ url {
   src: "https://github.com/nandor/offheap/archive/0.1.2.tar.gz"
   checksum: "md5=0278b913dc2cdb74231d0ca3e4196e36"
 }
+authors: "Nandor Licker <n@ndor.email>"


### PR DESCRIPTION
They rely on OCaml 4.x GC API, in particular `Caml_blue`:

    #=== ERROR while compiling offheap.0.1.2 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/offheap.0.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p offheap -j 31
    # exit-code            1
    # env-file             ~/.opam/log/offheap-8-2af3a8.env
    # output-file          ~/.opam/log/offheap-8-2af3a8.out
    ### output ###
    ...
    # In file included from offheap.c:10:
    # offheap.c: In function 'offheap_copy':
    # offheap.c:249:42: error: 'Caml_blue' undeclared (first use in this function); did you mean 'Caml_inline'?
    #   249 |   Hd_val(v) = Make_header(0, Tag_val(v), Caml_blue);
    #       |                                          ^~~~~~~~~
