### PR TITLE
Fix the lower-bounds constraints of febusy

### DIFF
--- a/packages/febusy/febusy.0.0.0/opam
+++ b/packages/febusy/febusy.0.0.0/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" { >= "4.03.0" }
   "jbuilder" {>= "1.0+beta20"}
-  "nonstd"
+  "nonstd" {>= "0.0.2"}
   "sosa"
   "rresult"
 ]

--- a/packages/febusy/febusy.0.0.0/opam
+++ b/packages/febusy/febusy.0.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "jbuilder" {>= "1.0+beta20"}
   "nonstd" {>= "0.0.2"}
   "sosa"
-  "rresult"
+  "rresult" {>= "0.3.0"}
 ]
 synopsis: "Embedded build system library"
 description: """


### PR DESCRIPTION
Split off from #22982 

```
#=== ERROR while compiling febusy.0.0.0 =======================================#
# context     2.0.10 | linux/arm64 | ocaml-base-compiler.4.12.1 | file:///home/opam/opam-repository
# path        ~/.opam/4.12/.opam-switch/build/febusy.0.0.0
# command     ~/.opam/4.12/bin/jbuilder build -p febusy -j 79
# exit-code   1
# env-file    ~/.opam/log/febusy-3028-d6d332.env
# output-file ~/.opam/log/febusy-3028-d6d332.out
### output ###
#       ocamlc src/lib/.febusy.objs/febusy__Build.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.12/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/.febusy.objs -I /home/opam/.opam/4.12/lib/nonstd -I /home/opam/.opam/4.12/lib/rresult -I /home/opam/.opam/4.12/lib/sosa -no-alias-deps -open Febusy -o src/lib/.febusy.objs/febusy__Build.cmo -c -impl src/lib/build.ml)
# File "src/lib/build.ml", line 164, characters 28-42:
# 164 |   let lookup_cache st key = List.Assoc.get key st.database.cache
#                                   ^^^^^^^^^^^^^^
# Error: Unbound module List.Assoc
```
```
#=== ERROR while compiling febusy.0.0.0 =======================================#
# context     2.0.10 | linux/arm64 | ocaml-base-compiler.4.05.0 | file:///home/opam/opam-repository
# path        ~/.opam/4.05/.opam-switch/build/febusy.0.0.0
# command     ~/.opam/4.05/bin/jbuilder build -p febusy -j 79
# exit-code   1
# env-file    ~/.opam/log/febusy-2433-ece7a3.env
# output-file ~/.opam/log/febusy-2433-ece7a3.out
### output ###
#       ocamlc src/lib/.febusy.objs/febusy__Build.{cmi,cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.05/bin/ocamlc.opt -w -40 -g -bin-annot -I src/lib/.febusy.objs -I /home/opam/.opam/4.05/lib/nonstd -I /home/opam/.opam/4.05/lib/rresult -I /home/opam/.opam/4.05/lib/sosa -no-alias-deps -open Febusy -o src/lib/.febusy.objs/febusy__Build.cmo -c -impl src/lib/build.ml)
# File "src/lib/build.ml", line 235, characters 8-28:
# Error: This expression has type
#          (($Bind_'a, $Bind_'b) build_status, Febusy.Common.Error.t) result
#        but an expression was expected of type ('a, 'b) Rresult.result
```