### PR TITLE
owl-base: add upper bound on ocaml 5

### DIFF
--- a/packages/owl-base/owl-base.0.7.0/opam
+++ b/packages/owl-base/owl-base.0.7.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "base-bigarray"
   "integers"
   "dune" {>= "1.7.0"}

--- a/packages/owl-base/owl-base.0.7.1/opam
+++ b/packages/owl-base/owl-base.0.7.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "1.7.0"}
   "stdlib-shims"

--- a/packages/owl-base/owl-base.0.7.2/opam
+++ b/packages/owl-base/owl-base.0.7.2/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "1.7.0"}
   "stdlib-shims"

--- a/packages/owl-base/owl-base.0.8.0/opam
+++ b/packages/owl-base/owl-base.0.8.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.06.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "2.0.0"}
   "stdlib-shims"

--- a/packages/owl-base/owl-base.0.9.0/opam
+++ b/packages/owl-base/owl-base.0.9.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "2.0.0"}
   "stdlib-shims"

--- a/packages/owl-base/owl-base.1.0.0/opam
+++ b/packages/owl-base/owl-base.1.0.0/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "2.0.0"}
 ]

--- a/packages/owl-base/owl-base.1.0.1/opam
+++ b/packages/owl-base/owl-base.1.0.1/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "2.0.0"}
 ]

--- a/packages/owl-base/owl-base.1.0.2/opam
+++ b/packages/owl-base/owl-base.1.0.2/opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.10.0" & < "5.0"}
   "base-bigarray"
   "dune" {>= "2.0.0"}
 ]


### PR DESCRIPTION
Parts of the library do work fine, however
some modules in owl-base (Owl_log, Owl_io and Owl_utils) use the Unix module without linking against it,
making packages fail in unexpected ways.

For example
```
=== ERROR while compiling owl-ode-odepack.0.4.0 ==============================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/owl-ode-odepack.0.4.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p owl-ode-odepack -j 255
 exit-code            1
 env-file             ~/.opam/log/owl-ode-odepack-7-f6b113.env
 output-file          ~/.opam/log/owl-ode-odepack-7-f6b113.out
\## output ###
 (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -o examples/van_der_pol_odepack.exe /home/opam/.opam/5.0/lib/bigarray-compat/bigarray_compat.cmxa /home/opam/.opam/5.0/lib/stdlib-shims/stdlib_shims.cmxa /home/opam/.opam/5.0/lib/integers/integers.cmxa -I /home/opam/.opam/5.0/lib/integers /home/opam/.opam/5.0/lib/ctypes/ctypes.cmxa -I /home/opam/.opam/5.0/lib/ctypes /home/opam/.opam/5.0/lib/ocaml/str/str.cmxa /home/opam/.opam/5.0/lib/ctypes/cstubs.cmxa -I /home/opam/.opam/5.0/lib/ctypes /home/opam/.opam/5.0/lib/eigen/cpp/eigen_cpp_stubs.cmxa -I /home/opam/.opam/5.0/lib/eigen/cpp /home/opam/.opam/5.0/lib/eigen/eigen.cmxa -I /home/opam/.opam/5.0/lib/eigen /home/opam/.opam/5.0/lib/owl-base/owl_base.cmxa /home/opam/.opam/5.0/lib/ocaml/unix/unix.cmxa /home/opam/.opam/5.0/lib/zip/zip.cmxa -I /home/opam/.opam/5.0/lib/zip /home/opam/.opam/5.0/lib/npy/npy.cmxa /home/opam/.opam/5.0/lib/owl/owl.cmxa -I /home/opam/.opam/5.0/lib/owl /home/opam/.opam/5.0/lib/owl-ode-base/owl_ode_base.cmxa /home/opam/.opam/5.0/lib/owl-ode/owl_ode.cmxa /home/opam/.opam/5.0/lib/odepack/fortran/odepack_fortran.cmxa -I /home/opam/.opam/5.0/lib/odepack/fortran /home/opam/.opam/5.0/lib/odepack/odepack.cmxa -I /home/opam/.opam/5.0/lib/odepack src/odepack/owl_ode_odepack.cmxa /home/opam/.opam/5.0/lib/plplot/plplot.cmxa -I /home/opam/.opam/5.0/lib/plplot /home/opam/.opam/5.0/lib/owl-plplot/owl_plplot.cmxa examples/.van_der_pol_odepack.eobjs/native/dune__exe__Van_der_pol_odepack.cmx)
 File "_none_", line 1:
 Error: No implementations provided for the following modules:
          Unix referenced from /home/opam/.opam/5.0/lib/owl-base/owl_base.cmxa(Owl_utils),
            /home/opam/.opam/5.0/lib/owl-base/owl_base.cmxa(Owl_log),
            /home/opam/.opam/5.0/lib/owl-base/owl_base.cmxa(Owl_io)
```

Seen on https://github.com/ocaml/opam-repository/pull/23357