### PR TITLE
Do not build mindstorm.0.{6,6.1} on OCaml 5

### DIFF
--- a/packages/mindstorm/mindstorm.0.6.1/opam
+++ b/packages/mindstorm/mindstorm.0.6.1/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "mindstorm"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bytes"
   "base-threads" {with-test}
   "base-unix"

--- a/packages/mindstorm/mindstorm.0.6/opam
+++ b/packages/mindstorm/mindstorm.0.6/opam
@@ -22,7 +22,7 @@ remove: [
   ["ocamlfind" "remove" "mindstorm"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0.0"}
   "base-bytes"
   "base-threads" {with-test}
   "base-unix"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling mindstorm.0.6 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mindstorm.0.6
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/mindstorm-8-a08420.env
    # output-file          ~/.opam/log/mindstorm-8-a08420.out
    ### output ###
    # File "./setup.ml", line 316, characters 20-36:
    # 316 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling mindstorm.0.6.1 ====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mindstorm.0.6.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/mindstorm-8-d397a0.env
    # output-file          ~/.opam/log/mindstorm-8-d397a0.out
    ### output ###
    # File "./setup.ml", line 316, characters 20-36:
    # 316 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
