### PR TITLE
ocaml 5: restrict sequence.0.2

### DIFF
--- a/packages/sequence/sequence.0.2/opam
+++ b/packages/sequence/sequence.0.2/opam
@@ -5,7 +5,7 @@ homepage: "https://github.com/c-cube/iter/"
 build: make
 remove: [["ocamlfind" "remove" "sequence"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
It relies on `String.capitalize`:

    #=== ERROR while compiling sequence.0.2 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/sequence.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/sequence-8-81dc2d.env
    # output-file          ~/.opam/log/sequence-8-81dc2d.out
    ### output ###
    # ocamlbuild tests.native sequence.cma sequence.cmxa sequence.cmi sequence.a sexpr.cma sexpr.cmxa sexpr.cmi sequence.docdir/index.html
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules tests.ml > tests.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules sequence.mli > sequence.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules sexpr.mli > sexpr.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -o sequence.cmi sequence.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -o sexpr.cmi sexpr.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -o tests.cmo tests.ml
    # + /home/opam/.opam/5.0/bin/ocamlc.opt -c -o tests.cmo tests.ml
    # File "tests.ml", line 49, characters 34-51:
    # 49 |     (function | `Atom s -> `Atom (String.capitalize s) | tok -> tok)
    #                                        ^^^^^^^^^^^^^^^^^
    # Error: Unbound value String.capitalize
