### PR TITLE
ocamlformat.0.24.1: require ocaml-version < 3.6.0

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.24.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.24.1/opam
@@ -19,7 +19,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocamlformat-rpc-lib" {with-test & = version}
   "ocp-indent"
   "odoc-parser" {>= "2.0.0" & < "3.0.0"}


### PR DESCRIPTION
This OCamlformat release base has a comparison against `v4_14` for a feature that has been added in `4.14.0`. So it breaks when using `ocaml-version.3.6.0`, which moves `v4_14` (the logical latest release in 4.14.x) to `4.14.1`.

The check has been fixed in ocaml-ppx/ocamlformat#2240.

(cc @gpetiot)