### PR TITLE
caldav 0.2.1: tests are incompatible with cohttp 6

### DIFF
--- a/packages/caldav/caldav.0.2.1/opam
+++ b/packages/caldav/caldav.0.2.1/opam
@@ -38,7 +38,7 @@ depends: [
   "ptime" {>= "0.8.5"}
   "cohttp" {>= "2.0.0"}
   "cohttp-lwt" {>= "2.0.0"}
-  "cohttp-lwt-unix" {with-test & >= "2.0.0"}
+  "cohttp-lwt-unix" {with-test & >= "2.0.0" & < "6.0~"}
   "mirage-crypto"
   "mirage-crypto-rng"
   "base64" {>= "3.0.0"}


### PR DESCRIPTION
Fails with
```
Error: The implementation app/cohttp_lwt_unix_test.ml
        does not match the interface app/.caldav_server.eobjs/byte/cohttp_lwt_unix_test.cmi:
         Values do not match:
           val temp_server :
             ?port:int ->
             (Http.Request.t ->
              Cohttp_lwt__.Body.t ->
              Cohttp_lwt_unix.Server.response_action Lwt.t) ->
             (Uri.t -> 'a Lwt.t) -> 'a Lwt.t
         is not included in
           val temp_server : ?port:int -> spec -> (Uri.t -> 'a io) -> 'a io
         The type
           ?port:int ->
           (Http.Request.t ->
            Cohttp_lwt__.Body.t ->
            Cohttp_lwt_unix.Server.response_action Lwt.t) ->
           (Uri.t -> 'a Lwt.t) -> 'a Lwt.t
         is not compatible with the type
           ?port:int -> spec -> (Uri.t -> 'b io) -> 'b io
         Type
           Http.Request.t ->
           Cohttp_lwt__.Body.t -> Cohttp_lwt_unix.Server.response_action Lwt.t
         is not compatible with type
           spec = Cohttp_lwt_unix.Request.t -> body -> response_action io
         Type Cohttp_lwt_unix.Server.response_action Lwt.t
         is not compatible with type
           response_action io = response_action Lwt.t
         Type
           Cohttp_lwt_unix.Server.response_action =
             [ `Expert of
                 Http.Response.t *
                 (Cohttp_lwt_unix.Server.IO.ic ->
                  Cohttp_lwt_unix.Server.IO.oc -> unit Lwt.t)
             | `Response of Http.Response.t * Cohttp_lwt__.Body.t ]
         is not compatible with type
           response_action =
             [ `Expert of Cohttp.Response.t * (ic -> oc -> unit io)
             | `Response of Cohttp.Response.t * body ]
         Type Cohttp_lwt_unix.Server.IO.ic = Cohttp_lwt_unix__Input_channel.t
         is not compatible with type ic = Lwt_io.input Lwt_io.channel
         Types for tag `Expert are incompatible
         File "app/cohttp_test.mli", line 34, characters 2-66:
           Expected declaration
         File "app/cohttp_lwt_unix_test.ml", line 31, characters 4-15:
           Actual declaration
```
Seen on CI for https://github.com/ocaml/opam-repository/pull/23262

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>