### PR TITLE
ocaml 5: restrict unix-type-representations

### DIFF
--- a/packages/unix-type-representations/unix-type-representations.0.1.1/opam
+++ b/packages/unix-type-representations/unix-type-representations.0.1.1/opam
@@ -12,7 +12,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "topkg" {build & >= "0.9.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/packages/unix-type-representations/unix-type-representations.0.1.2/opam
+++ b/packages/unix-type-representations/unix-type-representations.0.1.2/opam
@@ -12,7 +12,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "topkg" {build & >= "0.9.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build & != "0.9.0"}


### PR DESCRIPTION
It relies on unprefixed C API:

    #=== ERROR while compiling unix-type-representations.0.1.2 ====================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/unix-type-representations.0.1.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false --tests true
    # exit-code            1
    # env-file             ~/.opam/log/unix-type-representations-7-549cad.env
    # output-file          ~/.opam/log/unix-type-representations-7-549cad.out
    ### output ###
    ...
    # /usr/bin/ld: lib/libunix_type_representations_stubs.a(unix_type_representation_stubs.o): in function `dir_handle_of_nativeint_stub':
    # /home/opam/.opam/5.0/.opam-switch/build/unix-type-representations.0.1.2/_build/lib/unix_type_representation_stubs.c:29: undefined reference to `alloc_small'
