### PR TITLE
Package lib_parsing.1.5.5

### DIFF
--- a/packages/lib_parsing/lib_parsing.1.5.5/opam
+++ b/packages/lib_parsing/lib_parsing.1.5.5/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Small library to help writing parsers"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c to help writing
+parsers, especially ocamlyacc/menhir based parsers.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "commons" {>= "1.5.5"}
+  "profiling" {>= "1.5.5"}
+  "stdcompat" {>= "19"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/returntocorp/sgrep/archive/refs/tags/lib_parsing_1.5.5.tar.gz"
+  checksum: [
+    "md5=eb2ff5de81f03b32843e02747ec26625"
+    "sha512=33f5d21ada3be007d74abfe9d45bf4140a2f1241adfaa2ac2d35a6dbb9106b7bc959068f64257d7dc9da4b16399e30db5234f9cc2e0f1d7f7039b88e5c6bab60"
+  ]
+}


### PR DESCRIPTION
### `lib_parsing.1.5.5`
Small library to help writing parsers
This is a small library of utilities used by Semgrep and
a few other projects developed at r2c to help writing
parsers, especially ocamlyacc/menhir based parsers.



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0