### PR TITLE
Only run dtoa.0.3.2 tests on OCaml < 5

### DIFF
--- a/packages/dtoa/dtoa.0.3.2/opam
+++ b/packages/dtoa/dtoa.0.3.2/opam
@@ -12,7 +12,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0.0"}
 ]
 dev-repo: "git+https://github.com/flowtype/ocaml-dtoa.git"
 synopsis: "Converts OCaml floats into strings (doubles to ascii, 'd to a'), using the efficient Grisu3 algorithm"


### PR DESCRIPTION
Tests FTBFS due to requiring `Pervasives`:

```
    #=== ERROR while compiling dtoa.0.3.2 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/dtoa.0.3.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p dtoa -j 47
    # exit-code            1
    # env-file             ~/.opam/log/dtoa-7-b1521a.env
    # output-file          ~/.opam/log/dtoa-7-b1521a.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/oUnit -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/.dtoa.objs/byte -no-alias-deps -o test/.test.eobjs/byte/shortest_test.cmo -c -impl test/shortest_test.ml)
    # File "test/shortest_test.ml", line 56, characters 58-72:
    # 56 |     eq                    "NaN" (shortest_string_of_float Pervasives.nan);
    #                                                                ^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/oUnit -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/.dtoa.objs/byte -no-alias-deps -o test/.test.eobjs/byte/g_fmt_test.cmo -c -impl test/g_fmt_test.ml)
    # File "test/g_fmt_test.ml", line 52, characters 40-54:
    # 52 |     eq                     "NaN" (g_fmt Pervasives.nan);
    #                                              ^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I test/.test.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/oUnit -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/.dtoa.objs/byte -no-alias-deps -o test/.test.eobjs/byte/ecma_test.cmo -c -impl test/ecma_test.ml)
    # File "test/ecma_test.ml", line 52, characters 55-69:
    # 52 |     eq                     "NaN" (ecma_string_of_float Pervasives.nan);
    #                                                             ^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
```