### PR TITLE
[new release] xdg, stdune, ordering, ocamlc-loc, dyn, dune, dune-site, dune-rpc, dune-rpc-lwt, dune-private-libs, dune-glob, dune-configurator, dune-build-info, dune-action-plugin and chrome-trace (3.7.0~alpha1)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.7.0~alpha1/opam
+++ b/packages/chrome-trace/chrome-trace.3.7.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-action-plugin/dune-action-plugin.3.7.0~alpha1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.7.0~alpha1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-build-info/dune-build-info.3.7.0~alpha1/opam
+++ b/packages/dune-build-info/dune-build-info.3.7.0~alpha1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-configurator/dune-configurator.3.7.0~alpha1/opam
+++ b/packages/dune-configurator/dune-configurator.3.7.0~alpha1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.04.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-glob/dune-glob.3.7.0~alpha1/opam
+++ b/packages/dune-glob/dune-glob.3.7.0~alpha1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-private-libs/dune-private-libs.3.7.0~alpha1/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.7.0~alpha1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.7.0~alpha1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.7.0~alpha1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "dune-rpc" {= version}
+  "result" {>= "1.5"}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.3.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-rpc/dune-rpc.3.7.0~alpha1/opam
+++ b/packages/dune-rpc/dune-rpc.3.7.0~alpha1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune-site/dune-site.3.7.0~alpha1/opam
+++ b/packages/dune-site/dune-site.3.7.0~alpha1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dune/dune.3.7.0~alpha1/opam
+++ b/packages/dune/dune.3.7.0~alpha1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/dyn/dyn.3.7.0~alpha1/opam
+++ b/packages/dyn/dyn.3.7.0~alpha1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/ocamlc-loc/ocamlc-loc.3.7.0~alpha1/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.7.0~alpha1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/ordering/ordering.3.7.0~alpha1/opam
+++ b/packages/ordering/ordering.3.7.0~alpha1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/stdune/stdune.3.7.0~alpha1/opam
+++ b/packages/stdune/stdune.3.7.0~alpha1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"

--- a/packages/xdg/xdg.3.7.0~alpha1/opam
+++ b/packages/xdg/xdg.3.7.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.7.0_alpha1/dune-3.7.0.alpha1.tbz"
+  checksum: [
+    "sha256=56746c390a1be13408bf3805045a249d195db15d6adc94ca1840c5ae093a962b"
+    "sha512=a43ea6eedac600b5e55995297eb7df180ddb4c2ee7ff0b4299c141f838f8856b8955ecd68b1da77fd19357032dab84d0702500c3cd65a14616824010885a8e00"
+  ]
+}
+x-commit-hash: "5f227878ad830d7e6fe4f7c688471c6e7ccd3a24"


