### PR TITLE
Camlp5: Rewrote last scripts that depended on conf-perl-* packages

### DIFF
--- a/packages/camlp5/camlp5.8.00.05/opam
+++ b/packages/camlp5/camlp5.8.00.05/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.10" & < "5.01.0"}
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "camlp5-buildscripts"
+  "conf-diffutils" { with-test & os-distribution = "alpine" }
+  "re"
+  "pcre"
+  "ounit" { with-test }
+  "rresult"
+  "bos"
+  "fmt"
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test }
+  [make "-C" "test" "clean" "all"] { with-test }
+  [make "-C" "scripts" "clean" "test"] { with-test }
+]
+install: [make "install"]
+conflicts: [
+   "ocaml-option-bytecode-only"
+]
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.00.05.tar.gz"
+  checksum: [
+    "sha512=6ede5a8405b4a495b3b38aaffc228b85cc6bdb657d789a63b56aec9cc5bf85cdb4f3b8bc81a92b686aafabdd9d55ea80cbae4def71fe4d6795bd15aa6a46efb2"
+  ]
+}


### PR DESCRIPTION
viz, conf-perl-ipc-system-simple,conf-perl-string-shellquote

So now camlp5 should install cleanly on macos-homebrew