### PR TITLE
mirage-entropy.0.5: require mirage-unix<5.0.0

### DIFF
--- a/packages/mirage-entropy/mirage-entropy.0.5.0/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.5.0/opam
@@ -20,7 +20,7 @@ depends: [
   "cstruct" {>= "4.0.0"}
   "mirage-runtime" {>= "3.7.0"}
   "lwt" {>= "4.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
 ]
 depopts: [
   "mirage-solo5"

--- a/packages/mirage-entropy/mirage-entropy.0.5.1/opam
+++ b/packages/mirage-entropy/mirage-entropy.0.5.1/opam
@@ -18,7 +18,7 @@ depends: [
   "cstruct" {>= "4.0.0" & < "6.1.0"}
   "mirage-runtime" {>= "3.7.0" & < "4.0"}
   "lwt" {>= "4.0.0"}
-  "mirage-unix" {with-test & >= "3.0.0"}
+  "mirage-unix" {with-test & >= "3.0.0" & < "5.0.0"}
 ]
 depopts: [
   "ocaml-freestanding"


### PR DESCRIPTION
The tests expect mirage-unix<5.0.0 as it uses `OS` and not `Unix_os`. Discovered through https://github.com/ocaml/opam-repository/pull/23211.

I plan on doing a release of mirage-entropy.0.5.1-1 where the tests are updated to cstruct>=6.0.0 and mirage-unix>=5.0.0. However, the repository is archived. I'm trying to get it temporarily un-archived. Otherwise I can do a release from my fork...