### PR TITLE
[new release] mrmime (0.6.0)

### DIFF
--- a/packages/mrmime/mrmime.0.6.0/opam
+++ b/packages/mrmime/mrmime.0.6.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/mrmime"
+bug-reports:  "https://github.com/mirage/mrmime/issues"
+dev-repo:     "git+https://github.com/mirage/mrmime.git"
+doc:          "https://mirage.github.io/mrmime/"
+license:      "MIT"
+synopsis:     "Mr. MIME"
+description:  """Parser and generator of mail in OCaml"""
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "ke"                {>= "0.4"}
+  "unstrctrd"         {>= "0.3"}
+  "ptime"             {>= "0.8.2"}
+  "uutf"
+  "rosetta"           {>= "0.3.0"}
+  "ipaddr"            {>= "5.0.0"}
+  "emile"             {>= "1.0"}
+  "base64"            {>= "3.1.0"}
+  "pecu"              {>= "0.6"}
+  "prettym"           {>= "0.0.2"}
+  "bigstringaf"       {>= "0.5.0"}
+  "bigarray-overlap"  {>= "0.2.0"}
+  "angstrom"          {>= "0.14.0"}
+  "fpath"             {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ocplib-endian"     {with-test}
+  "afl-persistent"    {with-test}
+  "alcotest"          {with-test}
+  "jsonm"             {with-test}
+  "crowbar"           {with-test}
+  "lwt"               {with-test}
+  "cmdliner"          {with-test & >= "1.1.0"}
+  "logs"              {with-test}
+]
+conflicts: [
+  "result"            {< "1.5"}
+]
+url {
+  src:
+    "https://github.com/mirage/mrmime/releases/download/v0.6.0/mrmime-0.6.0.tbz"
+  checksum: [
+    "sha256=056e89df4fee37b9a1f09315c6aa45ea9c70350d23eff62ab57d5c96a665898c"
+    "sha512=20e02272ad4ecaaa4f07da8f042945b14b032ee3c5b49140e26d4d22bb6014fe68e0c32547abf43ffaf26b5e56f88de91e4042510065d363c033a1f83f7c15e6"
+  ]
+}
+x-commit-hash: "bba983479ae1ee4638cb4ffda33dbefa64f5d773"


### PR DESCRIPTION
Mr. MIME

- Project page: <a href="https://github.com/mirage/mrmime">https://github.com/mirage/mrmime</a>
- Documentation: <a href="https://mirage.github.io/mrmime/">https://mirage.github.io/mrmime/</a>

##### CHANGES:

- Be able to set field parsers when we parse an entire email (@dinosaure, mirage/mrmime#89)
- Be able to wrap a multipart email into a part (@dinosaure, mirage/mrmime#90)
- Don't use RNG to produce the example to be compatible with OCaml 5 (@dinosaure, mirage/mrmime#93)
- Upgrade to cmdliner.1.1.0 (@hannesm, mirage/mrmime#94)
- Use a smaller email to test isomorphism (@dinosaure, 931c6ad)
- Lint dependencies (@dinosaure, mirage/mrmime#95)
- Delete `rresult` dependency (@dinosaure, @hannesm, mirage/mrmime#96)
- Delete `fmt` dependency (@dinosaure, mirage/mrmime#97)
