### PR TITLE
Constrain jupyter releases away from 4.14.1

### DIFF
--- a/packages/jupyter/jupyter.2.7.7/opam
+++ b/packages/jupyter/jupyter.2.7.7/opam
@@ -15,7 +15,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.15"}
+  "ocaml" {>= "4.04.0" & < "4.14.1"}
   "base-threads"
   "base-unix"
   "uuidm" {>= "0.9.6"}

--- a/packages/jupyter/jupyter.2.7.8/opam
+++ b/packages/jupyter/jupyter.2.7.8/opam
@@ -15,7 +15,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.10.0" & < "4.15"}
+  "ocaml" {>= "4.10.0" & < "4.14.1"}
   "base-threads"
   "base-unix"
   "uuidm" {>= "0.9.6"}

--- a/packages/jupyter/jupyter.2.7.9/opam
+++ b/packages/jupyter/jupyter.2.7.9/opam
@@ -15,7 +15,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.10.0" & < "4.15"}
+  "ocaml" {>= "4.10.0" & < "4.14.1"}
   "base-threads"
   "base-unix"
   "uuidm" {>= "0.9.6"}

--- a/packages/jupyter/jupyter.2.8.0/opam
+++ b/packages/jupyter/jupyter.2.8.0/opam
@@ -15,7 +15,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.10.0" & < "4.15"}
+  "ocaml" {>= "4.10.0" & < "4.14.1"}
   "base-threads"
   "base-unix"
   "uuidm" {>= "0.9.6"}


### PR DESCRIPTION
Law of unintended consequences - see https://github.com/akabe/ocaml-jupyter/pull/196 for details.