### PR TITLE
opam-file-format < 2.1.5 is not compatible with OCaml 5.0

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.0.0/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0/opam
@@ -13,7 +13,9 @@ build: [
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.0.0.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.0.0~beta/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0~beta/opam
@@ -13,7 +13,9 @@ build: [
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.0.0-beta.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.0.0~beta3/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0~beta3/opam
@@ -13,7 +13,9 @@ build: [
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.0.0-beta3.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.0.0~beta5/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0~beta5/opam
@@ -13,7 +13,9 @@ build: [
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.0.0-beta5.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.0.0~rc2/opam
+++ b/packages/opam-file-format/opam-file-format.2.0.0~rc2/opam
@@ -13,7 +13,9 @@ build: [
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.0.0-rc2.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.0~alpha5/opam
+++ b/packages/opam-file-format/opam-file-format.2.0~alpha5/opam
@@ -13,7 +13,9 @@ build: [
 install: [make "install" "PREFIX=%{prefix}%"]
 remove: ["rm" "-rf" "%{opam-file-format:lib}%"]
 synopsis: "Parser and printer for the opam file syntax"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 flags: light-uninstall
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.0-alpha5.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.1.0/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.0/opam
@@ -6,9 +6,8 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml" {< "5.0.0"}
+  ("ocaml" {< "5.0.0"} | "dune")
 ]
-depopts: ["dune"]
 build: [
   [make "byte" {!ocaml-native} "all" {ocaml-native}] {!dune:installed}
   ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]

--- a/packages/opam-file-format/opam-file-format.2.1.0/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.0/opam
@@ -5,7 +5,9 @@ authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
-depends: ["ocaml"]
+depends: [
+  "ocaml" {< "5.0.0"}
+]
 depopts: ["dune"]
 build: [
   [make "byte" {!ocaml-native} "all" {ocaml-native}] {!dune:installed}

--- a/packages/opam-file-format/opam-file-format.2.1.1/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.1/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml" {< "5.0.0"}
+  "ocaml"
   "dune" {>= "2.0"}
   "alcotest" {with-test}
 ]

--- a/packages/opam-file-format/opam-file-format.2.1.1/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.1/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "dune" {>= "2.0"}
   "alcotest" {with-test}
 ]

--- a/packages/opam-file-format/opam-file-format.2.1.2/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.2/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "alcotest" {with-test}
 ]
 depopts: ["dune"]

--- a/packages/opam-file-format/opam-file-format.2.1.2/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.2/opam
@@ -6,10 +6,9 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml" {< "5.0.0"}
+  ("ocaml" {< "5.0.0"} | "dune")
   "alcotest" {with-test}
 ]
-depopts: ["dune"]
 build: [
   [make "byte" {!ocaml:native} "all" {ocaml:native}] {!dune:installed}
   ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]

--- a/packages/opam-file-format/opam-file-format.2.1.3/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.3/opam
@@ -13,7 +13,7 @@ build: [
 ]
 install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "alcotest" {with-test}
 ]
 depopts: [

--- a/packages/opam-file-format/opam-file-format.2.1.3/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.3/opam
@@ -16,8 +16,6 @@ depends: [
   ("ocaml" {< "5.0.0"} | "dune")
   "alcotest" {with-test}
 ]
-  "dune"
-]
 conflicts: "dune" {< "1.3.0"}
 url {
   src: "https://github.com/ocaml/opam-file-format/archive/2.1.3.tar.gz"

--- a/packages/opam-file-format/opam-file-format.2.1.3/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.3/opam
@@ -13,10 +13,9 @@ build: [
 ]
 install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
 depends: [
-  "ocaml" {< "5.0.0"}
+  ("ocaml" {< "5.0.0"} | "dune")
   "alcotest" {with-test}
 ]
-depopts: [
   "dune"
 ]
 conflicts: "dune" {< "1.3.0"}

--- a/packages/opam-file-format/opam-file-format.2.1.4/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.4/opam
@@ -6,10 +6,9 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml" {< "5.0.0"}
+  ("ocaml" {< "5.0.0"} | "dune")
   "alcotest" {with-test}
 ]
-depopts: ["dune"]
 conflicts: [
   "dune" {< "1.3.0"}
 ]

--- a/packages/opam-file-format/opam-file-format.2.1.4/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.4/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-file-format/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "alcotest" {with-test}
 ]
 depopts: ["dune"]


### PR DESCRIPTION
Expects ocamlc -vnum to match a certain number of characters
```
#=== ERROR while compiling opam-file-format.2.1.4 =============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/opam-file-format.2.1.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p opam-file-format -j 127
# exit-code            1
# env-file             ~/.opam/log/opam-file-format-7-fc783a.env
# output-file          ~/.opam/log/opam-file-format-7-fc783a.out
### output ###
# File "tests/legacy/dune", line 5, characters 0-120:
# 5 | (alias
# 6 |   (name runtest)
# 7 |   (deps Makefile legacy.ml opam-file-format.opam (glob_files src/*))
# 8 |   (action (run make test)))
# (cd _build/default/tests/legacy && /usr/bin/make test)
# /usr/bin/make -C src opam-file-format.cma
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/opam-file-format.2.1.4/_build/default/tests/legacy/src'
# sed -e 's/VERSION/"2.1.4"/' \
#      \
#      META.in > META
# ocamldep -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' *.mli *.ml > .depend
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamParserTypes.ml
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamBaseParser.mli
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamBaseParser.ml
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamLexer.mli
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamLexer.ml
# File "src/opamLexer.mll", line 21, characters 2-16:
# Alert deprecated: Stdlib.Printf.kprintf
# Use Printf.ksprintf instead.
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamParser.mli
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamParser.ml
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamPrinter.mli
# ocamlc -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamPrinter.ml
# ocamlc -a opamParserTypes.cmo opamBaseParser.cmo opamLexer.cmo opamParser.cmo opamPrinter.cmo -o opam-file-format.cma
# make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/opam-file-format.2.1.4/_build/default/tests/legacy/src'
# ocamlc -o legacy.byte -I src src/opam-file-format.cma legacy.ml
# /usr/bin/make -C src opam-file-format.cmxa
# make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/opam-file-format.2.1.4/_build/default/tests/legacy/src'
# sed -e 's/VERSION/"2.1.4"/' \
#      \
#      META.in > META
# ocamldep -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' *.mli *.ml > .depend
# ocamlopt -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamParserTypes.ml
# ocamlopt -c -pp 'sed -e s/\\[@@\\?ocaml[^]]*\\]//' opamBaseParser.ml
# File "opamBaseParser.ml", line 1:
# Error: The files opamParserTypes.cmi and opamBaseParser.cmi
#        make inconsistent assumptions over interface OpamParserTypes
# make[1]: *** [Makefile:32: opamBaseParser.cmx] Error 2
```
Fail without dune during build and with dune but we can't really distinguish between the two so it's easier to simply constrain everytime.