### PR TITLE
Restore ocaml-variants.4.04.0+copatterns

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.4.04.0+copatterns/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+copatterns/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "An extension of OCaml with copatterns (obsolete package)"
+description: "Replaced with ocaml-variants.4.04.1+copatterns"
+maintainer: "platform@lists.ocaml.org"
+flags: [ compiler avoid-version ]
+available: false
+license: "QPL-1.0 AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+homepage: "https://ocaml.org"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"


### PR DESCRIPTION
Follow-up to #22825 for the same reason as #22869