### PR TITLE
ocaml 5: restrict tests for irmin-tezos

### DIFF
--- a/packages/irmin-tezos/irmin-tezos.3.2.1/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.2.1/opam
@@ -7,6 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9.0"}
   "irmin" {>= version}
   "irmin-pack" {= version}
@@ -23,7 +24,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test & ocaml:version < "5.0.0"}]
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
 url {

--- a/packages/irmin-tezos/irmin-tezos.3.2.2/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.2.2/opam
@@ -7,6 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9.0"}
   "irmin" {>= version}
   "irmin-pack" {= version}
@@ -23,7 +24,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test & ocaml:version < "5.0.0"}]
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
 url {

--- a/packages/irmin-tezos/irmin-tezos.3.3.0/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.3.0/opam
@@ -7,6 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9.0"}
   "irmin" {>= version}
   "irmin-pack" {= version}
@@ -23,7 +24,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test & ocaml:version < "5.0.0"}]
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
 url {

--- a/packages/irmin-tezos/irmin-tezos.3.3.1/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.3.1/opam
@@ -7,6 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9.0"}
   "irmin" {>= version}
   "irmin-pack" {= version}
@@ -23,7 +24,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test & ocaml:version < "5.0.0"}]
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
 url {

--- a/packages/irmin-tezos/irmin-tezos.3.3.2/opam
+++ b/packages/irmin-tezos/irmin-tezos.3.3.2/opam
@@ -7,6 +7,7 @@ license: "ISC"
 homepage: "https://github.com/mirage/irmin"
 bug-reports: "https://github.com/mirage/irmin/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.9.0"}
   "irmin" {>= version}
   "irmin-pack" {= version}
@@ -23,7 +24,7 @@ depends: [
 ]
 build: [
   ["dune" "subst"] {dev}
-  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test}]
+  ["dune" "build" "-p" name "-j" jobs "@runtest" {with-test & ocaml:version < "5.0.0"}]
 ]
 dev-repo: "git+https://github.com/mirage/irmin.git"
 url {


### PR DESCRIPTION
They rely on the RNG which has changed.
