### PR TITLE
Do not build setr.0.{1,1.1} on OCaml 5

### DIFF
--- a/packages/setr/setr.0.1.1/opam
+++ b/packages/setr/setr.0.1.1/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "setr"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "mlbdd"

--- a/packages/setr/setr.0.1/opam
+++ b/packages/setr/setr.0.1/opam
@@ -9,7 +9,7 @@ build: [make]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "setr"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "ocamlfind" {build}
   "cppo" {build}
   "mlbdd"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling setr.0.1 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/setr.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/setr-9-ee50db.env
    # output-file          ~/.opam/log/setr-9-ee50db.out
    ### output ###
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1/src'
    # make -C setr
    # make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1/src/setr'
    # cppo -n -D PKG_MLBDD  -D 'SETR_VERSION 0.1' -o _tags _tags.in
    # cppo -n -D PKG_MLBDD  -D 'SETR_VERSION 0.1' -o SETr.mllib SETr.mllib.in
    # cppo -n -D PKG_MLBDD  -D 'SETR_VERSION 0.1' -o META META.in
    # ocamlbuild -use-ocamlfind -j 0 -cflag -short-paths -pp "cppo -D PKG_MLBDD  -D 'SETR_VERSION 0.1'" SETr.cma SETr.cmxa
    ...
    # + ocamlfind ocamlc -c -short-paths -pp 'cppo -D PKG_MLBDD -D '\''SETR_VERSION 0.1'\''' -I symsing -I symbolic -I ds -o SETr_DomainBuilder.cmo SETr_DomainBuilder.ml
    # File "SETr_DomainBuilder.ml", line 11, characters 8-24:
    # 11 | ........with
    #    |
    # 11 | (*********........................................
    # Error: Unbound value String.lowercase
    # Command exited with code 2.
    # make[2]: *** [Makefile:10: _build/SETr.cma] Error 10
    # make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1/src/setr'
    # make[1]: *** [Makefile:4: all] Error 2
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1/src'
    # make: *** [Makefile:4: all] Error 2

and

    #=== ERROR while compiling setr.0.1.1 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/setr.0.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/setr-8-27fc16.env
    # output-file          ~/.opam/log/setr-8-27fc16.out
    ### output ###
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1.1/src'
    # make -C setr
    # make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1.1/src/setr'
    # cppo -n -D PKG_MLBDD  -D 'SETR_VERSION 0.1.1' -o _tags _tags.in
    # cppo -n -D PKG_MLBDD  -D 'SETR_VERSION 0.1.1' -o SETr.mllib SETr.mllib.in
    # cppo -n -D PKG_MLBDD  -D 'SETR_VERSION 0.1.1' -o META META.in
    # ocamlbuild -use-ocamlfind -j 0 -cflag -short-paths -pp "cppo -D PKG_MLBDD  -D 'SETR_VERSION 0.1.1'" SETr.cma SETr.cmxa
    ...
    # + ocamlfind ocamlc -c -short-paths -pp 'cppo -D PKG_MLBDD -D '\''SETR_VERSION 0.1.1'\''' -I symsing -I symbolic -I ds -o SETr_DomainBuilder.cmo SETr_DomainBuilder.ml
    # File "SETr_DomainBuilder.ml", line 11, characters 8-24:
    # 11 | ........with
    #    |
    # 11 | (*********........................................
    # Error: Unbound value String.lowercase
    # Command exited with code 2.
    # make[2]: *** [Makefile:10: _build/SETr.cma] Error 10
    # make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1.1/src/setr'
    # make[1]: *** [Makefile:4: all] Error 2
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/setr.0.1.1/src'
    # make: *** [Makefile:4: all] Error 2
