### PR TITLE
Do not build libsvm.0.10.0 on OCaml 5

### DIFF
--- a/packages/libsvm/libsvm.0.10.0/opam
+++ b/packages/libsvm/libsvm.0.10.0/opam
@@ -30,7 +30,7 @@ depends: [
   "base"
   "dune" {>= "1.10"}
   "lacaml" {>= "10.0.0"}
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "stdio"
   "core_kernel" {with-test}
 ]


### PR DESCRIPTION
FTBFS due to `caml_failwith` C API change in OCaml 5. Also due to Bigarray API changes.

```
    #=== ERROR while compiling libsvm.0.10.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/libsvm.0.10.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p libsvm -j 31
    # exit-code            1
    # env-file             ~/.opam/log/libsvm-9-c4e078.env
    # output-file          ~/.opam/log/libsvm-9-c4e078.out
    ### output ###
    # File "lib/dune", line 6, characters 16-28:
    # 6 |  (cxx_names svm libsvm_stubs)
    #                     ^^^^^^^^^^^^
    # (cd _build/default/lib && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/lacaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdio -o libsvm_stubs.o -c libsvm_stubs.cpp)
    # libsvm_stubs.cpp: In function 'value svm_train_stub(value, value)':
    # libsvm_stubs.cpp:403:5: error: 'failwith' was not declared in this scope
    #   403 |     failwith(error_msg);
    #       |     ^~~~~~~~
    # libsvm_stubs.cpp: In function 'value svm_cross_validation_stub(value, value, value)':
    # libsvm_stubs.cpp:427:5: error: 'failwith' was not declared in this scope
    #   427 |     failwith(error_msg);
    #       |     ^~~~~~~~
    # libsvm_stubs.cpp:433:34: error: 'BIGARRAY_FLOAT64' was not declared in this scope
    #   433 |   v_target = alloc_bigarray_dims(BIGARRAY_FLOAT64 | BIGARRAY_FORTRAN_LAYOUT,
    #       |                                  ^~~~~~~~~~~~~~~~
    # libsvm_stubs.cpp:433:53: error: 'BIGARRAY_FORTRAN_LAYOUT' was not declared in this scope; did you mean 'CAML_BA_FORTRAN_LAYOUT'?
    #   433 |   v_target = alloc_bigarray_dims(BIGARRAY_FLOAT64 | BIGARRAY_FORTRAN_LAYOUT,
    #       |                                                     ^~~~~~~~~~~~~~~~~~~~~~~
    #       |                                                     CAML_BA_FORTRAN_LAYOUT
    # libsvm_stubs.cpp:433:14: error: 'alloc_bigarray_dims' was not declared in this scope
    #   433 |   v_target = alloc_bigarray_dims(BIGARRAY_FLOAT64 | BIGARRAY_FORTRAN_LAYOUT,
    #       |              ^~~~~~~~~~~~~~~~~~~
    # libsvm_stubs.cpp: In function 'value svm_save_model_stub(value, value)':
    # libsvm_stubs.cpp:442:5: error: 'failwith' was not declared in this scope
    #   442 |     failwith("Could not save model");
    #       |     ^~~~~~~~
    # libsvm_stubs.cpp: In function 'value svm_load_model_stub(value)':
    # libsvm_stubs.cpp:453:5: error: 'failwith' was not declared in this scope
    #   453 |     failwith("Could not load model.");
    #       |     ^~~~~~~~
```