### PR TITLE
ocurl is not compatible with the bytecode-only mode

### DIFF
--- a/packages/ocurl/ocurl.0.5.4/opam
+++ b/packages/ocurl/ocurl.0.5.4/opam
@@ -9,6 +9,9 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}

--- a/packages/ocurl/ocurl.0.5.5/opam
+++ b/packages/ocurl/ocurl.0.5.5/opam
@@ -9,6 +9,9 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}

--- a/packages/ocurl/ocurl.0.5.6/opam
+++ b/packages/ocurl/ocurl.0.5.6/opam
@@ -9,6 +9,9 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}

--- a/packages/ocurl/ocurl.0.6.0/opam
+++ b/packages/ocurl/ocurl.0.6.0/opam
@@ -10,6 +10,9 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
 ]

--- a/packages/ocurl/ocurl.0.6.1/opam
+++ b/packages/ocurl/ocurl.0.6.1/opam
@@ -10,6 +10,9 @@ depends: [
   "ocaml" {< "4.06.0"}
   "ocamlfind"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}

--- a/packages/ocurl/ocurl.0.7.0/opam
+++ b/packages/ocurl/ocurl.0.7.0/opam
@@ -14,6 +14,9 @@ depends: [
   "ocamlfind"
   "base-unix"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depopts: ["lwt"]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}

--- a/packages/ocurl/ocurl.0.7.1/opam
+++ b/packages/ocurl/ocurl.0.7.1/opam
@@ -19,6 +19,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {>= "4.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}

--- a/packages/ocurl/ocurl.0.7.10/opam
+++ b/packages/ocurl/ocurl.0.7.10/opam
@@ -26,6 +26,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {>= "4.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 synopsis: "Bindings to libcurl"
 description: """

--- a/packages/ocurl/ocurl.0.7.2/opam
+++ b/packages/ocurl/ocurl.0.7.2/opam
@@ -24,6 +24,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {>= "4.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}

--- a/packages/ocurl/ocurl.0.7.5/opam
+++ b/packages/ocurl/ocurl.0.7.5/opam
@@ -25,6 +25,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {>= "4.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 depexts: ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
 synopsis: "Bindings to libcurl"

--- a/packages/ocurl/ocurl.0.7.6/opam
+++ b/packages/ocurl/ocurl.0.7.6/opam
@@ -23,6 +23,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 patches: [ "examples.diff" ]
 synopsis: "Bindings to libcurl"
 description: """

--- a/packages/ocurl/ocurl.0.7.7/opam
+++ b/packages/ocurl/ocurl.0.7.7/opam
@@ -23,6 +23,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 patches: ["fix_depend.diff"]
 synopsis: "Bindings to libcurl"
 description: """

--- a/packages/ocurl/ocurl.0.7.8/opam
+++ b/packages/ocurl/ocurl.0.7.8/opam
@@ -23,6 +23,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 synopsis: "Bindings to libcurl"
 description: """
 Client-side URL transfer library, supporting HTTP and a multitude of

--- a/packages/ocurl/ocurl.0.7.9/opam
+++ b/packages/ocurl/ocurl.0.7.9/opam
@@ -23,6 +23,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 synopsis: "Bindings to libcurl"
 description: """
 Client-side URL transfer library, supporting HTTP and a multitude of

--- a/packages/ocurl/ocurl.0.8.0/opam
+++ b/packages/ocurl/ocurl.0.8.0/opam
@@ -26,6 +26,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {>= "4.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 synopsis: "Bindings to libcurl"
 description: """

--- a/packages/ocurl/ocurl.0.8.1/opam
+++ b/packages/ocurl/ocurl.0.8.1/opam
@@ -26,6 +26,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 synopsis: "Bindings to libcurl"
 description: """

--- a/packages/ocurl/ocurl.0.8.2/opam
+++ b/packages/ocurl/ocurl.0.8.2/opam
@@ -26,6 +26,7 @@ depends: [
 depopts: ["lwt"]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 synopsis: "Bindings to libcurl"
 description: """

--- a/packages/ocurl/ocurl.0.9.0/opam
+++ b/packages/ocurl/ocurl.0.9.0/opam
@@ -25,6 +25,7 @@ depends: [
 depopts: ["lwt" "lwt_ppx"]
 conflicts: [
   "lwt" {with-test & >= "5.0.0"}
+  "ocaml-option-bytecode-only"
 ]
 synopsis: "Bindings to libcurl"
 description: "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl), synchronous parallel and generic asynchronous API (Curl.Multi), and provides an Lwt-enabled asynchronous interface (Curl_lwt)."

--- a/packages/ocurl/ocurl.0.9.1/opam
+++ b/packages/ocurl/ocurl.0.9.1/opam
@@ -22,6 +22,9 @@ depends: [
   "base-unix"
   "conf-libcurl"
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 depopts: ["lwt" "lwt_ppx"]
 synopsis: "Bindings to libcurl"
 description: "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl), synchronous parallel and generic asynchronous API (Curl.Multi), and provides an Lwt-enabled asynchronous interface (Curl_lwt)."

--- a/packages/ocurl/ocurl.0.9.2/opam
+++ b/packages/ocurl/ocurl.0.9.2/opam
@@ -23,6 +23,9 @@ depends: [
   "conf-libcurl"
 ]
 depopts: ["lwt" "lwt_ppx"]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 synopsis: "Bindings to libcurl"
 description: "libcurl is a client-side URL transfer library, supporting HTTP and a multitude of other network protocols (FTP/SMTP/RTSP/etc). This library wrap easy synchronous API (Curl), synchronous parallel and generic asynchronous API (Curl.Multi), and provides an Lwt-enabled asynchronous interface (Curl_lwt)."
 url {


### PR DESCRIPTION
```
#=== ERROR while installing ocurl.0.9.2 =======================================#
# context              2.2.0~alpha~dev | linux/x86_32 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocurl.0.9.2
# command              ~/.opam/opam-init/hooks/sandbox.sh install make install
# exit-code            2
# env-file             ~/.opam/log/ocurl-7-621f68.env
# output-file          ~/.opam/log/ocurl-7-621f68.out
### output ###
# ocamlfind install -patch-version 0.9.2 -ldconf ignore curl META curl.a curl.cmi curl.mli curl.cma libcurl-helper.a dllcurl-helper.so curl.cmt curl.cmti
# Installed /home/opam/.opam/5.0/lib/curl/curl.cmti
# Installed /home/opam/.opam/5.0/lib/curl/curl.cmt
# Installed /home/opam/.opam/5.0/lib/curl/libcurl-helper.a
# Installed /home/opam/.opam/5.0/lib/curl/curl.cma
# Installed /home/opam/.opam/5.0/lib/curl/curl.mli
# Installed /home/opam/.opam/5.0/lib/curl/curl.cmi
# ocamlfind: curl.a: No such file or directory
# make: *** [Makefile:132: install] Error 2
```