### PR TITLE
ocaml 5: restrict kafka

### DIFF
--- a/packages/kafka/kafka.0.5/opam
+++ b/packages/kafka/kafka.0.5/opam
@@ -18,7 +18,7 @@ description: """
 Kafka is a high-throughput distributed messaging system.
 """
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "conf-zlib"
   "dune" {>= "1.10"}
 ]


### PR DESCRIPTION
It uses unprefixed C API:

    #=== ERROR while compiling kafka_lwt.0.5 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/kafka_lwt.0.5
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p kafka_lwt -j 71
    # exit-code            1
    # env-file             ~/.opam/log/kafka_lwt-7-748b7b.env
    # output-file          ~/.opam/log/kafka_lwt-7-748b7b.out
    ### output ###
    ...
    # File "bin/dune", line 2, characters 27-43:
    # 2 |  (names sendto_kafka_topic tail_kafka_topic)
    #                                ^^^^^^^^^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o bin/tail_kafka_topic.exe /home/opam/.opam/5.0/lib/kafka/kafka.cmxa -I /home/opam/.opam/5.0/lib/kafka /home/opam/.opam/5.0/lib/lwt/lwt.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.0/lib/lwt/unix lib_lwt/kafka_lwt.cmxa -I lib_lwt /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa bin/.sendto_kafka_topic.eobjs/native/tail_kafka_topic.cmx)
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/kafka/libkafka_stubs.a(ocaml_kafka.o): in function `alloc_caml_handler':
    # /home/opam/.opam/5.0/.opam-switch/build/kafka.0.5/_build/default/lib/ocaml_kafka.c:104: undefined reference to `alloc_small'
    # collect2: error: ld returned 1 exit status
