### PR TITLE
Do not build lens versions on OCaml 5

### DIFF
--- a/packages/lens/lens.1.0.0/opam
+++ b/packages/lens/lens.1.0.0/opam
@@ -3,6 +3,7 @@ maintainer: "Paolo Donadeo <p.donadeo@gmail.com>"
 authors: [ "Alessandro Strada <alessandro.strada@gmail.com>" ]
 license: "BSD-3-Clause"
 homepage: "https://github.com/pdonadeo/ocaml-lens"
+bug-reports: "https://github.com/pdonadeo/ocaml-lens/issues"
 build: [
   ["ocaml" "setup.ml" "-configure" "--prefix" prefix]
   ["ocaml" "setup.ml" "-build"]

--- a/packages/lens/lens.1.0.0/opam
+++ b/packages/lens/lens.1.0.0/opam
@@ -12,7 +12,7 @@ remove: [
   ["ocamlfind" "remove" "lens"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/lens/lens.1.0.2/opam
+++ b/packages/lens/lens.1.0.2/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "lens"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/lens/lens.1.1.0/opam
+++ b/packages/lens/lens.1.1.0/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "lens"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ounit" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
They fail to build for different reasons:

```
    #=== ERROR while compiling lens.1.1.0 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lens.1.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/lens-8-cdf476.env
    # output-file          ~/.opam/log/lens-8-cdf476.out
    ### output ###
    # File "./setup.ml", line 1404, characters 23-41:
    # 1404 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```

Whereas older versions fail because of ASCII functions presumably generated by OASIS:

```
    #=== ERROR while compiling lens.1.0.2 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lens.1.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/lens-7-dca6db.env
    # output-file          ~/.opam/log/lens-7-dca6db.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
```