### PR TITLE
Release ocaml-jupyter kernel v2.8.2

### DIFF
--- a/packages/jupyter/jupyter.2.8.2/opam
+++ b/packages/jupyter/jupyter.2.8.2/opam
@@ -27,7 +27,7 @@ depends: [
   "zmq" {>= "5.0.0"}
   "zmq-lwt" {>= "5.0.0"}
   "yojson" {>="1.6.0"}
-  "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_yojson_conv" {>= "v0.14.0"}
   "ppx_deriving" {>= "5.2.1"}
   "cryptokit" {>= "1.12"}
   "dune" {>= "1.0.0"}

--- a/packages/jupyter/jupyter.2.8.2/opam
+++ b/packages/jupyter/jupyter.2.8.2/opam
@@ -1,0 +1,59 @@
+opam-version: "2.0"
+maintainer: [
+  "Akinori ABE <aabe.65535@gmail.com>"
+]
+authors: [
+  "Akinori ABE"
+]
+license: "MIT"
+homepage: "https://akabe.github.io/ocaml-jupyter/"
+bug-reports: "https://github.com/akabe/ocaml-jupyter/issues"
+dev-repo: "git+https://github.com/akabe/ocaml-jupyter.git"
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.10.0" & < "5.0"}
+  "base-threads"
+  "base-unix"
+  "uuidm" {>= "0.9.6"}
+  "base64" {>= "3.2.0"}
+  "lwt" {>= "4.0.0"}
+  "lwt_ppx" {>= "1.0.0"}
+  "logs" {>= "0.6.0"}
+  "stdint" {>= "0.4.2"}
+  "zmq" {>= "5.0.0"}
+  "zmq-lwt" {>= "5.0.0"}
+  "yojson" {>="1.6.0"}
+  "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_deriving" {>= "5.2.1"}
+  "cryptokit" {>= "1.12"}
+  "dune" {>= "1.0.0"}
+  "ounit2" {with-test & >= "2.0.0"}
+  "ocp-indent" {with-test & >= "1.7.0"}
+]
+depopts: [
+  "merlin"
+]
+conflicts: [
+  "merlin" {< "3.0.0"}
+]
+
+post-messages: [
+  "Please run for registration of ocaml-jupyter kernel:"
+  ""
+  "$ ocaml-jupyter-opam-genspec"
+  "$ jupyter kernelspec install --name ocaml-jupyter \\"
+  "    %{share}%/jupyter"
+  {success}
+]
+
+synopsis: "An OCaml kernel for Jupyter notebook"
+description:
+  "OCaml Jupyter provides an OCaml REPL on Jupyter (a great interface with markdown/HTML documentation, LaTeX formula by MathJax, and image embedding). This is useful for data analysis in OCaml."
+url {
+  src: "https://github.com/akabe/ocaml-jupyter/releases/download/v2.8.2/jupyter-2.8.2.tbz"
+  checksum: "sha256=4d5862c254e16cd01be706d3d64d69467cadcadd305426dc9215a6dbcd24680b"
+}


### PR DESCRIPTION
Release note: https://github.com/akabe/ocaml-jupyter/releases/tag/v2.8.2