### PR TITLE
Do not build docker-api.0.1 on OCaml 5

### DIFF
--- a/packages/docker-api/docker-api.0.1/opam
+++ b/packages/docker-api/docker-api.0.1/opam
@@ -15,7 +15,7 @@ remove: [
   ["ocamlfind" "remove" "docker"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bytes"
   "base-unix"
   "ocamlbuild" {build}


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling docker-api.0.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/docker-api.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/docker-api-8-270854.env
    # output-file          ~/.opam/log/docker-api-8-270854.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
