### PR TITLE
webmachine 0.4.0 requires ocamlbuild

### DIFF
--- a/packages/webmachine/webmachine.0.4.0/opam
+++ b/packages/webmachine/webmachine.0.4.0/opam
@@ -21,6 +21,7 @@ depends: [
   "cohttp" {>= "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "ocamlfind" {build}
+  "ocamlbuild" {build}
   "ounit" {with-test & >= "1.0.2"}
   "re" {>= "1.3.0"}
 ]

--- a/packages/webmachine/webmachine.0.5.0/opam
+++ b/packages/webmachine/webmachine.0.5.0/opam
@@ -16,6 +16,7 @@ depends: [
   "cohttp" {>= "0.21.0"}
   "dispatch" {>= "0.3.0" & < "0.5.0"}
   "jbuilder" {>= "1.0+beta10"}
+  "base-bytes"
   "ounit" {with-test & >= "1.0.2"}
   "re" {>= "1.3.0"}
 ]


### PR DESCRIPTION
Without it, it fails with

```
=== ERROR while compiling webmachine.0.4.0 ===================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/webmachine.0.4.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/4.14
 exit-code            1
 env-file             ~/.opam/log/webmachine-8-d35021.env
 output-file          ~/.opam/log/webmachine-8-d35021.out
\## output ###
[...]
 W: Not_found
 W: Not_found
 E: Cannot find external tool 'ocamlbuild'
 E: Failure("1 configuration error")
```

Seen on CI for https://github.com/ocaml/opam-repository/pull/23262

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>