### PR TITLE
Package commons.1.5.5

### DIFF
--- a/packages/commons/commons.1.5.5/opam
+++ b/packages/commons/commons.1.5.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Yet another set of common utilities"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "alcotest" {>= "1.5.0"}
+  "ANSITerminal" {>= "0.8.4"}
+  "easy_logging" {>= "0.8.1" }
+  "easy_logging_yojson" {>= "0.8.1" }
+  "yojson" {>= "1.7.0"}
+  "re" {>= "1.10.4"}
+  "ppxlib" {>= "0.25.0"}
+  "ppx_deriving" {>= "5.2.1"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/returntocorp/sgrep/archive/refs/tags/1.5.5.tar.gz"
+  checksum: [
+    "md5=3536f6162fec35b13072e8fd84c4e985"
+    "sha512=89cdda71fe2036b94ae6142f55f1a55d8d142ec3c9e49206b5a91f5f217984fd5b7564a165011dd845f5b50f32a29d3b969dc404c41d6e140a81cb7106c1ac7b"
+  ]
+}


### PR DESCRIPTION
### `commons.1.5.5`
Yet another set of common utilities
This is a small library of utilities used by Semgrep and
a few other projects developed at r2c.



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0