### PR TITLE
[new release] current_web, current_ssh, current_slack, current_rpc, current_gitlab, current_github, current_git, current_examples, current_docker and current (0.6.4)

### DIFF
--- a/packages/current/current.0.6.4/opam
+++ b/packages/current/current.0.6.4/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Pipeline language for keeping things up-to-date"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+It is used in ocaml-ci (which provides CI for OCaml projects on GitHub),
+and in docker-base-images (a pipeline that builds Docker images for various
+Linux distributions, OCaml compiler versions and CPU types, and pushes them
+to Docker Hub).
+
+A pipeline is written much like you would write a one-shot sequential script,
+but OCurrent will automatically re-run steps when the inputs change, and will
+run steps in parallel where possible."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "astring" {>= "0.8.5"}
+  "bos"
+  "cmdliner" {>= "1.1.0"}
+  "conf-libev" {os != "win32"}
+  "current_incr" {>= "0.6.1"}
+  "duration"
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "lwt-dllist"
+  "ppx_deriving"
+  "prometheus"
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "sqlite3"
+  "alcotest" {with-test & >= "1.2.0"}
+  "alcotest-lwt" {with-test & >= "1.2.0"}
+  "prometheus-app" {with-test & >= "1.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_docker/current_docker.0.6.4/opam
+++ b/packages/current_docker/current_docker.0.6.4/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "OCurrent Docker plugin"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for interacting with Docker.
+It can pull, build, run and push images, and can coordinate
+multiple Docker Engine instances."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_git" {= version}
+  "ocaml" {>= "4.08.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "duration" {>= "0.1.3"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "result" {>= "1.5"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_examples/current_examples.0.6.4/opam
+++ b/packages/current_examples/current_examples.0.6.4/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Example pipelines for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides some example pipelines.
+It exists mainly to test the integration of various OCurrent
+plugins."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_docker" {= version}
+  "current_git" {= version}
+  "current_github" {= version}
+  "current_gitlab" {= version}
+  "current_rpc" {= version}
+  "current_web" {= version}
+  "current_ssh" {= version}
+  "ocaml" {>= "4.08.0"}
+  "capnp-rpc" {>= "1.2.3"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3"}
+  "capnp-rpc-unix" {>= "1.2.3"}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dockerfile" {>= "7.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "prometheus-app" {>= "1.2"}
+  "result" {>= "1.5"}
+  "routes" {>= "2.0.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_git/current_git.0.6.4/opam
+++ b/packages/current_git/current_git.0.6.4/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Git plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Git.
+It can pull from remote repositories, or monitor local ones for changes."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "astring" {>= "0.8.5"}
+  "bos" {>= "0.2.0"}
+  "conf-git"
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "irmin-watcher"
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "mirage-crypto" {>= "0.8.0"}
+  "ppx_deriving"
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "result" {>= "1.5"}
+  "yojson"
+  "mdx" {with-test}
+  "alcotest" {with-test & >= "1.2.0"}
+  "alcotest-lwt" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_github/current_github.0.6.4/opam
+++ b/packages/current_github/current_github.0.6.4/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "GitHub plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitHub.
+It can monitor and clone remote GitHub repositories, and can
+push GitHub status messages to show the results of testing
+PRs and branches."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "astring" {>= "0.8.5"}
+  "base64" {>= "3.4.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "cstruct" {>= "5.2.0"}
+  "duration"
+  "fmt" {>= "0.8.9"}
+  "github-unix" {>= "4.4.0"}
+  "hex" {>= "1.4.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "ptime"
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
+  "x509" {>= "0.10.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_gitlab/current_gitlab.0.6.4/opam
+++ b/packages/current_gitlab/current_gitlab.0.6.4/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "GitLab plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with GitLab.
+It can monitor and clone remote GitLab repositories, and can
+push GitLab status messages to show the results of testing
+PRs and branches."""
+maintainer: ["Tim McGilchrist <timmcgil@gmail.com>"]
+authors: ["Tim McGilchrist <timmcgil@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "current_git" {= version}
+  "current_web" {= version}
+  "ocaml" {>= "4.08.0"}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "fmt" {>= "0.8.9"}
+  "gitlab-unix" {>= "0.1.4"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "prometheus" {>= "0.7"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_rpc/current_rpc.0.6.4/opam
+++ b/packages/current_rpc/current_rpc.0.6.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto RPC plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a Cap'n Proto RPC interface, allowing
+an OCurrent engine to be controlled remotely."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08.0"}
+  "capnp" {>= "3.4.0"}
+  "capnp-rpc" {>= "1.2.3"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "fmt" {>= "0.8.9"}
+  "fpath"
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "result" {>= "1.5"}
+  "stdint" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "x509" {= "0.11.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_slack/current_slack.0.6.4/opam
+++ b/packages/current_slack/current_slack.0.6.4/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Slack plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides primitives for interacting with Slack.
+It can post messages to slack channels."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "tls-lwt" {>= "0.16.0"}
+  "uri" {>= "4.0.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_ssh/current_ssh.0.6.4/opam
+++ b/packages/current_ssh/current_ssh.0.6.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "SSH plugin for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a plugin for running ssh commands."""
+maintainer: ["Mark Elvers <mark.elvers@tunbury.org>"]
+authors: ["Mark Elvers <mark.elvers@tunbury.org>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"

--- a/packages/current_web/current_web.0.6.4/opam
+++ b/packages/current_web/current_web.0.6.4/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+synopsis: "Test web UI for OCurrent"
+description: """
+OCurrent provides an OCaml eDSL for writing CI/CD pipelines.
+
+This package provides a basic web UI for service administrators.
+It shows the current pipeline visually and allows viewing job
+logs and configuring the log analyser."""
+maintainer: ["Thomas Leonard <talex5@gmail.com>"]
+authors: ["Thomas Leonard <talex5@gmail.com>"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocurrent"
+doc: "https://ocurrent.github.io/ocurrent/"
+bug-reports: "https://github.com/ocurrent/ocurrent/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "crunch" {build & >= "3.3.0"}
+  "current" {= version}
+  "ocaml" {>= "4.08.0"}
+  "ansi" {>= "0.5.0"}
+  "astring" {>= "0.8.5"}
+  "base64"
+  "bos"
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "conduit-lwt-unix" {>= "2.2.2"}
+  "conf-graphviz"
+  "cstruct" {>= "5.2.0"}
+  "csv" {>= "2.4"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.6.1"}
+  "mirage-crypto" {>= "0.8.7"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "multipart_form-lwt" {>= "0.4.0"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.5.1"}
+  "ppx_sexp_conv" {>= "v0.14.1"}
+  "prometheus" {>= "0.7"}
+  "prometheus-app" {>= "1.2"}
+  "re" {>= "1.9.0"}
+  "result" {>= "1.5"}
+  "routes" {>= "2.0.0"}
+  "session"
+  "session-cohttp-lwt"
+  "sexplib" {>= "v0.14.0"}
+  "sqlite3" {>= "5.0.2"}
+  "tyxml" {>= "4.4.0"}
+  "uri" {>= "4.0.0"}
+  "yojson" {>= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocurrent.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocurrent/releases/download/0.6.4/current-0.6.4.tbz"
+  checksum: [
+    "sha256=e6cafa330166719e3f8bf30a4ffeec79b0f290e3dcd420c4a53d6a55912f961d"
+    "sha512=42d703a524ab61e3fd623ab4b1681bbe59c1d4426bebadb1bb50c3e6fcbb59d1aecb8041f2b6d09a9cb5eb5b6f79ec7b07eb4254ec39de30d406c20d4da7d664"
+  ]
+}
+x-commit-hash: "53fd3263d04407df6b7a627abe85667d011c0060"


### PR DESCRIPTION
Test web UI for OCurrent

- Project page: <a href="https://github.com/ocurrent/ocurrent">https://github.com/ocurrent/ocurrent</a>
- Documentation: <a href="https://ocurrent.github.io/ocurrent/">https://ocurrent.github.io/ocurrent/</a>

##### CHANGES:

API:

- Add an Active Waiting_for_confirmation state, allows manual
  confirmation to run a task. (@kit-ty-kate @maiste, ocurrent/ocurrent#269)
- Add Current_term.option_iter. (@kit-ty-kate, ocurrent/ocurrent#403)
- Add Current_term.cutoff operation to decide whether changes should
  propagate according to an equality function (@art-w, ocurrent/ocurrent#409)
- Expose eq parameter for Current_term.map and Current_term.bind (@art-w, ocurrent/ocurrent#409)

Web UI:

- Allow controlling and disabling the refresh timer for pipelines
  graphs and job page (@MisterDA, ocurrent/ocurrent#398, ocurrent/ocurrent#400)
- Shorten the PR labels (remove commit date and messages) (@kit-ty-kate, ocurrent/ocurrent#399)

Plugins:

- GitHub: Add information about labels in Api.Ref.pr_info (@ElectreAAS, ocurrent/ocurrent#402)
- SSH: Add a plugin for running ssh commands (@mtelvers, ocurrent/ocurrent#401)

Other:

- Replaced mdx tests with Alcotest (@maiste ocurrent/ocurrent#405, review by @MisterDA)
- Updated to mirage-crypto-rng.0.11.0 and capnp-rpc.1.2.3 (@hannesm, @MisterDA, ocurrent/ocurrent#412)
