### PR TITLE
Package proc-smaps.0.2.0

### DIFF
--- a/packages/proc-smaps/proc-smaps.0.2.0/opam
+++ b/packages/proc-smaps/proc-smaps.0.2.0/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Proc-smaps: An ocaml parser of /proc/[pid]/smaps"
+maintainer: "Hiromasa Saito <hiromasa.saito@dailambda.jp>"
+authors: "Hiromasa Saito <hiromasa.saito@dailambda.jp>"
+license: "MIT"
+homepage: "https://gitlab.com/dailambda/proc-smaps/"
+bug-reports: "https://gitlab.com/dailambda/proc-smaps/-/issues"
+depends: [
+  "ocaml" {>= "4.8.0"}
+  "dune" {>= "2.9.0"}
+  "lwt" {>= "5.4.0"}
+  "stdint"
+  "alcotest" {with-test}
+]
+available: os = "linux"
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/dailambda/proc-smaps.git"
+url {
+  src:
+    "https://gitlab.com/dailambda/proc-smaps/-/archive/0.2.0/proc-smaps-0.2.0.tar.bz2"
+  checksum: [
+    "md5=a1762a6b8d3799fdf1cba87edb969491"
+    "sha512=85fae795629ee0965f7e8ce48ed4e707a2d235337ef52cfabb50118046ab399de1ac0550a8b41fd9d4b274b5484af97c58854d1d0adcbb8fb07f3f89533090cf"
+  ]
+}

--- a/packages/proc-smaps/proc-smaps.0.2.0/opam
+++ b/packages/proc-smaps/proc-smaps.0.2.0/opam
@@ -12,6 +12,9 @@ depends: [
   "stdint"
   "alcotest" {with-test}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 available: os = "linux"
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://gitlab.com/dailambda/proc-smaps.git"


### PR DESCRIPTION
### `proc-smaps.0.2.0`
Proc-smaps: An ocaml parser of /proc/[pid]/smaps



---
* Homepage: https://gitlab.com/dailambda/proc-smaps/
* Source repo: git+https://gitlab.com/dailambda/proc-smaps.git
* Bug tracker: https://gitlab.com/dailambda/proc-smaps/-/issues

---
:camel: Pull-request generated by opam-publish v2.1.0