### PR TITLE
mlmpfr: make 4.1.1 version compatible with 4.2.0

### DIFF
--- a/packages/mlmpfr/mlmpfr.4.1.1/files/mlmpfr_compatibility_test.c
+++ b/packages/mlmpfr/mlmpfr.4.1.1/files/mlmpfr_compatibility_test.c
@@ -12,5 +12,9 @@ int main(int argc, char **argv)
   if(strcmp(subversion, "4.1.1") == 0)
     return 0;
 
+  // Version 4.1.1 is also compatible with 4.2.0
+  if(strcmp(subversion, "4.2.0") == 0)
+    return 0;
+
   return 1;
 }

--- a/packages/mlmpfr/mlmpfr.4.1.1/opam
+++ b/packages/mlmpfr/mlmpfr.4.1.1/opam
@@ -31,4 +31,4 @@ The package provides bindings for MPFR-4.1.1.
 You need to have MPFR-4.1.1 installed on your system. See opam info mlmpfr for
 all available versions."""
 extra-files: ["mlmpfr_compatibility_test.c"
-              "md5=e0072684415485936f3eb158a86fe38c"]
+              "md5=672af9ba23d8bea8a9d65081c3b64dc1"]


### PR DESCRIPTION
The new 4.2.0 version of the C mpfr library is compatible with the previous 4.1.1 one, so, make the latter compatible with it in order to allow users to install the mlmpfr package on up to date systems.

thvnx/mlmpfr#28