### PR TITLE
Do not build `conan.0.0.1` on OCaml 5

### DIFF
--- a/packages/conan/conan.0.0.1/opam
+++ b/packages/conan/conan.0.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mirage/conan"
 doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
-  "ocaml"               {>= "4.08.0"}
+  "ocaml"               {>= "4.08.0" & < "5.0.0"}
   "re"                  {>= "1.9.0"}
   "dune"                {>= "2.9.0"}
   "uutf"


### PR DESCRIPTION
Upstream fix exists: https://github.com/mirage/conan/pull/21 and `conan.0.0.2` has been marked as unavailable on 5.0, so this PR follows suit for 0.1.

The test fail due to %u:

```
    #=== ERROR while compiling conan-cli.0.0.1 ====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/conan-cli.0.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p conan-cli -j 255
    # exit-code            1
    # env-file             ~/.opam/log/conan-cli-7-51ad28.env
    # output-file          ~/.opam/log/conan-cli-7-51ad28.out
    ### output ###
    <many successfully passed tests snipped>
    # File "fuzz/dune", line 6, characters 0-158:
    #  6 | (rule
    #  7 |  (alias runtest)
    #  8 |  (deps
    #  9 |   fuzz.exe
    # 10 |   (source_tree ../database)
    # 11 |   (env_var CONAN))
    # 12 |  (action
    # 13 |   (setenv
    # 14 |    CONAN
    # 15 |    ../database
    # 16 |    (run %{exe:fuzz.exe}))))
    # (cd _build/default/fuzz && ./fuzz.exe)
    <more lines cut>
    # "DOS executable (COM, 0x8C-variant) PGP symmetric key encrypted data -" ("application/x-dosexec")
    # Found a solution for the given input: "OpenPGP Public Key".
    # lint (assert false / exception): FAIL
    #
    # When given the input:
    #
    #     "CI\175\226j\154\237\132&\140\1974\004O\018\227\209\237ZGm\202\202D\127\020\180;\019\173Z\187\151%\149\223+\244n\156c\027\148"
    #
    # the test threw an exception:
    #
    #     Invalid_argument("Invalid formatter u")
    #     Raised at Stdlib.invalid_arg in file "stdlib.ml", line 30, characters 20-45
    #     Called from Conan__Fmt.go in file "src/fmt.ml", line 618, characters 24-44
    #     Called from Conan__Fmt.parse in file "src/fmt.ml" (inlined), line 624, characters 2-17
    #     Called from Conan__Fmt.ty_of_string in file "src/fmt.ml", line 638, characters 18-30
    #     Called from Conan__Tree.key_of_ty in file "src/tree.ml", line 195, characters 21-50
    #     Called from Conan__Tree.format_of_ty in file "src/tree.ml", line 242, characters 18-38
    #     Called from Conan__Process.process_fmt in file "src/process.ml", line 16, characters 31-51
    #     Called from Conan__Process.process.(fun) in file "src/process.ml", line 53, characters 25-54
    #     Called from Conan__Process.descending_walk.iter in file "src/process.ml", line 131, characters 8-68
    #     Called from Conan__Process.descending_walk.iter.(fun) in file "src/process.ml", line 134, characters 12-69
    #     Called from Conan__Process.descending_walk.iter.(fun) in file "src/process.ml", line 134, characters 12-69
    #     Called from Conan__Process.descending_walk in file "src/process.ml" (inlined), line 171, characters 2-64
    #     Called from Conan_string.run in file "string/conan_string.ml", line 143, characters 25-79
    #     Called from Dune__exe__Fuzz.(fun) in file "fuzz/fuzz.ml", line 33, characters 8-38
    #     Called from Crowbar.gen_apply.go.(fun) in file "src/crowbar.ml", line 325, characters 16-19
```