### PR TITLE
Do not build mesh.0.8.8 on OCaml 5

### DIFF
--- a/packages/mesh/mesh.0.8.8/opam
+++ b/packages/mesh/mesh.0.8.8/opam
@@ -32,7 +32,7 @@ remove: [
   ["ocamlfind" "remove" "mesh"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "lacaml" {with-test}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling mesh.0.8.8 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mesh.0.8.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-lacaml
    # exit-code            2
    # env-file             ~/.opam/log/mesh-8-0f7d09.env
    # output-file          ~/.opam/log/mesh-8-0f7d09.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
