### PR TITLE
[new release] embedded_ocaml_templates (0.8)

### DIFF
--- a/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.8/opam
+++ b/packages/embedded_ocaml_templates/embedded_ocaml_templates.0.8/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "EML is a simple templating language that lets you generate text with plain OCaml"
+description:
+  "EML is a simple templating language that lets you generate text with plain OCaml"
+maintainer: ["Emile Trotignon <emile.trotignon@gmail.com>"]
+authors: ["Emile Trotignon <emile.trotignon@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/EmileTrotignon/embedded_ocaml_templates"
+bug-reports:
+  "https://github.com/EmileTrotignon/embedded_ocaml_templates/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.08.0"}
+  "sedlex" {>= "2.0"}
+  "uutf"
+  "pprint"
+  "ppxlib" {>= "0.18.0"}
+  "containers"
+  "ppx_inline_test"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/EmileTrotignon/embedded_ocaml_templates.git"
+url {
+  src:
+    "https://github.com/EmileTrotignon/embedded_ocaml_templates/releases/download/0.8/embedded_ocaml_templates-0.8.tbz"
+  checksum: [
+    "sha256=c2ff640ab8123e5403f2b6ee480a07603ed2f1a8a97432f40d9ddec38d315321"
+    "sha512=9159e0f62f0aa1d7fb566c1b057f73ce5aba7c749af3af03ecf9c23591256d19dd664deb11c067a2514cafa2fe483125d95a65c2b2342a84d78447c6205a72c3"
+  ]
+}
+x-commit-hash: "bcc76290d002ae1f5a6393ba21a763df23bb4ef4"


### PR DESCRIPTION
EML is a simple templating language that lets you generate text with plain OCaml

- Project page: <a href="https://github.com/EmileTrotignon/embedded_ocaml_templates">https://github.com/EmileTrotignon/embedded_ocaml_templates</a>

##### CHANGES:

Bugfixes
- Locations of errors in the ppx are now reported correctly.
