### PR TITLE
Add `build` field to XML-Light 2.4

### DIFF
--- a/packages/xml-light/xml-light.2.4/opam
+++ b/packages/xml-light/xml-light.2.4/opam
@@ -6,6 +6,10 @@ depends: [
   "ocamlfind"
 ]
 dev-repo: "git+https://github.com/ncannasse/xml-light"
+build: [
+  [make "all"]
+  [make "opt"]
+]
 install: [make "install_ocamlfind"]
 synopsis: "Xml-Light is a minimal XML parser & printer for OCaml"
 description: """


### PR DESCRIPTION
The current instructions are missing a `build` field (that `xml-light.2.3` has). It works because the `install` field uses the `install_ocamlfind` target which depends on `all` and `opt` but it seems a bit inelegant to build in the `install` step.

This was detected as opam-monorepo classifies packages without `build` instructions as packages without a source, which is not the case for `xml-light`. A PR exists
https://github.com/tarides/opam-monorepo/pull/376 but there is the question whether missing `build` steps is a packaging mistake or not.

In any case, this PR is a proposal to fix the issue and I'm looking forward to hear the input of opam-repository maintainers on this question.