### PR TITLE
ocaml5: restrict cairo2

### DIFF
--- a/packages/cairo2/cairo2.0.6.2/opam
+++ b/packages/cairo2/cairo2.0.6.2/opam
@@ -15,7 +15,7 @@ build: [
   ["dune" "build" "@doc"] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "base-bigarray"
   "dune"
   "dune-configurator" {>= "1.11.4"}

--- a/packages/cairo2/cairo2.0.6.3/opam
+++ b/packages/cairo2/cairo2.0.6.3/opam
@@ -15,7 +15,7 @@ build: [
   ["dune" "build" "@doc"] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "base-bigarray"
   "dune" {>= "2.7.0"}
   "dune-configurator" {>= "2.7.0"}


### PR DESCRIPTION
It uses unprefixed API:

    #=== ERROR while compiling cairo2.0.6.3 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/cairo2.0.6.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p cairo2 -j 255
    # exit-code            1
    # env-file             ~/.opam/log/cairo2-7-252ab9.env
    # output-file          ~/.opam/log/cairo2-7-252ab9.out
    ### output ###
    # File "tests/dune", line 3, characters 21-31:
    # 3 |  (names image_create matrix_set surface_gc test_for_stream
    #                          ^^^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o tests/matrix_set.exe src/cairo.cmxa -I src tests/.image_create.eobjs/native/matrix_set.cmx)
    # /usr/bin/ld: src/libcairo_stubs.a(cairo_stubs.o): in function `caml_cairo_create':
    # /home/opam/.opam/5.0/.opam-switch/build/cairo2.0.6.3/_build/default/src/cairo_stubs.c:53: undefined reference to `alloc_custom'
