### PR TITLE
Do not build shcaml.0.2.1 on OCaml 5

### DIFF
--- a/packages/shcaml/shcaml.0.2.1/opam
+++ b/packages/shcaml/shcaml.0.2.1/opam
@@ -7,7 +7,7 @@ bug-reports: "https://github.com/tov/shcaml/issues"
 doc: "https://tov.github.io/shcaml/doc"
 license: "MIT"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "0.9.0"}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling shcaml.0.2.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/shcaml.0.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false --with-lwt false
    # exit-code            1
    # env-file             ~/.opam/log/shcaml-8-9fb96b.env
    # output-file          ~/.opam/log/shcaml-8-9fb96b.out
    ### output ###
    # ocamlfind ocamlopt -package unix -package ocamlbuild -linkpkg -package cppo_ocamlbuild myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
    ...
    # + ocamlfind ocamlc -c -g -bin-annot -package pcre -package hmap -package unix -package stdcompat -I lib -o lib/shtream.cmi lib/shtream.mli
    # File "lib/shtream.mli", line 67, characters 23-31:
    # 67 |   val of_stream   : 'a Stream.t -> 'a t
    #                             ^^^^^^^^
    # Error: Unbound module Stream
    # Command exited with code 2.
    # pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
    #      '-build-dir' '_build' '-plugin-tag' 'package(cppo_ocamlbuild)' 'opam'
    #      'pkg/META' 'CHANGES.md' 'LICENSE.md' 'README.md' 'lib/shcaml.a'
    #      'lib/shcaml.cmxs' 'lib/shcaml.cmxa' 'lib/shcaml.cma' 'lib/shcaml.cmx'
    #      'lib/shcaml.cmi' 'lib/shcaml_top.a' 'lib/shcaml_top.cmxs'
    #      'lib/shcaml_top.cmxa' 'lib/shcaml_top.cma' 'lib/shcaml_top.cmx'
    #      'lib/shcaml_top_init.ml']: exited with 10
