### PR TITLE
[new release] dtoa (0.3.3)

### DIFF
--- a/packages/dtoa/dtoa.0.3.3/opam
+++ b/packages/dtoa/dtoa.0.3.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Converts OCaml floats into strings, using the efficient Grisu3 algorithm"
+maintainer: "Marshall Roch <mroch@meta.com>"
+authors: "Marshall Roch <mroch@meta.com>"
+license: "MIT"
+homepage: "https://github.com/flow/ocaml-dtoa"
+doc: "https://github.com/flow/ocaml-dtoa"
+bug-reports: "https://github.com/flow/ocaml-dtoa/issues"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "dune" {>= "2.0"}
+  "ounit2" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/flow/ocaml-dtoa.git"
+description: """
+This is a (partial) port of Google's double-conversion library from C++ to C.
+"""
+url {
+  src:
+    "https://github.com/flow/ocaml-dtoa/releases/download/v0.3.3/dtoa-0.3.3.tbz"
+  checksum: [
+    "sha256=d8f4608c9e92b29e25ea31f3bf5fccab396899094990a2d59d15c6e8a3c9ee3e"
+    "sha512=58dace1eccd9b55e4e3450c1c6767646ae9551169848b127283b7332cf25c0e0bdd7c8fdf987d55b71e10f82915e59c5439c3ae391696589b490c9184a3dd87c"
+  ]
+}
+x-commit-hash: "fcc14e3d3e5618767683e399438a01a2b05d7fc9"


### PR DESCRIPTION
Converts OCaml floats into strings, using the efficient Grisu3 algorithm

- Project page: <a href="https://github.com/flow/ocaml-dtoa">https://github.com/flow/ocaml-dtoa</a>
- Documentation: <a href="https://github.com/flow/ocaml-dtoa">https://github.com/flow/ocaml-dtoa</a>

##### CHANGES:

- Fixed `assert` on very long outputs (thanks @nevor!)
- Support MSVC (thanks @nojb!)
- Fixed tests under ocaml 5
