### PR TITLE
Add depopt on dune to batteries.3.6.0

### DIFF
--- a/packages/batteries/batteries.3.6.0/opam
+++ b/packages/batteries/batteries.3.6.0/opam
@@ -22,6 +22,9 @@ depends: [
   "benchmark" {with-test & >= "1.6"}
   "num"
 ]
+depopts: [
+  "dune" {>= "2.7"}
+]
 conflicts: ["base-effects" "ocaml-option-no-flat-float-array"]
 build: [
   [make "all"]


### PR DESCRIPTION
This change has already been upstreamed. Batteries can be built with dune though this is not the command used to build the package when installing with opam. Adding this depopt will make it possible to vendor batteries with opam-monorepo as that tool uses a dependency on dune as an heuristic to determine if a package can be vendored.