### PR TITLE
Do not build win-error.0.2 on OCaml 5

### DIFF
--- a/packages/win-error/win-error.0.2/opam
+++ b/packages/win-error/win-error.0.2/opam
@@ -14,7 +14,7 @@ install: [make "install"]
 remove: ["ocamlfind" "remove" "win-error"]
 
 depends: [
-  "ocaml" {>= "3.12.1"}
+  "ocaml" {>= "3.12.1" & < "5.0.0"}
   "base-bytes"
   "base-unix"
   "ocamlfind" {build}


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling win-error.0.2 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/win-error.0.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/win-error-8-8265a0.env
    # output-file          ~/.opam/log/win-error-8-8265a0.out
    ### output ###
    # ocaml setup.ml -configure
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make: *** [Makefile:34: setup.data] Error 2
