### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.9.1)

### DIFF
--- a/packages/shuttle/shuttle.0.9.1/opam
+++ b/packages/shuttle/shuttle.0.9.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.1/shuttle-0.9.1.tbz"
+  checksum: [
+    "sha256=d89447a79fc5edce56f56fe5ce69329471d03340b2976554f0e11d6d9525cf7b"
+    "sha512=5d687d027a6dfeeee39060cb8e9df68869a2a7fb45209221c501bf45b710cf44ea551eebc8e9b480a9f0252f923dc9e6eefa312fa659f45ec7045de9d7a426a3"
+  ]
+}
+x-commit-hash: "f85e199f30fe441bc51e43eb09d9e01dcb3ef64b"

--- a/packages/shuttle_http/shuttle_http.0.9.1/opam
+++ b/packages/shuttle_http/shuttle_http.0.9.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "shuttle_ssl" {= version}
+  "re2" {>= "v0.15.0"}
+  "ppx_jane" {with-test}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.1/shuttle-0.9.1.tbz"
+  checksum: [
+    "sha256=d89447a79fc5edce56f56fe5ce69329471d03340b2976554f0e11d6d9525cf7b"
+    "sha512=5d687d027a6dfeeee39060cb8e9df68869a2a7fb45209221c501bf45b710cf44ea551eebc8e9b480a9f0252f923dc9e6eefa312fa659f45ec7045de9d7a426a3"
+  ]
+}
+x-commit-hash: "f85e199f30fe441bc51e43eb09d9e01dcb3ef64b"

--- a/packages/shuttle_ssl/shuttle_ssl.0.9.1/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.9.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+doc: "https://anuragsoni.github.io/shuttle/"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.1/shuttle-0.9.1.tbz"
+  checksum: [
+    "sha256=d89447a79fc5edce56f56fe5ce69329471d03340b2976554f0e11d6d9525cf7b"
+    "sha512=5d687d027a6dfeeee39060cb8e9df68869a2a7fb45209221c501bf45b710cf44ea551eebc8e9b480a9f0252f923dc9e6eefa312fa659f45ec7045de9d7a426a3"
+  ]
+}
+x-commit-hash: "f85e199f30fe441bc51e43eb09d9e01dcb3ef64b"


### PR DESCRIPTION
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>
- Documentation: <a href="https://anuragsoni.github.io/shuttle/">https://anuragsoni.github.io/shuttle/</a>

##### CHANGES:

* Add HTTP/1.1 client that supports keep-alive.
* Add http clients that leverage Async_kernel's persistent connections. This allows for durable clients that will the underlying socket connection is closed.
