### PR TITLE
Restrict proj4.0.9.2 from building on OCaml 5

### DIFF
--- a/packages/proj4/proj4.0.9.2/opam
+++ b/packages/proj4/proj4.0.9.2/opam
@@ -13,7 +13,7 @@ remove: [
   ["ocamlfind" "remove" "proj4"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
FTBFS due to OASIS script using `Stream`:

```
    #=== ERROR while compiling proj4.0.9.2 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/proj4.0.9.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/proj4-7-db97e2.env
    # output-file          ~/.opam/log/proj4-7-db97e2.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
```