### PR TITLE
Restrict cmdtui.0.3.0 to not build on OCaml 5

### DIFF
--- a/packages/cmdtui/cmdtui.0.3.0/opam
+++ b/packages/cmdtui/cmdtui.0.3.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.02.3" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
-  "topkg" {build}
+  "topkg" {build & >= "0.7.8"}
   "astring" {>= "0.8.3"}
   "fmt" {>= "0.8.0"}
 ]

--- a/packages/cmdtui/cmdtui.0.3.0/opam
+++ b/packages/cmdtui/cmdtui.0.3.0/opam
@@ -7,7 +7,7 @@ license: "ISC"
 dev-repo: "git+https://gitlab.com/edwintorok/cmdtui.git"
 bug-reports: "https://gitlab.com/edwintorok/cmdtui/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
FTBFS on `Pervasives`

```
    === ERROR while compiling cmdtui.0.3.0 =======================================#
     context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
     path                 ~/.opam/5.0/.opam-switch/build/cmdtui.0.3.0
     command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --tests false --with-lambda-term false --with-cmdliner false --with-logs false
     exit-code            1
     env-file             ~/.opam/log/cmdtui-8-b971bf.env
     output-file          ~/.opam/log/cmdtui-8-b971bf.out
    ## output ###
     ocamlfind ocamldep -package astring -modules src/cmdtui.ml > src/cmdtui.ml.depends
     ocamlfind ocamldep -package astring -modules src/cmdtui.mli > src/cmdtui.mli.depends
     ocamlfind ocamlc -c -g -bin-annot -safe-string -short-paths -principal -strict-sequence -w A-44 -warn-error SU -package astring -I src -o src/cmdtui.cmi src/cmdtui.mli
     + ocamlfind ocamlc -c -g -bin-annot -safe-string -short-paths -principal -strict-sequence -w A-44 -warn-error SU -package astring -I src -o src/cmdtui.cmi src/cmdtui.mli
     File "_none_", line 1:
     Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
     like 'SU', is deprecated.
     Use the equivalent signed form: +S+U.
     Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
     ocamlfind ocamlopt -c -g -bin-annot -safe-string -short-paths -principal -strict-sequence -w A-44 -warn-error SU -package astring -I src -o src/cmdtui.cmx src/cmdtui.ml
     + ocamlfind ocamlopt -c -g -bin-annot -safe-string -short-paths -principal -strict-sequence -w A-44 -warn-error SU -package astring -I src -o src/cmdtui.cmx src/cmdtui.ml
     File "_none_", line 1:
     Alert ocaml_deprecated_cli: Setting a warning with a sequence of lowercase or uppercase letters,
     like 'SU', is deprecated.
     Use the equivalent signed form: +S+U.
     Hint: Enabling or disabling a warning by its mnemonic name requires a + or - prefix.
     File "src/cmdtui.ml", line 16, characters 21-25:
     16 | let const v l = l, { desc = None; choices_gen = None }, fun () -> v
                               ^^^^
     Warning 42 [disambiguated-name]: this use of desc relies on type-directed disambiguation,
     it will not compile with OCaml 4.00 or earlier.
     File "src/cmdtui.ml", line 30, characters 14-18:
     30 | | [] -> [], { desc; choices_gen = choices }, fun () -> invalid_arg "too few arguments"
                        ^^^^
     Warning 42 [disambiguated-name]: this use of desc relies on type-directed disambiguation,
     it will not compile with OCaml 4.00 or earlier.
     File "src/cmdtui.ml", line 32, characters 10-14:
     32 |     tl, { desc; choices_gen = choices }, fun () -> convert hd
                    ^^^^
     Warning 42 [disambiguated-name]: this use of desc relies on type-directed disambiguation,
     it will not compile with OCaml 4.00 or earlier.
     File "src/cmdtui.ml", line 47, characters 19-37:
     47 |     List.sort_uniq Pervasives.compare
                             ^^^^^^^^^^^^^^^^^^
     Error: Unbound module Pervasives
```