### PR TITLE
[new release] OCADml (0.4.0)

### DIFF
--- a/packages/OCADml/OCADml.0.4.0/opam
+++ b/packages/OCADml/OCADml.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.3"}
+  "gg" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "cairo2" {>= "0.6.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.4.0/OCADml-0.4.0.tbz"
+  checksum: [
+    "sha256=99fe6642ad7d4b0c3f46c780b897b542fbd3fb9b896beccda4ee80ac478d143e"
+    "sha512=cb0e50b18dda9194920da37a207d45a10a2d203dba47f0435d8ee0568c4611fcdc011ecd689e89b6b1f6e9667b4b3de8d799a357e268bbeed8dfc04c64e3feba"
+  ]
+}
+x-commit-hash: "14cfc751a158d5a2f53a79e71fe9bb46a0886df7"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- make cairo2 a depopt and break `PolyText` into optional sub-library
 (now free of non-OCaml dependencies)
- fix bug in `Path2.point_inside` (always returning outside)
- abstract `Poly{2,3}.t` (from private) free up for potential implementation change
- add missing `{of,to}_{seq,list,array}` to `Path` and `Poly` modules for
 convenience
