### PR TITLE
Package commons.1.8.0

### DIFF
--- a/packages/commons/commons.1.8.0/opam
+++ b/packages/commons/commons.1.8.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Yet another set of common utilities"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "alcotest" {>= "1.5.0"}
+  "ANSITerminal" {>= "0.8.4"}
+  "cmdliner" {>= "1.1.1" }
+  "logs" {>= "0.7.0" }
+  "easy_logging" {>= "0.8.1" }
+  "easy_logging_yojson" {>= "0.8.1" }
+  "yojson" {>= "1.7.0"}
+  "re" {>= "1.10.4"}
+  "pcre" {>= "7.5.0" }
+  "ppxlib" {>= "0.25.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_hash" {>= "v0.14.0" }
+  "parmap" {>= "1.2.4"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/returntocorp/sgrep/archive/refs/tags/commons_1.8.0.tar.gz"
+  checksum: [
+    "md5=00142d2d5f299c86ee44f19820bf9874"
+    "sha512=d25a57c434514ecb9adc5a129eeec9feca1cea2d1383e3bde74b52a05da174a09e0f46e7407f7b86ecdf1bf6faf7e0a66ef744d6fb389cb5f8398bc32e349555"
+  ]
+}


### PR DESCRIPTION
### `commons.1.8.0`
Yet another set of common utilities
This is a small library of utilities used by Semgrep and
a few other projects developed at r2c.



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0