### PR TITLE
herdtools7 release, follow LKMM changes.

### DIFF
--- a/packages/herdtools7/herdtools7.7.56.3/opam
+++ b/packages/herdtools7/herdtools7.7.56.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "The herdtools suite for simulating and studying weak memory models"
+maintainer: "Luc Maranget <Luc.Maranget@inria.fr>"
+authors: [
+  "Luc Maranget <Luc.Maranget@inria.fr>"
+  "Jade Alglave <j.alglave@ucl.ac.uk>"
+]
+homepage: "http://diy.inria.fr/"
+bug-reports: "http://github.com/herd/herdtools7/issues/"
+doc: "http://diy.inria.fr/doc/index.html"
+dev-repo: "git+https://github.com/herd/herdtools7.git"
+license: "CECILL-B"
+build: ["sh" "./dune-build.sh" "%{prefix}%"]
+install: ["sh" "./dune-install.sh" "%{prefix}%"]
+# @todo Add "build-doc" field
+# @todo Add "build-test" field
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"  {>= "1.4" }
+  "menhir" {>= "20181026"}
+]
+url {
+  src: "https://github.com/herd/herdtools7/archive/refs/tags/7.56.3.tar.gz"
+  checksum: [
+    "md5=bb7e487284559c04700a682aeed9d039"
+    "sha512=cc1bc3f356c3d81fcbae40d75e40a6b8bdc404907fcc9511a329b3f3bbbdef2342d69e55150713ccd3c5ff97652fcf4244c9e5ce707f692ccab6ee9068366145"
+   ]
+}

--- a/packages/herdtools7/herdtools7.7.56.3/opam
+++ b/packages/herdtools7/herdtools7.7.56.3/opam
@@ -17,7 +17,7 @@ install: ["sh" "./dune-install.sh" "%{prefix}%"]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune"  {>= "1.4" }
-  "menhir" {>= "20181026"}
+  "menhir" {>= "20200123"}
 ]
 url {
   src: "https://github.com/herd/herdtools7/archive/refs/tags/7.56.3.tar.gz"

--- a/packages/herdtools7/herdtools7.7.56.3/opam
+++ b/packages/herdtools7/herdtools7.7.56.3/opam
@@ -19,6 +19,7 @@ depends: [
   "dune"  {>= "1.4" }
   "menhir" {>= "20200123"}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 url {
   src: "https://github.com/herd/herdtools7/archive/refs/tags/7.56.3.tar.gz"
   checksum: [


### PR DESCRIPTION
This intermediate release is necessary to follow changes in the Linux Kernel Memory Model (LKMM).

Thanks