### PR TITLE
Do not build posix-time.1.0.0-0 on OCaml 5

### DIFF
--- a/packages/posix-time/posix-time.1.0.0-0/opam
+++ b/packages/posix-time/posix-time.1.0.0-0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "posix-time"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
FTBFS due to OASIS generating code that is not OCaml 5 compatible:

```
    #=== ERROR while compiling posix-time.1.0.0-0 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/posix-time.1.0.0-0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/posix-time-8-b1f668.env
    # output-file          ~/.opam/log/posix-time-8-b1f668.out
    ### output ###
    # File "./setup.ml", line 1404, characters 23-41:
    # 1404 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```