### PR TITLE
Package commons.1.5.3

### DIFF
--- a/packages/commons/commons.1.5.3/opam
+++ b/packages/commons/commons.1.5.3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Yet another set of common utilities"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0" }
+  "alcotest"
+  "ANSITerminal"
+  "easy_logging" { = "0.8.1" }
+  "easy_logging_yojson" { = "0.8.1" }
+  "yojson"
+  "ppxlib"
+  "ppx_deriving"
+]
+
+build: ["dune" "build" "./_build/default/commons.install"]
+install: ["dune" "install" "commons"]
+url {
+  src: "https://github.com/returntocorp/sgrep/archive/refs/tags/1.5.3.tar.gz"
+  checksum: [
+    "md5=ce28919515ff79a8f1db592a7daae47d"
+    "sha512=06ee994a9971bc77ee42a2a85a980eafb83f31569eda7329c40d3d90506a842925cef2eb1854a17f22eafc238ad5e6edc8fa489ea853afc87b4d8ecf4b1547de"
+  ]
+}


### PR DESCRIPTION
### `commons.1.5.3`
Yet another set of common utilities
This is a small library of utilities used by Semgrep and
a few other projects developed at r2c.



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0