### PR TITLE
[new release] ppx_deriving_cad (0.2.0)

### DIFF
--- a/packages/ppx_deriving_cad/ppx_deriving_cad.0.2.0/opam
+++ b/packages/ppx_deriving_cad/ppx_deriving_cad.0.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "PPX Deriver for OCADml transformation functions"
+description: """
+[@@deriving cad] generates functions for the
+spatial transformation of user defined abstract and record types containing
+types for which said transformation functions are defined, in particular, the types of OCADml (and CAD backend specific implementations)."""
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com>"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com>"]
+license: "GPL-2.0-or-later"
+homepage: "https://github.com/OCADml/ppx_deriving_cad"
+doc: "https://ocadml.github.io/ppx_deriving_cad/"
+bug-reports: "https://github.com/OCADml/ppx_deriving_cad/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.14.0"}
+  "base" {>= "0.14.1" & with-test}
+  "OCADml" {>= "0.3.0" & with-test}
+  "OSCADml" {>= "0.2.0" & with-test}
+  "gg" {>= "1.0.0" & with-test}
+  "ppxlib" {>= "0.22.2"}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/ppx_deriving_cad.git"
+url {
+  src:
+    "https://github.com/OCADml/ppx_deriving_cad/releases/download/v0.2.0/ppx_deriving_cad-0.2.0.tbz"
+  checksum: [
+    "sha256=e02238b26c8e249d8d246c02d59811ebccbc381fedc571a0fe86a7f8075e3d34"
+    "sha512=017d75492381b8b70a291b70619d4052591c8f6d0df21b087c9751d920ef9676c69e5062bd7a993c353cdcd9479712df7ff773f5813ea0e39b30a7f04eca635a"
+  ]
+}
+x-commit-hash: "c24aab53d2fba3395bee29f3d9954ec888de4c80"


### PR DESCRIPTION
PPX Deriver for OCADml transformation functions

- Project page: <a href="https://github.com/OCADml/ppx_deriving_cad">https://github.com/OCADml/ppx_deriving_cad</a>
- Documentation: <a href="https://ocadml.github.io/ppx_deriving_cad/">https://ocadml.github.io/ppx_deriving_cad/</a>

##### CHANGES:

- adjust to additional type parameter of `Scad.t` in OSCADml `v0.2.0`
- add cases to catch `gg` vector type identifiers (OCADml `v0.3.0`)
