### PR TITLE
Restrict csv.2.2 from building on OCaml 5

### DIFF
--- a/packages/csv/csv.2.2/opam
+++ b/packages/csv/csv.2.2/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "dune"
   "base-bytes"
   "base-unix"


### PR DESCRIPTION
FTBFS with missing `Pervasives`:

```
    === ERROR while compiling csv.2.2 ============================================#
     context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
     path                 ~/.opam/5.0/.opam-switch/build/csv.2.2
     command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p csv -j 255
     exit-code            1
     env-file             ~/.opam/log/csv-8-c32fd8.env
     output-file          ~/.opam/log/csv-8-c32fd8.out
    ### output ###
     (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -g -bin-annot -I src/.csv.objs/byte -I /home/opam/.opam/5.0/lib/bytes -no-alias-deps -open Csv__ -o src/.csv.objs/byte/csv.cmi -c -intf src/csv.mli)
     File "src/csv.mli", line 135, characters 17-38:
     135 |                  Pervasives.in_channel -> in_channel
                            ^^^^^^^^^^^^^^^^^^^^^
     Error: Unbound module Pervasives
```