### PR TITLE
ocaml 5: restrict ocplib_stuff.0.3.0

### DIFF
--- a/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
+++ b/packages/ocplib_stuff/ocplib_stuff.0.3.0/opam
@@ -31,7 +31,7 @@ build: [
   ]
 ]
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0.0"}
   "dune" {>= "2.6.0"}
   "dune" {with-test & < "2.8.0"}
   "ppx_inline_test" {with-test}


### PR DESCRIPTION
It assumes that `Sys.ocaml_version` is at least 6 characters long:

```ocaml
    try
      String.sub Sys.ocaml_version 0 6
    with _ -> failwith "Wrong ocaml version"
```

    #=== ERROR while compiling ocplib_stuff.0.3.0 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocplib_stuff.0.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocplib_stuff -j 255 @install
    # exit-code            1
    # env-file             ~/.opam/log/ocplib_stuff-8-8351e2.env
    # output-file          ~/.opam/log/ocplib_stuff-8-8351e2.out
    ### output ###
    # (cd src/ocplib_stuff && /home/opam/.opam/5.0/bin/ocaml -I +compiler-libs /home/opam/.opam/5.0/.opam-switch/build/ocplib_stuff.0.3.0/_build/.dune/default/src/ocplib_stuff/dune.ml)
    # File "src/ocplib_stuff/dune", line 19, characters 2-16:
    # Alert deprecated: Stdlib.Printf.kprintf
    # Use Printf.ksprintf instead.
    # Exception: Failure "Wrong ocaml version".
