### PR TITLE
2 packages from mransan/ocaml-protoc at 2.4

### DIFF
--- a/packages/ocaml-protoc/ocaml-protoc.2.4/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.2.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Protobuf compiler for OCaml"
+description: "Protobuf compiler for OCaml"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+post-messages: [
+"The runtime library is now called \"pbrt\"."
+]
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="2.0"}
+  "stdlib-shims"
+  "pbrt" {= version}
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.4.0.tar.gz"
+  checksum: [
+    "md5=8a294e86c6202b8ec8016e71d19264cb"
+    "sha512=67020bef50b59c6590c1b25d85a75d6e19d6cd37d42b87c94aef798bff51a45f38fe7024b4c67d71c22c13d3f2776bec83acd77794a518f1c4a7eddfc30b6d0b"
+  ]
+}

--- a/packages/pbrt/pbrt.2.4/opam
+++ b/packages/pbrt/pbrt.2.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Runtime library for Protobuf tooling"
+description: "Runtime library for Protobuf tooling"
+maintainer: "Maxime Ransan <maxime.ransan@gmail.com>"
+post-messages: [
+"Pbrt: runtime library for ocaml-protoc.
+
+A shim library named \"ocaml-protoc\" still exists, to ease the
+migration."
+]
+authors:[
+  "Maxime Ransan <maxime.ransan@gmail.com>"
+]
+homepage: "https://github.com/mransan/ocaml-protoc"
+bug-reports:"https://github.com/mransan/ocaml-protoc/issues"
+dev-repo:"git+https://github.com/mransan/ocaml-protoc.git"
+license: "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" "pbrt,ocaml-protoc" "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>="4.03.0"}
+  "dune"  {>="2.0"}
+  "stdlib-shims"
+  "odoc" {with-doc}
+]
+url {
+  src: "https://github.com/mransan/ocaml-protoc/archive/2.4.0.tar.gz"
+  checksum: [
+    "md5=8a294e86c6202b8ec8016e71d19264cb"
+    "sha512=67020bef50b59c6590c1b25d85a75d6e19d6cd37d42b87c94aef798bff51a45f38fe7024b4c67d71c22c13d3f2776bec83acd77794a518f1c4a7eddfc30b6d0b"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ocaml-protoc.2.4`: Protobuf compiler for OCaml
-`pbrt.2.4`: Runtime library for Protobuf tooling



---
* Homepage: https://github.com/mransan/ocaml-protoc
* Source repo: git+https://github.com/mransan/ocaml-protoc.git
* Bug tracker: https://github.com/mransan/ocaml-protoc/issues

---
:camel: Pull-request generated by opam-publish v2.0.3