### PR TITLE
[new release] tls, tls-mirage, tls-lwt, tls-eio and tls-async (0.16.1)

### DIFF
--- a/packages/tls-async/tls-async.0.16.1/opam
+++ b/packages/tls-async/tls-async.0.16.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "x509" {>= "0.14.0"}
+  "ptime" {>= "0.8.1"}
+  "async" {>= "v0.15"}
+  "async_unix" {>= "v0.15"}
+  "core" {>= "v0.15"}
+  "cstruct-async"
+  "ppx_jane" {>= "v0.15"}
+  "mirage-crypto-rng-async"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Async layer"
+description: """
+Tls-async provides Async-friendly tls bindings
+"""
+authors: [
+  "David Kaloper <david@numm.org>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Eric Ebinger <github@eric.theebingers.com>"
+  "Calascibetta Romain <romain.calascibetta@gmail.com>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.16.1/tls-0.16.1.tbz"
+  checksum: [
+    "sha256=acddf7dd77fdf2dc4868e055d45f4389ea45d4102a57e2ec6ccaae529b5db68e"
+    "sha512=32edf197de24746e046b733fbd877a4f74e71eac1a8e45fe4472ccaeeb3da2c279f48a38d8182b1d02dc460369ce447943be6cff73eb167c9d6212cec43fab2a"
+  ]
+}
+x-commit-hash: "30f0a8680bfbd537c0918ea63ac04c5cc08555cf"

--- a/packages/tls-eio/tls-eio.0.16.1/opam
+++ b/packages/tls-eio/tls-eio.0.16.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+authors:      ["Thomas Leonard"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
+  "x509" {>= "0.15.0"}
+  "eio" {>= "0.7"}
+  "eio_main" {>= "0.7" with-test}
+  "mdx" {with-test}
+  "crowbar" {>= "0.2.1" with-test}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml - Eio"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.16.1/tls-0.16.1.tbz"
+  checksum: [
+    "sha256=acddf7dd77fdf2dc4868e055d45f4389ea45d4102a57e2ec6ccaae529b5db68e"
+    "sha512=32edf197de24746e046b733fbd877a4f74e71eac1a8e45fe4472ccaeeb3da2c279f48a38d8182b1d02dc460369ce447943be6cff73eb167c9d6212cec43fab2a"
+  ]
+}
+x-commit-hash: "30f0a8680bfbd537c0918ea63ac04c5cc08555cf"

--- a/packages/tls-lwt/tls-lwt.0.16.1/opam
+++ b/packages/tls-lwt/tls-lwt.0.16.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "x509" {>= "0.15.0"}
+  "lwt" {>= "3.0.0"}
+  "cmdliner" {>= "1.1.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Lwt layer"
+description: """
+Tls-lwt provides an effectful Tls_lwt module to be used with Lwt.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.16.1/tls-0.16.1.tbz"
+  checksum: [
+    "sha256=acddf7dd77fdf2dc4868e055d45f4389ea45d4102a57e2ec6ccaae529b5db68e"
+    "sha512=32edf197de24746e046b733fbd877a4f74e71eac1a8e45fe4472ccaeeb3da2c279f48a38d8182b1d02dc460369ce447943be6cff73eb167c9d6212cec43fab2a"
+  ]
+}
+x-commit-hash: "30f0a8680bfbd537c0918ea63ac04c5cc08555cf"

--- a/packages/tls-mirage/tls-mirage.0.16.1/opam
+++ b/packages/tls-mirage/tls-mirage.0.16.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "x509" {>= "0.13.0"}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.16.1/tls-0.16.1.tbz"
+  checksum: [
+    "sha256=acddf7dd77fdf2dc4868e055d45f4389ea45d4102a57e2ec6ccaae529b5db68e"
+    "sha512=32edf197de24746e046b733fbd877a4f74e71eac1a8e45fe4472ccaeeb3da2c279f48a38d8182b1d02dc460369ce447943be6cff73eb167c9d6212cec43fab2a"
+  ]
+}
+x-commit-hash: "30f0a8680bfbd537c0918ea63ac04c5cc08555cf"

--- a/packages/tls/tls.0.16.1/opam
+++ b/packages/tls/tls.0.16.1/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto" {>= "0.11.0"}
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-rng" {>= "0.8.0"}
+  "x509" {>= "0.15.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "hkdf"
+  "logs"
+  "ipaddr"
+  "alcotest" {with-test}
+  "randomconv" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read [further](https://nqsb.io) and our [Usenix Security 2015 paper](https://usenix15.nqsb.io).
+"""
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v0.16.1/tls-0.16.1.tbz"
+  checksum: [
+    "sha256=acddf7dd77fdf2dc4868e055d45f4389ea45d4102a57e2ec6ccaae529b5db68e"
+    "sha512=32edf197de24746e046b733fbd877a4f74e71eac1a8e45fe4472ccaeeb3da2c279f48a38d8182b1d02dc460369ce447943be6cff73eb167c9d6212cec43fab2a"
+  ]
+}
+x-commit-hash: "30f0a8680bfbd537c0918ea63ac04c5cc08555cf"


### PR DESCRIPTION
Transport Layer Security purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* tls-async: remove ocaml < 5.0.0 constraint (mirleft/ocaml-tls#471 mirleft/ocaml-tls#474 @hannesm)
* remove dependency on ppx, especially ppx_cstruct and ppx_sexp_conv across
  the libraries (mirleft/ocaml-tls#473 @hannesm, discussion in mirleft/ocaml-tls#472)
