### PR TITLE
Do not build pci.1.0.1 on OCaml 5

### DIFF
--- a/packages/pci/pci.1.0.1/opam
+++ b/packages/pci/pci.1.0.1/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "pci_bindings"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ctypes" {>= "0.4"}
   "ocamlfind" {build}
 #  "ounit" {with-test}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling pci.1.0.1 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/pci.1.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure
    # exit-code            2
    # env-file             ~/.opam/log/pci-8-314db4.env
    # output-file          ~/.opam/log/pci-8-314db4.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
