### PR TITLE
Do not build qcheck.0.{3,4} on OCaml 5

### DIFF
--- a/packages/qcheck/qcheck.0.3/opam
+++ b/packages/qcheck/qcheck.0.3/opam
@@ -17,7 +17,7 @@ install: [
 ]
 remove: [["ocamlfind" "remove" "qcheck"]]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/qcheck/qcheck.0.4/opam
+++ b/packages/qcheck/qcheck.0.4/opam
@@ -19,7 +19,7 @@ remove: [
     ["ocamlfind" "remove" "qcheck"]
 ]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Note that for some reason, the build passes on http://check.ocamllabs.io/,
but fails on Dune's 3.6.2 ocaml-ci check: https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a27a671c76fba1d3b86d71f6a87f5e881186ce00

Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling qcheck.0.3 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/qcheck.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/qcheck-7-759758.env
    # output-file          ~/.opam/log/qcheck-7-759758.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling qcheck.0.4 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/qcheck.0.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-ounit
    # exit-code            2
    # env-file             ~/.opam/log/qcheck-8-833866.env
    # output-file          ~/.opam/log/qcheck-8-833866.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
