### PR TITLE
Do not build nproc.0.5.1 on OCaml 5

### DIFF
--- a/packages/nproc/nproc.0.5.1/opam
+++ b/packages/nproc/nproc.0.5.1/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "nproc"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "lwt"
 ]


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling nproc.0.5.1 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/nproc.0.5.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/nproc-8-eb4cb6.env
    # output-file          ~/.opam/log/nproc-8-eb4cb6.out
    ### output ###
    # echo "version = \"$(cat VERSION)\"" > META
    # cat META.in >> META
    # ocamlfind ocamlc -c nproc.mli -package lwt.unix
    # ocamlfind: [WARNING] Package `threads': Linking problems may arise because of the missing -thread or -vmthread switch
    # File "nproc.mli", line 106, characters 5-13:
    # 106 |   'a Stream.t -> unit
    #            ^^^^^^^^
    # Error: Unbound module Stream
    # make: *** [Makefile:13: all] Error 2
