### PR TITLE
Package opam-repository.1.2.0

### DIFF
--- a/packages/opam-repository/opam-repository.1.2.0/opam
+++ b/packages/opam-repository/opam-repository.1.2.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "claudio.sacerdoticoen@unibo.it"
+authors: ["Alain.Frisch@inria.fr"]
+license: "MIT"
+homepage: "https://github.com/whitequark/ulex"
+dev-repo: "git+https://github.com/whitequark/ulex.git"
+bug-reports: "https://github.com/whitequark/ulex/issues"
+synopsis: "A lexer generator for Unicode (backported to camlp5)"
+build: [
+  [make]
+  [make "all.opt"]
+]
+install: [make "install"]
+depends: [
+  "ocaml" {>="4.14.1"} 
+  "ocamlfind" {build}
+  "camlp5" {>= "8.00.04"}
+  "camlp-streams"
+  "ocamlbuild" {build}
+]
+url {
+  src:
+    "https://github.com/sacerdot/ulex/archive/refs/tags/v1.3-camlp5.tar.gz"
+  checksum: [
+    "md5=32033b89d244886d227801437f4b68fa"
+    "sha512=1087e554cc5e5841d42756904da60180a99a4b1d0c7df519b039bc891b0a9f28d547320b34732cefe5683323a5f6c547025dd925cebca14342f9d985d586fe12"
+  ]
+}


### PR DESCRIPTION
### `opam-repository.1.2.0`
A lexer generator for Unicode (backported to camlp5)



---
* Homepage: https://github.com/whitequark/ulex
* Source repo: git+https://github.com/whitequark/ulex.git
* Bug tracker: https://github.com/whitequark/ulex/issues

---
:camel: Pull-request generated by opam-publish v2.2.0