### PR TITLE
Do not build `lablqml.0.7` on OCaml 5

### DIFF
--- a/packages/lablqml/lablqml.0.7/opam
+++ b/packages/lablqml/lablqml.0.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" { >= "4.10.0"}
+  "ocaml" { >= "4.10.0" & < "5.0.0"}
   "ocamlfind" {build}
   "dune" { >= "2.7" }
   "dune-configurator"


### PR DESCRIPTION
FTBFS due do removal of `hash_variant` in the C API:

```
#=== ERROR while compiling lablqml.0.7 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/lablqml.0.7
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lablqml -j 71
# exit-code            1
# env-file             ~/.opam/log/lablqml-8-084a04.env
# output-file          ~/.opam/log/lablqml-8-084a04.out
### output ###
# File "lib/dune", line 22, characters 3-10:
# 22 |    variant
#         ^^^^^^^
# (cd _build/default/lib && /usr/bin/gcc -DQT_QUICK_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQuick -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -DQT_GUI_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtQml -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork -DQT_QMLMODELS_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQmlModels -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -Wall -std=c++11 -O3 -I . -Dprivate=public -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o variant.o -c variant.cpp)
# variant.cpp: In function 'value Val_QVariant(value, const QVariant&)':
# variant.cpp:37:17: error: 'hash_variant' was not declared in this scope
#    37 |         _dest = hash_variant("empty");
#       |                 ^~~~~~~~~~~~
# In file included from /home/opam/.opam/5.0/lib/ocaml/caml/callback.h:22,
#                  from ./lablqml.h:6,
#                  from variant.h:1,
#                  from variant.cpp:1:
# variant.cpp:44:35: error: 'hash_variant' was not declared in this scope
#    44 |             Store_field(_dest, 0, hash_variant("bool"));
#       |                                   ^~~~~~~~~~~~
# /home/opam/.opam/5.0/lib/ocaml/caml/memory.h:436:27: note: in definition of macro 'Store_field'
#   436 |   value caml__temp_val = (val); \
#       |                           ^~~
# variant.cpp:49:35: error: 'hash_variant' was not declared in this scope
#    49 |             Store_field(_dest, 0, hash_variant("string"));
#       |                                   ^~~~~~~~~~~~
# /home/opam/.opam/5.0/lib/ocaml/caml/memory.h:436:27: note: in definition of macro 'Store_field'
#   436 |   value caml__temp_val = (val); \
#       |                           ^~~
# variant.cpp:54:35: error: 'hash_variant' was not declared in this scope
#    54 |             Store_field(_dest, 0, hash_variant("int"));
#       |                                   ^~~~~~~~~~~~
# /home/opam/.opam/5.0/lib/ocaml/caml/memory.h:436:27: note: in definition of macro 'Store_field'
#   436 |   value caml__temp_val = (val); \
#       |                           ^~~
# variant.cpp:60:35: error: 'hash_variant' was not declared in this scope
#    60 |             Store_field(_dest, 0, hash_variant("float"));
#       |                                   ^~~~~~~~~~~~
# /home/opam/.opam/5.0/lib/ocaml/caml/memory.h:436:27: note: in definition of macro 'Store_field'
#   436 |   value caml__temp_val = (val); \
#       |                           ^~~
# variant.cpp:70:37: error: 'hash_variant' was not declared in this scope
#    70 |               Store_field(_dest, 0, hash_variant("qobject"));
#       |                                     ^~~~~~~~~~~~
# /home/opam/.opam/5.0/lib/ocaml/caml/memory.h:436:27: note: in definition of macro 'Store_field'
#   436 |   value caml__temp_val = (val); \
#       |                           ^~~
# ./lablqml.h: At global scope:
# ./lablqml.h:26:14: warning: 'value Val_some(value)' defined but not used [-Wunused-function]
#    26 | static value Val_some(value v) {
#       |              ^~~~~~~~
# (cd _build/default/lib && /usr/bin/gcc -DQT_QUICK_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQuick -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -DQT_GUI_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtQml -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork -DQT_QMLMODELS_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQmlModels -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -Wall -std=c++11 -O3 -I . -Dprivate=public -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o moc_object.o -c moc_object.cpp)
# In file included from object.h:9,
#                  from moc_object.cpp:10:
# ./lablqml.h:26:14: warning: 'value Val_some(value)' defined but not used [-Wunused-function]
#    26 | static value Val_some(value v) {
#       |              ^~~~~~~~
# (cd _build/default/lib && /usr/bin/gcc -DQT_QUICK_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQuick -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -DQT_GUI_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtQml -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork -DQT_QMLMODELS_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQmlModels -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -Wall -std=c++11 -O3 -I . -Dprivate=public -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o object_ml.o -c object_ml.cpp)
# In file included from object_ml.cpp:1:
# lablqml.h:26:14: warning: 'value Val_some(value)' defined but not used [-Wunused-function]
#    26 | static value Val_some(value v) {
#       |              ^~~~~~~~
# (cd _build/default/lib && /usr/bin/gcc -DQT_QUICK_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQuick -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -DQT_GUI_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtQml -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork -DQT_QMLMODELS_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQmlModels -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -Wall -std=c++11 -O3 -I . -Dprivate=public -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o propMap_stubs.o -c propMap_stubs.cpp)
# In file included from propMap_stubs.cpp:1:
# lablqml.h:26:14: warning: 'value Val_some(value)' defined but not used [-Wunused-function]
#    26 | static value Val_some(value v) {
#       |              ^~~~~~~~
# (cd _build/default/lib && /usr/bin/gcc -DQT_QUICK_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQuick -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -DQT_GUI_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtQml -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork -DQT_QMLMODELS_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQmlModels -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -Wall -std=c++11 -O3 -I . -Dprivate=public -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o test_stubs.o -c test_stubs.cpp)
# In file included from test_stubs.cpp:1:
# lablqml.h:26:14: warning: 'value Val_some(value)' defined but not used [-Wunused-function]
#    26 | static value Val_some(value v) {
#       |              ^~~~~~~~
# (cd _build/default/lib && /usr/bin/gcc -DQT_QUICK_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQuick -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -DQT_GUI_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtGui -I/usr/include/x86_64-linux-gnu/qt5/QtQml -I/usr/include/x86_64-linux-gnu/qt5/QtNetwork -DQT_QMLMODELS_LIB -I/usr/include/x86_64-linux-gnu/qt5/QtQmlModels -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CORE_LIB -Wall -std=c++11 -O3 -I . -Dprivate=public -fPIC -g -I /home/opam/.opam/5.0/lib/ocaml -I /home/opam/.opam/5.0/lib/ocaml/threads -I /home/opam/.opam/5.0/lib/ocaml/unix -o stubs.o -c stubs.cpp)
# stubs.cpp:74:2: warning: #warning "not tested" [-Wcpp]
#    74 | #warning "not tested"
#       |  ^~~~~~~
# stubs.cpp:148:2: warning: #warning "not tested" [-Wcpp]
#   148 | #warning "not tested"
#       |  ^~~~~~~
```

`hash_variant` was marked as deprecated in 4.x (at least 4.14 in `compatibility.h`) and removed in 5.0.