### PR TITLE
ocaml 5: restrict redis releases

### DIFF
--- a/packages/redis/redis.0.4/opam
+++ b/packages/redis/redis.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "dune" { >= "1.0" }
   "base-unix"
   "uuidm"
-  "re"
+  "re" {>= "1.7.2"}
   "ocaml" {>= "4.02.3" & < "5.0.0"}
   "odoc" {with-doc}
 ]

--- a/packages/redis/redis.0.4/opam
+++ b/packages/redis/redis.0.4/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "uuidm"
   "re"
-  "ocaml" { >= "4.02.3" }
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "odoc" {with-doc}
 ]
 url {

--- a/packages/redis/redis.0.5/opam
+++ b/packages/redis/redis.0.5/opam
@@ -21,7 +21,7 @@ depends: [
   "base-unix"
   "uuidm"
   "re" {>= "1.7.2"}
-  "ocaml" { >= "4.03.0" }
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "odoc" {with-doc}
 ]
 url {


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling redis.0.5 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/redis.0.5
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p redis -j 31
    # exit-code            1
    # env-file             ~/.opam/log/redis-9-c8d985.env
    # output-file          ~/.opam/log/redis-9-c8d985.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -warn-error -3-32-34 -g -bin-annot -I src/.redis.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/re -I /home/opam/.opam/5.0/lib/re/str -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/uuidm -intf-suffix .ml -no-alias-deps -open Redis -o src/.redis.objs/byte/redis__Client.cmo -c -impl src/client.ml)
    # File "src/client.ml", line 57, characters 20-38:
    # 57 |       let compare = Pervasives.compare
    #                          ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
