### PR TITLE
Restrict cubicle.1.1.2 from building on OCaml 5

### DIFF
--- a/packages/cubicle/cubicle.1.1.2/opam
+++ b/packages/cubicle/cubicle.1.1.2/opam
@@ -13,7 +13,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "ocamlfind"
   "num"
 ]


### PR DESCRIPTION
FTBFS with missing `Pervasives`:

```
   #=== ERROR while compiling cubicle.1.1.2 ======================================#
   # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
   # path                 ~/.opam/5.0/.opam-switch/build/cubicle.1.1.2
   # command              ~/.opam/opam-init/hooks/sandbox.sh build make
   # exit-code            2
   # env-file             ~/.opam/log/cubicle-8-0a6b6f.env
   # output-file          ~/.opam/log/cubicle-8-0a6b6f.out
   ### output ###
   # fatal: not a git repository (or any parent up to mount point /)
   # Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
   # Compiling parser.mly
   # Compiling lexer.mll
   # Compiling muparser.mly
   # Compiling mulexer.mll
   # Compiling version.cmx
   # Compiling options.cmi
   # Compiling options.cmx
   # File "_none_", line 1:
   # Alert ocaml_deprecated_auto_include:
   # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
   # automatically added to the search path, but you should add -I +unix to the
   # command-line to silence this alert (e.g. by adding unix to the list of
   # libraries in your dune file, or adding use_unix to your _tags file for
   # ocamlbuild, or using -package unix for ocamlfind).
   # Compiling common/timer.cmi
   # Compiling common/timer.cmx
   # File "_none_", line 1:
   # Alert ocaml_deprecated_auto_include:
   # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
   # automatically added to the search path, but you should add -I +unix to the
   # command-line to silence this alert (e.g. by adding unix to the list of
   # libraries in your dune file, or adding use_unix to your _tags file for
   # ocamlbuild, or using -package unix for ocamlfind).
   # Compiling common/hashcons.cmi
   # Compiling common/hashcons.cmx
   # Compiling common/hstring.cmi
   # Compiling common/hstring.cmx
   # Compiling common/vec.cmi
   # Compiling common/vec.cmx
   # Compiling common/heap.cmi
   # Compiling common/heap.cmx
   # Compiling common/iheap.cmi
   # Compiling common/iheap.cmx
   # Compiling smt/ty.cmi
   # Compiling smt/ty.cmx
   # File "smt/ty.ml", line 52, characters 16-34:
   # 52 |     | t1, t2 -> Pervasives.compare t1 t2
   #                      ^^^^^^^^^^^^^^^^^^
   # Error: Unbound module Pervasives
```