### PR TITLE
current_gitlab is not compatible with tls >= 0.16.0

### DIFF
--- a/packages/current_gitlab/current_gitlab.0.6.1/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.1/opam
@@ -29,6 +29,9 @@ depends: [
   "result" {>= "1.5"}
   "rresult" {>= "0.6.0"}
 ]
+conflicts: [
+  "tls" {>= "0.16.0"} # Uses ptime implicitly through tls via cohttp
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/current_gitlab/current_gitlab.0.6.2/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.2/opam
@@ -30,6 +30,9 @@ depends: [
   "result" {>= "1.5"}
   "rresult" {>= "0.6.0"}
 ]
+conflicts: [
+  "tls" {>= "0.16.0"} # Uses ptime implicitly through tls via cohttp
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}

--- a/packages/current_gitlab/current_gitlab.0.6/opam
+++ b/packages/current_gitlab/current_gitlab.0.6/opam
@@ -29,6 +29,9 @@ depends: [
   "result" {>= "1.5"}
   "rresult" {>= "0.6.0"}
 ]
+conflicts: [
+  "tls" {>= "0.16.0"} # Uses ptime implicitly through tls via cohttp
+]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}


### PR DESCRIPTION
Uses ptime implicitly throught tls and cohttp.
See #23344 
```
#=== ERROR while compiling current_gitlab.0.6.2 ===============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/current_gitlab.0.6.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p current_gitlab -j 255
# exit-code            1
# env-file             ~/.opam/log/current_gitlab-7-eda6b1.env
# output-file          ~/.opam/log/current_gitlab-7-eda6b1.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I plugins/gitlab/.current_gitlab.objs/byte -I /home/opam/.opam/4.14/lib/ISO8601 -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/ansi -I /home/opam/.opam/4.14/lib/asetmap -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base64/rfc2045 -I /home/opam/.opam/4.14/lib/bigarray-overlap -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/csv -I /home/opam/.opam/4.14/lib/current -I /home/opam/.opam/4.14/lib/current/cache -I /home/opam/.opam/4.14/lib/current/term -I /home/opam/.opam/4.14/lib/current_git -I /home/opam/.opam/4.14/lib/current_incr -I /home/opam/.opam/4.14/lib/current_web -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gitlab -I /home/opam/.opam/4.14/lib/gitlab-unix -I /home/opam/.opam/4.14/lib/inotify -I /home/opam/.opam/4.14/lib/inotify/lwt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/irmin-watcher -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-crypto-rng/unix -I /home/opam/.opam/4.14/lib/multipart_form -I /home/opam/.opam/4.14/lib/multipart_form-lwt -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_deriving/api -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/prettym -I /home/opam/.opam/4.14/lib/prometheus -I /home/opam/.opam/4.14/lib/prometheus-app -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/routes -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/session -I /home/opam/.opam/4.14/lib/session-cohttp -I /home/opam/.opam/4.14/lib/session-cohttp-lwt -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tyxml -I /home/opam/.opam/4.14/lib/tyxml/functor -I /home/opam/.opam/4.14/lib/unstrctrd -I /home/opam/.opam/4.14/lib/unstrctrd/parser -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Current_gitlab__ -o plugins/gitlab/.current_gitlab.objs/byte/current_gitlab__Api.cmo -c -impl plugins/gitlab/api.pp.ml)
# File "plugins/gitlab/api.ml", line 463, characters 2-18:
# 463 |   Ptime.of_rfc3339 str |> function
#         ^^^^^^^^^^^^^^^^
# Error: Unbound module Ptime
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I plugins/gitlab/.current_gitlab.objs/byte -I plugins/gitlab/.current_gitlab.objs/native -I /home/opam/.opam/4.14/lib/ISO8601 -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/ansi -I /home/opam/.opam/4.14/lib/asetmap -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/atdgen -I /home/opam/.opam/4.14/lib/atdgen-runtime -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base64/rfc2045 -I /home/opam/.opam/4.14/lib/bigarray-overlap -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/bos -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/csv -I /home/opam/.opam/4.14/lib/current -I /home/opam/.opam/4.14/lib/current/cache -I /home/opam/.opam/4.14/lib/current/term -I /home/opam/.opam/4.14/lib/current_git -I /home/opam/.opam/4.14/lib/current_incr -I /home/opam/.opam/4.14/lib/current_web -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/fpath -I /home/opam/.opam/4.14/lib/gitlab -I /home/opam/.opam/4.14/lib/gitlab-unix -I /home/opam/.opam/4.14/lib/inotify -I /home/opam/.opam/4.14/lib/inotify/lwt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/irmin-watcher -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt-dllist -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-crypto-rng/unix -I /home/opam/.opam/4.14/lib/multipart_form -I /home/opam/.opam/4.14/lib/multipart_form-lwt -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/pecu -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_deriving/api -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/prettym -I /home/opam/.opam/4.14/lib/prometheus -I /home/opam/.opam/4.14/lib/prometheus-app -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/routes -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/session -I /home/opam/.opam/4.14/lib/session-cohttp -I /home/opam/.opam/4.14/lib/session-cohttp-lwt -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/sqlite3 -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tyxml -I /home/opam/.opam/4.14/lib/tyxml/functor -I /home/opam/.opam/4.14/lib/unstrctrd -I /home/opam/.opam/4.14/lib/unstrctrd/parser -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -open Current_gitlab__ -o plugins/gitlab/.current_gitlab.objs/native/current_gitlab__Api.cmx -c -impl plugins/gitlab/api.pp.ml)
# File "plugins/gitlab/api.ml", line 463, characters 2-18:
# 463 |   Ptime.of_rfc3339 str |> function
#         ^^^^^^^^^^^^^^^^
# Error: Unbound module Ptime
```