### PR TITLE
Do not build ocaml-xdg-basedir.0.0.3 on OCaml 5

### DIFF
--- a/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.3/opam
+++ b/packages/ocaml-xdg-basedir/ocaml-xdg-basedir.0.0.3/opam
@@ -10,7 +10,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "xdg-basedir"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "fileutils"
   "ounit"


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling ocaml-xdg-basedir.0.0.3 ============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocaml-xdg-basedir.0.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/ocaml-xdg-basedir-8-e23d52.env
    # output-file          ~/.opam/log/ocaml-xdg-basedir-8-e23d52.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
