### PR TITLE
[new release] hdr_histogram (0.0.3)

### DIFF
--- a/packages/hdr_histogram/hdr_histogram.0.0.3/opam
+++ b/packages/hdr_histogram/hdr_histogram.0.0.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to Hdr Histogram"
+description: "OCaml bindings to Hdr Histogram"
+maintainer: ["KC Sivaramakrishnan" "Christiano Haesbaert"]
+authors: ["KC Sivaramakrishnan"]
+license: "MIT"
+tags: ["histogram" "tail latency"]
+homepage: "https://github.com/ocaml-multicore/hdr_histogram_ocaml"
+doc: "https://ocaml-multicore.github.io/hdr_histogram_ocaml"
+bug-reports: "https://github.com/ocaml-multicore/hdr_histogram_ocaml/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.7"}
+  "ctypes" {>= "0.20.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "conf-pkg-config" {build}
+  "conf-cmake" {build}
+  "conf-zlib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+available: [
+  (arch = "x86_64" | arch = "arm64")
+]
+dev-repo: "git+https://github.com/ocaml-multicore/hdr_histogram_ocaml.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/hdr_histogram_ocaml/releases/download/v0.0.3/hdr_histogram-0.0.3.tbz"
+  checksum: [
+    "sha256=2d912c03bb771823dd3b5cc8483b6911e935df8b4bf42b40f76fa65e14e1a415"
+    "sha512=c62bee6d9860ebbb525ccf6a34173cec7bee57ca29772e8844ab866fd24ac3e11868ebab4abe88afbaa6f10cdcded6e6d364ea8bebb39b36b3de332f10b65a55"
+  ]
+}
+x-commit-hash: "761ef0c398d897be3d662f7bff10cb6d5603c951"


### PR DESCRIPTION
OCaml bindings to Hdr Histogram

- Project page: <a href="https://github.com/ocaml-multicore/hdr_histogram_ocaml">https://github.com/ocaml-multicore/hdr_histogram_ocaml</a>
- Documentation: <a href="https://ocaml-multicore.github.io/hdr_histogram_ocaml">https://ocaml-multicore.github.io/hdr_histogram_ocaml</a>

##### CHANGES:

* Add memory_size function (@crackcomm, ocaml-multicore/hdr_histogram_ocaml#1)
* Change memory_size return type to int (@crackcomm, ocaml-multicore/hdr_histogram_ocaml#2)
* Fix build with dune 3.6 (@emillon, ocaml-multicore/hdr_histogram_ocaml#3)
* Remove ctypes include path hack by using ctypes 0.3 / dune 3.7 (@TheLortex, ocaml-multicore/hdr_histogram_ocaml#5)
