### PR TITLE
Do not build ocaml-systemd.1.{1,2} on OCaml 5

### DIFF
--- a/packages/ocaml-systemd/ocaml-systemd.1.1/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "systemd"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/ocaml-systemd/ocaml-systemd.1.2/opam
+++ b/packages/ocaml-systemd/ocaml-systemd.1.2/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "systemd"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
 ]


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling ocaml-systemd.1.1 ==================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocaml-systemd.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/ocaml-systemd-8-8a7388.env
    # output-file          ~/.opam/log/ocaml-systemd-8-8a7388.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling ocaml-systemd.1.2 ==================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocaml-systemd.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/ocaml-systemd-8-cccbf1.env
    # output-file          ~/.opam/log/ocaml-systemd-8-cccbf1.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
