### PR TITLE
ocaml 5: restrict spin releases

### DIFF
--- a/packages/spin/spin.0.8.0/opam
+++ b/packages/spin/spin.0.8.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/tmattio/spin"
 doc: "https://tmattio.github.io/spin/"
 bug-reports: "https://github.com/tmattio/spin/issues"
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0.0"}
   "dune" {>= "2.7"}
   "alcotest" {with-test}
   "js_of_ocaml" {with-test}

--- a/packages/spin/spin.0.8.1/opam
+++ b/packages/spin/spin.0.8.1/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/tmattio/spin"
 doc: "https://tmattio.github.io/spin/"
 bug-reports: "https://github.com/tmattio/spin/issues"
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0.0"}
   "dune" {>= "2.8"}
   "alcotest" {with-test}
   "js_of_ocaml" {with-test}

--- a/packages/spin/spin.0.8.2/opam
+++ b/packages/spin/spin.0.8.2/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/tmattio/spin"
 doc: "https://tmattio.github.io/spin/"
 bug-reports: "https://github.com/tmattio/spin/issues"
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0.0"}
   "dune" {>= "2.8"}
   "alcotest" {with-test}
   "js_of_ocaml" {with-test}

--- a/packages/spin/spin.0.8.3/opam
+++ b/packages/spin/spin.0.8.3/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/tmattio/spin"
 doc: "https://tmattio.github.io/spin/"
 bug-reports: "https://github.com/tmattio/spin/issues"
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0.0"}
   "dune" {>= "2.8"}
   "alcotest" {with-test}
   "js_of_ocaml" {with-test}


### PR DESCRIPTION
They rely on unprefixed C API:

    #=== ERROR while compiling spin.0.8.3 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/spin.0.8.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p spin -j 31 @install
    # exit-code            1
    # env-file             ~/.opam/log/spin-7-98cb0b.env
    # output-file          ~/.opam/log/spin-7-98cb0b.out
    ### output ###
    ...
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -open Spin_std -g -o bin/main.exe /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/spawn/spawn.cmxa -I /home/opam/.opam/5.0/lib/spawn lib/spin_std/spin_std.cmxa template/spin_template.cmxa vendor/ocaml-ansi/src/ansi.cmxa -I vendor/ocaml-ansi/src lib/inquire/inquire.cmxa /home/opam/.opam/5.0/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.0/lib/base/caml/caml.cmxa /home/opam/.opam/5.0/lib/parsexp/parsexp.cmxa /home/opam/.opam/5.0/lib/sexplib/sexplib.cmxa /home/opam/.opam/5.0/lib/ocaml/str/str.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/logs/logs.cmxa /home/opam/.opam/5.0/lib/ocaml/dynlink/dynlink.cmxa /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/uutf/uutf.cmxa /home/opam/.opam/5.0/lib/uucp/uucp.cmxa /home/opam/.opam/5.0/lib/result/result.cmxa /home/opam/.opam/5.0/lib/ppx_deriving/runtime/ppx_deriving_runtime.cmxa /home/opam/.opam/5.0/lib/jingoo/jingoo.cmxa /home/opam/.opam/5.0/lib/astring/astring.cmxa /home/opam/.opam/5.0/lib/fpath/fpath.cmxa lib/spin/spin.cmxa /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_tty.cmxa /home/opam/.opam/5.0/lib/logs/logs_fmt.cmxa /home/opam/.opam/5.0/lib/logs/logs_cli.cmxa bin/.main.eobjs/native/dune__exe.cmx bin/.main.eobjs/native/dune__exe__Common.cmx bin/.main.eobjs/native/dune__exe__Cmd_config.cmx bin/.main.eobjs/native/dune__exe__Cmd_hello.cmx bin/.main.eobjs/native/dune__exe__Cmd_ls.cmx bin/.main.eobjs/native/dune__exe__Cmd_new.cmx bin/.main.eobjs/native/dune__exe__Main.cmx)
    # /usr/bin/ld: vendor/ocaml-ansi/src/libansi_stubs.a(ansi_stubs.o): in function `Ansi_term_size':
    # /home/opam/.opam/5.0/.opam-switch/build/spin.0.8.3/_build/default/vendor/ocaml-ansi/src/ansi_stubs.c:45: undefined reference to `failwith'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
