### PR TITLE
Do not build mesh.0.8.7 on OCaml 5

### DIFF
--- a/packages/mesh/mesh.0.8.7/opam
+++ b/packages/mesh/mesh.0.8.7/opam
@@ -32,7 +32,7 @@ remove: [
   ["ocamlfind" "remove" "mesh"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "base-bigarray"
   "base-bytes"
   "ocamlbuild" {build}


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling mesh.0.8.7 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mesh.0.8.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-lacaml
    # exit-code            2
    # env-file             ~/.opam/log/mesh-8-67215f.env
    # output-file          ~/.opam/log/mesh-8-67215f.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
