### PR TITLE
Prevent qfs.0.12 from building on OCaml 5

### DIFF
--- a/packages/qfs/qfs.0.12/opam
+++ b/packages/qfs/qfs.0.12/opam
@@ -14,7 +14,7 @@ build: [
 ]
 install: ["ocaml" "setup.ml" "-install"]
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0.0"}
   "base-bytes"
   "base-unix"
   "extlib" | "extlib-compat"


### PR DESCRIPTION
FTBFS due to depending on `Stream`:

```
    #=== ERROR while compiling qfs.0.12 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/qfs.0.12
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/qfs-8-f5153f.env
    # output-file          ~/.opam/log/qfs-8-f5153f.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
```