### PR TITLE
Do not build netlink.0.2.1 on OCaml 5

### DIFF
--- a/packages/netlink/netlink.0.2.1/opam
+++ b/packages/netlink/netlink.0.2.1/opam
@@ -14,7 +14,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ctypes"
   "ctypes-foreign"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling netlink.0.2.1 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/netlink.0.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/netlink-8-31e4c6.env
    # output-file          ~/.opam/log/netlink-8-31e4c6.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make: *** [Makefile:34: setup.data] Error 2
