### PR TITLE
Pull lustre-v6.v6.107.1 from opam source archive

### DIFF
--- a/packages/lustre-v6/lustre-v6.6.107.1/opam
+++ b/packages/lustre-v6/lustre-v6.6.107.1/opam
@@ -34,7 +34,7 @@ dev-repo:
   "git+https://gricad-gitlab.univ-grenoble-alpes.fr/verimag/synchrone/lustre-v6"
 url {
   src:
-    "http://www-verimag.imag.fr/DIST-TOOLS/SYNCHRONE/pool/lustre-v6.v6.107.1.tgz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/lustre-v6.v6.107.1.tgz"
   checksum: [
     "md5=4b642b106a76e19de3751afb53ccdcf4"
     "sha512=ec6d35f0f4da219490cad7969d86e9128b7c3f03baa507f662b038b1915383581eda697ddb0e734a1a5311ef6b0908b1d0cf375a0be5dbb1aa7e9e79848037cc"


### PR DESCRIPTION
The upstream package has changed and no longer matches the checksums.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>