### PR TITLE
ocaml 5: restrict unison releases

### DIFF
--- a/packages/unison/unison.2.51.4/opam
+++ b/packages/unison/unison.2.51.4/opam
@@ -15,7 +15,7 @@ authors: [
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "dune" {>= "1.3"}
   "lablgtk" {>= "2.18.6"}
 ]

--- a/packages/unison/unison.2.51.5/opam
+++ b/packages/unison/unison.2.51.5/opam
@@ -12,7 +12,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "dune" {>= "2.3"}
   "lablgtk" {>= "2.18.6"}
 ]

--- a/packages/unison/unison.2.52.0/opam
+++ b/packages/unison/unison.2.52.0/opam
@@ -12,7 +12,7 @@ license: "GPL-3.0-or-later"
 homepage: "https://www.cis.upenn.edu/~bcpierce/unison/"
 bug-reports: "https://github.com/bcpierce00/unison/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "dune" {>= "2.3"}
   "lablgtk" {>= "2.18.6"}
 ]


### PR DESCRIPTION
They all rely on `String.lowercase`:

    #=== ERROR while compiling unison.2.52.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/unison.2.52.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p unison -j 47
    # exit-code            1
    # env-file             ~/.opam/log/unison-8-b565f5.env
    # output-file          ~/.opam/log/unison-8-b565f5.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3-27-39 -no-strict-sequence -g -bin-annot -I src/lwt/.lwt_lib.objs/byte -no-alias-deps -o src/lwt/.lwt_lib.objs/byte/lwt_unix.cmi -c -intf src/lwt/lwt_unix.mli)
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    # automatically added to the search path, but you should add -I +unix to the
    # command-line to silence this alert (e.g. by adding unix to the list of
    # libraries in your dune file, or adding use_unix to your _tags file for
    # ocamlbuild, or using -package unix for ocamlfind).
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -warn-error -3-27-39 -no-strict-sequence -g -bin-annot -I src/lwt/.lwt_lib.objs/byte -no-alias-deps -o src/lwt/.lwt_lib.objs/byte/lwt_unix_impl.cmo -c -impl src/lwt/lwt_unix_impl.ml)
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    # automatically added to the search path, but you should add -I +unix to the
    # command-line to silence this alert (e.g. by adding unix to the list of
    # libraries in your dune file, or adding use_unix to your _tags file for
    # ocamlbuild, or using -package unix for ocamlfind).
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-6-9-10-26-27-32-34-35-38-39-50-52 -warn-error -3-6-9-10-26-27-32-34-35-39-50-52 -no-strict-sequence -g -bin-annot -I src/.unison_lib.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I src/lwt/.lwt_lib.objs/byte -no-alias-deps -o src/.unison_lib.objs/byte/compat403.cmo -c -impl src/compat403.ml)
    # File "src/compat403.ml", line 8, characters 24-33:
    # 8 |   let lowercase_ascii = lowercase
    #                             ^^^^^^^^^
    # Error: Unbound value lowercase
