### PR TITLE
Add domainslib constraint in lwt_domain old versions

### DIFF
--- a/packages/lwt_domain/lwt_domain.0.1.0/opam
+++ b/packages/lwt_domain/lwt_domain.0.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "lwt" {>= "3.0.0"}
   "ocaml"
-  "domainslib" {>= "0.3.2"}
+  "domainslib" {>= "0.3.2" & < "0.5.0"}
 ]
 
 build: [

--- a/packages/lwt_domain/lwt_domain.0.2.0/opam
+++ b/packages/lwt_domain/lwt_domain.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.8.0"}
   "lwt" {>= "3.0.0"}
   "ocaml" {>= "4.08"}
-  "domainslib" {>= "0.3.2"}
+  "domainslib" {>= "0.3.2" & < "0.5.0"}
   "base-domains"
 ]
 


### PR DESCRIPTION
Version 0.3.0 of lwt_domain uses a recent version of domainslib. But version 0.1.0 and 0.2.0 are not compatible with the newer API of domainslib. This PR adds the necessary constraint to the older packages.