### PR TITLE
Do not run ppxlib tests with sexplib0 v0.15

### DIFF
--- a/packages/ppxlib/ppxlib.0.25.0/opam
+++ b/packages/ppxlib/ppxlib.0.25.0/opam
@@ -46,7 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & ocaml:version < "5.0.0"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppxlib/ppxlib.0.25.0/opam
+++ b/packages/ppxlib/ppxlib.0.25.0/opam
@@ -28,6 +28,7 @@ depends: [
   "ocamlfind" {with-test}
   "re" {with-test & >= "1.9.0"}
   "cinaps" {with-test & >= "v0.12.1"}
+  "sexplib0" {with-test & < "v0.15"}
   "base" {with-test}
   "stdio" {with-test}
   "odoc" {with-doc}
@@ -46,7 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & ocaml:version < "5.0.0"}
+    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
The tests succeed on OCaml 5 in theory but fail due to different rendering of expected errors:

```
    #=== ERROR while compiling ppxlib.0.25.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/ppxlib.0.25.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppxlib -j 255 @install @runtest
    # exit-code            1
    # env-file             ~/.opam/log/ppxlib-7-a87f01.env
    # output-file          ~/.opam/log/ppxlib-7-a87f01.out
    ### output ###
    # File "test/driver/exception_handling/run.t", line 1, characters 0-0:
    # /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/bc661e042f76d4bd5b62bf081897e5e8/default/test/driver/exception_handling/run.t _build/.sandbox/bc661e042f76d4bd5b62bf081897e5e8/default/test/driver/exception_handling/run.t.corrected
    # diff --git a/_build/.sandbox/bc661e042f76d4bd5b62bf081897e5e8/default/test/driver/exception_handling/run.t b/_build/.sandbox/bc661e042f76d4bd5b62bf081897e5e8/default/test/driver/exception_handling/run.t.corrected
    # index f0a5cc6..d303b14 100644
    # --- a/_build/.sandbox/bc661e042f76d4bd5b62bf081897e5e8/default/test/driver/exception_handling/run.t
    # +++ b/_build/.sandbox/bc661e042f76d4bd5b62bf081897e5e8/default/test/driver/exception_handling/run.t.corrected
    # @@ -102,10 +102,10 @@ and the whole AST is prepended with an error extension node.
    #
    #    $ echo "let _ = [%gen_raise_exc] + [%gen_raise_exc]" > impl.ml
    #    $ ./extender.exe impl.ml
    # -  Fatal error: exception (Failure "A raised exception")
    # +  Fatal error: exception Failure("A raised exception")
    #    [2]
    #    $ ./extender.exe -embed-errors impl.ml
    # -  Fatal error: exception (Failure "A raised exception")
    # +  Fatal error: exception Failure("A raised exception")
    #    [2]
    #
    #   In the case of derivers
    # @@ -113,14 +113,14 @@ and the whole AST is prepended with an error extension node.
    #    $ echo "type a = int" > impl.ml
    #    $ echo "type b = int [@@deriving deriver_raised_exception]" >> impl.ml
    #    $ ./deriver.exe -embed-errors impl.ml
    # -  Fatal error: exception (Failure "A raised exception")
    # +  Fatal error: exception Failure("A raised exception")
    #    [2]
    #
    #   In the case of whole file transformations:
    #
    #    $ ./whole_file_exception.exe impl.ml
    # -  Fatal error: exception (Failure "An exception in a whole file transform")
    # +  Fatal error: exception Failure("An exception in a whole file transform")
    #    [2]
    #    $ ./whole_file_exception.exe -embed-errors impl.ml
    # -  Fatal error: exception (Failure "An exception in a whole file transform")
    # +  Fatal error: exception Failure("An exception in a whole file transform")
    #    [2]
    # File "test/ppx_import_support/test.ml", line 1, characters 0-0:
    # /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/ppx_import_support/test.ml _build/default/test/ppx_import_support/test.ml.corrected
    # diff --git a/_build/default/test/ppx_import_support/test.ml b/_build/default/test/ppx_import_support/test.ml.corrected
    # index e32d39b..66fd12b 100644
    # --- a/_build/default/test/ppx_import_support/test.ml
    # +++ b/_build/default/test/ppx_import_support/test.ml.corrected
    # @@ -108,6 +108,6 @@ let id_for_core_types =
    #      (fun ~ctxt:_ core_type -> core_type)
    #  [%%expect{|
    #  Exception:
    # -(Failure
    # -  "Some ppx-es tried to register conflicting transformations: Extension 'id' on type declarations matches extension 'id'")
    # +Failure
    # + "Some ppx-es tried to register conflicting transformations: Extension 'id' on type declarations matches extension 'id'".
    #  |}]
    # File "test/base/test.ml", line 1, characters 0-0:
    # /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/base/test.ml _build/default/test/base/test.ml.corrected
    # diff --git a/_build/default/test/base/test.ml b/_build/default/test/base/test.ml.corrected
    # index 7cf282a..77c27e5 100644
    # --- a/_build/default/test/base/test.ml
    # +++ b/_build/default/test/base/test.ml.corrected
    # @@ -106,17 +106,17 @@ let _ = convert_longident "Base.( land )"
    #
    #  let _ = convert_longident "A(B)"
    #  [%%expect{|
    # -Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"")
    # +Exception: Invalid_argument "Ppxlib.Longident.parse: \"A(B)\"".
    #  |}]
    #
    #  let _ = convert_longident "A.B(C)"
    #  [%%expect{|
    # -Exception: (Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"")
    # +Exception: Invalid_argument "Ppxlib.Longident.parse: \"A.B(C)\"".
    #  |}]
    #
    #  let _ = convert_longident ")"
    #  [%%expect{|
    # -Exception: (Invalid_argument "Ppxlib.Longident.parse: \")\"")
    # +Exception: Invalid_argument "Ppxlib.Longident.parse: \")\"".
    #  |}]
    #
    #  let _ = Ppxlib.Code_path.(file_path @@ top_level ~file_path:"dir/main.ml")
```