### PR TITLE
ocaml 5: restrict sha releases

### DIFF
--- a/packages/sha/sha.1.13/opam
+++ b/packages/sha/sha.1.13/opam
@@ -15,6 +15,7 @@ license: "ISC"
 homepage: "https://github.com/djs55/ocaml-sha"
 bug-reports: "https://github.com/djs55/ocaml-sha/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "ounit" {with-test}
 ]

--- a/packages/sha/sha.1.14/opam
+++ b/packages/sha/sha.1.14/opam
@@ -24,6 +24,7 @@ license: "ISC"
 homepage: "https://github.com/djs55/ocaml-sha"
 bug-reports: "https://github.com/djs55/ocaml-sha/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "stdlib-shims" {>= "0.3.0"}
   "ounit" {with-test}


### PR DESCRIPTION
They rely on `Data_bigarray_val`:

    #=== ERROR while compiling sha.1.14 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/sha.1.14
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sha -j 31 @install
    # exit-code            1
    # env-file             ~/.opam/log/sha-8-5cb90d.env
    # output-file          ~/.opam/log/sha-8-5cb90d.out
    ### output ###
    # File "dune", line 14, characters 20-32:
    # 14 |   (names sha1_stubs sha256_stubs sha512_stubs)))
    #                          ^^^^^^^^^^^^
    # (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -Wall -O3 -funroll-loops -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdlib-shims -o sha256_stubs.o -c sha256_stubs.c)
    # sha256_stubs.c: In function 'stub_sha256_update_bigarray':
    # sha256_stubs.c:91:31: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
    #    91 |         unsigned char *data = Data_bigarray_val(buf);
    #       |                               ^~~~~~~~~~~~~~~~~
    #       |                               Caml_ba_array_val
    # sha256_stubs.c:91:31: warning: initialization of 'unsigned char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    # sha256_stubs.c:92:22: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
    #    92 |         size_t len = Bigarray_val(buf)->dim[0];
    #       |                      ^~~~~~~~~~~~
    # sha256_stubs.c:92:39: error: invalid type argument of '->' (have 'int')
    #    92 |         size_t len = Bigarray_val(buf)->dim[0];
    #       |                                       ^~
    # File "dune", line 14, characters 9-19:
    # 14 |   (names sha1_stubs sha256_stubs sha512_stubs)))
    #               ^^^^^^^^^^
    # (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -Wall -O3 -funroll-loops -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdlib-shims -o sha1_stubs.o -c sha1_stubs.c)
    # sha1_stubs.c: In function 'stub_sha1_update_bigarray':
    # sha1_stubs.c:92:31: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
    #    92 |         unsigned char *data = Data_bigarray_val(buf);
    #       |                               ^~~~~~~~~~~~~~~~~
    #       |                               Caml_ba_array_val
    # sha1_stubs.c:92:31: warning: initialization of 'unsigned char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    # sha1_stubs.c:93:22: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
    #    93 |         size_t len = Bigarray_val(buf)->dim[0];
    #       |                      ^~~~~~~~~~~~
    # sha1_stubs.c:93:39: error: invalid type argument of '->' (have 'int')
    #    93 |         size_t len = Bigarray_val(buf)->dim[0];
    #       |                                       ^~
    # File "dune", line 14, characters 33-45:
    # 14 |   (names sha1_stubs sha256_stubs sha512_stubs)))
    #                                       ^^^^^^^^^^^^
    # (cd _build/default && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -Wall -O3 -funroll-loops -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/stdlib-shims -o sha512_stubs.o -c sha512_stubs.c)
    # sha512_stubs.c: In function 'stub_sha512_update_bigarray':
    # sha512_stubs.c:91:31: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
    #    91 |         unsigned char *data = Data_bigarray_val(buf);
    #       |                               ^~~~~~~~~~~~~~~~~
    #       |                               Caml_ba_array_val
    # sha512_stubs.c:91:31: warning: initialization of 'unsigned char *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    # sha512_stubs.c:92:22: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
    #    92 |         size_t len = Bigarray_val(buf)->dim[0];
    #       |                      ^~~~~~~~~~~~
    # sha512_stubs.c:92:39: error: invalid type argument of '->' (have 'int')
    #    92 |         size_t len = Bigarray_val(buf)->dim[0];
    #       |                                       ^~
