### PR TITLE
[new release] sha (1.15.4)

### DIFF
--- a/packages/sha/sha.1.15.4/opam
+++ b/packages/sha/sha.1.15.4/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+synopsis: "Binding to the SHA cryptographic functions"
+description: """
+This is the binding for SHA interface code in OCaml. Offering the same
+interface than the MD5 digest included in the OCaml standard library.
+It's currently providing SHA1, SHA256 and SHA512 hash functions."""
+maintainer: ["dave@recoil.org"]
+authors: [
+  "Vincent Hanquez"
+  "Thomas Gazagnaire"
+  "Goswin von Brederlow"
+  "Eric Cooper"
+  "Florent Monnier"
+  "Forrest L Norvell"
+  "Vincent Bernadoff"
+  "David Scott"
+  "Olaf Hering"
+  "Arthur Teisseire"
+  "Nicolás Ojeda Bär"
+  "Christopher Zimmermann"
+  "Thomas Leonard"
+  "Antonin Décimo"
+]
+license: "ISC"
+homepage: "https://github.com/djs55/ocaml-sha"
+bug-reports: "https://github.com/djs55/ocaml-sha/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.02"}
+  "stdlib-shims" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/djs55/ocaml-sha.git"
+url {
+  src:
+    "https://github.com/djs55/ocaml-sha/releases/download/v1.15.4/sha-1.15.4.tbz"
+  checksum: [
+    "sha256=6de5b12139b1999ce9df4cc78a5a31886c2a547c9d448bf2853f8b53bcf1f1b1"
+    "sha512=dbb31b523ba0bace023bc1b0558a8f572a0ec20fb3f19f783935be755cd161e09aba352eda2bcf7c4e5ab838c7f874cfbfaed9debf0813df25d9dbe7b9314fdf"
+  ]
+}
+x-commit-hash: "c743398abee8f822fc0d12f229121e431d60dd5d"


### PR DESCRIPTION
Binding to the SHA cryptographic functions

- Project page: <a href="https://github.com/djs55/ocaml-sha">https://github.com/djs55/ocaml-sha</a>

##### CHANGES:

- Fix build on OCaml 4.02 and fix SHA equality bug by @djs55 (djs55/ocaml-sha#61)
