### PR TITLE
2 packages from extism/extism at 0.1.0

### DIFF
--- a/packages/extism-manifest/extism-manifest.0.1.0/opam
+++ b/packages/extism-manifest/extism-manifest.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Extism manifest bindings"
+description: "Bindings to the Extism manifest format"
+maintainer: "Extism Authors <oss@extism.org>"
+authors: "Extism Authors <oss@extism.org>"
+license: "BSD-3-Clause"
+tags: ["topics" "wasm" "plugin"]
+homepage: "https://github.com/extism/extism"
+doc: "https://github.com/extism/extism"
+bug-reports: "https://github.com/extism/extism/issues"
+depends: [
+  "ocaml" {>= "4.14.1"}
+  "dune" {>= "3.2" & >= "3.2"}
+  "ppx_yojson_conv" {>= "0.15.0"}
+  "ppx_inline_test" {>= "0.15.0"}
+  "base64" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/extism/extism.git"
+url {
+  src: "https://github.com/extism/extism/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "md5=02aee06a119237a777329052697fd3fc"
+    "sha512=d6545ff5b46cb7de5c8f1051b08679c6d9075f2af4cf21c0403794eb269fca1c2701b77ff1e4be52973541ed11be07b1ea4514af5a98d19d030526ef0a1dc5ec"
+  ]
+}

--- a/packages/extism-manifest/extism-manifest.0.1.0/opam
+++ b/packages/extism-manifest/extism-manifest.0.1.0/opam
@@ -10,9 +10,9 @@ doc: "https://github.com/extism/extism"
 bug-reports: "https://github.com/extism/extism/issues"
 depends: [
   "ocaml" {>= "4.14.1"}
-  "dune" {>= "3.2" & >= "3.2"}
-  "ppx_yojson_conv" {>= "0.15.0"}
-  "ppx_inline_test" {>= "0.15.0"}
+  "dune" {>= "3.2"}
+  "ppx_yojson_conv" {>= "v0.15.0"}
+  "ppx_inline_test" {>= "v0.15.0"}
   "base64" {>= "3.5.0"}
   "odoc" {with-doc}
 ]

--- a/packages/extism/extism.0.1.0/opam
+++ b/packages/extism/extism.0.1.0/opam
@@ -10,10 +10,11 @@ doc: "https://github.com/extism/extism"
 bug-reports: "https://github.com/extism/extism/issues"
 depends: [
   "ocaml" {>= "4.14.1"}
-  "dune" {>= "3.2" & >= "3.2"}
+  "dune" {>= "3.2"}
+  "ctypes" {>= "0.18.0"}
   "ctypes-foreign" {>= "0.18.0"}
   "bigstringaf" {>= "0.9.0"}
-  "ppx_yojson_conv" {>= "0.15.0"}
+  "ppx_yojson_conv" {>= "v0.15.0"}
   "extism-manifest"
   "ppx_inline_test" {>= "0.15.0"}
   "cmdliner" {>= "1.1.1"}

--- a/packages/extism/extism.0.1.0/opam
+++ b/packages/extism/extism.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "bigstringaf" {>= "0.9.0"}
   "ppx_yojson_conv" {>= "v0.15.0"}
   "extism-manifest"
-  "ppx_inline_test" {>= "0.15.0"}
+  "ppx_inline_test" {>= "v0.15.0"}
   "cmdliner" {>= "1.1.1"}
   "odoc" {with-doc}
 ]

--- a/packages/extism/extism.0.1.0/opam
+++ b/packages/extism/extism.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Extism bindings"
+description: "Bindings to Extism, the universal plugin system"
+maintainer: "Extism Authors <oss@extism.org>"
+authors: "Extism Authors <oss@extism.org>"
+license: "BSD-3-Clause"
+tags: ["topics" "wasm" "plugin"]
+homepage: "https://github.com/extism/extism"
+doc: "https://github.com/extism/extism"
+bug-reports: "https://github.com/extism/extism/issues"
+depends: [
+  "ocaml" {>= "4.14.1"}
+  "dune" {>= "3.2" & >= "3.2"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "ppx_yojson_conv" {>= "0.15.0"}
+  "extism-manifest"
+  "ppx_inline_test" {>= "0.15.0"}
+  "cmdliner" {>= "1.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+build-env: EXTISM_TEST_NO_LIB = ""
+post-messages:
+  "See https://extism.org/docs/install/ for information about installing libextism"
+dev-repo: "git+https://github.com/extism/extism.git"
+url {
+  src: "https://github.com/extism/extism/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "md5=02aee06a119237a777329052697fd3fc"
+    "sha512=d6545ff5b46cb7de5c8f1051b08679c6d9075f2af4cf21c0403794eb269fca1c2701b77ff1e4be52973541ed11be07b1ea4514af5a98d19d030526ef0a1dc5ec"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `extism.0.1.0`: Extism bindings
- `extism-manifest.0.1.0`: Extism manifest bindings



---
* Homepage: https://github.com/extism/extism
* Source repo: git+https://github.com/extism/extism.git
* Bug tracker: https://github.com/extism/extism/issues

---
:camel: Pull-request generated by opam-publish v2.2.0