### PR TITLE
Do not build ocal.0.1.{1,2} on OCaml 5

### DIFF
--- a/packages/ocal/ocal.0.1.1/opam
+++ b/packages/ocal/ocal.0.1.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "astring" {build}
   "calendar" {build & >= "2.00"}
   "cmdliner" {build}

--- a/packages/ocal/ocal.0.1.2/opam
+++ b/packages/ocal/ocal.0.1.2/opam
@@ -10,7 +10,7 @@ build: [
   [make "build"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "astring" {build}
   "calendar" {build & >= "2.00"}
   "cmdliner" {build}


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling ocal.0.1.1 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocal.0.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make configure
    # exit-code            2
    # env-file             ~/.opam/log/ocal-9-9c15de.env
    # output-file          ~/.opam/log/ocal-9-9c15de.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make: *** [Makefile.local:46: configure] Error 2

and

    #=== ERROR while compiling ocal.0.1.2 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocal.0.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make configure
    # exit-code            2
    # env-file             ~/.opam/log/ocal-8-0dfd5d.env
    # output-file          ~/.opam/log/ocal-8-0dfd5d.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make: *** [Makefile.local:48: configure] Error 2
