### PR TITLE
Only run eqaf.0.2 tests on OCaml < 5

### DIFF
--- a/packages/eqaf/eqaf.0.2/opam
+++ b/packages/eqaf/eqaf.0.2/opam
@@ -12,7 +12,7 @@ This package provides an equal function on string in constant-time to avoid timi
 """
 
 build: [
-  [ "dune" "subst" ] {dev}
+  [ "dune" "subst" ]
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & ocaml:version < "5.0.0"}
 ]

--- a/packages/eqaf/eqaf.0.2/opam
+++ b/packages/eqaf/eqaf.0.2/opam
@@ -12,7 +12,7 @@ This package provides an equal function on string in constant-time to avoid timi
 """
 
 build: [
-  [ "dune" "subst" ]
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
   [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & ocaml:version < "5.0.0"}
 ]

--- a/packages/eqaf/eqaf.0.2/opam
+++ b/packages/eqaf/eqaf.0.2/opam
@@ -14,7 +14,7 @@ This package provides an equal function on string in constant-time to avoid timi
 build: [
   [ "dune" "subst" ]
   [ "dune" "build" "-p" name "-j" jobs ]
-  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & ocaml:version < "5.0.0"}
 ]
 
 depends: [


### PR DESCRIPTION
Tests fail otherwise due to `Pervasives`:

```
    #=== ERROR while compiling eqaf.0.2 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/eqaf.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p eqaf -j 71
    # exit-code            1
    # env-file             ~/.opam/log/eqaf-7-4445ac.env
    # output-file          ~/.opam/log/eqaf-7-4445ac.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/5.0/lib/fmt -I lib/.eqaf.objs/byte -I test/.clock.objs/byte -no-alias-deps -o test/.test.eobjs/byte/test.cmo -c -impl test/test.ml)
    # File "test/test.ml", line 362, characters 20-28:
    # 362 |             { name= Fmt.strf "%s:%d" name v
    #                           ^^^^^^^^
    # Alert deprecated: Fmt.strf
    # use Fmt.str instead.
    # File "test/test.ml", line 689, characters 13-31:
    # 689 |   Array.sort Pervasives.compare arr ;
    #                    ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```