### PR TITLE
Do not run ppx_deriving tests on OCaml 5

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.5.2.1/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2.1/opam
@@ -10,7 +10,7 @@ tags: [ "syntax" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0.0"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [

--- a/packages/ppx_deriving/ppx_deriving.5.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.5.2/opam
@@ -10,7 +10,7 @@ tags: [ "syntax" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "5.0.0"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 depends: [


### PR DESCRIPTION
Test fail due to `Pervasives` and `String` changes:

```
        #=== ERROR while compiling ppx_deriving.5.2.1 =================================#
        # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
        # path                 ~/.opam/5.0/.opam-switch/build/ppx_deriving.5.2.1
        # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p ppx_deriving -j 31
        # exit-code            1
        # env-file             ~/.opam/log/ppx_deriving-7-6321ae.env
        # output-file          ~/.opam/log/ppx_deriving-7-6321ae.out
        ### output ###
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/iter/.test_deriving_iter.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/iter/.test_deriving_iter.eobjs/byte/test_deriving_iter.cmo -c -impl src_test/iter/test_deriving_iter.pp.ml)
        # File "test_deriving_iter.cppo.ml", line 24, characters 23-37:
        # Error: Unbound module Pervasives
        # (cd _build/default/src_test/create && ./test_deriving_create.exe)
        # ..
        # Ran: 2 tests in: 0.10 seconds.
        # OK
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/runtime/.test_runtime.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/runtime/.test_runtime.eobjs/byte/test_runtime.cmo -c -impl src_test/runtime/test_runtime.pp.ml)
        # File "test_runtime.cppo.ml", line 9, characters 10-45:
        # Error: Unbound module Ppx_deriving_runtime.Pervasives
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/eq/.test_deriving_eq.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/eq/.test_deriving_eq.eobjs/byte/test_deriving_eq.cmo -c -impl src_test/eq/test_deriving_eq.pp.ml)
        # File "test_deriving_eq.cppo.ml", line 17, characters 14-28:
        # Error: Unbound module Pervasives
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/fold/.test_deriving_fold.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/fold/.test_deriving_fold.eobjs/byte/test_deriving_fold.cmo -c -impl src_test/fold/test_deriving_fold.pp.ml)
        # File "test_deriving_fold.cppo.ml", line 10, characters 21-35:
        # Error: Unbound module Pervasives
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/show/.test_deriving_show.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/show/.test_deriving_show.eobjs/byte/test_deriving_show.cmo -c -impl src_test/show/test_deriving_show.pp.ml)
        # File "test_deriving_show.cppo.ml", line 15, characters 14-28:
        # Error: Unbound module Pervasives
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/ord/.test_deriving_ord.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/ord/.test_deriving_ord.eobjs/byte/test_deriving_ord.cmo -c -impl src_test/ord/test_deriving_ord.pp.ml)
        # File "test_deriving_ord.cppo.ml", line 121, characters 14-28:
        # Error: Unbound module Pervasives
        # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -w -27-9 -g -bin-annot -I src_test/map/.test_deriving_map.eobjs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/ounit2 -I /home/opam/.opam/5.0/lib/ounit2/advanced -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/runtime/.ppx_deriving_runtime.objs/byte -no-alias-deps -o src_test/map/.test_deriving_map.eobjs/byte/test_deriving_map.cmo -c -impl src_test/map/test_deriving_map.pp.ml)
        # File "test_deriving_map.cppo.ml", line 102, characters 60-76:
        # Error: Unbound value String.uppercase
```

There is a test failure due to `Ppx_deriving_runtime.Pervasives` not existing anymore in OCaml 5.0 due to `Stdlib.Pervasives` disappearing, but except for one test it doesn't seem to be referenced.