### PR TITLE
Do not build textwrap.0.2 on OCaml 5

### DIFF
--- a/packages/textwrap/textwrap.0.2/opam
+++ b/packages/textwrap/textwrap.0.2/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "textwrap"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling textwrap.0.2 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/textwrap.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/textwrap-8-aad0a2.env
    # output-file          ~/.opam/log/textwrap-8-aad0a2.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
