### PR TITLE
2 packages from returntocorp/semgrep

### DIFF
--- a/packages/ast_generic/ast_generic.1.8.0/opam
+++ b/packages/ast_generic/ast_generic.1.8.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Abstract Syntax Tree (AST) supporting 31 programming languages"
+description: """
+This is a library defining a generic AST to factorize similar
+analysis on different programming languages
+(e.g., naming, semantic code highlighting, semgrep matching).
+
+Right now this generic AST is mostly the factorized union of the ASTs of:
+ - Python, Ruby, Lua, Julia, Elixir
+ - Javascript, Typescript, Vue
+ - PHP, Hack
+ - Java, CSharp, Kotlin
+ - C, C++
+ - Go
+ - Swift
+ - OCaml, Scala, Rust
+ - Clojure, Lisp, Scheme
+ - R
+ - Solidity
+ - Bash, Docker
+ - JSON, YAML, HCL, Jsonnet
+
+This is a core library used by Semgrep but which can be of use in other
+projects. This AST is also specified using ATD and so can be leveraged
+from other programming languages such as Typescript, Java, Scala, and
+the other programming languages supported by atdgen.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "commons" {>= "1.8.0"}
+  "lib_parsing" {>= "1.12.0"}
+  "profiling" {>= "1.5.5"}
+  "atdgen" {>= "2.8.0" }
+  "visitors" {= "20210608"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/returntocorp/semgrep/releases/download/ast_generic_full_1.8.0/semgrep-full-1.12.0.tar.gz"
+  checksum: [
+    "md5=d72b17df65c5cea30701cdf25f186bca"
+    "sha512=b135affadcdeb892352ec269a8761e41d2b34383ee839b83855f9604983eae324732b76f1b2b8b305dfc06f1f8863dd32afe83528bf605daa910a3fc107474c5"
+  ]
+}

--- a/packages/lib_parsing/lib_parsing.1.12.0/opam
+++ b/packages/lib_parsing/lib_parsing.1.12.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Small library to help writing parsers"
+description: """
+This is a small library of utilities used by Semgrep and
+a few other projects developed at r2c to help writing
+parsers, especially ocamlyacc/menhir based parsers.
+"""
+
+maintainer: "Yoann Padioleau <pad@r2c.dev>"
+authors: [ "Yoann Padioleau <pad@r2c.dev>" ]
+license: "LGPL-2.1-only"
+homepage: "https://semgrep.dev"
+dev-repo: "git+https://github.com/returntocorp/semgrep"
+bug-reports: "https://github.com/returntocorp/semgrep/issues"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.2.0" }
+  "commons" {>= "1.5.5"}
+  "profiling" {>= "1.5.5"}
+  "stdcompat" {>= "19"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/returntocorp/semgrep/releases/download/ast_generic_full_1.8.0/semgrep-full-1.12.0.tar.gz"
+  checksum: [
+    "md5=d72b17df65c5cea30701cdf25f186bca"
+    "sha512=b135affadcdeb892352ec269a8761e41d2b34383ee839b83855f9604983eae324732b76f1b2b8b305dfc06f1f8863dd32afe83528bf605daa910a3fc107474c5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ast_generic.1.8.0`: Abstract Syntax Tree (AST) supporting 31 programming languages
- `lib_parsing.1.12.0`: Small library to help writing parsers



---
* Homepage: https://semgrep.dev
* Source repo: git+https://github.com/returntocorp/semgrep
* Bug tracker: https://github.com/returntocorp/semgrep/issues

---
:camel: Pull-request generated by opam-publish v2.2.0