### PR TITLE
[new release] base64 (3.5.1)

### DIFF
--- a/packages/base64/base64.3.5.1/opam
+++ b/packages/base64/base64.3.5.1/opam
@@ -16,7 +16,7 @@ representation.  It is specified in RFC 4648.
 """
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {>= "2.0"}
+  "dune" {>= "2.3"}
   "fmt" {with-test & >= "0.8.7"}
   "bos" {with-test}
   "rresult" {with-test}

--- a/packages/base64/base64.3.5.1/opam
+++ b/packages/base64/base64.3.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "mirageos-devel@lists.xenproject.org"
+authors: [ "Thomas Gazagnaire"
+           "Anil Madhavapeddy" "Calascibetta Romain"
+           "Peter Zotov" ]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-base64"
+doc: "https://mirage.github.io/ocaml-base64/"
+bug-reports: "https://github.com/mirage/ocaml-base64/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-base64.git"
+synopsis: "Base64 encoding for OCaml"
+description: """
+Base64 is a group of similar binary-to-text encoding schemes that represent
+binary data in an ASCII string format by translating it into a radix-64
+representation.  It is specified in RFC 4648.
+"""
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "fmt" {with-test & >= "0.8.7"}
+  "bos" {with-test}
+  "rresult" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz"
+  checksum: [
+    "sha256=d8fedaa59bd12feae7acc08b5928dd478aac523f4ca8d240470d2500651c65ed"
+    "sha512=278bd2029800d90ed88ff59b9de723013e645523556a1667b64178d6b5058a7d6da91efffef3589c35569b5fa10ddee74c93f5a3d156b9146c8af5b7fe44aeaf"
+  ]
+}
+x-commit-hash: "084346f14ed1e6706d733402dd6ff65b0dc4f718"


### PR DESCRIPTION
Base64 encoding for OCaml

- Project page: <a href="https://github.com/mirage/ocaml-base64">https://github.com/mirage/ocaml-base64</a>
- Documentation: <a href="https://mirage.github.io/ocaml-base64/">https://mirage.github.io/ocaml-base64/</a>

##### CHANGES:

- Few fixes about benchmarks and tests (mirage/ocaml-base64#51, @tbrk, @dinosaure)
- Add missing dependency about `fmt` and fix the compilation for OCaml 5.0 (mirage/ocaml-base64#52, @kit-ty-kate)
