### PR TITLE
[new release] ocluster, ocluster-worker, ocluster-api and current_ocluster (0.2.1)

### DIFF
--- a/packages/current_ocluster/current_ocluster.0.2.1/opam
+++ b/packages/current_ocluster/current_ocluster.0.2.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "OCurrent plugin for OCluster builds"
+description:
+  "Creates a stage in an OCurrent pipeline for submitting jobs to OCluster."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocluster-api" {= version}
+  "ocaml" {>= "4.12.0"}
+  "capnp-rpc-unix" {>= "1.2.3"}
+  "current" {>= "0.6.4"}
+  "current_git" {>= "0.6.4"}
+  "duration"
+  "fmt"
+  "logs"
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "prometheus" {>= "1.2"}
+  "current_github" {>= "0.6.4" & with-test}
+  "current_web" {>= "0.6.4" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2.1/ocluster-0.2.1.tbz"
+  checksum: [
+    "sha256=3b88db5ad1edfaf3295bb145c64d5afc6fb7271ac20f69054eb91860dd4a5dff"
+    "sha512=88b885c2556b822f7970f4ef9ffd6402ff6cc21cf9aa9ac10a13992e144d23398a99ed1dc71ff09f47c026222c6cfd009af316a45e425d5f058c2f522ebb909d"
+  ]
+}
+x-commit-hash: "d177823e29803387eb12e2db9e55981ae9f00a2f"

--- a/packages/ocluster-api/ocluster-api.0.2.1/opam
+++ b/packages/ocluster-api/ocluster-api.0.2.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto API for OCluster"
+description: "OCaml bindings for the OCluster Cap'n Proto API."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "fmt"
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2.1/ocluster-0.2.1.tbz"
+  checksum: [
+    "sha256=3b88db5ad1edfaf3295bb145c64d5afc6fb7271ac20f69054eb91860dd4a5dff"
+    "sha512=88b885c2556b822f7970f4ef9ffd6402ff6cc21cf9aa9ac10a13992e144d23398a99ed1dc71ff09f47c026222c6cfd009af316a45e425d5f058c2f522ebb909d"
+  ]
+}
+x-commit-hash: "d177823e29803387eb12e2db9e55981ae9f00a2f"

--- a/packages/ocluster-worker/ocluster-worker.0.2.1/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.2.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "OCluster library for defining workers"
+description: "OCluster library for defining workers"
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocluster-api" {= version}
+  "ocaml" {>= "4.12.0"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "cohttp-lwt-unix" {>= "4.0"}
+  "digestif" {>= "0.8"}
+  "extunix" {>= "0.4.1"}
+  "fpath"
+  "logs"
+  "lwt" {>= "5.6.1"}
+  "obuilder" {>= "0.5.1"}
+  "prometheus-app" {>= "1.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2.1/ocluster-0.2.1.tbz"
+  checksum: [
+    "sha256=3b88db5ad1edfaf3295bb145c64d5afc6fb7271ac20f69054eb91860dd4a5dff"
+    "sha512=88b885c2556b822f7970f4ef9ffd6402ff6cc21cf9aa9ac10a13992e144d23398a99ed1dc71ff09f47c026222c6cfd009af316a45e425d5f058c2f522ebb909d"
+  ]
+}
+x-commit-hash: "d177823e29803387eb12e2db9e55981ae9f00a2f"

--- a/packages/ocluster/ocluster.0.2.1/opam
+++ b/packages/ocluster/ocluster.0.2.1/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+synopsis: "Distribute build jobs to workers"
+description: """
+OCluster manages a pool of build workers.
+A build scheduler service accepts build jobs from clients and distributes them to worker machines using Cap'n Proto.
+Workers register themselves by connecting to the scheduler (and workers do not need to be able to accept incoming network connections).
+
+The scheduler can manage multiple pools (e.g. `linux-x86_64` and `linux-arm32`).
+Clients say which pool should handle their requests.
+At the moment, two build types are provided: building a Dockerfile, or building an OBuilder spec.
+In either case, the build may done in the context of some Git commit.
+The scheduler tries to schedule similar builds on the same machine, to benefit from caching."""
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocluster-api" {= version}
+  "ocluster-worker" {= version}
+  "ocaml" {>= "4.12.0"}
+  "capnp-rpc-lwt" {>= "1.2.3"}
+  "capnp-rpc-net" {>= "1.2.3"}
+  "capnp-rpc-unix" {>= "1.2.3"}
+  "cmdliner" {>= "1.1.0"}
+  "conf-libev" {os != "win32"}
+  "digestif" {>= "0.8"}
+  "dune-build-info"
+  "fmt"
+  "fpath"
+  "logs"
+  "lwt" {>= "5.6.1"}
+  "lwt-dllist"
+  "mirage-crypto" {>= "0.8.5"}
+  "obuilder" {>= "0.5.1"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_sexp_conv"
+  "prometheus"
+  "prometheus-app" {>= "1.2"}
+  "psq" {>= "0.2.1"}
+  "sqlite3"
+  "winsvc" {>= "1.0.1" & os = "win32"}
+  "current_ocluster" {= version & with-test}
+  "alcotest" {>= "1.0.0" & with-test}
+  "alcotest-lwt" {>= "1.0.1" & with-test}
+  "mirage-crypto-rng" {>= "0.11.0" & with-test}
+  "mirage-crypto-rng-lwt" {>= "0.11.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.2.1/ocluster-0.2.1.tbz"
+  checksum: [
+    "sha256=3b88db5ad1edfaf3295bb145c64d5afc6fb7271ac20f69054eb91860dd4a5dff"
+    "sha512=88b885c2556b822f7970f4ef9ffd6402ff6cc21cf9aa9ac10a13992e144d23398a99ed1dc71ff09f47c026222c6cfd009af316a45e425d5f058c2f522ebb909d"
+  ]
+}
+x-commit-hash: "d177823e29803387eb12e2db9e55981ae9f00a2f"


### PR DESCRIPTION
Distribute build jobs to workers

- Project page: <a href="https://github.com/ocurrent/ocluster">https://github.com/ocurrent/ocluster</a>
- Documentation: <a href="https://ocurrent.github.io/ocluster/">https://ocurrent.github.io/ocluster/</a>

##### CHANGES:

- Expose the ocluster-worker library in the ocluster-worker package
  (@MisterDA @art-w, ocurrent/ocluster#219 ocurrent/ocluster#217 ocurrent/ocluster#151, reviewed by @tmcgilchrist)
- Remove corrupted repositories from the cache (@kit-ty-kate ocurrent/ocluster#216, reviewed by @talex5)
- Allow workers to report additional prometheus metrics (@patricoferris ocurrent/ocluster#210, reviewed by @tmcgilchrist, @MisterDA)
- Smother Cap'n Proto and TLS debug logs (@MisterDA ocurrent/ocluster#213, reviewed by @talex5)
- Added command line option to set obuilder health check period (@mtelvers ocurrent/ocluster#214, reviewed by @tmcgilchrist)
- Conditionally compile macos user_temp fetcher (@tmcgilchrist ocurrent/ocluster#209, reviewed by @MisterDA, @mtelvers)
- Make rsync-mode mandatory when using rsync store (@tmcgilchrist ocurrent/ocluster#202, reviewed by @MisterDA)
- Windows service bugfixes (@MisterDA ocurrent/ocluster#200, reviewed by @tmcgilchrist)
- Fix build and opam metadata (@MisterDA @tmcgilchrist ocurrent/ocluster#199 ocurrent/ocluster#203)
