### PR TITLE
Package catala.0.8.0

### DIFF
--- a/packages/catala/catala.0.8.0/opam
+++ b/packages/catala/catala.0.8.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description:
+  "Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information"
+maintainer: ["contact@catala-lang.org"]
+authors: [
+  "Denis Merigoux"
+  "Nicolas Chataing"
+  "Emile Rolley"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Alain Delaët-Tixeuil"
+  "Raphaël Monat"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ANSITerminal" {>= "0.8.2"}
+  "benchmark" {>= "1.6"}
+  "bindlib" {>= "5.0.1"}
+  "cmdliner" {>= "1.1.0"}
+  "cppo" {>= "1"}
+  "dates_calc" {>= "0.0.4"}
+  "dune" {>= "2.8"}
+  "js_of_ocaml-ppx" {>= "4.0.0"}
+  "menhir" {>= "20200211"}
+  "menhirLib" {>= "20200211"}
+  "ocaml" {>= "4.13.0"}
+  "ocamlfind" {!= "1.9.5"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_yojson_conv" {>= "0.14.0"}
+  "re" {>= "1.9.0"}
+  "sedlex" {>= "2.4"}
+  "uutf" {>= "1.0.3"}
+  "ubase" {>= "0.05"}
+  "unionFind" {>= "20200320"}
+  "visitors" {>= "20200210"}
+  "zarith" {>= "1.12"}
+  "zarith_stubs_js" {>= "v0.14.1"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "odoc" {with-doc}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.11"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/catala.git"
+url {
+  src: "https://github.com/CatalaLang/catala/archive/0.8.0.tar.gz"
+  checksum: [
+    "md5=1408a1cce45c7d5990b981e83e7589c2"
+    "sha512=eb3b923aa1f743378b4a05e30f50be5d180dc862a716270d747a90e469017f42fa5fc41352f02fbbf59cd2560f91c4f1b32cf38d80085b105d9387b0aed2039d"
+  ]
+}

--- a/packages/catala/catala.0.8.0/opam
+++ b/packages/catala/catala.0.8.0/opam
@@ -45,6 +45,7 @@ depends: [
 depopts: ["z3"]
 conflicts: [
   "z3" {< "4.8.11"}
+  "ocaml-option-bytecode-only"
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/catala/catala.0.8.0/opam
+++ b/packages/catala/catala.0.8.0/opam
@@ -23,11 +23,11 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "cppo" {>= "1"}
   "dates_calc" {>= "0.0.4"}
-  "dune" {>= "2.8"}
+  "dune" {>= "3.0"}
   "js_of_ocaml-ppx" {>= "4.0.0"}
   "menhir" {>= "20200211"}
   "menhirLib" {>= "20200211"}
-  "ocaml" {>= "4.13.0"}
+  "ocaml" {>= "4.14.0"}
   "ocamlfind" {!= "1.9.5"}
   "ocamlgraph" {>= "1.8.8"}
   "ppx_yojson_conv" {>= "0.14.0"}
@@ -35,7 +35,7 @@ depends: [
   "sedlex" {>= "2.4"}
   "uutf" {>= "1.0.3"}
   "ubase" {>= "0.05"}
-  "unionFind" {>= "20200320"}
+  "unionFind" {>= "20220109"}
   "visitors" {>= "20200210"}
   "zarith" {>= "1.12"}
   "zarith_stubs_js" {>= "v0.14.1"}

--- a/packages/catala/catala.0.8.0/opam
+++ b/packages/catala/catala.0.8.0/opam
@@ -31,7 +31,7 @@ depends: [
   "ocamlfind" {!= "1.9.5"}
   "ocamlgraph" {>= "1.8.8"}
   "ppx_yojson_conv" {>= "0.14.0"}
-  "re" {>= "1.9.0"}
+  "re" {>= "1.10.0"}
   "sedlex" {>= "2.4"}
   "uutf" {>= "1.0.3"}
   "ubase" {>= "0.05"}


### PR DESCRIPTION
### `catala.0.8.0`
Compiler and library for the literate programming language for tax code specification
Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information



---
* Homepage: https://github.com/CatalaLang/catala
* Source repo: git+https://github.com/CatalaLang/catala.git
* Bug tracker: https://github.com/CatalaLang/catala/issues

---
:camel: Pull-request generated by opam-publish v2.1.0