### PR TITLE
ocaml 5: restrict dbm releases

### DIFF
--- a/packages/dbm/dbm.1.0/opam
+++ b/packages/dbm/dbm.1.0/opam
@@ -11,7 +11,7 @@ build: [
   [make "test"] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 depexts: [

--- a/packages/dbm/dbm.1.1/opam
+++ b/packages/dbm/dbm.1.1/opam
@@ -11,7 +11,7 @@ build: [
   [make "test"] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
 ]
 depexts: [

--- a/packages/dbm/dbm.1.2/opam
+++ b/packages/dbm/dbm.1.2/opam
@@ -11,7 +11,7 @@ build: [
   [make "test"] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind" {build}
   "conf-dbm"
 ]


### PR DESCRIPTION
They rely on unprefixed C API:

    #=== ERROR while compiling dbm.1.2 ============================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/dbm.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make test
    # exit-code            2
    # env-file             ~/.opam/log/dbm-7-f5993c.env
    # output-file          ~/.opam/log/dbm-7-f5993c.out
    ### output ###
    # ocamlc -o testdbm.byte dbm.cma testdbm.ml
    # ocamlopt -ccopt -L. -o testdbm.opt dbm.cmxa testdbm.ml
    # /usr/bin/ld: ./libcamldbm.a(cldbm.o): in function `raise_dbm':
    # cldbm.c:(.text+0x19): undefined reference to `raise_with_string'
