### PR TITLE
fix checksum for scfg.0.1

### DIFF
--- a/packages/scfg/scfg.0.1/opam
+++ b/packages/scfg/scfg.0.1/opam
@@ -37,7 +37,7 @@ dev-repo: "git+https://git.zapashcanon.fr/zapashcanon/scfg.git"
 url {
   src: "https://git.zapashcanon.fr/zapashcanon/scfg/archive/0.1.tar.gz"
   checksum: [
-  "sha256=b68874c310174f4df3f8f2e13375dffe1738b40511f424bdc41b29b893762a79"
-  "sha512=edcd1f3653a7dd356f289a023756eb52681f2c4b08d347f5e7b668b8de42cc7c9d935dbf2a478babc1862f0a55cfbef614a758325d728cefa1bba004f1202cd5"
+  "sha256=faaafdd2cbb36e61c074aad2a28e0a63d00ef5060f436172edaf345f34071e7f"
+  "sha512=b35fb0989f1becf23c52b2c832d30c41ac705f0da2214e5535869251dcda7cb4368daae28857369273e55503344da69d404b70156f9a827db733dd8ae1b18f7f"
   ]
 }


### PR DESCRIPTION
Hi,

In #23048 and #23052 I noticed that something was wrong with `scfg.0.1`'s checksum.

After investigating a bit, it turns out `gitea` is deleting archives automatically after some times using a cronjob. I disabled it so it should not happen again.

I checked that the new archive content is OK.