### PR TITLE
Do not build quest.0.1 on OCaml 5

### DIFF
--- a/packages/quest/quest.0.1/opam
+++ b/packages/quest/quest.0.1/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "PREFIX=%{prefix}%" "install"]
 remove: [make "PREFIX=%{prefix}%" "remove"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "lipsum"
 ]
 synopsis:


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling quest.0.1 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/quest.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/quest-8-6d92a2.env
    # output-file          ~/.opam/log/quest-8-6d92a2.out
    ### output ###
    # make -C lua-ml all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/quest.0.1/lua-ml'
    # lipsum tangle -f cpp lua.ml lua.nw > lua.ml
    # lipsum tangle -f cpp lua.mli lua.nw > lua.mli
    # lipsum tangle -f cpp luaast.ml luaast.nw > luaast.ml
    # lipsum tangle -f cpp luaast.mli luaast.nw > luaast.mli
    # lipsum tangle -f cpp luabaselib.ml luabaselib.nw > luabaselib.ml
    # lipsum tangle -f cpp luabaselib.mli luabaselib.nw > luabaselib.mli
    # lipsum tangle -f cpp luacamllib.ml luacamllib.nw > luacamllib.ml
    # lipsum tangle -f cpp luacamllib.mli luacamllib.nw > luacamllib.mli
    # lipsum tangle -f cpp luacode.mli luacode.nw > luacode.mli
    # lipsum tangle -f cpp luafloat.mll luavalue.nw > luafloat.mll
    # lipsum tangle -f cpp luahash.ml luahash.nw > luahash.ml
    # lipsum tangle -f cpp luahash.mli luahash.nw > luahash.mli
    # lipsum tangle -f cpp luainterp.ml luastdinterp.nw > luainterp.ml
    # lipsum tangle -f cpp luainterp.mli luastdinterp.nw > luainterp.mli
    # lipsum tangle -f cpp luaiolib.ml luaiolib.nw > luaiolib.ml
    # lipsum tangle -f cpp luaiolib.mli luaiolib.nw > luaiolib.mli
    # lipsum tangle -f cpp lualib.ml lualib.nw > lualib.ml
    # lipsum tangle -f cpp lualib.mli lualib.nw > lualib.mli
    # lipsum tangle -f cpp lualink.ml lualink.nw > lualink.ml
    # lipsum tangle -f cpp lualink.mli lualink.nw > lualink.mli
    # lipsum tangle -f cpp luamathlib.ml luamathlib.nw > luamathlib.ml
    # lipsum tangle -f cpp luamathlib.mli luamathlib.nw > luamathlib.mli
    # lipsum tangle -f cpp luaparser.mli luasyntax.nw > luaparser.mli
    # lipsum tangle -f cpp luaparser.mly luasyntax.nw > luaparser.mly
    # lipsum tangle -f cpp luarun.ml luarun.nw > luarun.ml
    # lipsum tangle -f cpp luarun.mli luarun.nw > luarun.mli
    # lipsum tangle -f cpp luascanner.mll luasyntax.nw > luascanner.mll
    # lipsum tangle -f cpp luasrcmap.ml luasrcmap.nw > luasrcmap.ml
    # lipsum tangle -f cpp luasrcmap.mli luasrcmap.nw > luasrcmap.mli
    # lipsum tangle -f cpp luastrlib.ml luastrlib.nw > luastrlib.ml
    # lipsum tangle -f cpp luastrlib.mli luastrlib.nw > luastrlib.mli
    # lipsum tangle -f cpp luavalue.ml luavalue.nw > luavalue.ml
    # lipsum tangle -f cpp luavalue.mli luavalue.nw > luavalue.mli
    # mv luaparser.mly luaparsex.mly
    # ocamlyacc luaparsex.mly
    # mv luaparsex.ml luaparser.ml
    # ( sed '/^val/,$d' luaparsex.mli ;\
    # 	lipsum tangle luaparser.mli luasyntax.nw ) > luaparser.mli
    # rm -f luaparsex.mli
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/quest.0.1/lua-ml'
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/quest.0.1/src'
    # lipsum tangle -f cpp cee.ml cee.nw > cee.ml
    # lipsum tangle -f cpp cee.mli cee.nw > cee.mli
    # lipsum tangle -f cpp emit.ml emit.nw > emit.ml
    # lipsum tangle -f cpp emit.mli emit.nw > emit.mli
    # lipsum tangle -f cpp main.ml main.nw > main.ml
    # lipsum tangle -f cpp main.mli main.nw > main.mli
    # lipsum tangle -f cpp ppcee.ml ppcee.nw > ppcee.ml
    # lipsum tangle -f cpp ppcee.mli ppcee.nw > ppcee.mli
    # lipsum tangle -f cpp pretty.ml pretty.nw > pretty.ml
    # lipsum tangle -f cpp pretty.mli pretty.nw > pretty.mli
    # lipsum tangle -f cpp prg.ml prg.nw > prg.ml
    # lipsum tangle -f cpp prg.mli prg.nw > prg.mli
    # lipsum tangle -f cpp randinit.ml randinit.nw > randinit.ml
    # lipsum tangle -f cpp randinit.mli randinit.nw > randinit.mli
    # lipsum tangle -f cpp randomize.ml randomize.nw > randomize.ml
    # lipsum tangle -f cpp randomize.mli randomize.nw > randomize.mli
    # lipsum tangle -f cpp rtype.ml rtype.nw > rtype.ml
    # lipsum tangle -f cpp rtype.mli rtype.nw > rtype.mli
    # lipsum tangle -f cpp strategy.ml strategy.nw > strategy.ml
    # lipsum tangle -f cpp strategy.mli strategy.nw > strategy.mli
    # lipsum tangle -f cpp tc.ml tc.nw > tc.ml
    # lipsum tangle -f cpp tc.mli tc.nw > tc.mli
    # lipsum tangle -f cpp testcase.ml testcase.nw > testcase.ml
    # lipsum tangle -f cpp testcase.mli testcase.nw > testcase.mli
    # lipsum tangle -f cpp unique.ml unique.nw > unique.ml
    # lipsum tangle -f cpp unique.mli unique.nw > unique.mli
    # lipsum tangle -f cpp util.ml util.nw > util.ml
    # lipsum tangle -f cpp util.mli util.nw > util.mli
    # pod2text ../doc/quest.pod > quest.man
    # echo 'let quest = "'		    >  luacode.ml
    # sed 's/\\/\\\\/g;s/"/\\"/g' ../share/quest.lua ../share/ansi.lua ../share/cc.lua ../share/gcc.lua ../share/mips.lua ../share/demo.lua ../share/toy.lua  >> luacode.ml
    # echo '"'				    >> luacode.ml
    # echo 'let manual = "'		    >> luacode.ml
    # sed 's/\\/\\\\/g;s/"/\\"/g' quest.man   >> luacode.ml
    # echo '"'				    >> luacode.ml
    # echo 'let date = "'`date`'"'	    >> luacode.ml
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/quest.0.1/src'
    # ocamlbuild -I lua-ml -I src -libs unix src/main.native
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/main.ml > src/main.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/main.mli > src/main.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/main.cmi src/main.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/luacode.ml > src/luacode.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/luacode.cmo src/luacode.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/lualink.ml > lua-ml/lualink.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/lualink.mli > lua-ml/lualink.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/lua.mli > lua-ml/lua.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luaast.mli > lua-ml/luaast.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luavalue.mli > lua-ml/luavalue.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luahash.mli > lua-ml/luahash.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luasrcmap.mli > lua-ml/luasrcmap.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/luahash.cmi lua-ml/luahash.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/luasrcmap.cmi lua-ml/luasrcmap.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/luavalue.cmi lua-ml/luavalue.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luaparser.mli > lua-ml/luaparser.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/luaast.cmi lua-ml/luaast.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/luaparser.cmi lua-ml/luaparser.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/lua.cmi lua-ml/lua.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/lualink.cmi lua-ml/lualink.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/cee.ml > src/cee.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/cee.mli > src/cee.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/cee.cmi src/cee.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/emit.ml > src/emit.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/emit.mli > src/emit.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/tc.mli > src/tc.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/strategy.mli > src/strategy.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/rtype.mli > src/rtype.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/randomize.mli > src/randomize.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/unique.mli > src/unique.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/randomize.cmi src/randomize.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/unique.cmi src/unique.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/rtype.cmi src/rtype.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/strategy.cmi src/strategy.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/tc.cmi src/tc.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/emit.cmi src/emit.mli
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/cee.cmx src/cee.ml
    # + /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/cee.cmx src/cee.ml
    # File "cee.nw", line 284, characters 45-74:
    # Warning 23 [useless-record-with]: all the fields are explicitly listed in this record:
    # the 'with' clause is useless.
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/ppcee.ml > src/ppcee.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/ppcee.mli > src/ppcee.mli.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/pretty.mli > src/pretty.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/pretty.cmi src/pretty.mli
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/ppcee.cmi src/ppcee.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/pretty.ml > src/pretty.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/pretty.cmx src/pretty.ml
    # + /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/pretty.cmx src/pretty.ml
    # File "pretty.nw", line 92, characters 26-40:
    # Alert deprecated: Stdlib.Printf.kprintf
    # Use Printf.ksprintf instead.
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/tc.ml > src/tc.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/prg.ml > src/prg.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/prg.mli > src/prg.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/prg.cmi src/prg.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/randinit.ml > src/randinit.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/randinit.mli > src/randinit.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/randinit.cmi src/randinit.mli
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/randomize.ml > src/randomize.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/prg.cmx src/prg.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/rtype.ml > src/rtype.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/randomize.cmx src/randomize.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/unique.ml > src/unique.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/unique.cmx src/unique.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/strategy.ml > src/strategy.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/rtype.cmx src/rtype.ml
    # + /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/rtype.cmx src/rtype.ml
    # File "rtype.nw", line 138, characters 16-30:
    # Alert deprecated: Stdlib.Printf.kprintf
    # Use Printf.ksprintf instead.
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/randinit.cmx src/randinit.ml
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/strategy.cmx src/strategy.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/util.ml > src/util.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/util.mli > src/util.mli.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I src -I lua-ml -o src/util.cmi src/util.mli
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/ppcee.cmx src/ppcee.ml
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/tc.cmx src/tc.ml
    # + /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/tc.cmx src/tc.ml
    # File "tc.nw", line 51, characters 15-29:
    # Alert deprecated: Stdlib.Printf.kprintf
    # Use Printf.ksprintf instead.
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I src -I lua-ml -o src/util.cmx src/util.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/lua.ml > lua-ml/lua.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luaast.ml > lua-ml/luaast.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luavalue.ml > lua-ml/luavalue.ml.depends
    # /home/opam/.opam/5.0/bin/ocamllex.opt -q lua-ml/luafloat.mll
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luafloat.ml > lua-ml/luafloat.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -I lua-ml -I src -o lua-ml/luafloat.cmo lua-ml/luafloat.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luahash.ml > lua-ml/luahash.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules lua-ml/luasrcmap.ml > lua-ml/luasrcmap.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I lua-ml -I src -o lua-ml/luafloat.cmx lua-ml/luafloat.ml
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I lua-ml -I src -o lua-ml/luahash.cmx lua-ml/luahash.ml
    # /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I lua-ml -I src -o lua-ml/luasrcmap.cmx lua-ml/luasrcmap.ml
    # + /home/opam/.opam/5.0/bin/ocamlopt.opt -c -I lua-ml -I src -o lua-ml/luasrcmap.cmx lua-ml/luasrcmap.ml
    # File "luasrcmap.nw", line 394, characters 47-61:
    # Error: Unbound module Pervasives
```