### PR TITLE
[new release] conduit, conduit-mirage, conduit-lwt, conduit-lwt-unix and conduit-async (6.2.0)

### DIFF
--- a/packages/conduit-async/conduit-async.6.2.0/opam
+++ b/packages/conduit-async/conduit-async.6.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "core" {>= "v0.15.0"}
+  "uri" {>= "4.0.0"}
+  "ppx_here" {>= "v0.9.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "async" {>= "v0.15.0"}
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp" {>= "4.0.0"}
+]
+depopts: ["async_ssl"]
+conflicts: [
+  "async_ssl" {< "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Async"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.0/conduit-6.2.0.tbz"
+  checksum: [
+    "sha256=3ed440b0edda1b212dd762bdb24831f394dca05985dd1b4ac4f94581d1452394"
+    "sha512=017a28bd9873ea7f49ce69e9f4b680df7fa17440b1ff68c2af880df5527fae205249667fa7d35e4a8fe8d101081b6f7d6a384bee1eb0f6f38a2c57beae56aaac"
+  ]
+}
+x-commit-hash: "83a12ddcb7898d2a94e966b8f66654e898ae47c8"

--- a/packages/conduit-lwt-unix/conduit-lwt-unix.6.2.0/opam
+++ b/packages/conduit-lwt-unix/conduit-lwt-unix.6.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "logs"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "conduit-lwt" {=version}
+  "lwt" {>= "3.0.0"}
+  "uri" {>= "1.9.4"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+  "ca-certs"
+  "lwt_log" {with-test}
+  "ssl" {with-test}
+  "lwt_ssl" {with-test}
+]
+depopts: ["tls-lwt" "lwt_ssl" "launchd"]
+conflicts: [
+  "tls-lwt" {< "0.16.0"}
+  "ssl" {< "0.5.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for Lwt_unix"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.0/conduit-6.2.0.tbz"
+  checksum: [
+    "sha256=3ed440b0edda1b212dd762bdb24831f394dca05985dd1b4ac4f94581d1452394"
+    "sha512=017a28bd9873ea7f49ce69e9f4b680df7fa17440b1ff68c2af880df5527fae205249667fa7d35e4a8fe8d101081b6f7d6a384bee1eb0f6f38a2c57beae56aaac"
+  ]
+}
+x-commit-hash: "83a12ddcb7898d2a94e966b8f66654e898ae47c8"

--- a/packages/conduit-lwt/conduit-lwt.6.2.0/opam
+++ b/packages/conduit-lwt/conduit-lwt.6.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "base-unix"
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "conduit" {=version}
+  "lwt" {>= "3.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A portable network connection establishment library using Lwt"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.0/conduit-6.2.0.tbz"
+  checksum: [
+    "sha256=3ed440b0edda1b212dd762bdb24831f394dca05985dd1b4ac4f94581d1452394"
+    "sha512=017a28bd9873ea7f49ce69e9f4b680df7fa17440b1ff68c2af880df5527fae205249667fa7d35e4a8fe8d101081b6f7d6a384bee1eb0f6f38a2c57beae56aaac"
+  ]
+}
+x-commit-hash: "83a12ddcb7898d2a94e966b8f66654e898ae47c8"

--- a/packages/conduit-mirage/conduit-mirage.6.2.0/opam
+++ b/packages/conduit-mirage/conduit-mirage.6.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire"]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "uri" {>= "4.0.0"}
+  "cstruct" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-flow-combinators" {>= "2.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
+  "conduit-lwt" {=version}
+  "vchan" {>= "5.0.0"}
+  "xenstore"
+  "tls" {>= "0.11.0"}
+  "tls-mirage" {>= "0.11.0"}
+  "ca-certs-nss"
+  "ipaddr" {>= "3.0.0"}
+  "ipaddr-sexp"
+  "tcpip" {>= "7.0.0"}
+  "fmt" {>= "0.8.7"}
+]
+conflicts: [
+  "mirage-conduit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library for MirageOS"
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.0/conduit-6.2.0.tbz"
+  checksum: [
+    "sha256=3ed440b0edda1b212dd762bdb24831f394dca05985dd1b4ac4f94581d1452394"
+    "sha512=017a28bd9873ea7f49ce69e9f4b680df7fa17440b1ff68c2af880df5527fae205249667fa7d35e4a8fe8d101081b6f7d6a384bee1eb0f6f38a2c57beae56aaac"
+  ]
+}
+x-commit-hash: "83a12ddcb7898d2a94e966b8f66654e898ae47c8"

--- a/packages/conduit/conduit.6.2.0/opam
+++ b/packages/conduit/conduit.6.2.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy" "Thomas Leonard" "Thomas Gazagnaire" "Rudi Grinberg"
+]
+license: "ISC"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-conduit"
+doc: "https://mirage.github.io/ocaml-conduit/"
+bug-reports: "https://github.com/mirage/ocaml-conduit/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "ppx_sexp_conv" {>="v0.13.0"}
+  "sexplib"
+  "astring"
+  "uri"
+  "logs" {>= "0.5.0"}
+  "ipaddr" {>= "4.0.0"}
+  "ipaddr-sexp"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-conduit.git"
+synopsis: "A network connection establishment library"
+description: """
+The `conduit` library takes care of establishing and listening for
+TCP and SSL/TLS connections for the Lwt and Async libraries.
+
+The reason this library exists is to provide a degree of abstraction
+from the precise SSL library used, since there are a variety of ways
+to bind to a library (e.g. the C FFI, or the Ctypes library), as well
+as well as which library is used (just OpenSSL for now).
+
+By default, OpenSSL is used as the preferred connection library, but
+you can force the use of the pure OCaml TLS stack by setting the
+environment variable `CONDUIT_TLS=native` when starting your program.
+
+The useful opam packages available that extend this library are:
+
+- `conduit`: the main `Conduit` module
+- `conduit-lwt`: the portable Lwt implementation
+- `conduit-lwt-unix`: the Lwt/Unix implementation
+- `conduit-async` the Jane Street Async implementation
+- `conduit-mirage`: the MirageOS compatible implementation
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-conduit/releases/download/v6.2.0/conduit-6.2.0.tbz"
+  checksum: [
+    "sha256=3ed440b0edda1b212dd762bdb24831f394dca05985dd1b4ac4f94581d1452394"
+    "sha512=017a28bd9873ea7f49ce69e9f4b680df7fa17440b1ff68c2af880df5527fae205249667fa7d35e4a8fe8d101081b6f7d6a384bee1eb0f6f38a2c57beae56aaac"
+  ]
+}
+x-commit-hash: "83a12ddcb7898d2a94e966b8f66654e898ae47c8"


### PR DESCRIPTION
A network connection establishment library

- Project page: <a href="https://github.com/mirage/ocaml-conduit">https://github.com/mirage/ocaml-conduit</a>
- Documentation: <a href="https://mirage.github.io/ocaml-conduit/">https://mirage.github.io/ocaml-conduit/</a>

##### CHANGES:

* conduit-lwt-unix: adapt tls 0.16 split: tls.lwt is now tls-lwt (mirage/ocaml-conduit#419 @hannesm)
* conduit-mirage: adapt dns-client 7.0.0 split: dns-client-mirage (mirage/ocaml-conduit#419 @hannesm)
