### PR TITLE
Restrict ctypes from building on OCaml 5

### DIFF
--- a/packages/ctypes/ctypes.0.20.0/opam
+++ b/packages/ctypes/ctypes.0.20.0/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.20.0/opam
+++ b/packages/ctypes/ctypes.0.20.0/opam
@@ -12,13 +12,13 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-base" "ctypes-stubs"]
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"]
     {ctypes-foreign:installed}
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "5.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0" & < "5.0.0"}
+  "ocaml" {>= "4.03.0"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.20.1/opam
+++ b/packages/ctypes/ctypes.0.20.1/opam
@@ -18,7 +18,7 @@ install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}

--- a/packages/ctypes/ctypes.0.20.1/opam
+++ b/packages/ctypes/ctypes.0.20.1/opam
@@ -12,13 +12,13 @@ build: [
   [make "XEN=%{mirage-xen:enable}%" "ctypes-base" "ctypes-stubs"]
   [make "XEN=%{mirage-xen:enable}%" "ctypes-foreign"]
     {ctypes-foreign:installed}
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "5.0"}
 ]
 install: [
   [make "install" "XEN=%{mirage-xen:enable}%"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0" & < "5.0.0"}
+  "ocaml" {>= "4.03.0"}
   "integers" { >= "0.3.0" }
   "ocamlfind" {build}
   "lwt" {with-test & >= "3.2.0"}


### PR DESCRIPTION
FTBFS with missing Pervasives:

```
    #=== ERROR while compiling ctypes.0.20.1 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ctypes.0.20.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make test
    # exit-code            2
    # env-file             ~/.opam/log/ctypes-7-1fddc1.env
    # output-file          ~/.opam/log/ctypes-7-1fddc1.out
    ### output ###
    # gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64  -c -fPIC -Wall -g  "-I/home/opam/.opam/5.0/lib/integers" -I "/home/opam/.opam/5.0/.opam-switch/build/ctypes.0.20.1/src/ctypes" -I "/home/opam/.opam/5.0/.opam-switch/build/ctypes.0.20.1/tests" -I `ocamlfind  ocamlc -where | sed 's|\r$||'` -o _build/clib/test_functions.o tests/clib/test_functions.c
    # gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC  -D_FILE_OFFSET_BITS=64  -shared   -o _build/clib/libtest_functions.so _build/clib/test_functions.o -lm
    # ocamlfind  ocamlc    -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers"   -c -o _build/tests/tests-common/tests_common.cmo -I _build/tests/tests-common  -I _build/src/ctypes  -I _build/src/cstubs  -I _build/src/ctypes-foreign tests/tests-common/tests_common.ml
    # ocamlfind  ocamlc -a -linkall -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers"       -o _build/tests-common.cma _build/tests/tests-common/tests_common.cmo -cclib -Wl,--no-as-needed
    # ocamlfind  opt -bin-annot -c -o _build/tests/tests-common/tests_common.cmx    -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers"      -I _build/tests/tests-common  -I _build/src/ctypes  -I _build/src/cstubs  -I _build/src/ctypes-foreign tests/tests-common/tests_common.ml
    # ocamlfind  opt -a -linkall -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers"       -o _build/tests-common.cmxa _build/tests/tests-common/tests_common.cmx -cclib -Wl,--no-as-needed
    # ocamlfind  opt -bin-annot -c -o _build/tests/test-raw/test_raw.cmx -package bigarray-compat -package oUnit -package str -package integers -thread -package threads  -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread -package bigarray-compat -package oUnit -package str -package integers -thread -package threads   -I _build/tests/test-raw  -I _build/src/ctypes  -I _build/src/ctypes-foreign tests/test-raw/test_raw.ml
    # ocamlfind  opt -I _build -linkpkg -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread -package bigarray-compat -package oUnit -package str -package integers -thread -package threads  _build/ctypes.cmxa _build/ctypes-foreign.cmxa -o _build/test-raw.native _build/tests/test-raw/test_raw.cmx  -cclib -Wl,--no-as-needed
    # ocamlfind  ocamlc  -thread -package threads  -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread  -c -o _build/tests/test-pointers/stubs/functions.cmo -I _build/tests/test-pointers/stubs  -I _build/src/ctypes  -I _build/src/ctypes-foreign  -I _build/tests/tests-common tests/test-pointers/stubs/functions.ml
    # ocamlfind  ocamlc -a -linkall -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread    -thread -package threads  -o _build/test-pointers-stubs.cma _build/tests/test-pointers/stubs/functions.cmo -cclib -Wl,--no-as-needed
    # ocamlfind  opt -bin-annot -c -o _build/tests/test-pointers/stubs/functions.cmx  -thread -package threads  -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread  -thread -package threads   -I _build/tests/test-pointers/stubs  -I _build/src/ctypes  -I _build/src/ctypes-foreign  -I _build/tests/tests-common tests/test-pointers/stubs/functions.ml
    # ocamlfind  opt -a -linkall -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread  -thread -package threads    -o _build/test-pointers-stubs.cmxa _build/tests/test-pointers/stubs/functions.cmx -cclib -Wl,--no-as-needed
    # ocamlfind  opt -bin-annot -c -o _build/tests/test-pointers/stub-generator/driver.cmx -package str -package bigarray-compat -package integers -thread -package threads  -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread -package str -package bigarray-compat -package integers -thread -package threads   -I _build/tests/test-pointers/stub-generator  -I _build/src/ctypes  -I _build/src/cstubs  -I _build/src/ctypes-foreign  -I _build/tests/test-pointers/stubs  -I _build/tests/tests-common tests/test-pointers/stub-generator/driver.ml
    # ocamlfind  opt -I _build -linkpkg -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread -package str -package bigarray-compat -package integers -thread -package threads  _build/ctypes.cmxa _build/cstubs.cmxa _build/ctypes-foreign.cmxa _build/test-pointers-stubs.cmxa _build/tests-common.cmxa -o _build/test-pointers-stub-generator.native _build/tests/test-pointers/stub-generator/driver.cmx  -cclib -Wl,--no-as-needed
    # _build/test-pointers-stub-generator.native --ml-file tests/test-pointers/generated_bindings.ml
    # _build/test-pointers-stub-generator.native --c-file tests/test-pointers/generated_stubs.c
    # ocamlfind  opt -bin-annot -c -o _build/tests/test-pointers/generated_bindings.cmx -package str -package bigarray-compat -package oUnit -package integers -thread -package threads  -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread -package str -package bigarray-compat -package oUnit -package integers -thread -package threads   -I _build/tests/test-pointers  -I _build/src/ctypes  -I _build/src/ctypes-foreign  -I _build/src/cstubs  -I _build/tests/tests-common  -I _build/tests/test-pointers/stubs tests/test-pointers/generated_bindings.ml
    # ocamlfind  opt -bin-annot -c -o _build/tests/test-pointers/test_pointers.cmx -package str -package bigarray-compat -package oUnit -package integers -thread -package threads  -principal -short-paths -strict-sequence -g -ccopt "-I/home/opam/.opam/5.0/lib/integers" -thread -package str -package bigarray-compat -package oUnit -package integers -thread -package threads   -I _build/tests/test-pointers  -I _build/src/ctypes  -I _build/src/ctypes-foreign  -I _build/src/cstubs  -I _build/tests/tests-common  -I _build/tests/test-pointers/stubs tests/test-pointers/test_pointers.ml
    # File "tests/test-pointers/test_pointers.ml", line 66, characters 6-16:
    # 66 |       Pervasives.(1 + 2 + 3 + 4)
    #            ^^^^^^^^^^
    # Error: Unbound module Pervasives
```