### PR TITLE
conex 0.9.2 is not compatible with ocaml5 (uses Pervasives)

### DIFF
--- a/packages/conex/conex.0.9.2/opam
+++ b/packages/conex/conex.0.9.2/opam
@@ -23,7 +23,7 @@ build: [
   ["ocaml" "pkg/pkg.ml" "test"] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}


### PR DESCRIPTION
observed in #23397

```
#=== ERROR while compiling conex.0.9.2 ========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/conex.0.9.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --pinned false --tests false --with-format false
# exit-code            1
# env-file             ~/.opam/log/conex-7-5e8a41.env
# output-file          ~/.opam/log/conex-7-5e8a41.out
### output ###
# ocamlfind ocamldep -modules src/conex.ml > src/conex.ml.depends
# ocamlfind ocamldep -modules src/conex.mli > src/conex.mli.depends
# ocamlfind ocamldep -modules src/conex_crypto.mli > src/conex_crypto.mli.depends
# ocamlfind ocamldep -modules src/conex_resource.mli > src/conex_resource.mli.depends
# ocamlfind ocamldep -modules src/conex_utils.mli > src/conex_utils.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_utils.cmi src/conex_utils.mli
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_resource.cmi src/conex_resource.mli
# ocamlfind ocamldep -modules src/conex_io.mli > src/conex_io.mli.depends
# ocamlfind ocamldep -modules src/conex_repository.mli > src/conex_repository.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_crypto.cmi src/conex_crypto.mli
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_io.cmi src/conex_io.mli
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_repository.cmi src/conex_repository.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_crypto.cmi src/conex_crypto.mli
# File "src/conex_crypto.mli", line 53, characters 20-21:
# 53 | module Make_verify (C : VERIFY_BACK) : VERIFY
#                          ^
# Warning 67 [unused-functor-parameter]: unused functor parameter C.
# File "src/conex_crypto.mli", line 95, characters 18-19:
# 95 | module Make_sign (C : SIGN_BACK) : SIGN
#                        ^
# Warning 67 [unused-functor-parameter]: unused functor parameter C.
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex.cmi src/conex.mli
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex.cmi src/conex.mli
# File "src/conex.mli", line 23, characters 13-14:
# 23 | module Make (L : LOGS) (C : VERIFY): sig
#                   ^
# Warning 67 [unused-functor-parameter]: unused functor parameter L.
# File "src/conex.mli", line 23, characters 24-25:
# 23 | module Make (L : LOGS) (C : VERIFY): sig
#                              ^
# Warning 67 [unused-functor-parameter]: unused functor parameter C.
# ocamlfind ocamldep -modules src/conex_crypto.ml > src/conex_crypto.ml.depends
# ocamlfind ocamldep -modules src/conex_resource.ml > src/conex_resource.ml.depends
# ocamlfind ocamldep -modules src/conex_utils.ml > src/conex_utils.ml.depends
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_utils.cmx src/conex_utils.ml
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_resource.cmx src/conex_resource.ml
# ocamlfind ocamldep -modules src/conex_diff.ml > src/conex_diff.ml.depends
# ocamlfind ocamldep -modules src/conex_diff.mli > src/conex_diff.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff.cmi src/conex_diff.mli
# ocamlfind ocamldep -modules src/conex_opam_repository_layout.ml > src/conex_opam_repository_layout.ml.depends
# ocamlfind ocamldep -modules src/conex_opam_repository_layout.mli > src/conex_opam_repository_layout.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_repository_layout.cmi src/conex_opam_repository_layout.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_repository_layout.cmx src/conex_opam_repository_layout.ml
# ocamlfind ocamldep -modules src/conex_diff_provider.ml > src/conex_diff_provider.ml.depends
# ocamlfind ocamldep -modules src/conex_diff_provider.mli > src/conex_diff_provider.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff_provider.cmi src/conex_diff_provider.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff.cmx src/conex_diff.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff.cmx src/conex_diff.ml
# File "src/conex_diff.ml", line 6, characters 2-22:
# 6 |   mine : string list ;
#       ^^^^^^^^^^^^^^^^^^^^
# Warning 69 [unused-field]: record field mine is never read.
# (However, this field is used to build or mutate values.)
# File "src/conex_diff.ml", line 7, characters 2-21:
# 7 |   their_start : int ;
#       ^^^^^^^^^^^^^^^^^^^
# Warning 69 [unused-field]: record field their_start is never read.
# (However, this field is used to build or mutate values.)
# File "src/conex_diff.ml", line 8, characters 2-19:
# 8 |   their_len : int ;
#       ^^^^^^^^^^^^^^^^^
# Warning 69 [unused-field]: record field their_len is never read.
# (However, this field is used to build or mutate values.)
# ocamlfind ocamldep -modules src/conex_io.ml > src/conex_io.ml.depends
# ocamlfind ocamldep -package opam-file-format -modules src/conex_opam_encoding.ml > src/conex_opam_encoding.ml.depends
# ocamlfind ocamldep -package opam-file-format -modules src/conex_opam_encoding.mli > src/conex_opam_encoding.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package opam-file-format -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_encoding.cmi src/conex_opam_encoding.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package opam-file-format -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_encoding.cmx src/conex_opam_encoding.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package opam-file-format -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_encoding.cmx src/conex_opam_encoding.ml
# File "src/conex_opam_encoding.ml", line 27, characters 2-29:
# 27 |   OpamPrinter.format_opamfile Format.str_formatter file ;
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: OpamPrinter.format_opamfile
# Use OpamPrinter.FullPos.format_opamfile instead.
# File "src/conex_opam_encoding.ml", line 67, characters 11-28:
# 67 |   (try Ok (OpamParser.string data "noname") with
#                 ^^^^^^^^^^^^^^^^^
# Alert deprecated: OpamParser.string
# Use OpamParser.FullPos.string instead.
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_io.cmx src/conex_io.ml
# ocamlfind ocamldep -modules src/conex_repository.ml > src/conex_repository.ml.depends
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_crypto.cmx src/conex_crypto.ml
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff_provider.cmx src/conex_diff_provider.ml
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_repository.cmx src/conex_repository.ml
# ocamlfind ocamldep -modules src/conex_unix_persistency.ml > src/conex_unix_persistency.ml.depends
# ocamlfind ocamldep -modules src/conex_unix_persistency.mli > src/conex_unix_persistency.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_persistency.cmi src/conex_unix_persistency.mli
# ocamlfind ocamldep -modules src/conex_unix_provider.ml > src/conex_unix_provider.ml.depends
# ocamlfind ocamldep -modules src/conex_unix_provider.mli > src/conex_unix_provider.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_provider.cmi src/conex_unix_provider.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_persistency.cmx src/conex_unix_persistency.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_persistency.cmx src/conex_unix_persistency.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# ocamlfind ocamldep -modules src/conex_unix_private_key.ml > src/conex_unix_private_key.ml.depends
# ocamlfind ocamldep -modules src/conex_unix_private_key.mli > src/conex_unix_private_key.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_private_key.cmi src/conex_unix_private_key.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex.cmx src/conex.ml
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_provider.cmx src/conex_unix_provider.ml
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_private_key.cmx src/conex_unix_private_key.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_private_key.cmx src/conex_unix_private_key.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# ocamlfind ocamlopt -a -I src src/conex_utils.cmx src/conex_resource.cmx src/conex_crypto.cmx src/conex_opam_repository_layout.cmx src/conex_diff.cmx src/conex_opam_encoding.cmx src/conex_io.cmx src/conex_diff_provider.cmx src/conex_repository.cmx src/conex.cmx src/conex_unix_persistency.cmx src/conex_unix_provider.cmx src/conex_unix_private_key.cmx -o src/conex.cmxa
# ocamlfind ocamlopt -shared -linkall -I src src/conex.cmxa -o src/conex.cmxs
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex.cmo src/conex.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_utils.cmo src/conex_utils.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_resource.cmo src/conex_resource.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_repository_layout.cmo src/conex_opam_repository_layout.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff.cmo src/conex_diff.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_crypto.cmo src/conex_crypto.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff.cmo src/conex_diff.ml
# File "src/conex_diff.ml", line 6, characters 2-22:
# 6 |   mine : string list ;
#       ^^^^^^^^^^^^^^^^^^^^
# Warning 69 [unused-field]: record field mine is never read.
# (However, this field is used to build or mutate values.)
# File "src/conex_diff.ml", line 7, characters 2-21:
# 7 |   their_start : int ;
#       ^^^^^^^^^^^^^^^^^^^
# Warning 69 [unused-field]: record field their_start is never read.
# (However, this field is used to build or mutate values.)
# File "src/conex_diff.ml", line 8, characters 2-19:
# 8 |   their_len : int ;
#       ^^^^^^^^^^^^^^^^^
# Warning 69 [unused-field]: record field their_len is never read.
# (However, this field is used to build or mutate values.)
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package opam-file-format -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_encoding.cmo src/conex_opam_encoding.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_repository.cmo src/conex_repository.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_persistency.cmo src/conex_unix_persistency.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package opam-file-format -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_opam_encoding.cmo src/conex_opam_encoding.ml
# File "src/conex_opam_encoding.ml", line 27, characters 2-29:
# 27 |   OpamPrinter.format_opamfile Format.str_formatter file ;
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Alert deprecated: OpamPrinter.format_opamfile
# Use OpamPrinter.FullPos.format_opamfile instead.
# File "src/conex_opam_encoding.ml", line 67, characters 11-28:
# 67 |   (try Ok (OpamParser.string data "noname") with
#                 ^^^^^^^^^^^^^^^^^
# Alert deprecated: OpamParser.string
# Use OpamParser.FullPos.string instead.
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_provider.cmo src/conex_unix_provider.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_persistency.cmo src/conex_unix_persistency.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_private_key.cmo src/conex_unix_private_key.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_diff_provider.cmo src/conex_diff_provider.ml
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_io.cmo src/conex_io.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src -I src/openssl -I src/nocrypto -o src/conex_unix_private_key.cmo src/conex_unix_private_key.ml
# File "_none_", line 1:
# Alert ocaml_deprecated_auto_include: 
# OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
# automatically added to the search path, but you should add -I +unix to the
# command-line to silence this alert (e.g. by adding unix to the list of
# libraries in your dune file, or adding use_unix to your _tags file for
# ocamlbuild, or using -package unix for ocamlfind).
# ocamlfind ocamlc -a -I src src/conex_utils.cmo src/conex_resource.cmo src/conex_crypto.cmo src/conex_opam_repository_layout.cmo src/conex_diff.cmo src/conex_opam_encoding.cmo src/conex_io.cmo src/conex_diff_provider.cmo src/conex_repository.cmo src/conex.cmo src/conex_unix_persistency.cmo src/conex_unix_provider.cmo src/conex_unix_private_key.cmo -o src/conex.cma
# ocamlfind ocamldep -package 'x509 nocrypto cstruct' -modules src/nocrypto/conex_nocrypto.ml > src/nocrypto/conex_nocrypto.ml.depends
# ocamlfind ocamldep -package 'x509 nocrypto cstruct' -modules src/nocrypto/conex_nocrypto.mli > src/nocrypto/conex_nocrypto.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'x509 nocrypto cstruct' -w +A-4-33-44-48-58 -color always -I src/nocrypto -I src -I src/openssl -o src/nocrypto/conex_nocrypto.cmi src/nocrypto/conex_nocrypto.mli
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package 'x509 nocrypto cstruct' -w +A-4-33-44-48-58 -color always -I src/nocrypto -I src -I src/openssl -o src/nocrypto/conex_nocrypto.cmx src/nocrypto/conex_nocrypto.ml
# ocamlfind ocamlopt -a -I src/nocrypto src/nocrypto/conex_nocrypto.cmx -o src/nocrypto/conex-nocrypto.cmxa
# ocamlfind ocamlopt -shared -linkall -I src/nocrypto src/nocrypto/conex-nocrypto.cmxa -o src/nocrypto/conex-nocrypto.cmxs
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'x509 nocrypto cstruct' -w +A-4-33-44-48-58 -color always -I src/nocrypto -I src -I src/openssl -o src/nocrypto/conex_nocrypto.cmo src/nocrypto/conex_nocrypto.ml
# ocamlfind ocamlc -a -I src/nocrypto src/nocrypto/conex_nocrypto.cmo -o src/nocrypto/conex-nocrypto.cma
# ocamlfind ocamldep -package 'cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult' -package 'cmdliner opam-file-format unix' -modules app/conex_author.ml > app/conex_author.ml.depends
# ocamlfind ocamldep -package 'cmdliner opam-file-format unix' -modules app/conex_opts.ml > app/conex_opts.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_opts.cmo app/conex_opts.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_opts.cmo app/conex_opts.ml
# File "app/conex_opts.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult' -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_author.cmo app/conex_author.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult' -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_author.cmo app/conex_author.ml
# File "app/conex_author.ml", line 726, characters 2-11:
# 726 |   Term.info "status" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 735, characters 2-11:
# 735 |   Term.info "verify" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 744, characters 2-11:
# 744 |   Term.info "authorisation" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 753, characters 2-11:
# 753 |   Term.info "release" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 762, characters 2-11:
# 762 |   Term.info "team" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 775, characters 2-11:
# 775 |   Term.info "key" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 784, characters 2-11:
# 784 |   Term.info "reset" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 793, characters 2-11:
# 793 |   Term.info "sign" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 806, characters 2-11:
# 806 |   Term.info "init" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 818, characters 67-82:
# 818 |   Term.(ret Conex_opts.(const help $ setup_log $ dry $ repo $ id $ Term.man_format $ Term.choice_names $ topic)),
#                                                                          ^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.man_format
# Use Arg.man_format instead.
# File "app/conex_author.ml", line 819, characters 2-11:
# 819 |   Term.info "help" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 824, characters 67-82:
# 824 |   Term.(ret Conex_opts.(const help $ setup_log $ dry $ repo $ id $ Term.man_format $ Term.choice_names $ Term.pure None)),
#                                                                          ^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.man_format
# Use Arg.man_format instead.
# File "app/conex_author.ml", line 824, characters 105-114:
# 824 |   Term.(ret Conex_opts.(const help $ setup_log $ dry $ repo $ id $ Term.man_format $ Term.choice_names $ Term.pure None)),
#                                                                                                                ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "app/conex_author.ml", line 825, characters 2-11:
# 825 |   Term.info "conex_author" ~version:"0.9.2" ~sdocs:docs ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 835, characters 8-24:
# 835 |   match Term.eval_choice default_cmd cmds
#               ^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.eval_choice
# Use Cmd.group and one of Cmd.eval* instead.
# File "app/conex_author.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_opts.cmx app/conex_opts.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_opts.cmx app/conex_opts.ml
# File "app/conex_opts.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package 'cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult' -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_author.cmx app/conex_author.ml
# + ocamlfind ocamlopt -c -g -bin-annot -safe-string -principal -package 'cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult' -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_author.cmx app/conex_author.ml
# File "app/conex_author.ml", line 726, characters 2-11:
# 726 |   Term.info "status" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 735, characters 2-11:
# 735 |   Term.info "verify" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 744, characters 2-11:
# 744 |   Term.info "authorisation" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 753, characters 2-11:
# 753 |   Term.info "release" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 762, characters 2-11:
# 762 |   Term.info "team" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 775, characters 2-11:
# 775 |   Term.info "key" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 784, characters 2-11:
# 784 |   Term.info "reset" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 793, characters 2-11:
# 793 |   Term.info "sign" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 806, characters 2-11:
# 806 |   Term.info "init" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 818, characters 67-82:
# 818 |   Term.(ret Conex_opts.(const help $ setup_log $ dry $ repo $ id $ Term.man_format $ Term.choice_names $ topic)),
#                                                                          ^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.man_format
# Use Arg.man_format instead.
# File "app/conex_author.ml", line 819, characters 2-11:
# 819 |   Term.info "help" ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 824, characters 67-82:
# 824 |   Term.(ret Conex_opts.(const help $ setup_log $ dry $ repo $ id $ Term.man_format $ Term.choice_names $ Term.pure None)),
#                                                                          ^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.man_format
# Use Arg.man_format instead.
# File "app/conex_author.ml", line 824, characters 105-114:
# 824 |   Term.(ret Conex_opts.(const help $ setup_log $ dry $ repo $ id $ Term.man_format $ Term.choice_names $ Term.pure None)),
#                                                                                                                ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.pure
# Use Term.const instead.
# File "app/conex_author.ml", line 825, characters 2-11:
# 825 |   Term.info "conex_author" ~version:"0.9.2" ~sdocs:docs ~doc ~man
#         ^^^^^^^^^
# Alert deprecated: Cmdliner.Term.info
# Use Cmd.info instead.
# File "app/conex_author.ml", line 835, characters 8-24:
# 835 |   match Term.eval_choice default_cmd cmds
#               ^^^^^^^^^^^^^^^^
# Alert deprecated: Cmdliner.Term.eval_choice
# Use Cmd.group and one of Cmd.eval* instead.
# File "app/conex_author.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# ocamlfind ocamlopt -linkpkg -g -package 'cstruct nocrypto nocrypto.unix x509 logs fmt.tty logs.fmt logs.cli fmt.cli rresult' -package 'cmdliner opam-file-format unix' -I src -I app -I src/nocrypto src/conex_utils.cmx src/conex_resource.cmx src/conex_opam_repository_layout.cmx app/conex_opts.cmx src/conex_crypto.cmx src/conex_diff.cmx src/conex_opam_encoding.cmx src/conex_io.cmx src/conex_diff_provider.cmx src/conex_repository.cmx src/conex.cmx src/conex_unix_persistency.cmx src/conex_unix_private_key.cmx src/conex_unix_provider.cmx src/nocrypto/conex_nocrypto.cmx app/conex_author.cmx -o app/conex_author.native
# ocamlfind ocamldep -package 'cmdliner opam-file-format unix' -modules app/conex_verify_openssl.ml > app/conex_verify_openssl.ml.depends
# ocamlfind ocamldep -modules src/openssl/conex_openssl.mli > src/openssl/conex_openssl.mli.depends
# ocamlfind ocamldep -package 'cmdliner opam-file-format unix' -modules app/conex_verify.ml > app/conex_verify.ml.depends
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -w +A-4-33-44-48-58 -color always -I src/openssl -I src -I src/nocrypto -o src/openssl/conex_openssl.cmi src/openssl/conex_openssl.mli
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_verify.cmo app/conex_verify.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_verify.cmo app/conex_verify.ml
# File "app/conex_verify.ml", line 1:
# Warning 70 [missing-mli]: Cannot find interface file.
# ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_verify_openssl.cmo app/conex_verify_openssl.ml
# + ocamlfind ocamlc -c -g -bin-annot -safe-string -principal -package 'cmdliner opam-file-format unix' -w +A-4-33-44-48-58 -color always -I app -I src -I src/openssl -I src/nocrypto -o app/conex_verify_openssl.cmo app/conex_verify_openssl.ml
# File "app/conex_verify_openssl.ml", line 76, characters 54-71:
# 76 |   let isatty = try Unix.(isatty (descr_of_out_channel Pervasives.stdout)) with
#                                                            ^^^^^^^^^^^^^^^^^
# Error: Unbound module Pervasives
# Command exited with code 2.
# pkg.ml: [ERROR] cmd ['ocamlbuild' '-use-ocamlfind' '-classic-display' '-j' '4' '-tag' 'debug'
#      '-build-dir' '_build' 'opam' 'pkg/META' 'CHANGES.md' 'LICENSE.md'
#      'README.md' 'src/conex.a' 'src/conex.cmxs' 'src/conex.cmxa'
#      'src/conex.cma' 'src/conex_io.cmx' 'src/conex_io.cmi' 'src/conex_io.mli'
#      'src/conex_diff_provider.cmx' 'src/conex_diff_provider.cmi'
#      'src/conex_diff_provider.mli' 'src/conex_unix_private_key.cmx'
#      'src/conex_unix_private_key.cmi' 'src/conex_unix_private_key.mli'
#      'src/conex_unix_provider.cmx' 'src/conex_unix_provider.cmi'
#      'src/conex_unix_provider.mli' 'src/conex_unix_persistency.cmx'
#      'src/conex_unix_persistency.cmi' 'src/conex_unix_persistency.mli'
#      'src/conex_repository.cmx' 'src/conex_repository.cmi'
#      'src/conex_repository.mli' 'src/conex_opam_encoding.cmx'
#      'src/conex_opam_encoding.cmi' 'src/conex_opam_encoding.mli'
#      'src/conex_crypto.cmx' 'src/conex_crypto.cmi' 'src/conex_crypto.mli'
#      'src/conex_diff.cmx' 'src/conex_diff.cmi' 'src/conex_diff.mli'
#      'src/conex_opam_repository_layout.cmx'
#      'src/conex_opam_repository_layout.cmi'
#      'src/conex_opam_repository_layout.mli' 'src/conex_resource.cmx'
#      'src/conex_resource.cmi' 'src/conex_resource.mli' 'src/conex_utils.cmx'
#      'src/conex_utils.cmi' 'src/conex_utils.mli' 'src/conex.cmx'
#      'src/conex.cmi' 'src/conex.mli' 'src/nocrypto/conex-nocrypto.a'
#      'src/nocrypto/conex-nocrypto.cmxs' 'src/nocrypto/conex-nocrypto.cmxa'
#      'src/nocrypto/conex-nocrypto.cma' 'src/nocrypto/conex_nocrypto.cmx'
#      'src/nocrypto/conex_nocrypto.cmi' 'src/nocrypto/conex_nocrypto.mli'
#      'app/conex_author.native' 'app/conex_verify_openssl.native'
#      'app/conex_verify_nocrypto.native']: exited with 10
```