### PR TITLE
ocaml5: restrict ANSIterminal

### DIFF
--- a/packages/ANSITerminal/ANSITerminal.0.8.1/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.1/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "dune"
   "base-bytes"
   "base-unix"

--- a/packages/ANSITerminal/ANSITerminal.0.8.2/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.2/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "dune"
   "base-bytes"
   "base-unix"

--- a/packages/ANSITerminal/ANSITerminal.0.8.3/opam
+++ b/packages/ANSITerminal/ANSITerminal.0.8.3/opam
@@ -14,7 +14,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "dune"
   "base-bytes"
   "base-unix"


### PR DESCRIPTION
They are missing a `caml_` prefix:

    #=== ERROR while compiling ANSITerminal.0.8.3 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ANSITerminal.0.8.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p ANSITerminal -j 71
    # exit-code            1
    # env-file             ~/.opam/log/ANSITerminal-7-e98bb5.env
    # output-file          ~/.opam/log/ANSITerminal-7-e98bb5.out
    ### output ###
    # File "tests/dune", line 2, characters 12-22:
    # 2 |  (names     showcolors test)
    #                 ^^^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o tests/showcolors.exe /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa src/ANSITerminal.cmxa -I src tests/.showcolors.eobjs/native/showcolors.cmx)
    # /usr/bin/ld: src/libANSITerminal_stubs.a(ANSITerminal_stubs.o): in function `ANSITerminal_term_size':
    # /home/opam/.opam/5.0/.opam-switch/build/ANSITerminal.0.8.3/_build/default/src/ANSITerminal_stubs.c:50: undefined reference to `failwith'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
    # File "tests/dune", line 2, characters 23-27:
    # 2 |  (names     showcolors test)
    #                            ^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o tests/test.exe /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa src/ANSITerminal.cmxa -I src tests/.showcolors.eobjs/native/test.cmx)
    # /usr/bin/ld: src/libANSITerminal_stubs.a(ANSITerminal_stubs.o): in function `ANSITerminal_term_size':
    # /home/opam/.opam/5.0/.opam-switch/build/ANSITerminal.0.8.3/_build/default/src/ANSITerminal_stubs.c:50: undefined reference to `failwith'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
