### PR TITLE
conf-srt-openssl: allow failures on Debian 11

### DIFF
--- a/packages/conf-srt-openssl/conf-srt-openssl.1/opam
+++ b/packages/conf-srt-openssl/conf-srt-openssl.1/opam
@@ -16,3 +16,4 @@ synopsis: "Virtual package relying on srt compiled with openssl"
 description:
   "This package can only install if the srt library is installed on the system and compiled using openssl."
 flags: conf
+x-ci-accept-failures: ["debian-11"]


### PR DESCRIPTION
This package is affected by <https://bugs.debian.org/1001529> in Debian 11: the wrong `.pc` file is installed, so `pkg-config --exists srt` exits with an error (since `gnutls` is not installed).
