### PR TITLE
ocaml 5: restrict hidapi.1.1

### DIFF
--- a/packages/hidapi/hidapi.1.1/opam
+++ b/packages/hidapi/hidapi.1.1/opam
@@ -8,7 +8,7 @@ doc: "https://vbmithr.github.io/ocaml-hidapi/doc"
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0.0"}
   "dune" {>= "1.8.2"}
   "dune-configurator"
   "conf-hidapi" {build}


### PR DESCRIPTION
It uses unprefixed C API:

    #=== ERROR while compiling hidapi.1.1 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/hidapi.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p hidapi -j 127
    # exit-code            1
    # env-file             ~/.opam/log/hidapi-7-797e50.env
    # output-file          ~/.opam/log/hidapi-7-797e50.out
    ### output ###
    # (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -I/usr/include/hidapi -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/bigstring -I /home/opam/.opam/5.0/lib/bytes -o hidapi_stubs.o -c hidapi_stubs.c)
    # hidapi_stubs.c: In function 'alloc_hid':
    # hidapi_stubs.c:37:24: warning: implicit declaration of function 'alloc_custom'; did you mean 'caml_alloc_custom'? [-Wimplicit-function-declaration]
    #    37 |         value custom = alloc_custom(&hidapi_##SNAME##_ops, sizeof(CNAME *), 0, 1); \
    #       |                        ^~~~~~~~~~~~
    # hidapi_stubs.c:42:1: note: in expansion of macro 'Gen_custom_block'
    #    42 | Gen_custom_block(hid, hid_device, Hid_val)
    #       | ^~~~~~~~~~~~~~~~
    # File "test/dune", line 2, characters 7-16:
    # 2 |  (name enumerate)
    #            ^^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o test/enumerate.exe /home/opam/.opam/5.0/lib/bigstring/bigstring.cmxa src/hidapi.cmxa -I src test/.enumerate.eobjs/native/enumerate.cmx)
    # /usr/bin/ld: src/libhidapi_stubs.a(hidapi_stubs.o): in function `alloc_hidinfo':
    # /home/opam/.opam/5.0/.opam-switch/build/hidapi.1.1/_build/default/src/hidapi_stubs.c:43: undefined reference to `alloc_custom'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/hidapi.1.1/_build/default/src/hidapi_stubs.c:43: undefined reference to `alloc_custom'
    # /usr/bin/ld: src/libhidapi_stubs.a(hidapi_stubs.o): in function `alloc_hid':
    # /home/opam/.opam/5.0/.opam-switch/build/hidapi.1.1/_build/default/src/hidapi_stubs.c:42: undefined reference to `alloc_custom'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/hidapi.1.1/_build/default/src/hidapi_stubs.c:42: undefined reference to `alloc_custom'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
