### PR TITLE
current_git: skip tests that hang

### DIFF
--- a/packages/current_git/current_git.0.6.1/opam
+++ b/packages/current_git/current_git.0.6.1/opam
@@ -32,7 +32,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 license: "Apache-2.0"

--- a/packages/current_git/current_git.0.6.2/opam
+++ b/packages/current_git/current_git.0.6.2/opam
@@ -33,7 +33,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
 url {


### PR DESCRIPTION
These releases trigger an infinite loop in certain versions of git.

This is discussed in ocurrent/ocurrent#386 and ocurrent/ocurrent#405.

cc @maiste
