### PR TITLE
Fixes Alt-ergo links

### DIFF
--- a/packages/alt-ergo-lib/alt-ergo-lib.2.4.2/opam
+++ b/packages/alt-ergo-lib/alt-ergo-lib.2.4.2/opam
@@ -37,7 +37,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "https://github.com/OCamlPro/alt-ergo/archive/2.4.2.tar.gz"
+  src: "https://github.com/OCamlPro/alt-ergo/archive/refs/tags/2.4.2.tar.gz"
   checksum: [
     "md5=c47327ae132c860890c820bfd5d49d51"
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"

--- a/packages/alt-ergo-parsers/alt-ergo-parsers.2.4.2/opam
+++ b/packages/alt-ergo-parsers/alt-ergo-parsers.2.4.2/opam
@@ -36,7 +36,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "https://github.com/OCamlPro/alt-ergo/archive/2.4.2.tar.gz"
+  src: "https://github.com/OCamlPro/alt-ergo/archive/refs/tags/2.4.2.tar.gz"
   checksum: [
     "md5=c47327ae132c860890c820bfd5d49d51"
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"

--- a/packages/alt-ergo/alt-ergo.2.4.2/opam
+++ b/packages/alt-ergo/alt-ergo.2.4.2/opam
@@ -34,7 +34,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "https://github.com/OCamlPro/alt-ergo/archive/2.4.2.tar.gz"
+  src: "https://github.com/OCamlPro/alt-ergo/archive/refs/tags/2.4.2.tar.gz"
   checksum: [
     "md5=c47327ae132c860890c820bfd5d49d51"
     "sha512=61ae181ccd60a49f833ea79bbd5184a46f8eef24e7fe1169b15e905ed86584bdbe993ef86c203d5bfc3d79961024f96af0e4e623dc15479aa9538648291c9a75"


### PR DESCRIPTION
The link provided for the Alt-Ergo packages is ambiguous on GitHub (2.4.2 both correspond to a branch and a tag) it seems that for a few days, the archive that is obtained is the one that correspond to the branch and not to the tag, leading to checksum failures. This MR disambiguate the link so that it corresponds to the tag.

FYI @Stevendeo 