### PR TITLE
dns-client 6.x: require tls < 0.16.0 for tls.lwt

### DIFF
--- a/packages/dns-client/dns-client.6.0.0/opam
+++ b/packages/dns-client/dns-client.6.0.0/opam
@@ -32,7 +32,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.0.6" & < "0.1.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.0.1/opam
+++ b/packages/dns-client/dns-client.6.0.1/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.0.6" & < "0.1.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.0.2/opam
+++ b/packages/dns-client/dns-client.6.0.2/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.1.0/opam
+++ b/packages/dns-client/dns-client.6.1.0/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.1.1/opam
+++ b/packages/dns-client/dns-client.6.1.1/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.1.2/opam
+++ b/packages/dns-client/dns-client.6.1.2/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.1.3/opam
+++ b/packages/dns-client/dns-client.6.1.3/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.1.4/opam
+++ b/packages/dns-client/dns-client.6.1.4/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "ca-certs"
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.2.0/opam
+++ b/packages/dns-client/dns-client.6.2.0/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "x509" {>= "0.16.0"}
   "ca-certs"

--- a/packages/dns-client/dns-client.6.2.1/opam
+++ b/packages/dns-client/dns-client.6.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "x509" {>= "0.16.0"}
   "ca-certs"

--- a/packages/dns-client/dns-client.6.2.2/opam
+++ b/packages/dns-client/dns-client.6.2.2/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "x509" {>= "0.16.0"}
   "ca-certs"

--- a/packages/dns-client/dns-client.6.3.0/opam
+++ b/packages/dns-client/dns-client.6.3.0/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "x509" {>= "0.16.0"}
   "ca-certs"

--- a/packages/dns-client/dns-client.6.4.0/opam
+++ b/packages/dns-client/dns-client.6.4.0/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.1.0" & < "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "x509" {>= "0.16.0"}
   "ca-certs"

--- a/packages/dns-client/dns-client.6.4.1/opam
+++ b/packages/dns-client/dns-client.6.4.1/opam
@@ -31,7 +31,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "happy-eyeballs" {>= "0.4.0"}
   "alcotest" {with-test}
-  "tls" {>= "0.15.0"}
+  "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}
   "x509" {>= "0.16.0"}
   "ca-certs"


### PR DESCRIPTION
First fix for revdeps of #23311 