### PR TITLE
openbabel: allow failures on Debian 11

### DIFF
--- a/packages/conf-openbabel/conf-openbabel.0.1/opam
+++ b/packages/conf-openbabel/conf-openbabel.0.1/opam
@@ -15,7 +15,7 @@ build: [
     "-lopenbabel"
   ] {os = "macos"}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   ["libopenbabel-dev"] {os-family = "debian"}
   ["open-babel"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
Followup to #16514 now that Debian 11 has been released.
