### PR TITLE
Package opam-graph.0.1.0

### DIFF
--- a/packages/opam-graph/opam-graph.0.1.0/opam
+++ b/packages/opam-graph/opam-graph.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Graphing dependencies of opam packages"
+description: """\
+This package outputs dependency graphs (in svg and dot) of opam package
+universes (opam switch export)."""
+maintainer: "Robur <team@robur.coop>"
+authors: "Robur <team@robur.coop>"
+license: "ISC"
+homepage: "https://git.robur.io/robur/opam-graph"
+bug-reports: "https://github.com/roburio/opam-graph/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "opam-core"
+  "opam-format"
+  "ocamldot"
+  "tyxml"
+  "gg"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian"}
+]
+dev-repo: "git+https://git.robur.io/robur/opam-graph.git"
+url {
+  src:
+    "https://git.robur.io/attachments/d1fa3187-e242-4b39-9f3f-ccae7a4a9739"
+  checksum: [
+    "md5=a10dd28b8feb9c9920c7f688e30219eb"
+    "sha512=5436ee5bf379c51d48e41e4fa8fb874f4921eea61d878fd9e6c0a892e2d30ec6726b495a0525e4d37614c4a667745055739e5d81b1137fab3f5190dd37dd1d75"
+  ]
+}

--- a/packages/opam-graph/opam-graph.0.1.1/opam
+++ b/packages/opam-graph/opam-graph.0.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "opam-core"
   "opam-format" {>= "2.1.1"}
   "ocamldot"
-  "tyxml"
+  "tyxml" {>= "3.0.0"}
   "gg"
 ]
 build: [

--- a/packages/opam-graph/opam-graph.0.1.1/opam
+++ b/packages/opam-graph/opam-graph.0.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "logs"
   "opam-core"
-  "opam-format"
+  "opam-format" {>= "2.1.1"}
   "ocamldot"
   "tyxml"
   "gg"

--- a/packages/opam-graph/opam-graph.0.1.1/opam
+++ b/packages/opam-graph/opam-graph.0.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "opam-core"
   "opam-format" {>= "2.1.1"}
   "ocamldot"
-  "tyxml" {>= "3.0.0"}
+  "tyxml" {>= "4.3.0"}
   "gg"
 ]
 build: [

--- a/packages/opam-graph/opam-graph.0.1.1/opam
+++ b/packages/opam-graph/opam-graph.0.1.1/opam
@@ -29,9 +29,8 @@ build: [
 dev-repo: "git+https://git.robur.io/robur/opam-graph.git"
 url {
   src:
-    "https://git.robur.io/attachments/d1fa3187-e242-4b39-9f3f-ccae7a4a9739"
+    "https://git.robur.io/attachments/aabe0e23-c411-4747-a44e-62e33f7f0658"
   checksum: [
-    "md5=a10dd28b8feb9c9920c7f688e30219eb"
-    "sha512=5436ee5bf379c51d48e41e4fa8fb874f4921eea61d878fd9e6c0a892e2d30ec6726b495a0525e4d37614c4a667745055739e5d81b1137fab3f5190dd37dd1d75"
+    "sha512=33e76715684b9f34f97f34a3033975beafa3cbcf88a861e937b80b6c4b08d4dd9b2aa1f7da51830a44166ae519c9a6c3f695c9b9af5583e17140359e0de1d73e"
   ]
 }


### PR DESCRIPTION
### `opam-graph.0.1.0`
Graphing dependencies of opam packages
This package outputs dependency graphs (in svg and dot) of opam package
universes (opam switch export).



---
* Homepage: https://git.robur.io/robur/opam-graph
* Source repo: git+https://git.robur.io/robur/opam-graph.git
* Bug tracker: https://github.com/roburio/opam-graph/issues

---
:camel: Pull-request generated by opam-publish v2.2.0