### PR TITLE
gg < 1.0.0 is not compatible with OCaml 5.0

### DIFF
--- a/packages/gg/gg.0.9.2/opam
+++ b/packages/gg/gg.0.9.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/dbuenzli/gg/issues"
 tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/gg/gg.0.9.3/opam
+++ b/packages/gg/gg.0.9.3/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/gg/issues"
 tags: [ "matrix" "vector" "color" "data-structure" "graphics" "org:erratique"]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.02.2"}
+  "ocaml" {>= "4.02.2" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
expects the bigarray library to exist
```
#=== ERROR while compiling gg.0.9.3 ===========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/gg.0.9.3
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false
# exit-code            1
# env-file             ~/.opam/log/gg-8-a70b0d.env
# output-file          ~/.opam/log/gg-8-a70b0d.out
### output ###
# ocamlfind ocamldep -package bigarray -modules src/gg.ml > src/gg.ml.depends
# + ocamlfind ocamldep -package bigarray -modules src/gg.ml > src/gg.ml.depends
# ocamlfind: Package `bigarray' not found
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/gg.a' 'src/gg.cmxs' 'src/gg.cmxa' 'src/gg.cma'
#      'src/gg.cmx' 'src/gg.cmi' 'src/gg.mli' 'src/gg_top.a' 'src/gg_top.cmxs'
#      'src/gg_top.cmxa' 'src/gg_top.cma' 'src/gg_top.cmx'
#      'src/gg_top_init.ml']: exited with 10
```