### PR TITLE
[new release] mirage-solo5 (0.9.2)

### DIFF
--- a/packages/mirage-solo5/mirage-solo5.0.9.2/opam
+++ b/packages/mirage-solo5/mirage-solo5.0.9.2/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer:   "martin@lucina.net"
+homepage:     "https://github.com/mirage/mirage-solo5"
+bug-reports:  "https://github.com/mirage/mirage-solo5/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-solo5.git"
+license:      "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bheap" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+  "mirage-runtime" {>= "4.0"}
+  "duration"
+]
+conflicts: [
+  "io-page" {< "2.4.0"}
+  "tcpip" {< "6.1.0"}
+]
+synopsis: "Solo5 core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+[Solo5](https://github.com/Solo5/solo5) targets, which handles the main loop
+and timers. It also provides the low level C startup code and C stubs required
+by the OCaml code.
+
+Currently this package also includes the C stubs used by the Solo5 `console`,
+`block` and `net` implementations.
+
+The OCaml runtime and C runtime required to support it are provided separately
+by the [ocaml-freestanding](https://github.com/mirage/ocaml-freestanding) package.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-solo5/releases/download/v0.9.2/mirage-solo5-0.9.2.tbz"
+  checksum: [
+    "sha256=7ed6979d9148455db921c1e2d1216c73bfcff1dce389561af1b5d7e712048a97"
+    "sha512=b0773efa69e23c33990d152ba8a110e04aa28fc331615d621384f75aa7a2e662f6faa94f4e88f5ebffd1601ed5953d566c7a640b4a630f0b4f7ebd7c7f641c67"
+  ]
+}
+x-commit-hash: "abdc5dae6a62f6113b95001cfd15982747735c14"


### PR DESCRIPTION
Solo5 core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-solo5">https://github.com/mirage/mirage-solo5</a>

##### CHANGES:

* Provide Memory.metrics, a metrics source. Remove Mm.metrics metrics source.
  (mirage/mirage-solo5#94 @hannesm)
