### PR TITLE
[new release] OCADml (0.3.1)

### DIFF
--- a/packages/OCADml/OCADml.0.3.1/opam
+++ b/packages/OCADml/OCADml.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.3"}
+  "gg" {>= "1.0.0"}
+  "cairo2" {>= "0.6.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.3.1/OCADml-0.3.1.tbz"
+  checksum: [
+    "sha256=b8d3e9cae10f4a7a6ff67ae8b1aeff8bf8a8f1b202b2a24f098a9a5ad69b145f"
+    "sha512=166964f8c86e81ef31c8448b350b960b7a5a137eab3234d3200069841e5567778d29dc801ce2f7e7fc312953e8bacfc9e1c3d360d6b9d171a02e2a8c98c8438a"
+  ]
+}
+x-commit-hash: "53c5193548d16857ffcb355a9202c6ca5a6ba246"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- v0.3.0 being marked unavailable on opam due to bugs with Path{2,3}.bbox
- add dune to package dependencies
