### PR TITLE
Mark topkg as incompatible with the bytecode-only mode

### DIFF
--- a/packages/topkg/topkg.0.7.5/opam
+++ b/packages/topkg/topkg.0.7.5/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build:[[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" "%{name}%"

--- a/packages/topkg/topkg.0.7.6/opam
+++ b/packages/topkg/topkg.0.7.6/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.7.7/opam
+++ b/packages/topkg/topkg.0.7.7/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.7.8/opam
+++ b/packages/topkg/topkg.0.7.8/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.7.9/opam
+++ b/packages/topkg/topkg.0.7.9/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.8.0/opam
+++ b/packages/topkg/topkg.0.8.0/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.8.1/opam
+++ b/packages/topkg/topkg.0.8.1/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild" {build}
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.9.0/opam
+++ b/packages/topkg/topkg.0.9.0/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild"
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.0.9.1/opam
+++ b/packages/topkg/topkg.0.9.1/opam
@@ -13,6 +13,9 @@ depends: [
   "ocamlbuild"
   "result"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.1.0.0/opam
+++ b/packages/topkg/topkg.1.0.0/opam
@@ -12,6 +12,9 @@ depends: [
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild"
   "result" ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.1.0.1/opam
+++ b/packages/topkg/topkg.1.0.1/opam
@@ -11,6 +11,9 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild" ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.1.0.2/opam
+++ b/packages/topkg/topkg.1.0.2/opam
@@ -11,6 +11,9 @@ depends: [
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild" ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.1.0.3/opam
+++ b/packages/topkg/topkg.1.0.3/opam
@@ -11,6 +11,9 @@ depends: [
   "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild" ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
           "--pkg-name" name

--- a/packages/topkg/topkg.1.0.4/opam
+++ b/packages/topkg/topkg.1.0.4/opam
@@ -11,6 +11,9 @@ tags: ["packaging" "ocamlbuild" "org:erratique"]
 depends: ["ocaml" {>= "4.03.0" & < "5.0"}
           "ocamlfind" {build & >= "1.6.1"}
           "ocamlbuild"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
                                       "--dev-pkg" "%{dev}%"]]
 url {

--- a/packages/topkg/topkg.1.0.5/opam
+++ b/packages/topkg/topkg.1.0.5/opam
@@ -11,6 +11,9 @@ tags: ["packaging" "ocamlbuild" "org:erratique"]
 depends: ["ocaml" {>= "4.05.0" & < "5.0"}
           "ocamlfind" {build & >= "1.6.1"}
           "ocamlbuild"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name
                                       "--dev-pkg" "%{dev}%"]]
 url {

--- a/packages/topkg/topkg.1.0.6/opam
+++ b/packages/topkg/topkg.1.0.6/opam
@@ -38,6 +38,9 @@ depends: [
   "ocamlfind" {build & >= "1.6.1"}
   "ocamlbuild"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: ["ocaml" "pkg/pkg.ml" "build" "--pkg-name" name "--dev-pkg" "%{dev}%"]
 dev-repo: "git+https://erratique.ch/repos/topkg.git"
 url {


### PR DESCRIPTION
See https://github.com/dbuenzli/topkg/issues/140
Wait for the next release of topkg before merging.

This might be a bit overkill as only part of the feature set is broken in bytecode-only mode but it makes it less tedious to maintain this way. If you prefer to only mark the revdeps that actually have C bindings (e.g. mtime) i can do that too but meh.

cc @dbuenzli 