### PR TITLE
Do not build lzo.0.0.2 on OCaml 5

### DIFF
--- a/packages/lzo/lzo.0.0.2/opam
+++ b/packages/lzo/lzo.0.0.2/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "lzo"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling lzo.0.0.2 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/lzo.0.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --enable-tests --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/lzo-8-3d5b92.env
    # output-file          ~/.opam/log/lzo-8-3d5b92.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
