### PR TITLE
aacplus: do not test in Debian 11

### DIFF
--- a/packages/aacplus/aacplus.0.2.1/opam
+++ b/packages/aacplus/aacplus.0.2.1/opam
@@ -12,7 +12,7 @@ depexts: [
   ["libaacplus"] {os-distribution = "gentoo"}
   ["libaacplus"] {os = "freebsd"}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 install: [make "install"]
 synopsis:
   "Bindings for the aacplus library which provides functions for decoding AAC audio files"

--- a/packages/aacplus/aacplus.0.2.2/opam
+++ b/packages/aacplus/aacplus.0.2.2/opam
@@ -16,7 +16,7 @@ depexts: [
   ["libaacplus"] {os-distribution = "gentoo"}
   ["libaacplus"] {os = "freebsd"}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 bug-reports: "https://github.com/savonet/ocaml-aacplus/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-aacplus.git"
 synopsis:


### PR DESCRIPTION
Follow-up to #14800. These changes have propagated to Debian 11.
