### PR TITLE
piqi is not compatible with safe-string

### DIFF
--- a/packages/piqi/piqi.0.7.0/opam
+++ b/packages/piqi/piqi.0.7.0/opam
@@ -5,7 +5,7 @@ remove: [
   ["rm" "-f" "%{prefix}%/bin/piqic-ocaml"]
   ["ocamlfind" "remove" "piqirun"]
 ]
-depends: ["ocaml" "ocamlfind" "piqilib"]
+depends: ["ocaml" {< "4.06"} "ocamlfind" "piqilib"]
 dev-repo: "git+https://github.com/alavrik/piqi-ocaml"
 install: [make "DESTDIR=%{prefix}%" "install"]
 synopsis: "Protocol Buffers, JSON and XML serialization system for OCaml"

--- a/packages/piqi/piqi.0.7.1/opam
+++ b/packages/piqi/piqi.0.7.1/opam
@@ -5,7 +5,7 @@ remove: [
   ["rm" "-f" "%{prefix}%/bin/piqic-ocaml"]
   ["ocamlfind" "remove" "piqirun"]
 ]
-depends: ["ocaml" "ocamlfind" "piqilib"]
+depends: ["ocaml" {< "4.06"} "ocamlfind" "piqilib"]
 dev-repo: "git+https://github.com/alavrik/piqi-ocaml"
 install: [make "DESTDIR=%{prefix}%" "install"]
 synopsis: "Protocol Buffers, JSON and XML serialization system for OCaml"

--- a/packages/piqi/piqi.0.7.4/opam
+++ b/packages/piqi/piqi.0.7.4/opam
@@ -5,7 +5,7 @@ remove: [
   ["rm" "-f" "%{prefix}%/bin/piqic-ocaml"]
   ["ocamlfind" "remove" "piqirun"]
 ]
-depends: ["ocaml" "ocamlfind" "piqilib" "base-bytes"]
+depends: ["ocaml" {< "4.06"} "ocamlfind" "piqilib" "base-bytes"]
 dev-repo: "git+https://github.com/alavrik/piqi-ocaml"
 install: [make "DESTDIR=%{prefix}%" "install"]
 synopsis: "Protocol Buffers, JSON and XML serialization system for OCaml"

--- a/packages/piqi/piqi.0.7.5/opam
+++ b/packages/piqi/piqi.0.7.5/opam
@@ -13,7 +13,7 @@ remove: [
   ["rm" "-f" "%{prefix}%/bin/piqic-ocaml"]
   ["ocamlfind" "remove" "piqirun"]
 ]
-depends: ["ocaml" "ocamlfind" "piqilib" "base-bytes"]
+depends: ["ocaml" {< "4.06"} "ocamlfind" "piqilib" "base-bytes"]
 dev-repo: "git+https://github.com/alavrik/piqi-ocaml"
 synopsis: "Protocol Buffers, JSON and XML serialization system for OCaml"
 authors: "Anton Lavrik <alavrik@piqi.org>"


### PR DESCRIPTION
```
# File "piqirun.ml", line 157, characters 22-23:
# 157 |             of_string s start_pos
#                             ^
# Error: This expression has type bytes but an expression was expected of type
#          string
```

```
# File "piqic_common.ml", line 57, characters 27-28:
# 57 |         let s = Bytes.copy s in
#                                 ^
# Error: This expression has type string but an expression was expected of type
#          bytes
```

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>