### PR TITLE
[capnp-rcp-unix] Add upper bound for mirage-crypto-rng

### DIFF
--- a/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
@@ -20,6 +20,7 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
+  "cstruct" {<= "6.0.1"}
   "mirage-flow" {>="2.0.0"}
   "tls" {>= "0.13.1" & < "0.15.0"}
   "base64" {>= "3.0.0"}

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.1/opam
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
-  "cstruct" {<= "6.0.1"}
+  "cstruct" {< "6.1.0"}
   "mirage-flow" {>="2.0.0"}
   "tls" {>= "0.13.1" & < "0.15.0"}
   "base64" {>= "3.0.0"}

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
@@ -20,6 +20,7 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
+  "cstruct" {<= "6.0.1"}
   "mirage-flow" {>="2.0.0"}
   "tls" {>= "0.13.1" & < "0.15.0"}
   "base64" {>= "3.0.0"}

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2/opam
@@ -20,7 +20,7 @@ depends: [
   "fmt"
   "logs"
   "asetmap"
-  "cstruct" {<= "6.0.1"}
+  "cstruct" {< "6.1.0"}
   "mirage-flow" {>="2.0.0"}
   "tls" {>= "0.13.1" & < "0.15.0"}
   "base64" {>= "3.0.0"}

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.0.9.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.0.9.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" { >= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.7.0" & < "0.11.0"}
   "lwt"
   "asetmap" {with-test}
 ]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.0/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" { >= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.7.0" & < "0.11.0"}
   "lwt"
   "asetmap" {with-test}
 ]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" { >= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.7.0" & < "0.11.0"}
   "lwt"
   "asetmap" {with-test}
 ]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.1/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" { >= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.7.0" & < "0.11.0"}
   "lwt"
   "asetmap" {with-test}
 ]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "2.0"}
   "alcotest" {>= "1.0.1" & with-test}
   "alcotest-lwt" { >= "1.0.1" & with-test}
-  "mirage-crypto-rng" {>= "0.7.0"}
+  "mirage-crypto-rng" {>= "0.7.0" & < "0.11.0"}
   "lwt"
   "asetmap" {with-test}
 ]


### PR DESCRIPTION
PR #23314 already added an upperbound to `mirage-crypto-rng` for `capnp-rcp-unix.1.2.2`. We backport this all the way back to `0.9.0`. Relevant failure:

```
#=== ERROR while compiling capnp-rpc-unix.1.2.1 ===============================#
# context     2.1.4 | linux/x86_64 |  | https://opam.ocaml.org#d95a0fc8
# path        ~/Documents/Projects/Tactician/develop/_opam/.opam-switch/build/capnp-rpc-unix.1.2.1
# command     ~/.opam/opam-init/hooks/sandbox.sh build tactician exec -- dune build -p capnp-rpc-unix -j 15
# exit-code   1
# env-file    ~/.opam/log/capnp-rpc-unix-242093-15f9a1.env
# output-file ~/.opam/log/capnp-rpc-unix-242093-15f9a1.out
### output ###
# File "unix/dune", line 5, characters 3-24:
# 5 |    mirage-crypto-rng.lwt cmdliner cstruct-lwt extunix))
#        ^^^^^^^^^^^^^^^^^^^^^
# Error: Library "mirage-crypto-rng.lwt" not found.
# -> required by library "capnp-rpc-unix" in _build/default/unix
# -> required by _build/default/META.capnp-rpc-unix
# -> required by _build/install/default/lib/capnp-rpc-unix/META
# -> required by _build/default/capnp-rpc-unix.install
# -> required by alias install

```