### PR TITLE
ocaml 5: restrict eqaf.0.8

### DIFF
--- a/packages/eqaf/eqaf.0.8/opam
+++ b/packages/eqaf/eqaf.0.8/opam
@@ -18,7 +18,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"          {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0.0"}
   "dune"           {>= "2.0"}
   "cstruct"        {>= "1.1.0"}
   "base64"         {with-test}


### PR DESCRIPTION
It uses unprefixed C API:

    #=== ERROR while compiling eqaf.0.8 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/eqaf.0.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p eqaf -j 1 --no-buffer --verbose
    # exit-code            1
    # env-file             ~/.opam/log/eqaf-7-7b8116.env
    # output-file          ~/.opam/log/eqaf-7-7b8116.out
    ### output ###
    ...
    # /usr/bin/ld: clock/libclock_stubs.a(clock_stubs.o): in function `clock_linux_get_time_byte':
    # /home/opam/.opam/5.0/.opam-switch/build/eqaf.0.8/_build/default/clock/clock_stubs.c:25: undefined reference to `copy_int64'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
