### PR TITLE
[new release] talaria-bibtex (0.5)

### DIFF
--- a/packages/talaria-bibtex/talaria-bibtex.0.5/opam
+++ b/packages/talaria-bibtex/talaria-bibtex.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A parser for bibtex files"
+description: """
+Talaria-bibtex is a parser for bibtex files. Talaria-bibtex parses bibtex-file into record
+   with an extensible sets of known fields to make it easy to handle well-formed bibtex file and
+   extract data like the publication year."""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/Octachron/talaria_bibtex"
+bug-reports: "https://github.com/Octachron/talaria_bibtex/issues"
+depends: [
+  "orec"
+  "dune" {>= "2.7"}
+  "menhir" {>= "20180523"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/talaria_bibtex.git"
+url {
+  src:
+    "https://github.com/Octachron/talaria_bibtex/releases/download/0.5/talaria-bibtex-0.5.tbz"
+  checksum: [
+    "sha256=e1a48585efa9bdbfd1bdebe37c5b77388b04a0cdffcc6f528bd7b7b8c6e00ad5"
+    "sha512=c7fd05c24fce678761343039ede101f69551f616e8a74705cb25226a6b51494eafc9c672febcf5cf8ab1991caef7668ae774a7edf66c83e53261cbec8713071a"
+  ]
+}
+x-commit-hash: "244772f9fc8f3381df4692f82f7a3bac463d95d9"


### PR DESCRIPTION
A simple bibtex parser using open records to store the parsed bibtex fields.

##### CHANGES:

- First opam release
- Removed global state in the parser: the typed keys are now a separate argument.
- Basic documentation
