### PR TITLE
ptime 0.8.*: avoid ocamlbuild 0.9.0

### DIFF
--- a/packages/ptime/ptime.0.8.0/opam
+++ b/packages/ptime/ptime.0.8.0/opam
@@ -10,7 +10,7 @@ license: "BSD-3-Clause"
 depends: [
   "ocaml" {>= "4.01.0" & < "4.06.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "result"
 ]
 depopts: [ "js_of_ocaml" ]

--- a/packages/ptime/ptime.0.8.1/opam
+++ b/packages/ptime/ptime.0.8.1/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build != "0.9.0"}
+  "ocamlbuild" {build & != "0.9.0"}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.1/opam
+++ b/packages/ptime/ptime.0.8.1/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build != "0.9.0"}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.2/opam
+++ b/packages/ptime/ptime.0.8.2/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build & != "0.9.0"}}
+  "ocamlbuild" {build & != "0.9.0"}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.2/opam
+++ b/packages/ptime/ptime.0.8.2/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.3/opam
+++ b/packages/ptime/ptime.0.8.3/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build & != "0.9.0"}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.4/opam
+++ b/packages/ptime/ptime.0.8.4/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build != "0.9.0"}
+  "ocamlbuild" {build & != "0.9.0"}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.4/opam
+++ b/packages/ptime/ptime.0.8.4/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
   "ocaml" {>= "4.01.0" & < "5.0"}
   "ocamlfind" {build}
-  "ocamlbuild" {build}
+  "ocamlbuild" {build != "0.9.0"}
   "topkg" {build}
   "result"
 ]

--- a/packages/ptime/ptime.0.8.5/opam
+++ b/packages/ptime/ptime.0.8.5/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
  "ocaml" {>= "4.01.0" & < "5.0"}
  "ocamlfind" {build}
- "ocamlbuild" {build}
+ "ocamlbuild" {build != "0.9.0"}
  "topkg" {build}
  "result"
 ]

--- a/packages/ptime/ptime.0.8.5/opam
+++ b/packages/ptime/ptime.0.8.5/opam
@@ -10,7 +10,7 @@ license: "ISC"
 depends: [
  "ocaml" {>= "4.01.0" & < "5.0"}
  "ocamlfind" {build}
- "ocamlbuild" {build != "0.9.0"}
+ "ocamlbuild" {build & != "0.9.0"}
  "topkg" {build}
  "result"
 ]


### PR DESCRIPTION
It has a known issue with C stubs.

Seen on: https://github.com/ocaml/opam-repository/pull/23347

Logs:
```
#=== ERROR while installing ptime.0.8.0 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/ptime.0.8.0
# command              ~/.opam/opam-init/hooks/sandbox.sh install ocaml pkg/build.ml native=true native-dynlink=true jsoo=false
# exit-code            10
# env-file             ~/.opam/log/ptime-7-b4a8a1.env
# output-file          ~/.opam/log/ptime-7-b4a8a1.out
### output ###
# ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/4.03/lib/ocamlbuild /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/4.03/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
# ocamlfind ocamlc -package result -c -o src-os/ptime_clock_stubs.o src-os/ptime_clock_stubs.c
# ocamlfind ocamlmklib -o src-os/ptime_clock_stubs src-os/ptime_clock_stubs.o
# + ocamlfind ocamlmklib -o src-os/ptime_clock_stubs src-os/ptime_clock_stubs.o
# gcc: error: src-os/ptime_clock_stubs.o: No such file or directory
# gcc: fatal error: no input files
# compilation terminated.
# Command exited with code 2.
```

More recent versions already include the fix