### PR TITLE
ocaml 5: restrict rml.1.09.05

### DIFF
--- a/packages/rml/rml.1.09.05/opam
+++ b/packages/rml/rml.1.09.05/opam
@@ -14,7 +14,7 @@ remove: [
  [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlbuild" {build}
   "num"
 ]


### PR DESCRIPTION
It uses an API in `Format` that has been removed:

    ##=== ERROR while compiling rml.1.09.05 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/rml.1.09.05
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/rml-8-1b144d.env
    # output-file          ~/.opam/log/rml-8-1b144d.out
    ### output ###
    ...
    # ocamlopt -for-pack Rmlcompiler -c -I global -I parsing -I external -I static -I typing -I other_analysis -I reac -I lco -I lk -I caml -I optimization -I main global/warnings.ml
    # File "global/warnings.ml", line 156, characters 4-48:
    # 156 |     Format.pp_get_all_formatter_output_functions ppf ()
    #           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    # Error: Unbound value Format.pp_get_all_formatter_output_functions
