### PR TITLE
bump conf-pkg-config to 3: remove OpenBSD hack to install a port version

### DIFF
--- a/packages/conf-pkg-config/conf-pkg-config.3/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+authors: ["Francois Berenger"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["pkg-config" "--help"] {os != "openbsd"}
+]
+depexts: [
+  ["pkg-config"] {os-family = "debian"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-distribution = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkgconfig"] {os-distribution = "nixos"}
+  ["pkg-config"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+]
+synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+flags: conf

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.1.1/opam
@@ -10,7 +10,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3" & <= "4.03.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind"
   "ocaml-src"
   "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.1/opam
@@ -11,7 +11,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.05.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind"
   "ocaml-src"
   "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"}

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.2/opam
@@ -11,7 +11,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.06.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind"
   "ocaml-src"
   "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.2.3/opam
@@ -11,7 +11,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3" & < "4.07.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind"
   "ocaml-src"
   "solo5-kernel-ukvm" {< "0.3.0"} | "solo5-kernel-virtio" {< "0.3.0"} |

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.0/opam
@@ -11,7 +11,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.04.2" & < "4.07.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind"
   "ocaml-src"
   "solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} |

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.3.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.3.1/opam
@@ -11,7 +11,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.04.2" & < "4.08.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   "solo5-kernel-ukvm" {>= "0.3.0"} | "solo5-kernel-virtio" {>= "0.3.0"} |

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.0/opam
@@ -11,7 +11,7 @@ install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.04.2" & < "4.08.0"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   "solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen"

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.1/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.1/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" )

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.2/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.4/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.4/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.5/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.5/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.6/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.6/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.4.7/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.4.7/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.5.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.5.0/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.0/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.0/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.2/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.2/opam
@@ -10,7 +10,7 @@ build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: [make "uninstall" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.3/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.3/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.4/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.4/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.5/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.5/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.6/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.6/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")

--- a/packages/ocaml-freestanding/ocaml-freestanding.0.6.7/opam
+++ b/packages/ocaml-freestanding/ocaml-freestanding.0.6.7/opam
@@ -9,7 +9,7 @@ dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
 build: [make]
 install: [make "install" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "ocamlfind" {build}
   "ocaml-src" {build}
   ("solo5-bindings-hvt" | "solo5-bindings-spt" | "solo5-bindings-virtio" | "solo5-bindings-muen" | "solo5-bindings-genode" | "solo5-bindings-xen")

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.4.1/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.4.1/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "genode"]
 install: [make "opam-genode-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-genode-uninstall" "PREFIX=%{prefix}%"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config"  {< "3"}
 conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-muen"

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.2/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.2/opam
@@ -16,7 +16,7 @@ remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]
 ]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 conflicts: [
   "solo5-bindings-hvt"
   "solo5-bindings-spt"

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.3/opam
@@ -17,7 +17,7 @@ remove: [
   [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.4/opam
+++ b/packages/solo5-bindings-genode/solo5-bindings-genode.0.6.4/opam
@@ -17,7 +17,7 @@ remove: [
   [make "V=1" "uninstall-opam-genode" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.0/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "hvt"]
 install: [make "opam-hvt-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.4.1/opam
@@ -12,7 +12,7 @@ dev-repo: "git+https://github.com/solo5/solo5.git"
 build: [make "hvt"]
 install: [make "opam-hvt-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-hvt-uninstall" "PREFIX=%{prefix}%"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.2/opam
@@ -18,7 +18,7 @@ remove: [
   ["touch" "./Makeconf"]
   [make "V=1" "uninstall-opam-hvt" "PREFIX=%{prefix}%"]
 ]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 x-ci-accept-failures: ["debian-unstable"]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.3/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.4/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.5/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-hvt" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.6/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.6/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-hvt" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.7/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-hvt" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.8/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-hvt" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [

--- a/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
+++ b/packages/solo5-bindings-hvt/solo5-bindings-hvt.0.6.9/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-hvt" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 depexts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.0/opam
@@ -13,7 +13,7 @@ build: [make "muen"]
 install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.1/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.4.1/opam
@@ -13,7 +13,7 @@ build: [make "muen"]
 install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.2/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.2/opam
@@ -19,7 +19,7 @@ remove: [
   [make "V=1" "uninstall-opam-muen" "PREFIX=%{prefix}%"]
 ]
 x-ci-accept-failures: ["debian-unstable"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.3/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.4/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.4/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.5/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "install-opam-muen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.6/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.6/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-muen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.7/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-muen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.8/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-muen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.9/opam
+++ b/packages/solo5-bindings-muen/solo5-bindings-muen.0.6.9/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-muen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.0/opam
@@ -13,7 +13,7 @@ build: [make "virtio"]
 install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.1/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.4.1/opam
@@ -13,7 +13,7 @@ build: [make "virtio"]
 install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-genode"

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.2/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.2/opam
@@ -19,7 +19,7 @@ remove: [
   [make "V=1" "uninstall-opam-virtio" "PREFIX=%{prefix}%"]
 ]
 x-ci-accept-failures: ["debian-unstable"]
-depends: "conf-pkg-config"
+depends: "conf-pkg-config" {< "3"}
 flags: avoid-version # ./configure.sh is broken for gcc>=10
 conflicts: [
   "solo5-bindings-hvt"

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.3/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.4/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.4/opam
@@ -20,7 +20,7 @@ remove: [
 ]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 flags: avoid-version # ./configure.sh is broken for gcc>=10

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.5/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-virtio" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.6/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.6/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-virtio" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.7/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-virtio" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.8/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-virtio" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.9/opam
+++ b/packages/solo5-bindings-virtio/solo5-bindings-virtio.0.6.9/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_MUEN=" "CONFIG_GENODE=" "CONFIG_XEN=" "install-opam-virtio" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.6/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.6/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-xen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.7/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.7/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-xen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.8/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.8/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-xen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.9/opam
+++ b/packages/solo5-bindings-xen/solo5-bindings-xen.0.6.9/opam
@@ -15,7 +15,7 @@ build: [
 ]
 install: [make "V=1" "CONFIG_HVT=" "CONFIG_SPT=" "CONFIG_VIRTIO=" "CONFIG_MUEN=" "CONFIG_GENODE=" "install-opam-xen" "PREFIX=%{prefix}%"]
 depends: [
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
   "conf-libseccomp" {build & os = "linux"}
 ]
 conflicts: [

--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/opam
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.0/opam
@@ -14,7 +14,7 @@ install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: [
   "solo5-kernel-ukvm"

--- a/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.1/opam
+++ b/packages/solo5-kernel-muen/solo5-kernel-muen.0.3.1/opam
@@ -14,7 +14,7 @@ install: [make "opam-muen-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-muen-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: [
   "solo5-kernel-ukvm"

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.0/opam
@@ -14,7 +14,7 @@ install: [make "opam-ukvm-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-ukvm-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
+++ b/packages/solo5-kernel-ukvm/solo5-kernel-ukvm.0.3.1/opam
@@ -15,7 +15,7 @@ remove: [make "opam-ukvm-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.1.1/opam
@@ -14,7 +14,7 @@ install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: "solo5-kernel-ukvm"
 x-ci-accept-failures: ["debian-unstable"]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.1/opam
@@ -14,7 +14,7 @@ install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: "solo5-kernel-ukvm"
 x-ci-accept-failures: ["debian-unstable"]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2-1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2-1/opam
@@ -14,7 +14,7 @@ install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: "solo5-kernel-ukvm"
 available: (arch = "x86_64" | arch = "x86_64") & os != "macos"

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.2.2/opam
@@ -14,7 +14,7 @@ install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: "solo5-kernel-ukvm"
 x-ci-accept-failures: ["debian-unstable"]

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.0/opam
@@ -14,7 +14,7 @@ install: [make "opam-virtio-install" "PREFIX=%{prefix}%"]
 remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: [
   "solo5-kernel-ukvm"

--- a/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.1/opam
+++ b/packages/solo5-kernel-virtio/solo5-kernel-virtio.0.3.1/opam
@@ -15,7 +15,7 @@ remove: [make "opam-virtio-uninstall" "PREFIX=%{prefix}%"]
 x-ci-accept-failures: ["debian-unstable"]
 depends: [
   "ocaml" {>= "4.02.3"}
-  "conf-pkg-config"
+  "conf-pkg-config" {< "3"}
 ]
 conflicts: [
   "solo5-kernel-ukvm"

--- a/packages/zarith-freestanding/zarith-freestanding.1.10/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.10/opam
@@ -12,7 +12,7 @@ depends: [
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.10"}
   "ocamlfind" {build}
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {build & < "3"}
 ]
 patches: [ "no-dynlink.patch" ]
 synopsis:

--- a/packages/zarith-freestanding/zarith-freestanding.1.11/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.11/opam
@@ -12,7 +12,7 @@ depends: [
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.11"}
   "ocamlfind" {build}
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {build & < "3"}
 ]
 patches: [ "no-dynlink.patch" ]
 synopsis:

--- a/packages/zarith-freestanding/zarith-freestanding.1.12/opam
+++ b/packages/zarith-freestanding/zarith-freestanding.1.12/opam
@@ -12,7 +12,7 @@ depends: [
   "gmp-freestanding" {>= "6.1.2-2"}
   "zarith" {= "1.12"}
   "ocamlfind" {build}
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {build & < "3"}
 ]
 patches: [ "no-dynlink.patch" ]
 synopsis:


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/pull/20343 and https://github.com/mirage/mirage/issues/1262 for the background story:

Mirage 3.x used for "cross-compilation" a pkg-config universe (for opam packages that contained C libraries). Now, on OpenBSD the system pkg-config was not powerful enough, and we needed the pkgconfig from ports, and pkg-config < 3 installed a symbolic link to have the pkg-config binary linked to ports/pkgconfig (which install a binary called pkgconf) in PATH.

Since MirageOS 4 is out of the door since ~1 year, we can finally remove this hack and to enable forensics / archaeology we put upper bounds to conf-pkg-config on the relevant packages.

//cc @madroach who reported #20343 -- and of course everyone is welcome to provide feedback and test on OpenBSD machines.