### PR TITLE
Add max version bounds to OCADml dependent libraries

### DIFF
--- a/packages/OSCADml/OSCADml.0.1.1/opam
+++ b/packages/OSCADml/OSCADml.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.3"}
   "ocaml" {>= "4.14.0"}
   "cairo2" {>= "0.6.2"}
-  "OCADml" {>= "0.1.0"}
+  "OCADml" {>= "0.1.0" & < "0.3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.0/opam
+++ b/packages/ppx_deriving_cad/ppx_deriving_cad.0.1.0/opam
@@ -14,8 +14,8 @@ depends: [
   "dune" {>= "3.2"}
   "ocaml" {>= "4.14.0"}
   "base" {>= "v0.14.1" & with-test}
-  "OCADml" {>= "0.1.0" & with-test}
-  "OSCADml" {>= "0.1.0" & with-test}
+  "OCADml" {>= "0.1.0" & < "0.3.0" & with-test}
+  "OSCADml" {>= "0.1.0" & < "0.2.0" & with-test}
   "ppxlib" {>= "0.22.2"}
   "ppx_inline_test" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
Protect against upcoming breaking changes to both OCADml and OSCADml by making the version cutoffs explicit.