### PR TITLE
[new release] ssh-agent and ssh-agent-unix (0.4.1)

### DIFF
--- a/packages/ssh-agent-unix/ssh-agent-unix.0.4.1/opam
+++ b/packages/ssh-agent-unix/ssh-agent-unix.0.4.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation for unix platforms"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+license: "BSD-2-clause"
+build: ["dune" "build" "-p" name "-j" jobs]
+depends: [
+  "ocaml"
+  "dune" {>= "1.0"}
+  "ssh-agent" {= version}
+  "angstrom-unix"
+  "faraday"
+]
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/v0.4.1/ssh-agent-0.4.1.tbz"
+  checksum: [
+    "sha256=ecb77fdcb60b25274b95714201919a7c202b88de24332234b9462a1415165a46"
+    "sha512=d4684519c6026c654ef745dee19f2bb9df75dbd09e30d9e4644df06b616d6489715d67a857f1629c3c2205638432a25763bbbc46b99c479da4123abe4cd2c49f"
+  ]
+}
+x-commit-hash: "15517b6aec5637510559097ae4cedaecd83939c0"

--- a/packages/ssh-agent/ssh-agent.0.4.1/opam
+++ b/packages/ssh-agent/ssh-agent.0.4.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Ssh-agent protocol parser and serialization implementation"
+maintainer: "Reynir Björnsson <reynir@reynir.dk>"
+dev-repo: "git+https://github.com/reynir/ocaml-ssh-agent.git"
+homepage: "https://github.com/reynir/ocaml-ssh-agent/"
+bug-reports: "https://github.com/reynir/ocaml-ssh-agent/issues/"
+license: "BSD-2-clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.0"}
+  "ppx_cstruct" {build & >= "5.2.0"}
+  "angstrom" {>= "0.15.0"}
+  "faraday" {>= "0.6"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "cstruct"
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {< "0.9.0"}
+]
+authors: "Reynir Björnsson <reynir@reynir.dk>"
+url {
+  src:
+    "https://github.com/reynir/ocaml-ssh-agent/releases/download/v0.4.1/ssh-agent-0.4.1.tbz"
+  checksum: [
+    "sha256=ecb77fdcb60b25274b95714201919a7c202b88de24332234b9462a1415165a46"
+    "sha512=d4684519c6026c654ef745dee19f2bb9df75dbd09e30d9e4644df06b616d6489715d67a857f1629c3c2205638432a25763bbbc46b99c479da4123abe4cd2c49f"
+  ]
+}
+x-commit-hash: "15517b6aec5637510559097ae4cedaecd83939c0"


### PR DESCRIPTION
Ssh-agent protocol parser and serialization implementation

- Project page: <a href="https://github.com/reynir/ocaml-ssh-agent/">https://github.com/reynir/ocaml-ssh-agent/</a>

##### CHANGES:

* Update tests to mirage-crypto-rng 0.11.0
