### PR TITLE
ocaml 5: restrict secp256k1-internal.0.1.0

### DIFF
--- a/packages/secp256k1-internal/secp256k1-internal.0.1.0/opam
+++ b/packages/secp256k1-internal/secp256k1-internal.0.1.0/opam
@@ -14,6 +14,7 @@ build: [
 ]
 depends: [
   "conf-gmp" {build}
+  "ocaml" {< "5.0.0"}
   "dune" {>= "1.0.1"}
   "cstruct" {>= "3.2.1" & < "6.1.0"}
   "bigstring" {>= "0.1.1"}


### PR DESCRIPTION
It uses unprefixed C API:

    #=== ERROR while compiling secp256k1-internal.0.1.0 ===========================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/secp256k1-internal.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p secp256k1-internal -j 255
    # exit-code            1
    # env-file             ~/.opam/log/secp256k1-internal-7-f79074.env
    # output-file          ~/.opam/log/secp256k1-internal-7-f79074.out
    ### output ###
    # File "test/dune", line 2, characters 7-11:
    # 2 |  (name test)
    #            ^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o test/test.exe /home/opam/.opam/5.0/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.0/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.0/lib/cstruct /home/opam/.opam/5.0/lib/hex/hex.cmxa /home/opam/.opam/5.0/lib/bigstring/bigstring.cmxa src/libsecp256k1.cmxa -I src /home/opam/.opam/5.0/lib/astring/astring.cmxa /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/uutf/uutf.cmxa /home/opam/.opam/5.0/lib/alcotest/stdlib_ext/alcotest_stdlib_ext.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_cli.cmxa /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/alcotest/engine/alcotest_engine.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_tty.cmxa /home/opam/.opam/5.0/lib/alcotest/alcotest.cmxa -I /home/opam/.opam/5.0/lib/alcotest test/.test.eobjs/native/test.cmx)
    # /usr/bin/ld: src/liblibsecp256k1_stubs.a(secp256k1_wrap.o): in function `alloc_context':
    # /home/opam/.opam/5.0/.opam-switch/build/secp256k1-internal.0.1.0/_build/default/src/secp256k1_wrap.c:28: undefined reference to `alloc_custom'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/secp256k1-internal.0.1.0/_build/default/src/secp256k1_wrap.c:28: undefined reference to `alloc_custom'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
