### PR TITLE
Do not build stemmer.0.2 on OCaml 5

### DIFF
--- a/packages/stemmer/stemmer.0.2/opam
+++ b/packages/stemmer/stemmer.0.2/opam
@@ -10,7 +10,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "stemmer"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 dev-repo: "git+https://github.com/pymander/ocaml-stemmer"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling stemmer.0.2 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/stemmer.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/stemmer-9-28c4ba.env
    # output-file          ~/.opam/log/stemmer-9-28c4ba.out
    ### output ###
    # ocamlc    -c stemmer.mli
    # ocamlfind ocamlc -package "" -c stemmer.ml
    # File "stemmer.ml", line 268, characters 13-29:
    # 268 |   let word = String.lowercase in_word in
    #                    ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make: *** [Makefile:53: stemmer.cmo] Error 2
