### PR TITLE
[new release] curly (0.3.0)

### DIFF
--- a/packages/curly/curly.0.3.0/opam
+++ b/packages/curly/curly.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Curly is a brain dead wrapper around the curl command line utility"
+maintainer: ["rudi.grinberg@gmail.com"]
+authors: ["Rudi Grinberg"]
+license: "ISC"
+homepage: "https://github.com/rgrinberg/curly"
+bug-reports: "https://github.com/rgrinberg/curly/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "base-unix"
+  "result"
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rgrinberg/curly.git"
+url {
+  src:
+    "https://github.com/rgrinberg/curly/releases/download/0.3.0/curly-0.3.0.tbz"
+  checksum: [
+    "sha256=427fcf28134e70cb77764d9feee243f31d32a38447a1b5d28d341c93b7dc5d3c"
+    "sha512=a8313c902f96a352fb5f592b0b4d2dbd72efcd92a688c812350be5561442d418b64ab0325e2ffe181385268224dc51a66107451a11b59e45a50e38827b9a9912"
+  ]
+}
+x-commit-hash: "a76ff4070d41b884afb10ad7bf74976fef5c66a4"

--- a/packages/curly/curly.0.3.0/opam
+++ b/packages/curly/curly.0.3.0/opam
@@ -25,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version >= "4.08"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/curly/curly.0.3.0/opam
+++ b/packages/curly/curly.0.3.0/opam
@@ -25,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & ocaml:version >= "4.08"}
+    "@runtest" {with-test & ocaml:version >= "4.04"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Curly is a brain dead wrapper around the curl command line utility

- Project page: <a href="https://github.com/rgrinberg/curly">https://github.com/rgrinberg/curly</a>

##### CHANGES:

* Passthrough case-insensitive PATH and SYSTEMROOT on Windows (@emillon,
  @jonahbeckford, rgrinberg/curly#6, rgrinberg/curly#8)
* Passthrough PATH to Unixes too. (@bikal, rgrinberg/curly#12)
* Add `?follow_redirects` argument to `run` and related functions
  (@rawleyfowler, rgrinberg/curly#5).
