### PR TITLE
Do not build sosa.0.{2,3}.0 on OCaml 5

### DIFF
--- a/packages/sosa/sosa.0.2.0/opam
+++ b/packages/sosa/sosa.0.2.0/opam
@@ -18,7 +18,7 @@ remove: [
     [ make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/sosa/sosa.0.3.0/opam
+++ b/packages/sosa/sosa.0.3.0/opam
@@ -17,7 +17,7 @@ remove: [
     [ make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while installing sosa.0.3.0 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/sosa.0.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh install make build
    # exit-code            2
    # env-file             ~/.opam/log/sosa-8-10b233.env
    # output-file          ~/.opam/log/sosa-8-10b233.out
    ### output ###
    # ocamlbuild -use-ocamlfind -cflag -safe-string -I src/lib sosa.cmx sosa.cma sosa.cmxa sosa.cmxs
    # ocamlfind ocamldep -modules src/lib/api.mli > src/lib/api.mli.depends
    # ocamlfind ocamlc -c -safe-string -annot -bin-annot -principal -I src/lib -o src/lib/api.cmi src/lib/api.mli
    # ocamlfind ocamldep -modules src/lib/functors.ml > src/lib/functors.ml.depends
    # ocamlfind ocamldep -modules src/lib/native_character.mli > src/lib/native_character.mli.depends
    # ocamlfind ocamldep -modules src/lib/sosa_pervasives.ml > src/lib/sosa_pervasives.ml.depends
    # ocamlfind ocamlc -c -safe-string -annot -bin-annot -principal -I src/lib -o src/lib/native_character.cmi src/lib/native_character.mli
    # ocamlfind ocamlc -c -safe-string -annot -bin-annot -principal -I src/lib -o src/lib/sosa_pervasives.cmo src/lib/sosa_pervasives.ml
    # ocamlfind ocamldep -modules src/lib/native_character.ml > src/lib/native_character.ml.depends
    # ocamlfind ocamldep -modules src/lib/native_string.mli > src/lib/native_string.mli.depends
    # ocamlfind ocamlc -c -safe-string -annot -bin-annot -principal -I src/lib -o src/lib/native_string.cmi src/lib/native_string.mli
    # ocamlfind ocamldep -modules src/lib/native_string.ml > src/lib/native_string.ml.depends
    # ocamlfind ocamlc -c -safe-string -annot -bin-annot -principal -I src/lib -o src/lib/functors.cmo src/lib/functors.ml
    # + ocamlfind ocamlc -c -safe-string -annot -bin-annot -principal -I src/lib -o src/lib/functors.cmo src/lib/functors.ml
    # File "src/lib/functors.ml", line 302, characters 14-29:
    # 302 |     try Some (chop_prefix_exn t prefix)
    #                     ^^^^^^^^^^^^^^^
    # Warning 6 [labels-omitted]: label prefix was omitted in the application of this function.
    # File "src/lib/functors.ml", line 312, characters 14-29:
    # 312 |     try Some (chop_suffix_exn t suffix)
    #                     ^^^^^^^^^^^^^^^
    # Warning 6 [labels-omitted]: label suffix was omitted in the application of this function.
    # File "src/lib/functors.ml", line 404, characters 15-21:
    # 404 |     else Some (B.mapi (fun i c -> if i = index then v else c) s)
    #                      ^^^^^^
    # Warning 6 [labels-omitted]: label f was omitted in the application of this function.
    # File "src/lib/functors.ml", line 429, characters 11-29:
    # 429 |           (Pervasives.compare (lena : int) lenb)
    #                  ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```