### PR TITLE
conf-sdl2: add libwayland-egl + adwaita-cursor-theme to avoid SIGSEGV

### DIFF
--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -10,6 +10,7 @@ depexts: [
   ["sdl2"] {os-distribution = "arch"}
   ["libsdl2-dev"] {os-family = "debian"}
   ["SDL2-devel"] {os-distribution = "fedora"}
+  ["SDL2-devel" "libwayland-egl" "adwaita-cursor-theme"] {os-distribution = "fedora" & (os-version = "37" | os-version = "36")}
   ["epel-release" "SDL2-devel"] {os-distribution = "centos"}
   ["SDL2-devel"] {os-distribution = "ol"}
   ["sdl2"] {os = "freebsd"}


### PR DESCRIPTION
Fedora 37 uses wayland as the default driver for SDL2, however it is still quite buggy.

See upstream bugs:
 * crash in `CreateWindow` if `libwayland-egl` is missing https://bugzilla.redhat.com/show_bug.cgi?id=2165386
 * crash in `wayland_get_system_cursor` if no cursor theme is installed https://bugzilla.redhat.com/show_bug.cgi?id=2165387

These are being fixed, but meanwhile try to avoid SIGSEGV by adding these packages as dependencies.

A workaround would be to use the X11 SDL driver, but that isn't the default (one can still chose to use the X11 driver even if these packages are installed).

Only add the workaround for Fedora 36 and 37, hopefully newer versions of Fedora will have the bug fixed.

Tested that Fedora 36 has same bug (didn't test older versions since they are EOL).

Fixes https://github.com/dbuenzli/tsdl/issues/87