### PR TITLE
[new release] camyll (0.4.2)

### DIFF
--- a/packages/camyll/camyll.0.4.2/opam
+++ b/packages/camyll/camyll.0.4.2/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+synopsis: "A static site generator"
+description: """
+Camyll is a static site generator.
+
+Features:
+
+- Conversion from Markdown to HTML
+- Syntax highlighting of any language via user-provided TextMate grammars
+- Post tagging
+- Processing of literate Agda"""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+tags: ["blog" "web" "website"]
+homepage: "https://alan-j-hu.github.io/camyll"
+bug-reports: "https://github.com/alan-j-hu/camyll/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "angstrom" {>= "0.15" & < "0.16"}
+  "calendar" {>= "2.01" & < "4"}
+  "cmdliner" {>= "1.1" & < "2"}
+  "ezjsonm" {>= "1.3" & < "2"}
+  "httpaf" {>= "0.7.1" & < "0.8"}
+  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
+  "jingoo" {>= "1.4" & < "2"}
+  "markup" {>= "0.8" & < "2"}
+  "ocaml" {>= "4.14"}
+  "omd" {>= "2.0.0~"}
+  "otoml" {>= "0.9.3"}
+  "plist-xml" {< "0.4"}
+  "re" {>= "1.9" & < "2"}
+  "slug" {>= "1.0" & < "2"}
+  "textmate-language" {>= "0.3.2" & < "0.4"}
+  "uri" {>= "4.2" & < "5"}
+  "yaml" {>= "3.1" & < "4"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "omd" {= "2.0.0~alpha1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/camyll.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/camyll/releases/download/0.4.2/camyll-0.4.2.tbz"
+  checksum: [
+    "sha256=48212a173606749d14fb90d4becb80dadbe3aa3d3ff7a6945dda8cf9307cc205"
+    "sha512=085ecc6c840be2d5afabd98fb1c4cc8ac7d79c8701e8540f6497c12c71580e4c8db782353e19309b459da40e9d84cfbaeef9c1ff841da073e73f5449af9579fa"
+  ]
+}
+x-commit-hash: "7caa78b2930e77c40c3906f383a5264a99588821"

--- a/packages/camyll/camyll.0.4.2/opam
+++ b/packages/camyll/camyll.0.4.2/opam
@@ -17,23 +17,23 @@ homepage: "https://alan-j-hu.github.io/camyll"
 bug-reports: "https://github.com/alan-j-hu/camyll/issues"
 depends: [
   "dune" {>= "2.7"}
-  "angstrom" {>= "0.15" & < "0.16"}
-  "calendar" {>= "2.01" & < "4"}
-  "cmdliner" {>= "1.1" & < "2"}
-  "ezjsonm" {>= "1.3" & < "2"}
-  "httpaf" {>= "0.7.1" & < "0.8"}
-  "httpaf-lwt-unix" {>= "0.7.1" & < "0.8"}
-  "jingoo" {>= "1.4" & < "2"}
-  "markup" {>= "0.8" & < "2"}
+  "angstrom" {>= "0.15"}
+  "calendar" {>= "2.01"}
+  "cmdliner" {>= "1.1"}
+  "ezjsonm" {>= "1.3"}
+  "httpaf" {>= "0.7.1"}
+  "httpaf-lwt-unix" {>= "0.7.1"}
+  "jingoo" {>= "1.4"}
+  "markup" {>= "0.8"}
   "ocaml" {>= "4.14"}
   "omd" {>= "2.0.0~"}
   "otoml" {>= "0.9.3"}
   "plist-xml" {< "0.4"}
-  "re" {>= "1.9" & < "2"}
-  "slug" {>= "1.0" & < "2"}
-  "textmate-language" {>= "0.3.2" & < "0.4"}
-  "uri" {>= "4.2" & < "5"}
-  "yaml" {>= "3.1" & < "4"}
+  "re" {>= "1.9"}
+  "slug" {>= "1.0"}
+  "textmate-language" {>= "0.3.2"}
+  "uri" {>= "4.2"}
+  "yaml" {>= "3.1"}
   "odoc" {with-doc}
 ]
 conflicts: [


### PR DESCRIPTION
A static site generator

- Project page: <a href="https://alan-j-hu.github.io/camyll">https://alan-j-hu.github.io/camyll</a>

##### CHANGES:

- Remove dependency on `lambdasoup`, allowing Camyll to build on OCaml 5
- Use `In_channel` and `Out_channel` modules, requiring OCaml 4.14 or higher
