### PR TITLE
Restrict wiringpi.0.0.1 from building on OCaml 5

### DIFF
--- a/packages/wiringpi/wiringpi.0.0.1/opam
+++ b/packages/wiringpi/wiringpi.0.0.1/opam
@@ -10,7 +10,7 @@ remove: [
   ["ocamlfind" "remove" "WiringPi"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
FTBFS due to OASIS generating removed function calls:

```
    #=== ERROR while compiling wiringpi.0.0.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/wiringpi.0.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/wiringpi-7-b0d079.env
    # output-file          ~/.opam/log/wiringpi-7-b0d079.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
```