### PR TITLE
further mirage-crypto 0.11.0 fallout

### DIFF
--- a/packages/awa/awa.0.0.1/opam
+++ b/packages/awa/awa.0.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "x509" {>= "0.10.0" & < "0.12.0"}
   "cstruct" {>= "3.2.0"}

--- a/packages/awa/awa.0.0.2/opam
+++ b/packages/awa/awa.0.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "mirage-crypto-ec" {< "0.10.0"}
   "x509" {>= "0.12.0"}

--- a/packages/awa/awa.0.0.3/opam
+++ b/packages/awa/awa.0.0.3/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "x509" {>= "0.12.0"}

--- a/packages/awa/awa.0.0.4/opam
+++ b/packages/awa/awa.0.0.4/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "x509" {>= "0.12.0"}

--- a/packages/awa/awa.0.0.5/opam
+++ b/packages/awa/awa.0.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "x509" {>= "0.15.2"}

--- a/packages/awa/awa.0.1.0/opam
+++ b/packages/awa/awa.0.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "x509" {>= "0.15.2"}

--- a/packages/awa/awa.0.1.1/opam
+++ b/packages/awa/awa.0.1.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_cstruct"
   "mirage-crypto" {>= "0.8.1"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "mirage-crypto-pk"
   "mirage-crypto-ec" {>= "0.10.0"}
   "x509" {>= "0.15.2"}

--- a/packages/certify/certify.0.3.3/opam
+++ b/packages/certify/certify.0.3.3/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "dune" {>= "1.0"}
   "mirage-crypto-pk"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.12.1" & < "0.15.1"}
   "cstruct" {>= "3.2.0" & < "6.1.0"}
   "ptime"

--- a/packages/chamelon-unix/chamelon-unix.0.0.10/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.0.10/opam
@@ -17,7 +17,7 @@ depends: [
   "dune" {>= "2.9.0"}
   "alcotest" {>= "1.5.0" & with-test}
   "alcotest-lwt" {>= "1.5.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & < "0.11.0" & with-test}
   "bos" {>= "0.2.0"}
   "chamelon" {= version}
   "cmdliner" {>= "1.1.0"}

--- a/packages/chamelon-unix/chamelon-unix.0.0.9.1/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.0.9.1/opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.10.0"}
   "dune" {>= "2.9.0"}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & < "0.11.0" & with-test}
   "alcotest" {>= "1.5.0" & with-test}
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "bos" {>= "0.2.0"}

--- a/packages/chamelon-unix/chamelon-unix.0.1.1/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.1.1/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest" {>= "1.5.0" & with-test}
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "mirage-block-combinators" {>= "3.0.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & < "0.11.0" & with-test}
   "bos" {>= "0.2.0"}
   "chamelon" {= version}
   "cmdliner" {>= "1.1.0"}

--- a/packages/chamelon-unix/chamelon-unix.0.1.2/opam
+++ b/packages/chamelon-unix/chamelon-unix.0.1.2/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest" {>= "1.5.0" & with-test}
   "alcotest-lwt" {>= "1.5.0" & with-test}
   "mirage-block-combinators" {>= "3.0.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & < "0.11.0" & with-test}
   "bos" {>= "0.2.0"}
   "chamelon" {= version}
   "cmdliner" {>= "1.1.0"}

--- a/packages/chamelon/chamelon.0.1.1/opam
+++ b/packages/chamelon/chamelon.0.1.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-block-combinators" {>= "3.0.0" & with-test}
   "mirage-block-unix" {>= "2.13.0" & with-test}
   "mirage-clock-unix" {>= "4.0.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & < "0.11.0" & with-test}
   "bechamel" {>= "0.2.0" & with-test}
   "bechamel-js" {>= "0.2.0" & with-test}
   "checkseum" {>= "0.3.2"}

--- a/packages/chamelon/chamelon.0.1.2/opam
+++ b/packages/chamelon/chamelon.0.1.2/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-block-combinators" {>= "3.0.0" & with-test}
   "mirage-block-unix" {>= "2.13.0" & with-test}
   "mirage-clock-unix" {>= "4.0.0" & with-test}
-  "mirage-crypto-rng" {>= "0.10.6" & with-test}
+  "mirage-crypto-rng" {>= "0.10.6" & < "0.11.0" & with-test}
   "bechamel" {>= "0.2.0" & with-test}
   "bechamel-js" {>= "0.2.0" & with-test}
   "checkseum" {>= "0.3.2"}

--- a/packages/conex-mirage-crypto/conex-mirage-crypto.0.11.1/opam
+++ b/packages/conex-mirage-crypto/conex-mirage-crypto.0.11.1/opam
@@ -14,7 +14,7 @@ depends: [
   "cstruct" {>= "1.6.0"}
   "mirage-crypto"
   "mirage-crypto-pk"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.7.0" & < "0.13.0"}
   "logs"
   "fmt"

--- a/packages/current_web/current_web.0.3/opam
+++ b/packages/current_web/current_web.0.3/opam
@@ -23,7 +23,7 @@ depends: [
   "base64"
   "session"
   "session-cohttp-lwt"
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "fmt"
   "bos"
   "lwt"

--- a/packages/current_web/current_web.0.4/opam
+++ b/packages/current_web/current_web.0.4/opam
@@ -19,7 +19,7 @@ depends: [
   "session"
   "session-cohttp-lwt"
   "mirage-crypto" {>= "0.8.7"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "fmt"
   "bos"
   "lwt"

--- a/packages/current_web/current_web.0.5/opam
+++ b/packages/current_web/current_web.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "session"
   "session-cohttp-lwt"
   "mirage-crypto" {>= "0.8.7"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "fmt" {>= "0.8.9"}
   "bos"
   "lwt"

--- a/packages/current_web/current_web.0.6.1/opam
+++ b/packages/current_web/current_web.0.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "session"
   "session-cohttp-lwt"
   "mirage-crypto" {>= "0.8.7"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "fmt" {>= "0.8.9"}
   "bos"
   "lwt"

--- a/packages/current_web/current_web.0.6.2/opam
+++ b/packages/current_web/current_web.0.6.2/opam
@@ -21,7 +21,7 @@ depends: [
   "session"
   "session-cohttp-lwt"
   "mirage-crypto" {>= "0.8.7"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "fmt" {>= "0.8.9"}
   "bos"
   "lwt"

--- a/packages/current_web/current_web.0.6/opam
+++ b/packages/current_web/current_web.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "session"
   "session-cohttp-lwt"
   "mirage-crypto" {>= "0.8.7"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "fmt" {>= "0.8.9"}
   "bos"
   "lwt"

--- a/packages/dirsp-proscript-mirage/dirsp-proscript-mirage.0.1.0/opam
+++ b/packages/dirsp-proscript-mirage/dirsp-proscript-mirage.0.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.6.0"}
   "dirsp-proscript" {= version}
-  "mirage-crypto-rng" {>= "0.8.1"}
+  "mirage-crypto-rng" {>= "0.8.1" & < "0.11.0"}
   "mirage-crypto-ec" {>= "0.10.0"}
   "ppx_deriving_protobuf" {>= "3.0.0"}
   "alcotest" {>= "1.4.0" & with-test}

--- a/packages/dns-client/dns-client.4.5.0/opam
+++ b/packages/dns-client/dns-client.4.5.0/opam
@@ -28,7 +28,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
 ]
 synopsis: "Pure DNS resolver API"
 description: """

--- a/packages/dns-client/dns-client.4.6.0/opam
+++ b/packages/dns-client/dns-client.4.6.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/packages/dns-client/dns-client.4.6.1/opam
+++ b/packages/dns-client/dns-client.4.6.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/packages/dns-client/dns-client.4.6.2/opam
+++ b/packages/dns-client/dns-client.4.6.2/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/packages/dns-client/dns-client.4.6.3/opam
+++ b/packages/dns-client/dns-client.4.6.3/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/packages/dns-client/dns-client.5.0.0/opam
+++ b/packages/dns-client/dns-client.5.0.0/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/packages/dns-client/dns-client.5.0.1/opam
+++ b/packages/dns-client/dns-client.5.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
-  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0" & < "0.11.0"}
   "alcotest" {with-test}
 ]
 synopsis: "Pure DNS resolver API"

--- a/packages/dns-server/dns-server.4.4.0/opam
+++ b/packages/dns-server/dns-server.4.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "metrics"

--- a/packages/dns-server/dns-server.4.4.1/opam
+++ b/packages/dns-server/dns-server.4.4.1/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "metrics"

--- a/packages/dns-server/dns-server.4.5.0/opam
+++ b/packages/dns-server/dns-server.4.5.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "metrics"

--- a/packages/dns-server/dns-server.4.6.0/opam
+++ b/packages/dns-server/dns-server.4.6.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "metrics"

--- a/packages/dns-server/dns-server.4.6.1/opam
+++ b/packages/dns-server/dns-server.4.6.1/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "metrics"

--- a/packages/dns-server/dns-server.4.6.2/opam
+++ b/packages/dns-server/dns-server.4.6.2/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "metrics"

--- a/packages/dns-server/dns-server.4.6.3/opam
+++ b/packages/dns-server/dns-server.4.6.3/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.5.0.0/opam
+++ b/packages/dns-server/dns-server.5.0.0/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.5.0.1/opam
+++ b/packages/dns-server/dns-server.5.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.0.0/opam
+++ b/packages/dns-server/dns-server.6.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.0.1/opam
+++ b/packages/dns-server/dns-server.6.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.0.2/opam
+++ b/packages/dns-server/dns-server.6.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.1.0/opam
+++ b/packages/dns-server/dns-server.6.1.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.1.1/opam
+++ b/packages/dns-server/dns-server.6.1.1/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
   "mirage-protocols" {>= "6.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.1.2/opam
+++ b/packages/dns-server/dns-server.6.1.2/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mirage-stack" {>= "2.2.0"}
   "mirage-protocols" {>= "6.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.1.3/opam
+++ b/packages/dns-server/dns-server.6.1.3/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.1.4/opam
+++ b/packages/dns-server/dns-server.6.1.4/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.2.0/opam
+++ b/packages/dns-server/dns-server.6.2.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.2.1/opam
+++ b/packages/dns-server/dns-server.6.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.2.2/opam
+++ b/packages/dns-server/dns-server.6.2.2/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.3.0/opam
+++ b/packages/dns-server/dns-server.6.3.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.4.0/opam
+++ b/packages/dns-server/dns-server.6.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}

--- a/packages/dns-server/dns-server.6.4.1/opam
+++ b/packages/dns-server/dns-server.6.4.1/opam
@@ -19,7 +19,7 @@ depends: [
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   "tcpip" {>= "7.0.0"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "alcotest" {with-test}
   "dns-tsig" {with-test}
   "base64" {with-test & >= "3.0.0"}


### PR DESCRIPTION
continued for #23237 

Miage_crypto_rng_lwt is now part of the separate package mirage-crypto-rng-lwt

- awa
- certify
- chamelon
- conex-mirage-crypto
- current_web
- dirsp-proscript-mirage
- dns-client
- dns-server