### PR TITLE
ocaml 5: restrict posixat

### DIFF
--- a/packages/posixat/posixat.v0.15.0/opam
+++ b/packages/posixat/posixat.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "4.08.0"}
+  "ocaml"         {>= "4.08.0" & < "5.0"}
   "base"          {>= "v0.15" & < "v0.16"}
   "ppx_optcomp"   {>= "v0.15" & < "v0.16"}
   "ppx_sexp_conv" {>= "v0.15" & < "v0.16"}


### PR DESCRIPTION
Consider the following failure in a posixat revdep:

    #=== ERROR while compiling pyml_bindgen.0.4.1 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/pyml_bindgen.0.4.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p pyml_bindgen -j 127 @install @runtest
    # exit-code            1
    # env-file             ~/.opam/log/pyml_bindgen-7-e0f471.env
    # output-file          ~/.opam/log/pyml_bindgen-7-e0f471.out
    ### output ###
    # File "test/dune", line 1, characters 0-211:
    #  1 | (library
    #  2 |  (name test_lib)
    #  3 |  (libraries base base_quickcheck lib shexp.process stdio)
    # ....
    # 10 |    ppx_string
    # 11 |    ppx_inline_test
    # 12 |    ppx_expect)))
    # ...
    # /usr/bin/ld: /home/opam/.opam/5.0/lib/posixat/libposixat_stubs.a(posixat_stubs.o): in function `alloc_stats':
    # /home/opam/.opam/5.0/.opam-switch/build/posixat.v0.15.0/_build/default/src/posixat_stubs.c:147: undefined reference to `cst_to_constr'
    # collect2: error: ld returned 1 exit status
    # File "caml_startup", line 1:
    # Error: Error during linking (exit code 1)

The code for posixat refers to a function `cst_to_constr` in the unix library. This function has been renamed in 5.0. But since it is declared as an `extern` in posixat itself, the error is not found until link time:

https://github.com/janestreet/posixat/blob/v0.15.0/src/posixat_stubs.c#L120
