### PR TITLE
[new release] OSCADml (0.2.1)

### DIFF
--- a/packages/OSCADml/OSCADml.0.2.1/opam
+++ b/packages/OSCADml/OSCADml.0.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml DSL for 3D solid modelling in OpenSCAD"
+description:
+  "OSCADml is an OCaml front-end to the OpenSCAD CAD programming language."
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: [
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+  "Masaki Nakano<namachan10777@gmail.com>"
+]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD" "OpenSCAD"]
+homepage: "https://github.com/OCADml/OSCADml"
+doc: "https://ocadml.github.io/OSCADml"
+bug-reports: "https://github.com/OCADml/OSCADml/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
+  "gg" {>= "1.0.0"}
+  "cairo2" {>= "0.6.2"}
+  "OCADml" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OSCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OSCADml/releases/download/v0.2.1/OSCADml-0.2.1.tbz"
+  checksum: [
+    "sha256=406e45c5df8122e8b065342e10ba9deb7a066683b256619462c405da69ba5baa"
+    "sha512=20db4192d6204d9fd5914562ec83d8edbbb1f5c89a72e61928bf662fdcc9ecea38760b26c99af801ddfc5b877c451ad11c16fc89a6a36ef8c20881375627295b"
+  ]
+}
+x-commit-hash: "44ee3e3bb7197b07506a9bf9104a8ea9803515f6"


### PR DESCRIPTION
OCaml DSL for 3D solid modelling in OpenSCAD

- Project page: <a href="https://github.com/OCADml/OSCADml">https://github.com/OCADml/OSCADml</a>
- Documentation: <a href="https://ocadml.github.io/OSCADml">https://ocadml.github.io/OSCADml</a>

##### CHANGES:

- make odoc manual compatible with odig
- update PolyText example to reflect move into optional sublibrary (OCADml v0.4.0)
