### PR TITLE
[new release] iomux (0.2)

### DIFF
--- a/packages/iomux/iomux.0.2/opam
+++ b/packages/iomux/iomux.0.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "IO Multiplexer bindings"
+description:
+  "Low level bindings for Unix IO Multiplexers (poll/ppoll/kevent/epoll)"
+maintainer: ["Christiano Haesbaert"]
+authors: ["Christiano Haesbaert"]
+license: "ISC"
+tags: ["io" "multiplexing" "poll" "ppoll" "epoll" "kevent" "kqueue"]
+homepage: "https://github.com/haesbaert/ocaml-iomux"
+doc: "https://haesbaert.github.io/ocaml-iomux"
+bug-reports: "https://github.com/haesbaert/ocaml-iomux/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.6"}
+  "dune-configurator"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/haesbaert/ocaml-iomux.git"
+url {
+  src:
+    "https://github.com/haesbaert/ocaml-iomux/releases/download/v0.2/iomux-0.2.tbz"
+  checksum: [
+    "sha256=d2ada31f9bad4902e57a4213170ab7d4b123ccac6bdfb59224d31eec127d6181"
+    "sha512=0e0e8ba50b3c40f0e3f93b111d17dcf3f564d3c5bfd5fb90e0e4e395f229db65705fa1b6914660b65e65ec5d431590253805598e442ac2a329eecb811c97afef"
+  ]
+}
+x-commit-hash: "3d0dbb5b6f63afbd6f721d03fc213d68ba27833a"


### PR DESCRIPTION
IO Multiplexer bindings

- Project page: <a href="https://github.com/haesbaert/ocaml-iomux">https://github.com/haesbaert/ocaml-iomux</a>
- Documentation: <a href="https://haesbaert.github.io/ocaml-iomux">https://haesbaert.github.io/ocaml-iomux</a>

##### CHANGES:

* Narrowed the type of Util.fd_of_unix (@reynir)
* Use older school uerror instead of caml_uerror (@reynir)
* Added c_standard to dune build flags (@reynir)
* Addded ppoll(2) discoverability and a mini compat layer (@haesbaert)
* Improved tests (@haesbaert)
* Re-added macos support (@haesbaert)
