### PR TITLE
[new release] OSCADml (0.2.0)

### DIFF
--- a/packages/OSCADml/OSCADml.0.2.0/opam
+++ b/packages/OSCADml/OSCADml.0.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml DSL for 3D solid modelling in OpenSCAD"
+description:
+  "OSCADml is an OCaml front-end to the OpenSCAD CAD programming language."
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: [
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+  "Masaki Nakano<namachan10777@gmail.com>"
+]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD" "OpenSCAD"]
+homepage: "https://github.com/OCADml/OSCADml"
+doc: "https://ocadml.github.io/OSCADml"
+bug-reports: "https://github.com/OCADml/OSCADml/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.14.0"}
+  "gg" {>= "1.0.0"}
+  "cairo2" {>= "0.6.2"}
+  "OCADml" {>= "0.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OSCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OSCADml/releases/download/v0.2.0/OSCADml-0.2.0.tbz"
+  checksum: [
+    "sha256=051ef28b6224a75f7374967934aa849adcc7497b35e657d55dd880d2d4e9f1d0"
+    "sha512=5cc4735ea4dce058c8eb43395ebb597a407541883370e32e9ea2981114f26a15b030e73c66e200b8dcce35a97140452967ff587d6ba30d6a0c455671f80104be"
+  ]
+}
+x-commit-hash: "7b00751b96ffb096f506b3344355f30fa7e2be51"


### PR DESCRIPTION
OCaml DSL for 3D solid modelling in OpenSCAD

- Project page: <a href="https://github.com/OCADml/OSCADml">https://github.com/OCADml/OSCADml</a>
- Documentation: <a href="https://ocadml.github.io/OSCADml">https://ocadml.github.io/OSCADml</a>

##### CHANGES:

- add dimension type parameter to `Scad.t` (adjust to abstract Gg types in OCADml)
