### PR TITLE
Add lower bound on ptime 1.1.0.

### DIFF
--- a/packages/current_github/current_github.0.6.1/opam
+++ b/packages/current_github/current_github.0.6.1/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "lwt"
   "duration"
-  "ptime"
+  "ptime" {>= "1.1.0"}
   "yojson"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "mirage-crypto"

--- a/packages/current_github/current_github.0.6.2/opam
+++ b/packages/current_github/current_github.0.6.2/opam
@@ -20,7 +20,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "lwt"
   "duration"
-  "ptime"
+  "ptime" {>= "1.1.0"}
   "yojson"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "mirage-crypto"

--- a/packages/current_github/current_github.0.6/opam
+++ b/packages/current_github/current_github.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "lwt"
   "duration"
-  "ptime"
+  "ptime" {>= "1.1.0"}
   "yojson"
   "cohttp-lwt-unix" {>= "4.0.0"}
   "mirage-crypto"

--- a/packages/current_gitlab/current_gitlab.0.6.1/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.1/opam
@@ -19,6 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "lwt"
   "yojson"
+  "ptime" {>= "1.1.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "2.9"}
   "gitlab-unix" {>= "0.1.3"}

--- a/packages/current_gitlab/current_gitlab.0.6.2/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.2/opam
@@ -23,6 +23,7 @@ depends: [
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "2.9"}
   "gitlab-unix" {>= "0.1.4"}
+  "ptime" {>= "1.1.0"}
   "cmdliner" {>= "1.1.0"}
   "logs" {>= "0.7.0"}
   "ppx_deriving_yojson" {>= "3.6.1"}

--- a/packages/current_gitlab/current_gitlab.0.6/opam
+++ b/packages/current_gitlab/current_gitlab.0.6/opam
@@ -19,6 +19,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "lwt"
   "yojson"
+  "ptime" {>= "1.1.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "dune" {>= "2.9"}
   "gitlab-unix" {= "0.1.2"}


### PR DESCRIPTION
We depend on the Ptime.of_rfc3339 functionality provided in that version of the library.