### PR TITLE
ocaml 5: restrict cmark.0.2.0

### DIFF
--- a/packages/cmark/cmark.0.2.0/opam
+++ b/packages/cmark/cmark.0.2.0/opam
@@ -8,7 +8,7 @@ dev-repo: "git+ssh://git@github.com/jonathanyc/ocaml-cmark.git"
 install: ["./car" "lib"]
 remove: ["./car" "unlib"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ctypes" {>= "0.4.1"}


### PR DESCRIPTION
It fails because of Pervasives:

    #=== ERROR while installing cmark.0.2.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/cmark.0.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh install ./car lib
    # exit-code            2
    # env-file             ~/.opam/log/cmark-8-e3d0db.env
    # output-file          ~/.opam/log/cmark-8-e3d0db.out
    ### output ###
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    # automatically added to the search path, but you should add -I +unix to the
    # command-line to silence this alert (e.g. by adding unix to the list of
    # libraries in your dune file, or adding use_unix to your _tags file for
    # ocamlbuild, or using -package unix for ocamlfind).
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The str subdirectory has been
    # automatically added to the search path, but you should add -I +str to the
    # command-line to silence this alert (e.g. by adding str to the list of
    # libraries in your dune file, or adding use_str to your _tags file for
    # ocamlbuild, or using -package str for ocamlfind).
    # File "./car", line 17, characters 5-15:
    # 17 | open Pervasives
    #           ^^^^^^^^^^
    # Error: Unbound module Pervasives
