### PR TITLE
tsdl.0.9.7+: not available on OpenSUSE Leap

### DIFF
--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -5,6 +5,7 @@ homepage: "http://libsdl.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
 build: [["pkg-config" "sdl2"]]
+available: [!((os-distribution = "oracelinux" | os-distribution = "ol") & os-version < 9)]
 depexts: [
   ["sdl2-dev"] {os-distribution = "alpine"}
   ["sdl2"] {os-distribution = "arch"}

--- a/packages/tsdl/tsdl.0.9.7/opam
+++ b/packages/tsdl/tsdl.0.9.7/opam
@@ -16,7 +16,11 @@ depends: [
   "conf-sdl2"
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign" ]
-available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
+available: [
+    ! ((os-distribution = "opensuse-leap" & os-version < 16)
+       | (os-distribution = "oraclelinux" & os-version < 9)
+       | (os-distribution = "ubuntu" & os-version < "18.10")
+      )]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"

--- a/packages/tsdl/tsdl.0.9.7/opam
+++ b/packages/tsdl/tsdl.0.9.7/opam
@@ -9,7 +9,7 @@ tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
         "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}

--- a/packages/tsdl/tsdl.0.9.7/opam
+++ b/packages/tsdl/tsdl.0.9.7/opam
@@ -16,6 +16,7 @@ depends: [
   "conf-sdl2"
   "ctypes" {>= "0.14.0"}
   "ctypes-foreign" ]
+available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
 build: [[
   "ocaml" "pkg/pkg.ml" "build"
            "--pinned" "%{pinned}%"

--- a/packages/tsdl/tsdl.0.9.8/opam
+++ b/packages/tsdl/tsdl.0.9.8/opam
@@ -14,7 +14,7 @@ available: [
        | (os-distribution = "ubuntu" & os-version < "18.10")
       )]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.04.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.1"}

--- a/packages/tsdl/tsdl.0.9.8/opam
+++ b/packages/tsdl/tsdl.0.9.8/opam
@@ -8,7 +8,11 @@ bug-reports: "https://github.com/dbuenzli/tsdl/issues"
 tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
         "org:erratique" ]
 license: "ISC"
-available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
+available: [
+    ! ((os-distribution = "opensuse-leap" & os-version < 16)
+       | (os-distribution = "oraclelinux" & os-version < 9)
+       | (os-distribution = "ubuntu" & os-version < "18.10")
+      )]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}

--- a/packages/tsdl/tsdl.0.9.8/opam
+++ b/packages/tsdl/tsdl.0.9.8/opam
@@ -8,6 +8,7 @@ bug-reports: "https://github.com/dbuenzli/tsdl/issues"
 tags: [ "audio" "bindings" "graphics" "media" "opengl" "input" "hci"
         "org:erratique" ]
 license: "ISC"
+available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
 depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind" {build}

--- a/packages/tsdl/tsdl.0.9.9/opam
+++ b/packages/tsdl/tsdl.0.9.9/opam
@@ -15,7 +15,12 @@ Home page: http://erratique.ch/software/tsdl"""
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: "The tsdl programmers"
 license: "ISC"
-available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
+available: [
+    ! ((os-distribution = "opensuse-leap" & os-version < 16)
+       | (os-distribution = "debian" & os-version < 11)
+       | (os-distribution = "oraclelinux" & os-version < 9)
+       | (os-distribution = "ubuntu" & os-version < "18.10")
+      )]
 tags: [
   "audio"
   "bindings"

--- a/packages/tsdl/tsdl.0.9.9/opam
+++ b/packages/tsdl/tsdl.0.9.9/opam
@@ -15,6 +15,7 @@ Home page: http://erratique.ch/software/tsdl"""
 maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
 authors: "The tsdl programmers"
 license: "ISC"
+available: [ (os-distribution != "opensuse-leap" | os-version >= 16) ]
 tags: [
   "audio"
   "bindings"


### PR DESCRIPTION
OpenSUSE Leap 15.4 has SDL2 version 2.0.8.
However tsdl 0.9.7 [requires SDL_DISPLAYEVENT](https://github.com/dbuenzli/tsdl/blob/master/CHANGES.md#v097-2019-07-19-zagreb) which got introduced in SDL2 [version 2.0.9](https://github.com/libsdl-org/SDL/blob/264da8c127f8bf8930fa62f106763855efbf2a93/WhatsNew.txt#L439)

tsdl.0.9.6 is latest version that installs on OpenSUSE Leap 15.x. However OpenSUSE Tumbleweed has a newer version, so assume that version will have it, and make the package unavailable only on 'Leap < 16'.

The package is unavailable on: OpenSUSE-Leap <= 15, therefore it is available if distro != OpenSUSE-Leap, or distro == OpenSUSE-Leap && version > 16.

Without this change there is an 'ocaml-ci' failure building packages downstream of 'tsdl': https://ci.ocamllabs.io/github/sanette/bogue/commit/c05d874d5bc217625abdf1fe8c73dc8acd0a8986/variant/opensuse-15.3-5.0_opam-2.1