### PR TITLE
[new release] mirage-crypto, mirage-crypto-rng, mirage-crypto-rng-mirage, mirage-crypto-rng-lwt, mirage-crypto-rng-eio, mirage-crypto-rng-async, mirage-crypto-pk and mirage-crypto-ec (0.11.0)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.0.11.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.0.11.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P224 (SECP224R1), P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "mirage-crypto-pk" {with-test & =version}
+  "hex" {with-test}
+  "alcotest" {with-test & >= "0.8.1"}
+  "asn1-combinators" {with-test & >= "0.2.5"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.0.11.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+  "cstruct" {>="6.00"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "sexplib0"
+  "zarith" {>= "1.4"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"

--- a/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.11.0/opam
+++ b/packages/mirage-crypto-rng-async/mirage-crypto-rng-async.0.11.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an Async-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "async" {>= "v0.14"}
+  "logs"
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+]
+available: os != "win32"
+description: """
+
+Mirage-crypto-rng-async feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an Async-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"
+

--- a/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.0.11.0/opam
+++ b/packages/mirage-crypto-rng-eio/mirage-crypto-rng-eio.0.11.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Bikal Gurung <gbikal@gmail.com>" ]
+maintainer:   "Bikal Gurung <gbikal@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in an eio-friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "eio" {>= "0.3"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "mtime"
+  "eio_main" {with-test}
+]
+description: """
+Mirage-crypto-rng-eio feeds the entropy source for Mirage_crypto_rng-based
+random number genreator implementations, in an eio-friendly way.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"

--- a/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.0.11.0/opam
+++ b/packages/mirage-crypto-rng-lwt/mirage-crypto-rng-lwt.0.11.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "duration"
+  "logs"
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "4.0.0"}
+]
+description: """
+Mirage-crypto-rng-lwt provides entropy collection code for the RNG using Lwt.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.11.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.0.11.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "cstruct" {>= "4.0.0"}
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-unix" {with-test & >= "5.0.0"}
+  "mirage-time-unix" {with-test & >= "2.0.0"}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.0.11.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "mirage-crypto" {=version}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.1.3"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"

--- a/packages/mirage-crypto/mirage-crypto.0.11.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.0.11.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "cstruct" {>="6.0.0"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305), and
+hashes (MD5, SHA-1, SHA-2).
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v0.11.0/mirage-crypto-0.11.0.tbz"
+  checksum: [
+    "sha256=039482b9599c209a3774bd13bbffdf42a115d2fdc5b82c6e00d5a7068ee151e4"
+    "sha512=74c09d7a8b480b13e17e19d6225a3289479fbd73b6e9b77411463d5729f1063b0c1f4bec72a63e5b56df2f08e24c15368c21dd6bb22a3788dc838110e27d903d"
+  ]
+}
+x-commit-hash: "b579fc0d8cf3b8737f4368a2420b091e81820aad"


### PR DESCRIPTION
Simple symmetric cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

- BREAKING split mirage-crypto-rng-lwt away from mirage-crypto-rng (mirage/mirage-crypto#168
  @hannesm, reported by @bikallem mirage/mirage-crypto#158)
  This means, a "mirage-crypto-rng.lwt" should now be "mirage-crypto-rng-lwt"
  in your dune file (or in META requires, or in _tags).
- AEAD API improvements: provide tag_size, of_secret, and functions that deal
  with the tag separately (mirage/mirage-crypto#171 @hannesm, fixes mirage/mirage-crypto#74 mirage/mirage-crypto#144 @orbitz @anmonteiro)
  Only CCM16 (with tag size 16) is now exposed, the former API does not exist
  anymore (passing `~maclen` to `of_secret`), according to sherlocode the only
  usage was CCM16 anyways
  This means any "Mirage_crypto.AES.CCM" should now be "Mirage_crypto.AES.CCM16"
  and any "CCM.of_secret ~maclen:16 key" should now be "CCM16.of_secret key"
  Any occurrence of "Mirage_crypto.Cipher_block.S.CCM" should now be
  "Mirage_crypto.Cipher_block.S.CCM16"
- BREAKING unify RNG initialization (reported by @talex5 in mirage/mirage-crypto#155, fixes mirage/mirage-crypto#160,
  PR mirage/mirage-crypto#162 @hannesm)
  This means:
  - "Mirage_crypto_rng_lwt.initialize ()" should now be
    "Mirage_crypto_rng_lwt.initialize (module Mirage_crypto_rng.Fortuna)"
  - "Mirage_crypto_rng_unix.initialize ()" should now be
    "Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)"
- remove mirage 3 cross-compilation runes (mirage/mirage-crypto#163 @hannesm)
- CI: mirage-crypto-rng-eio requires ocaml 5 and dune 2.7 (mirage/mirage-crypto#170 @hannesm, fixes
  mirage/mirage-crypto#169 thanks to @bikallem @talex5)
- CI: use miage 4 (mirage/mirage-crypto#166 @hannesm)
