### PR TITLE
Do not build mparser.1.2.{2,3} on OCaml 5

### DIFF
--- a/packages/mparser/mparser.1.2.2/opam
+++ b/packages/mparser/mparser.1.2.2/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git://https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/mparser/mparser.1.2.3/opam
+++ b/packages/mparser/mparser.1.2.3/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git://https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling mparser.1.2.2 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mparser.1.2.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-re --disable-pcre
    # exit-code            2
    # env-file             ~/.opam/log/mparser-8-354a6c.env
    # output-file          ~/.opam/log/mparser-8-354a6c.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream

and

    #=== ERROR while compiling mparser.1.2.3 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mparser.1.2.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-re --disable-pcre
    # exit-code            2
    # env-file             ~/.opam/log/mparser-8-2dacbe.env
    # output-file          ~/.opam/log/mparser-8-2dacbe.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
