### PR TITLE
Do not build voqc.0.2.{0,1} on OCaml 5

### DIFF
--- a/packages/voqc/voqc.0.2.0/opam
+++ b/packages/voqc/voqc.0.2.0/opam
@@ -10,7 +10,7 @@ doc: "https://inQWIRE.github.io/mlvoqc"
 bug-reports: "https://github.com/inQWIRE/mlvoqc/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "openQASM"
   "zarith"
   "odoc" {with-doc}

--- a/packages/voqc/voqc.0.2.1/opam
+++ b/packages/voqc/voqc.0.2.1/opam
@@ -10,7 +10,7 @@ doc: "https://inQWIRE.github.io/mlvoqc"
 bug-reports: "https://github.com/inQWIRE/mlvoqc/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "openQASM"
   "zarith" {>= "1.5"}
   "odoc" {with-doc}


### PR DESCRIPTION
FTBFS due to missing `Pervasives`:

```
    #=== ERROR while compiling voqc.0.2.1 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/voqc.0.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p voqc -j 71 @install
    # exit-code            1
    # env-file             ~/.opam/log/voqc-8-5eef7c.env
    # output-file          ~/.opam/log/voqc-8-5eef7c.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-33-39 -g -bin-annot -I ml/.voqc.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/openQASM -I /home/opam/.opam/5.0/lib/zarith -no-alias-deps -open Voqc__ -o ml/.voqc.objs/byte/voqc__PeanoNat.cmo -c -impl ml/extracted/PeanoNat.ml)
    # File "ml/extracted/PeanoNat.ml", line 10, characters 16-31:
    # 10 |       (fun p -> Pervasives.succ (add p m))
    #                      ^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-33-39 -g -bin-annot -I ml/.voqc.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/openQASM -I /home/opam/.opam/5.0/lib/zarith -no-alias-deps -open Voqc__ -o ml/.voqc.objs/byte/voqc__BinPos.cmo -c -impl ml/extracted/BinPos.ml)
    # File "ml/extracted/BinPos.ml", line 8, characters 17-32:
    # 8 |   let rec succ = Pervasives.succ
    #                      ^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-33-39 -g -bin-annot -I ml/.voqc.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/openQASM -I /home/opam/.opam/5.0/lib/zarith -no-alias-deps -open Voqc__ -o ml/.voqc.objs/byte/voqc__HadamardReduction.cmo -c -impl ml/extracted/HadamardReduction.ml)
    # File "ml/extracted/HadamardReduction.ml", line 125, characters 12-27:
    # 125 |     (( * ) (Pervasives.succ (Pervasives.succ 0)) (List.length l)) []
    #                   ^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -3-33-39 -g -bin-annot -I ml/.voqc.objs/byte -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/openQASM -I /home/opam/.opam/5.0/lib/zarith -no-alias-deps -open Voqc__ -o ml/.voqc.objs/byte/voqc__GateCancellation.cmo -c -impl ml/extracted/GateCancellation.ml)
    # File "ml/extracted/GateCancellation.ml", line 379, characters 48-63:
    # 379 |   propagate l [] ((coq_H_cancel_rule q) :: []) (Pervasives.succ 0)
    #                                                       ^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```