### PR TITLE
[new release] mdx (2.2.1)

### DIFF
--- a/packages/mdx/mdx.2.2.1/opam
+++ b/packages/mdx/mdx.2.2.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build & >= "1.1.0"}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "ocaml-version" {>= "2.3.0"}
+  "odoc-parser" {>= "1.0.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/2.2.1/mdx-2.2.1.tbz"
+  checksum: [
+    "sha256=f09ed733fe4461605f029773748a6353d01b95be65eb986bcce17d6ddaf509d8"
+    "sha512=5f918fbafcb55c3959f6cce69b8d8e640883dea5c21d159b5ebb6ead31230569100813555d2637f74028d51f79f23a226dc69811524d9cf1c2ca50b87a93dbf2"
+  ]
+}
+x-commit-hash: "96cef6ca65b55c629a265686a0ae471c378d5fca"


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Fixed

- Undid the change to the pipe code to restore compatibility with Windows
  (realworldocaml/mdx#403, @MisterDA)
