### PR TITLE
[new release] obuilder and obuilder-spec (0.5.1)

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.5.1/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.5.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "fmt" {>= "0.8.9"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ocaml" {>= "4.10.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.5.1/obuilder-0.5.1.tbz"
+  checksum: [
+    "sha256=9de36c0a7f3df94bbe6ae3fa8c77ab31cf0c890a7580cbcf4c9f522d896594d7"
+    "sha512=d6c98d7e44f5d877fd77af29c16129cc57f7fcbe0161a48441ca38c4a73d15d319d41065ffe24f42430a5c733c088c65bfc4a4b50b92bf1b3a204f72bc580d49"
+  ]
+}
+x-commit-hash: "7015f4f00ac5183c70b27d044e8582b6c33105bd"

--- a/packages/obuilder/obuilder.0.5.1/opam
+++ b/packages/obuilder/obuilder.0.5.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "lwt" {>= "5.6.1"}
+  "astring"
+  "fmt" {>= "0.8.9"}
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "tar-unix" {>= "2.0.0"}
+  "yojson" {>= "1.6.0"}
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha" {>= "1.15.4"}
+  "sqlite3"
+  "obuilder-spec" {= version}
+  "ocaml" {>= "4.14.0"}
+  "alcotest-lwt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.5.1/obuilder-0.5.1.tbz"
+  checksum: [
+    "sha256=9de36c0a7f3df94bbe6ae3fa8c77ab31cf0c890a7580cbcf4c9f522d896594d7"
+    "sha512=d6c98d7e44f5d877fd77af29c16129cc57f7fcbe0161a48441ca38c4a73d15d319d41065ffe24f42430a5c733c088c65bfc4a4b50b92bf1b3a204f72bc580d49"
+  ]
+}
+x-commit-hash: "7015f4f00ac5183c70b27d044e8582b6c33105bd"

--- a/packages/ocluster/ocluster.0.2/opam
+++ b/packages/ocluster/ocluster.0.2/opam
@@ -38,7 +38,7 @@ depends: [
   "prometheus-app" {>= "1.2"}
   "cohttp-lwt-unix"
   "sqlite3"
-  "obuilder" {>= "0.5"}
+  "obuilder" {= "0.5"}
   "psq" {>= "0.2.1"}
   "mirage-crypto" {>= "0.8.5"}
   "ocaml" {>= "4.12.0"}


### PR DESCRIPTION
Run build scripts for CI

- Project page: <a href="https://github.com/ocurrent/obuilder">https://github.com/ocurrent/obuilder</a>
- Documentation: <a href="https://ocurrent.github.io/obuilder/">https://ocurrent.github.io/obuilder/</a>

##### CHANGES:

- Updates to address rsync and sandbox issues.
  (@mtelvers ocurrent/obuilder#139, reviewed by @tmcgilchrist and @MisterDA)
- Add an obuilder clean command to clean all build results.
  (@MisterDA ocurrent/obuilder#140, reviewed by @tmcgilchrist)
- Make rsync-mode mandatory when using rsync store.
  (@tmcgilchrist ocurrent/obuilder#132, reviewed by @kit-ty-kate and @MisterDA)
