### PR TITLE
Do not build win-eventlog.0.1 on OCaml 5

### DIFF
--- a/packages/win-eventlog/win-eventlog.0.1/opam
+++ b/packages/win-eventlog/win-eventlog.0.1/opam
@@ -15,7 +15,7 @@ install: [make "PREFIX=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "win-eventlog"]]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "result"
   "logs"
   "ocamlfind" {build}


### PR DESCRIPTION
FTBFS on OCaml 5 due to missing `Pervasives` that OASIS uses:

```
    #=== ERROR while compiling win-eventlog.0.1 ===================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/win-eventlog.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make PREFIX=/home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/win-eventlog-8-d38a5f.env
    # output-file          ~/.opam/log/win-eventlog-8-d38a5f.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 1404, characters 23-41:
    # 1404 |          let compare = Pervasives.compare
    #                               ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # make: *** [Makefile:34: setup.data] Error 2
```