### PR TITLE
ulex-camlp5 1.3: point to upstream tarball

### DIFF
--- a/packages/ulex-camlp5/ulex-camlp5.1.3/opam
+++ b/packages/ulex-camlp5/ulex-camlp5.1.3/opam
@@ -20,9 +20,9 @@ depends: [
 ]
 url {
   src:
-    "https://github.com/sacerdot/ulex/archive/refs/tags/v1.3-camlp5.tar.gz"
+    "https://github.com/whitequark/ulex/archive/refs/tags/v1.3.tar.gz"
   checksum: [
-    "md5=32033b89d244886d227801437f4b68fa"
-    "sha512=1087e554cc5e5841d42756904da60180a99a4b1d0c7df519b039bc891b0a9f28d547320b34732cefe5683323a5f6c547025dd925cebca14342f9d985d586fe12"
+    "md5=5c39fbcf082e76acbe94ce7e1f934b97"
+    "sha512=e3c7313dcbdbff40d3bc8e6be014edf71113a34bf29a3464300d1a05d73a9f0b7aef4f42a16d64c0bf2e85090ac381895a3dcc9a20ebc2afe35b4b4847c0e493"
   ]
 }


### PR DESCRIPTION
The content is identical (modulo the fix to the opam file which is included upstream)