### PR TITLE
3 packages from c-cube/ocaml-containers at 3.11

### DIFF
--- a/packages/containers-data/containers-data.3.11/opam
+++ b/packages/containers-data/containers-data.3.11/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "A set of advanced datatypes for containers"
+license: "BSD-2-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "containers" { = version }
+  "seq"
+  (("ocaml" {with-test & < "4.08"} & "qcheck-core" {>= "0.17" & with-test})
+  | ("ocaml" {with-test & >= "4.08"} & "qcheck-core" {>= "0.18" & with-test}))
+  "iter" { with-test }
+  "gen" { with-test }
+  "mdx" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "RAL" "functional" "vector" "okasaki" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.11.tar.gz"
+  checksum: [
+    "md5=897b5af970ba48508a2ee001d90e8869"
+    "sha512=d4bf1219cc32017d6dee1462c9a6c555e3da833512cdc6e176a92e3a229497734cf6bc0cf2c2abd30183de860858468115c000c719742162e78080074149d317"
+  ]
+}

--- a/packages/containers-thread/containers-thread.3.11/opam
+++ b/packages/containers-thread/containers-thread.3.11/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "An extension of containers for threading"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "base-threads"
+  "dune-configurator"
+  "containers" { = version }
+  "iter" { with-test }
+  (("ocaml" {with-test & < "4.08"} & "qcheck-core" {>= "0.17" & with-test})
+  | ("ocaml" {with-test & >= "4.08"} & "qcheck-core" {>= "0.18" & with-test}))
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+tags: [ "containers" "thread" "semaphore" "blocking queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.11.tar.gz"
+  checksum: [
+    "md5=897b5af970ba48508a2ee001d90e8869"
+    "sha512=d4bf1219cc32017d6dee1462c9a6c555e3da833512cdc6e176a92e3a229497734cf6bc0cf2c2abd30183de860858468115c000c719742162e78080074149d317"
+  ]
+}

--- a/packages/containers/containers.3.11/opam
+++ b/packages/containers/containers.3.11/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-Clause"
+synopsis: "A modular, clean and powerful extension of the OCaml standard library"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name ] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+depends: [
+  "ocaml" { >= "4.03.0" }
+  "dune" { >= "2.0" }
+  "dune-configurator"
+  "seq" # compat
+  "either" # compat
+  (("ocaml" {with-test & < "4.08"} & "qcheck-core" {>= "0.17" & with-test})
+  | ("ocaml" {with-test & >= "4.08"} & "qcheck-core" {>= "0.18" & with-test}))
+  "yojson" { with-test }
+  "iter" { with-test }
+  "gen" { with-test }
+  "csexp" { with-test }
+  "uutf" { with-test }
+  "odoc" { with-doc }
+]
+depopts: [
+  "base-unix"
+  "base-threads"
+]
+tags: [ "stdlib" "containers" "iterators" "list" "heap" "queue" ]
+homepage: "https://github.com/c-cube/ocaml-containers/"
+doc: "https://c-cube.github.io/ocaml-containers"
+dev-repo: "git+https://github.com/c-cube/ocaml-containers.git"
+bug-reports: "https://github.com/c-cube/ocaml-containers/issues/"
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/ocaml-containers/archive/v3.11.tar.gz"
+  checksum: [
+    "md5=897b5af970ba48508a2ee001d90e8869"
+    "sha512=d4bf1219cc32017d6dee1462c9a6c555e3da833512cdc6e176a92e3a229497734cf6bc0cf2c2abd30183de860858468115c000c719742162e78080074149d317"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`containers.3.11`: A modular, clean and powerful extension of the OCaml standard library
-`containers-data.3.11`: A set of advanced datatypes for containers
-`containers-thread.3.11`: An extension of containers for threading



---
* Homepage: https://github.com/c-cube/ocaml-containers/
* Source repo: git+https://github.com/c-cube/ocaml-containers.git
* Bug tracker: https://github.com/c-cube/ocaml-containers/issues/

---
:camel: Pull-request generated by opam-publish v2.0.3