### PR TITLE
ubpf.0.1: require dune < 3.0

### DIFF
--- a/packages/ubpf/ubpf.0.1/opam
+++ b/packages/ubpf/ubpf.0.1/opam
@@ -15,7 +15,7 @@ available: [
 depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
-  "dune"
+  "dune" {< "3.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
It builds with 2.9.3 but not with dune 3.0.2.
