### PR TITLE
2 packages from c-cube/ezcurl at 0.2.2

### DIFF
--- a/packages/ezcurl-lwt/ezcurl-lwt.0.2.2/opam
+++ b/packages/ezcurl-lwt/ezcurl-lwt.0.2.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl, Lwt version"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "ezcurl" { = version }
+  "lwt"
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "mdx" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" "lwt" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.2.2.tar.gz"
+  checksum: [
+    "md5=75eafead85b6fe5ba2652a4eb580a9a9"
+    "sha512=dde8178f2c06adb047b8fcecc8c14bc2c5f9f51748c725c2917f7f5d3faeff385303123eb0213c55d7f2e29dad9e8c88da1b0460fa643cfba958fbe531c097fd"
+  ]
+}

--- a/packages/ezcurl/ezcurl.0.2.2/opam
+++ b/packages/ezcurl/ezcurl.0.2.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.2.2.tar.gz"
+  checksum: [
+    "md5=75eafead85b6fe5ba2652a4eb580a9a9"
+    "sha512=dde8178f2c06adb047b8fcecc8c14bc2c5f9f51748c725c2917f7f5d3faeff385303123eb0213c55d7f2e29dad9e8c88da1b0460fa643cfba958fbe531c097fd"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezcurl.0.2.2`: Friendly wrapper around OCurl
-`ezcurl-lwt.0.2.2`: Friendly wrapper around OCurl, Lwt version



---
* Homepage: https://github.com/c-cube/ezcurl/
* Source repo: git+https://github.com/c-cube/ezcurl.git
* Bug tracker: https://github.com/c-cube/ezcurl/issues

---
:camel: Pull-request generated by opam-publish v2.0.3