### PR TITLE
[new release] jose (0.9.0)

### DIFF
--- a/packages/jose/jose.0.9.0/opam
+++ b/packages/jose/jose.0.9.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: ["ulrik.strid@outlook.com"]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/reason-jose"
+doc: "https://ulrikstrid.github.io/reason-jose"
+bug-reports: "https://github.com/ulrikstrid/reason-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.3.0"}
+  "dune" {>= "2.8"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "0.10.0"}
+  "x509" {>= "0.13.0"}
+  "cstruct" {>= "6.0.0"}
+  "astring"
+  "yojson" {>= "1.6.0"}
+  "zarith"
+  "ptime"
+  "mirage-crypto-rng" {with-test & < "0.11.0"}
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/reason-jose.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/reason-jose/releases/download/v0.9.0/jose-v0.9.0.tbz"
+  checksum: [
+    "sha256=c449a63c53043deb149cfc1305e578971bb5b460f17b4a66e286e826f2dbc18d"
+    "sha512=9c4df87be3bb4b13cc948c1378eecb0f74326783c9ed6660a2657757f60f070fe9b29e8d1a17536076da658b36d9db0ffe99098a9da1eac04465e9f593e7e33a"
+  ]
+}
+x-commit-hash: "305710c60bffe5099d31d6b443bb96eff305f0d1"

--- a/packages/jose/jose.0.9.0/opam
+++ b/packages/jose/jose.0.9.0/opam
@@ -28,6 +28,9 @@ depends: [
   "junit_alcotest" {with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
CHANGES:

- Support all serialization formats, previously only the compact serialization was supported, now we support both general and flattened JSON format (by @ulrikstrid)
- Add support for ES384 (P-384 with SHA384) (by @ulrikstrid)
- Allow creating a JWK from X509 keys directly (by @ulrikstrid)
- Support extra headers (by @ulrikstrid)
- Add a parameter to JWT validation for the current time represented as `Ptime.t` (by @ulrikstrid)
- Add support for EdDSA keys (Ed25519 curve) from rfc8037 (by @ulrikstrid)