### PR TITLE
Release ocaml-jupyter kernel 2.8.1

### DIFF
--- a/packages/jupyter/jupyter.2.8.1/opam
+++ b/packages/jupyter/jupyter.2.8.1/opam
@@ -15,7 +15,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.10.0" & <= "4.14.1"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "base-threads"
   "base-unix"
   "uuidm" {>= "0.9.6"}

--- a/packages/jupyter/jupyter.2.8.1/opam
+++ b/packages/jupyter/jupyter.2.8.1/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "git+https://github.com/akabe/ocaml-jupyter.git"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.10.0" & <= "4.14.1"}
+  "base-threads"
+  "base-unix"
+  "uuidm" {>= "0.9.6"}
+  "base64" {>= "3.2.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ppx" {>= "1.0.0"}
+  "logs" {>= "0.6.0"}
+  "stdint" {>= "0.4.2"}
+  "zmq" {>= "5.0.0"}
+  "zmq-lwt" {>= "5.0.0"}
+  "yojson" {>="1.6.0"}
+  "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "cryptokit" {>= "1.12"}
+  "dune" {>= "1.0.0"}
+  "ounit2" {with-test & >= "2.0.0"}
+  "ocp-indent" {with-test & >= "1.7.0"}
+]
+depopts: [
+  "merlin"
+]
+conflicts: [
+  "merlin" {< "3.0.0"}
+]
+
+post-messages: [
+  "Please run for registration of ocaml-jupyter kernel:"
+  ""
+  "$ ocaml-jupyter-opam-genspec"
+  "$ jupyter kernelspec install --name ocaml-jupyter \\"
+  "    %{share}%/jupyter"
+  {success}
+]
+
+synopsis: "An OCaml kernel for Jupyter notebook"
+description:
+  "OCaml Jupyter provides an OCaml REPL on Jupyter (a great interface with markdown/HTML documentation, LaTeX formula by MathJax, and image embedding). This is useful for data analysis in OCaml."
+url {
+  src: "https://github.com/akabe/ocaml-jupyter/releases/download/v2.8.1/jupyter-2.8.1.tbz"
+  checksum: "sha256=d0afa7c7ad515285413d75fe08d0cb6d070df2e455073b6cfe56a04ae2fb45fd"
+}


### PR DESCRIPTION
I release ocaml jupyter kernel v2.8.1 https://github.com/akabe/ocaml-jupyter/releases/tag/v2.8.1 for supporting ocaml 4.14.1.
related: https://github.com/ocaml/opam-repository/pull/23021