### PR TITLE
[new release] x509 (0.16.4)

### DIFF
--- a/packages/x509/x509.0.16.4/opam
+++ b/packages/x509/x509.0.16.4/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "6.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf"
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.4/x509-0.16.4.tbz"
+  checksum: [
+    "sha256=5de83185d01240afc8ed777480948bba64c66c2605a56b2347b3e56525aa695a"
+    "sha512=fd7c0275d91e717b04a57939dea4d0c1a0133903c37de2e5a1650e321401c39b4684bc885a29d5c5093a51b5b43b95a2a2a57cd4554af191159d32a44d489c66"
+  ]
+}
+x-commit-hash: "0005042e5b5a84e600f78eccbd9c4646ec01dd2f"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Adapt to mirage-crypto-rng 0.11.0 API changes (mirleft/ocaml-x509#162 @hannesm)
