### PR TITLE
[new release] coq-serapi (8.16.0+0.16.3)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.16.0+0.16.3/opam
+++ b/packages/coq-serapi/coq-serapi.8.16.0+0.16.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {           >= "4.09.0"              }
+  "coq"                 {           >= "8.16" & < "8.17"     }
+  "cmdliner"            {           >= "1.1.0"               }
+  "ocamlfind"           {           >= "1.8.0"               }
+  "sexplib"             {           >= "v0.13.0"             }
+  "dune"                {           >= "2.0.1"               }
+  "ppx_import"          { build   & >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        {           >= "4.2.1"               }
+  "ppx_sexp_conv"       {           >= "v0.13.0"             }
+  "ppx_compare"         {           >= "v0.13.0"             }
+  "ppx_hash"            {           >= "v0.13.0"             }
+  "yojson"              {           >= "1.7.0"               }
+  "ppx_deriving_yojson" {           >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.16.0%2B0.16.3/coq-serapi-8.16.0.0.16.3.tbz"
+  checksum: [
+    "sha256=66137df53e01398a26e9e51056af7439997bcf562fbe4503946fe89e0c5df443"
+    "sha512=5c71f7acd4537c33853122d9c526e61f35d2934504c77ce95196f8d595f1c619a680fccd46ba9deb69b509eeb936984056380b18b65fae617ae1cce704df90a1"
+  ]
+}
+x-commit-hash: "b25eb8efd0ab4dff4f3ac049376486c758b38310"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serlib] Fix JSON serialization for generic arguments (@ejgallego, ejgallego/coq-serapi#321)
