### PR TITLE
[new release] x509 (0.16.3)

### DIFF
--- a/packages/x509/x509.0.16.3/opam
+++ b/packages/x509/x509.0.16.3/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.7"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/x509/x509.0.16.3/opam
+++ b/packages/x509/x509.0.16.3/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "6.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf"
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.3/x509-0.16.3.tbz"
+  checksum: [
+    "sha256=4281275d4701d962167387ef20e5834375dc63f24dc6af0b0c0656189c9668b3"
+    "sha512=e90a9cd4bed59f0f48d1f36ecb034d328b8b638324d7b37d92db4113b1c3a8c7ec31c041fd573214c122a71356225d78520872b92ddee6f111acf8084b0c4a0d"
+  ]
+}
+x-commit-hash: "dcc9d274463643110d7f201598c71c533bcb91c9"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Validation: allow self-signed server certificate with BasicConstraints CA=true
  (reported by @mbacarella in mirleft/ocaml-tls#446
   (https://github.com/lightningnetwork/lnd/issues/5450), fix mirleft/ocaml-x509#161 by @hannesm)
