### PR TITLE
Do not build mrmime.0.1.0 on OCaml 5

### DIFF
--- a/packages/mrmime/mrmime.0.1.0/opam
+++ b/packages/mrmime/mrmime.0.1.0/opam
@@ -13,7 +13,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
 
 depends: [
-  "ocaml" {>= "4.07.0"}
+  "ocaml" {>= "4.07.0" & < "5.0.0"}
   "dune" {>= "1.0"}
   "uutf"
   "ke" {>= "0.4"}


### PR DESCRIPTION
FTBFS due to a multiple of reasons: `Obj.extension_id` removal, `Pervasives`:

```
    #=== ERROR while compiling mrmime.0.1.0 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mrmime.0.1.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mrmime -j 71
    # exit-code            1
    # env-file             ~/.opam/log/mrmime-8-8626ab.env
    # output-file          ~/.opam/log/mrmime-8-8626ab.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -32-27 -g -bin-annot -I lib/.mrmime.objs/byte -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/base64/rfc2045 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/coin -I /home/opam/.opam/5.0/lib/domain-name -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/ipaddr -I /home/opam/.opam/5.0/lib/ke -I /home/opam/.opam/5.0/lib/macaddr -I /home/opam/.opam/5.0/lib/pecu -I /home/opam/.opam/5.0/lib/ptime -I /home/opam/.opam/5.0/lib/rosetta -I /home/opam/.opam/5.0/lib/rresult -I /home/opam/.opam/5.0/lib/uutf -I /home/opam/.opam/5.0/lib/uuuu -I /home/opam/.opam/5.0/lib/yuscii -I lib/butils/.butils.objs/byte -I lib/encoder/.encoder.objs/byte -intf-suffix .ml -no-alias-deps -open Mrmime__ -o lib/.mrmime.objs/byte/mrmime__Extension.cmo -c -impl lib/extension.ml)
    # File "lib/extension.ml", line 21, characters 9-25:
    # 21 |         (Obj.extension_id [%extension_constructor T])
    #               ^^^^^^^^^^^^^^^^
    # Error: Unbound value Obj.extension_id
    # File "lib/encoded_word.ml", line 91, characters 25-41:
    # 91 | let equal_charset a b = (Pervasives.( = ) : charset -> charset -> bool) a b
    #                               ^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # File "lib/extension.ml", line 21, characters 9-25:
    # 21 |         (Obj.extension_id [%extension_constructor T])
    #               ^^^^^^^^^^^^^^^^
    # Error: Unbound value Obj.extension_id
    # File "lib/encoded_word.ml", line 91, characters 25-41:
    # 91 | let equal_charset a b = (Pervasives.( = ) : charset -> charset -> bool) a b
    #                               ^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```

(Deprecation warnings from Fmt removed from output since these are not causing failures)