### PR TITLE
ocaml 5: restrict vhd-format-lwt releases

### DIFF
--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.1/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "cstruct"
   "lwt" {>= "3.2.0"}
   "mirage-block" {>= "2.0.1"}

--- a/packages/vhd-format-lwt/vhd-format-lwt.0.12.2/opam
+++ b/packages/vhd-format-lwt/vhd-format-lwt.0.12.2/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-vhd"
 doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
-  "ocaml" {>= "4.02.3"}
+  "ocaml" {>= "4.02.3" & < "5.0.0"}
   "cstruct"
   "lwt" {>= "3.2.0"}
   "mirage-block" {>= "2.0.1"}


### PR DESCRIPTION
They rely on unprefixed C API:

    #=== ERROR while compiling vhd-format-lwt.0.12.2 ==============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p vhd-format-lwt -j 127
    # exit-code            1
    # env-file             ~/.opam/log/vhd-format-lwt-7-0e9653.env
    # output-file          ~/.opam/log/vhd-format-lwt-7-0e9653.out
    ### output ###
    ...
    # File "vhd_format_lwt_test/dune", line 2, characters 7-17:
    # 2 |  (name parse_test)
    #            ^^^^^^^^^^
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o vhd_format_lwt_test/parse_test.exe /home/opam/.opam/5.0/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.0/lib/cstruct/cstruct.cmxa -I /home/opam/.opam/5.0/lib/cstruct /home/opam/.opam/5.0/lib/lwt/lwt.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/ocplib_endian.cmxa /home/opam/.opam/5.0/lib/ocplib-endian/bigstring/ocplib_endian_bigstring.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/ocaml/threads/threads.cmxa /home/opam/.opam/5.0/lib/lwt/unix/lwt_unix.cmxa -I /home/opam/.opam/5.0/lib/lwt/unix disk/disk.cmxa /home/opam/.opam/5.0/lib/io-page/io_page.cmxa -I /home/opam/.opam/5.0/lib/io-page /home/opam/.opam/5.0/lib/io-page/unix/io_page_unix.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/ounit2/advanced/oUnitAdvanced.cmxa /home/opam/.opam/5.0/lib/ounit2/oUnit.cmxa /home/opam/.opam/5.0/lib/rresult/rresult.cmxa /home/opam/.opam/5.0/lib/uuidm/uuidm.cmxa /home/opam/.opam/5.0/lib/vhd-format/vhd_format.cmxa /home/opam/.opam/5.0/lib/fmt/fmt.cmxa /home/opam/.opam/5.0/lib/mirage-block/mirage_block.cmxa vhd_format_lwt/vhd_format_lwt.cmxa -I vhd_format_lwt vhd_format_lwt_test/.parse_test.eobjs/native/create_vhd.cmx vhd_format_lwt_test/.parse_test.eobjs/native/diff_vhd.cmx vhd_format_lwt_test/.parse_test.eobjs/native/input.cmx vhd_format_lwt_test/.parse_test.eobjs/native/patterns_lwt.cmx vhd_format_lwt_test/.parse_test.eobjs/native/parse_test.cmx)
    # /usr/bin/ld: vhd_format_lwt/libvhd_format_lwt_stubs.a(odirect_stubs.o): in function `stub_openfile_direct':
    # /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/odirect_stubs.c:42: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/odirect_stubs.c:53: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/odirect_stubs.c:57: undefined reference to `uerror'
    # /usr/bin/ld: vhd_format_lwt/libvhd_format_lwt_stubs.a(odirect_stubs.o): in function `stub_fsync':
    # /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/odirect_stubs.c:66: undefined reference to `uerror'
    # /usr/bin/ld: vhd_format_lwt/libvhd_format_lwt_stubs.a(lseek64_stubs.o): in function `stub_lseek64_data':
    # /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/lseek64_stubs.c:60: undefined reference to `uerror'
    # /usr/bin/ld: vhd_format_lwt/libvhd_format_lwt_stubs.a(lseek64_stubs.o): in function `stub_lseek64_hole':
    # /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/lseek64_stubs.c:85: undefined reference to `uerror'
    # /usr/bin/ld: vhd_format_lwt/libvhd_format_lwt_stubs.a(blkgetsize64_stubs.o): in function `stub_blkgetsize64':
    # /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/blkgetsize64_stubs.c:60: undefined reference to `enter_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/blkgetsize64_stubs.c:76: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/blkgetsize64_stubs.c:79: undefined reference to `uerror'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/blkgetsize64_stubs.c:76: undefined reference to `leave_blocking_section'
    # /usr/bin/ld: /home/opam/.opam/5.0/.opam-switch/build/vhd-format-lwt.0.12.2/_build/default/vhd_format_lwt/blkgetsize64_stubs.c:85: undefined reference to `uerror'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)
