### PR TITLE
process: build requires ocamlopt

### DIFF
--- a/packages/process/process.0.1.0/opam
+++ b/packages/process/process.0.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "base-unix"
   "base-bytes"
 ]
+conflicts:["ocaml-option-bytecode-only"]
 synopsis: "Easy process control"
 description: "process makes it easy to use commands like functions."
 flags: light-uninstall

--- a/packages/process/process.0.2.0/opam
+++ b/packages/process/process.0.2.0/opam
@@ -16,6 +16,7 @@ depends: [
   "base-unix"
   "base-bytes"
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 synopsis: "Easy process control"
 description: "process makes it easy to use commands like functions."
 flags: light-uninstall

--- a/packages/process/process.0.2.1/opam
+++ b/packages/process/process.0.2.1/opam
@@ -16,6 +16,7 @@ depends: [
   "base-unix"
   "base-bytes"
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 synopsis: "Easy process control"
 description: "process makes it easy to use commands like functions."
 flags: light-uninstall


### PR DESCRIPTION

Failure:
```
#=== ERROR while compiling process.0.2.1 ======================================#
# context              2.2.0~alpha~dev | linux/ppc64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/process.0.2.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/process-6-3b5c87.env
# output-file          ~/.opam/log/process-6-3b5c87.out
### output ###
# ocamlbuild -use-ocamlfind -classic-display process.cma process.cmxa process.cmx
# ocamlfind ocamldep -package bytes -modules lib/process.mli > lib/process.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -strict-sequence -package bytes -w @5@8@10@11@12@14@23@24@26@29 -I lib -o lib/process.cmi lib/process.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -strict-sequence -package bytes -w @5@8@10@11@12@14@23@24@26@29 -I lib -o lib/process.cmi lib/process.mli
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# ocamlfind ocamldep -package bytes -modules lib/process.ml > lib/process.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -strict-sequence -package bytes -w @5@8@10@11@12@14@23@24@26@29 -I lib -o lib/process.cmo lib/process.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -strict-sequence -package bytes -w @5@8@10@11@12@14@23@24@26@29 -I lib -o lib/process.cmo lib/process.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# ocamlfind ocamlc -a -package bytes -I lib lib/process.cmo -o lib/process.cma
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -strict-sequence -package bytes -w @5@8@10@11@12@14@23@24@26@29 -I lib -o lib/process.cmx lib/process.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -strict-sequence -package bytes -w @5@8@10@11@12@14@23@24@26@29 -I lib -o lib/process.cmx lib/process.ml
# ocamlfind: Not supported in your configuration: ocamlopt
# Command exited with code 2.
# make: *** [Makefile:22: build] Error 10
```

Seen on https://github.com/ocaml/opam-repository/pull/23267

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>