### PR TITLE
[hotfix] OCADml (0.3.0)

### DIFF
--- a/packages/OCADml/OCADml.0.3.0/opam
+++ b/packages/OCADml/OCADml.0.3.0/opam
@@ -34,8 +34,8 @@ url {
   src:
     "https://github.com/OCADml/OCADml/releases/download/v0.3.0/OCADml-0.3.0.tbz"
   checksum: [
-    "sha256=418f066c06a5abbae7e2751eef1f2bb707637f1cd7b4f7d6413678ac11a390bb"
-    "sha512=078acd5672e116b18161f5549ec02cb7d1f4dc7f2411fa535e77e6070fe56a1c7bcbaca1e26b3fcaf352b0869f42e16fcda5ce2037e979f39c1e0609bb37d6de"
+    "sha256=9614beb1c81f1f4da39e5c4a8ee820ebf44beb34a44a7e32602782079efad8c8"
+    "sha512=0a8f6c02f0b97c1a4cd270117bd744a26cf29070a6c704dde9379967d0fadfcfdcaeaa6bd286c7696b0dbd2a9e9aa95ccae517ac487a6771897ff4805e2750f6"
   ]
 }
-x-commit-hash: "4cb17c84e225bb873441b03ccb0ad196730d1ef3"
+x-commit-hash: "c35a30fc64a006fc9b81ec21bd8d38b957afe800"

--- a/packages/OCADml/OCADml.0.3.0/opam
+++ b/packages/OCADml/OCADml.0.3.0/opam
@@ -39,3 +39,4 @@ url {
   ]
 }
 x-commit-hash: "c35a30fc64a006fc9b81ec21bd8d38b957afe800"
+available: false


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- add gg library dependency
- replaced vector (V{2,3,4}.t), matrix (Affine{2,3}), and bounding box types
 with those from gg
- protect bezier memoization with mutex (OCaml 5 compatibility)
