### PR TITLE
initial release of ocaml buildscripts for camlp5 and pa_ppx packages

### DIFF
--- a/packages/camlp5-buildscripts/camlp5-buildscripts.0.01/opam
+++ b/packages/camlp5-buildscripts/camlp5-buildscripts.0.01/opam
@@ -1,0 +1,36 @@
+synopsis: "Camlp5 Build scripts (written in OCaml)"
+description:
+"""
+These are build-scripts that are helpful in building Camlp5 and packages based on Camlp5.
+As such, they need to *not* depend on Camlp5.  The command are *not* installed in a
+bin-directory, but in the package-directory, hence invoked via the "ocamlfind package/exe"
+method.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/camlp5-buildscripts"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5-buildscripts/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5-buildscripts.git"
+doc: "https://github.com/camlp5/camlp5-buildscripts/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "not-ocamlfind" { >= "0.01" }
+  "mdx" { with-test & >= "2.2.1" }
+  "fmt"
+  "re" { >= "1.10.4" }
+  "bos" { >= "0.2.1" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/camlp5-buildscripts/archive/refs/tags/0.01.tar.gz"
+  checksum: [
+    "sha512=d96efb620bfcf64e60c05b5745a56c3df74bcf8c4294970aeb02de3a2e28a42ef48533753c75a31dc7fe2d957bdba2582c075bfbf8eea879445b592ad12c012f"
+  ]
+}


### PR DESCRIPTION
These are build-scripts used by camlp5 and pa_ppx, to replace the ones that are currently used, and that rely on conf-perl-* packages.  Once these scripts are released, I can push releases to camlp5 and the pa_ppx_* packages that no longer use these Perl packages, so they should all build without a hitch on macos-homebrew.