### PR TITLE
paf-cohttp 0.4.0 is not compatible with cohttp 6

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.4.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.4.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
   "paf" {= version}
-  "cohttp-lwt"
+  "cohttp-lwt" {< "6.0~"}
   "domain-name"
   "httpaf"
   "ipaddr"


### PR DESCRIPTION
Fails with

```
=== ERROR while compiling paf-cohttp.0.4.0 ===================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/paf-cohttp.0.4.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p paf-cohttp -j 127
 exit-code            1
 env-file             ~/.opam/log/paf-cohttp-7-8fc6af.env
 output-file          ~/.opam/log/paf-cohttp-7-8fc6af.out
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lib/.paf_cohttp.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/httpaf -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -intf-suffix .ml -no-alias-deps -o lib/.paf_cohttp.objs/byte/paf_cohttp.cmo -c -impl lib/paf_cohttp.ml)
 File "lib/paf_cohttp.ml", line 1:
 Error: The implementation lib/paf_cohttp.ml
        does not match the interface lib/.paf_cohttp.objs/byte/paf_cohttp.cmi:
         The value `set_cache' is required but not provided
        File "cohttp-lwt/src/s.ml", line 190, characters 2-30:
          Expected declaration
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lib/.paf_cohttp.objs/byte -I lib/.paf_cohttp.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/http/__private__/http_bytebuffer -I /home/opam/.opam/4.14/lib/httpaf -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -intf-suffix .ml -no-alias-deps -o lib/.paf_cohttp.objs/native/paf_cohttp.cmx -c -impl lib/paf_cohttp.ml)
 File "lib/paf_cohttp.ml", line 1:
 Error: The implementation lib/paf_cohttp.ml
        does not match the interface lib/.paf_cohttp.objs/byte/paf_cohttp.cmi:
         The value `set_cache' is required but not provided
        File "cohttp-lwt/src/s.ml", line 190, characters 2-30:
          Expected declaration
```

Seen on CI for https://github.com/ocaml/opam-repository/pull/23262


Signed-off-by: Marcello Seri <marcello.seri@gmail.com>