### PR TITLE
ocaml 5: restrict uecc.0.3

### DIFF
--- a/packages/uecc/uecc.0.3/opam
+++ b/packages/uecc/uecc.0.3/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03"}
+  "ocaml" {>= "4.03" & < "5.0.0"}
   "dune" {>= "2.0"}
   "bigstring" {>= "0.1.1"}
   "alcotest" {with-test & >= "0.8.1"}


### PR DESCRIPTION
It relies on unprefixed C API:

    #=== ERROR while compiling uecc.0.3 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/uecc.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p uecc -j 71
    # exit-code            1
    # env-file             ~/.opam/log/uecc-7-a65174.env
    # output-file          ~/.opam/log/uecc-7-a65174.out
    ### output ###
    # File "test/dune", line 8, characters 7-19:
    # 8 |  (name test_vectors)
    #            ^^^^^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o test/test_vectors.exe /home/opam/.opam/5.0/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.0/lib/cstruct /home/opam/.opam/5.0/lib/hex/hex.cmxa /home/opam/.opam/5.0/lib/astring/astring.cmxa /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/uutf/uutf.cmxa /home/opam/.opam/5.0/lib/alcotest/stdlib_ext/alcotest_stdlib_ext.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_cli.cmxa /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/alcotest/engine/alcotest_engine.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_tty.cmxa /home/opam/.opam/5.0/lib/alcotest/alcotest.cmxa -I /home/opam/.opam/5.0/lib/alcotest /home/opam/.opam/5.0/lib/bigstring/bigstring.cmxa src/uecc.cmxa -I src test/.test_vectors.eobjs/native/dune__exe.cmx test/.test_vectors.eobjs/native/dune__exe__Vectors.cmx test/.test_vectors.eobjs/native/dune__exe__Test_vectors.cmx)
    # /usr/bin/ld: src/libuecc_stubs.a(uecc_stubs.o): in function `alloc_curve':
    # /home/opam/.opam/5.0/.opam-switch/build/uecc.0.3/_build/default/src/uecc_stubs.c:37: undefined reference to `alloc_custom'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
    # File "test/dune", line 2, characters 7-11:
    # 2 |  (name test)
    #            ^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o test/test.exe /home/opam/.opam/5.0/lib/astring/astring.cmxa /home/opam/.opam/5.0/lib/cmdliner/cmdliner.cmxa /home/opam/.opam/5.0/lib/uutf/uutf.cmxa /home/opam/.opam/5.0/lib/alcotest/stdlib_ext/alcotest_stdlib_ext.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_cli.cmxa /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/alcotest/engine/alcotest_engine.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/fmt/fmt_tty.cmxa /home/opam/.opam/5.0/lib/alcotest/alcotest.cmxa -I /home/opam/.opam/5.0/lib/alcotest /home/opam/.opam/5.0/lib/bigstring/bigstring.cmxa src/uecc.cmxa -I src test/.test.eobjs/native/dune__exe__Test.cmx)
    # /usr/bin/ld: src/libuecc_stubs.a(uecc_stubs.o): in function `alloc_curve':
    # /home/opam/.opam/5.0/.opam-switch/build/uecc.0.3/_build/default/src/uecc_stubs.c:37: undefined reference to `alloc_custom'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
