### PR TITLE
ocaml 5: restrict freetds.0.7

### DIFF
--- a/packages/freetds/freetds.0.7/opam
+++ b/packages/freetds/freetds.0.7/opam
@@ -23,7 +23,7 @@ depends: [
   "dune-configurator"
   "cppo" {build}
   "ounit" {with-test & >= "2.0.0"}
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0.0"}
 ]
 depexts: [
   ["freetds-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
It uses unprefixed C API:

    #=== ERROR while compiling freetds.0.7 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/freetds.0.7
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p freetds -j 71
    # exit-code            1
    # env-file             ~/.opam/log/freetds-7-0e0df1.env
    # output-file          ~/.opam/log/freetds-7-0e0df1.out
    ### output ###
    ...
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o examples/ct_example.exe src/freetds.cmxa -I src examples/.ct_example.eobjs/native/ct_example.cmx)
    # /usr/bin/ld: src/libfreetds_stubs.a(ct_c.o): in function `cons':
    # /home/opam/.opam/5.0/.opam-switch/build/freetds.0.7/_build/default/src/ct_c.c:265: undefined reference to `alloc'
    # /usr/bin/ld: src/libfreetds_stubs.a(ct_c.o): in function `retval_inspect':
    # /home/opam/.opam/5.0/.opam-switch/build/freetds.0.7/_build/default/src/ct_c.c:76: undefined reference to `failwith'
