### PR TITLE
Do not build oolc.0.{2,3} on OCaml 5

### DIFF
--- a/packages/oolc/oolc.0.2/opam
+++ b/packages/oolc/oolc.0.2/opam
@@ -11,7 +11,7 @@ remove: [
   ["ocamlfind" "remove" "oolc"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/oolc/oolc.0.3/opam
+++ b/packages/oolc/oolc.0.3/opam
@@ -11,7 +11,7 @@ remove: [
   ["ocamlfind" "remove" "oolc"]
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling oolc.0.2 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/oolc.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/oolc-8-3551b9.env
    # output-file          ~/.opam/log/oolc-8-3551b9.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling oolc.0.3 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/oolc.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/oolc-8-4a2ad2.env
    # output-file          ~/.opam/log/oolc-8-4a2ad2.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
