### PR TITLE
added chase.1.5

### DIFF
--- a/packages/chase/chase.1.5/opam
+++ b/packages/chase/chase.1.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+name: "chase"
+version: "1.5"
+synopsis: "Model finder for geometric theories using the chase"
+description: """
+Chase is a model finder for first order logic with equality.  It finds
+minimal models of a theory expressed in geometric form, where
+functions in models may be partial.  A formula is in geometric form if
+it is a sentence consisting of a single implication, the antecedent is
+a conjunction of atomic formulas, and the consequent is a disjunction.
+Each disjunct is a possibly existentially quantified conjunction of
+atomic formulas.  A function is partial if it is defined only on a
+proper subset of its domain.
+"""
+maintainer: "John D. Ramsdell <ramsdell@mitre.org>"
+authors: "John D. Ramsdell <ramsdell@mitre.org>"
+license: "BSD"
+homepage: "https://github.com/ramsdell/chase"
+dev-repo: "git+https://github.com/ramsdell/chase.git"
+bug-reports: "https://github.com/ramsdell/chase/issues"
+depends: ["ocaml" { >= "4.05" } "dune" { >= "1.1" }]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/ramsdell/chase/archive/1.5.tar.gz"
+  checksum: "md5=d41d8cd98f00b204e9800998ecf8427e"
+}


### PR DESCRIPTION
Updated chase to work with OCaml 5.0 by incorporating and fixing the getopt module.