### PR TITLE
ocluster is not compatible with conduit >= 6.2.0

### DIFF
--- a/packages/ocluster/ocluster.0.1/opam
+++ b/packages/ocluster/ocluster.0.1/opam
@@ -41,6 +41,9 @@ depends: [
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
 ]
+conflicts: [
+  "conduit" {>= "6.2.0"} # conduit-lwt-unix doesn't implicitly pull tls.lwt anymore if lwt is installed
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/ocluster/ocluster.0.2/opam
+++ b/packages/ocluster/ocluster.0.2/opam
@@ -47,6 +47,9 @@ depends: [
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "odoc" {with-doc}
 ]
+conflicts: [
+  "conduit" {>= "6.2.0"} # conduit-lwt-unix doesn't implicitly pull tls.lwt anymore if lwt is installed
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
conduit-lwt-unix doesn't implicitly pull tls.lwt anymore if lwt is installed
See https://github.com/ocaml/opam-repository/pull/23344

**no logs: infinit loops due to a lack of Mirage_crypto_rng_lwt.initialize**