### PR TITLE
Do not build sqlgg.0.4.{4,5} on OCaml 5

### DIFF
--- a/packages/sqlgg/sqlgg.0.4.4/opam
+++ b/packages/sqlgg/sqlgg.0.4.4/opam
@@ -26,7 +26,7 @@ remove: [
   ["rm" "-f" "%{bin}%/sqlgg" "%{bin}%/sqlgg.exe"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "mybuild" {build}

--- a/packages/sqlgg/sqlgg.0.4.5/opam
+++ b/packages/sqlgg/sqlgg.0.4.5/opam
@@ -26,7 +26,7 @@ remove: [
   ["rm" "-f" "%{bin}%/sqlgg" "%{bin}%/sqlgg.exe"]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "mybuild" {build}


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling sqlgg.0.4.4 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/sqlgg.0.4.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --enable-tests --disable-mysql --disable-sqlite3 --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/sqlgg-9-62c01c.env
    # output-file          ~/.opam/log/sqlgg-9-62c01c.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream

and

    #=== ERROR while compiling sqlgg.0.4.5 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/sqlgg.0.4.5
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --enable-tests --disable-mysql --disable-sqlite3 --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/sqlgg-8-74f546.env
    # output-file          ~/.opam/log/sqlgg-8-74f546.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
