### PR TITLE
dune 3.7: fix revdeps

### DIFF
--- a/packages/chamelon/chamelon.0.0.10/opam
+++ b/packages/chamelon/chamelon.0.0.10/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.7.0"}
   "chamelon-unix" {= version & with-test}
   "crowbar" {>= "0.2.1" & with-test}
   "fpath" {>= "0.7.3" & with-test}

--- a/packages/chamelon/chamelon.0.0.7/opam
+++ b/packages/chamelon/chamelon.0.0.7/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.7.0"}
   "chamelon-unix" {= version & with-test}
   "fpath" {>= "0.7.3" & with-test}
   "alcotest" {>= "1.5.0" & with-test}

--- a/packages/chamelon/chamelon.0.0.8/opam
+++ b/packages/chamelon/chamelon.0.0.8/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.7.0"}
   "chamelon-unix" {= version & with-test}
   "fpath" {>= "0.7.3" & with-test}
   "alcotest" {>= "1.5.0" & with-test}

--- a/packages/chamelon/chamelon.0.0.9.1/opam
+++ b/packages/chamelon/chamelon.0.0.9.1/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.7.0"}
   "chamelon-unix" {= version & with-test}
   "crowbar" {>= "0.2.1" & with-test}
   "fpath" {>= "0.7.3" & with-test}

--- a/packages/chamelon/chamelon.0.1.1/opam
+++ b/packages/chamelon/chamelon.0.1.1/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.7.0"}
   "crowbar" {>= "0.2.1" & with-test}
   "fpath" {>= "0.7.3" & with-test}
   "alcotest" {>= "1.5.0" & with-test}

--- a/packages/chamelon/chamelon.0.1.2/opam
+++ b/packages/chamelon/chamelon.0.1.2/opam
@@ -21,7 +21,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.10.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.7.0"}
   "crowbar" {>= "0.2.1" & with-test}
   "fpath" {>= "0.7.3" & with-test}
   "alcotest" {>= "1.5.0" & with-test}

--- a/packages/commons/commons.1.5.5/opam
+++ b/packages/commons/commons.1.5.5/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
 depends: [
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.2.0" }
+  "dune" {>= "3.2.0" & < "3.7.0"}
   "alcotest" {>= "1.5.0"}
   "ANSITerminal" {>= "0.8.4"}
   "easy_logging" {>= "0.8.1" }

--- a/packages/commons/commons.1.8.0/opam
+++ b/packages/commons/commons.1.8.0/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/returntocorp/semgrep/issues"
 
 depends: [
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.2.0" }
+  "dune" {>= "3.2.0" & < "3.7.0"}
   "alcotest" {>= "1.5.0"}
   "ANSITerminal" {>= "0.8.4"}
   "cmdliner" {>= "1.1.1" }


### PR DESCRIPTION
Two packages got broken by dune 3.7: commons and chamelon. They were relying on behavior in dune's dependency cycle detection that we classified as a bug (see ocaml/dune#7018).

Since the latest versions are affected, we sent patches upstream: yomimono/chamelon#18, returntocorp/semgrep#7173.
