### PR TITLE
ffmpeg: disable CI on Debian 11

### DIFF
--- a/packages/ffmpeg/ffmpeg.0.2.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-pkg-config" {build}
   "base-bigarray"
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   ["libavutil-dev" "libswscale-dev" "libavformat-dev"] {os-family = "debian"}
   ["ffmpeg-dev"] {os-distribution = "alpine"}

--- a/packages/ffmpeg/ffmpeg.0.2.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.2.1/opam
@@ -16,7 +16,7 @@ depends: [
   "conf-pkg-config" {build}
   "base-bigarray"
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   [
     "libavutil-dev"

--- a/packages/ffmpeg/ffmpeg.0.3.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.3.0/opam
@@ -20,7 +20,7 @@ build: [
   [make]
 ]
 install: [make "install"]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   [
     "libavutil-dev"

--- a/packages/ffmpeg/ffmpeg.0.4.0/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.0/opam
@@ -20,7 +20,7 @@ build: [
   [make]
 ]
 install: [make "install"]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   [
     "libavutil-dev"

--- a/packages/ffmpeg/ffmpeg.0.4.1/opam
+++ b/packages/ffmpeg/ffmpeg.0.4.1/opam
@@ -20,7 +20,7 @@ build: [
   [make]
 ]
 install: [make "install"]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   [
     "libavutil-dev"


### PR DESCRIPTION
This is a followup of #16743 - the version that was unstable at that
time is now debian 11.
