### PR TITLE
Do not build cfstream.1.3.1 on OCaml 5

### DIFF
--- a/packages/cfstream/cfstream.1.3.1/opam
+++ b/packages/cfstream/cfstream.1.3.1/opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.04.1"}
+  "ocaml" {>= "4.04.1" & < "5.0.0"}
   "dune"
   "core_kernel" {>= "v0.11.0"}
   "conf-m4" {build}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling cfstream.1.3.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/cfstream.1.3.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p cfstream -j 71
    # exit-code            1
    # env-file             ~/.opam/log/cfstream-8-516d56.env
    # output-file          ~/.opam/log/cfstream-8-516d56.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.CFStream.objs/byte -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/md5 -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/base_bigstring -I /home/opam/.opam/5.0/lib/base_quickcheck -I /home/opam/.opam/5.0/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.0/lib/bin_prot -I /home/opam/.opam/5.0/lib/bin_prot/shape -I /home/opam/.opam/5.0/lib/core -I /home/opam/.opam/5.0/lib/core/base_for_tests -I /home/opam/.opam/5.0/lib/core/validate -I /home/opam/.opam/5.0/lib/core_kernel -I /home/opam/.opam/5.0/lib/fieldslib -I /home/opam/.opam/5.0/lib/int_repr -I /home/opam/.opam/5.0/lib/jane-street-headers -I /home/opam/.opam/5.0/lib/parsexp -I /home/opam/.opam/5.0/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_expect/collector -I /home/opam/.opam/5.0/lib/ppx_expect/common -I /home/opam/.opam/5.0/lib/ppx_expect/config -I /home/opam/.opam/5.0/lib/ppx_expect/config_types -I /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_inline_test/config -I /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_log/types -I /home/opam/.opam/5.0/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/sexplib -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/splittable_random -I /home/opam/.opam/5.0/lib/stdio -I /home/opam/.opam/5.0/lib/time_now -I /home/opam/.opam/5.0/lib/typerep -I /home/opam/.opam/5.0/lib/variantslib -no-alias-deps -open CFStream__ -o lib/.CFStream.objs/byte/cFStream__CFStream_streamable.cmo -c -impl lib/CFStream_streamable.ml)
    # File "lib/CFStream_streamable.ml", line 14, characters 29-37:
    # 14 |   val to_stream : 'a t -> 'a Stream.t
    #                                   ^^^^^^^^
    # Error: Unbound module Stream
