### PR TITLE
new file:   packages/dokeysto/dokeysto.4.0.1/opam

### DIFF
--- a/packages/dokeysto/dokeysto.4.0.1/opam
+++ b/packages/dokeysto/dokeysto.4.0.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+authors: "Francois Berenger"
+maintainer: "unixjunkie@sdf.org"
+homepage: "https://github.com/UnixJunkie/dokeysto"
+bug-reports: "https://github.com/UnixJunkie/dokeysto/issues"
+dev-repo: "git+https://github.com/UnixJunkie/dokeysto.git"
+license: "LGPL-2.1-only"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "exec" "-p" name "-j" jobs "src/test.exe"] {with-test}
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.11"}
+  "base-bytes"
+  "base-unix"
+  "extunix"
+]
+synopsis: "The dumb OCaml key-value store"
+description: """Persistent hash table (i.e. in a file on disk)."""
+url {
+  src: "https://github.com/UnixJunkie/dokeysto/archive/v4.0.1.tar.gz"
+  checksum: "md5=9fe891ee55d33b551be763c7cba53397"
+}


### PR DESCRIPTION
bug fix in Internal.create; was refusing to create a DB if file was already existing; now overwrites it