### PR TITLE
Package hacl_func.0.1.0

### DIFF
--- a/packages/hacl_func/hacl_func.0.1.0/opam
+++ b/packages/hacl_func/hacl_func.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Minimal Hacl bindings"
+maintainer: "contact@functori.com"
+authors: "Maxime Levillain <maxime.levillain@functori.com>"
+license: "MIT"
+homepage: "https://gitlab.com/functori/dev/hacl"
+bug-reports: "https://gitlab.com/functori/dev/hacl/-/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.6"}
+  "alcotest" {with-test}
+  "hex" {with-test}
+  "js_of_ocaml-compiler" {with-test}
+  "odoc" {with-doc}
+]
+available: arch = "x86_64" | arch = "arm64"
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+dev-repo: "git://gitlab.com/functori/dev/hacl"
+url {
+  src:
+    "https://gitlab.com/functori/dev/hacl/-/archive/0.1.0/hacl-0.1.0.tar.gz"
+  checksum: [
+    "md5=08463792ab10bf73948e6616e46a81df"
+    "sha512=d370d94be68d4514482a8adf5fd808ca9369c3b76f3a92251f2efc79d344b8d3bcc267a7524bf1a612b1fa5edb70c68f42cdd73d61265c29f896e205c97ba4bc"
+  ]
+}


### PR DESCRIPTION
### `hacl_func.0.1.0`
Minimal Hacl bindings



---
* Homepage: https://gitlab.com/functori/dev/hacl
* Source repo: git://gitlab.com/functori/dev/hacl
* Bug tracker: https://gitlab.com/functori/dev/hacl/-/issues

---
:camel: Pull-request generated by opam-publish v2.2.0