### PR TITLE
ocaml 5: restrict mm releases

### DIFF
--- a/packages/mm/mm.0.6.0/opam
+++ b/packages/mm/mm.0.6.0/opam
@@ -12,7 +12,7 @@ install: [
   [make "install"]
 ]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0.0"}
   "ocamlfind" {build}
 ]
 depopts: [

--- a/packages/mm/mm.0.7.0/opam
+++ b/packages/mm/mm.0.7.0/opam
@@ -7,6 +7,7 @@ license: "GPL-2.0-only"
 homepage: "https://github.com/savonet/ocaml-mm"
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "dune-configurator"
 ]

--- a/packages/mm/mm.0.7.1/opam
+++ b/packages/mm/mm.0.7.1/opam
@@ -7,6 +7,7 @@ license: "GPL-2.0-only"
 homepage: "https://github.com/savonet/ocaml-mm"
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "dune-configurator"
 ]

--- a/packages/mm/mm.0.7.2/opam
+++ b/packages/mm/mm.0.7.2/opam
@@ -7,6 +7,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-mm"
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.8"}
   "dune-configurator"
   "odoc" {with-doc}

--- a/packages/mm/mm.0.7.4/opam
+++ b/packages/mm/mm.0.7.4/opam
@@ -8,6 +8,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-mm"
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 depends: [
+  "ocaml" {< "5.0.0"}
   "ocaml" {with-test & >= "4.07"}
   "dune" {>= "2.8"}
   "dune-configurator"

--- a/packages/mm/mm.0.8.0/opam
+++ b/packages/mm/mm.0.8.0/opam
@@ -8,7 +8,7 @@ license: "GPL-2.0"
 homepage: "https://github.com/savonet/ocaml-mm"
 bug-reports: "https://github.com/savonet/ocaml-mm/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0.0"}
   "ocaml" {with-test & >= "4.12"}
   "dune" {>= "2.8"}
   "dune-configurator"


### PR DESCRIPTION
These rely on removed bigarray C constants:

    #=== ERROR while compiling mm.0.8.0 ===========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mm.0.8.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mm -j 31 @install
    # exit-code            1
    # env-file             ~/.opam/log/mm-7-783b3f.env
    # output-file          ~/.opam/log/mm-7-783b3f.out
    ### output ###
    ...
    # image_rgb.c:80:25: error: 'BIGARRAY_MANAGED' undeclared (first use in this function)
    #    80 | #define CAML_BA_MANAGED BIGARRAY_MANAGED
    #       |                         ^~~~~~~~~~~~~~~~
