### PR TITLE
ocaml 5: restrict conex releases

### DIFF
--- a/packages/conex/conex.0.10.0/opam
+++ b/packages/conex/conex.0.10.0/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "dune"
   "cmdliner"
   "opam-file-format" {>= "2.0.0~rc2"}

--- a/packages/conex/conex.0.10.1/opam
+++ b/packages/conex/conex.0.10.1/opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "dune"
   "cmdliner"
   "opam-file-format" {>= "2.0.0~rc2"}


### PR DESCRIPTION
They rely on `Pervasives`:

    #=== ERROR while compiling conex.0.10.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/conex.0.10.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p conex -j 127
    # exit-code            1
    # env-file             ~/.opam/log/conex-8-8f5ed4.env
    # output-file          ~/.opam/log/conex-8-8f5ed4.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.conex.objs/byte -I /home/opam/.opam/5.0/lib/opam-file-format -intf-suffix .ml -no-alias-deps -o src/.conex.objs/byte/conex_opam_encoding.cmo -c -impl src/conex_opam_encoding.ml)
    # File "src/conex_opam_encoding.ml", line 34, characters 2-29:
    # 34 |   OpamPrinter.format_opamfile Format.str_formatter file ;
    #        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    # Alert deprecated: OpamPrinter.format_opamfile
    # Use OpamPrinter.FullPos.format_opamfile instead.
    # File "src/conex_opam_encoding.ml", line 92, characters 11-28:
    # 92 |   (try Ok (OpamParser.string data "noname") with
    #                 ^^^^^^^^^^^^^^^^^
    # Alert deprecated: OpamParser.string
    # Use OpamParser.FullPos.string instead.
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I app/.conex_verify_openssl.eobjs/byte -I /home/opam/.opam/5.0/lib/cmdliner -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/opam-file-format -I app/.conex_cmd.objs/byte -I openssl/.conex_openssl.objs/byte -I src/.conex.objs/byte -I unix/.conex_unix.objs/byte -no-alias-deps -o app/.conex_verify_openssl.eobjs/byte/conex_verify_openssl.cmo -c -impl app/conex_verify_openssl.ml)
    # File "app/conex_verify_openssl.ml", line 78, characters 54-71:
    # 78 |   let isatty = try Unix.(isatty (descr_of_out_channel Pervasives.stdout)) with
    #                                                            ^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
