### PR TITLE
Do not build osdp on OCaml 5

### DIFF
--- a/packages/osdp/osdp.0.6.0/opam
+++ b/packages/osdp/osdp.0.6.0/opam
@@ -10,7 +10,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind remove osdp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild"
   "zarith"

--- a/packages/osdp/osdp.1.0.0/opam
+++ b/packages/osdp/osdp.1.0.0/opam
@@ -12,6 +12,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "conf-autoconf" {build}

--- a/packages/osdp/osdp.1.1.0/opam
+++ b/packages/osdp/osdp.1.1.0/opam
@@ -12,6 +12,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "conf-autoconf" {build}


### PR DESCRIPTION
FTBFS due to `Pervasives`:

```
    #=== ERROR while compiling osdp.1.1.0 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/osdp.1.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/osdp-8-b34d55.env
    # output-file          ~/.opam/log/osdp-8-b34d55.out
    ### output ###
    # make -C src osdp
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/osdp.1.1.0/src'
    # ocamlbuild -use-ocamlfind -classic-display -no-links osdp.cma osdp_top.cmo osdp.cmxa osdp.cmxs
    # ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
    # ocamlfind ocamlc -g -ccopt -frounding-math -package zarith -package ocplib-simplex -c csdp_stubs.c
    # ocamlfind ocamlc -g -ccopt -frounding-math -package zarith -package ocplib-simplex -c moseksdp_stubs.c
    # ocamlfind ocamlc -g -ccopt -frounding-math -package zarith -package ocplib-simplex -c posdef_stubs.c
    # ocamlfind ocamlmklib -o osdp -g csdp_stubs.o moseksdp_stubs.o posdef_stubs.o
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules csdp.mli > csdp.mli.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpRet.mli > sdpRet.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdpRet.cmi sdpRet.mli
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o csdp.cmi csdp.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules csdp.ml > csdp.ml.depends
    # /home/opam/.opam/5.0/bin/ocamllex.opt -q csdp_lexer.mll
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules csdp_lexer.ml > csdp_lexer.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlyacc csdp_parser.mly
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules csdp_parser.mli > csdp_parser.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o csdp_parser.cmi csdp_parser.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules csdp_path.ml > csdp_path.ml.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o csdp_lexer.cmo csdp_lexer.ml
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o csdp_path.cmo csdp_path.ml
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules csdp_parser.ml > csdp_parser.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules dualize.mli > dualize.mli.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules ident.mli > ident.mli.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules linExpr.mli > linExpr.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o ident.cmi ident.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules scalar.mli > scalar.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o scalar.cmi scalar.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdp.mli > sdp.mli.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdp_default.ml > sdp_default.ml.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdp_default.cmo sdp_default.ml
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o linExpr.cmi linExpr.mli
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdp.cmi sdp.mli
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o dualize.cmi dualize.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules dualize.ml > dualize.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules utils.mli > utils.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o utils.cmi utils.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules ident.ml > ident.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules linExpr.ml > linExpr.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules lmi.mli > lmi.mli.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules matrix.mli > matrix.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o matrix.cmi matrix.mli
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o lmi.cmi lmi.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules lmi.ml > lmi.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules posdef.mli > posdef.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o posdef.cmi posdef.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules matrix.ml > matrix.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules monomial.mli > monomial.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o monomial.cmi monomial.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules monomial.ml > monomial.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules moseksdp.mli > moseksdp.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o moseksdp.cmi moseksdp.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules moseksdp.ml > moseksdp.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules newtonPolytope.mli > newtonPolytope.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o newtonPolytope.cmi newtonPolytope.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules newtonPolytope.ml > newtonPolytope.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules polynomial.mli > polynomial.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o polynomial.cmi polynomial.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules polynomial.ml > polynomial.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules posdef.ml > posdef.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules preSdp.mli > preSdp.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o preSdp.cmi preSdp.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules preSdp.ml > preSdp.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules scalar.ml > scalar.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdp.ml > sdp.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpa.mli > sdpa.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdpa.cmi sdpa.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpa.ml > sdpa.ml.depends
    # /home/opam/.opam/5.0/bin/ocamllex.opt -q sdpa_lexer.mll
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpa_lexer.ml > sdpa_lexer.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlyacc sdpa_parser.mly
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpa_parser.mli > sdpa_parser.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdpa_parser.cmi sdpa_parser.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpa_paths.ml > sdpa_paths.ml.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdpa_lexer.cmo sdpa_lexer.ml
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sdpa_paths.cmo sdpa_paths.ml
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpa_parser.ml > sdpa_parser.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sdpRet.ml > sdpRet.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sos.mli > sos.mli.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o sos.cmi sos.mli
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules sos.ml > sos.ml.depends
    # ocamlfind ocamldep -package zarith -package ocplib-simplex -modules utils.ml > utils.ml.depends
    # ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o csdp.cmo csdp.ml
    # + ocamlfind ocamlc -c -g -package zarith -package ocplib-simplex -o csdp.cmo csdp.ml
    # File "csdp.ml", line 38, characters 11-30:
    # 38 |   let oc = Pervasives.open_out filename in
    #                 ^^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```