### PR TITLE
Do not build exenum.0.7 on OCaml 5

### DIFF
--- a/packages/exenum/exenum.0.7/opam
+++ b/packages/exenum/exenum.0.7/opam
@@ -31,7 +31,7 @@ remove: [
   ["ocamlfind" "remove" "exenum"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "num"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling exenum.0.7 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/exenum.0.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-lwt
    # exit-code            2
    # env-file             ~/.opam/log/exenum-8-c77b4b.env
    # output-file          ~/.opam/log/exenum-8-c77b4b.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
