### PR TITLE
[new release] lockfree (0.3.1)

### DIFF
--- a/packages/lockfree/lockfree.0.3.1/opam
+++ b/packages/lockfree/lockfree.0.3.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage: "https://github.com/ocaml-multicore/lockfree"
+doc: "https://ocaml-multicore.github.io/lockfree"
+synopsis: "Lock-free data structures for multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/lockfree.git"
+bug-reports: "https://github.com/ocaml-multicore/lockfree/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "3.0"}
+  "domain_shims" {>= "0.1.0"}
+  "qcheck" {with-test & >= "0.18.1"}
+  "qcheck-stm" {with-test & >= "0.1"}
+  "qcheck-alcotest" {with-test & >= "0.18.1"}
+  "alcotest" {>= "1.6.0"}
+  "yojson" {>= "2.0.2"}
+  "dscheck" {with-test & >= "0.0.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/ocaml-multicore/lockfree/releases/download/0.3.1/lockfree-0.3.1.tbz"
+  checksum: [
+    "sha256=565f758aef2134af4c242e82df91e6262ace6fdebe25b070de01c07bc9fd49b7"
+    "sha512=f27242e825588ec569417ef9bf510975b1ee17b7bc78ed54c879b2f6d731e03c300f38ee20fef6bc45ed715e59a4a3bdb61cbccefe817570f916fe20ce4cefeb"
+  ]
+}
+x-commit-hash: "850f44a55277af7b0734667ccab13ed9b929f303"


### PR DESCRIPTION
Lock-free data structures for multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/lockfree">https://github.com/ocaml-multicore/lockfree</a>
- Documentation: <a href="https://ocaml-multicore.github.io/lockfree">https://ocaml-multicore.github.io/lockfree</a>

##### CHANGES:

All notable changes to this project will be documented in this file.

## 0.3.1

* Rework dscheck integration to work with utop (@lyrm)
* Add OCaml 4 compatability (@sudha247)
* Add STM ws_deque tests (@jmid, @lyrm)

