### PR TITLE
[new release] mirage-kv (6.1.0)

### DIFF
--- a/packages/mirage-kv/mirage-kv.6.1.0/opam
+++ b/packages/mirage-kv/mirage-kv.6.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "optint" {>= "0.2.0"}
+  "ptime" {>= "1.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v6.1.0/mirage-kv-6.1.0.tbz"
+  checksum: [
+    "sha256=51136885bc128d40ae3c71c5736608688db2d97ebb1987b057a2662bd452ce44"
+    "sha512=92d5399e985718f75c02cee06202c7de82c467dd01b9e49fc73c8c9a33eecf5864695adec40b0065dfa0c135c9b7f6f184573bdb8ceaee74b9e5d9457c6cb85c"
+  ]
+}
+x-commit-hash: "1e3cdbd8167193de8a78b924fd3ccdf3f09c4afa"


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Mirage_kv.Key.add now raises Invalid_argument (instead of Failure). Document
  that it raises (mirage/mirage-kv#40 @reynir)
