### PR TITLE
git-unix: add upper bound on mirage-crypto-rng dep

### DIFF
--- a/packages/git-unix/git-unix.3.10.0/opam
+++ b/packages/git-unix/git-unix.3.10.0/opam
@@ -43,7 +43,7 @@ depends: [
   "awa-mirage" {>= "0.1.0"}
   "mirage-flow" {>= "2.0.1"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & < "0.11.0" & with-test}
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}

--- a/packages/git-unix/git-unix.3.10.1/opam
+++ b/packages/git-unix/git-unix.3.10.1/opam
@@ -43,7 +43,7 @@ depends: [
   "awa-mirage" {>= "0.1.0"}
   "mirage-flow" {>= "2.0.1"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & < "0.11.0" & with-test}
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}

--- a/packages/git-unix/git-unix.3.11.0/opam
+++ b/packages/git-unix/git-unix.3.11.0/opam
@@ -43,7 +43,7 @@ depends: [
   "awa-mirage" {>= "0.1.0"}
   "mirage-flow" {>= "2.0.1"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & < "0.11.0" & with-test}
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}

--- a/packages/git-unix/git-unix.3.12.0/opam
+++ b/packages/git-unix/git-unix.3.12.0/opam
@@ -43,7 +43,7 @@ depends: [
   "awa-mirage" {>= "0.1.0"}
   "mirage-flow" {>= "2.0.1"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & < "0.11.0" & with-test}
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}

--- a/packages/git-unix/git-unix.3.9.0/opam
+++ b/packages/git-unix/git-unix.3.9.0/opam
@@ -45,7 +45,7 @@ depends: [
   "awa-mirage" {>= "0.1.0"}
   "mirage-flow" {>= "2.0.1"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & < "0.11.0" & with-test}
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}

--- a/packages/git-unix/git-unix.3.9.1/opam
+++ b/packages/git-unix/git-unix.3.9.1/opam
@@ -43,7 +43,7 @@ depends: [
   "awa-mirage" {>= "0.1.0"}
   "mirage-flow" {>= "2.0.1"}
   "ke" {>= "0.4" & with-test}
-  "mirage-crypto-rng" {>= "0.8.8" & with-test}
+  "mirage-crypto-rng" {>= "0.8.8" & < "0.11.0" & with-test}
   "ptime"
   "mimic"
   "ca-certs-nss" {>= "3.60"}


### PR DESCRIPTION
Similar to #23322:

    #=== ERROR while compiling git-unix.3.12.0 ====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/git-unix.3.12.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p git-unix -j 71 --no-buffer
    # exit-code            1
    # env-file             ~/.opam/log/git-unix-7-4542c2.env
    # output-file          ~/.opam/log/git-unix-7-4542c2.out
    ### output ###
    # File "_none_", line 1:
    # Alert ocaml_deprecated_auto_include:
    # OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
    # automatically added to the search path, but you should add -I +unix to the
    # command-line to silence this alert (e.g. by adding unix to the list of
    # libraries in your dune file, or adding use_unix to your _tags file for
    # ocamlbuild, or using -package unix for ocamlfind).
    # File "test/smart/test.ml", line 57, characters 43-45:
    # 57 | let () = Mirage_crypto_rng_unix.initialize ()
    #                                                 ^^
    # Error: This expression has type unit but an expression was expected of type
    #          'a Mirage_crypto_rng.generator
