### PR TITLE
paf-cohttp.0.1.0: disable tests

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.1.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.1.0/opam
@@ -26,7 +26,7 @@ depends: [
   "astring"           {with-test}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
-run-test: ["dune" "runtest" "-p" name "-j" jobs]
+#run-test: ["dune" "runtest" "-p" name "-j" jobs]
 dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
 url {
   src:


### PR DESCRIPTION
The tests in this package hang, causing the CI to timeout.
It has been fixed in dinosaure/paf-le-chien@38c24ef608f which is part of 0.2.0.
So this is the only affected release.