### PR TITLE
Restrict diet from building on OCaml 5

### DIFF
--- a/packages/diet/diet.0.2/opam
+++ b/packages/diet/diet.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0" & < "5.0.0"}
   "result"
   "sexplib"
-  "dune"
+  "dune" {>= "1.2"}
   "ppx_sexp_conv" {>= "v0.9.0"}
 ]
 synopsis: "Discrete Interval Encoding Trees"

--- a/packages/diet/diet.0.2/opam
+++ b/packages/diet/diet.0.2/opam
@@ -12,7 +12,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "result"
   "sexplib"
   "dune"

--- a/packages/diet/diet.0.3/opam
+++ b/packages/diet/diet.0.3/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/mirage/ocaml-diet"
 doc: "https://mirage.github.io/ocaml-diet/"
 bug-reports: "https://github.com/mirage/ocaml-diet/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "sexplib"
   "dune"
   "ppx_sexp_conv" {>= "v0.9.0"}


### PR DESCRIPTION
FTBFS with missing `Pervasives`:

```
    #=== ERROR while compiling diet.0.3 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/diet.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p diet -j 127
    # exit-code            1
    # env-file             ~/.opam/log/diet-9-9f0768.env
    # output-file          ~/.opam/log/diet-9-9f0768.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I lib/.diet.objs/byte -I lib/.diet.objs/native -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -o lib/.diet.objs/native/diet.cmx -c -impl lib/diet.pp.ml)
    # File "lib/diet.ml", line 134, characters 11-21:
    # 134 |   let open Pervasives in
    #                  ^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.diet.objs/byte -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -intf-suffix .ml -no-alias-deps -o lib/.diet.objs/byte/diet.cmo -c -impl lib/diet.pp.ml)
    # File "lib/diet.ml", line 134, characters 11-21:
    # 134 |   let open Pervasives in
    #                  ^^^^^^^^^^
    # Error: Unbound module Pervasives
```