### PR TITLE
Do not build debian-formats.0.1.1 on OCaml 5

### DIFF
--- a/packages/debian-formats/debian-formats.0.1.1/opam
+++ b/packages/debian-formats/debian-formats.0.1.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "debian-formats"]
 ]
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   ("extlib" {>= "1.7.0"} | "extlib-compat" {>= "1.7.0"})
   "re"
   "ocamlfind"


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling debian-formats.0.1.1 ===============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/debian-formats.0.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/debian-formats-8-eb675d.env
    # output-file          ~/.opam/log/debian-formats-8-eb675d.out
    ### output ###
    # File "./setup.ml", line 602, characters 4-15:
    # 602 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
