### PR TITLE
Package gradescope_submit.0.1

### DIFF
--- a/packages/gradescope_submit/gradescope_submit.0.1/opam
+++ b/packages/gradescope_submit/gradescope_submit.0.1/opam
@@ -19,6 +19,7 @@ depends: [
   "lambdasoup" {>= "0.7.3"}
   "toml" {>= "7.1.0"}
   "yojson" {>= "2.0.2"}
+  "lwt_ssl" {>= "1.1.3"}
   "odoc" {with-doc}
 ]
 build: [
@@ -40,7 +41,7 @@ url {
   src:
     "https://github.com/nmittu/gradescope-submit/archive/refs/tags/0.1.tar.gz"
   checksum: [
-    "md5=2a01cbba2495eac7a0734e3db757a9f5"
-    "sha512=566419e32c883adb5dd5dd8f7ba4b9131b15e332ee77b974c098d4e5db8aca444a2563bfbd95f37c4d86a2adb6c1c466dced85d1edaddfe4836ab00f440951a5"
+    "md5=2f49c8b7ba29b8ad9d64f6d642d99f3e"
+    "sha512=920e863740d8edd65de61eed843a143f082c5d3ac69582aaf187970860bb55b6c54c99fe6cee64c58cb4ea616d6e29de29036b8a934b830f26bd4f48ad2cd087"
   ]
 }


### PR DESCRIPTION
### `gradescope_submit.0.1`
A small script to submit to Gradescope via GitHub
Submits the current git repository to Gradescope



---
* Homepage: https://github.com/nmittu/gradescope-submit
* Source repo: git+https://github.com/nmittu/gradescope-submit.git
* Bug tracker: https://github.com/nmittu/gradescope-submit/issues

---
:camel: Pull-request generated by opam-publish v2.2.0