### PR TITLE
Package commons.1.5.2

### DIFF
--- a/packages/commons/commons.1.5.2/opam
+++ b/packages/commons/commons.1.5.2/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Yet another set of common utilities"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0" }
+  "alcotest"
+  "ANSITerminal"
+  "easy_logging" { = "0.8.1" }
+  "easy_logging_yojson" { = "0.8.1" }
+  "yojson"
+  "ppxlib"
+  "ppx_deriving"
+]
+
+build: ["dune" "build" "./_build/default/commons.install"]
+install: ["dune" "install" "commons"]
+url {
+  src: "https://github.com/returntocorp/sgrep/archive/refs/tags/1.5.2.tar.gz"
+  checksum: [
+    "md5=047b4d9fea94089181f76076246a3fae"
+    "sha512=998090c15d9c7d3fdccf8c1ac77fcf8d7489651309f2fc7fe03da40b656663a27480e235b5d9067e58df7a0792486650b8e4b2baaa896c889e8a70ffd31ba885"
+  ]
+}


### PR DESCRIPTION
### `commons.1.5.2`
Yet another set of common utilities
This is a small library of utilities used by Semgrep and
a few other projects developed at r2c.



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0