### PR TITLE
Release of esperanto.0.0.3

### DIFF
--- a/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.3/opam
+++ b/packages/esperanto-cosmopolitan/esperanto-cosmopolitan.0.0.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/esperanto"
+bug-reports: "https://github.com/dinosaure/esperanto/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/esperanto.git"
+build: [
+  [ "sh" "-c" "cd toolchain && ./configure.sh --prefix=%{prefix}%" ]
+  [ make "-C" "toolchain" "all" "V=1" ]
+]
+# We should depend on conf-binutils but the package does not work on FreeBSD
+# even if we can do [pkg install binutils] on FreeBSD 12
+# depends: [
+#   "conf-binutils"
+# ]
+install: [ make "-C" "toolchain" "install" ]
+synopsis: "Cosmopolitan toolchain for OCaml compiler"
+description: "A little toolchain for OCaml with Cosmopolitan"
+available: [ arch = "x86_64" & (os = "linux" | os = "freebsd" | os = "openbsd") ]
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.3/esperanto-v0.0.3.tar.gz"
+  checksum: "sha512=cd3caf25716a185431cd97fa7a9b3a7e6a286819cc83d0e1fe1f1f94f3985f5a6f4a328511f8b7f8c26b9f3eb0d24ff586bb8095b2d5475ceb42ea1e224cce67"
+}

--- a/packages/esperanto/esperanto.0.0.3/opam
+++ b/packages/esperanto/esperanto.0.0.3/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/gilbraltar"
+bug-reports: "https://github.com/dinosaure/gilbraltar/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/gilbraltar.git"
+build: [
+  ["sh" "-c" "cd caml && ./configure.sh --prefix=%{prefix}% --target=x86_64-esperanto-none-static"]
+  [make "-C" "caml" "-j%{jobs}%"]
+]
+install: [make "-C" "caml" "install" ]
+depends: [
+  "conf-which" {build}
+  "ocaml-src" {build}
+  "esperanto-cosmopolitan" {build}
+#  "cosmopolitan-pth" {build}
+  "ocaml" {>= "4.13.0" & < "4.15.0"}
+]
+synopsis: "An OCaml compiler with Cosmopolitan"
+description:
+  "An OCaml compiler (toolchain) with Cosmopolitan as the C library"
+url {
+  src: "https://github.com/dinosaure/esperanto/releases/download/v0.0.3/esperanto-v0.0.3.tar.gz"
+  checksum: "sha512=cd3caf25716a185431cd97fa7a9b3a7e6a286819cc83d0e1fe1f1f94f3985f5a6f4a328511f8b7f8c26b9f3eb0d24ff586bb8095b2d5475ceb42ea1e224cce67"
+}


### PR DESCRIPTION
- Delete the `pth` relicat and directly use `pthread` from Cosmopolitan (dinosaure/esperanto#33, @dinosaure)
- Delete the `-mnop-mcount` and fix the issue with `dune.3.7.0` (dinosaure/esperanto#34, @dinosaure) The `-mnop-mcount` is important only if we use `-pg` which is not the case. The initial issue is a conflict with this option and `-fPIC` introduced by `dune.3.7.0`.
- Upgrade Esperanto with Cosmopolitan 2.2-96-gae365928c (dinosaure/esperanto#36, @dinosaure) This specific version of Cosmopolitan fixes an issue about Esperanto and the LWT support. However, this specific version of Cosmopolitan loses the support of `speed_t` (all values of this type disappeared).