### PR TITLE
aws-s3-lwt.4.4.0 is not compatible with OCaml 5.0 (uses Pervasives)

### DIFF
--- a/packages/aws-s3-lwt/aws-s3-lwt.4.4.0/opam
+++ b/packages/aws-s3-lwt/aws-s3-lwt.4.4.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.05.0"}
+  "ocaml" {>= "4.05.0" & < "5.0.0"}
   "dune"
   "aws-s3" {= "4.4.0" }
   "lwt"


### PR DESCRIPTION
```
#=== ERROR while compiling aws-s3-lwt.4.4.0 ===================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/aws-s3-lwt.4.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p aws-s3-lwt -j 31
# exit-code            1
# env-file             ~/.opam/log/aws-s3-lwt-7-09cec8.env
# output-file          ~/.opam/log/aws-s3-lwt-7-09cec8.out
### output ###
# (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I cli/.aws_cli.objs/byte -I /home/opam/.opam/5.0/lib/angstrom -I /home/opam/.opam/5.0/lib/aws-s3 -I /home/opam/.opam/5.0/lib/base -I /home/opam/.opam/5.0/lib/base/base_internalhash_types -I /home/opam/.opam/5.0/lib/base/caml -I /home/opam/.opam/5.0/lib/base/shadow_stdlib -I /home/opam/.opam/5.0/lib/base64 -I /home/opam/.opam/5.0/lib/bigstringaf -I /home/opam/.opam/5.0/lib/cmdliner -I /home/opam/.opam/5.0/lib/digestif -I /home/opam/.opam/5.0/lib/digestif/c -I /home/opam/.opam/5.0/lib/eqaf -I /home/opam/.opam/5.0/lib/inifiles -I /home/opam/.opam/5.0/lib/jane-street-headers -I /home/opam/.opam/5.0/lib/ocaml-compiler-libs/common -I /home/opam/.opam/5.0/lib/ocaml-compiler-libs/shadow -I /home/opam/.opam/5.0/lib/ocaml/compiler-libs -I /home/opam/.opam/5.0/lib/ocaml/str -I /home/opam/.opam/5.0/lib/ocaml/unix -I /home/opam/.opam/5.0/lib/pcre -I /home/opam/.opam/5.0/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_derivers -I /home/opam/.opam/5.0/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_inline_test/config -I /home/opam/.opam/5.0/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.0/lib/ppx_protocol_conv -I /home/opam/.opam/5.0/lib/ppx_protocol_conv/driver -I /home/opam/.opam/5.0/lib/ppx_protocol_conv/runtime -I /home/opam/.opam/5.0/lib/ppx_protocol_conv_json -I /home/opam/.opam/5.0/lib/ppx_protocol_conv_xml_light -I /home/opam/.opam/5.0/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.0/lib/ppxlib -I /home/opam/.opam/5.0/lib/ppxlib/ast -I /home/opam/.opam/5.0/lib/ppxlib/astlib -I /home/opam/.opam/5.0/lib/ppxlib/print_diff -I /home/opam/.opam/5.0/lib/ppxlib/stdppx -I /home/opam/.opam/5.0/lib/ppxlib/traverse_builtins -I /home/opam/.opam/5.0/lib/ptime -I /home/opam/.opam/5.0/lib/seq -I /home/opam/.opam/5.0/lib/sexplib0 -I /home/opam/.opam/5.0/lib/stdlib-shims -I /home/opam/.opam/5.0/lib/stringext -I /home/opam/.opam/5.0/lib/time_now -I /home/opam/.opam/5.0/lib/uri -I /home/opam/.opam/5.0/lib/xml-light -I /home/opam/.opam/5.0/lib/yojson -no-alias-deps -open Aws_cli -o cli/.aws_cli.objs/byte/aws_cli__Aws.cmo -c -impl cli/aws.ml)
# File "cli/aws.ml", line 47, characters 19-49:
# 47 |         let data = Pervasives.really_input_string ic n in
#                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
```