### PR TITLE
[new release] kittyimg (0.1)

### DIFF
--- a/packages/kittyimg/kittyimg.0.1/opam
+++ b/packages/kittyimg/kittyimg.0.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "An implementation of Kitty's terminal graphics protocol"
+description:
+  "Kitty's terminal graphics protocol allows displaying images in compatible terminal emulators"
+maintainer: ["Armaël Guéneau <armael.gueneau@ens-lyon.org>"]
+authors: ["Armaël Guéneau <armael.gueneau@ens-lyon.org>"]
+license: "MIT"
+homepage: "https://github.com/Armael/ocaml-kittyimg"
+bug-reports: "https://github.com/Armael/ocaml-kittyimg/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "base64" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "arm32" & arch != "x86_32"
+dev-repo: "git+https://github.com/Armael/ocaml-kittyimg.git"
+url {
+  src:
+    "https://github.com/Armael/ocaml-kittyimg/releases/download/0.1/kittyimg-0.1.tbz"
+  checksum: [
+    "sha256=41888e4321f9e4df13652b8a836b067d9001561bb01d0d1fcd26a2ca004ac8aa"
+    "sha512=7910a297176fb972bf50cfe38e776e3c6f9f85d652ab57186b7367de77259c8e55708600de8f3860db57eeb20c13a53ed5f2de0c38fac3fadc3d80d5d2bed97b"
+  ]
+}
+x-commit-hash: "4f3df37b311a680aa805a4069d3105e9874e1d94"


### PR DESCRIPTION
An implementation of Kitty's terminal graphics protocol

- Project page: <a href="https://github.com/Armael/ocaml-kittyimg">https://github.com/Armael/ocaml-kittyimg</a>

##### CHANGES:

- initial release
