### PR TITLE
Do not build ocamlfind-lint on OCaml 5

### DIFF
--- a/packages/ocamlfind-lint/ocamlfind-lint.0.1.0/opam
+++ b/packages/ocamlfind-lint/ocamlfind-lint.0.1.0/opam
@@ -8,7 +8,10 @@ tags: ["findlib" "ocamlfind" "check" "META"]
 
 build: [make "all"]
 remove: [["ocamlfind" "remove" "findlib-lint"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0.0"}
+  "ocamlfind"
+]
 dev-repo: "git+https://github.com/zoggy/findlib-lint"
 install: [make "install-lib"]
 synopsis: "Simple tool performing checks on installed findlib META files"


### PR DESCRIPTION
FTBFS due to `Pervasives`:

```
    #=== ERROR while compiling ocamlfind-lint.0.1.0 ===============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocamlfind-lint.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make all
    # exit-code            2
    # env-file             ~/.opam/log/ocamlfind-lint-8-acaf0e.env
    # output-file          ~/.opam/log/ocamlfind-lint-8-acaf0e.out
    ### output ###
    # ocamlfind ocamlopt -o ocamlfind-lint -package findlib -linkpkg findlib_lint.ml
    # File "findlib_lint.ml", line 111, characters 36-54:
    # 111 |         let pkg_missing = List.sort Pervasives.compare pkg_missing in
    #                                           ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```