### PR TITLE
Update cstruct bounds of vhd-format

### DIFF
--- a/packages/vhd-format/vhd-format.0.12.3/opam
+++ b/packages/vhd-format/vhd-format.0.12.3/opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-vhd/"
 bug-reports: "https://github.com/mirage/ocaml-vhd/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "cstruct" {>= "1.9" & < "6.0.0"}
+  "cstruct" {>= "1.9" & < "6.1.0"}
   "io-page"
   "rresult" {>= "0.3.0"}
   "uuidm" {>= "0.9.6"}


### PR DESCRIPTION
6.0.0 is too low of an upper bound, relax it to be 6.1.0, like vhd-format-lwt