### PR TITLE
sihl.0.1.{6,7,8,9,10} is not compatible with conduit >= 6.1.0

### DIFF
--- a/packages/sihl/sihl.0.1.10/opam
+++ b/packages/sihl/sihl.0.1.10/opam
@@ -40,6 +40,7 @@ depends: [
 ]
 conflicts: [
   "yojson" {>= "2.0.0"}
+  "conduit" {>= "6.2.0"} # mirage-crypto is used implicitly somewhere through conduit
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/sihl/sihl.0.1.6/opam
+++ b/packages/sihl/sihl.0.1.6/opam
@@ -42,6 +42,7 @@ conflicts: [
   "yojson" {>= "2.0.0"}
   "result" {< "1.5"}
   "http"
+  "conduit" {>= "6.2.0"} # mirage-crypto is used implicitly somewhere through conduit
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/sihl/sihl.0.1.7/opam
+++ b/packages/sihl/sihl.0.1.7/opam
@@ -40,6 +40,7 @@ depends: [
 ]
 conflicts: [
   "yojson" {>= "2.0.0"}
+  "conduit" {>= "6.2.0"} # mirage-crypto is used implicitly somewhere through conduit
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/sihl/sihl.0.1.8/opam
+++ b/packages/sihl/sihl.0.1.8/opam
@@ -40,6 +40,7 @@ depends: [
 ]
 conflicts: [
   "yojson" {>= "2.0.0"}
+  "conduit" {>= "6.2.0"} # mirage-crypto is used implicitly somewhere through conduit
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/sihl/sihl.0.1.9/opam
+++ b/packages/sihl/sihl.0.1.9/opam
@@ -40,6 +40,7 @@ depends: [
 ]
 conflicts: [
   "yojson" {>= "2.0.0"}
+  "conduit" {>= "6.2.0"} # mirage-crypto is used implicitly somewhere through conduit
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Uses mirage-crypto implicitly through conduit
See #23344 
```
#=== ERROR while compiling sihl.0.1.10 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/sihl.0.1.10
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p sihl -j 31 @install
# exit-code            1
# env-file             ~/.opam/log/sihl-7-f7c6f5.env
# output-file          ~/.opam/log/sihl-7-f7c6f5.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I sihl/http/.sihl_http.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/biniou -I /home/opam/.opam/4.14/lib/camlp-streams -I /home/opam/.opam/4.14/lib/cmdliner -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/conformist -I /home/opam/.opam/4.14/lib/containers -I /home/opam/.opam/4.14/lib/containers/monomorphic -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/digestif -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/easy-format -I /home/opam/.opam/4.14/lib/either -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/ezjsonm -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/hex -I /home/opam/.opam/4.14/lib/hmap -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jsonm -I /home/opam/.opam/4.14/lib/jwto -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_ssl -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/multipart-form-data -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/common -I /home/opam/.opam/4.14/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/4.14/lib/ocaml/compiler-libs -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/opium -I /home/opam/.opam/4.14/lib/opium_kernel -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_derivers -I /home/opam/.opam/4.14/lib/ppx_deriving/api -I /home/opam/.opam/4.14/lib/ppx_deriving/create -I /home/opam/.opam/4.14/lib/ppx_deriving/enum -I /home/opam/.opam/4.14/lib/ppx_deriving/eq -I /home/opam/.opam/4.14/lib/ppx_deriving/fold -I /home/opam/.opam/4.14/lib/ppx_deriving/iter -I /home/opam/.opam/4.14/lib/ppx_deriving/make -I /home/opam/.opam/4.14/lib/ppx_deriving/map -I /home/opam/.opam/4.14/lib/ppx_deriving/ord -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_deriving/show -I /home/opam/.opam/4.14/lib/ppx_deriving/std -I /home/opam/.opam/4.14/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppxlib -I /home/opam/.opam/4.14/lib/ppxlib/ast -I /home/opam/.opam/4.14/lib/ppxlib/astlib -I /home/opam/.opam/4.14/lib/ppxlib/print_diff -I /home/opam/.opam/4.14/lib/ppxlib/stdppx -I /home/opam/.opam/4.14/lib/ppxlib/traverse_builtins -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/re/str -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/safepass -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/ssl -I /home/opam/.opam/4.14/lib/stdlib-shims -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/tsort -I /home/opam/.opam/4.14/lib/tyxml -I /home/opam/.opam/4.14/lib/tyxml/functor -I /home/opam/.opam/4.14/lib/uchar -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/yojson -I sihl/core/.sihl_core.objs/byte -I sihl/utils/.sihl_utils.objs/byte -intf-suffix .ml -no-alias-deps -open Sihl_http__ -o sihl/http/.sihl_http.objs/byte/sihl_http__Cookie.cmo -c -impl sihl/http/cookie.pp.ml)
# File "sihl/http/cookie.ml", line 78, characters 4-26:
# 78 |     Mirage_crypto.Hash.mac
#          ^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Mirage_crypto
```