### PR TITLE
tls: require mirage-crypto-rng < 0.11.0

### DIFF
--- a/packages/tls/tls.0.11.0/opam
+++ b/packages/tls/tls.0.11.0/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.10.0" & < "0.11.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.11.1/opam
+++ b/packages/tls/tls.0.11.1/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.0/opam
+++ b/packages/tls/tls.0.12.0/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.1/opam
+++ b/packages/tls/tls.0.12.1/opam
@@ -23,7 +23,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.2/opam
+++ b/packages/tls/tls.0.12.2/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {< "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.3/opam
+++ b/packages/tls/tls.0.12.3/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.4/opam
+++ b/packages/tls/tls.0.12.4/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.5/opam
+++ b/packages/tls/tls.0.12.5/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.6/opam
+++ b/packages/tls/tls.0.12.6/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.7/opam
+++ b/packages/tls/tls.0.12.7/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.12.8/opam
+++ b/packages/tls/tls.0.12.8/opam
@@ -22,7 +22,7 @@ depends: [
   "sexplib"
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.13.0/opam
+++ b/packages/tls/tls.0.13.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {< "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.12.0" & < "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.13.1/opam
+++ b/packages/tls/tls.0.13.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.13.0" & < "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.13.2/opam
+++ b/packages/tls/tls.0.13.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.13.0" & < "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.14.0/opam
+++ b/packages/tls/tls.0.14.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.13.0" & < "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.14.1/opam
+++ b/packages/tls/tls.0.14.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.13.0" & < "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt"

--- a/packages/tls/tls.0.15.0/opam
+++ b/packages/tls/tls.0.15.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}

--- a/packages/tls/tls.0.15.1/opam
+++ b/packages/tls/tls.0.15.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}

--- a/packages/tls/tls.0.15.2/opam
+++ b/packages/tls/tls.0.15.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}

--- a/packages/tls/tls.0.15.3/opam
+++ b/packages/tls/tls.0.15.3/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}

--- a/packages/tls/tls.0.15.4/opam
+++ b/packages/tls/tls.0.15.4/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-crypto" {>= "0.8.1"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "x509" {>= "0.15.0"}
   "domain-name" {>= "0.3.0"}
   "fmt" {>= "0.8.7"}


### PR DESCRIPTION
part 2 of #23237 revdeps: restrict tls to older mirage-crypto releases