### PR TITLE
Disable tests for mrmime.0.4.0 and .0.5.0 on ocaml5

### DIFF
--- a/packages/mrmime/mrmime.0.4.0/opam
+++ b/packages/mrmime/mrmime.0.4.0/opam
@@ -11,7 +11,7 @@ description:  """Parser and generator of mail in OCaml"""
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0"}
 ]
 
 depends: [

--- a/packages/mrmime/mrmime.0.5.0/opam
+++ b/packages/mrmime/mrmime.0.5.0/opam
@@ -11,7 +11,7 @@ description:  """Parser and generator of mail in OCaml"""
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0"}
 ]
 
 depends: [


### PR DESCRIPTION
These tests are dependent on the PRNG which is *differently predictible* on ocaml5 than on previous ocaml versions.

See https://github.com/mirage/mrmime/issues/91 for additional context.

ping @dinosaure 