### PR TITLE
Do not build edn.0.1.6-1-gff9db95 on OCaml 5

### DIFF
--- a/packages/edn/edn.0.1.6-1-gff9db95/opam
+++ b/packages/edn/edn.0.1.6-1-gff9db95/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "dune"
   "menhir" {build & < "20211215"}
   "ounit" {with-test}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling edn.0.1.6-1-gff9db95 ===============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/edn.0.1.6-1-gff9db95
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p edn -j 31
    # exit-code            1
    # env-file             ~/.opam/log/edn-8-99d237.env
    # output-file          ~/.opam/log/edn-8-99d237.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.edn.objs/byte -no-alias-deps -open Edn__ -o src/.edn.objs/byte/edn.cmi -c -intf src/edn.mli)
    # File "src/edn.mli", line 24, characters 42-50:
    # 24 | val stream_from_channel : in_channel -> t Stream.t
    #                                                ^^^^^^^^
    # Error: Unbound module Stream