### PR DESCRIPTION
XDG Base Directory Specification

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Fix parsing of OCaml errors that contain code excerpts with `...` in them.
  (ocaml/dune#7008, @rgrinberg)

- Pre-emptively clear screen in watch mode (ocaml/dune#6987, fixes ocaml/dune#6884, @rgrinberg)

- Fix cross compilation configuration when a context with targets is itself a
  host of another context (ocaml/dune#6958, fixes ocaml/dune#6843, @rgrinberg)

- Fix parsing of the `<=` operator in *blang* expressions of `dune` files.
  Previously, the operator would be interpreted as `,`. (ocaml/dune#6928, @tatchi)

- Fix `--trace-file` output. Dune now emits a single *complete* event for every
  executed process. Unterminated *async* events are no longer written. (ocaml/dune#6892,
  @rgrinberg)

- Fix preprocessing with `staged_pps` (ocaml/dune#6748, fixes ocaml/dune#6644, @rgrinberg)

- Use colored output with MDX when Dune colors are enabled.
  (ocaml/dune#6462, @MisterDA)

- Make `dune describe workspace` return consistent dependencies for
  executables and for libraries. By default, compile-time dependencies
  towards PPX-rewriters are from now not taken into account (but
  runtime dependencies always are). Compile-time dependencies towards
  PPX-rewriters can be taken into account by providing the
  `--with-pps` flag. (ocaml/dune#6727, fixes ocaml/dune#6486, @esope)

- Print missing newline after `$ dune exec`. (ocaml/dune#6821, fixes ocaml/dune#6700, @rgrinberg,
  @Alizter)

- Fix binary corruption when installing or promoting in parallel (ocaml/dune#6669, fixes
  ocaml/dune#6668, @edwintorok)

- Use colored output with GCC and Clang when compiling C stubs. The
  flag `-fdiagnostics-color=always` is added to the `:standard` set of
  flags. (ocaml/dune#4083, @MisterDA)

- Fix the parsing of decimal and hexadecimal escape literals in `dune`,
  `dune-package`, and other dune s-expression based files (ocaml/dune#6710, @shym)

- Report an error if `dune init ...` would create a "dune" file in a location
  which already contains a "dune" directory (ocaml/dune#6705, @gridbugs)

- Fix the parsing of alerts. They will now show up in diagnostics correctly.
  (ocaml/dune#6678, @rginberg)

- Fix the compilation of modules generated at link time when
  `implicit_transitive_deps` is enabled (ocaml/dune#6642, @rgrinberg)

- Allow `$ dune utop` to load libraries defined in data only directories
  defined using `(subdir ..)` (ocaml/dune#6631, @rgrinberg)

- Format dune files when they are named `dune-file`. This occurs when we enable
  the alternative file names project option. (ocaml/dune#6566, @rgrinberg)

- Move `$ dune ocaml-merlin -dump-config=$dir` to `$ dune ocaml merlin
  dump-config $dir`. (ocaml/dune#6547, @rgrinberg)

- Allow compilation rules to be impacted by `(env ..)` stanzas that modify the
  environment or set binaries. (ocaml/dune#6527, @rgrinberg)

- Coq native mode is now automatically detected by Dune starting with Coq lang
  0.7. `(mode native)` has been deprecated in favour of detection from the
  configuration of Coq. (ocaml/dune#6409, @Alizter)

- Print "Leaving Directory" whenever "Entering Directory" is printed. (ocaml/dune#6149,
  fixes ocaml/dune#138, @cpitclaudel, @rgrinberg)

- Allow `$ dune ocaml dump-dot-merlin` to run in watch mode. Also this command
  shouldn't print "Entering Directory" mesages. (ocaml/dune#6497, @rgrinberg)

- `dune clean` should no longer fail under Windows due to the inability to
  remove the `.lock` file. Also, bring the implementation of the global lock
  under Windows closer to that of Unix. (ocaml/dune#6523, @nojb)

- Remove "Entering Directory" messages for `$ dune install`. (ocaml/dune#6513,
  @rgrinberg)

- Stop passing `-q` flag in `dune coq top`, which allows for `.coqrc` to be
  loaded. (ocaml/dune#6848, fixes ocaml/dune#6847, @Alizter)

- Fix missing dependencies when detecting the kind of C compiler we're using
  (ocaml/dune#6610, fixes ocaml/dune#6415, @emillon)

- Allow `(include_subdirs qualified)` for OCaml projects. (ocaml/dune#6594, fixes ocaml/dune#1084,
  @rgrinberg)

- Accurately determine merlin configuration for all sources selected with
  `copy#` and `copy_files#`. The old heuristic of looking for a module in
  parent directories is removed (ocaml/dune#6594, @rgrinberg)

- Fix inline tests with *js_of_ocaml* and whole program compilation mode
  enabled (ocaml/dune#6645, @hhugo)

- Fix *js_of_ocaml* separate compilation rules when `--enable=effects`
  ,`--enable=use-js-string` or `--toplevel` is used. (ocaml/dune#6714, ocaml/dune#6828, ocaml/dune#6920, @hhugo)

- Fix *js_of_ocaml* separate compilation in presence of linkall (ocaml/dune#6832, ocaml/dune#6916, @hhugo)

- Remove spurious build dir created when running `dune init proj ...` (ocaml/dune#6707,
  fixes ocaml/dune#5429, @gridbugs)

- Allow `--sandbox` to affect `ocamldep` invocations. Previously, they were
  wrongly marked as incompatible (ocaml/dune#6749, @rgrinberg)

- Validate the command line arguments for `$ dune ocaml top-module`. This
  command requires one positional argument (ocaml/dune#6796, fixes ocaml/dune#6793, @rgrinberg)

- Add a `dune cache size` command for displaying the size of the cache (ocaml/dune#6638,
  @Alizter)

- Add 4.14.0 MSVC to CI (ocaml/dune#6917, @jonahbeckford)

- Fix dependency cycle when installing files to the bin section with
  `glob_files` (ocaml/dune#6764, fixes ocaml/dune#6708, @gridbugs)

- Handle "Too many links" errors when using Dune cache on Windows (ocaml/dune#6993, @nojb)
