### PR TITLE
ocamlformat: add more bounds against ocaml-version

### DIFF
--- a/packages/ocamlformat/ocamlformat.0.20.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.20.0/opam
@@ -21,7 +21,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocp-indent"
   "odoc-parser" {>= "0.9.0" & < "1.0.0"}
   "re" {>= "1.7.2"}

--- a/packages/ocamlformat/ocamlformat.0.20.1/opam
+++ b/packages/ocamlformat/ocamlformat.0.20.1/opam
@@ -21,7 +21,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocp-indent"
   "odoc-parser" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}

--- a/packages/ocamlformat/ocamlformat.0.21.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.21.0/opam
@@ -20,7 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocp-indent"
   "odoc-parser" {>= "1.0.0" & < "2.0.0"}
   "re" {>= "1.7.2"}

--- a/packages/ocamlformat/ocamlformat.0.22.4/opam
+++ b/packages/ocamlformat/ocamlformat.0.22.4/opam
@@ -20,7 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocamlformat-rpc-lib" {with-test & post & = version}
   "ocp-indent"
   "odoc-parser" {>= "1.0.0" & < "2.0.0"}

--- a/packages/ocamlformat/ocamlformat.0.23.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.23.0/opam
@@ -20,7 +20,7 @@ depends: [
   "menhir" {>= "20201216"}
   "menhirLib" {>= "20201216"}
   "menhirSdk" {>= "20201216"}
-  "ocaml-version" {>= "3.3.0"}
+  "ocaml-version" {>= "3.3.0" & < "3.6.0"}
   "ocamlformat-rpc-lib" {with-test & post & = version}
   "ocp-indent"
   "odoc-parser" {>= "1.0.0" & < "2.0.0"}


### PR DESCRIPTION
Followup to #23259:

The offending test is present in versions 0.20.0 to 0.24.1 included, but
for all the versions except 0.24.1 the problematic combination can not
exist when `{with-test}` is set since ocamformat depends on dune < 3
and ocaml-version requires dune >= 3. Still these need to be fixed.
