### PR TITLE
ocaml 5: restrict mpp releases

### DIFF
--- a/packages/mpp/mpp.0.3.4/opam
+++ b/packages/mpp/mpp.0.3.4/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocaml/MPP-language-blender.git"
 bug-reports: "https://github.com/ocaml/MPP-language-blender/issues"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "dune" {>"1.11.0"}
   "stdlib-shims"
 ]

--- a/packages/mpp/mpp.0.3.5/opam
+++ b/packages/mpp/mpp.0.3.5/opam
@@ -7,7 +7,7 @@ dev-repo: "git+https://github.com/ocaml/MPP-language-blender.git"
 bug-reports: "https://github.com/ocaml/MPP-language-blender/issues"
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "dune" {>"1.11.0"}
   "stdlib-shims"
 ]


### PR DESCRIPTION
They rely on `Stream`:

    #=== ERROR while compiling mpp.0.3.5 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mpp.0.3.5
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mpp -j 255
    # exit-code            1
    # env-file             ~/.opam/log/mpp-8-1463e0.env
    # output-file          ~/.opam/log/mpp-8-1463e0.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.mpp.objs/byte -I /home/opam/.opam/5.0/lib/stdlib-shims -no-alias-deps -o src/.mpp.objs/byte/mpp_charstream.cmo -c -impl src/mpp_charstream.ml)
    # File "src/mpp_charstream.ml", line 523, characters 48-56:
    # 523 | let stream_of_charstream (cs:charstream) : char Stream.t =
    #                                                       ^^^^^^^^
    # Error: Unbound module Stream
