### PR TITLE
scfg.0.2

### DIFF
--- a/packages/scfg/scfg.0.2/opam
+++ b/packages/scfg/scfg.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "OCaml library and executable to work with the scfg configuration file format"
+description:
+  "scfg is an OCaml library and executable to work with the scfg configuration file format. It provides a parser, a pretty printer and a module to perform queries."
+maintainer: ["Léo Andrès <contact@ndrs.fr>"]
+authors: ["Léo Andrès <contact@ndrs.fr>"]
+license: "ISC"
+tags: ["scfg" "configuration" "format" "simple" "config" "parser" "printer"]
+homepage: "https://git.zapashcanon.fr/zapashcanon/scfg"
+doc: "https://doc.zapashcanon.fr/scfg"
+bug-reports: "https://git.zapashcanon.fr/zapashcanon/scfg/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.13"}
+  "menhir" {>= "20211230"}
+  "sedlex"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://git.zapashcanon.fr/zapashcanon/scfg.git"
+url {
+  src: "https://git.zapashcanon.fr/zapashcanon/scfg/archive/0.2.tar.gz"
+  checksum: [
+  "sha256=75bddc93dd19c2d7da6583f959b0d0a4a44aa41e9173a66d6193275f5cc1917c"
+  "sha512=92e6fa84f8ff73efd29e62babe4ca3ffbd86743443e80c743d6dd49a01597b831d832ca5bff85a2ca4ad16f99b24b717692f34e84820413c9fcc918bb96f53da"
+  ]
+}


### PR DESCRIPTION
Hi,

This is the `0.2` release of [scfg](https://git.zapashcanon.fr/zapashcanon/scfg).

Changes are:

- add `get_param_bool`, `get_param_int`, `get_param_pos_int` to the `Query` module
- fix bug with files starting with newlines
- use a proper Format box instead of an int to indent

Cheers,