### PR TITLE
Fix json-data-encoding upper-bounds on old data-encoding releases

### DIFF
--- a/packages/data-encoding/data-encoding.0.4/opam
+++ b/packages/data-encoding/data-encoding.0.4/opam
@@ -11,8 +11,8 @@ depends: [
   "ezjsonm"
   "zarith" {>= "1.4"}
   "hex" {>= "1.3.0"}
-  "json-data-encoding" { >= "0.9.1" }
-  "json-data-encoding-bson" { >= "0.9.1" }
+  "json-data-encoding" { >= "0.9.1" & < "1.0.0" }
+  "json-data-encoding-bson" { >= "0.9.1" & < "1.0.0" }
   "alcotest" { with-test }
   "crowbar" { >= "0.2" & with-test }
   "ocamlformat" { = "0.15.0" & dev }

--- a/packages/data-encoding/data-encoding.0.6/opam
+++ b/packages/data-encoding/data-encoding.0.6/opam
@@ -12,8 +12,8 @@ depends: [
   "zarith" {>= "1.4"}
   "zarith_stubs_js"
   "hex" {>= "1.3.0"}
-  "json-data-encoding" { >= "0.11" }
-  "json-data-encoding-bson" { >= "0.11" }
+  "json-data-encoding" { >= "0.11" & < "1.0.0" }
+  "json-data-encoding-bson" { >= "0.11" & < "1.0.0" }
   "alcotest" { with-test }
   "crowbar" { >= "0.2" & with-test }
   "ppx_expect" { with-test }


### PR DESCRIPTION
Some missing upper-bounds on some constraints