### PR TITLE
Lambda Soup 1.0.0: HTML scraping using CSS

### DIFF
--- a/packages/lambdasoup/lambdasoup.1.0.0/opam
+++ b/packages/lambdasoup/lambdasoup.1.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+
+synopsis: "Easy functional HTML scraping and manipulation with CSS selectors"
+
+license: "MIT"
+homepage: "https://github.com/aantron/lambdasoup"
+doc: "https://aantron.github.io/lambdasoup"
+bug-reports: "https://github.com/aantron/lambdasoup/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/lambdasoup.git"
+
+depends: [
+  "camlp-streams" {>= "5.0.1"}
+  "dune" {>= "2.7.0"}
+  "markup" {>= "1.0.0"}
+  "ocaml" {>= "4.03.0"}
+
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ounit2" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+description: """
+Lambda Soup is an HTML scraping library inspired by Python's Beautiful Soup. It
+provides lazy traversals from HTML nodes to their parents, children, siblings,
+etc., and to nodes matching CSS selectors. The traversals can be manipulated
+using standard functional combinators such as fold, filter, and map.
+
+The DOM tree is mutable. You can use Lambda Soup for automatic HTML rewriting in
+scripts. Lambda Soup rewrites its own ocamldoc page this way.
+
+A major goal of Lambda Soup is to be easy to use, including in interactive
+sessions, and to have a minimal learning curve. It is a very simple library.
+"""
+
+url {
+  src: "https://github.com/aantron/lambdasoup/archive/1.0.0.tar.gz"
+  checksum: "md5=35d2d399d1033c0cc081b80dd1a04cc7"
+}


### PR DESCRIPTION
- Adapt to breaking changes in OCaml 5.0.0 (aantron/lambdasoup#51, @kit-ty-kate).
- Add [`Soup.prepend_root`](https://github.com/aantron/lambdasoup/blob/416f4e9770d769702963342bc3cb0d93a19d2346/src/soup.mli#L639-L640) (aantron/lambdasoup#45, Daniil Baturin).