### PR TITLE
mirage-monitoring: fix conflicts

### DIFF
--- a/packages/mirage-monitoring/mirage-monitoring.0.0.4/opam
+++ b/packages/mirage-monitoring/mirage-monitoring.0.0.4/opam
@@ -21,7 +21,8 @@ depends: [
   "mirage-clock" {>= "4.0.0"}
 ]
 conflicts: [
-  "mirage-solo5" {< "8.0.2"}
+  "mirage-solo5" {< "0.9.2"}
+  "mirage-xen" {< "8.0.2"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
In https://github.com/ocaml/opam-repository/pull/23459 there was a typo in the conflicts section (sorry, all my fault).

The build actually succeeds without the conflicts, but the semantics is not the intended one (memory metrics are missing). This is the reason to have mirage-solo5 0.9.2 and mirage-xen 8.0.2 released.

Furthermore, the suggestion https://github.com/ocaml/opam-repository/pull/23459/commits/360270a9d854ff733f82451a6a6dffa6ba85d1f9 used the wrong constraint (mirage-solo5 < 8.0.2) -- making this package uninstallable with any mirage-solo5 release.

Thanks for your merge of #23459, and thanks for considering this PR.