### PR TITLE
Restrict leveldb.1.3.0 from building on OCaml 5

### DIFF
--- a/packages/leveldb/leveldb.1.3.0/opam
+++ b/packages/leveldb/leveldb.1.3.0/opam
@@ -14,7 +14,7 @@ license: "MIT"
 homepage: "https://github.com/mfp/ocaml-leveldb"
 bug-reports: "https://github.com/mfp/ocaml-leveldb/issues"
 depends: [
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "dune" {>= "2.0"}
   "ounit2" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
FTBFS due to C API renames:

```
    #=== ERROR while compiling leveldb.1.3.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/leveldb.1.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p leveldb -j 47 @install
    # exit-code            1
    # env-file             ~/.opam/log/leveldb-8-8eb1b9.env
    # output-file          ~/.opam/log/leveldb-8-8eb1b9.out
    ### output ###
    # File "src/dune", line 6, characters 9-22:
    # 6 |   (names leveldb_stubs))
    #              ^^^^^^^^^^^^^
    # (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o leveldb_stubs.o -c leveldb_stubs.cc)
    # leveldb_stubs.cc: In function 'value ldb_destroy(value)':
    # leveldb_stubs.cc:376:32: error: 'string_length' was not declared in this scope; did you mean 'caml_string_length'?
    #   376 |  std::string _s(String_val(s), string_length(s));
    #       |                                ^~~~~~~~~~~~~
    #       |                                caml_string_length
```