### PR TITLE
[new release] http-lwt-client (0.2.1)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.1/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.14.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.2.1/http-lwt-client-0.2.1.tbz"
+  checksum: [
+    "sha256=c34733e1546794d93e9d0560d1633c0818a9677965d2157078dd8d1635c25cfb"
+    "sha512=2c16d3d3867bcdedb80d658b94d7219b91a3ffdffe4efd16887d04e55b68faa04108953bc5bf20775b97af18a2c3208e8338c1c2da70c3d21fd7db8b77f2cfbf"
+  ]
+}
+x-commit-hash: "853e1f070b44b3eb3644164072d9ceb14bbe37e3"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Fix ownership of buffers given by the HTTP scheduler (roburio/http-lwt-client#16 by @dinosaure)
