### PR TITLE
Do not build tdk.0.{1.1,2.0} on OCaml 5

### DIFF
--- a/packages/tdk/tdk.0.1.1/opam
+++ b/packages/tdk/tdk.0.1.1/opam
@@ -7,7 +7,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "tdk"]]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]

--- a/packages/tdk/tdk.0.2.0/opam
+++ b/packages/tdk/tdk.0.2.0/opam
@@ -18,7 +18,7 @@ remove: [
   ["ocamlfind" "remove" "tdk"]
 ]
 depends: [
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "ocamlfind" {build}
   "ounit" {with-test & >= "1.0.2"}
   "ocamlbuild" {build}


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling tdk.0.1.1 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/tdk.0.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure
    # exit-code            2
    # env-file             ~/.opam/log/tdk-10-a74d3b.env
    # output-file          ~/.opam/log/tdk-10-a74d3b.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase

and

    #=== ERROR while compiling tdk.0.2.0 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/tdk.0.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/tdk-8-ada490.env
    # output-file          ~/.opam/log/tdk-8-ada490.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
