### PR TITLE
Do not test ocurl.0.9.1 on OCaml 5

### DIFF
--- a/packages/ocurl/ocurl.0.9.1/opam
+++ b/packages/ocurl/ocurl.0.9.1/opam
@@ -11,7 +11,7 @@ build: [
   ["./configure"]
   [make]
   [make "doc"] {with-doc}
-  [make "test"] {with-test}
+  [make "test"] {with-test & ocaml:version < "5.0.0"}
 ]
 install: [
   [make "install"]


### PR DESCRIPTION
Test FTBFS due to removal of `Scanf.fscanf`:

```
    #=== ERROR while compiling ocurl.0.9.1 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocurl.0.9.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make test
    # exit-code            2
    # env-file             ~/.opam/log/ocurl-7-cf7493.env
    # output-file          ~/.opam/log/ocurl-7-cf7493.out
    ### output ###
    # make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ocurl.0.9.1'
    # File "test_memory_leaks.ml", line 24, characters 12-24:
    # 24 |     let n = Scanf.fscanf ch "%_d %d" (fun x -> 4*1024*x) in close_in_noerr ch; n
    #                  ^^^^^^^^^^^^
    # Error: Unbound value Scanf.fscanf
    # Hint: Did you mean bscanf, kscanf, scanf or sscanf?
```