### PR TITLE
Fetch session-cookie-lwt.0.1.8 from source archive

### DIFF
--- a/packages/session-cookie-lwt/session-cookie-lwt.0.1.8/opam
+++ b/packages/session-cookie-lwt/session-cookie-lwt.0.1.8/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/ulrikstrid/ocaml-cookie.git"
 url {
   src:
-    "https://github.com/ulrikstrid/ocaml-cookie/releases/download/0.1.8/session-cookie-lwt-0.1.8.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/session-cookie-lwt-0.1.8.tbz"
   checksum: [
     "sha256=bc405a88a6f94453fbaee19b98469818c09b567646a46e1f4ac1a9d5d9fee2db"
     "sha512=fd66a50db8ca8431e7e0ec847c828f448a61b7fbfea9581a75b2b93c205ec4728b072fa2bdc6c70e7afe41f6e6254756fb176ce9c3f71a0cb6da0086479644ed"


### PR DESCRIPTION
Intended to be merged after https://github.com/ocaml/opam-source-archives/pull/19