### PR TITLE
Do not build rfc7748.1.0.0 on OCaml 5

### DIFF
--- a/packages/rfc7748/rfc7748.1.0/opam
+++ b/packages/rfc7748/rfc7748.1.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" { >= "4.03" }
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "zarith" { >= "1.5" }
   "dune" { >= "1.2.1" }
   "ounit" { with-test & >= "2.0.5" }


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling rfc7748.1.0 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/rfc7748.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p rfc7748 -j 127
    # exit-code            1
    # env-file             ~/.opam/log/rfc7748-8-4f0c48.env
    # output-file          ~/.opam/log/rfc7748-8-4f0c48.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.rfc7748.objs/byte -I /home/opam/.opam/5.0/lib/zarith -intf-suffix .ml -no-alias-deps -open Rfc7748__ -o src/.rfc7748.objs/byte/rfc7748__Curve.cmo -c -impl src/curve.ml)
    # File "src/curve.ml", line 75, characters 32-42:
    # 75 |         aux x1 x2 x3 z2 z3 swap Pervasives.(t - 1)
    #                                      ^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.rfc7748.objs/byte -I src/.rfc7748.objs/native -I /home/opam/.opam/5.0/lib/zarith -intf-suffix .ml -no-alias-deps -open Rfc7748__ -o src/.rfc7748.objs/native/rfc7748__Curve.cmx -c -impl src/curve.ml)
    # File "src/curve.ml", line 75, characters 32-42:
    # 75 |         aux x1 x2 x3 z2 z3 swap Pervasives.(t - 1)
    #                                      ^^^^^^^^^^
    # Error: Unbound module Pervasives
```