### PR TITLE
[new release] rfc1951 and decompress (1.5.2)

### DIFF
--- a/packages/decompress/decompress.1.5.2/opam
+++ b/packages/decompress/decompress.1.5.2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "cmdliner"    {>= "1.1.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bigstringaf" {with-test}
+  "alcotest"    {with-test}
+  "ctypes"      {with-test & >= "0.18.0"}
+  "fmt"         {with-test & >= "0.8.7"}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+  "rresult"     {with-test}
+  "bos"         {with-test}
+  "astring"     {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.2/decompress-1.5.2.tbz"
+  checksum: [
+    "sha256=a8c9a6ba132514d56ad3626fbd5e79124844836010350ee161d43bb29bf5762e"
+    "sha512=1a5a935ff55ebad83682cffb9792b1b5e3a189d2df483f77856ea683706219f7c50ff14b7ab1de0c5ce90e0d779bd06ab86afb29d39461192fbbf4b3fbaf600c"
+  ]
+}
+x-commit-hash: "6d0c542923328b1fade4a0d3d4ff6a90923f1c2b"

--- a/packages/rfc1951/rfc1951.1.5.2/opam
+++ b/packages/rfc1951/rfc1951.1.5.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "checkseum"
+  "optint"
+  "ctypes"     {with-test & >= "0.18.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.5.2/decompress-1.5.2.tbz"
+  checksum: [
+    "sha256=a8c9a6ba132514d56ad3626fbd5e79124844836010350ee161d43bb29bf5762e"
+    "sha512=1a5a935ff55ebad83682cffb9792b1b5e3a189d2df483f77856ea683706219f7c50ff14b7ab1de0c5ce90e0d779bd06ab86afb29d39461192fbbf4b3fbaf600c"
+  ]
+}
+x-commit-hash: "6d0c542923328b1fade4a0d3d4ff6a90923f1c2b"


### PR DESCRIPTION
Implementation of RFC1951 in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Remove remaining `bigarray-compat` dependencies (@copy, mirage/decompress#147)
