### PR TITLE
Update c++ test for conf-snappy

### DIFF
--- a/packages/conf-snappy/conf-snappy.1/opam
+++ b/packages/conf-snappy/conf-snappy.1/opam
@@ -3,7 +3,7 @@ maintainer: "gabriel.scherer@inria.fr"
 homepage: "https://google.github.io/snappy/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["c++" "test.cpp" "-lsnappy"]
+  ["c++" "test.cpp" "-lsnappy" "-std=c++11"]
 ]
 depexts: [
   ["libsnappy-dev"] {os-family = "debian"}


### PR DESCRIPTION
Snappy uses C++11 including the constexpr specifier [spec](https://en.cppreference.com/w/cpp/language/constexpr). The compilation fails on macOS 12.6 with this error (I've not tested on Linux):
```
[ERROR] The compilation of conf-snappy.1 failed at "c++ test.cpp -lsnappy".
....

#=== ERROR while compiling conf-snappy.1 ======================================#
# context     2.1.4 | macos/x86_64 |  | https://opam.ocaml.org/#d85efebe
# path        ~/code/ocaml/ocaml-snappy/_opam/.opam-switch/build/conf-snappy.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build c++ test.cpp -lsnappy
# exit-code   1
# env-file    ~/.opam/log/conf-snappy-51324-f4a946.env
# output-file ~/.opam/log/conf-snappy-51324-f4a946.out
### output ###
# /usr/local/include/snappy.h:203:26: error: expected ';' after top level declarator
# [...]
# /usr/local/include/snappy.h:205:10: error: unknown type name 'constexpr'
#   static constexpr int kMaxHashTableBits = 14;
#          ^
# /usr/local/include/snappy.h:206:10: error: unknown type name 'constexpr'
#   static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
#          ^
# /usr/local/include/snappy.h:206:26: error: expected ';' after top level declarator
#   static constexpr size_t kMaxHashTableSize = 1 << kMaxHashTableBits;
#                          ^
#                          ;
# 9 errors generated.
```

This package should accurately specify which C++ standard it is targeting. 
Apart from compiling the test program manually, how else can I test this change? 