### PR TITLE
[new release] awa, awa-mirage and awa-lwt (0.1.2)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.1.2/opam
+++ b/packages/awa-lwt/awa-lwt.0.1.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.7"}
   "awa" {= version}
   "cstruct" {>= "6.0.0"}
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "lwt"
   "cstruct-unix"
   "mirage-crypto-rng"

--- a/packages/awa-lwt/awa-lwt.0.1.2/opam
+++ b/packages/awa-lwt/awa-lwt.0.1.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.2/awa-0.1.2.tbz"
+  checksum: [
+    "sha256=1df22abe6be6762ccf49f487b618f6b32b335595d5863bbbb48f323447ad737f"
+    "sha512=0e3b210c131f3d095e49108caf26a64283b4bb95947d2c01bbbac728b611eb9f943c6737bbf3d7dc1e0da0e2dc15c17c5c2dee3185899cf6d68bcbb83a6e0272"
+  ]
+}
+x-commit-hash: "7c65292939ae4dff25170b1dbad6e3bc48d177a4"

--- a/packages/awa-mirage/awa-mirage.0.1.2/opam
+++ b/packages/awa-mirage/awa-mirage.0.1.2/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "2.7"}
   "awa" {= version}
   "cstruct" {>= "6.0.0"}
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "lwt"
   "mirage-time" {>= "2.0.0"}
   "duration" {>= "0.2.0"}

--- a/packages/awa-mirage/awa-mirage.0.1.2/opam
+++ b/packages/awa-mirage/awa-mirage.0.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime"
+  "lwt"
+  "mirage-time" {>= "2.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.2/awa-0.1.2.tbz"
+  checksum: [
+    "sha256=1df22abe6be6762ccf49f487b618f6b32b335595d5863bbbb48f323447ad737f"
+    "sha512=0e3b210c131f3d095e49108caf26a64283b4bb95947d2c01bbbac728b611eb9f943c6737bbf3d7dc1e0da0e2dc15c17c5c2dee3185899cf6d68bcbb83a6e0272"
+  ]
+}
+x-commit-hash: "7c65292939ae4dff25170b1dbad6e3bc48d177a4"

--- a/packages/awa/awa.0.1.2/opam
+++ b/packages/awa/awa.0.1.2/opam
@@ -27,7 +27,7 @@ depends: [
   "cstruct-unix"
   "cstruct-sexp"
   "sexplib"
-  "mtime"
+  "mtime" {>= "1.0.0"}
   "logs"
   "fmt"
   "cmdliner" {>= "1.1.0"}

--- a/packages/awa/awa.0.1.2/opam
+++ b/packages/awa/awa.0.1.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "ppx_sexp_conv"
+  "ppx_cstruct"
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.15.2"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "cstruct-sexp"
+  "sexplib"
+  "mtime"
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.1.2/awa-0.1.2.tbz"
+  checksum: [
+    "sha256=1df22abe6be6762ccf49f487b618f6b32b335595d5863bbbb48f323447ad737f"
+    "sha512=0e3b210c131f3d095e49108caf26a64283b4bb95947d2c01bbbac728b611eb9f943c6737bbf3d7dc1e0da0e2dc15c17c5c2dee3185899cf6d68bcbb83a6e0272"
+  ]
+}
+x-commit-hash: "7c65292939ae4dff25170b1dbad6e3bc48d177a4"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Adapt to mirage-crypto-rng 0.11.0 API changes (mirage/awa-ssh#49 @hannesm)
* Output key seeds, as expected by of_string (mirage/awa-ssh#48 @reynir)
* Update dune-project (formatting disabled) (mirage/awa-ssh#47 @tmcgilchrist)
