### PR TITLE
sun.0.1

### DIFF
--- a/packages/sun/sun.0.1/opam
+++ b/packages/sun/sun.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Take screenshot under Wayland"
+description:
+  "Sun is an OCaml executable to take screenshot from the command line in Wayland, using grim and slurp."
+maintainer: ["Léo Andrès <contact@ndrs.fr>"]
+authors: ["Léo Andrès <contact@ndrs.fr>"]
+license: "ISC"
+tags: ["sun" "screenshot" "wayland" "grim" "slurp"]
+homepage: "https://git.zapashcanon.fr/zapashcanon/sun"
+bug-reports: "https://git.zapashcanon.fr/zapashcanon/sun/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.13"}
+  "cmdliner"
+  "directories"
+  "scfg"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.zapashcanon.fr/zapashcanon/sun.git"
+url {
+  src: "https://git.zapashcanon.fr/zapashcanon/sun/archive/0.1.tar.gz"
+  checksum: [
+  "sha256=360ee3228b2bbcf066d87a3f5e158531237e087d0b746d399752df82404445ca"
+  "sha512=cbf98697bf607f7342663a0e9dfa023bc0bebfdf2080e52f76dfb43fb1cbadb75627dc4789c55d6bfe7a80df2c75266e39a2e8b3df41481ef4d377f77ed9ef40"
+  ]
+}


### PR DESCRIPTION
Hi,

This is the first release of [sun](https://git.zapashcanon.fr/zapashcanon/sun), a command line tool to take screenshots under Wayland using `grim` and `slurp`.

Cheers,