### PR TITLE
bls12-381: disable tests on ocaml 5

### DIFF
--- a/packages/bls12-381-unix/bls12-381-unix.1.1.0/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.1.1.0/opam
@@ -25,7 +25,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # default C compiler too old?
 ]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381-unix/bls12-381-unix.1.1.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.1.1.1/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 available: arch != "ppc64"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.0/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381-unix/bls12-381-unix.2.0.1/opam
+++ b/packages/bls12-381-unix/bls12-381-unix.2.0.1/opam
@@ -21,7 +21,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/dannywillems/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.3.0.0/opam
+++ b/packages/bls12-381/bls12-381.3.0.0/opam
@@ -23,7 +23,7 @@ depends: [
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 x-ci-accept-failures: ["centos-7" "oraclelinux-7"]
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.3.0.1/opam
+++ b/packages/bls12-381/bls12-381.3.0.1/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.3.0.2/opam
+++ b/packages/bls12-381/bls12-381.3.0.2/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.3.0.3/opam
+++ b/packages/bls12-381/bls12-381.3.0.3/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.4.0.0/opam
+++ b/packages/bls12-381/bls12-381.4.0.0/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.5.0.0/opam
+++ b/packages/bls12-381/bls12-381.5.0.0/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:

--- a/packages/bls12-381/bls12-381.6.0.0/opam
+++ b/packages/bls12-381/bls12-381.6.0.0/opam
@@ -22,7 +22,7 @@ depends: [
 ]
 available: arch != "ppc64" & arch != "arm32" & arch != "x86_32"
 build: ["dune" "build" "-j" jobs "-p" name "@install"]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version < "5.0.0" }
 dev-repo: "git+https://gitlab.com/nomadic-labs/cryptography/ocaml-bls12-381.git"
 url {
   src:


### PR DESCRIPTION
The random number generator has changed in OCaml 5.0.0 and the test suite has different expected values depending on the version.

There is a patch upstream that has been applied in later versions.