### PR TITLE
[new release] coq-lsp (0.1.6+8.16)

### DIFF
--- a/packages/coq-lsp/coq-lsp.0.1.6+8.16/opam
+++ b/packages/coq-lsp/coq-lsp.0.1.6+8.16/opam
@@ -1,0 +1,49 @@
+synopsis: "Language Server Protocol native server for Coq"
+description:
+"""
+Language Server Protocol native server for Coq
+"""
+opam-version: "2.0"
+maintainer: "e@x80.org"
+bug-reports: "https://github.com/ejgallego/coq-lsp/issues"
+homepage: "https://github.com/ejgallego/coq-lsp"
+dev-repo: "git+https://github.com/ejgallego/coq-lsp.git"
+authors: [
+  "Emilio Jesús Gallego Arias <e@x80.org>"
+  "Ali Caglayan <alizter@gmail.com>"
+  "Shachar Itzhaky <shachari@cs.technion.ac.il>"
+  "Ramkumar Ramachandra <r@artagnon.com>"
+]
+license: "LGPL-2.1-or-later"
+doc: "https://ejgallego.github.io/coq-lsp/"
+
+depends: [
+  "ocaml"        { >= "4.11.0" }
+  "dune"         { >= "3.2.0"  }
+
+  # lsp dependencies
+  "cmdliner"     { >= "1.1.0" }
+  "yojson"       { >= "1.7.0" }
+  "uri"          { >= "4.2.0" }
+  "dune-build-info" { >= "3.2.0" }
+
+  # waterproof parser
+  "menhir"       { >= "20220210" }
+
+  # Uncomment this for releases
+  "coq"           { >= "8.16.0" & < "8.17" }
+  "coq-serapi"    { >= "8.16.0+0.16.2" & < "8.17" }
+  "camlp-streams" { >= "5.0" }
+]
+
+build: [ [ "dune" "build" "-p" name "-j" jobs ] ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-lsp/archive/refs/tags/0.1.6.1+8.16.tar.gz"
+  checksum: [
+    "sha256=714e28280df575a9aac5c382bfbaee2815ee278d11782f670d220372892554a3"
+    "sha512=ba713ecfb2f1f097c0a355991f65f3b8e46453efb08ee78073d9d9504225b83208907f2c6dfa39256fb9a34bece81fccbeb05b59f6c0f0e1729221c5ef1d97b8"
+  ]
+}
+x-commit-hash: "29d4cf9bc325bc4d8670bed25f6ca5ea34db21df"


### PR DESCRIPTION
Language Server Protocol native server for Coq

- Project page: <a href="https://github.com/ejgallego/coq-lsp">https://github.com/ejgallego/coq-lsp</a>
- Documentation: <a href="https://ejgallego.github.io/coq-lsp/">https://ejgallego.github.io/coq-lsp/</a>

##### CHANGES:

---------------------

 - The info / goal view now uses jsCoq's client-side rendering, with
   better highlighting and layout rendering (@artagnon, @ejgallego,
   ejgallego/coq-lsp#143, fixes ejgallego/coq-lsp#96)
 - Printing method is now configurable by the user (@ejgallego, ejgallego/coq-lsp#143,
   fixes ejgallego/coq-lsp#321)
 - Trigger completion on quote char "'" (@ejgallego, ejgallego/coq-lsp#350)
 - Fix typo on keybinding config for show goals (@tomtomjhj, ejgallego/coq-lsp#357)
 - New request `coq/getDocument` to get serialized full document
   contents. Thanks to Clément Pit-Claudel for feedback and ideas.
   (@ejgallego, ejgallego/coq-lsp#350)
 - Auto-ignore Coq object files; can be disabled in config
   (@ejgallego, ejgallego/coq-lsp#365)
 - Support workspaces with multiple roots, this is very useful for
   projects that contain several `_CoqProject` files in different
   directories (@ejgallego, ejgallego/coq-lsp#374)
 - Add VS Code commands to start / stop the server (@ejgallego, ejgallego/coq-lsp#377,
   cc ejgallego/coq-lsp#209)
 - Fix bug that made the server not exit on `exit` LSP notification
   (@artagnon, @ejgallego, ejgallego/coq-lsp#375, fixes ejgallego/coq-lsp#230)
 - Lay the foundation for server tests (@artagnon, ejgallego/coq-lsp#356)
 - Remove the `coq-lsp.ok_diagnostics` setting (@artagnon, ejgallego/coq-lsp#129)
 - Print abbreviations on hover (@ejgallego, ejgallego/coq-lsp#384)
 - Print hover types without parenthesis (@ejgallego, ejgallego/coq-lsp#384)
 - Parse identifiers with dot for hover and jump to definition
   (@ejallego, ejgallego/coq-lsp#385)
 - Update `vscode-languageclient` to 8.1.0 (@ejgallego, @Alizter,
   ejgallego/coq-lsp#383, fixes ejgallego/coq-lsp#273)
 - Fix typo on max_errors checking, this made coq-lsp stop on the
   number of total diagnostics, instead of only errors (@ejgallego,
   ejgallego/coq-lsp#386)
 - Hover symbol information: hypothesis names must shadow globals of
   the same name (@ejgallego, ejgallego/coq-lsp#391, fixes ejgallego/coq-lsp#388)
 - De-schedule document on didClose, otherwise the scheduler will keep
   trying to resume it if it didn't finish (@ejgallego, ejgallego/coq-lsp#392)
 - Hover symbol information: correctly handle identifiers before '.'
   and containing a quote (') themselves (@ejgallego, ejgallego/coq-lsp#393)
 - Add children entries to the table-of-contents (@ejgallego, ejgallego/coq-lsp#394)
 - Invalidate Coq's imperative cache on error (@ejgallego, @r-muhairi,
   ejgallego/coq-lsp#395)
 - Add status bar button to toggle server run status (@ejgallego,
   @Alizter, ejgallego/coq-lsp#378, closes ejgallego/coq-lsp#209)
 - Support for `COQLIB` and `COQCORELIB` environment variables, added
   `--coqcorelib` command line argument (@ejgallego, ejgallego/coq-lsp#403)
 - Protocol infrastructure for code lenses (@ejgallego, ejgallego/coq-lsp#396)
 - Set binary more for protocol input / output (@ejgallego, ejgallego/coq-lsp#408)
 - Allow to set `ocamlpath` from the command line (@ejgallego, ejgallego/coq-lsp#408)
 - Windows support (@ejgallego, @jim-portegies, ejgallego/coq-lsp#408)
 - Scroll active goal into view (@ejgallego, ejgallego/coq-lsp#410, fixes ejgallego/coq-lsp#381)
 - Server status icon will now react properly to fatal server errors
   (@ejgallego, reported by @Alizter, ejgallego/coq-lsp#411, fixes ejgallego/coq-lsp#399)
 - Info on memory and time is now disabled by default, new option
   `coq-lsp.stats_on_hover_option` to re-enable it (@ejgallego, ejgallego/coq-lsp#412,
   fixes ejgallego/coq-lsp#398).
 - `coq-lsp` can now save `.vo` files for files opened in the
   editor. Use the new "Save to .vo" command, or the new protocol
   `coq/saveVo` request (@ejgallego, ejgallego/coq-lsp#417, fixes ejgallego/coq-lsp#339)
