### PR TITLE
syslog-message requires rresult >= 0.3.0 (Rresult.result != Stdlib.result before 0.3.0)

### DIFF
--- a/packages/syslog-message/syslog-message.1.0.0/opam
+++ b/packages/syslog-message/syslog-message.1.0.0/opam
@@ -16,7 +16,6 @@ depends: [
   "rresult" {>= "0.3.0"}
   "qcheck" {with-test}
 ]
-conflicts: [ "result" {< "1.5"} ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/syslog-message/syslog-message.1.0.0/opam
+++ b/packages/syslog-message/syslog-message.1.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "astring"
   "ptime"
-  "rresult"
+  "rresult" {>= "0.3.0"}
   "qcheck" {with-test}
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/packages/syslog-message/syslog-message.1.1.0/opam
+++ b/packages/syslog-message/syslog-message.1.1.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "astring"
   "ptime"
-  "rresult"
+  "rresult" {>= "0.3.0"}
   "qcheck" {with-test}
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/packages/syslog-message/syslog-message.1.1.0/opam
+++ b/packages/syslog-message/syslog-message.1.1.0/opam
@@ -15,7 +15,6 @@ depends: [
   "rresult" {>= "0.3.0"}
   "qcheck" {with-test}
 ]
-conflicts: [ "result" {< "1.5"} ]
 
 build: [
   [ "dune" "subst" ] {dev}


### PR DESCRIPTION
```
#=== ERROR while compiling syslog-message.1.0.0 ===============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.03.0 | file:///home/opam/opam-repository
# path                 ~/.opam/4.03/.opam-switch/build/syslog-message.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p syslog-message -j 71
# exit-code            1
# env-file             ~/.opam/log/syslog-message-7-4692a5.env
# output-file          ~/.opam/log/syslog-message-7-4692a5.out
### output ###
#       ocamlc src/.syslog_message.objs/syslog_message.{cmo,cmt} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlc.opt -w +A-4-6-41-42-44-48-58 -principal -safe-string -g -bin-annot -I src/.syslog_message.objs -I /home/opam/.opam/4.03/lib/astring -I /home/opam/.opam/4.03/lib/bytes -I /home/opam/.opam/4.03/lib/ptime -I /home/opam/.opam/4.03/lib/result -I /home/opam/.opam/4.03/lib/rresult -intf-suffix .ml -no-alias-deps -o src/.syslog_message.objs/syslog_message.cmo -c -impl src/syslog_message.ml)
# File "src/syslog_message.ml", line 301, characters 17-19:
# Warning 40: Ok was selected from type Rresult.result.
# It is not visible in the current scope, and will not 
# be selected if the type becomes unknown.
# File "src/syslog_message.ml", line 302, characters 29-31:
# Warning 40: Ok was selected from type Rresult.result.
# It is not visible in the current scope, and will not 
# be selected if the type becomes unknown.
# File "src/syslog_message.ml", line 303, characters 19-24:
# Warning 40: Error was selected from type Rresult.result.
# It is not visible in the current scope, and will not 
# be selected if the type becomes unknown.
# File "src/syslog_message.ml", line 300, characters 6-216:
# Error: This expression has type
#          (string * string, [> `Msg of string ]) Rresult.result
#        but an expression was expected of type
#          (string * string, [> Rresult.R.msg ]) result
#     ocamlopt src/.syslog_message.objs/syslog_message.{cmx,o} (exit 2)
# (cd _build/default && /home/opam/.opam/4.03/bin/ocamlopt.opt -w +A-4-6-41-42-44-48-58 -principal -safe-string -g -I src/.syslog_message.objs -I /home/opam/.opam/4.03/lib/astring -I /home/opam/.opam/4.03/lib/bytes -I /home/opam/.opam/4.03/lib/ptime -I /home/opam/.opam/4.03/lib/result -I /home/opam/.opam/4.03/lib/rresult -intf-suffix .ml -no-alias-deps -o src/.syslog_message.objs/syslog_message.cmx -c -impl src/syslog_message.ml)
# File "src/syslog_message.ml", line 301, characters 17-19:
# Warning 40: Ok was selected from type Rresult.result.
# It is not visible in the current scope, and will not 
# be selected if the type becomes unknown.
# File "src/syslog_message.ml", line 302, characters 29-31:
# Warning 40: Ok was selected from type Rresult.result.
# It is not visible in the current scope, and will not 
# be selected if the type becomes unknown.
# File "src/syslog_message.ml", line 303, characters 19-24:
# Warning 40: Error was selected from type Rresult.result.
# It is not visible in the current scope, and will not 
# be selected if the type becomes unknown.
# File "src/syslog_message.ml", line 300, characters 6-216:
# Error: This expression has type
#          (string * string, [> `Msg of string ]) Rresult.result
#        but an expression was expected of type
#          (string * string, [> Rresult.R.msg ]) result
```