### PR TITLE
Constrain older versions of curses to OCaml < 5.0.0

### DIFF
--- a/packages/curses/curses.1.0.10/opam
+++ b/packages/curses/curses.1.0.10/opam
@@ -11,7 +11,7 @@ depends: [
   "conf-ncurses" {build}
   "conf-pkg-config" {build}
   "dune-configurator" {build}
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/curses/curses.1.0.3/opam
+++ b/packages/curses/curses.1.0.3/opam
@@ -6,7 +6,10 @@ build: [
   [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
 ]
 remove: [["ocamlfind" "remove" "curses"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0.0"}
+  "ocamlfind"
+  ]
 depexts: [
   ["libncurses-dev"] {os-family = "debian"}
 ]

--- a/packages/curses/curses.1.0.4/opam
+++ b/packages/curses/curses.1.0.4/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "curses"]]
 depends: [
-    "ocaml"
+    "ocaml" {< "5.0.0"}
     "ocamlfind" {build}
     "conf-ncurses"
 ]

--- a/packages/curses/curses.1.0.5/opam
+++ b/packages/curses/curses.1.0.5/opam
@@ -10,7 +10,7 @@ build: [
   [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
 ]
 depends: [
-    "ocaml"
+    "ocaml" {< "5.0.0"}
     "ocamlfind" {build}
     "conf-ncurses"
 ]

--- a/packages/curses/curses.1.0.6/opam
+++ b/packages/curses/curses.1.0.6/opam
@@ -10,7 +10,7 @@ build: [
   [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
 ]
 depends: [
-    "ocaml"
+    "ocaml" {< "5.0.0"}
     "ocamlfind" {build}
     "conf-ncurses"
 ]

--- a/packages/curses/curses.1.0.8/opam
+++ b/packages/curses/curses.1.0.8/opam
@@ -11,7 +11,7 @@ build: [
   [make "OCAMLMAKEFILE=OCamlMakefile" "opt"]
 ]
 depends: [
-    "ocaml"
+    "ocaml" {< "5.0.0"}
     "ocamlfind" {build}
     "conf-ncurses"
 ]

--- a/packages/curses/curses.1.0.9/opam
+++ b/packages/curses/curses.1.0.9/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.11"}
   "conf-ncurses"
   "dune-configurator"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0" }
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
curses doesn't build on 5.0.0 due to C stub symbol changes, which is fixed in this PR
https://github.com/ocaml/opam-repository/pull/23015

This new PR is to constrain older versions of curses to OCaml <5.0.0.