### PR TITLE
2 packages from cryptosense/ocaml-mock at 1.0.0

### DIFF
--- a/packages/mock-ounit/mock-ounit.1.0.0/opam
+++ b/packages/mock-ounit/mock-ounit.1.0.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
+homepage: "https://github.com/cryptosense/ocaml-mock"
+bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/cryptosense/ocaml-mock.git"
+doc: "https://cryptosense.github.io/ocaml-mock/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune"
+  "mock"
+  "ocaml" {>= "4.07.0"}
+  "ounit2"
+  "ppx_deriving" {with-test}
+]
+synopsis: "OUnit wrapper for OCaml mock"
+url {
+  src:
+    "https://github.com/cryptosense/ocaml-mock/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=67deb0f8161f966bef6a422349dd88ad"
+    "sha512=3cad4d869563f4f187cc388170186825e0259a3f0a2d0c956ba47cb1f22ce08860677d80c04451d0b448745d76fef7f1c87e11ac1130548cb8506d5bc5715cd8"
+  ]
+}

--- a/packages/mock/mock.1.0.0/opam
+++ b/packages/mock/mock.1.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: ["Cryptosense <opensource@cryptosense.com>"]
+authors: ["Cryptosense <opensource@cryptosense.com>"]
+homepage: "https://github.com/cryptosense/ocaml-mock"
+bug-reports: "https://github.com/cryptosense/ocaml-mock/issues"
+license: "BSD-2-Clause"
+dev-repo: "git+https://github.com/cryptosense/ocaml-mock.git"
+doc: "https://cryptosense.github.io/ocaml-mock/doc"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune"
+  "ocaml" {>= "4.07.0"}
+]
+synopsis: "Configurable functions to test impure code"
+description: """
+This package provides "mocks", fake functions that can be configured to return
+values or raise exceptions. It is possible to inspect their arguments after
+their execution. The API is greatly inspired by unittest.mock in Python.
+"""
+url {
+  src:
+    "https://github.com/cryptosense/ocaml-mock/archive/refs/tags/1.0.0.tar.gz"
+  checksum: [
+    "md5=67deb0f8161f966bef6a422349dd88ad"
+    "sha512=3cad4d869563f4f187cc388170186825e0259a3f0a2d0c956ba47cb1f22ce08860677d80c04451d0b448745d76fef7f1c87e11ac1130548cb8506d5bc5715cd8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `mock.1.0.0`: Configurable functions to test impure code
- `mock-ounit.1.0.0`: OUnit wrapper for OCaml mock



---
* Homepage: https://github.com/cryptosense/ocaml-mock
* Source repo: git+https://github.com/cryptosense/ocaml-mock.git
* Bug tracker: https://github.com/cryptosense/ocaml-mock/issues

---
:camel: Pull-request generated by opam-publish v2.2.0