### PR TITLE
conf-gmp: use pkg-config where available

### DIFF
--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
@@ -6,11 +6,13 @@ license: "GPL-1.0-or-later"
 build: [
   ["sh" "-c" "pkg-config --print-errors --exists gmp || cc -c $CFLAGS -I/usr/local/include test.c"] { os != "win32" }
   [
-	"sh"
-	"-exc"
-	"$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
+    "sh"
+    "-exc"
+    "$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
   ] {os = "win32" & os-distribution = "cygwinports"}
-  ["sh" "-exc"
+  [
+    "sh"
+    "-exc"
     "%{host-arch-x86_64:installed?x86_64:}%%{host-arch-x86_32:installed?i686:}%-w64-mingw32-gcc -c $CFLAGS test.c"
   ] {os = "win32"}
 ]

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Etienne Millon <etienne@cryptosense.com>"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-c" "pkg-config --print-errors --exists gmp || cc -c $CFLAGS -I/usr/local/include test.c"] { os != "win32" }
+  [
+	"sh"
+	"-exc"
+	"$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
+  ] {os = "win32" & os-distribution = "cygwinports"}
+  ["sh" "-exc"
+    "%{host-arch-x86_64:installed?x86_64:}%%{host-arch-x86_32:installed?i686:}%-w64-mingw32-gcc -c $CFLAGS test.c"
+  ] {os = "win32"}
+]
+depends: [
+  "conf-gmp"
+  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+]
+synopsis:
+  "Virtual package relying on a GMP lib with constant-time modular exponentiation"
+description: """
+This package can only install if the GMP lib is installed on the system and
+corresponds to a version that has the mpz_powm_sec function."""
+authors: "Etienne Millon <etienne@cryptosense.com>"
+flags: conf
+extra-source "test.c" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp-powm-sec/test.c.3"
+  checksum: [
+    "sha256=388b3879530257a7e6e59b68208ee2a52de7be30e40eb4d3a54419708fdad490"
+    "md5=29317f477fa828e18428660ef31064fb"
+  ]
+}

--- a/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
+++ b/packages/conf-gmp-powm-sec/conf-gmp-powm-sec.4/opam
@@ -14,7 +14,7 @@ build: [
     "sh"
     "-exc"
     "%{host-arch-x86_64:installed?x86_64:}%%{host-arch-x86_32:installed?i686:}%-w64-mingw32-gcc -c $CFLAGS test.c"
-  ] {os = "win32"}
+  ] {os = "win32" & os-distribution != "cygwinports"}
 ]
 depends: [
   "conf-gmp"

--- a/packages/conf-gmp/conf-gmp.5/opam
+++ b/packages/conf-gmp/conf-gmp.5/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+maintainer: "nbraud"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" "-c" "pkg-config --print-errors --exists gmp || cc -c $CFLAGS -I/usr/local/include test.c"] { os != "win32" }
+  [
+		"sh"
+		"-exc"
+		"$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
+	] {os = "win32" & os-distribution = "cygwinports"}
+  [
+    "sh"
+    "-exc"
+    "%{host-arch-x86_64:installed?x86_64:}%%{host-arch-x86_32:installed?i686:}%-w64-mingw32-gcc -c $CFLAGS test.c"
+  ] {os = "win32" & os-distribution != "cygwinports"}
+]
+depends: [
+  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gmp-i686" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gmp-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
+]
+depexts: [
+  ["libgmp-dev"] {os-family = "debian"}
+  ["libgmp-dev"] {os-family = "ubuntu"}
+  ["gmp"] {os = "macos" & os-distribution = "homebrew"}
+  ["gmp"] {os-distribution = "macports" & os = "macos"}
+  ["gmp" "gmp-devel"] {os-distribution = "centos"}
+  ["gmp" "gmp-devel"] {os-distribution = "fedora" | os-family = "fedora"}
+  ["gmp" "gmp-devel"] {os-distribution = "ol"}
+  ["gmp"] {os = "openbsd"}
+  ["gmp"] {os = "freebsd"}
+  ["gmp-dev"] {os-distribution = "alpine"}
+  ["gmp-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gmp"] {os-distribution = "nixos"}
+]
+synopsis: "Virtual package relying on a GMP lib system installation"
+description:
+  "This package can only install if the GMP lib is installed on the system."
+authors: "nbraud"
+flags: conf
+extra-source "test.c" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp/test.c.4"
+  checksum: [
+    "sha256=54a30735f1f271a2531526747e75716f4490dd7bc1546efd6498ccfe3cc4d6fb"
+    "md5=2fd2970c293c36222a6d299ec155823f"
+  ]
+}

--- a/packages/conf-gmp/conf-gmp.5/opam
+++ b/packages/conf-gmp/conf-gmp.5/opam
@@ -6,10 +6,10 @@ license: "GPL-1.0-or-later"
 build: [
   ["sh" "-c" "pkg-config --print-errors --exists gmp || cc -c $CFLAGS -I/usr/local/include test.c"] { os != "win32" }
   [
-		"sh"
-		"-exc"
-		"$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
-	] {os = "win32" & os-distribution = "cygwinports"}
+    "sh"
+    "-exc"
+    "$(ocamlc -config-var c_compiler) -c $CFLAGS -I/usr/local/include test.c"
+  ] {os = "win32" & os-distribution = "cygwinports"}
   [
     "sh"
     "-exc"
@@ -17,6 +17,7 @@ build: [
   ] {os = "win32" & os-distribution != "cygwinports"}
 ]
 depends: [
+  "conf-pkg-config" {os = "macos"}
   (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gmp-i686" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gmp-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
 ]


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/18129 and https://github.com/ocaml/opam-repository/pull/22954

I need to test the dependencies in `opam list --depends-on conf-gmp` before un-drafting