### PR TITLE
ocaml 5: restrict lascar releases

### DIFF
--- a/packages/lascar/lascar.0.6-alpha/opam
+++ b/packages/lascar/lascar.0.6-alpha/opam
@@ -9,7 +9,7 @@ doc: "http://jserot.github.io/lascar"
 bug-reports: "jocelyn.serot@uca.fr"
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/lascar/lascar.0.6.0/opam
+++ b/packages/lascar/lascar.0.6.0/opam
@@ -9,7 +9,7 @@ doc: "http://jserot.github.io/lascar"
 bug-reports: "jocelyn.serot@uca.fr"
 depends: [
   "dune" {>= "1.11"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/lascar/lascar.0.7.0/opam
+++ b/packages/lascar/lascar.0.7.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.6"}
   "ppxlib" {>= "0.13.0"}
   "ppx_deriving"
-  "ocaml" {>= "4.10"}
+  "ocaml" {>= "4.10" & < "5.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
They rely on `Stream`:

    #=== ERROR while compiling lascar.0.7.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lascar.0.7.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lascar -j 31 @install
    # exit-code            1
    # env-file             ~/.opam/log/lascar-8-eb833d.env
    # output-file          ~/.opam/log/lascar-8-eb833d.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/utils/.utils.objs/byte -no-alias-deps -open Utils -o src/utils/.utils.objs/byte/utils__Parsing.cmi -c -intf src/utils/parsing.mli)
    # File "src/utils/parsing.mli", line 19, characters 19-27:
    # 19 |   -> (Genlex.token Stream.t -> 'a)
    #                         ^^^^^^^^
    # Error: Unbound module Stream
