### PR TITLE
Exclude torch 0.3 from OCaml 5 compatibility

### DIFF
--- a/packages/torch/torch.0.3/opam
+++ b/packages/torch/torch.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune-configurator"
   "libtorch" {>= "1.0.1" & < "1.1.0"}
   "npy"
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.06" & < "5.0.0"}
   "ocaml-compiler-libs"
   "ppx_custom_printf"
   "ppx_expect"


### PR DESCRIPTION
FTBFS due to depending on `Caml.Pervasives` from Base. Base generates the `Caml` module automatically so the removal of `Stdlib.Pervasives` also lead to the disappearance of `Caml.Pervasives`.

This issue is really just a transitive failure but I don't know whether Base plans to bring back `Caml.Pervasives` on OCaml 5.0 so for now marking it as unavailable seems reasonable.

```
    #=== ERROR while compiling torch.0.3 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/torch.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p torch -j 71
    # exit-code            1
    # env-file             ~/.opam/log/torch-7-5581c9.env
    # output-file          ~/.opam/log/torch-7-5581c9.out
    ### output ###
    # File "src/wrapper/dune", line 1, characters 0-311:
    # 1 | (library
    # 2 |   (name torch_core)
    # 3 |   (public_name torch.core)
    # 4 |   (c_names torch_stubs)
    # 5 |   (cxx_names torch_api)
    # 6 |   (cxx_flags -std=c++11 (:include cxx_flags.sexp) -D_GLIBCXX_USE_CXX11_ABI=0)
    # 7 |   (c_library_flags :standard -lstdc++ (:include c_library_flags.sexp))
    # 8 |   (libraries bigarray ctypes.foreign ctypes.stubs ctypes))
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlmklib.opt -g -o src/wrapper/torch_core_stubs src/wrapper/torch_stubs.o src/wrapper/torch_api.o -ldopt -lstdc++ -ldopt -Wl,-rpath,/home/opam/.opam/5.0/lib/libtorch/lib -ldopt -L/home/opam/.opam/5.0/lib/libtorch/lib -ldopt -lc10 -ldopt -lcaffe2 -ldopt -ltorch)
    # /usr/bin/ld: src/wrapper/torch_api.o: warning: relocation against `_ZTVN5torch5optim3SGDE' in read-only section `.text._ZN5torch5optim3SGDC2ISt6vectorIN2at6TensorESaIS5_EEEEOT_RKNS0_10SGDOptionsE[_ZN5torch5optim3SGDC5ISt6vectorIN2at6TensorESaIS5_EEEEOT_RKNS0_10SGDOptionsE]'
    # /usr/bin/ld: src/wrapper/torch_api.o: relocation R_X86_64_PC32 against symbol `_ZN3c105ErrorD1Ev' can not be used when making a shared object; recompile with -fPIC
    # /usr/bin/ld: final link failed: bad value
    # collect2: error: ld returned 1 exit status
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/torch/.torch.objs/byte -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ctypes -I /home/opam/.opam/5.0/lib/integers -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdio -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/wrapper/.torch_core.objs/byte -intf-suffix .ml -no-alias-deps -open Torch -o src/torch/.torch.objs/byte/torch__Checkpointing.cmo -c -impl src/torch/checkpointing.ml)
    # File "src/torch/checkpointing.ml", line 15, characters 24-47:
    # 15 |   |> List.sort ~compare:Caml.Pervasives.compare
    #                              ^^^^^^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Caml.Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/torch/.torch.objs/byte -I src/torch/.torch.objs/native -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/bigarray-compat -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/ctypes -I /home/opam/.opam/5.0/lib/integers -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdio -I /home/opam/.opam/5.0/lib/stdlib-shims -I src/wrapper/.torch_core.objs/byte -I src/wrapper/.torch_core.objs/native -intf-suffix .ml -no-alias-deps -open Torch -o src/torch/.torch.objs/native/torch__Checkpointing.cmx -c -impl src/torch/checkpointing.ml)
    # File "src/torch/checkpointing.ml", line 15, characters 24-47:
    # 15 |   |> List.sort ~compare:Caml.Pervasives.compare
    #                              ^^^^^^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Caml.Pervasives
```