### PR TITLE
Package jext.0.1.0

### DIFF
--- a/packages/jext/jext.0.1.0/opam
+++ b/packages/jext/jext.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml tools to help handling web extension"
+description:
+  "jext provides functors to deal with the connection between background, contentscript, popup and main page."
+maintainer: "contact@functori.com"
+authors: "Maxime Levillain <maxime.levillain@functori.com>"
+license: "MIT"
+homepage: "https://gitlab.com/functori/dev/jext"
+bug-reports: "https://gitlab.com/functori/dev/jext/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.08"}
+  "ezjs_extension"
+  "ez_api" {>= "1.2.0"}
+  "ezjs_fetch" {>= "0.3"}
+  "ppx_deriving_jsoo" {>= "0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/functori/dev/jext"
+url {
+  src:
+    "https://gitlab.com/functori/dev/jext/-/archive/0.1.0/jext-0.1.0.tar.gz"
+  checksum: [
+    "md5=fed8296cfc592824344f21fb4185cf29"
+    "sha512=b1cbd394782aaa7a24baf1d8f17d0e6076b5fb209f1467123a3a609975a8906ec55de02a1c6ccc5841c7f1fda5ce506004b161242ba16263f19cc44c007b26a4"
+  ]
+}


### PR DESCRIPTION
### `jext.0.1.0`
Js_of_ocaml tools to help handling web extension
jext provides functors to deal with the connection between background, contentscript, popup and main page.



---
* Homepage: https://gitlab.com/functori/dev/jext
* Source repo: git://gitlab.com/functori/dev/jext
* Bug tracker: https://gitlab.com/functori/dev/jext/-/issues

---
:camel: Pull-request generated by opam-publish v2.2.0