### PR TITLE
Do not build CGI 0.{9,10} on OCaml 5

### DIFF
--- a/packages/cgi/cgi.0.10/opam
+++ b/packages/cgi/cgi.0.10/opam
@@ -13,7 +13,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {> "4.01.0"}
+  "ocaml" {> "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Library for writing CGIs"

--- a/packages/cgi/cgi.0.9/opam
+++ b/packages/cgi/cgi.0.9/opam
@@ -14,7 +14,7 @@ build: [
 install: [make "install"]
 remove: [["ocamlfind" "remove" "cgi"]]
 depends: [
-  "ocaml" {> "4.01.0"}
+  "ocaml" {> "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 synopsis: "Library for writing CGIs"


### PR DESCRIPTION
FTBFS due to immutable string/bytes syntax:

```
    #=== ERROR while compiling cgi.0.10 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/cgi.0.10
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/cgi-8-1e2494.env
    # output-file          ~/.opam/log/cgi-8-1e2494.out
    ### output ###
    # rm -f .depend
    # ocamldep  *.ml *.mli > .depend
    # File "cgi.ml", line 57, characters 14-35:
    # 57 |               s1.[i1] <- Char.chr v; i + 3
    #                    ^^^^^^^^^^^^^^^^^^^^^
    # Error: Syntax error: strings are immutable, there is no assignment syntax for them.
    # Hint: Mutable sequences of bytes are available in the Bytes module.
    # Hint: Did you mean to use 'Bytes.set'?
```