### PR TITLE
x509 requires mirage-crypto-rng < 0.11.0 for tests

### DIFF
--- a/packages/x509/x509.0.10.0/opam
+++ b/packages/x509/x509.0.10.0/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "gmap" {>= "0.3.0"}
   "domain-name" {>= "0.3.0"}
 ]

--- a/packages/x509/x509.0.11.0/opam
+++ b/packages/x509/x509.0.11.0/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "gmap" {>= "0.3.0"}
   "domain-name" {>= "0.3.0"}
   "logs"

--- a/packages/x509/x509.0.11.1/opam
+++ b/packages/x509/x509.0.11.1/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "gmap" {>= "0.3.0"}
   "domain-name" {>= "0.3.0"}
   "logs"

--- a/packages/x509/x509.0.11.2/opam
+++ b/packages/x509/x509.0.11.2/opam
@@ -24,7 +24,7 @@ depends: [
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-crypto-pk" {with-test & < "0.8.9"}
   "gmap" {>= "0.3.0"}
   "domain-name" {>= "0.3.0"}

--- a/packages/x509/x509.0.12.0/opam
+++ b/packages/x509/x509.0.12.0/opam
@@ -23,6 +23,7 @@ depends: [
   "mirage-crypto-pk" {with-test & >= "0.8.10"}
   "mirage-crypto-ec"
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "rresult"
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}

--- a/packages/x509/x509.0.13.0/opam
+++ b/packages/x509/x509.0.13.0/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "rresult"
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}

--- a/packages/x509/x509.0.14.0/opam
+++ b/packages/x509/x509.0.14.0/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "rresult"
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}

--- a/packages/x509/x509.0.14.1/opam
+++ b/packages/x509/x509.0.14.1/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "rresult"
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}

--- a/packages/x509/x509.0.15.0/opam
+++ b/packages/x509/x509.0.15.0/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "rresult"
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}

--- a/packages/x509/x509.0.15.1/opam
+++ b/packages/x509/x509.0.15.1/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/x509/x509.0.15.2/opam
+++ b/packages/x509/x509.0.15.2/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/x509/x509.0.16.0/opam
+++ b/packages/x509/x509.0.16.0/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/x509/x509.0.16.1/opam
+++ b/packages/x509/x509.0.16.1/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.7"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}

--- a/packages/x509/x509.0.16.2/opam
+++ b/packages/x509/x509.0.16.2/opam
@@ -22,6 +22,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.7"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "fmt" {>= "0.8.7"}
   "alcotest" {with-test}
   "cstruct-unix" {with-test & >= "3.0.0"}


### PR DESCRIPTION
first part of #23237 revdeps