### PR TITLE
Package docker_hub.0.1.1

### DIFF
--- a/packages/docker_hub/docker_hub.0.1.1/opam
+++ b/packages/docker_hub/docker_hub.0.1.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "Library aiming to provide data from hub.docker.com"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: "Kate <kit.ty.kate@disroot.org>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/ocaml-docker-hub"
+doc: "https://kit-ty-kate.github.io/ocaml-docker-hub/"
+bug-reports: "https://github.com/kit-ty-kate/ocaml-docker-hub/issues"
+depends: [
+  "ocaml" {>= "4.10"}
+  "dune" {>= "2.0"}
+  "http-lwt-client" {>= "0.2.0"}
+  "lwt"
+  "lwt_ppx"
+  "yojson" {>= "1.6.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/ocaml-docker-hub.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/ocaml-docker-hub/releases/download/v0.1.1/docker_hub-0.1.1.tar.gz"
+  checksum: [
+    "md5=7c3a468da507b742a1eb4e142528b6d2"
+    "sha512=d84d9bd4ec52051bdf3da759267aefd3442275e5e21be0c33f77370029abff049401a9e664be1fcf4e6688cdedd71a053e67cec296c493d8b90960875cf24926"
+  ]
+}


### PR DESCRIPTION
### `docker_hub.0.1.1`
Library aiming to provide data from hub.docker.com



---
* Homepage: https://github.com/kit-ty-kate/ocaml-docker-hub
* Source repo: git+https://github.com/kit-ty-kate/ocaml-docker-hub.git
* Bug tracker: https://github.com/kit-ty-kate/ocaml-docker-hub/issues

---
:camel: Pull-request generated by opam-publish v2.2.0