### PR TITLE
Package binaryen.0.20.1

### DIFF
--- a/packages/binaryen/binaryen.0.20.1/opam
+++ b/packages/binaryen/binaryen.0.20.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "5.0.0"}
+  "libbinaryen" {>= "110.0.0" & < "111.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.20.1/binaryen-archive-v0.20.1.tar.gz"
+  checksum: [
+    "md5=168401594cb3a9d9c9eec2cc33521776"
+    "sha512=a4bc081fe373fdaff17b1f8550e949a2d44664c08db3df15cf2885ed386ec3ae6b2b91dfbb30e591dd5c8716d4c3659cc5ce140d3db2b33052cc02e6092c0fc6"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.20.1`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.20.1](https://github.com/grain-lang/binaryen.ml/compare/v0.20.0...v0.20.1) (2023-01-19)


### Features

* Add gufa & gufa_optimizing passes ([#180](https://github.com/grain-lang/binaryen.ml/issues/180)) ([7395a1f](https://github.com/grain-lang/binaryen.ml/commit/7395a1fe0591a835eeeeb6e6e58c28c32b69342d))


### Bug Fixes

* Properly handle load & store instructions in JS ([#178](https://github.com/grain-lang/binaryen.ml/issues/178)) ([becd3b8](https://github.com/grain-lang/binaryen.ml/commit/becd3b82ac31c7f2ba1055b320c7ff537b58d971))

---
:camel: Pull-request generated by opam-publish v2.0.3