### PR TITLE
Package multicont.1.0.0

### DIFF
--- a/packages/multicont/multicont.1.0.0/opam
+++ b/packages/multicont/multicont.1.0.0/opam
@@ -9,7 +9,11 @@ bug-reports: "https://github.com/dhil/ocaml-multicont"
 license: "MIT"
 
 build: [
-  [ make "all" ]
+  [
+    make
+    "byte" {!ocaml:native}
+    "all" {ocaml:native}
+  ]
 ]
 
 depends: [

--- a/packages/multicont/multicont.1.0.0/opam
+++ b/packages/multicont/multicont.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+authors: "Daniel Hillerström <daniel.hillerstrom@ed.ac.uk>"
+synopsis: "Multi-shot continuations in OCaml"
+description: "This library provides facilities for programming with multi-shot continuations in OCaml"
+homepage: "https://github.com/dhil/ocaml-multicont"
+dev-repo: "git+https://github.com/dhil/ocaml-multicont.git"
+bug-reports: "https://github.com/dhil/ocaml-multicont"
+license: "MIT"
+
+build: [
+  [ make "all" ]
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+]
+
+install: [
+  [ make "install" ]
+]
+url {
+  src:
+    "https://github.com/dhil/ocaml-multicont/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: [
+    "md5=08406f0a0dc8bf3770408b4866e1452d"
+    "sha512=bfd2f98614a6bd936c3a47ff12469d6c110c7b8eea21e82d7bb50ed35bdb5e77003c5d14b9553c7b7392b80b46e3b008c5ba2be469555b4e429ee61723b77dd2"
+  ]
+}


### PR DESCRIPTION
### `multicont.1.0.0`
Multi-shot continuations in OCaml
This library provides facilities for programming with multi-shot continuations in OCaml



---
* Homepage: https://github.com/dhil/ocaml-multicont
* Source repo: git+https://github.com/dhil/ocaml-multicont.git
* Bug tracker: https://github.com/dhil/ocaml-multicont

---
:camel: Pull-request generated by opam-publish v2.2.0