### PR TITLE
paf-cohttp.0.{0,2,3,4}.0 and paf-cohttp.0.0.{6,7,8,8-1,9} are incompatible with mirage-crypto-rng.0.11.0

### DIFF
--- a/packages/git-unix/git-unix.2.1.3/opam
+++ b/packages/git-unix/git-unix.2.1.3/opam
@@ -26,7 +26,7 @@ depends: [
   "mtime" {>= "1.0.0" & < "2.0.0"}
   "base-unix"
   "alcotest"          {with-test & >= "0.8.1"}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "tls"               {with-test}
   "io-page"           {with-test & >= "1.6.1"}
 ]

--- a/packages/git-unix/git-unix.2.1.3/opam
+++ b/packages/git-unix/git-unix.2.1.3/opam
@@ -10,14 +10,14 @@ doc:          "https://mirage.github.io/ocaml-git/"
 synopsis:     "Virtual package to install and configure ocaml-git's Unix backend"
 
 build: [
-  ["dune" "subst"]
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j1" "--no-buffer"] {with-test}
 ]
 
 depends: [
   "ocaml"             {>= "4.07.0"}
-  "dune"
+  "dune"              {>= "1.1"}
   "mmap"              {>= "1.1.0"}
   "cmdliner" {< "1.1.0"}
   "git-http"          {= version}

--- a/packages/paf-cohttp/paf-cohttp.0.0.6/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.6/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.0.7/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.7/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.0.8-1/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.8-1/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.0.8/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.8/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.0.9/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.0.9/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.2.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.3.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.3.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}

--- a/packages/paf-cohttp/paf-cohttp.0.4.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "alcotest-lwt"      {with-test}
   "fmt"               {with-test}
   "logs"              {with-test}
-  "mirage-crypto-rng" {with-test}
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
   "mirage-time-unix"  {with-test}
   "tcpip"             {with-test & >= "6.0.0"}
   "uri"               {with-test}


### PR DESCRIPTION
Spotted by the `tls` revdeps:

tls.0.16.0
    revdeps
        [git-unix.2.1.3 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,git-unix.2.1.3)
        [paf-cohttp.0.0.6 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.0.6)
        [paf-cohttp.0.0.7 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.0.7)
        [paf-cohttp.0.0.8 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.0.8)
        [paf-cohttp.0.0.8-1 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.0.8-1)
        [paf-cohttp.0.0.9 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.0.9)
        [paf-cohttp.0.2.0 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.2.0)
        [paf-cohttp.0.3.0 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.3.0)
        [paf-cohttp.0.4.0 (failed: This expression should not be a unit literal, the expected type is)](https://opam-ci.ci3.ocamllabs.io/github/ocaml/opam-repository/commit/24ceafbbc2111081ab0d456a4f911b4134924b2c/variant/compilers,4.14,tls.0.16.0,revdeps,paf-cohttp.0.4.0)

```
# Error: This expression should not be a unit literal, the expected type is
#        'a Mirage_crypto_rng.generator
# File "test/git-unix/dune", line 1, characters 0-140:
# 1 | (executable
# 2 |  (name      test)
# 3 |  (libraries checkseum.c digestif.c test_git test_smart test_smart_regression git-unix mirage-crypto-rng.unix))
```