### PR TITLE
plist 0.1 is not compatible with ocaml 5

### DIFF
--- a/packages/plist/plist.0.1/opam
+++ b/packages/plist/plist.0.1/opam
@@ -15,7 +15,7 @@ build: [
 install: ["ocaml" "setup.ml" "-install"]
 remove: ["ocamlfind" "remove" "plist"]
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.0"}
   "ocamlfind" {build}
   "yojson" {< "2.0.0"}
   "lambdasoup"


### PR DESCRIPTION
Fails with
```
=== ERROR while compiling plist.0.1 ==========================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/plist.0.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0
 exit-code            2
 env-file             ~/.opam/log/plist-8-da06f3.env
 output-file          ~/.opam/log/plist-8-da06f3.out
 File "./setup.ml", line 318, characters 20-36:
 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
                           ^^^^^^^^^^^^^^^^
 Error: Unbound value String.lowercase
```
Seen on revdeps of https://github.com/ocaml/opam-repository/pull/23445