### PR TITLE
Restrict `thrift.0.10.0` from building on OCaml 5

### DIFF
--- a/packages/thrift/thrift.0.10.0/opam
+++ b/packages/thrift/thrift.0.10.0/opam
@@ -6,7 +6,7 @@ homepage: "https://github.com/vbmithr/ocaml-thrift-lib"
 bug-reports: "https://github.com/vbmithr/ocaml-thrift-lib/issues"
 doc: "https://vbmithr.github.io/ocaml-thrift-lib/doc"
 depends: [
-  "ocaml" { >= "4.03.0" }
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "dune" { >= "1.1" }
 ]
 depexts: [


### PR DESCRIPTION
FTBFS due to immutable string/bytes syntax removed:

```
    #=== ERROR while compiling thrift.0.10.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/thrift.0.10.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p thrift -j 255
    # exit-code            1
    # env-file             ~/.opam/log/thrift-9-8ff6db.env
    # output-file          ~/.opam/log/thrift-9-8ff6db.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamldep.opt -modules -impl src/TBinaryProtocol.ml) > _build/default/src/.thrift.objs/TBinaryProtocol.ml.d
    # File "src/TBinaryProtocol.ml", line 56, characters 4-49:
    # 56 |     ibyte.[0] <- char_of_int (if b then 1 else 0);
    #          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    # Error: Syntax error: strings are immutable, there is no assignment syntax for them.
    # Hint: Mutable sequences of bytes are available in the Bytes module.
    # Hint: Did you mean to use 'Bytes.set'?
```