### PR TITLE
Do not build statverif.1.97pl1.{1,2} on OCaml 5

### DIFF
--- a/packages/statverif/statverif.1.97pl1.1/opam
+++ b/packages/statverif/statverif.1.97pl1.1/opam
@@ -11,7 +11,7 @@ build: [
 install: [make "prefix=%{prefix}%" "install"]
 remove: [["ocamlfind" "remove" "statverif"] ["rm" "-f" "%{bin}%/statverif"] ["rm" "-f" "%{bin}%/statveriftotex"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]

--- a/packages/statverif/statverif.1.97pl1.2/opam
+++ b/packages/statverif/statverif.1.97pl1.2/opam
@@ -10,7 +10,7 @@ build: [
 ]
 install: [make "prefix=%{prefix}%" "install"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
Build fails due to removed function `String.uppercase`:

    #=== ERROR while compiling statverif.1.97pl1.1 ================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/statverif.1.97pl1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/statverif-8-f5e717.env
    # output-file          ~/.opam/log/statverif-8-f5e717.out
    ### output ###
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/statverif.1.97pl1.1/src'
    # ocamlbuild -use-ocamlfind main.native
    ...
    # + ocamlfind ocamlc -c -g -annot -o main.cmo main.ml
    # File "main.ml", line 339, characters 14-30:
    # 339 | 	  let s_up = String.uppercase s in
    #       	             ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.uppercase
    # Command exited with code 2.
    # make[1]: *** [Makefile:4: all] Error 10
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/statverif.1.97pl1.1/src'
    # make: *** [Makefile:4: all] Error 2

and

    #=== ERROR while compiling statverif.1.97pl1.2 ================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/statverif.1.97pl1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/statverif-7-b72614.env
    # output-file          ~/.opam/log/statverif-7-b72614.out
    ### output ###
    # make -C src all
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/statverif.1.97pl1.2/src'
    # ocamlbuild -use-ocamlfind main.native
    ...
    # + ocamlfind ocamlc -c -g -annot -o main.cmo main.ml
    # File "main.ml", line 339, characters 14-30:
    # 339 | 	  let s_up = String.uppercase s in
    #       	             ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.uppercase
    # Command exited with code 2.
    # make[1]: *** [Makefile:4: all] Error 10
    # make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/statverif.1.97pl1.2/src'
    # make: *** [Makefile:4: all] Error 2
