### PR TITLE
[new release] spoke (0.0.2)

### DIFF
--- a/packages/spoke/spoke.0.0.2/opam
+++ b/packages/spoke/spoke.0.0.2/opam
@@ -10,7 +10,7 @@ synopsis:     "SPAKE+EE implementation in OCaml"
 description: """A Password-authenticated key agreement protocol in OCaml"""
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
-run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ] {os != "macos"}
 
 depends: [
   "ocaml"         {>= "4.08.0"}

--- a/packages/spoke/spoke.0.0.2/opam
+++ b/packages/spoke/spoke.0.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/spoke"
+bug-reports:  "https://github.com/dinosaure/spoke/issues"
+dev-repo:     "git+https://github.com/dinosaure/spoke.git"
+doc:          "https://dinosaure.github.io/spoke/"
+license:      "MIT"
+synopsis:     "SPAKE+EE implementation in OCaml"
+description: """A Password-authenticated key agreement protocol in OCaml"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"         {>= "4.08.0"}
+  "dune"          {>= "2.9.0"}
+  "fmt"
+  "hxd"
+  "logs"
+  "base64"        {>= "3.0.0"}
+  "digestif"      {>= "0.8.1"}
+  "bigstringaf"   {>= "0.9.0"}
+  "encore"        {>= "0.8"}
+  "ke"
+  "mirage-crypto" {>= "0.11.0"}
+  "mirage-flow"   {>= "3.0.0"}
+  "lwt"           {>= "5.6.1"}
+  "result"        {>= "1.5"}
+  "mimic"         {with-test}
+  "rresult"       {with-test}
+  "tcpip"         {with-test}
+]
+url {
+  src:
+    "https://github.com/dinosaure/spoke/releases/download/v0.0.2/spoke-0.0.2.tbz"
+  checksum: [
+    "sha256=b9999ab024b8b6d0949d198551c9d0a20a564b1c8a56a6fb9a875e7e008d4d68"
+    "sha512=135d138d4a6d4793e782e42a27fb2d0acb1f41bd304897792acd16d0a450a31cd4f8fab2bdeeb7fecaa7c6cbeb002b0be3c51baca71629548ab2b7b04d96b784"
+  ]
+}
+x-commit-hash: "32fbcbb7c285d3a6788581d2aecdceb24ce91959"


### PR DESCRIPTION
SPAKE+EE implementation in OCaml

- Project page: <a href="https://github.com/dinosaure/spoke">https://github.com/dinosaure/spoke</a>
- Documentation: <a href="https://dinosaure.github.io/spoke/">https://dinosaure.github.io/spoke/</a>

##### CHANGES:

- Update to `mirage-crypto.0.11.0` (@hannesm, dinosaure/spoke#3)
