### PR TITLE
Restrict ocaml-protoc-plugin.1.0.0 to not build on OCaml 5

### DIFF
--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.1.0.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.1.0.0/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "conf-protoc"
   "dune" {>= "1.10"}
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0.0"}
   "ppx_expect" {with-test}
   "ppx_inline_test" {with-test}
   "ppx_deriving" {with-test}


### PR DESCRIPTION
FTBFS with missing `Pervasives`:

```
    #=== ERROR while compiling ocaml-protoc-plugin.1.0.0 ==========================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocaml-protoc-plugin.1.0.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocaml-protoc-plugin -j 47
    # exit-code            1
    # env-file             ~/.opam/log/ocaml-protoc-plugin-7-c6bf80.env
    # output-file          ~/.opam/log/ocaml-protoc-plugin-7-c6bf80.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/protobuf/.protobuf.objs/byte -no-alias-deps -open Protobuf__ -o src/protobuf/.protobuf.objs/byte/protobuf__Writer.cmo -c -impl src/protobuf/writer.ml)
    # File "src/protobuf/writer.ml", line 37, characters 6-16:
    # 37 |       Pervasives.(offset + 1)
    #            ^^^^^^^^^^
    # Error: Unbound module Pervasives
```