### PR TITLE
[new release] colombe, sendmail and sendmail-lwt (0.8.0)

### DIFF
--- a/packages/colombe/colombe.0.8.0/opam
+++ b/packages/colombe/colombe.0.8.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+synopsis:     "SMTP protocol in OCaml"
+doc:          "https://mirage.github.io/colombe/"
+description: """SMTP protocol according RFC5321 without extension."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "ipaddr" {>= "3.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "ocaml-syntax-shims"
+  "alcotest" {with-test}
+  "crowbar" {>= "0.2" & with-test}
+]
+depopts: [ "emile" ]
+conflicts: [ "emile" {< "0.8"} ]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.8.0/colombe-0.8.0.tbz"
+  checksum: [
+    "sha256=9d3ad39d5b7af765947ff9ff01cec15e4226924d816827fc15c7ec1e5be7fff3"
+    "sha512=8f9a8aefd33426064fead137374b134ad30f90d653afcf4f30043c3e82764edaa17e9b5323c040da3d60a9c1f491d9d265a069ae4ac887685719ecc47c812308"
+  ]
+}
+x-commit-hash: "cdd3ea41888df003020806213200c057eb43aa25"

--- a/packages/sendmail-lwt/sendmail-lwt.0.8.0/opam
+++ b/packages/sendmail-lwt/sendmail-lwt.0.8.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command over LWT"
+description: """A library to be able to send an email with LWT and TLS."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "sendmail" {= version}
+  "domain-name"
+  "lwt"
+  "tls" {>= "0.13.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "x509" {>= "0.12.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.8.0/colombe-0.8.0.tbz"
+  checksum: [
+    "sha256=9d3ad39d5b7af765947ff9ff01cec15e4226924d816827fc15c7ec1e5be7fff3"
+    "sha512=8f9a8aefd33426064fead137374b134ad30f90d653afcf4f30043c3e82764edaa17e9b5323c040da3d60a9c1f491d9d265a069ae4ac887685719ecc47c812308"
+  ]
+}
+x-commit-hash: "cdd3ea41888df003020806213200c057eb43aa25"

--- a/packages/sendmail/sendmail.0.8.0/opam
+++ b/packages/sendmail/sendmail.0.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+license:      "MIT"
+authors:      [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   [ "Charles-Edouard Lecat" "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/colombe"
+bug-reports:  "https://github.com/mirage/colombe/issues"
+dev-repo:     "git+https://github.com/mirage/colombe.git"
+doc:          "https://mirage.github.io/colombe/"
+synopsis:     "Implementation of the sendmail command"
+description: """A library to be able to send an email."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.03.0"}
+  "dune" {>= "2.0"}
+  "colombe" {= version}
+  "tls" {>= "0.13.0"}
+  "base64" {>= "3.0.0"}
+  "ke" {>= "0.4"}
+  "logs"
+  "rresult"
+  "bigstringaf" {>= "0.2.0"}
+  "emile" {>= "0.8" & with-test}
+  "mrmime" {>= "0.3.2" & with-test}
+  "cstruct" {>= "6.0.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/colombe/releases/download/v0.8.0/colombe-0.8.0.tbz"
+  checksum: [
+    "sha256=9d3ad39d5b7af765947ff9ff01cec15e4226924d816827fc15c7ec1e5be7fff3"
+    "sha512=8f9a8aefd33426064fead137374b134ad30f90d653afcf4f30043c3e82764edaa17e9b5323c040da3d60a9c1f491d9d265a069ae4ac887685719ecc47c812308"
+  ]
+}
+x-commit-hash: "cdd3ea41888df003020806213200c057eb43aa25"


### PR DESCRIPTION
SMTP protocol in OCaml

- Project page: <a href="https://github.com/mirage/colombe">https://github.com/mirage/colombe</a>
- Documentation: <a href="https://mirage.github.io/colombe/">https://mirage.github.io/colombe/</a>

##### CHANGES:

- Provide a basic line decoder (mirage/colombe#66, @dinosaure)
- Upgrade `sendmail-lwt` to `tls.0.16.0` (mirage/colombe#67, @dinosaure)
