### PR TITLE
Package syncweb.0.5

### DIFF
--- a/packages/syncweb/syncweb.0.5/opam
+++ b/packages/syncweb/syncweb.0.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Syncweb, Literate Programming meets Unison"
+description: """
+Syncweb is a command-line tool enabling programmers to use the
+literate programming[1] development methodology, using the noweb[2]
+tool, while still being able to modify the generated files
+from the literate document. syncweb provides a way to
+"synchronize" the possibly modified original document with its
+possibly modified views with an interface similar to unison[3]. In
+addition, syncweb synchronizes data at a fine grained level by
+computing and storing md5sum of the different chunks.
+
+[1] http://en.wikipedia.org/wiki/Literate_programming
+[2] http://www.cs.tufts.edu/~nr/noweb/
+[3] http://www.seas.upenn.edu/~bcpierce/unison/
+"""
+
+maintainer: "Yoann Padioleau <yoann.padioleau@gmail.com>"
+authors: [ "Yoann Padioleau <yoann.padioleau@gmail.com>" ]
+license: "GPL-2.0-only"
+homepage: "https://github.com/aryx/syncweb"
+dev-repo: "git+https://github.com/aryx/syncweb"
+bug-reports: "https://github.com/aryx/syncweb/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "commons" {>= "1.5.5" }
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/aryx/syncweb/archive/refs/tags/0.5.tar.gz"
+  checksum: [
+    "md5=33fe37dee4cf461a8c9545e12d81004d"
+    "sha512=02db7ffa1f79b21fc4f188667875633fe342f91b88340ce3fab5f0622053f7216313e7772d3a9ccc7e2b5a200c405068d504f67dbffc843083c32270d073d816"
+  ]
+}


### PR DESCRIPTION
### `syncweb.0.5`
Syncweb, Literate Programming meets Unison
Syncweb is a command-line tool enabling programmers to use the
literate programming[1] development methodology, using the noweb[2]
tool, while still being able to modify the generated files
from the literate document. syncweb provides a way to
"synchronize" the possibly modified original document with its
possibly modified views with an interface similar to unison[3]. In
addition, syncweb synchronizes data at a fine grained level by
computing and storing md5sum of the different chunks.

[1] http://en.wikipedia.org/wiki/Literate_programming
[2] http://www.cs.tufts.edu/~nr/noweb/
[3] http://www.seas.upenn.edu/~bcpierce/unison/



---
* Homepage: https://github.com/aryx/syncweb
* Source repo: git+https://github.com/aryx/syncweb
* Bug tracker: https://github.com/aryx/syncweb/issues

---
:camel: Pull-request generated by opam-publish v2.2.0