### PR TITLE
molenc >= 5.0.0 requires minicli >= 5.0.0

### DIFF
--- a/packages/molenc/molenc.5.0.1/opam
+++ b/packages/molenc/molenc.5.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-rdkit"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
-  "minicli"
+  "minicli" {>= "5.0.0"}
   "ocaml" {>= "4.04.0" & < "5.0"}
   "parmap"
 ]

--- a/packages/molenc/molenc.7.0.1/opam
+++ b/packages/molenc/molenc.7.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "dokeysto"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
-  "minicli"
+  "minicli" {>= "5.0.0"}
   "ocaml" {< "5.0"}
   "parany" {>= "9.0.0" & < "11.0.0"}
 ]

--- a/packages/molenc/molenc.8.0.2/opam
+++ b/packages/molenc/molenc.8.0.2/opam
@@ -23,7 +23,7 @@ depends: [
   "dokeysto"
   "dolog" {>= "4.0.0" & < "5.0.0"}
   "dune" {>= "1.11"}
-  "minicli"
+  "minicli" {>= "5.0.0"}
   "ocaml" {< "5.0"}
   "parany" {>= "9.0.0" & < "11.0.0"}
 ]


### PR DESCRIPTION
Minicli module did not exist before
```
#=== ERROR while compiling molenc.5.0.1 =======================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/molenc.5.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p molenc -j 255
# exit-code            1
# env-file             ~/.opam/log/molenc-7-f94642.env
# output-file          ~/.opam/log/molenc-7-f94642.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.encoder.eobjs/byte -I /home/opam/.opam/4.14/lib/batteries -I /home/opam/.opam/4.14/lib/bst -I /home/opam/.opam/4.14/lib/bytes -I /home/opam/.opam/4.14/lib/dolog -I /home/opam/.opam/4.14/lib/minicli -I /home/opam/.opam/4.14/lib/num -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/parmap -I src/.molenc.objs/byte -no-alias-deps -o src/.encoder.eobjs/byte/butina.cmo -c -impl src/butina.ml)
# File "src/butina.ml", line 19, characters 13-24:
# 19 | module CLI = Minicli.CLI
#                   ^^^^^^^^^^^
# Error: Unbound module Minicli
```