### PR TITLE
Do not build vlq.0.2.1 on OCaml 5

### DIFF
--- a/packages/vlq/vlq.0.2.1/opam
+++ b/packages/vlq/vlq.0.2.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/flowtype/ocaml-vlq"
 doc: "https://github.com/flowtype/ocaml-vlq"
 bug-reports: "https://github.com/flowtype/ocaml-vlq/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "ounit2" {with-test}
 ]


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling vlq.0.2.1 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/vlq.0.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p vlq -j 31
    # exit-code            1
    # env-file             ~/.opam/log/vlq-8-453683.env
    # output-file          ~/.opam/log/vlq-8-453683.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.vlq.objs/byte -no-alias-deps -o src/.vlq.objs/byte/vlq.cmi -c -intf src/vlq.mli)
    # File "src/vlq.mli", line 13, characters 19-27:
    # 13 |   val decode: char Stream.t -> int
    #                         ^^^^^^^^
    # Error: Unbound module Stream
