### PR TITLE
Do not build semver.0.1.0 on OCaml 5

### DIFF
--- a/packages/semver/semver.0.1.0/opam
+++ b/packages/semver/semver.0.1.0/opam
@@ -16,7 +16,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "semver"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling semver.0.1.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/semver.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure
    # exit-code            2
    # env-file             ~/.opam/log/semver-8-78e999.env
    # output-file          ~/.opam/log/semver-8-78e999.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
