### PR TITLE
textmate-language: add missing test dependency on markup

### DIFF
--- a/packages/textmate-language/textmate-language.0.3.0/opam
+++ b/packages/textmate-language/textmate-language.0.3.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "oniguruma" {< "0.2.0"}
   "plist-xml" {with-test}
+  "markup" {with-test}
   "alcotest" {>= "1.4" & < "2" & with-test}
   "ezjsonm" {>= "1.2" & < "2" & with-test}
   "yojson" {>= "1.7" & < "2" & with-test}

--- a/packages/textmate-language/textmate-language.0.3.1/opam
+++ b/packages/textmate-language/textmate-language.0.3.1/opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "oniguruma" {< "0.2.0"}
   "plist-xml" {with-test}
+  "markup" {with-test}
   "alcotest" {>= "1.4" & < "2" & with-test}
   "ezjsonm" {>= "1.2" & < "2" & with-test}
   "yojson" {>= "1.7" & < "2" & with-test}

--- a/packages/textmate-language/textmate-language.0.3.2/opam
+++ b/packages/textmate-language/textmate-language.0.3.2/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "oniguruma" {< "0.2.0"}
   "plist-xml" {with-test}
+  "markup" {with-test}
   "alcotest" {>= "1.4" & < "2" & with-test}
   "ezjsonm" {>= "1.2" & < "2" & with-test}
   "yojson" {>= "1.7" & < "2" & with-test}

--- a/packages/textmate-language/textmate-language.0.3.3/opam
+++ b/packages/textmate-language/textmate-language.0.3.3/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "oniguruma" {>= "0.1.2" & < "0.2.0"}
   "plist-xml" {with-test}
+  "markup" {with-test}
   "alcotest" {>= "1.4" & < "2" & with-test}
   "ezjsonm" {>= "1.2" & < "2" & with-test}
   "yojson" {>= "1.7" & < "2" & with-test}


### PR DESCRIPTION
```
#=== ERROR while compiling textmate-language.0.3.0 ============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/textmate-language.0.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p textmate-language -j 47 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/textmate-language-7-439fef.env
# output-file          ~/.opam/log/textmate-language-7-439fef.out
### output ###
# File "test/dune", line 4, characters 29-35:
# 4 |  (libraries alcotest ezjsonm markup plist-xml textmate-language yojson))
#                                  ^^^^^^
# Error: Library "markup" not found.
# -> required by _build/default/test/test.exe
# -> required by alias test/runtest in test/dune:2
```