### PR TITLE
Do not run tests for pbrt.2.2 on OCaml 5

### DIFF
--- a/packages/pbrt/pbrt.2.2/opam
+++ b/packages/pbrt/pbrt.2.2/opam
@@ -18,7 +18,7 @@ license: "MIT"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "@install" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" "pbrt,ocaml-protoc" "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" "pbrt,ocaml-protoc" "-j" jobs] {with-test & ocaml:version < "5.0"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [


### PR DESCRIPTION
Tests fails due to removed function `String.capitalize`:

    #=== ERROR while compiling pbrt.2.2 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/pbrt.2.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p pbrt,ocaml-protoc -j 47
    # exit-code            1
    # env-file             ~/.opam/log/pbrt-7-3db1f3.env
    # output-file          ~/.opam/log/pbrt-7-3db1f3.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -bin-annot -annot -safe-string -strict-sequence -keep-locs -no-alias-deps -w A-4-42-41-48-70 -g -I src/compilerlib/.compiler_lib.objs/byte -I src/compilerlib/.compiler_lib.objs/native -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/compilerlib/.compiler_lib.objs/native/pb_codegen_util.cmx -c -impl src/compilerlib/pb_codegen_util.ml)
    # File "src/compilerlib/pb_codegen_util.ml", line 103, characters 15-32:
    # 103 |   | Some () -> String.capitalize s [@@ocaml.warning "-3"]
    #                      ^^^^^^^^^^^^^^^^^
    # Error: Unbound value String.capitalize
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -bin-annot -annot -safe-string -strict-sequence -keep-locs -no-alias-deps -w A-4-42-41-48-70 -g -I src/compilerlib/.compiler_lib.objs/byte -I src/compilerlib/.compiler_lib.objs/native -I /home/opam/.opam/5.0/lib/stdlib-shims -intf-suffix .ml -no-alias-deps -o src/compilerlib/.compiler_lib.objs/native/pb_codegen_backend.cmx -c -impl src/compilerlib/pb_codegen_backend.ml)
    # File "src/compilerlib/pb_codegen_backend.ml", line 131, characters 5-22:
    # 131 |   |> String.capitalize [@@ocaml.warning "-3"]
    #            ^^^^^^^^^^^^^^^^^
    # Error: Unbound value String.capitalize
