### PR TITLE
Do not build olmi.1.{0,1} on OCaml 5

### DIFF
--- a/packages/olmi/olmi.1.0/opam
+++ b/packages/olmi/olmi.1.0/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "olmi"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/olmi/olmi.1.1/opam
+++ b/packages/olmi/olmi.1.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "olmi"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling olmi.1.0 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/olmi.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/olmi-8-07c4bf.env
    # output-file          ~/.opam/log/olmi-8-07c4bf.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling olmi.1.1 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/olmi.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/olmi-8-925a4c.env
    # output-file          ~/.opam/log/olmi-8-925a4c.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
