### PR TITLE
Do not build mustache.2.{2,3}.0 on OCaml 5

### DIFF
--- a/packages/mustache/mustache.2.2.0/opam
+++ b/packages/mustache/mustache.2.2.0/opam
@@ -23,7 +23,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ounit" {with-test}

--- a/packages/mustache/mustache.2.3.0/opam
+++ b/packages/mustache/mustache.2.3.0/opam
@@ -23,7 +23,7 @@ remove: [
 ]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "ounit" {with-test}


### PR DESCRIPTION
Build on 2.2.2 fails due to the removed `String.lowercase` function:

    #=== ERROR while compiling mustache.2.2.0 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mustache.2.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --disable-cli
    # exit-code            2
    # env-file             ~/.opam/log/mustache-8-3c68ef.env
    # output-file          ~/.opam/log/mustache-8-3c68ef.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

Build on 2.2.3 fails due to missing `Stream` module:

    #=== ERROR while compiling mustache.2.3.0 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mustache.2.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --disable-cli
    # exit-code            2
    # env-file             ~/.opam/log/mustache-8-ed7799.env
    # output-file          ~/.opam/log/mustache-8-ed7799.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
