### PR TITLE
Do not build mparser.1.2 on OCaml 5

### DIFF
--- a/packages/mparser/mparser.1.2/opam
+++ b/packages/mparser/mparser.1.2/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git://https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "base-bytes"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling mparser.1.2 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mparser.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-re --disable-pcre
    # exit-code            2
    # env-file             ~/.opam/log/mparser-8-1ea32e.env
    # output-file          ~/.opam/log/mparser-8-1ea32e.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
