### PR TITLE
libssh: disable tests

### DIFF
--- a/packages/libssh/libssh.0.1/opam
+++ b/packages/libssh/libssh.0.1/opam
@@ -10,9 +10,9 @@ build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-#  ["oasis" "setup"] {with-test}
-#  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-#  ["ocaml" "setup.ml" "-build"] {with-test}
+  ["oasis" "setup"] {with-test}
+  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
+  ["ocaml" "setup.ml" "-build"] {with-test}
 #  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]

--- a/packages/libssh/libssh.0.1/opam
+++ b/packages/libssh/libssh.0.1/opam
@@ -10,10 +10,10 @@ build: [
   ["oasis" "setup"]
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]
-  ["oasis" "setup"] {with-test}
-  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
-  ["ocaml" "setup.ml" "-build"] {with-test}
-  ["ocaml" "setup.ml" "-test"] {with-test}
+#  ["oasis" "setup"] {with-test}
+#  ["ocaml" "setup.ml" "-configure" "--enable-tests"] {with-test}
+#  ["ocaml" "setup.ml" "-build"] {with-test}
+#  ["ocaml" "setup.ml" "-test"] {with-test}
   ["ocaml" "setup.ml" "-doc"] {with-doc}
 ]
 install: ["ocaml" "setup.ml" "-install"]


### PR DESCRIPTION
The only test in the package tries to hit a private server, which does
not exist anymore (and probably requires authentication):

https://github.com/fxfactorial/ocaml-libssh/blob/v0.1/tests/r_test.ml
