### PR TITLE
[new release] eio_main, eio_luv, eio_linux and eio (0.8.1)

### DIFF
--- a/packages/eio/eio.0.8.1/opam
+++ b/packages/eio/eio.0.8.1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "5.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-base-compiler" {< "5.0.0~beta1"}
+  "ocaml-variants" {< "5.0.0~beta1"}
+  "ocaml-system" {< "5.0.0~beta1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.8.1/eio-0.8.1.tbz"
+  checksum: [
+    "sha256=c4222f9b081465486a1c1a8dde6aa00178936d7c7b3a8565e0883a421e0e3547"
+    "sha512=d63d8b9500b492be93df4f29159aa6955588ca1e35e6a5817856e32ee4fec3395604dc7b64fc5a973ee8bd436bd65831e7b08fca9bf909f41afec4a65c4443b8"
+  ]
+}
+x-commit-hash: "38c337e888bac215c52b696d61e2f58cab75380f"

--- a/packages/eio_linux/eio_linux.0.8.1/opam
+++ b/packages/eio_linux/eio_linux.0.8.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.8.1/eio-0.8.1.tbz"
+  checksum: [
+    "sha256=c4222f9b081465486a1c1a8dde6aa00178936d7c7b3a8565e0883a421e0e3547"
+    "sha512=d63d8b9500b492be93df4f29159aa6955588ca1e35e6a5817856e32ee4fec3395604dc7b64fc5a973ee8bd436bd65831e7b08fca9bf909f41afec4a65c4443b8"
+  ]
+}
+x-commit-hash: "38c337e888bac215c52b696d61e2f58cab75380f"

--- a/packages/eio_luv/eio_luv.0.8.1/opam
+++ b/packages/eio_luv/eio_luv.0.8.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Eio implementation using luv (libuv)"
+description: "An eio implementation for most platforms, using luv."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "eio" {= version}
+  "luv" {>= "0.5.11"}
+  "luv_unix" {>= "0.5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.8.1/eio-0.8.1.tbz"
+  checksum: [
+    "sha256=c4222f9b081465486a1c1a8dde6aa00178936d7c7b3a8565e0883a421e0e3547"
+    "sha512=d63d8b9500b492be93df4f29159aa6955588ca1e35e6a5817856e32ee4fec3395604dc7b64fc5a973ee8bd436bd65831e7b08fca9bf909f41afec4a65c4443b8"
+  ]
+}
+x-commit-hash: "38c337e888bac215c52b696d61e2f58cab75380f"

--- a/packages/eio_main/eio_main.0.8.1/opam
+++ b/packages/eio_main/eio_main.0.8.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "eio_linux" {= version & os = "linux"}
+  "mdx" {>= "1.10.0" & with-test}
+  "eio_luv" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.8.1/eio-0.8.1.tbz"
+  checksum: [
+    "sha256=c4222f9b081465486a1c1a8dde6aa00178936d7c7b3a8565e0883a421e0e3547"
+    "sha512=d63d8b9500b492be93df4f29159aa6955588ca1e35e6a5817856e32ee4fec3395604dc7b64fc5a973ee8bd436bd65831e7b08fca9bf909f41afec4a65c4443b8"
+  ]
+}
+x-commit-hash: "38c337e888bac215c52b696d61e2f58cab75380f"
+x-ci-accept-failures: ["macos-homebrew"]


### PR DESCRIPTION
CHANGES:

Some build fixes:

- Fix build on various architectures (@talex5 ocaml-multicore/eio#432).
  - Work around dune `%{system}` bug.
  - eio_luv: fix `max_luv_buffer_size` on 32-bit platforms.

- Add missing test-dependency on MDX (@talex5 ocaml-multicore/eio#430).