### PR TITLE
ocaml 5: ocp-indent-nlfork.1.5.4 uses bytes

### DIFF
--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml"
   "dune"
   "cmdliner" {>= "1.0.0"}
-  "base-bytes"
+  "base-bytes" {ocaml:version >= "5.0"}
 ]
 synopsis: """ocp-indent library, "newline tokens" fork"""
 description: """

--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml"
   "dune"
   "cmdliner" {>= "1.0.0"}
+  "base-bytes"
 ]
 synopsis: """ocp-indent library, "newline tokens" fork"""
 description: """

--- a/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
+++ b/packages/ocp-indent-nlfork/ocp-indent-nlfork.1.5.4/opam
@@ -13,10 +13,9 @@ tags: ["org:ocamlpro" "org:typerex"]
 dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git#nlfork"
 build: ["dune" "build" "-j" jobs "-p" name]
 depends: [
-  "ocaml"
+  ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
   "dune"
   "cmdliner" {>= "1.0.0"}
-  "base-bytes" {ocaml:version >= "5.0"}
 ]
 synopsis: """ocp-indent library, "newline tokens" fork"""
 description: """


### PR DESCRIPTION
Depend on base-bytes to avoid this:

    #=== ERROR while compiling ocp-indent-nlfork.1.5.4 ============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocp-indent-nlfork.1.5.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -j 47 -p ocp-indent-nlfork
    # exit-code            1
    # env-file             ~/.opam/log/ocp-indent-nlfork-8-08e2ff.env
    # output-file          ~/.opam/log/ocp-indent-nlfork-8-08e2ff.out
    ### output ###
    # File "src/dune", line 27, characters 12-17:
    # 27 |  (libraries bytes ocp-indent-nlfork.lexer)
    #                  ^^^^^
    # Error: Library "bytes" not found.
