### PR TITLE
ocamldot is not compatible with the bytecode-only mode

### DIFF
--- a/packages/ocamldot/ocamldot.1.0/opam
+++ b/packages/ocamldot/ocamldot.1.0/opam
@@ -10,6 +10,9 @@ depends: ["ocaml" {< "4.06.0"} "ocamlfind" "lablgtk" "camlp4"]
 depopts: [
   "conf-gnomecanvas"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 install: [make "install"]
 dev-repo: "git+https://github.com/zoggy/ocamldot.git"
 bug-reports: "https://github.com/zoggy/ocamldot/issues"

--- a/packages/ocamldot/ocamldot.1.1/opam
+++ b/packages/ocamldot/ocamldot.1.1/opam
@@ -13,6 +13,7 @@ depends: [
 depopts: ["lablgtk3"]
 conflicts: [
   "lablgtk3" {< "3.1.1"}
+  "ocaml-option-bytecode-only"
 ]
 build: [
   ["./configure" "--prefix" prefix]


### PR DESCRIPTION
```
#=== ERROR while compiling ocamldot.1.1 =======================================#
# context              2.2.0~alpha~dev | linux/ppc64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocamldot.1.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/ocamldot-7-14303f.env
# output-file          ~/.opam/log/ocamldot-7-14303f.out
### output ###
# /home/opam/.opam/5.0/bin/ocamlyacc -v odot_parser.mly
# /home/opam/.opam/5.0/bin/ocamllex odot_lexer.mll
# 62 states, 621 transitions, table size 2856 bytes
# rm -fr .depend
# /home/opam/.opam/5.0/bin/ocamldep *.ml *.mli > .depend
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_version.mli
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_misc.mli
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_types.mli
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_parser.mli
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_lexer.ml
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot.mli
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_version.ml
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_misc.ml
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot_parser.ml
# /home/opam/.opam/5.0/bin/ocamlfind ocamlc -package unix,  -thread -c odot.ml
# /home/opam/.opam/5.0/bin/ocamlc -warn-error F -a -o odot.cma odot_version.cmo odot_misc.cmo odot_parser.cmo odot_lexer.cmo odot.cmo
# /home/opam/.opam/5.0/bin/ocamlfind ocamlopt -package unix,  -thread -c odot_version.ml
# ocamlfind: Not supported in your configuration: ocamlopt
# make: *** [master.Makefile:81: odot_version.cmx] Error 2
```