### PR TITLE
8 packages from gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz

### DIFF
--- a/packages/resto-acl/resto-acl.1.1/opam
+++ b/packages/resto-acl/resto-acl.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Access Control Lists for Resto"
+maintainer: "contact@nomadic-labs.com"
+authors: "Nomadic Labs"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "resto" {= version}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.1.1/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.1.1/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "resto-cohttp" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto-cohttp-client/resto-cohttp-client.1.1/opam
+++ b/packages/resto-cohttp-client/resto-cohttp-client.1.1/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "1.11"}
   "uri" {>= "1.9.0"}
   "resto-cohttp" {= version}
-  "cohttp-lwt" {>= "1.0.0"}
+  "cohttp-lwt" {>= "4.0.0"}
   "lwt" {>= "3.0.0" & < "6.0.0"}
 ]
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.1.1/opam
+++ b/packages/resto-cohttp-self-serving-client/resto-cohttp-self-serving-client.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: "Nomadic Labs"
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "resto-cohttp-client" {= version}
+  "resto-cohttp-server" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto-cohttp-server/resto-cohttp-server.1.1/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.1.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "A minimal OCaml library for type-safe HTTP/JSON RPCs - server library"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto-directory" {= version}
+  "resto-cohttp" {= version}
+  "resto-acl" {= version}
+  "cohttp-lwt-unix" {>= "2.0.0"}
+  "conduit-lwt-unix" {>= "2.0.0"}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto-cohttp/resto-cohttp.1.1/opam
+++ b/packages/resto-cohttp/resto-cohttp.1.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto-directory" {= version}
+  "cohttp-lwt" {>= "1.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto-directory/resto-directory.1.1/opam
+++ b/packages/resto-directory/resto-directory.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto" {= version}
+  "resto-json" {= version & with-test}
+  "lwt" {>= "3.0.0" & < "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto-json/resto-json.1.1/opam
+++ b/packages/resto-json/resto-json.1.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "resto" {= version}
+  "json-data-encoding" {>= "0.9.1" & < "1.0"}
+  "json-data-encoding-bson" {>= "0.9.1" & < "1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}

--- a/packages/resto/resto.1.1/opam
+++ b/packages/resto/resto.1.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A minimal OCaml library for type-safe HTTP/JSON RPCs"
+maintainer: "contact@nomadic-labs.com"
+authors: ["Nomadic Labs" "Ocamlpro"]
+license: "MIT"
+homepage: "https://gitlab.com/nomadic-labs/resto"
+bug-reports: "https://gitlab.com/nomadic-labs/resto/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "1.11"}
+  "uri" {>= "1.9.0"}
+  "json-data-encoding" {>= "0.9.1" & < "1.0" & with-test}
+  "json-data-encoding-bson" {>= "0.9.1" & < "1.0" & with-test}
+  "ezjsonm" {with-test}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "alcotest" {>= "1.5.0" & with-test}
+  "alcotest-lwt" {>= "1.5.0" & with-test}
+  "ocamlformat" {= "0.20.1" & with-doc}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/nomadic-labs/resto"
+url {
+  src:
+    "https://gitlab.com/nomadic-labs/resto/-/archive/v1.1/resto-v1.1.tar.gz"
+  checksum: [
+    "md5=d8a6024e07861320e619532068392ebb"
+    "sha512=921e86bca062e70d27acd2d7e7b2a4c383f31ecae09f711f77878d81beeb8f7082bc4476cc62ece21e3884b3d28547e1e9360b4949038491275c35e28a93f7e5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `resto.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs
- `resto-acl.1.1`: Access Control Lists for Resto
- `resto-cohttp.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs
- `resto-cohttp-client.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs
- `resto-cohttp-self-serving-client.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs
- `resto-cohttp-server.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs - server library
- `resto-directory.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs
- `resto-json.1.1`: A minimal OCaml library for type-safe HTTP/JSON RPCs



---
* Homepage: https://gitlab.com/nomadic-labs/resto
* Source repo: git+https://gitlab.com/nomadic-labs/resto
* Bug tracker: https://gitlab.com/nomadic-labs/resto/issues

---
:camel: Pull-request generated by opam-publish v2.2.0