### PR TITLE
[new release] OCADml (.0.4.0)

### DIFF
--- a/packages/OCADml/OCADml..0.4.0/opam
+++ b/packages/OCADml/OCADml..0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.3"}
+  "gg" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "cairo2" {>= "0.6.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v.0.4.0/OCADml-.0.4.0.tbz"
+  checksum: [
+    "sha256=bef6e81e30255eeae700e753ea4090b0ae1797b8c069f6613232fb96280df6bd"
+    "sha512=9618e574b6f7f9412c4855edb169a2f15dda980fd97b09cda7da7c89f376a4350e300c3a99557d4fa25cc07947dea736856bbb65da49303321eed2123311864b"
+  ]
+}
+x-commit-hash: "4460adc891c3fc33442799f93ab5d422823de431"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- make cairo2 a depopt and break `PolyText` into optional sub-library
 (now free of non-OCaml dependencies)
- fix bug in `Path2.point_inside` (always returning outside)
