### PR TITLE
ocaml 5: restrict ocf releases

### DIFF
--- a/packages/ocf/ocf.0.6.0/opam
+++ b/packages/ocf/ocf.0.6.0/opam
@@ -9,7 +9,7 @@ homepage: "https://zoggy.frama.io/ocf/"
 doc: "https://zoggy.frama.io/ocf/doc.html"
 bug-reports: "https://framagit.org/zoggy/ocf/-/issues"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
   "ocamlfind" {build}
   "yojson" {>= "1.7.0"}
   "ppx_tools" {>= "6.3"}

--- a/packages/ocf/ocf.0.7.0/opam
+++ b/packages/ocf/ocf.0.7.0/opam
@@ -9,7 +9,7 @@ homepage: "https://zoggy.frama.io/ocf/"
 doc: "https://zoggy.frama.io/ocf/doc.html"
 bug-reports: "https://framagit.org/zoggy/ocf/-/issues"
 depends: [
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.12.0" & < "5.0.0"}
   "ocamlfind" {build}
   "yojson" {>= "1.7.0"}
   "ppx_tools" {>= "6.3"}


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling ocf.0.7.0 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocf.0.7.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0
    # exit-code            1
    # env-file             ~/.opam/log/ocf-8-c6badc.env
    # output-file          ~/.opam/log/ocf-8-c6badc.out
    ### output ###
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    # automatically added to the search path, but you should add -I +unix to the
    # command-line to silence this alert (e.g. by adding unix to the list of
    # libraries in your dune file, or adding use_unix to your _tags file for
    # ocamlbuild, or using -package unix for ocamlfind).
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The str subdirectory has been
    # automatically added to the search path, but you should add -I +str to the
    # command-line to silence this alert (e.g. by adding str to the list of
    # libraries in your dune file, or adding use_str to your _tags file for
    # ocamlbuild, or using -package str for ocamlfind).
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    # automatically added to the search path, but you should add -I +unix to the
    # command-line to silence this alert (e.g. by adding unix to the list of
    # libraries in your dune file, or adding use_unix to your _tags file for
    # ocamlbuild, or using -package unix for ocamlfind).
    # File "./checkocaml.ml", line 53, characters 48-65:
    # 53 | let print = ref (fun s -> print_string s; flush Pervasives.stdout)
    #                                                      ^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
