### PR TITLE
ocaml 5: inquire.0.3.0 uses bytes

### DIFF
--- a/packages/inquire/inquire.0.3.0/opam
+++ b/packages/inquire/inquire.0.3.0/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/tmattio/inquire"
 doc: "https://tmattio.github.io/inquire/"
 bug-reports: "https://github.com/tmattio/inquire/issues"
 depends: [
-  ("ocaml" {>= "4.08" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "2.7"}
   "odoc" {with-doc}
 ]

--- a/packages/inquire/inquire.0.3.0/opam
+++ b/packages/inquire/inquire.0.3.0/opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "odoc" {with-doc}
+  "base-bytes"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/inquire/inquire.0.3.0/opam
+++ b/packages/inquire/inquire.0.3.0/opam
@@ -9,10 +9,9 @@ homepage: "https://github.com/tmattio/inquire"
 doc: "https://tmattio.github.io/inquire/"
 bug-reports: "https://github.com/tmattio/inquire/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  ("ocaml" {>= "4.08" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
   "dune" {>= "2.7"}
   "odoc" {with-doc}
-  "base-bytes" {ocaml:version >= "5.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/inquire/inquire.0.3.0/opam
+++ b/packages/inquire/inquire.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.7"}
   "odoc" {with-doc}
-  "base-bytes"
+  "base-bytes" {ocaml:version >= "5.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Add a dependency to base-bytes to avoid this failure:

    #=== ERROR while compiling inquire.0.3.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/inquire.0.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p inquire -j 255 @install
    # exit-code            1
    # env-file             ~/.opam/log/inquire-8-bfe3ae.env
    # output-file          ~/.opam/log/inquire-8-bfe3ae.out
    ### output ###
    # File "vendor/ocaml-ansi/src/dune", line 9, characters 17-22:
    # 9 |  (libraries unix bytes))
    #                      ^^^^^
    # Error: Library "bytes" not found.
