### PR TITLE
jose: mark unavailable

### DIFF
--- a/packages/jose/jose.0.2.0/opam
+++ b/packages/jose/jose.0.2.0/opam
@@ -39,6 +39,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 url {
   src:

--- a/packages/jose/jose.0.3.0/opam
+++ b/packages/jose/jose.0.3.0/opam
@@ -39,6 +39,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 url {
   src:

--- a/packages/jose/jose.0.3.1/opam
+++ b/packages/jose/jose.0.3.1/opam
@@ -40,6 +40,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 url {
   src:

--- a/packages/jose/jose.0.4.0/opam
+++ b/packages/jose/jose.0.4.0/opam
@@ -40,6 +40,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 url {
   src:

--- a/packages/jose/jose.0.5.0/opam
+++ b/packages/jose/jose.0.5.0/opam
@@ -41,6 +41,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 x-commit-hash: "207db96bee33c10b062734383760db4792d5f282"
 url {

--- a/packages/jose/jose.0.5.1/opam
+++ b/packages/jose/jose.0.5.1/opam
@@ -41,6 +41,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 x-commit-hash: "d90a584f737a45556ca135f373aa10fbc3b5d45d"
 url {

--- a/packages/jose/jose.0.6.0/opam
+++ b/packages/jose/jose.0.6.0/opam
@@ -42,6 +42,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 x-commit-hash: "30215c30b0b14907f54a951e7db8d2062cd29774"
 url {

--- a/packages/jose/jose.0.7.0/opam
+++ b/packages/jose/jose.0.7.0/opam
@@ -45,6 +45,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 url {
   src:

--- a/packages/jose/jose.0.8.1/opam
+++ b/packages/jose/jose.0.8.1/opam
@@ -41,6 +41,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: false
 dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
 url {
   src:


### PR DESCRIPTION
Mark all versions of JOSE prior to 0.8.2 unavailable, due to https://github.com/ulrikstrid/reason--jose/security/advisories/GHSA-7jj9-6qwv-wpm7

This should probably be merged after #23199 