### PR TITLE
Do not build linksem.0.7 on OCaml 5

### DIFF
--- a/packages/linksem/linksem.0.7/opam
+++ b/packages/linksem/linksem.0.7/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://github.com/rems-project/linksem.git"
 build: [make]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.06.1"}
+  "ocaml" {>= "4.06.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "lem" {>= "2018-05-11"}


### PR DESCRIPTION
FTBFS because it uses `Pervasives`:

```
    #=== ERROR while compiling linksem.0.7 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/linksem.0.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/linksem-8-2c3b76.env
    # output-file          ~/.opam/log/linksem-8-2c3b76.out
    ### output ###
    # make -C src
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/linksem.0.7/src'
    # OCAMLPATH is
    # lem.mk:13: MAKECMDGOALS is
    # CAML_LD_LIBRARY_PATH=/home/opam/.opam/5.0/lib/stublibs:/home/opam/.opam/5.0/lib/ocaml/stublibs:/home/opam/.opam/5.0/lib/ocaml
    # OCAML_TOPLEVEL_PATH=/home/opam/.opam/5.0/lib/toplevel
    # fatal: not a git repository (or any parent up to mount point /)
    # Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
    # Makefile:11: warning: overriding recipe for target 'clean'
    # no_ocamlbuild.mk:108: warning: ignoring old recipe for target 'clean'
    <hundreds of lines skipped>
    # mkdir -p "build_zarith/"
    # ocamlfind ocamlc -c -g -I adaptors -I abis -I abis/amd64 -I abis/power64 -I abis/aarch64 -I abis/x86 -I abis/mips64 -I abis/riscv -I abis/cheri_mips64 -I gnu_extensions -package num -package lem uint64_wrapper.ml uint32_wrapper.ml show.ml endianness.ml error.ml ml_bindings.ml missing_pervasives.ml multimap.ml default_printing.ml byte_sequence_wrapper.ml byte_sequence_impl.ml filesystem.ml filesystem_wrapper.ml byte_sequence.ml byte_pattern.ml byte_pattern_extra.ml archive.ml elf_types_native_uint.ml hex_printing.ml string_table.ml auxv.ml elf_header.ml elf_symbol_table.ml elf_program_header_table.ml elf_section_header_table.ml elf_relocation.ml elf_interpreted_segment.ml elf_interpreted_section.ml elf_note.ml elf_file.ml elf_dynamic.ml dwarf_ctypes.ml dwarf.ml ldconfig.ml abis/abi_classes.ml memory_image.ml memory_image_orderings.ml abis/abi_utilities.ml gnu_extensions/gnu_ext_abi.ml abis/power64/abi_power64.ml abis/power64/abi_power64_elf_header.ml abis/power64/abi_power64_section_header_table.ml abis/power64/abi_power64_dynamic.ml abis/aarch64/abi_aarch64_le_elf_header.ml abis/aarch64/abi_aarch64_symbol_table.ml abis/aarch64/abi_aarch64_section_header_table.ml abis/aarch64/abi_aarch64_program_header_table.ml abis/aarch64/abi_aarch64_le_serialisation.ml abis/aarch64/abi_aarch64_relocation.ml abis/aarch64/abi_aarch64_le.ml abstract_linker_script.ml abis/amd64/abi_amd64_elf_header.ml abis/amd64/abi_amd64_serialisation.ml abis/amd64/abi_amd64_relocation.ml abis/amd64/abi_amd64_program_header_table.ml abis/amd64/abi_amd64_section_header_table.ml abis/amd64/abi_amd64_symbol_table.ml abis/amd64/abi_amd64.ml abis/mips64/abi_mips64_dynamic.ml abis/mips64/abi_mips64_elf_header.ml abis/mips64/abi_mips64_relocation.ml abis/mips64/abi_mips64_serialisation.ml abis/mips64/abi_mips64_program_header_table.ml abis/mips64/abi_mips64_section_header_table.ml abis/mips64/abi_mips64_symbol_table.ml abis/mips64/abi_mips64.ml abis/x86/abi_x86_relocation.ml abis/power64/abi_power64_relocation.ml abis/riscv/abi_riscv_elf_header.ml abis/riscv/abi_riscv_program_header_table.ml abis/riscv/abi_riscv_relocation.ml abis/riscv/abi_riscv_section_header_table.ml abis/riscv/abi_riscv_serialisation.ml abis/riscv/abi_riscv_symbol_table.ml abis/riscv/abi_riscv.ml abis/cheri_mips64/abi_cheri_mips64_capability.ml abis/cheri_mips64/abi_cheri_mips64_dynamic.ml abis/cheri_mips64/abi_cheri_mips64_elf_header.ml abis/cheri_mips64/abi_cheri_mips64_relocation.ml abis/cheri_mips64/abi_cheri_mips64.ml gnu_extensions/gnu_ext_types_native_uint.ml gnu_extensions/gnu_ext_section_header_table.ml gnu_extensions/gnu_ext_dynamic.ml gnu_extensions/gnu_ext_symbol_versioning.ml gnu_extensions/gnu_ext_program_header_table.ml gnu_extensions/gnu_ext_section_to_segment_mapping.ml gnu_extensions/gnu_ext_note.ml abis/abis.ml adaptors/sail_interface.ml adaptors/harness_interface.ml elf_memory_image.ml elf_memory_image_of_elf64_file.ml command_line.ml input_list.ml linkable_list.ml linker_script.ml link.ml load.ml elf64_file_of_elf_memory_image.ml test_image.ml
    # File "show.ml", line 113, characters 16-40:
    # 113 |   show_method = Pervasives.string_of_int})
    #                       ^^^^^^^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```