### PR TITLE
Do not build minisat.0.1 on OCaml 5

### DIFF
--- a/packages/minisat/minisat.0.1/opam
+++ b/packages/minisat/minisat.0.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "minisat"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling minisat.0.1 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/minisat.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0 --docdir=/home/opam/.opam/5.0/doc --disable-docs
    # exit-code            2
    # env-file             ~/.opam/log/minisat-8-0dac10.env
    # output-file          ~/.opam/log/minisat-8-0dac10.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
