### PR TITLE
[new release] lwt_ssl (1.2.0)

### DIFF
--- a/packages/lwt_ssl/lwt_ssl.1.2.0/opam
+++ b/packages/lwt_ssl/lwt_ssl.1.2.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+
+synopsis: "OpenSSL binding with concurrent I/O"
+license: "LGPL with OpenSSL linking exception"
+homepage: "https://github.com/ocsigen/lwt_ssl"
+doc: "https://github.com/ocsigen/lwt_ssl/blob/master/src/lwt_ssl.mli"
+bug-reports: "https://github.com/ocsigen/lwt_ssl/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocsigen/lwt_ssl.git"
+
+depends: [
+  "base-unix"
+  "dune"
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "ssl" {>= "0.5.13"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/ocsigen/lwt_ssl/releases/download/1.2.0/lwt_ssl-1.2.0.tbz"
+  checksum: [
+    "sha256=b3020ad27aecf377e1c3f2740a08b36dcbba991f843066511357410548889a77"
+    "sha512=cf2ef7d4db26e40c044e743ce85849a10eb57c916cbd7d6291bf4458291689098293bfb4cd7f1023f3ae8bc8e9a68cb2c7470669501a9b44695659405a75aa00"
+  ]
+}
+x-commit-hash: "d9ea0ab93da68f0d13ed710cc16f80983923f9ba"


### PR DESCRIPTION
OpenSSL binding with concurrent I/O

- Project page: <a href="https://github.com/ocsigen/lwt_ssl">https://github.com/ocsigen/lwt_ssl</a>
- Documentation: <a href="https://github.com/ocsigen/lwt_ssl/blob/master/src/lwt_ssl.mli">https://github.com/ocsigen/lwt_ssl/blob/master/src/lwt_ssl.mli</a>

##### CHANGES:

  * add Lwt_ssl.close_notify to issue one-way SSL shutdown (ocsigen/lwt_ssl#2, @madroach).
  * use Lwt.pause instead of the deprecated Lwt_unix.yield (ocsigen/lwt_ssl#3, @anmonteiro).
