### PR TITLE
Restrict crdt-ml from building on OCaml 5

### DIFF
--- a/packages/crdt-ml/crdt-ml.0.10.0/opam
+++ b/packages/crdt-ml/crdt-ml.0.10.0/opam
@@ -24,7 +24,6 @@ description: """
 A set of useful state-based CRDTs for OCaml. Includes 6 different datatypes in both mutable and immutable versions.
 
 Please note that these implementations are for educational purposes only. They are not suited for production work."""
-flags: light-uninstall
 url {
   src: "https://github.com/ergl/crdt-ml/archive/v0.10.0.tar.gz"
   checksum: "md5=b8337dcb24a3220a3c35bd5bae5c8f12"

--- a/packages/crdt-ml/crdt-ml.0.10.0/opam
+++ b/packages/crdt-ml/crdt-ml.0.10.0/opam
@@ -13,7 +13,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "qtest" {with-test}


### PR DESCRIPTION
FTBFS with this error:

```
    #=== ERROR while compiling crdt-ml.0.10.0 =====================================#
     context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
     path                 ~/.opam/5.0/.opam-switch/build/crdt-ml.0.10.0
     command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
     exit-code            2
     env-file             ~/.opam/log/crdt-ml-8-24858e.env
     output-file          ~/.opam/log/crdt-ml-8-24858e.out
    ### output ###
     File "./setup.ml", line 1404, characters 23-41:
     1404 |          let compare = Pervasives.compare
                                   ^^^^^^^^^^^^^^^^^^
     Error: Unbound module Pervasives
```