### PR TITLE
Do not build odepack.0.6.{7,8} on OCaml 5

### DIFF
--- a/packages/odepack/odepack.0.6.7/opam
+++ b/packages/odepack/odepack.0.6.7/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "odepack"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "base-bigarray"
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/odepack/odepack.0.6.8/opam
+++ b/packages/odepack/odepack.0.6.8/opam
@@ -19,7 +19,7 @@ remove: [
   ["ocamlfind" "remove" "odepack"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "base-bigarray"
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
They fail due to various issues. `odepack.0.6.7` is missing `Pervasives`:

```
    #=== ERROR while compiling odepack.0.6.7 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/odepack.0.6.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/odepack-8-6fff7f.env
    # output-file          ~/.opam/log/odepack-8-6fff7f.out
    ### output ###
    # File "./setup.ml", line 1402, characters 23-41:
    # 1402 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```

Whereas `odepack.0.6.8` fails due to missing `Stream`:

```
    #=== ERROR while compiling odepack.0.6.8 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/odepack.0.6.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/odepack-8-8c0d41.env
    # output-file          ~/.opam/log/odepack-8-8c0d41.out
    ### output ###
    # File "./setup.ml", line 579, characters 4-15:
    # 579 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
```

Given the nature of these failures is quite related, I put them in the same PR to not deal with odepack twice.