### PR TITLE
conf-trexio: ignore CI failures on Debian 11

### DIFF
--- a/packages/conf-trexio/conf-trexio.0.1/opam
+++ b/packages/conf-trexio/conf-trexio.0.1/opam
@@ -19,3 +19,4 @@ This package can only install if the trexio devel library is installed
 on the system."""
 extra-files: ["test.c" "md5=823a15457fd40d8959b0cc812ba485c7"]
 flags: conf
+x-ci-accept-failures: ["debian-11"]


### PR DESCRIPTION
This package is not packaged in Debian 11, so all CI builds will fail.
