### PR TITLE
[new release] capnp-rpc, capnp-rpc-unix, capnp-rpc-net, capnp-rpc-mirage and capnp-rpc-lwt (1.2.3)

### DIFF
--- a/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2.3/opam
+++ b/packages/capnp-rpc-lwt/capnp-rpc-lwt.1.2.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Lwt for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "stdint" {>= "0.6.0"}
+  "lwt" {>= "5.6.1"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "3.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.3/capnp-rpc-1.2.3.tbz"
+  checksum: [
+    "sha256=828002d67b9591d1645266c504e3fabc66b750229244a68b0a846c3c93f73715"
+    "sha512=c29f13ada74f3f8c80aa591f0fad60801ea72aea6aaa5299b2edee08e080061c5ac054392678ed8910962b1348f1e61790ce30febfc391ddb8c5ac01d56f3160"
+  ]
+}
+x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"

--- a/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.3/opam
+++ b/packages/capnp-rpc-mirage/capnp-rpc-mirage.1.2.3/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package provides a version of the Cap'n Proto RPC system for use with MirageOS."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.1.0"}
+  "capnp-rpc-net" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "dns-client-mirage" {>= "7.0.0"}
+  "tls-mirage"
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {>= "1.0.1" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "arp" {>= "3.0.0" & with-test}
+  "asetmap" {with-test}
+  "astring" {with-test}
+  "ethernet" {>= "3.0.0" & with-test}
+  "io-page-unix" {with-test}
+  "mirage-vnetif" {with-test}
+  "mirage-crypto-rng-lwt" {>= "0.11.0" & with-test}
+  "dune" {>= "3.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.3/capnp-rpc-1.2.3.tbz"
+  checksum: [
+    "sha256=828002d67b9591d1645266c504e3fabc66b750229244a68b0a846c3c93f73715"
+    "sha512=c29f13ada74f3f8c80aa591f0fad60801ea72aea6aaa5299b2edee08e080061c5ac054392678ed8910962b1348f1e61790ce30febfc391ddb8c5ac01d56f3160"
+  ]
+}
+x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"

--- a/packages/capnp-rpc-net/capnp-rpc-net.1.2.3/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.1.2.3/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {= version}
+  "capnp-rpc-lwt" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "cstruct" {>= "6.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "tls" {>= "0.13.1"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "0.15.0"}
+  "tls-mirage"
+  "dune" {>= "3.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.3/capnp-rpc-1.2.3.tbz"
+  checksum: [
+    "sha256=828002d67b9591d1645266c504e3fabc66b750229244a68b0a846c3c93f73715"
+    "sha512=c29f13ada74f3f8c80aa591f0fad60801ea72aea6aaa5299b2edee08e080061c5ac054392678ed8910962b1348f1e61790ce30febfc391ddb8c5ac01d56f3160"
+  ]
+}
+x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.3/opam
@@ -28,11 +28,11 @@ depends: [
   "asetmap" {with-test}
 ]
 conflicts: [
-  "jbuilder" {with-test}
+  "jbuilder"
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
 ]
 dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
 url {
@@ -44,4 +44,3 @@ url {
   ]
 }
 x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"
-x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.3/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.1.2.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc-net" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct-lwt"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "extunix"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "3.0"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "alcotest-lwt" { >= "1.6.0" & with-test}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "mdx" {>= "2.2.1" & with-test}
+  "lwt" {>= "5.6.1"}
+  "asetmap" {with-test}
+]
+conflicts: [
+  "jbuilder" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.3/capnp-rpc-1.2.3.tbz"
+  checksum: [
+    "sha256=828002d67b9591d1645266c504e3fabc66b750229244a68b0a846c3c93f73715"
+    "sha512=c29f13ada74f3f8c80aa591f0fad60801ea72aea6aaa5299b2edee08e080061c5ac054392678ed8910962b1348f1e61790ce30febfc391ddb8c5ac01d56f3160"
+  ]
+}
+x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/capnp-rpc/capnp-rpc.1.2.3/opam
+++ b/packages/capnp-rpc/capnp-rpc.1.2.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package contains the core protocol.
+Users will normally want to use `capnp-rpc-lwt` and, in most cases,
+`capnp-rpc-unix` rather than using this one directly."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "stdint"
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "asetmap"
+  "dune" {>= "3.0"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v1.2.3/capnp-rpc-1.2.3.tbz"
+  checksum: [
+    "sha256=828002d67b9591d1645266c504e3fabc66b750229244a68b0a846c3c93f73715"
+    "sha512=c29f13ada74f3f8c80aa591f0fad60801ea72aea6aaa5299b2edee08e080061c5ac054392678ed8910962b1348f1e61790ce30febfc391ddb8c5ac01d56f3160"
+  ]
+}
+x-commit-hash: "86427f68fa9a851fad6317cfda5e8b596add7fe9"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Update to cmdliner 1.1.0 (@MisterDA mirage/capnp-rpc#249).

- Fix tests on Windows, avoid using Unix domain sockets (@talex5 mirage/capnp-rpc#251).

- Fix warning on `Unix.ENOTCONN` under macos (@talex5 mirage/capnp-rpc#252).

- Add `Capnp_rpc_unix.Cap_file.save_uri` (@talex5 mirage/capnp-rpc#253).

- Update README to use MDX (@talex5 mirage/capnp-rpc#254).

- Update tests to Cap'n Proto 0.10.3 (@MisterDA mirage/capnp-rpc#257 mirage/capnp-rpc#260).

- Update to mirage-crypto-rng 0.11 and dns 7.0.0 API changes (@hannesm mirage/capnp-rpc#261).

- Update for opam 2.1+ installations (@frumioj mirage/capnp-rpc#259).

- Install Cap'n Proto binaries in Windows GHA (@MisterDA mirage/capnp-rpc#248).
