### PR TITLE
Do not build tptp.0.3.2 on OCaml 5

### DIFF
--- a/packages/tptp/tptp.0.3.2/opam
+++ b/packages/tptp/tptp.0.3.2/opam
@@ -11,7 +11,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "tptp"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "zarith"
   "pprint"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling tptp.0.3.2 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/tptp.0.3.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/tptp-8-9a7716.env
    # output-file          ~/.opam/log/tptp-8-9a7716.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
