### PR TITLE
Do not build rope.0.6.2 on OCaml 5

### DIFF
--- a/packages/rope/rope.0.6.2/opam
+++ b/packages/rope/rope.0.6.2/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "base-bytes"
   "dune"
   "benchmark" {with-test}


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling rope.0.6.2 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/rope.0.6.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p rope -j 71
    # exit-code            1
    # env-file             ~/.opam/log/rope-8-6df64e.env
    # output-file          ~/.opam/log/rope-8-6df64e.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/.rope.objs/byte -I src/.rope.objs/native -I /home/opam/.opam/5.0/lib/bytes -intf-suffix .ml -no-alias-deps -o src/.rope.objs/native/rope.cmx -c -impl src/rope.ml)
    # File "src/rope.ml", line 1291, characters 16-34:
    # 1291 |   let compare = Pervasives.compare
    #                        ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.rope.objs/byte -I /home/opam/.opam/5.0/lib/bytes -intf-suffix .ml -no-alias-deps -o src/.rope.objs/byte/rope.cmo -c -impl src/rope.ml)
    # File "src/rope.ml", line 1291, characters 16-34:
    # 1291 |   let compare = Pervasives.compare
    #                        ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```