### PR TITLE
[new release] http-lwt-client (0.2.2)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.2/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.2.2/http-lwt-client-0.2.2.tbz"
+  checksum: [
+    "sha256=ed5e2217f089da2e77519248ff4e5195607dacd12dce3f6fdbbeb80f5749a90f"
+    "sha512=faaef64de6b9de06f53af57c8b5c8e7cb17c623fb8304f12f4543e6ab22fe88ae4429cebb8431db81ff1ccfb7f52f9986b4bbda911ab8d24640c0ebd9bddaf79"
+  ]
+}
+x-commit-hash: "15e0de30d0e1ac01b102d10f16897cb59e103cd2"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Update to tls 0.16.0 package split: tls.lwt is now tls-lwt (roburio/http-lwt-client#17 by @hannesm)
