### PR TITLE
Do not build xmlplaylist.0.1.3 on OCaml 5

### DIFF
--- a/packages/xmlplaylist/xmlplaylist.0.1.3/opam
+++ b/packages/xmlplaylist/xmlplaylist.0.1.3/opam
@@ -5,7 +5,7 @@ build: [
   [make]
 ]
 remove: [["ocamlfind" "remove" "xmlplaylist"]]
-depends: ["ocaml" "ocamlfind" "xmlm"]
+depends: ["ocaml" {< "5.0.0"} "ocamlfind" "xmlm"]
 install: [make "install"]
 synopsis: "Library to parse various file playlists in XML format"
 flags: light-uninstall


### PR DESCRIPTION
Build fails due to removed function `String.lowercase`:

    #=== ERROR while compiling xmlplaylist.0.1.3 ==================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/xmlplaylist.0.1.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/xmlplaylist-8-0fac0d.env
    # output-file          ~/.opam/log/xmlplaylist-8-0fac0d.out
    ### output ###
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/xmlplaylist.0.1.3/src'
    # make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/xmlplaylist.0.1.3/src'
    # making ._bcdi/xmlplaylist.di from xmlplaylist.mli
    # making ._d/xmlplaylist.d from xmlplaylist.ml
    # ocamlc.opt -c -I /home/opam/.opam/5.0/lib/xmlm xmlplaylist.mli
    # ocamlc.opt -c -I /home/opam/.opam/5.0/lib/xmlm xmlplaylist.ml
    # File "xmlplaylist.ml", line 98, characters 16-32:
    # 98 |         Element(String.lowercase s,
    #                      ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
    # make[2]: *** [OCamlMakefile:951: xmlplaylist.cmo] Error 2
    # make[2]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/xmlplaylist.0.1.3/src'
    # make[1]: *** [OCamlMakefile:716: byte-code-library] Error 2
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/xmlplaylist.0.1.3/src'
    # make: *** [Makefile:11: all] Error 2
