### PR TITLE
further mirage-crypto 0.11.0 breaking reverse dependencies:

### DIFF
--- a/packages/dream/dream.1.0.0~alpha1/opam
+++ b/packages/dream/dream.1.0.0~alpha1/opam
@@ -65,7 +65,7 @@ depends: [
   "logs" {>= "0.5.0"}
   "magic-mime"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
-  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}  # Signature of initialize.
   "multipart-form-data" {>= "0.3.0" & < "0.4.0"}
   "ocaml" {>= "4.08.0" & < "5.0"}
   "opam-installer" {build}

--- a/packages/dream/dream.1.0.0~alpha2/opam
+++ b/packages/dream/dream.1.0.0~alpha2/opam
@@ -66,7 +66,7 @@ depends: [
   "logs" {>= "0.5.0"}
   "magic-mime"
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
-  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}  # Signature of initialize.
   "multipart_form" {>= "0.3.0" & < "0.4.0"}
   "ocaml" {>= "4.08.0" & < "5.0"}
   "uri" {>= "4.2.0"}

--- a/packages/dream/dream.1.0.0~alpha3/opam
+++ b/packages/dream/dream.1.0.0~alpha3/opam
@@ -66,7 +66,7 @@ depends: [
   "magic-mime"
   "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
-  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}  # Signature of initialize.
   "multipart_form" {>= "0.4.0"}
   "multipart_form-lwt"
   "ocaml" {>= "4.08.0" & < "5.0"}

--- a/packages/dream/dream.1.0.0~alpha4/opam
+++ b/packages/dream/dream.1.0.0~alpha4/opam
@@ -67,7 +67,7 @@ depends: [
   "magic-mime"
   "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
   "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
-  "mirage-crypto-rng" {>= "0.8.0"}  # Signature of initialize.
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}  # Signature of initialize.
   "multipart_form" {>= "0.4.0"}
   "multipart_form-lwt"
   "ocaml" {>= "4.08.0"}

--- a/packages/hyper/hyper.1.0.0~alpha1/opam
+++ b/packages/hyper/hyper.1.0.0~alpha1/opam
@@ -18,7 +18,7 @@ depends: [
   "lwt_ppx"
   "ocaml"
   "dune" {>= "2.7"}
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "uri"
 
   "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.

--- a/packages/jose/jose.0.8.2/opam
+++ b/packages/jose/jose.0.8.2/opam
@@ -14,6 +14,7 @@ depends: [
   "dune" {>= "2.8"}
   "eqaf" {>= "0.7"}
   "mirage-crypto" {>= "0.10.0"}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.13.0"}
   "cstruct" {>= "6.0.0"}
   "astring"

--- a/packages/letsencrypt/letsencrypt.0.2.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.1/opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & != "0.8.9"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.10.0" & < "0.11.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.2/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.2/opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & != "0.8.9"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.3/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.3/opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.4/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.4/opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.11.0" & < "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.5/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.5/opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.3.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.3.0/opam
@@ -21,6 +21,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.4.0/opam
+++ b/packages/letsencrypt/letsencrypt.0.4.0/opam
@@ -21,6 +21,7 @@ depends: [
   "mirage-crypto-ec"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.4.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.4.1/opam
@@ -20,6 +20,7 @@ depends: [
   "mirage-crypto-ec"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "x509" {>= "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/mirage-block-ccm/mirage-block-ccm.1.1.0/opam
+++ b/packages/mirage-block-ccm/mirage-block-ccm.1.1.0/opam
@@ -35,8 +35,8 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "lwt" {>= "2.4.3"}
   "mirage-block" {>= "2.0.0"}
-  "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto" {>= "0.8.1" & < "0.11.0"}
+  "mirage-crypto-rng" {< "0.11.0"}
   "ounit2" {with-test}
   "bisect_ppx" {dev}
   "cmdliner" {>= "1.1.0"}

--- a/packages/rfc6287/rfc6287.1.0.4/opam
+++ b/packages/rfc6287/rfc6287.1.0.4/opam
@@ -23,6 +23,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "astring"
   "hex"

--- a/packages/ssh-agent/ssh-agent.0.3.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.3.0/opam
@@ -18,6 +18,7 @@ depends: [
   "faraday" {>= "0.6" & < "0.8"}
   "mirage-crypto"
   "mirage-crypto-pk"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "cstruct" {< "6.1.0"}
   "sexplib"
   "alcotest" {with-test}

--- a/packages/ssh-agent/ssh-agent.0.3.1/opam
+++ b/packages/ssh-agent/ssh-agent.0.3.1/opam
@@ -18,6 +18,7 @@ depends: [
   "faraday" {>= "0.6"}
   "mirage-crypto"
   "mirage-crypto-pk"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "cstruct"
   "sexplib"
   "alcotest" {with-test}

--- a/packages/ssh-agent/ssh-agent.0.4.0/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.0/opam
@@ -18,6 +18,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-ec"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "cstruct"
   "alcotest" {with-test}
 ]

--- a/packages/twostep/twostep.1.0.1/opam
+++ b/packages/twostep/twostep.1.0.1/opam
@@ -27,7 +27,7 @@ depends: [
   "base" {>= "v0.9.3"}
   "hex" {>= "1.2.0"}
   "mirage-crypto" {>= "0.6.1"}
-  "mirage-crypto-rng" {>= "0.6.1"}
+  "mirage-crypto-rng" {>= "0.6.1" & < "0.11.0"}
   "mirage-crypto-pk" {>= "0.6.1"}
   "dune" {>= "1.7.0"}
   "alcotest" {with-test & >= "0.8.4"}


### PR DESCRIPTION
in order to fix #23237 revdeps

(a) Mirage_crypto_rng_lwt is now in the separate package mirage-crypto-rng-lwt (b) Mirage_crypto_rng_unix.initialize signature changed
- dream
- hyper
- jose
- letsencrypt
- rfc6287
- ssh-agent
- twostep

And in mirage-block-ccm: now AES.CCM16, no AES.CCM anymore