### PR TITLE
ocaml 5: cry uses bytes

### DIFF
--- a/packages/cry/cry.0.6.5/opam
+++ b/packages/cry/cry.0.6.5/opam
@@ -8,9 +8,8 @@ license: "GPL-2.0-only"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
-  "ocaml"
+  ("ocaml" {< "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
   "dune" {> "2.0"}
-  "base-bytes" {ocaml:version >= "5.0"}
 ]
 depopts: [
   "ssl"

--- a/packages/cry/cry.0.6.5/opam
+++ b/packages/cry/cry.0.6.5/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
   "dune" {> "2.0"}
-  "base-bytes"
+  "base-bytes" {ocaml:version >= "5.0"}
 ]
 depopts: [
   "ssl"

--- a/packages/cry/cry.0.6.5/opam
+++ b/packages/cry/cry.0.6.5/opam
@@ -8,6 +8,7 @@ license: "GPL-2.0-only"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
+  "ocaml"
   "dune" {> "2.0"}
   "base-bytes" {ocaml:version >= "5.0"}
 ]

--- a/packages/cry/cry.0.6.5/opam
+++ b/packages/cry/cry.0.6.5/opam
@@ -9,6 +9,7 @@ homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
   "dune" {> "2.0"}
+  "base-bytes"
 ]
 depopts: [
   "ssl"

--- a/packages/cry/cry.0.6.6/opam
+++ b/packages/cry/cry.0.6.6/opam
@@ -9,10 +9,9 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
-  "ocaml"
+  ("ocaml" {< "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
   "dune" {>= "2.8"}
   "odoc" {with-doc}
-  "base-bytes" {ocaml:version >= "5.0"}
 ]
 depopts: ["ssl" "osx-secure-transport"]
 conflicts: [

--- a/packages/cry/cry.0.6.6/opam
+++ b/packages/cry/cry.0.6.6/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
   "dune" {>= "2.8"}
   "odoc" {with-doc}
-  "base-bytes"
+  "base-bytes" {ocaml:version >= "5.0"}
 ]
 depopts: ["ssl" "osx-secure-transport"]
 conflicts: [

--- a/packages/cry/cry.0.6.6/opam
+++ b/packages/cry/cry.0.6.6/opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
   "dune" {>= "2.8"}
   "odoc" {with-doc}
+  "base-bytes"
 ]
 depopts: ["ssl" "osx-secure-transport"]
 conflicts: [

--- a/packages/cry/cry.0.6.6/opam
+++ b/packages/cry/cry.0.6.6/opam
@@ -9,6 +9,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "base-bytes" {ocaml:version >= "5.0"}

--- a/packages/cry/cry.0.6.7/opam
+++ b/packages/cry/cry.0.6.7/opam
@@ -9,10 +9,9 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
-  "ocaml"
+  ("ocaml" {< "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
   "dune" {>= "2.8"}
   "odoc" {with-doc}
-  "base-bytes" {ocaml:version >= "5.0"}
 ]
 depopts: ["ssl" "osx-secure-transport"]
 conflicts: [

--- a/packages/cry/cry.0.6.7/opam
+++ b/packages/cry/cry.0.6.7/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
   "dune" {>= "2.8"}
   "odoc" {with-doc}
-  "base-bytes"
+  "base-bytes" {ocaml:version >= "5.0"}
 ]
 depopts: ["ssl" "osx-secure-transport"]
 conflicts: [

--- a/packages/cry/cry.0.6.7/opam
+++ b/packages/cry/cry.0.6.7/opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
   "dune" {>= "2.8"}
   "odoc" {with-doc}
+  "base-bytes"
 ]
 depopts: ["ssl" "osx-secure-transport"]
 conflicts: [

--- a/packages/cry/cry.0.6.7/opam
+++ b/packages/cry/cry.0.6.7/opam
@@ -9,6 +9,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-cry"
 bug-reports: "https://github.com/savonet/ocaml-cry/issues"
 depends: [
+  "ocaml"
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "base-bytes" {ocaml:version >= "5.0"}


### PR DESCRIPTION
Depend on `base-bytes` to avoid this failure:

    #=== ERROR while compiling cry.0.6.7 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/cry.0.6.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p cry -j 255 @install
    # exit-code            1
    # env-file             ~/.opam/log/cry-8-6efd18.env
    # output-file          ~/.opam/log/cry-8-6efd18.out
    ### output ###
    # File "src/dune", line 5, characters 2-7:
    # 5 |   bytes
    #       ^^^^^
    # Error: Library "bytes" not found.
