### PR TITLE
Do not build opal.0.1.{0,1} on OCaml 5

### DIFF
--- a/packages/opal/opal.0.1.0/opam
+++ b/packages/opal/opal.0.1.0/opam
@@ -12,7 +12,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "opal"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/opal/opal.0.1.1/opam
+++ b/packages/opal/opal.0.1.1/opam
@@ -9,7 +9,7 @@ build: [make "ncl" "bcl"]
 install: [make "libinstall"]
 remove: ["ocamlfind" "remove" "opal"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Self-contained monadic parser combinators for OCaml"


### PR DESCRIPTION
Build on 0.1.0 fails due to the removed `String.lowercase` function:

    #=== ERROR while compiling opal.0.1.0 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/opal.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/opal-8-7030b8.env
    # output-file          ~/.opam/log/opal-8-7030b8.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

Build on 0.1.1 fails due to missing `Stream` module:

    #=== ERROR while compiling opal.0.1.1 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/opal.0.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make ncl bcl
    # exit-code            2
    # env-file             ~/.opam/log/opal-8-618542.env
    # output-file          ~/.opam/log/opal-8-618542.out
    ### output ###
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/opal.0.1.1'
    # ocamldep opal.ml > ._d/opal.d
    # ocamlopt -c opal.ml
    # File "opal.ml", line 8, characters 15-26:
    # 8 |       try Cons(Stream.next stream, lazy (next stream))
    #                    ^^^^^^^^^^^
    # Error: Unbound module Stream
    # make[1]: *** [OCamlMakefile:1076: opal.cmx] Error 2
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/opal.0.1.1'
    # make: *** [OCamlMakefile:801: native-code-library] Error 2
