### PR TITLE
biocaml is not compatible with OCaml 5.0 (uses deprecated C API)

### DIFF
--- a/packages/biocaml/biocaml.0.10.0/opam
+++ b/packages/biocaml/biocaml.0.10.0/opam
@@ -26,6 +26,7 @@ authors: [
 build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
+  "ocaml" {< "5.0"}
   "base64"
   "dune"
   "core_kernel" {>= "v0.12.0" & < "v0.13"}

--- a/packages/biocaml/biocaml.0.11.0/opam
+++ b/packages/biocaml/biocaml.0.11.0/opam
@@ -26,6 +26,7 @@ authors: [
 build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
+  "ocaml" {< "5.0"}
   "base64"
   "dune" {>= "1.0"}
   "core_kernel" {>= "v0.14.0"}

--- a/packages/biocaml/biocaml.0.11.1/opam
+++ b/packages/biocaml/biocaml.0.11.1/opam
@@ -26,6 +26,7 @@ authors: [
 build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
+  "ocaml" {< "5.0"}
   "base64"
   "dune" {>= "1.0"}
   "core_kernel" {>= "v0.14.0"}

--- a/packages/biocaml/biocaml.0.11.2/opam
+++ b/packages/biocaml/biocaml.0.11.2/opam
@@ -30,6 +30,7 @@ contact us with any comments and suggestions for features you would
 like added.
 """
 depends: [
+  "ocaml" {< "5.0"}
   "base64"
   "dune" {>= "1.10"}
   "core" {>= "v0.15.0"}

--- a/packages/biocaml/biocaml.0.2.0/opam
+++ b/packages/biocaml/biocaml.0.2.0/opam
@@ -25,7 +25,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "biocaml"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "core" {<= "109.17.00"}
   "sexplib" {< "v0.14"}

--- a/packages/biocaml/biocaml.0.3.0/opam
+++ b/packages/biocaml/biocaml.0.3.0/opam
@@ -29,7 +29,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "biocaml"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "core" {>= "109.27.00" & <= "109.47.00"}
   "sexplib" {< "v0.14"}

--- a/packages/biocaml/biocaml.0.3.1/opam
+++ b/packages/biocaml/biocaml.0.3.1/opam
@@ -29,7 +29,7 @@ build: [
 ]
 remove: [["ocamlfind" "remove" "biocaml"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "ocamlfind"
   "core" {>= "109.27.00" & <= "109.47.00"}
   "sexplib" {< "v0.14"}

--- a/packages/biocaml/biocaml.0.4.0/opam
+++ b/packages/biocaml/biocaml.0.4.0/opam
@@ -24,7 +24,7 @@ install: [
   ["omake" "install_doc" "DOCDIR=%{doc}%/biocaml"] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
   "omake" {build & < "0.10"}
   "core" {>= "111.13.00" & <= "113.00.00"}

--- a/packages/biocaml/biocaml.0.6.0/opam
+++ b/packages/biocaml/biocaml.0.6.0/opam
@@ -21,7 +21,7 @@ build: [
   [make "%{name}%.install"]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "solvuu-build" {build & >= "0.2.0" & < "0.3.0"}
   "core_kernel" {>= "111.13.00" & <= "113.33.03"}

--- a/packages/biocaml/biocaml.0.7.0/opam
+++ b/packages/biocaml/biocaml.0.7.0/opam
@@ -23,7 +23,7 @@ build: [
   ["omake" "-j%{jobs}%" "doc"] {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind" {build}
   "solvuu-build" {build & >= "0.3.0"}
   "core_kernel" {>= "111.13.00" & <= "113.33.03"}

--- a/packages/biocaml/biocaml.0.9.0/opam
+++ b/packages/biocaml/biocaml.0.9.0/opam
@@ -26,7 +26,7 @@ authors: [
 build: ["dune" "build" "-p" name "-j" jobs]
 
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base64" {< "3.0.0"}
   "dune"
   "core_kernel" {>= "v0.11.0" & < "v0.12"}


### PR DESCRIPTION
```
#=== ERROR while compiling biocaml.0.11.2 =====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/biocaml.0.11.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p biocaml -j 31
# exit-code            1
# env-file             ~/.opam/log/biocaml-7-6cfe9d.env
# output-file          ~/.opam/log/biocaml-7-6cfe9d.out
### output ###
# File "lib/unix/dune", line 1, characters 0-309:
# 1 | (library
# 2 |  (name biocaml_unix)
# 3 |  (public_name biocaml.unix)
# 4 |  (c_names mzData_stubs pwm_stub)
# 5 |  (flags :standard -short-paths -open Core)
# 6 |  (libraries base64 biocaml.base zip cfstream core core_kernel.binary_packing re.perl xmlm ppx_expect.evaluator)
# 7 |  (inline_tests)
# 8 |  (preprocess (pps ppx_jane ppx_inline_test))
# 9 |  )
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -w -24 -g -g -o lib/unix/.biocaml_unix.inline-tests/inline_test_runner_biocaml_unix.exe /home/opam/.opam/5.0/lib/base64/base64.cmxa /home/opam/.opam/5.0/lib/base/base_internalhash_types/base_internalhash_types.cmxa -I /home/opam/.opam/5.0/lib/base/base_internalhash_types /home/opam/.opam/5.0/lib/base/caml/caml.cmxa /home/opam/.opam/5.0/lib/sexplib0/sexplib0.cmxa /home/opam/.opam/5.0/lib/base/shadow_stdlib/shadow_stdlib.cmxa /home/opam/.opam/5.0/lib/base/base.cmxa -I /home/opam/.opam/5.0/lib/base /home/opam/.opam/5.0/lib/rresult/rresult.cmxa /home/opam/.opam/5.0/lib/stringext/stringext.cmxa /home/opam/.opam/5.0/lib/bigstringaf/bigstringaf.cmxa -I /home/opam/.opam/5.0/lib/bigstringaf /home/opam/.opam/5.0/lib/angstrom/angstrom.cmxa /home/opam/.opam/5.0/lib/uri/uri.cmxa /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib/ppx_sexp_conv_lib.cmxa /home/opam/.opam/5.0/lib/ppx_inline_test/config/inline_test_config.cmxa /home/opam/.opam/5.0/lib/jane-street-headers/jane_street_headers.cmxa /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib/ppx_compare_lib.cmxa /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib/ppx_enumerate_lib.cmxa /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib/ppx_hash_lib.cmxa /home/opam/.opam/5.0/lib/time_now/time_now.cmxa -I /home/opam/.opam/5.0/lib/time_now /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib/ppx_inline_test_lib.cmxa lib/base/biocaml_base.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/zip/zip.cmxa -I /home/opam/.opam/5.0/lib/zip /home/opam/.opam/5.0/lib/ppx_here/runtime-lib/ppx_here_lib.cmxa /home/opam/.opam/5.0/lib/ppx_assert/runtime-lib/ppx_assert_lib.cmxa /home/opam/.opam/5.0/lib/ppx_bench/runtime-lib/ppx_bench_lib.cmxa /home/opam/.opam/5.0/lib/base/md5/md5_lib.cmxa /home/opam/.opam/5.0/lib/fieldslib/fieldslib.cmxa /home/opam/.opam/5.0/lib/variantslib/variantslib.cmxa /home/opam/.opam/5.0/lib/bin_prot/shape/bin_shape_lib.cmxa /home/opam/.opam/5.0/lib/bin_prot/bin_prot.cmxa -I /home/opam/.opam/5.0/lib/bin_prot /home/opam/.opam/5.0/lib/stdio/stdio.cmxa /home/opam/.opam/5.0/lib/ppx_module_timer/runtime/ppx_module_timer_runtime.cmxa /home/opam/.opam/5.0/lib/typerep/typerep_lib.cmxa /home/opam/.opam/5.0/lib/ppx_expect/common/expect_test_common.cmxa /home/opam/.opam/5.0/lib/ppx_expect/config_types/expect_test_config_types.cmxa /home/opam/.opam/5.0/lib/ppx_expect/collector/expect_test_collector.cmxa -I /home/opam/.opam/5.0/lib/ppx_expect/collector /home/opam/.opam/5.0/lib/ppx_expect/config/expect_test_config.cmxa /home/opam/.opam/5.0/lib/parsexp/parsexp.cmxa /home/opam/.opam/5.0/lib/sexplib/sexplib.cmxa /home/opam/.opam/5.0/lib/ppx_log/types/ppx_log_types.cmxa /home/opam/.opam/5.0/lib/splittable_random/splittable_random.cmxa /home/opam/.opam/5.0/lib/base_quickcheck/base_quickcheck.cmxa /home/opam/.opam/5.0/lib/base_quickcheck/ppx_quickcheck/runtime/ppx_quickcheck_runtime.cmxa /home/opam/.opam/5.0/lib/int_repr/int_repr.cmxa /home/opam/.opam/5.0/lib/base_bigstring/base_bigstring.cmxa -I /home/opam/.opam/5.0/lib/base_bigstring /home/opam/.opam/5.0/lib/core/base_for_tests/base_for_tests.cmxa /home/opam/.opam/5.0/lib/core/validate/validate.cmxa /home/opam/.opam/5.0/lib/core/core.cmxa -I /home/opam/.opam/5.0/lib/core /home/opam/.opam/5.0/lib/core_kernel/core_kernel.cmxa /home/opam/.opam/5.0/lib/camlp-streams/camlp_streams.cmxa /home/opam/.opam/5.0/lib/cfstream/CFStream.cmxa /home/opam/.opam/5.0/lib/core_kernel/binary_packing/binary_packing.cmxa /home/opam/.opam/5.0/lib/re/re.cmxa /home/opam/.opam/5.0/lib/re/perl/re_perl.cmxa /home/opam/.opam/5.0/lib/xmlm/xmlm.cmxa /home/opam/.opam/5.0/lib/ppx_expect/matcher/expect_test_matcher.cmxa /home/opam/.opam/5.0/lib/ppxlib/print_diff/ppxlib_print_diff.cmxa /home/opam/.opam/5.0/lib/ppx_expect/evaluator/ppx_expect_evaluator.cmxa lib/unix/biocaml_unix.cmxa -I lib/unix /home/opam/.opam/5.0/lib/ppx_inline_test/runner/lib/ppx_inline_test_runner_lib.cmxa -I /home/opam/.opam/5.0/lib/ppx_inline_test/runner/lib lib/unix/.biocaml_unix.inline-tests/.biocaml_unix.inline-tests.eobjs/native/dune__exe__Inline_test_runner_biocaml_unix.cmx -linkall)
# /usr/bin/ld: lib/unix/libbiocaml_unix_stubs.a(mzData_stubs.o): in function `biocaml_base64_little32':
# /home/opam/.opam/5.0/.opam-switch/build/biocaml.0.11.2/_build/default/lib/unix/mzData_stubs.c:269: undefined reference to `Data_bigarray_val'
# /usr/bin/ld: lib/unix/libbiocaml_unix_stubs.a(mzData_stubs.o): in function `biocaml_base64_big32':
# /home/opam/.opam/5.0/.opam-switch/build/biocaml.0.11.2/_build/default/lib/unix/mzData_stubs.c:277: undefined reference to `Data_bigarray_val'
# /usr/bin/ld: lib/unix/libbiocaml_unix_stubs.a(mzData_stubs.o): in function `biocaml_base64_little64':
# /home/opam/.opam/5.0/.opam-switch/build/biocaml.0.11.2/_build/default/lib/unix/mzData_stubs.c:295: undefined reference to `Data_bigarray_val'
# /usr/bin/ld: lib/unix/libbiocaml_unix_stubs.a(mzData_stubs.o): in function `biocaml_base64_big64':
# /home/opam/.opam/5.0/.opam-switch/build/biocaml.0.11.2/_build/default/lib/unix/mzData_stubs.c:303: undefined reference to `Data_bigarray_val'
# collect2: error: ld returned 1 exit status
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```