### PR TITLE
ocaml 5: restrict nonstd releases

### DIFF
--- a/packages/nonstd/nonstd.0.0.1/opam
+++ b/packages/nonstd/nonstd.0.0.1/opam
@@ -7,7 +7,7 @@ remove:
     ["ocaml" "please.ml" "uninstall"]
     ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
 ]
 install: ["ocaml" "please.ml" "install"]

--- a/packages/nonstd/nonstd.0.0.2/opam
+++ b/packages/nonstd/nonstd.0.0.2/opam
@@ -10,7 +10,7 @@ build: ["ocaml" "please.ml" "build"]
 install: ["ocaml" "please.ml" "install"]
 remove: ["ocaml" "please.ml" "uninstall"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
 ]
 synopsis: "Non-standard mini-library"


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling nonstd.0.0.2 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/nonstd.0.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml please.ml build
    # exit-code            2
    # env-file             ~/.opam/log/nonstd-8-d4042d.env
    # output-file          ~/.opam/log/nonstd-8-d4042d.out
    ### output ###
    # Please-> Building
    # ! cp ../nonstd.ml .
    # ! ocamlfind ocamlc  -c nonstd.ml -o nonstd.cmo
    # File "nonstd.ml", line 296, characters 22-40:
    # 296 |   let dedup ?(compare=Pervasives.compare) list =
    #                             ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
