### PR TITLE
Package tezos-rust-libs.1.4

### DIFF
--- a/packages/tezos-rust-libs/tezos-rust-libs.1.4/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.4/opam
@@ -2,7 +2,7 @@ opam-version: "2.0"
 synopsis: "Tezos: all rust dependencies and their dependencies"
 maintainer: "contact@tezos.com"
 authors: "Tezos devteam"
-license: "multiple"
+license: "LicenseRef-multiple"
 homepage: "https://www.tezos.com/"
 bug-reports: "https://gitlab.com/tezos/tezos-rust-libs/issues"
 depends: ["conf-rust-2021"]

--- a/packages/tezos-rust-libs/tezos-rust-libs.1.4/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Tezos: all rust dependencies and their dependencies"
+maintainer: "contact@tezos.com"
+authors: "Tezos devteam"
+license: "multiple"
+homepage: "https://www.tezos.com/"
+bug-reports: "https://gitlab.com/tezos/tezos-rust-libs/issues"
+depends: ["conf-rust"]
+build: [
+  [
+    "cargo"
+    "build"
+    "--target-dir"
+    "target-librustzcash"
+    "--release"
+    "--package"
+    "librustzcash"
+  ]
+  [
+    "cargo"
+    "build"
+    "--target-dir"
+    "target-wasmer"
+    "--release"
+    "--package"
+    "wasmer-c-api"
+    "--no-default-features"
+    "--features"
+    "singlepass,cranelift,wat,middlewares,universal"
+  ]
+]
+install: [
+  ["mkdir" "-p" "%{lib}%/tezos-rust-libs"]
+  ["mkdir" "-p" "%{lib}%/tezos-rust-libs/rust"]
+  [
+    "cp"
+    "librustzcash/include/librustzcash.h"
+    "target-librustzcash/release/librustzcash.a"
+    "wasmer-2.3.0/lib/c-api/wasm.h"
+    "wasmer-2.3.0/lib/c-api/wasmer.h"
+    "target-wasmer/release/libwasmer.a"
+    "%{lib}%/tezos-rust-libs"
+  ]
+  ["cp" "librustzcash/include/rust/types.h" "%{lib}%/tezos-rust-libs/rust"]
+]
+dev-repo: "git+https://gitlab.com/tezos/tezos-rust-libs.git"
+url {
+  src:
+    "https://gitlab.com/tezos/tezos-rust-libs/-/archive/v1.4/tezos-rust-libs-v1.4.zip"
+  checksum: [
+    "md5=0579c5b9be4c526f5a30586c1f80a864"
+    "sha512=387f6382e1eb8ea1a52abc02ffec50c61b1d18a7b6b9268a977763593ca0fbe28c24ba1076fcae36e963e3ce62aa78cd21e23223f8ab6a22b73fe09fdb4b9cfa"
+  ]
+}

--- a/packages/tezos-rust-libs/tezos-rust-libs.1.4/opam
+++ b/packages/tezos-rust-libs/tezos-rust-libs.1.4/opam
@@ -5,7 +5,7 @@ authors: "Tezos devteam"
 license: "multiple"
 homepage: "https://www.tezos.com/"
 bug-reports: "https://gitlab.com/tezos/tezos-rust-libs/issues"
-depends: ["conf-rust"]
+depends: ["conf-rust-2021"]
 build: [
   [
     "cargo"


### PR DESCRIPTION
### `tezos-rust-libs.1.4`
Tezos: all rust dependencies and their dependencies



---
* Homepage: https://www.tezos.com/
* Source repo: git+https://gitlab.com/tezos/tezos-rust-libs.git
* Bug tracker: https://gitlab.com/tezos/tezos-rust-libs/issues

---
:camel: Pull-request generated by opam-publish v2.2.0