### PR TITLE
[new release] OCADml (0.3.0)

### DIFF
--- a/packages/OCADml/OCADml.0.3.0/opam
+++ b/packages/OCADml/OCADml.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.14.0"}
+  "gg" {>= "1.0.0"}
+  "cairo2" {>= "0.6.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.3.0/OCADml-0.3.0.tbz"
+  checksum: [
+    "sha256=418f066c06a5abbae7e2751eef1f2bb707637f1cd7b4f7d6413678ac11a390bb"
+    "sha512=078acd5672e116b18161f5549ec02cb7d1f4dc7f2411fa535e77e6070fe56a1c7bcbaca1e26b3fcaf352b0869f42e16fcda5ce2037e979f39c1e0609bb37d6de"
+  ]
+}
+x-commit-hash: "4cb17c84e225bb873441b03ccb0ad196730d1ef3"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- add gg library dependency
- replaced vector (V{2,3,4}.t), matrix (Affine{2,3}), and bounding box types
 with those from gg
- protect bezier memoization with mutex (OCaml 5 compatibility)
