### PR TITLE
Package libbinaryen.111.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.111.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.111.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "5.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v111.0.0/libbinaryen-v111.0.0.tar.gz"
+  checksum: [
+    "md5=8f48641f10c63cd86ccf4d68d0b7a90c"
+    "sha512=abb6a8d9537484a2b1b370c75d82933ad840881ecc766b69760f1f12a5caafda3d4f980801f5abea4ca521df9180254a1bed57cc206d9383fa4116fa556db58b"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.111.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [111.0.0](https://github.com/grain-lang/libbinaryen/compare/v110.0.0...v111.0.0) (2023-02-07)


### ⚠ BREAKING CHANGES

* Upgrade to libbinaryen v111 ([#75](https://github.com/grain-lang/libbinaryen/issues/75))

### Features

* Upgrade to libbinaryen v111 ([#75](https://github.com/grain-lang/libbinaryen/issues/75)) ([e43a7ff](https://github.com/grain-lang/libbinaryen/commit/e43a7ffeb865034a3fbf6584b434eae890f980e5))

---
:camel: Pull-request generated by opam-publish v2.0.3