### PR TITLE
Do not build posix-math.0.3.{0-0,1-0} on OCaml 5

### DIFF
--- a/packages/posix-math/posix-math.0.3.0-0/opam
+++ b/packages/posix-math/posix-math.0.3.0-0/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "posix-math"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "result"
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}

--- a/packages/posix-math/posix-math.0.3.1-0/opam
+++ b/packages/posix-math/posix-math.0.3.1-0/opam
@@ -17,7 +17,7 @@ remove: [
   ["ocamlfind" "remove" "posix-math"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "result"
   "ocamlfind" {>= "1.5"}
   "ocamlbuild" {build}


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling posix-math.0.3.0-0 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/posix-math.0.3.0-0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/posix-math-8-145d93.env
    # output-file          ~/.opam/log/posix-math-8-145d93.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling posix-math.0.3.1-0 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/posix-math.0.3.1-0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/posix-math-8-0d87cc.env
    # output-file          ~/.opam/log/posix-math-8-0d87cc.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
