### PR TITLE
ocsigenserver.3.0.0 is not compatible with OCaml 5.0 (uses String.copy)

### DIFF
--- a/packages/ocsigenserver/ocsigenserver.3.0.0/opam
+++ b/packages/ocsigenserver/ocsigenserver.3.0.0/opam
@@ -38,7 +38,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.08.1"}
+  "ocaml" {>= "4.08.1" & < "5.0.0"}
   "ocamlfind"
   "base-unix"
   "base-threads"


### PR DESCRIPTION
```
#=== ERROR while compiling ocsigenserver.3.0.0 ================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/ocsigenserver-7-9197df.env
# output-file          ~/.opam/log/ocsigenserver-7-9197df.out
### output ###
# make -C src all
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/src'
# cat files/META.in \
#   | sed s/%%CAMLZIPNAME%%// \
#   | sed s/%%NAME%%/ocsigenserver/g \
#   | sed s/%%DEPS%%/lwt_ssl,bytes,lwt.unix,lwt_log,ipaddr,findlib,cryptokit,pcre,str,xml-light,dynlink,cohttp-lwt-unix,hmap/g \
#   | sed s/%%BASEDEPS%%/lwt,ipaddr,bytes/g \
#   > files/META
# echo directory = \"../server\" > files/META.ocsigenserver
# cat files/META.in \
#   | sed s/%%CAMLZIPNAME%%// \
#   | sed s/%%NAME%%/ocsigenserver/g \
#   | sed s/%%DEPS%%/lwt_ssl,bytes,lwt.unix,lwt_log,ipaddr,findlib,cryptokit,pcre,str,xml-light,dynlink,cohttp-lwt-unix,hmap/g \
#   | sed s/%%BASEDEPS%%/lwt,ipaddr,bytes/g \
#   | sed "s%package \"\(polytables\|baselib\)\" (%package \"\1\" (\n  directory = \"../baselib\"%" \
#   | sed "s%package \"\(http\|cookies\)\" (%package \"\1\" (\n  directory = \"../http\"%" \
#   | sed "s%directory = \"extensions\"%directory = \"../extensions\"%" \
#   >> files/META.ocsigenserver
# cat files/ocsigenserver.conf.in \
#   | sed s%_LOGDIR_%/home/opam/.opam/5.0/lib/ocsigenserver/var/log/ocsigenserver%g \
#   | sed s%_DATADIR_%/home/opam/.opam/5.0/lib/ocsigenserver/var/lib/ocsigenserver%g \
#   | sed s%_OCSIGENUSER_%opam%g \
#   | sed s%_OCSIGENGROUP_%"opam"%g \
#   | sed s%_COMMANDPIPE_%/home/opam/.opam/5.0/lib/ocsigenserver/var/run/ocsigenserver_command%g \
#   | sed s%_MIMEFILE_%/home/opam/.opam/5.0/lib/ocsigenserver/etc/ocsigenserver/mime.types%g \
#   | sed s%_METADIR_%/home/opam/.opam/5.0/lib%g \
#   | sed s%_PROJECTNAME_%ocsigenserver%g \
#   | sed s%_LIBDIR_%/home/opam/.opam/5.0/lib%g \
#   | sed s%_EXTDIR_%/home/opam/.opam/5.0/lib/ocsigenserver/extensions%g \
#   | sed s%_CONFIGDIR_%/home/opam/.opam/5.0/lib/ocsigenserver/etc/ocsigenserver%g \
#   | sed s%_STATICPAGESDIR_%/home/opam/.opam/5.0/lib/ocsigenserver/var/www%g \
#   | sed s%_EXTPACKAGENAME_%ocsigenserver.ext%g \
#   > ../ocsigenserver.conf.sample
# mkdir -p ../local/etc ../local/var/log ../local/var/run
# cat files/ocsigenserver.conf.in \
#   | sed s%80\</port\>%8080\</port\>%g \
#   | sed s%_LOGDIR_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/local/var/log%g \
#   | sed s%_DATADIR_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/local/var/lib%g \
#   | sed s%\<user\>_OCSIGENUSER_\</user\>%%g \
#   | sed s%\<group\>_OCSIGENGROUP_\</group\>%%g \
#   | sed s%_COMMANDPIPE_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/local/var/run/ocsigenserver_command%g \
#   | sed s%_MIMEFILE_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/src/files/mime.types%g \
#   | sed s%_METADIR_%/home/opam/.opam/5.0/lib\"/\>\<findlib\ path=\"/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/src/files/\"/\>\<findlib\ path=\"/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/src/extensions/files/%g \
#   | sed s%_PROJECTNAME_%ocsigenserver%g \
#   | sed s%_EXTLIBDIR_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/src/extensions/ocsipersist-dbm%g \
#   | sed s%_CONFIGDIR_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/local/etc%g \
#   | sed s%_STATICPAGESDIR_%/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/local/var/www%g \
#   | sed s%_EXTPACKAGENAME_%ocsigenserver.ext%g \
#   | sed s%\<\!--\ \<commandpipe%\<commandpipe%g \
#   | sed s%\</commandpipe\>\ --\>%\</commandpipe\>%g \
#   | sed s%\<\!--\ \<mimefile%\<mimefile%g \
#   | sed s%\</mimefile\>\ --\>%\</mimefile\>%g \
#   | sed s%store\ dir=\"/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/var/lib\"%store\ dir=\"/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/local/var/lib/ocsipersist\"%g \
#   > ../local/etc/ocsigenserver.conf
# make -C baselib all
# make[2]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/ocsigenserver.3.0.0/src/baselib'
# ocamlfind ocamlc -no-keep-locs -g -bin-annot -thread -package bytes -package lwt.unix -package lwt_log -package cryptokit -package findlib -package pcre -package hmap -package ipaddr -c ocsigen_lib_base.mli
# ocamlfind ocamlc -no-keep-locs -g -bin-annot -thread -package bytes -package lwt.unix -package lwt_log -package cryptokit -package findlib -package pcre -package hmap -package ipaddr -c ocsigen_lib_base.ml
# ocamlfind ocamlc -no-keep-locs -g -bin-annot -thread -package bytes -package lwt.unix -package lwt_log -package cryptokit -package findlib -package pcre -package hmap -package ipaddr -c ocsigen_lib.mli
# ocamlfind ocamlc -no-keep-locs -g -bin-annot -thread -package bytes -package lwt.unix -package lwt_log -package cryptokit -package findlib -package pcre -package hmap -package ipaddr -c ocsigen_lib.ml
# File "ocsigen_lib.ml", line 243, characters 10-21:
# 243 |           String.copy s
#                 ^^^^^^^^^^^
# Error: Unbound value String.copy
```