### PR TITLE
Prevent gd and magic from building with ocaml 5.

### DIFF
--- a/packages/gd/gd.1.0a5/opam
+++ b/packages/gd/gd.1.0a5/opam
@@ -11,7 +11,7 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "gd"]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-gd" {build}
 ]

--- a/packages/magic/magic.0.7.3/opam
+++ b/packages/magic/magic.0.7.3/opam
@@ -8,7 +8,10 @@ remove: [
   ["./configure" "--prefix" prefix "--datarootdir" prefix]
   [make "uninstall"]
 ]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+]
 depexts: [
   ["file-dev"] {os-distribution = "alpine"}
   ["file-devel"] {os-distribution = "centos"}

--- a/packages/magic/magic.0.7.3/opam
+++ b/packages/magic/magic.0.7.3/opam
@@ -11,6 +11,7 @@ remove: [
 depends: [
   "ocaml" {< "5.0"}
   "ocamlfind"
+  "conf-which" {build}
 ]
 depexts: [
   ["file-dev"] {os-distribution = "alpine"}


### PR DESCRIPTION
The packages will build but won't link because they are using deprecated OCaml C symbols.