### PR TITLE
Restrict dolmen.0.4.1 from building on OCaml 5

### DIFF
--- a/packages/dolmen/dolmen.0.4.1/opam
+++ b/packages/dolmen/dolmen.0.4.1/opam
@@ -6,7 +6,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "menhir" {>= "20151005"}
   "dune" {>= "1.5.0"}
 ]

--- a/packages/dolmen/dolmen.0.4.1/opam
+++ b/packages/dolmen/dolmen.0.4.1/opam
@@ -7,7 +7,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "5.0.0"}
-  "menhir" {>= "20151005"}
+  "menhir" {>= "20151023"}
   "dune" {>= "1.5.0"}
 ]
 tags: [ "parser" "tptp" "logic" "smtlib" "dimacs" ]

--- a/packages/dolmen/dolmen.0.4.1/opam
+++ b/packages/dolmen/dolmen.0.4.1/opam
@@ -7,7 +7,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.02.3" & < "5.0.0"}
-  "menhir" {>= "20151023"}
+  "menhir" {>= "20180528"}
   "dune" {>= "1.5.0"}
 ]
 tags: [ "parser" "tptp" "logic" "smtlib" "dimacs" ]


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling dolmen.0.4.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/dolmen.0.4.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dolmen -j 127
    # exit-code            1
    # env-file             ~/.opam/log/dolmen-8-1816f7.env
    # output-file          ~/.opam/log/dolmen-8-1816f7.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/standard/.dolmen_std.objs/byte -I /home/opam/.opam/5.0/lib/menhirLib -I src/interface/.dolmen_intf.objs/byte -I src/languages/line/.dolmen_line.objs/byte -intf-suffix .ml -no-alias-deps -open Dolmen_std -o src/standard/.dolmen_std.objs/byte/dolmen_std__Id.cmo -c -impl src/standard/id.ml)
    # File "src/standard/id.ml", line 18, characters 14-32:
    # 18 | let compare = Pervasives.compare
    #                    ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/standard/.dolmen_std.objs/byte -I src/standard/.dolmen_std.objs/native -I /home/opam/.opam/5.0/lib/menhirLib -I src/interface/.dolmen_intf.objs/byte -I src/interface/.dolmen_intf.objs/native -I src/languages/line/.dolmen_line.objs/byte -I src/languages/line/.dolmen_line.objs/native -intf-suffix .ml -no-alias-deps -open Dolmen_std -o src/standard/.dolmen_std.objs/native/dolmen_std__Id.cmx -c -impl src/standard/id.ml)
    # File "src/standard/id.ml", line 18, characters 14-32:
    # 18 | let compare = Pervasives.compare
    #                    ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/standard/.dolmen_std.objs/byte -I /home/opam/.opam/5.0/lib/menhirLib -I src/interface/.dolmen_intf.objs/byte -I src/languages/line/.dolmen_line.objs/byte -intf-suffix .ml -no-alias-deps -open Dolmen_std -o src/standard/.dolmen_std.objs/byte/dolmen_std__Term.cmo -c -impl src/standard/term.ml)
    # File "src/standard/term.ml", line 205, characters 29-47:
    # 205 |   | Builtin b, Builtin b' -> Pervasives.compare b b'
    #                                    ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```