### PR TITLE
Do not build sessions.0.1.0 on OCaml 5

### DIFF
--- a/packages/sessions/sessions.0.1.0/opam
+++ b/packages/sessions/sessions.0.1.0/opam
@@ -17,7 +17,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "sessions"]
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "base-threads"
   "base-unix"
   "lwt"


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling sessions.0.1.0 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/sessions.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --enable-lwt
    # exit-code            2
    # env-file             ~/.opam/log/sessions-8-6dca2b.env
    # output-file          ~/.opam/log/sessions-8-6dca2b.out
    ### output ###
    # File "./setup.ml", line 1404, characters 23-41:
    # 1404 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```