### PR TITLE
ocaml 5: restrict crc.2.1.0

### DIFF
--- a/packages/crc/crc.2.1.0/opam
+++ b/packages/crc/crc.2.1.0/opam
@@ -8,7 +8,7 @@ build: [[ "dune" "build" "-p" name ]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "dune" {>= "1.4"}
-  "ocaml" {>= "4.00.1"}
+  "ocaml" {>= "4.00.1" & < "5.0.0"}
   "cstruct" {>= "1.0.1"}
   "ounit" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
It uses a removed macro `Data_bigarray_val`:

    #=== ERROR while compiling crc.2.1.0 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/crc.2.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p crc -j 255
    # exit-code            1
    # env-file             ~/.opam/log/crc-7-9b63d7.env
    # output-file          ~/.opam/log/crc-7-9b63d7.out
    ### output ###
    # File "_build/.dune/default/test/dune", line 3, characters 8-16:
    # 3 |   (name crc_test)
    #             ^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o test/crc_test.exe /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/ounit2/advanced/oUnitAdvanced.cmxa /home/opam/.opam/5.0/lib/ounit2/oUnit.cmxa /home/opam/.opam/5.0/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.0/lib/cstruct /home/opam/.opam/5.0/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/5.0/lib/result/result.cmxa /home/opam/.opam/5.0/lib/base64/base64.cmxa /home/opam/.opam/5.0/lib/rresult/rresult.cmxa /home/opam/.opam/5.0/lib/rpclib/core/rpclib_core.cmxa /home/opam/.opam/5.0/lib/rpclib/internals/internals.cmxa /home/opam/.opam/5.0/lib/xmlm/xmlm.cmxa /home/opam/.opam/5.0/lib/rpclib/xml/xml.cmxa /home/opam/.opam/5.0/lib/rpclib/rpclib.cmxa lib/crc.cmxa -I lib test/.crc_test.eobjs/native/crc_test.cmx)
    # /usr/bin/ld: lib/libcrc_stubs.a(crc_stubs.o): in function `crc32_cstruct':
    # /home/opam/.opam/5.0/.opam-switch/build/crc.2.1.0/_build/default/lib/crc_stubs.c:97: undefined reference to `Data_bigarray_val'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
