### PR TITLE
Only run lwt-dllist tests on OCaml < 5

### DIFF
--- a/packages/lwt-dllist/lwt-dllist.1.0.0/opam
+++ b/packages/lwt-dllist/lwt-dllist.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
 build: [
  ["dune" "subst"] {dev}
  ["dune" "build" "-p" name "-j" jobs]
- ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0.0"}
 ]
 dev-repo: "git+https://github.com/mirage/lwt-dllist.git"
 synopsis: "Mutable doubly-linked list with Lwt iterators"


### PR DESCRIPTION
Building the test fails on `Pervasives`:

```
    #=== ERROR while compiling lwt-dllist.1.0.0 ===================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lwt-dllist.1.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p lwt-dllist -j 71
    # exit-code            1
    # env-file             ~/.opam/log/lwt-dllist-7-cf9f36.env
    # output-file          ~/.opam/log/lwt-dllist-7-cf9f36.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w +A-40-42 -g -I test/.main.eobjs/byte -I test/.main.eobjs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/lwt/unix -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ocplib-endian -I /home/opam/.opam/5.0/lib/ocplib-endian/bigstring -I src/.lwt_dllist.objs/byte -I src/.lwt_dllist.objs/native -intf-suffix .ml -no-alias-deps -o test/.main.eobjs/native/test.cmx -c -impl test/test.ml)
    # File "test/test.ml", line 99, characters 4-20:
    # 99 |     Pervasives.flush stdout;
    #          ^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```