### PR TITLE
[new release] memgraph_kitty and memgraph (1.0)

### DIFF
--- a/packages/memgraph/memgraph.1.0/opam
+++ b/packages/memgraph/memgraph.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "A small library to inspect memory representation of ocaml values"
+description:
+  "Memgraph allows one to inspect an ocaml value and get a representation of its layout in memory, and helpers to dump such representation as dot files to easily print them as graphs"
+maintainer: [
+  "Guillaume Bury <guillaume.bury@gmail.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.org>"
+]
+authors: [
+  "Guillaume Bury <guillaume.bury@gmail.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.org>"
+]
+license: "MIT"
+homepage: "https://github.com/gbury/ocaml-memgraph"
+doc: "https://gbury.github.io/ocaml-memgraph/"
+bug-reports: "https://github.com/gbury/ocaml-memgraph/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.05.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gbury/ocaml-memgraph.git"
+url {
+  src:
+    "https://github.com/Gbury/ocaml-memgraph/releases/download/v1.0/memgraph-1.0.tbz"
+  checksum: [
+    "sha256=5e53bb092d0a5f8c025a7b17118c068c7d998cf47f459e9d634fdd26dc84af26"
+    "sha512=407382d1fb7de266983949f57d4ff882a4666b5cfea8845a75c67d397f055d9b00c9a2d4aff5ce7f3c2d198f1a4a8a921ff0ac5cd10c82a5a75b471e9b900a43"
+  ]
+}
+x-commit-hash: "2045b73588c2e683eff077555086a5ef3263712a"

--- a/packages/memgraph/memgraph.1.0/opam
+++ b/packages/memgraph/memgraph.1.0/opam
@@ -16,7 +16,7 @@ doc: "https://gbury.github.io/ocaml-memgraph/"
 bug-reports: "https://github.com/gbury/ocaml-memgraph/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.12.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/memgraph_kitty/memgraph_kitty.1.0/opam
+++ b/packages/memgraph_kitty/memgraph_kitty.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "Display the representation of memory values in the Kitty terminal emulator"
+description:
+  "Memgraph_kitty inspects ocaml values and displays their graphical representation using the graphics protocol of the kitty terminal emulator"
+maintainer: [
+  "Guillaume Bury <guillaume.bury@gmail.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.org>"
+]
+authors: [
+  "Guillaume Bury <guillaume.bury@gmail.com>"
+  "Armaël Guéneau <armael.gueneau@ens-lyon.org>"
+]
+license: "MIT"
+homepage: "https://github.com/gbury/ocaml-memgraph"
+doc: "https://gbury.github.io/ocaml-memgraph/"
+bug-reports: "https://github.com/gbury/ocaml-memgraph/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.05.0"}
+  "memgraph" {= version}
+  "ppx_blob" {build & >= "0.7.0"}
+  "nanosvg" {>= "0.1"}
+  "nanosvg_text" {>= "0.1"}
+  "kittyimg" {>= "0.1"}
+  "stb_truetype" {>= "0.7"}
+  "conf-graphviz"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/gbury/ocaml-memgraph.git"
+url {
+  src:
+    "https://github.com/Gbury/ocaml-memgraph/releases/download/v1.0/memgraph-1.0.tbz"
+  checksum: [
+    "sha256=5e53bb092d0a5f8c025a7b17118c068c7d998cf47f459e9d634fdd26dc84af26"
+    "sha512=407382d1fb7de266983949f57d4ff882a4666b5cfea8845a75c67d397f055d9b00c9a2d4aff5ce7f3c2d198f1a4a8a921ff0ac5cd10c82a5a75b471e9b900a43"
+  ]
+}
+x-commit-hash: "2045b73588c2e683eff077555086a5ef3263712a"


### PR DESCRIPTION
Display the representation of memory values in the Kitty terminal emulator

- Project page: <a href="https://github.com/gbury/ocaml-memgraph">https://github.com/gbury/ocaml-memgraph</a>
- Documentation: <a href="https://gbury.github.io/ocaml-memgraph/">https://gbury.github.io/ocaml-memgraph/</a>

##### CHANGES:

First release
