### PR TITLE
Do not build ocaml-sat-solvers.0.{3,4} on OCaml 5

### DIFF
--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.3/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.3/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "ocaml-sat-solvers"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "minisat"
   "ocamlbuild" {build}
   "ocamlfind" {build}

--- a/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.4/opam
+++ b/packages/ocaml-sat-solvers/ocaml-sat-solvers.0.4/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "ocaml-sat-solvers"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "minisat"
   "ocamlbuild" {build}
   "ocamlfind" {build}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling ocaml-sat-solvers.0.3 ==============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocaml-sat-solvers.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/ocaml-sat-solvers-8-d2123d.env
    # output-file          ~/.opam/log/ocaml-sat-solvers-8-d2123d.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream

and

    #=== ERROR while compiling ocaml-sat-solvers.0.4 ==============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocaml-sat-solvers.0.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/ocaml-sat-solvers-8-15c123.env
    # output-file          ~/.opam/log/ocaml-sat-solvers-8-15c123.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
