### PR TITLE
ocaml 5: restrict binsec releases

### DIFF
--- a/packages/binsec/binsec.0.4.1/opam
+++ b/packages/binsec/binsec.0.4.1/opam
@@ -51,7 +51,7 @@ homepage: "https://binsec.github.io"
 bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "menhir" {build & >= "20181113" & < "20211223"}
   "ocamlgraph" {>= "1.8.5"}
   "zarith" {>= "1.4"}

--- a/packages/binsec/binsec.0.5.0/opam
+++ b/packages/binsec/binsec.0.5.0/opam
@@ -51,7 +51,7 @@ homepage: "https://binsec.github.io"
 bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "menhir" {build & >= "20181113"}
   "ocamlgraph" {>= "1.8.5"}
   "zarith" {>= "1.4"}


### PR DESCRIPTION
They rely on an API in `Format` that has been removed:

    #=== ERROR while compiling binsec.0.5.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/binsec.0.5.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p binsec -j 31 --promote-install-files=false @install
    # exit-code            1
    # env-file             ~/.opam/log/binsec-11-c30b7b.env
    # output-file          ~/.opam/log/binsec-11-c30b7b.out
    ### output ###
    ...
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3 -g -bin-annot -I src/.binsec.objs/byte -I /home/opam/.opam/5.0/lib/dune-private-libs/dune-section -I /home/opam/.opam/5.0/lib/dune-site -I /home/opam/.opam/5.0/lib/dune-site/private -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocamlgraph -I /home/opam/.opam/5.0/lib/stdlib-shims -I /home/opam/.opam/5.0/lib/zarith -intf-suffix .ml -no-alias-deps -open Binsec -o src/.binsec.objs/byte/binsec__Disasm.cmo -c -impl src/disasm/disasm.ml)
    # File "src/disasm/disasm.ml", line 80, characters 6-19:
    # 80 |     { mark_open_tag; mark_close_tag; print_open_tag; print_close_tag }
    #            ^^^^^^^^^^^^^
    # Error: Unbound record field mark_open_tag
    # Hint: Did you mean mark_open_stag?
    # (cd _build/default && /home/opam/.opam/5.0/bin/menhir src/parser/parser.mly --base src/parser/parser --infer-read-reply src/parser/parser__mock.mli.inferred)
    # Warning: 5 states have shift/reduce conflicts.
    # Warning: 5 shift/reduce conflicts were arbitrarily resolved.
