### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.9.2)

### DIFF
--- a/packages/shuttle/shuttle.0.9.2/opam
+++ b/packages/shuttle/shuttle.0.9.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.2/shuttle-0.9.2.tbz"
+  checksum: [
+    "sha256=69bf4d3ec9262dc981db5b6073c1d9e581c24fa1f1a49d20798eb3ae953ecdc3"
+    "sha512=36e95dcfce349f1acc586afa30c6b74d8212b9a8c0e32a2abcdbe09a87208b9ed2dc2c27aed3d65f4e9031260a3c54af7d0e9ebd7ba3d0b80182f17773dae24f"
+  ]
+}
+x-commit-hash: "e42176f2ed24c23254e2c6ac6d26e0afc0194819"

--- a/packages/shuttle_http/shuttle_http.0.9.2/opam
+++ b/packages/shuttle_http/shuttle_http.0.9.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "shuttle_ssl" {= version}
+  "re2" {>= "v0.15.0"}
+  "ppx_jane" {with-test}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.2/shuttle-0.9.2.tbz"
+  checksum: [
+    "sha256=69bf4d3ec9262dc981db5b6073c1d9e581c24fa1f1a49d20798eb3ae953ecdc3"
+    "sha512=36e95dcfce349f1acc586afa30c6b74d8212b9a8c0e32a2abcdbe09a87208b9ed2dc2c27aed3d65f4e9031260a3c54af7d0e9ebd7ba3d0b80182f17773dae24f"
+  ]
+}
+x-commit-hash: "e42176f2ed24c23254e2c6ac6d26e0afc0194819"

--- a/packages/shuttle_ssl/shuttle_ssl.0.9.2/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.9.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.2/shuttle-0.9.2.tbz"
+  checksum: [
+    "sha256=69bf4d3ec9262dc981db5b6073c1d9e581c24fa1f1a49d20798eb3ae953ecdc3"
+    "sha512=36e95dcfce349f1acc586afa30c6b74d8212b9a8c0e32a2abcdbe09a87208b9ed2dc2c27aed3d65f4e9031260a3c54af7d0e9ebd7ba3d0b80182f17773dae24f"
+  ]
+}
+x-commit-hash: "e42176f2ed24c23254e2c6ac6d26e0afc0194819"


### PR DESCRIPTION
- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Allow creating ssl encrypted servers
