### PR TITLE
Switch to preserved ffmpeg 1.0.0~rc1 tarball

### DIFF
--- a/packages/ffmpeg-av/ffmpeg-av.1.0.0~rc1/opam
+++ b/packages/ffmpeg-av/ffmpeg-av.1.0.0~rc1/opam
@@ -34,7 +34,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg-avcodec/ffmpeg-avcodec.1.0.0~rc1/opam
+++ b/packages/ffmpeg-avcodec/ffmpeg-avcodec.1.0.0~rc1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg-avdevice/ffmpeg-avdevice.1.0.0~rc1/opam
+++ b/packages/ffmpeg-avdevice/ffmpeg-avdevice.1.0.0~rc1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg-avfilter/ffmpeg-avfilter.1.0.0~rc1/opam
+++ b/packages/ffmpeg-avfilter/ffmpeg-avfilter.1.0.0~rc1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg-avutil/ffmpeg-avutil.1.0.0~rc1/opam
+++ b/packages/ffmpeg-avutil/ffmpeg-avutil.1.0.0~rc1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg-swresample/ffmpeg-swresample.1.0.0~rc1/opam
+++ b/packages/ffmpeg-swresample/ffmpeg-swresample.1.0.0~rc1/opam
@@ -34,7 +34,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg-swscale/ffmpeg-swscale.1.0.0~rc1/opam
+++ b/packages/ffmpeg-swscale/ffmpeg-swscale.1.0.0~rc1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"

--- a/packages/ffmpeg/ffmpeg.1.0.0~rc1/opam
+++ b/packages/ffmpeg/ffmpeg.1.0.0~rc1/opam
@@ -33,7 +33,7 @@ build: [
 ]
 dev-repo: "git+https://github.com/savonet/ocaml-ffmpeg.git"
 url {
-  src: "https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz"
+  src: "https://github.com/ocaml/opam-source-archives/raw/main/ffmpeg-1.0.0~rc1.tar.gz"
   checksum: [
     "md5=996d69434972553ecf3ae04e95d5c09d"
     "sha512=1ae911c8cf4743a39bdb8b6b38185975955adeb8f0dc263f9b8c93259df0f85492a0213a8c7ac13a56eee63a5c46f8184d6015ddc8b3047876d6226a75562d50"


### PR DESCRIPTION
The tarball got recreated by GitHub, thus invalidating the previous checksums. This PR replaces the URL by the preserved original tarball that came from the OPAM cache.

Error message:

```
    #=== ERROR while fetching sources for ffmpeg-av.1.0.0~rc1, ffmpeg-avcodec.1.0.0~rc1 and ffmpeg-avutil.1.0.0~rc1
    OpamSolution.Fetch_fail("https://github.com/savonet/ocaml-ffmpeg/archive/v1.0.0-rc1.tar.gz (Bad checksum, expected md5=996d69434972553ecf3ae04e95d5c09d)")
```