### PR TITLE
[new release] xml-light (2.5)

### DIFF
--- a/packages/xml-light/xml-light.2.5/opam
+++ b/packages/xml-light/xml-light.2.5/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "Xml-Light is a minimal XML parser & printer for OCaml"
+description: """
+It provide functions to parse an XML document into an OCaml data
+structure, work with it, and print it back to an XML document. It
+support also DTD parsing and checking, and is entirely written in
+OCaml, hence it does not require additional C library.
+"""
+homepage: "https://github.com/ncannasse/xml-light"
+authors: "https://github.com/ocaml/opam-repository/issues"
+bug-reports: "https://github.com/ncannasse/xml-light/issues"
+maintainer: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml" {>= "4.03"}
+  "dune" {>= "2.7"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ncannasse/xml-light"
+url {
+  src:
+    "https://github.com/ncannasse/xml-light/releases/download/2.5/xml-light-2.5.tbz"
+  checksum: [
+    "sha256=f58c2b3db70ad1ba080b0d306ae32f82ccbb95dabb92c599cdc467d1e44e003d"
+    "sha512=fec6b83f8342a37bdad0fc745032f1faa57b359365ab53c2376fb031613a83a3139766f2d646a9b9b8d67da25252f2499a03de4caaef7bd8738f9b183ef84b6e"
+  ]
+}
+x-commit-hash: "fd62588fb7515e61d43771d885f585d3cd3fb9ca"

--- a/packages/xml-light/xml-light.2.5/opam
+++ b/packages/xml-light/xml-light.2.5/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Xml-Light is a minimal XML parser & printer for OCaml"
 description: """
 It provide functions to parse an XML document into an OCaml data


### PR DESCRIPTION
Xml-Light is a minimal XML parser & printer for OCaml

- Project page: <a href="https://github.com/ncannasse/xml-light">https://github.com/ncannasse/xml-light</a>

##### CHANGES:

## Features/Changes
- Fix to allow parsing of hexadecimal entities
- Build with OCaml 5
- Switch to dune
- Use Ocamlformat
- Introduce Github action CI
