### PR TITLE
[new release] gluten, gluten-mirage, gluten-lwt, gluten-lwt-unix, gluten-eio and gluten-async (0.4.0)

### DIFF
--- a/packages/gluten-async/gluten-async.0.4.0/opam
+++ b/packages/gluten-async/gluten-async.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "gluten" {= version}
+  "faraday-async" {>= "0.7.2"}
+  "async" { >= "v0.15.0" }
+  "core" { >= "v0.15.0" }
+]
+depopts: [
+  "async_ssl"
+  "tls-async"
+ ]
+synopsis: "Async runtime for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.0/gluten-0.4.0.tbz"
+  checksum: [
+    "sha256=f938b82c6a870db051d604898bb53b2f3bedd6143ac5e877c4f29c3a52d6bc49"
+    "sha512=b521fb95d0f12e48464738b8172a71db766b47168beee667a455c979c19d08b039c2a485402c7e8bf2231265e16f1d1c61c325baf0b8e3d3a9ba94f4b2698bc2"
+  ]
+}
+x-commit-hash: "531bfcf5316fbdb67181c46a9db80a9e7c4edbcd"

--- a/packages/gluten-eio/gluten-eio.0.4.0/opam
+++ b/packages/gluten-eio/gluten-eio.0.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "gluten" {= version}
+  "dune" {>= "1.0"}
+  "eio"
+]
+synopsis: "EIO runtime for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.0/gluten-0.4.0.tbz"
+  checksum: [
+    "sha256=f938b82c6a870db051d604898bb53b2f3bedd6143ac5e877c4f29c3a52d6bc49"
+    "sha512=b521fb95d0f12e48464738b8172a71db766b47168beee667a455c979c19d08b039c2a485402c7e8bf2231265e16f1d1c61c325baf0b8e3d3a9ba94f4b2698bc2"
+  ]
+}
+x-commit-hash: "531bfcf5316fbdb67181c46a9db80a9e7c4edbcd"
+

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.0/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "1.0"}
+  "faraday-lwt-unix" {>= "0.5.0"}
+  "gluten" {= version}
+  "gluten-lwt" {= version}
+  "lwt"
+]
+depopts: [
+  "tls"
+  "lwt_ssl"
+]
+conflicts: [ "tls" {< "0.15.0"} ]
+synopsis: "Lwt + Unix support for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.0/gluten-0.4.0.tbz"
+  checksum: [
+    "sha256=f938b82c6a870db051d604898bb53b2f3bedd6143ac5e877c4f29c3a52d6bc49"
+    "sha512=b521fb95d0f12e48464738b8172a71db766b47168beee667a455c979c19d08b039c2a485402c7e8bf2231265e16f1d1c61c325baf0b8e3d3a9ba94f4b2698bc2"
+  ]
+}
+x-commit-hash: "531bfcf5316fbdb67181c46a9db80a9e7c4edbcd"

--- a/packages/gluten-lwt/gluten-lwt.0.4.0/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.4.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "gluten" {= version}
+  "dune" {>= "1.0"}
+  "lwt"
+  "ke"
+]
+synopsis: "Lwt-specific runtime for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.0/gluten-0.4.0.tbz"
+  checksum: [
+    "sha256=f938b82c6a870db051d604898bb53b2f3bedd6143ac5e877c4f29c3a52d6bc49"
+    "sha512=b521fb95d0f12e48464738b8172a71db766b47168beee667a455c979c19d08b039c2a485402c7e8bf2231265e16f1d1c61c325baf0b8e3d3a9ba94f4b2698bc2"
+  ]
+}
+x-commit-hash: "531bfcf5316fbdb67181c46a9db80a9e7c4edbcd"

--- a/packages/gluten-mirage/gluten-mirage.0.4.0/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "faraday-lwt"
+  "gluten-lwt" {= version}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "dune" {>= "1.0"}
+  "lwt"
+]
+synopsis: "Mirage support for gluten"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.0/gluten-0.4.0.tbz"
+  checksum: [
+    "sha256=f938b82c6a870db051d604898bb53b2f3bedd6143ac5e877c4f29c3a52d6bc49"
+    "sha512=b521fb95d0f12e48464738b8172a71db766b47168beee667a455c979c19d08b039c2a485402c7e8bf2231265e16f1d1c61c325baf0b8e3d3a9ba94f4b2698bc2"
+  ]
+}
+x-commit-hash: "531bfcf5316fbdb67181c46a9db80a9e7c4edbcd"

--- a/packages/gluten/gluten.0.4.0/opam
+++ b/packages/gluten/gluten.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Antonio Monteiro <anmonteiro@gmail.com>"
+authors: [ "Antonio Monteiro <anmonteiro@gmail.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+doc: "https://anmonteiro.github.io/gluten/"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "faraday"
+  "ke" {>= "0.5"}
+]
+synopsis:
+  "A reusable runtime library for network protocols"
+description: """
+gluten implements platform specific runtime code for driving network libraries
+based on state machines, such as http/af, h2 and websocketaf.
+"""
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.0/gluten-0.4.0.tbz"
+  checksum: [
+    "sha256=f938b82c6a870db051d604898bb53b2f3bedd6143ac5e877c4f29c3a52d6bc49"
+    "sha512=b521fb95d0f12e48464738b8172a71db766b47168beee667a455c979c19d08b039c2a485402c7e8bf2231265e16f1d1c61c325baf0b8e3d3a9ba94f4b2698bc2"
+  ]
+}
+x-commit-hash: "531bfcf5316fbdb67181c46a9db80a9e7c4edbcd"


### PR DESCRIPTION
A reusable runtime library for network protocols

- Project page: <a href="https://github.com/anmonteiro/gluten">https://github.com/anmonteiro/gluten</a>
- Documentation: <a href="https://anmonteiro.github.io/gluten/">https://anmonteiro.github.io/gluten/</a>

##### CHANGES:

- gluten-eio: Add `gluten-eio` package, a gluten backend for
  [eio](https://github.com/ocaml-multicore/eio)
  ([anmonteiro/gluten#35](https://github.com/anmonteiro/gluten/pull/35))
- gluten-async: Allow connecting to a UNIX domain socket
  ([anmonteiro/gluten#40](https://github.com/anmonteiro/gluten/pull/40))
- gluten-async: Fix memory leak in the SSL / TLS implementations
  ([anmonteiro/gluten#48](https://github.com/anmonteiro/gluten/pull/48))
