### PR TITLE
Do not build lwt_glib.1.0.1 on OCaml 5

### DIFF
--- a/packages/lwt_glib/lwt_glib.1.0.1/opam
+++ b/packages/lwt_glib/lwt_glib.1.0.1/opam
@@ -21,7 +21,7 @@ remove: [
     ["ocamlfind" "remove" "lwt_glib"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "lwt" {>= "3.0.0"}
   "base-unix"


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling lwt_glib.1.0.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lwt_glib.1.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make configure
    # exit-code            2
    # env-file             ~/.opam/log/lwt_glib-8-5fd95d.env
    # output-file          ~/.opam/log/lwt_glib-8-5fd95d.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
    # make: *** [Makefile:37: configure] Error 2
