### PR TITLE
[new release] checkseum (0.5.0)

### DIFF
--- a/packages/checkseum/checkseum.0.5.0/opam
+++ b/packages/checkseum/checkseum.0.5.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/checkseum"
+bug-reports:  "https://github.com/mirage/checkseum/issues"
+dev-repo:     "git+https://github.com/mirage/checkseum.git"
+doc:          "https://mirage.github.io/checkseum/"
+license:      "MIT"
+synopsis:     "Adler-32, CRC32 and CRC32-C implementation in C and OCaml"
+description: """
+Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C
+in C and OCaml.
+
+This library use the linking trick to choose between the C implementation
+(checkseum.c) or the OCaml implementation (checkseum.ocaml). This library is on
+top of optint to get the best representation of an int32. """
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+install: [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.6.0"}
+  "dune-configurator"
+  "optint"        {>= "0.3.0"}
+  "alcotest"      {with-test}
+  "bos"           {with-test}
+  "astring"       {with-test}
+  "fmt"           {with-test}
+  "fpath"         {with-test}
+  "rresult"       {with-test}
+  "ocamlfind"     {with-test}
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+]
+url {
+  src:
+    "https://github.com/mirage/checkseum/releases/download/v0.5.0/checkseum-0.5.0.tbz"
+  checksum: [
+    "sha256=7b15657499f0958fc7f6d01e03a5ac41e5349fed641005fedd8cb0a776ffde2e"
+    "sha512=d0344e6bf9e3bb48fa20efe186ac30fd383e73a0de0f249c3b18ce1b3e27f85a5e0f9433dd199c2c60ea27c6425c34a01a2b48dbd3d93f36fa6eec79d3f086da"
+  ]
+}
+x-commit-hash: "b68d57c053f08314cc23fc7505f2bb981d360379"


### PR DESCRIPTION
Adler-32, CRC32 and CRC32-C implementation in C and OCaml

- Project page: <a href="https://github.com/mirage/checkseum">https://github.com/mirage/checkseum</a>
- Documentation: <a href="https://mirage.github.io/checkseum/">https://mirage.github.io/checkseum/</a>

##### CHANGES:

- Fixup deprecations from `optint.0.3.0` (@tmcgilchrist, mirage/checkseum#76)
- Fix C stubs on 32-bits machines (@dinosaure, mirage/checkseum#76)
- Delete the old linking trick about MirageOS 3 (@dinosaure, mirage/checkseum#77)
