### PR TITLE
mlmpfr: ignore errors on Debian 11

### DIFF
--- a/packages/mlmpfr/mlmpfr.3.1.6/opam
+++ b/packages/mlmpfr/mlmpfr.3.1.6/opam
@@ -22,7 +22,7 @@ depends: [
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 post-messages: [
   "Make sure you had MPFR version 3.1.6 installed on your system.
    If you need support for an older MPFR release, please contact me." {failure}

--- a/packages/mlmpfr/mlmpfr.4.0.0/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.0/opam
@@ -22,7 +22,7 @@ depends: [
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 post-messages: [
   "Make sure you had MPFR version 4.0.0 installed on your system." {failure}
 ]

--- a/packages/mlmpfr/mlmpfr.4.0.1/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.1/opam
@@ -22,7 +22,7 @@ depends: [
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 post-messages: [
   "Make sure you had MPFR version 4.0.1 installed on your system." {failure}
 ]

--- a/packages/mlmpfr/mlmpfr.4.0.2/opam
+++ b/packages/mlmpfr/mlmpfr.4.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind"
   "oasis"
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: ["debian-11" "debian-unstable"]
 depexts: [
   ["libmpfr-dev"] {os-family = "debian"}
 ]


### PR DESCRIPTION
The "test_installed" program checks the upstream version and aborts if
this version is not supported.

- 3.1.6 wants <= 3.1.6
- 4.0.0 wants 4.0.0
- 4.0.1 wants 4.0.0 or 4.0.1
- 4.0.2 wants 4.0.0, 4.0.1, or 4.0.2

But Debian 11 has 4.1.0 so none of these releases are expected to work.
