### PR TITLE
[new release] mirage-xen (8.0.2)

### DIFF
--- a/packages/mirage-xen/mirage-xen.8.0.2/opam
+++ b/packages/mirage-xen/mirage-xen.8.0.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "mirage-profile" {>= "0.3"}
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v8.0.2/mirage-xen-8.0.2.tbz"
+  checksum: [
+    "sha256=2e5b86ec48a74c0cd4d24cc5ed40155e4819ce853e508d024dc362efe07327bc"
+    "sha512=d2b2e919f8669bd0f8691db460025fd5d1a79a2744a551eb3e016db55ca915e8f2d747844ec7774abffabb9fff43c23aab95f76027b74b08d72d75ad3c584c19"
+  ]
+}
+x-commit-hash: "d1ee224fbdaa79bd4c1136a80c4594c454d12c27"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Provide Memory.metrics, a metrics source. Remove Mm.metrics metrics source.
  (mirage/mirage-xen#51 @hannesm)
