### PR TITLE
Do not build ocamlrss.2.0 on OCaml 5

### DIFF
--- a/packages/ocamlrss/ocamlrss.2.0/opam
+++ b/packages/ocamlrss/ocamlrss.2.0/opam
@@ -4,7 +4,7 @@ authors: ["Zoggy <zoggy@bat8.org>"]
 homepage: "https://zoggy.frama.io/ocamlrss/"
 build: make
 remove: [["ocamlfind" "remove" "rss"]]
-depends: ["ocaml" "ocamlfind" "xmlm"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind" "xmlm"]
 install: [make "install"]
 synopsis: "Library providing functions to parse and print RSS 2.0 files"
 description: """


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling ocamlrss.2.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocamlrss.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/ocamlrss-7-ff4276.env
    # output-file          ~/.opam/log/ocamlrss-7-ff4276.out
    ### output ###
    # ocamlfind ocamlc -package xmlm,unix -annot -c rss_date.mli
    # ocamlfind ocamlc -package xmlm,unix -annot -c rss_types.ml
    # ocamlfind ocamlc -package xmlm,unix -annot -c rss_io.ml
    # File "rss_io.ml", line 82, characters 35-51:
    # 82 |       E ((("",e),_),_) when name = String.lowercase e -> true
    #                                         ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make: *** [Makefile:119: rss_io.cmi] Error 2
