### PR TITLE
[new release] ocaml-version (3.6.0)

### DIFF
--- a/packages/ocaml-version/ocaml-version.3.6.0/opam
+++ b/packages/ocaml-version/ocaml-version.3.6.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """
+This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: ["Anil Madhavapeddy <anil@recoil.org>"]
+license: "ISC"
+tags: ["org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v3.6.0/ocaml-version-3.6.0.tbz"
+  checksum: [
+    "sha256=9c6a9c4e34444618c17fc15e8c5aebc879efd427087be083dae61ab65289dbfa"
+    "sha512=02624d2e4e9d493cb2147c9ba66b9e87822a72f668ba41b9e4ff6c0ed487a0e54f05c3b8845e71af6c8d275d4a37cb1c9c4d71ecccc50a87a0736a7e4b43a250"
+  ]
+}
+x-commit-hash: "5b5413a42c3a9e3c10ca0a9b247ef11c78b23b9b"


### PR DESCRIPTION
Manipulate, parse and generate OCaml compiler version strings

- Project page: <a href="https://github.com/ocurrent/ocaml-version">https://github.com/ocurrent/ocaml-version</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-version/doc">https://ocurrent.github.io/ocaml-version/doc</a>

##### CHANGES:

* Add 4.14.1 entry (@avsm ocurrent/ocaml-version#56)
* Update for OCaml 5.0.0 release (@octachron ocurrent/ocaml-version#52)
* Remove 4.12+domains and 4.12+domains+effects, they're deprecated.
  (@MisterDA ocurrent/ocaml-version#51)
* Expose 4.00.0 entry and include in all_patches (@dra27 ocurrent/ocaml-version#43)
* Add 3.07+, to match opam (@dra27 ocurrent/ocaml-version#43)
