### PR TITLE
[new release] coq-lsp (0.1.5.1+8.16)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.1.5.1+8.16/opam
+++ b/packages/coq-lsp/coq-lsp.0.1.5.1+8.16/opam
@@ -1,0 +1,48 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+  "Ali Caglayan <alizter@gmail.com>"
+  "Shachar Itzhaky <shachari@cs.technion.ac.il>"
+  "Ramkumar Ramachandra <r@artagnon.com>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+  "ocaml"        { >= "4.11.0" }
+  "dune"         { >= "3.2"  }
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+  "uri"          { >= "4.2.0" }
+
+  # waterproof parser
+  "menhir"       { >= "20220210" }
+
+  # Uncomment this for releases
+  "coq"           { >= "8.16.0" & < "8.17" }
+  "coq-serapi"    { >= "8.16.0+0.16.2" & < "8.17" }
+  "camlp-streams" { >= "5.0" }
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/releases/download/0.1.5.1%2B8.16/coq-lsp-0.1.5.1.8.16.tbz"
+  checksum: [
+    "sha256=bd1d61581eed552aef1b2a37442684a9f96240f1faaf695330c33391a8742a4a"
+    "sha512=44566902af1ef750d901527b4b9f5ef9872cfed88a935fe94a78e5a07692855949fed5d71e6709a19f5bf619cf3640391f393fdfeaa98834e72c35106af460c3"
+  ]
+}
+x-commit-hash: "8995e95e17c714e855df0de1cc250cfbc52693bb"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

-----------------------

 - Fix handling of `COQPATH` and `OCAMLPATH` (@ejgallego, ejgallego/coq-lsp#364)
