### PR TITLE
Do not build rdr versions on OCaml 5

### DIFF
--- a/packages/rdr/rdr.1.0/opam
+++ b/packages/rdr/rdr.1.0/opam
@@ -6,7 +6,7 @@ dev-repo: "git+https://github.com/m4b/rdr"
 homepage: "http://www.m4b.io"
 build: [make "build"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/rdr/rdr.1.1/opam
+++ b/packages/rdr/rdr.1.1/opam
@@ -9,7 +9,7 @@ build: [
   [make "build"]
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
FTBFS on missing `Pervasives`:

```
    #=== ERROR while compiling rdr.1.1 ============================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/rdr.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make build
    # exit-code            2
    # env-file             ~/.opam/log/rdr-7-c1df68.env
    # output-file          ~/.opam/log/rdr-7-c1df68.out
    ### output ###
    # ocamlbuild.native -lib unix -lib str src/Rdr.native && mv _build/src/Rdr.native rdr && rm Rdr.native
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/Rdr.ml > src/Rdr.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/utils/Config.ml > src/utils/Config.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/utils/Object.ml > src/utils/Object.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -bin-annot -I src/utils -I src/mach -I src/goblin -I src/elf -o src/utils/Config.cmo src/utils/Config.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/elf/Elf.ml > src/elf/Elf.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/utils/Binary.ml > src/utils/Binary.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/elf/Dynamic.ml > src/elf/Dynamic.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -bin-annot -I src/utils -I src/mach -I src/goblin -I src/elf -o src/utils/Binary.cmo src/utils/Binary.ml
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/elf/ProgramHeader.ml > src/elf/ProgramHeader.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/elf/SymbolTable.ml > src/elf/SymbolTable.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/elf/ElfReloc.ml > src/elf/ElfReloc.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/goblin/GoblinSymbol.ml > src/goblin/GoblinSymbol.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/goblin/Goblin.ml > src/goblin/Goblin.ml.depends
    # /home/opam/.opam/5.0/bin/ocamldep.opt -modules src/utils/Generics.ml > src/utils/Generics.ml.depends
    # /home/opam/.opam/5.0/bin/ocamlc.opt -c -bin-annot -I src/utils -I src/mach -I src/goblin -I src/elf -o src/utils/Generics.cmo src/utils/Generics.ml
    # + /home/opam/.opam/5.0/bin/ocamlc.opt -c -bin-annot -I src/utils -I src/mach -I src/goblin -I src/elf -o src/utils/Generics.cmo src/utils/Generics.ml
    # File "src/utils/Generics.ml", line 86, characters 43-61:
    # 86 |                              let compare = Pervasives.compare
    #                                                 ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```