### PR TITLE
ocaml 5: patch.1.0.0 uses bytes

### DIFF
--- a/packages/patch/patch.1.0.0/opam
+++ b/packages/patch/patch.1.0.0/opam
@@ -9,7 +9,7 @@ license: "ISC"
 
 depends: [
   ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
-  "dune" {>= "1.4.0"}
+  ("dune" {>= "1.4.0"} | "dune" {< "1.4.0"} & "base-bytes")
   "alcotest" {with-test}
   "crowbar" {with-test}
 ]

--- a/packages/patch/patch.1.0.0/opam
+++ b/packages/patch/patch.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "crowbar" {with-test}
-  "base-bytes"
+  "base-bytes" {ocaml:version >= "5.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/patch/patch.1.0.0/opam
+++ b/packages/patch/patch.1.0.0/opam
@@ -8,11 +8,10 @@ bug-reports: "https://github.com/hannesm/patch/issues"
 license: "ISC"
 
 depends: [
-  "ocaml" {>= "4.04.2"}
+  ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
   "dune"
   "alcotest" {with-test}
   "crowbar" {with-test}
-  ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/patch/patch.1.0.0/opam
+++ b/packages/patch/patch.1.0.0/opam
@@ -9,7 +9,7 @@ license: "ISC"
 
 depends: [
   ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
-  "dune"
+  "dune" {>= "1.4.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
 ]

--- a/packages/patch/patch.1.0.0/opam
+++ b/packages/patch/patch.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "crowbar" {with-test}
-  "base-bytes" {ocaml:version >= "5.0"}
+  ("ocaml" {>= "4.04.2" & < "5.0"} | "ocaml" {>= "5.0"} & "base-bytes")
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/patch/patch.1.0.0/opam
+++ b/packages/patch/patch.1.0.0/opam
@@ -12,6 +12,7 @@ depends: [
   "dune"
   "alcotest" {with-test}
   "crowbar" {with-test}
+  "base-bytes"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Depend on base-bytes to avoid this failure:

    #=== ERROR while compiling patch.1.0.0 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/patch.1.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p patch -j 47
    # exit-code            1
    # env-file             ~/.opam/log/patch-10-53f31d.env
    # output-file          ~/.opam/log/patch-10-53f31d.out
    ### output ###
    # File "src/dune", line 7, characters 12-17:
    # 7 |  (libraries bytes))
    #                 ^^^^^
    # Error: Library "bytes" not found.
