### PR TITLE
ahrocksdb: ignore CI failures

### DIFF
--- a/packages/ahrocksdb/ahrocksdb.0.2.0/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.0/opam
@@ -39,7 +39,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"

--- a/packages/ahrocksdb/ahrocksdb.0.2.0/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.0/opam
@@ -41,7 +41,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"
 url {
   src:

--- a/packages/ahrocksdb/ahrocksdb.0.2.0/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.0/opam
@@ -24,11 +24,11 @@ doc: "https://ahrefs.github.io/ocaml-ahrocksdb/"
 bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"
+  "dune" {>= "1.3"}
   "dune-configurator"
   "base" {build}
   "stdio" {build}
-  "ctypes" {>= "0.12.0"}
+  "ctypes" {>= "0.13.0"}
   "astring"
   "conf-rocksdb"
   "rresult"

--- a/packages/ahrocksdb/ahrocksdb.0.2.1/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.1/opam
@@ -37,7 +37,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest"] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 x-ci-accept-failures: ["debian-unstable"]
 dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"

--- a/packages/ahrocksdb/ahrocksdb.0.2.1/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.1/opam
@@ -24,9 +24,9 @@ doc: "https://ahrefs.github.io/ocaml-ahrocksdb/"
 bug-reports: "https://github.com/ahrefs/ocaml-ahrocksdb/issues"
 depends: [
   "ocaml" {>= "4.06.0"}
-  "dune"
+  "dune" {>= "1.3"}
   "dune-configurator"
-  "ctypes" {>= "0.12.0"}
+  "ctypes" {>= "0.13.0"}
   "astring"
   "conf-rocksdb"
   "rresult"

--- a/packages/ahrocksdb/ahrocksdb.0.2.1/opam
+++ b/packages/ahrocksdb/ahrocksdb.0.2.1/opam
@@ -39,7 +39,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 dev-repo: "git+https://github.com/ahrefs/ocaml-ahrocksdb.git"
 url {
   src:


### PR DESCRIPTION
The error message is:

> installed RocksDB installation is too old: found 6.11, expected 5.14 minimum

Which is actually fine! There's a logic error which has been fixed upstream in ahrefs/ocaml-ahrocksdb@d74dc6f8337557c23b66c2a2488957d7ce3c278c.

This PR ignores CI errors caused by this.