### PR TITLE
Package commons.1.5.4

### DIFF
--- a/packages/commons/commons.1.5.4/opam
+++ b/packages/commons/commons.1.5.4/opam
@@ -25,8 +25,7 @@ depends: [
   "ppx_deriving" {>= "5.2.1"}
 ]
 
-build: ["dune" "build" "./_build/default/commons.install"]
-install: ["dune" "install" "commons"]
+build: ["dune" "build" "-p" name "-j" jobs]
 url {
   src: "https://github.com/returntocorp/sgrep/archive/refs/tags/1.5.4.tar.gz"
   checksum: [

--- a/packages/commons/commons.1.5.4/opam
+++ b/packages/commons/commons.1.5.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Yet another set of common utilities"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0" }
+  "alcotest" {>= "1.5.0"}
+  "ANSITerminal" {>= "0.8.4"}
+  "easy_logging" { = "0.8.1" }
+  "easy_logging_yojson" { = "0.8.1" }
+  "yojson" {>= "1.7.0"}
+  "re" {>= "1.10.4"}
+  "ppxlib" {>= "0.25.0"}
+  "ppx_deriving" {>= "5.2.1"}
+]
+
+build: ["dune" "build" "./_build/default/commons.install"]
+install: ["dune" "install" "commons"]
+url {
+  src: "https://github.com/returntocorp/sgrep/archive/refs/tags/1.5.4.tar.gz"
+  checksum: [
+    "md5=d256c2711a1beac4d6fab8a4ef61a979"
+    "sha512=ed75766ec32b4f3f71530331da402f7ec90318f34307b62fb3db31229b0547d8af345f36de8d6d767f8e2fee972ff24753e2ad5c7ee1003deb29b44f9e8d6004"
+  ]
+}

--- a/packages/commons/commons.1.5.4/opam
+++ b/packages/commons/commons.1.5.4/opam
@@ -17,8 +17,8 @@ depends: [
   "dune" {>= "2.7.0" }
   "alcotest" {>= "1.5.0"}
   "ANSITerminal" {>= "0.8.4"}
-  "easy_logging" { = "0.8.1" }
-  "easy_logging_yojson" { = "0.8.1" }
+  "easy_logging" {>= "0.8.1"}
+  "easy_logging_yojson" {>= "0.8.1"}
   "yojson" {>= "1.7.0"}
   "re" {>= "1.10.4"}
   "ppxlib" {>= "0.25.0"}


### PR DESCRIPTION
### `commons.1.5.4`
Yet another set of common utilities
This is a small library of utilities used by Semgrep and
a few other projects developed at r2c.



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0