### PR TITLE
letsencrypt 0.2*, letsencrypt-app*: restrict to mirage-crypto-rng < 0.11.0

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.0.3.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "fmt"
   "lwt" {>= "2.6.0"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "ptime"
   "bos"
   "fpath"

--- a/packages/letsencrypt-app/letsencrypt-app.0.4.0/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "fmt"
   "lwt" {>= "2.6.0"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "ptime"
   "bos"
   "fpath"

--- a/packages/letsencrypt-app/letsencrypt-app.0.4.1/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.4.1/opam
@@ -18,7 +18,7 @@ depends: [
   "logs"
   "fmt" {>= "0.8.7"}
   "lwt" {>= "2.6.0"}
-  "mirage-crypto-rng"
+  "mirage-crypto-rng" {< "0.11.0"}
   "ptime"
   "bos"
   "fpath"

--- a/packages/letsencrypt/letsencrypt.0.2.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.1/opam
@@ -25,8 +25,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & != "0.8.9"}
-  "mirage-crypto-rng"
-  "mirage-crypto-rng" {with-test & < "0.11.0"}
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.10.0" & < "0.11.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.2/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.2/opam
@@ -25,8 +25,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & != "0.8.9"}
-  "mirage-crypto-rng"
-  "mirage-crypto-rng" {with-test & < "0.11.0"}
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.3/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.3/opam
@@ -25,8 +25,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
-  "mirage-crypto-rng"
-  "mirage-crypto-rng" {with-test & < "0.11.0"}
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.11.0" & < "0.12.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.4/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.4/opam
@@ -25,8 +25,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
-  "mirage-crypto-rng"
-  "mirage-crypto-rng" {with-test & < "0.11.0"}
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.11.0" & < "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}

--- a/packages/letsencrypt/letsencrypt.0.2.5/opam
+++ b/packages/letsencrypt/letsencrypt.0.2.5/opam
@@ -25,8 +25,7 @@ depends: [
   "mirage-crypto"
   "mirage-crypto-pk"
   "mirage-crypto-pk" {with-test & >= "0.8.9"}
-  "mirage-crypto-rng"
-  "mirage-crypto-rng" {with-test & < "0.11.0"}
+  "mirage-crypto-rng" {< "0.11.0"}
   "x509" {>= "0.13.0"}
   "yojson" {>= "1.6.0"}
   "ounit" {with-test}


### PR DESCRIPTION
The bin/oacmel uses Mirage_crypto_rng_unix.initialize, which API has been changed in mirage-crypto-rng 0.11.0 (spotted in #23282)

```
#=== ERROR while compiling letsencrypt.0.2.1 ==================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/letsencrypt.0.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p letsencrypt -j 255
# exit-code            1
# env-file             ~/.opam/log/letsencrypt-7-d83de3.env
# output-file          ~/.opam/log/letsencrypt-7-d83de3.out
### output ###
[...] (removed deprecation warnings)
# File "bin/oacmel.ml", line 22, characters 36-38:
# 22 |   Mirage_crypto_rng_unix.initialize () ;
#                                          ^^
# Error: This expression should not be a unit literal, the expected type is
#        'a Mirage_crypto_rng.generator
[...] (removed deprecation warnings)
```