### PR TITLE
ocaml 5: restrict ancient

### DIFF
--- a/packages/ancient/ancient.0.9.1/opam
+++ b/packages/ancient/ancient.0.9.1/opam
@@ -11,7 +11,7 @@ build: [
 ]
 remove: ["ocamlfind" "remove" "ancient"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 install: [make "install" "DESTDIR=%{lib}%"]


### PR DESCRIPTION
It refers to removed C API:

    #=== ERROR while compiling ancient.0.9.1 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ancient.0.9.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/ancient-7-ccd6f2.env
    # output-file          ~/.opam/log/ancient-7-ccd6f2.out
    ### output ###
    ...
    # /usr/bin/ld: ./libancient.a(ancient_c.o): in function `_mark':
    # /home/opam/.opam/5.0/.opam-switch/build/ancient.0.9.1/ancient_c.c:206: undefined reference to `caml_page_table_lookup'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/ancient.0.9.1/ancient_c.c:238: undefined reference to `caml_page_table_lookup'
    # /usr/bin/ld: ./libancient.a(ancient_c.o): in function `ancient_delete':
    # /home/opam/.opam/5.0/.opam-switch/build/ancient.0.9.1/ancient_c.c:418: undefined reference to `caml_page_table_lookup'
    # /usr/bin/ld: ./libancient.a(ancient_c.o): in function `ancient_is_ancient':
    # /home/opam/.opam/5.0/.opam-switch/build/ancient.0.9.1/ancient_c.c:434: undefined reference to `caml_page_table_lookup'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
    # make: *** [Makefile:35: test_ancient_dict_write.opt] Error 2
