### PR TITLE
Lablgl 1.06 works on ocaml 5.0.0

### DIFF
--- a/packages/lablgl/lablgl.1.06/opam
+++ b/packages/lablgl/lablgl.1.06/opam
@@ -21,7 +21,7 @@ remove: [
   ["rm" "-f" "%{bin}%/lablglut"]
 ]
 depends: [
-  "ocaml" {>= "4.03" & < "5.0"}
+  "ocaml" {>= "4.03"}
 ]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]


### PR DESCRIPTION
So there is no need to make it unavailable on 5.0.0.