### PR TITLE
Do not build unix-type-representations.0.1.0 on OCaml 5

### DIFF
--- a/packages/unix-type-representations/unix-type-representations.0.1.0/opam
+++ b/packages/unix-type-representations/unix-type-representations.0.1.0/opam
@@ -15,7 +15,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "unix-type-representations"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-unix"


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling unix-type-representations.0.1.0 ====================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/unix-type-representations.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/unix-type-representations-8-18dd25.env
    # output-file          ~/.opam/log/unix-type-representations-8-18dd25.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
