### PR TITLE
Release of esperanto v0.0.2

### DIFF
--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.2/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.2/opam
@@ -15,7 +15,7 @@ build: [
 # depends: [
 #   "conf-binutils"
 # ]
-install: [ "sh" "-c" "cd toolchain ; %{make}% install" ]
+install: [ "make" "-C" "toolchain" "install" ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
 description: "A little toolchain for OCaml with Cosmopolitan"
 available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.2/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.2/opam
@@ -15,7 +15,7 @@ build: [
 # depends: [
 #   "conf-binutils"
 # ]
-install: [ "make" "-C" "toolchain" "install" ]
+install: [ make "-C" "toolchain" "install" ]
 synopsis: "Cosmopolitan toolchain for OCaml compiler"
 description: "A little toolchain for OCaml with Cosmopolitan"
 available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]

--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.2/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.2/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/esperanto"
+bug-reports: "https://github.com/dinosaure/esperanto/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/esperanto.git"
+build: [
+  [ "sh" "-c" "cd toolchain && ./configure.sh --prefix=%{prefix}%" ]
+  [ make "-C" "toolchain" "all" "V=1" ]
+]
+# We should depend on conf-binutils but the package does not work on FreeBSD
+# even if we can do [pkg install binutils] on FreeBSD 12
+# depends: [
+#   "conf-binutils"
+# ]
+install: [ "sh" "-c" "cd toolchain ; %{make}% install" ]
+synopsis: "Cosmopolitan toolchain for OCaml compiler"
+description: "A little toolchain for OCaml with Cosmopolitan"
+available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.2/esperanto-v0.0.2.tar.gz"
+  checksum: "sha512=11a1226ffe1cd1a9c168b2ecc5dbd9fa4cbee8bc5bcb1654445dfc8040dad97a24323ccc61a3716e4127797468729a82e48ea143a266a3777340dcf5d1ccca06"
+}

--- a/packages/esperanto/esperanto.0.0.1/opam
+++ b/packages/esperanto/esperanto.0.0.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-src" {build}
   "esperanto-cosmopolitan" {build}
 #  "cosmopolitan-pth" {build}
-  "ocaml" {>= "4.13.0" & < "4.15.0"}
+  "ocaml" {>= "4.13.0" & < "4.14.1"}
 ]
 synopsis: "An OCaml compiler with Cosmopolitan"
 description:

--- a/packages/esperanto/esperanto.0.0.2/opam
+++ b/packages/esperanto/esperanto.0.0.2/opam
@@ -10,7 +10,7 @@ build: [
   ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
   [make "-C" "caml" "-j%{jobs}%"]
 ]
-install: ["sh" "-c" "cd caml ; %{make}% install" ]
+install: ["make" "-C" "caml" "install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto/esperanto.0.0.2/opam
+++ b/packages/esperanto/esperanto.0.0.2/opam
@@ -10,7 +10,7 @@ build: [
   ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
   [make "-C" "caml" "-j%{jobs}%"]
 ]
-install: ["make" "-C" "caml" "install" ]
+install: [make "-C" "caml" "install" ]
 depends: [
   "conf-which" {build}
   "ocaml-src" {build}

--- a/packages/esperanto/esperanto.0.0.2/opam
+++ b/packages/esperanto/esperanto.0.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/gilbraltar"
+bug-reports: "https://github.com/dinosaure/gilbraltar/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/gilbraltar.git"
+build: [
+  ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
+  [make "-C" "caml" "-j%{jobs}%"]
+]
+install: ["sh" "-c" "cd caml ; %{make}% install" ]
+depends: [
+  "conf-which" {build}
+  "ocaml-src" {build}
+  "esperanto-cosmopolitan" {build}
+#  "cosmopolitan-pth" {build}
+  "ocaml" {>= "4.13.0" & < "4.15.0"}
+]
+synopsis: "An OCaml compiler with Cosmopolitan"
+description:
+  "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.2/esperanto-v0.0.2.tar.gz"
+  checksum: "sha512=11a1226ffe1cd1a9c168b2ecc5dbd9fa4cbee8bc5bcb1654445dfc8040dad97a24323ccc61a3716e4127797468729a82e48ea143a266a3777340dcf5d1ccca06"
+}


### PR DESCRIPTION
- Delete `conf-gcc` (we currently are able to use `clang`)
- The current toolchain does not work on MacOS
- Add conf-cosmopolitan package
- Upgrade to Cosmopolitan v2.2 (#28)
- Update the provided `extract.com` (#30)
- Fix the support of OCaml 4.14.1
- Delete `pth` (Cosmopolitan provides `pthread`)