### PR TITLE
Do not build `linkage.0.1` on OCaml 5

### DIFF
--- a/packages/linkage/linkage.0.1/opam
+++ b/packages/linkage/linkage.0.1/opam
@@ -9,7 +9,7 @@ build:
 [[ "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"]]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "topkg" {build & >= "0.7.4"}


### PR DESCRIPTION
FTBFS due to `Obj.extension_name` removal:

```
    #=== ERROR while compiling linkage.0.1 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/linkage.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false
    # exit-code            1
    # env-file             ~/.opam/log/linkage-8-5d2580.env
    # output-file          ~/.opam/log/linkage-8-5d2580.out
    ### output ###
    # ocamlfind ocamldep -modules src/linkage.ml > src/linkage.ml.depends
    # ocamlfind ocamldep -modules src/linkage.mli > src/linkage.mli.depends
    # ocamlfind ocamlc -c -g -I src -o src/linkage.cmi src/linkage.mli
    # + ocamlfind ocamlc -c -g -I src -o src/linkage.cmi src/linkage.mli
    <warnings about Unix skipped>
    # File "src/linkage.ml", line 46, characters 12-26:
    # 46 |        Obj.(extension_name (extension_constructor p)) in
    #                  ^^^^^^^^^^^^^^
    # Error: Unbound value extension_name
```