### PR TITLE
ocaml 5: restrict omd.1.3.1

### DIFF
--- a/packages/omd/omd.1.3.1/opam
+++ b/packages/omd/omd.1.3.1/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocaml" "%{etc}%/omd/setup.ml" "-C" "%{etc}%/omd" "-uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.01"}
+  "ocaml" {>= "4.01" & < "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}


### PR DESCRIPTION
It relies on `Stream`:

    #=== ERROR while compiling omd.1.3.1 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/omd.1.3.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/omd-8-f48c59.env
    # output-file          ~/.opam/log/omd-8-f48c59.out
    ### output ###
    # File "./setup.ml", line 577, characters 4-15:
    # 577 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
