### PR TITLE
release fmlib 0.5.2

### DIFF
--- a/packages/fmlib/fmlib.0.5.2/opam
+++ b/packages/fmlib/fmlib.0.5.2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+synopsis: "Functional monadic library"
+
+
+description: """
+
+Umbrella for a collection of libraries supporting functional programming with
+managed effects. The umbrella contains only documentation. See the following
+packages to get the functionality:
+
+- fmlib_std: A lot of standard data types.
+
+- fmlib_parse: Monadic parsing functions with combinators suitable for
+  incremental and indentation sensitive parsing.
+
+- fmlib_pretty: Pretty printing functions. Prints hierachical structures like
+  expressions and indented paragraphs nicely.
+
+- fmlib_js: Interface to javscript via js_of_ocaml.
+
+"""
+
+
+maintainer: "Helmut Brandl <helmut.brandl@gmx.net>"
+
+authors: [ "Helmut Brandl <helmut.brandl@gmx.net>" ]
+
+license: "BSD-3-Clause"
+homepage: "https://github.com/hbr/fmlib"
+dev-repo: "git+https://github.com/hbr/fmlib.git"
+bug-reports: "https://github.com/hbr/fmlib/issues"
+
+
+build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+
+
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "1.10"}
+    "odoc" {with-doc}
+    "fmlib_std"    {=version}
+    "fmlib_pretty" {=version}
+    "fmlib_parse"  {=version}
+    "fmlib_js"     {=version}
+]
+url {
+    src: "https://github.com/hbr/fmlib/archive/0.5.2.tar.gz"
+    checksum: "md5=8e0a9f94ebcbd69366c940e978270a07"
+}

--- a/packages/fmlib_js/fmlib_js.0.5.2/opam
+++ b/packages/fmlib_js/fmlib_js.0.5.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+
+synopsis: "Library for easy compilation from ocaml to javascript"
+
+description: """
+
+At thin and easy to use library which implements wrappers around js_of_ocaml to
+write javascript applications for the browser or for nodejs in ocaml.
+
+"""
+
+maintainer: "Helmut Brandl <helmut.brandl@gmx.net>"
+
+authors: [ "Helmut Brandl <helmut.brandl@gmx.net>" ]
+
+license: "BSD-3-Clause"
+homepage: "https://github.com/hbr/fmlib"
+dev-repo: "git+https://github.com/hbr/fmlib.git"
+bug-reports: "https://github.com/hbr/fmlib/issues"
+
+
+build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+
+
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "1.10"}
+    "odoc" {with-doc}
+    "js_of_ocaml" {>= "4.0.0"}
+    "js_of_ocaml-ppx" {>= "4.0.0"}
+    "fmlib_std" {=version}
+]
+url {
+    src: "https://github.com/hbr/fmlib/archive/0.5.2.tar.gz"
+    checksum: "md5=8e0a9f94ebcbd69366c940e978270a07"
+}

--- a/packages/fmlib_parse/fmlib_parse.0.5.2/opam
+++ b/packages/fmlib_parse/fmlib_parse.0.5.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+
+synopsis: "Parsing with combinators and indentation sensitivity"
+
+description: """
+
+A parsing library with combinators in the style of Haskell's parsec.
+
+The parsing combinators have support for indentation sensitivity. Therefore it
+is easy to parse yaml files and indentation sensitive languages like Haskell and
+Python.
+
+Futhermore it is easy to generate user friendly error messages.
+
+"""
+
+maintainer: "Helmut Brandl <helmut.brandl@gmx.net>"
+
+authors: [ "Helmut Brandl <helmut.brandl@gmx.net>" ]
+
+license: "BSD-3-Clause"
+homepage: "https://github.com/hbr/fmlib"
+dev-repo: "git+https://github.com/hbr/fmlib.git"
+bug-reports: "https://github.com/hbr/fmlib/issues"
+
+
+build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+
+
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "1.10"}
+    "odoc" {with-doc}
+    "ppx_inline_test" {>= "v0.13.0"}
+    "fmlib_std"    {=version}
+    "fmlib_pretty" {=version}
+]
+url {
+    src: "https://github.com/hbr/fmlib/archive/0.5.2.tar.gz"
+    checksum: "md5=8e0a9f94ebcbd69366c940e978270a07"
+}

--- a/packages/fmlib_pretty/fmlib_pretty.0.5.2/opam
+++ b/packages/fmlib_pretty/fmlib_pretty.0.5.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+synopsis: "Pretty printing support for tree like structures"
+
+description: """
+
+Easy to use pretty printing library.
+
+"""
+
+maintainer: "Helmut Brandl <helmut.brandl@gmx.net>"
+
+authors: [ "Helmut Brandl <helmut.brandl@gmx.net>" ]
+
+license: "BSD-3-Clause"
+homepage: "https://github.com/hbr/fmlib"
+dev-repo: "git+https://github.com/hbr/fmlib.git"
+bug-reports: "https://github.com/hbr/fmlib/issues"
+
+
+build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+
+
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "1.10"}
+    "odoc" {with-doc}
+    "ppx_inline_test" {>= "v0.13.0"}
+    "fmlib_std" {=version}
+]
+url {
+    src: "https://github.com/hbr/fmlib/archive/0.5.2.tar.gz"
+    checksum: "md5=8e0a9f94ebcbd69366c940e978270a07"
+}

--- a/packages/fmlib_std/fmlib_std.0.5.2/opam
+++ b/packages/fmlib_std/fmlib_std.0.5.2/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+
+synopsis: "Standard datatypes of Fmlib"
+
+description: """
+
+Some small wrappers around ocamls stdlib modules to facilitate more functional
+programming. E.g. the module 'Option' and 'Result' support the 'let*' operator.
+The module 'Array' has a 'push' operation to append functionally elements at the
+end.
+
+Besides some wrapper around Stdlib modules it has the additional modules:
+
+- Deque: A double ended queue with efficient pushing of elements from the front
+  and the rear end and efficient popping of elements from the front end.
+
+- Btree: Finite sets and maps based on B trees. B trees have better cache
+  efficiency and locality than AVL or Redblack trees.
+
+"""
+
+
+maintainer: "Helmut Brandl <helmut.brandl@gmx.net>"
+
+authors: [ "Helmut Brandl <helmut.brandl@gmx.net>" ]
+
+license: "BSD-3-Clause"
+homepage: "https://github.com/hbr/fmlib"
+dev-repo: "git+https://github.com/hbr/fmlib.git"
+bug-reports: "https://github.com/hbr/fmlib/issues"
+
+
+build: [
+    ["dune" "subst"] {dev}
+    ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+
+
+depends: [
+    "ocaml" {>= "4.08.0"}
+    "dune" {>= "1.10"}
+    "odoc" {with-doc}
+    "ppx_inline_test" {>= "v0.13.0"}
+]
+url {
+    src: "https://github.com/hbr/fmlib/archive/0.5.2.tar.gz"
+    checksum: "md5=8e0a9f94ebcbd69366c940e978270a07"
+}


### PR DESCRIPTION
	new file:   packages/fmlib/fmlib.0.5.2/opam
	new file:   packages/fmlib_js/fmlib_js.0.5.2/opam
	new file:   packages/fmlib_parse/fmlib_parse.0.5.2/opam
	new file:   packages/fmlib_pretty/fmlib_pretty.0.5.2/opam
	new file:   packages/fmlib_std/fmlib_std.0.5.2/opam