### PR TITLE
Do not build safepass.2.0 on OCaml 5

### DIFF
--- a/packages/safepass/safepass.2.0/opam
+++ b/packages/safepass/safepass.2.0/opam
@@ -16,7 +16,7 @@ remove: [
   ["rm" "-rf" safepass:doc]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling safepass.2.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/safepass.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0 --docdir /home/opam/.opam/5.0/doc/safepass
    # exit-code            2
    # env-file             ~/.opam/log/safepass-8-73cfbd.env
    # output-file          ~/.opam/log/safepass-8-73cfbd.out
    ### output ###
    # File "./setup.ml", line 1404, characters 23-41:
    # 1404 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```