### PR TITLE
Do not build stemming.0.2.1 on OCaml 5

### DIFF
--- a/packages/stemming/stemming.0.2.1/opam
+++ b/packages/stemming/stemming.0.2.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "stemming"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling stemming.0.2.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/stemming.0.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/stemming-8-857053.env
    # output-file          ~/.opam/log/stemming-8-857053.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
