### PR TITLE
Restrict ocamlsdl.0.9.1 from building on OCaml 5

### DIFF
--- a/packages/ocamlsdl/ocamlsdl.0.9.1/opam
+++ b/packages/ocamlsdl/ocamlsdl.0.9.1/opam
@@ -9,7 +9,10 @@ build: [
   [make]
 ]
 remove: [["ocamlfind" "remove" "sdl"]]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0.0"}
+  "ocamlfind"
+]
 depopts: [
   "lablgl"
   "conf-sdl-gfx"


### PR DESCRIPTION
FTBFS due to changes in Bigarray C API:

```
    #=== ERROR while compiling ocamlsdl.0.9.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocamlsdl.0.9.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/ocamlsdl-8-caf801.env
    # output-file          ~/.opam/log/ocamlsdl-8-caf801.out
    ### output ###
    <lots of warnings skipped>
    # sdlkey_stub.c: In function 'ml_SDL_GetKeyState':
    # sdlkey_stub.c:31:13: warning: implicit declaration of function 'alloc_bigarray' [-Wimplicit-function-declaration]
    #    31 |   value v = alloc_bigarray(BIGARRAY_UINT8 |
    #       |             ^~~~~~~~~~~~~~
    # sdlkey_stub.c:31:28: error: 'BIGARRAY_UINT8' undeclared (first use in this function)
    #    31 |   value v = alloc_bigarray(BIGARRAY_UINT8 |
    #       |                            ^~~~~~~~~~~~~~
    # sdlkey_stub.c:31:28: note: each undeclared identifier is reported only once for each function it appears in
    # sdlkey_stub.c:32:28: error: 'BIGARRAY_C_LAYOUT' undeclared (first use in this function)
    #    32 |                            BIGARRAY_C_LAYOUT |
    #       |                            ^~~~~~~~~~~~~~~~~
    # sdlkey_stub.c:33:28: error: 'BIGARRAY_EXTERNAL' undeclared (first use in this function)
    #    33 |                            BIGARRAY_EXTERNAL, 1, data, &llen);
    #       |                            ^~~~~~~~~~~~~~~~~
```