### PR TITLE
Do not build zmq.4.0-8 on OCaml 5

### DIFF
--- a/packages/zmq/zmq.4.0-8/opam
+++ b/packages/zmq/zmq.4.0-8/opam
@@ -14,7 +14,7 @@ remove: [
   ["ocamlfind" "remove" "ZMQ"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "conf-zmq"
   "ocamlfind"
   "base-unix"


### PR DESCRIPTION
Build fails due to missing `Stream` module:

    #=== ERROR while compiling zmq.4.0-8 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/zmq.4.0-8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/zmq-8-d78c84.env
    # output-file          ~/.opam/log/zmq-8-d78c84.out
    ### output ###
    # File "./setup.ml", line 581, characters 4-15:
    # 581 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
