### PR TITLE
Package syncweb.0.5.1

### DIFF
--- a/packages/syncweb/syncweb.0.5.1/opam
+++ b/packages/syncweb/syncweb.0.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Syncweb, Literate Programming meets Unison"
+description: """
+Syncweb is a command-line tool enabling programmers to use the
+literate programming[1] development methodology, using the noweb[2]
+tool, while still being able to modify the generated files
+from the literate document. syncweb provides a way to
+"synchronize" the possibly modified original document with its
+possibly modified views with an interface similar to unison[3]. In
+addition, syncweb synchronizes data at a fine grained level by
+computing and storing md5sum of the different chunks.
+
+[1] http://en.wikipedia.org/wiki/Literate_programming
+[2] http://www.cs.tufts.edu/~nr/noweb/
+[3] http://www.seas.upenn.edu/~bcpierce/unison/
+"""
+
+maintainer: "Yoann Padioleau <yoann.padioleau@gmail.com>"
+authors: [ "Yoann Padioleau <yoann.padioleau@gmail.com>" ]
+license: "GPL-2.0-only"
+homepage: "https://github.com/aryx/syncweb"
+dev-repo: "git+https://github.com/aryx/syncweb"
+bug-reports: "https://github.com/aryx/syncweb/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "commons" {>= "1.5.5" }
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src: "https://github.com/aryx/syncweb/archive/refs/tags/0.5.1.tar.gz"
+  checksum: [
+    "md5=04226690418259ab08f787d855c7726a"
+    "sha512=9fa7979892b1121a0bac7cfdcc45faaa8c62c8336df1a222b91530ba284ef09d52cc04409087979a148d32f0c871d66f59693f0a31d043533077590165042704"
+  ]
+}


### PR DESCRIPTION
### `syncweb.0.5.1`
Syncweb, Literate Programming meets Unison
Syncweb is a command-line tool enabling programmers to use the
literate programming[1] development methodology, using the noweb[2]
tool, while still being able to modify the generated files
from the literate document. syncweb provides a way to
"synchronize" the possibly modified original document with its
possibly modified views with an interface similar to unison[3]. In
addition, syncweb synchronizes data at a fine grained level by
computing and storing md5sum of the different chunks.

[1] http://en.wikipedia.org/wiki/Literate_programming
[2] http://www.cs.tufts.edu/~nr/noweb/
[3] http://www.seas.upenn.edu/~bcpierce/unison/



---
* Homepage: https://github.com/aryx/syncweb
* Source repo: git+https://github.com/aryx/syncweb
* Bug tracker: https://github.com/aryx/syncweb/issues

---
:camel: Pull-request generated by opam-publish v2.2.0