### PR TITLE
[new release] sha (1.15.3)

### DIFF
--- a/packages/sha/sha.1.15.3/opam
+++ b/packages/sha/sha.1.15.3/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Binding to the SHA cryptographic functions"
+description: """
+This is the binding for SHA interface code in OCaml. Offering the same
+interface than the MD5 digest included in the OCaml standard library.
+It's currently providing SHA1, SHA256 and SHA512 hash functions."""
+maintainer: ["dave@recoil.org"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Goswin von Brederlow"
+  "Eric Cooper"
+  "Florent Monnier"
+  "Forrest L Norvell"
+  "Vincent Bernadoff"
+  "David Scott"
+  "Olaf Hering"
+  "Arthur Teisseire"
+  "Nicolás Ojeda Bär"
+  "Christopher Zimmermann"
+  "Thomas Leonard"
+  "Antonin Décimo"
+]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-sha"
+bug-reports: "https://github.com/djs55/ocaml-sha/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.02"}
+  "stdlib-shims" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/djs55/ocaml-sha.git"
+url {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.15.3/sha-1.15.3.tbz"
+  checksum: [
+    "sha256=4119896723bd5325c2f5a21884fddf8d7952eb22782d9b82b02d75246e05de2c"
+    "sha512=0ba70b310f78ced7d396b0a74eb9fff0efd8e6108f3c7fcc5a8f7d723b40b640f4f1aacef2c414ab09df9e9fcc4c93150bcf01a937d23aa5804b4eb689e492dc"
+  ]
+}
+x-commit-hash: "d829fb653b3be314605129b26405ccf38604fdeb"


### PR DESCRIPTION
Binding to the SHA cryptographic functions

- Project page: <a href="https://github.com/djs55/ocaml-sha">https://github.com/djs55/ocaml-sha</a>

##### CHANGES:

- Fix build on OpenBSD by @kit-ty-kate (djs55/ocaml-sha#58)
- More unit tests by @c-cube (djs55/ocaml-sha#57)
