### PR TITLE
[new release] alcotest, alcotest-mirage, alcotest-lwt, alcotest-js and alcotest-async (1.7.0)

### DIFF
--- a/packages/alcotest-async/alcotest-async.1.7.0/opam
+++ b/packages/alcotest-async/alcotest-async.1.7.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Async-based helpers for Alcotest"
+description: "Async-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "fmt" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "base"
+  "async_kernel"
+  "ocaml" {>= "4.11.0"}
+  "alcotest" {= version}
+  "async" {>= "v0.15.0"}
+  "async_unix" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz"
+  checksum: [
+    "sha256=812bacdb34b45e88995e07d7306bdab2f72479ef1996637f1d5d1f41667902df"
+    "sha512=4ae1ba318949ec9db8b87bc8072632a02f0e4003a95ab21e474f5c34c3b5bde867b0194a2d0ea7d9fc4580c70a30ca39287d33a8c134acc7611902f79c7b7ce8"
+  ]
+}
+x-commit-hash: "927088ffadce153306a36cef4d0fed52609208f6"

--- a/packages/alcotest-js/alcotest-js.1.7.0/opam
+++ b/packages/alcotest-js/alcotest-js.1.7.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+description:
+  "Virtual package containing optional JavaScript dependencies for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "alcotest" {= version}
+  "js_of_ocaml-compiler" {>= "3.11.0"}
+  "fmt" {with-test & >= "0.8.7"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz"
+  checksum: [
+    "sha256=812bacdb34b45e88995e07d7306bdab2f72479ef1996637f1d5d1f41667902df"
+    "sha512=4ae1ba318949ec9db8b87bc8072632a02f0e4003a95ab21e474f5c34c3b5bde867b0194a2d0ea7d9fc4580c70a30ca39287d33a8c134acc7611902f79c7b7ce8"
+  ]
+}
+x-commit-hash: "927088ffadce153306a36cef4d0fed52609208f6"

--- a/packages/alcotest-lwt/alcotest-lwt.1.7.0/opam
+++ b/packages/alcotest-lwt/alcotest-lwt.1.7.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Lwt-based helpers for Alcotest"
+description: "Lwt-based helpers for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt"
+  "ocaml" {>= "4.05.0"}
+  "alcotest" {= version}
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz"
+  checksum: [
+    "sha256=812bacdb34b45e88995e07d7306bdab2f72479ef1996637f1d5d1f41667902df"
+    "sha512=4ae1ba318949ec9db8b87bc8072632a02f0e4003a95ab21e474f5c34c3b5bde867b0194a2d0ea7d9fc4580c70a30ca39287d33a8c134acc7611902f79c7b7ce8"
+  ]
+}
+x-commit-hash: "927088ffadce153306a36cef4d0fed52609208f6"

--- a/packages/alcotest-mirage/alcotest-mirage.1.7.0/opam
+++ b/packages/alcotest-mirage/alcotest-mirage.1.7.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Mirage implementation for Alcotest"
+description: "Mirage implementation for Alcotest"
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "re" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt"
+  "ocaml" {>= "4.05.0"}
+  "alcotest" {= version}
+  "mirage-clock" {>= "2.0.0"}
+  "duration"
+  "lwt"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz"
+  checksum: [
+    "sha256=812bacdb34b45e88995e07d7306bdab2f72479ef1996637f1d5d1f41667902df"
+    "sha512=4ae1ba318949ec9db8b87bc8072632a02f0e4003a95ab21e474f5c34c3b5bde867b0194a2d0ea7d9fc4580c70a30ca39287d33a8c134acc7611902f79c7b7ce8"
+  ]
+}
+x-commit-hash: "927088ffadce153306a36cef4d0fed52609208f6"

--- a/packages/alcotest/alcotest.1.7.0/opam
+++ b/packages/alcotest/alcotest.1.7.0/opam
@@ -42,7 +42,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/alcotest/alcotest.1.7.0/opam
+++ b/packages/alcotest/alcotest.1.7.0/opam
@@ -42,7 +42,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}
+    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"
+                          & arch != "s390x" & arch != "ppc64"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/alcotest/alcotest.1.7.0/opam
+++ b/packages/alcotest/alcotest.1.7.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run.
+"""
+maintainer: ["thomas@gazagnaire.org"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.05.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "stdlib-shims"
+  "uutf" {>= "1.0.1"}
+  "ocaml-syntax-shims"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.7.0/alcotest-1.7.0.tbz"
+  checksum: [
+    "sha256=812bacdb34b45e88995e07d7306bdab2f72479ef1996637f1d5d1f41667902df"
+    "sha512=4ae1ba318949ec9db8b87bc8072632a02f0e4003a95ab21e474f5c34c3b5bde867b0194a2d0ea7d9fc4580c70a30ca39287d33a8c134acc7611902f79c7b7ce8"
+  ]
+}
+x-commit-hash: "927088ffadce153306a36cef4d0fed52609208f6"


### PR DESCRIPTION
Alcotest is a lightweight and colourful test framework

- Project page: <a href="https://github.com/mirage/alcotest">https://github.com/mirage/alcotest</a>
- Documentation: <a href="https://mirage.github.io/alcotest">https://mirage.github.io/alcotest</a>

##### CHANGES:

- compile with MSVC (mirage/alcotest#369, @jonahbeckfordm review by @TheLortex
  and @MisterDA)

- Allow skipping a test case from inside the test case (mirage/alcotest#368, @apeschar)

- Fix compilation on bytecode architectures (mirage/alcotest#335, @glondu)

- Get `alcotest_stubs.c` to compile with MSVC (mirage/alcotest#369, @jonahbeckford)

- Try automatically reporting the location of calls to Alcotest.check.
  (mirage/alcotest#366, @MisterDA, review by @TheLortex)

- Detect that Alcotest is running in CI and change output accordingly.
  (mirage/alcotest#364, @MisterDA)

- Upgrade to `dune >= 3.0`. (mirage/alcotest#360, @MisterDA)
