### PR TITLE
Do not build `fftw3.0.8.4` on OCaml 5

### DIFF
--- a/packages/fftw3/fftw3.0.8.4/opam
+++ b/packages/fftw3/fftw3.0.8.4/opam
@@ -16,7 +16,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "dune" {>= "1.1"}
   "dune-configurator"
   "cppo" {build}


### PR DESCRIPTION
FTBFS due to usage of deprecated Bigarray C API, in particular `caml_bigarray` has been deprecated and removed:

```
    #=== ERROR while compiling fftw3.0.8.4 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/fftw3.0.8.4
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p fftw3 -j 47
    # exit-code            1
    # env-file             ~/.opam/log/fftw3-7-0453ed.env
    # output-file          ~/.opam/log/fftw3-7-0453ed.out
    ### output ###
    # File "src/dune", line 8, characters 14-27:
    # 8 |  (c_names     fftw3_stubs_c)
    #                   ^^^^^^^^^^^^^
    # (cd _build/default/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -DFFTW3F_EXISTS -g -I /home/opam/.opam/5.0/lib/ocaml -o fftw3_stubs_c.o -c fftw3_stubs_c.c)
    # fftw3_stubs_c.c: In function 'fftw3_caml_ba_finalize':
    # fftw3_stubs_c.c:77:30: warning: implicit declaration of function 'Bigarray_val' [-Wimplicit-function-declaration]
    #    77 |   struct caml_bigarray * b = Bigarray_val(v);
    #       |                              ^~~~~~~~~~~~
    # fftw3_stubs_c.c:77:30: warning: initialization of 'struct caml_bigarray *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    # fftw3_stubs_c.c:81:8: error: invalid use of undefined type 'struct caml_bigarray'
    #    81 |   if (b->proxy == NULL) {
    #       |        ^~
    # fftw3_stubs_c.c:82:16: error: invalid use of undefined type 'struct caml_bigarray'
    #    82 |     fftw_free(b->data);
    #       |                ^~
    # fftw3_stubs_c.c:84:13: error: invalid use of undefined type 'struct caml_bigarray'
    #    84 |     if (-- b->proxy->refcount == 0) {
    #       |             ^~
    # fftw3_stubs_c.c:85:18: error: invalid use of undefined type 'struct caml_bigarray'
    #    85 |       fftw_free(b->proxy->data);
    #       |                  ^~
    # fftw3_stubs_c.c:86:23: error: invalid use of undefined type 'struct caml_bigarray'
    #    86 |       caml_stat_free(b->proxy);
    #       |                       ^~
    # In file included from fftw3_stubs_c.c:262:
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute':
    # fftw3SD_stubs.c:53:3: warning: implicit declaration of function 'enter_blocking_section'; did you mean 'caml_enter_blocking_section'? [-Wimplicit-function-declaration]
    #    53 |   enter_blocking_section();  /* Allow other threads */
    #       |   ^~~~~~~~~~~~~~~~~~~~~~
    #       |   caml_enter_blocking_section
    # fftw3SD_stubs.c:55:3: warning: implicit declaration of function 'leave_blocking_section'; did you mean 'caml_leave_blocking_section'? [-Wimplicit-function-declaration]
    #    55 |   leave_blocking_section();  /* Disallow other threads */
    #       |   ^~~~~~~~~~~~~~~~~~~~~~
    #       |   caml_leave_blocking_section
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_dft':
    # fftw3SD_stubs.c:63:22: warning: implicit declaration of function 'Data_bigarray_val'; did you mean 'Caml_ba_array_val'? [-Wimplicit-function-declaration]
    #    63 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    #       |                      Caml_ba_array_val
    # fftw3SD_stubs.c:63:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    # fftw3SD_stubs.c:64:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    64 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_split_dft':
    # fftw3SD_stubs.c:79:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    79 |   FLOAT *ri = Data_bigarray_val(vri);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:80:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    80 |   FLOAT *ii = Data_bigarray_val(vii);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:81:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    81 |   FLOAT *ro = Data_bigarray_val(vro);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:82:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    82 |   FLOAT *io = Data_bigarray_val(vio);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_dft_r2c':
    # fftw3SD_stubs.c:96:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    96 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:97:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    97 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_split_dft_r2c':
    # fftw3SD_stubs.c:112:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   112 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:113:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   113 |   FLOAT *ro = Data_bigarray_val(vro);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:114:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   114 |   FLOAT *io = Data_bigarray_val(vio);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_dft_c2r':
    # fftw3SD_stubs.c:128:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   128 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:129:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   129 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_split_dft_c2r':
    # fftw3SD_stubs.c:144:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   144 |   FLOAT *ri = Data_bigarray_val(vri);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:145:15: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   145 |   FLOAT *ii = Data_bigarray_val(vii);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:146:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   146 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_execute_r2r':
    # fftw3SD_stubs.c:160:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   160 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:161:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   161 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_guru_dft':
    # fftw3SD_stubs.c:206:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   206 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:207:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   207 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:179:20: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:208:3: note: in expansion of macro 'MAKE_DIMS'
    #   208 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c:179:20: note: each undeclared identifier is reported only once for each function it appears in
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:208:3: note: in expansion of macro 'MAKE_DIMS'
    #   208 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c:6:3: warning: implicit declaration of function 'alloc_custom'; did you mean 'caml_alloc_custom'? [-Wimplicit-function-declaration]
    #     6 |   alloc_custom(&FFTW_OCAML(plan_ops), sizeof(FFTW(plan)),       \
    #       |   ^~~~~~~~~~~~
    # fftw3SD_stubs.c:219:10: note: in expansion of macro 'ALLOC_PLAN'
    #   219 |   plan = ALLOC_PLAN();
    #       |          ^~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_guru_r2c':
    # fftw3SD_stubs.c:245:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   245 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:246:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   246 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:179:20: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:247:3: note: in expansion of macro 'MAKE_DIMS'
    #   247 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_guru_c2r':
    # fftw3SD_stubs.c:285:22: warning: initialization of 'double (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   285 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:286:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   286 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:179:20: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:287:3: note: in expansion of macro 'MAKE_DIMS'
    #   287 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftw_ocaml_guru_r2r':
    # fftw3SD_stubs.c:324:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   324 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:325:14: warning: initialization of 'double *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   325 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:326:23: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   326 |   FFTW(r2r_kind) kind[MAX_NUM_DIMS];
    #       |                       ^~~~~~~~~~~~
    # In file included from fftw3_stubs_c.c:283:
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_dft':
    # fftw3SD_stubs.c:63:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    63 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:64:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    64 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_split_dft':
    # fftw3SD_stubs.c:79:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    79 |   FLOAT *ri = Data_bigarray_val(vri);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:80:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    80 |   FLOAT *ii = Data_bigarray_val(vii);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:81:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    81 |   FLOAT *ro = Data_bigarray_val(vro);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:82:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    82 |   FLOAT *io = Data_bigarray_val(vio);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_dft_r2c':
    # fftw3SD_stubs.c:96:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    96 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:97:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #    97 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_split_dft_r2c':
    # fftw3SD_stubs.c:112:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   112 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:113:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   113 |   FLOAT *ro = Data_bigarray_val(vro);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:114:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   114 |   FLOAT *io = Data_bigarray_val(vio);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_dft_c2r':
    # fftw3SD_stubs.c:128:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   128 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:129:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   129 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_split_dft_c2r':
    # fftw3SD_stubs.c:144:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   144 |   FLOAT *ri = Data_bigarray_val(vri);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:145:15: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   145 |   FLOAT *ii = Data_bigarray_val(vii);
    #       |               ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:146:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   146 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_execute_r2r':
    # fftw3SD_stubs.c:160:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   160 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:161:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   161 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_guru_dft':
    # fftw3SD_stubs.c:206:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   206 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:207:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   207 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:179:20: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:208:3: note: in expansion of macro 'MAKE_DIMS'
    #   208 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_guru_r2c':
    # fftw3SD_stubs.c:245:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   245 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:246:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   246 |   FFTW(complex) *o = Data_bigarray_val(vo);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:179:20: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:247:3: note: in expansion of macro 'MAKE_DIMS'
    #   247 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_guru_c2r':
    # fftw3SD_stubs.c:285:22: warning: initialization of 'float (*)[2]' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   285 |   FFTW(complex) *i = Data_bigarray_val(vi);
    #       |                      ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:286:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   286 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:179:20: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   179 |   FFTW(iodim) dims[MAX_NUM_DIMS], howmany_dims[MAX_NUM_DIMS];   \
    #       |                    ^~~~~~~~~~~~
    # fftw3SD_stubs.c:287:3: note: in expansion of macro 'MAKE_DIMS'
    #   287 |   MAKE_DIMS();
    #       |   ^~~~~~~~~
    # fftw3SD_stubs.c: In function 'fftwf_ocaml_guru_r2r':
    # fftw3SD_stubs.c:324:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   324 |   FLOAT *i = Data_bigarray_val(vi);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:325:14: warning: initialization of 'float *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
    #   325 |   FLOAT *o = Data_bigarray_val(vo);
    #       |              ^~~~~~~~~~~~~~~~~
    # fftw3SD_stubs.c:326:23: error: 'MAX_NUM_DIMS' undeclared (first use in this function)
    #   326 |   FFTW(r2r_kind) kind[MAX_NUM_DIMS];
    #       |                       ^~~~~~~~~~~~
```