### PR TITLE
ocaml 5: restrict lymp releases

### DIFF
--- a/packages/lymp/lymp.0.2.4/opam
+++ b/packages/lymp/lymp.0.2.4/opam
@@ -13,7 +13,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "lymp"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/lymp/lymp.0.2.5/opam
+++ b/packages/lymp/lymp.0.2.5/opam
@@ -13,7 +13,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "lymp"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
They rely on `Stream`:

    #=== ERROR while compiling lymp.0.2.5 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lymp.0.2.5
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make build
    # exit-code            2
    # env-file             ~/.opam/log/lymp-8-a5dd70.env
    # output-file          ~/.opam/log/lymp-8-a5dd70.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
    # make: *** [Makefile:37: setup.data] Error 2
