### PR TITLE
mirage 4.3.4: relax dune bound

### DIFF
--- a/packages/mirage/mirage.4.3.4/opam
+++ b/packages/mirage/mirage.4.3.4/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0" & < "3.7.0"}
+  "dune" {>= "2.9.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}


### PR DESCRIPTION
We thought (for Mirage CI and chamelon-based unikernels) this to be a great idea, but unfortunately our mirage-www website unikernel fails (due to opam-monorepo deciding to use dune 3.7.0 and then selecting mirage 4.3.3).

The whole story is https://github.com/mirage/mirage-www/pull/795#issuecomment-1443564307 combined with https://github.com/mirage/mirage/pull/1401#issuecomment-1440762994

For the medium term, we already have another solution in mind.