### PR TITLE
mark mrmime.0.6.0 revdeps breakages

### DIFF
--- a/packages/dkim/dkim.0.3.0/opam
+++ b/packages/dkim/dkim.0.3.0/opam
@@ -21,7 +21,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0.0"}
-  "mrmime"     {>= "0.5.0"}
+  "mrmime"     {>= "0.5.0" & < "0.6.0"}
   "digestif"   {>= "0.9.0"}
   "ipaddr"
   "astring"    {>= "0.8.5"}

--- a/packages/dkim/dkim.0.3.1/opam
+++ b/packages/dkim/dkim.0.3.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml"      {>= "4.08.0"}
   "dune"       {>= "2.0.0"}
-  "mrmime"     {>= "0.5.0"}
+  "mrmime"     {>= "0.5.0" & < "0.6.0"}
   "digestif"   {>= "0.9.0"}
   "ipaddr"
   "astring"    {>= "0.8.5"}

--- a/packages/dkim/dkim.0.4.0/opam
+++ b/packages/dkim/dkim.0.4.0/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml"             {>= "4.08.0"}
   "dune"              {>= "2.0.0"}
-  "mrmime"            {>= "0.5.0"}
+  "mrmime"            {>= "0.5.0" & < "0.6.0"}
   "digestif"          {>= "0.9.0"}
   "ipaddr"
   "astring"           {>= "0.8.5"}

--- a/packages/letters/letters.0.2.1/opam
+++ b/packages/letters/letters.0.2.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/oxidizing/letters/issues"
 depends: [
   "ocaml" {>= "4.08.1"}
   "dune" {>= "2.3"}
-  "mrmime" {>= "0.3.1"}
+  "mrmime" {>= "0.3.1" & < "0.6.0"}
   "colombe" {>= "0.4.0" & < "0.5.0"}
   "sendmail" {>= "0.4.0"}
   "fmt" {>= "0.8.8"}

--- a/packages/received/received.0.5.1/opam
+++ b/packages/received/received.0.5.1/opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "ocaml"    {>= "4.03.0"}
   "dune"     {>= "2.0"}
-  "mrmime"   {>= "0.5.0"}
+  "mrmime"   {>= "0.5.0" & < "0.6.0"}
   "emile"    {>= "0.8"}
   "angstrom" {>= "0.14.0"}
   "colombe"  {>= "0.4.0"}

--- a/packages/sendmail/sendmail.0.4.0/opam
+++ b/packages/sendmail/sendmail.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "logs"
   "emile" {>= "0.8" & with-test}
-  "mrmime" {>= "0.3.2" & with-test}
+  "mrmime" {>= "0.3.2" & < "0.6.0" & with-test}
   "alcotest" {with-test}
 ]
 x-commit-hash: "83782537d0c0ca860c1062d7a5d601ac30e00d5f"

--- a/packages/sendmail/sendmail.0.4.1/opam
+++ b/packages/sendmail/sendmail.0.4.1/opam
@@ -22,7 +22,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "logs"
   "emile" {>= "0.8" & with-test}
-  "mrmime" {>= "0.3.2" & with-test}
+  "mrmime" {>= "0.3.2" & < "0.6.0" & with-test}
   "alcotest" {with-test}
   "cstruct" {< "6.1.0"}
 ]

--- a/packages/sendmail/sendmail.0.4.2/opam
+++ b/packages/sendmail/sendmail.0.4.2/opam
@@ -22,7 +22,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "logs"
   "emile" {>= "0.8" & with-test}
-  "mrmime" {>= "0.3.2" & with-test}
+  "mrmime" {>= "0.3.2" & < "0.6.0" & with-test}
   "alcotest" {with-test}
   "cstruct" {< "6.1.0"}
 ]

--- a/packages/sendmail/sendmail.0.5.0/opam
+++ b/packages/sendmail/sendmail.0.5.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base64" {>= "3.0.0"}
   "logs"
   "emile" {>= "0.8" & with-test}
-  "mrmime" {>= "0.3.2" & with-test}
+  "mrmime" {>= "0.3.2" & < "0.6.0" & with-test}
   "cstruct" {>= "6.0.0"}
   "alcotest" {with-test}
 ]

--- a/packages/uspf/uspf.0.0.1/opam
+++ b/packages/uspf/uspf.0.0.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"        {>= "2.8.0"}
   "logs"
   "colombe"     {>= "0.4.2"}
-  "mrmime"      {>= "0.5.0"}
+  "mrmime"      {>= "0.5.0" & < "0.6.0"}
   "ipaddr"      {>= "5.2.0"}
   "hmap"
   "angstrom"    {>= "0.15.0"}


### PR DESCRIPTION
https://github.com/ocaml/opam-repository/pull/23429 releases 0.6.0 which breaks some revdeps relying on transitive dependencies.