### PR TITLE
[new release] uspf, uspf-unix and uspf-lwt (0.0.3)

### DIFF
--- a/packages/uspf-lwt/uspf-lwt.0.0.3/opam
+++ b/packages/uspf-lwt/uspf-lwt.0.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml (with LWT)"
+description: """uspf-lwt is an implementation of the SPF verifier in OCaml
+compatible with MirageOS. It uses LWT as the scheduler."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "uspf"        {= version}
+  "lwt"
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.0.3/uspf-0.0.3.tbz"
+  checksum: [
+    "sha256=9e7903a149b1a9708bf33d0b34ea243172feebe60737e81522f487711e910568"
+    "sha512=d95c6b61ded3b5fff91a13ab2ea9df43ccec26f0f5fd52fe4f6561575313898947a24b591fb85ea697fd703bd402af494491de5d5e9e0b18c6954c33f92f439f"
+  ]
+}
+x-commit-hash: "4cc467d3d95ed0671688923ea1ec4df473626b9d"

--- a/packages/uspf-unix/uspf-unix.0.0.3/opam
+++ b/packages/uspf-unix/uspf-unix.0.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml"
+description: """uspf is an implementation of the SPF verifier
+in OCaml compatible with MirageOS."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "uspf"        {= version}
+  "dns-client"  {>= "7.0.0"}
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.0.3/uspf-0.0.3.tbz"
+  checksum: [
+    "sha256=9e7903a149b1a9708bf33d0b34ea243172feebe60737e81522f487711e910568"
+    "sha512=d95c6b61ded3b5fff91a13ab2ea9df43ccec26f0f5fd52fe4f6561575313898947a24b591fb85ea697fd703bd402af494491de5d5e9e0b18c6954c33f92f439f"
+  ]
+}
+x-commit-hash: "4cc467d3d95ed0671688923ea1ec4df473626b9d"

--- a/packages/uspf/uspf.0.0.3/opam
+++ b/packages/uspf/uspf.0.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml"
+description: """uspf is an implementation of the SPF verifier in OCaml
+compatible with MirageOS."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "logs"
+  "colombe"     {>= "0.4.2"}
+  "mrmime"      {>= "0.5.0"}
+  "ipaddr"      {>= "5.2.0"}
+  "hmap"
+  "angstrom"    {>= "0.15.0"}
+  "domain-name"
+  "dns"         {>= "5.0.1"}
+  "lwt"
+  "dns-client"  {>= "6.1.0"}
+  "fmt"         {>= "0.8.9"}
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.0.3/uspf-0.0.3.tbz"
+  checksum: [
+    "sha256=9e7903a149b1a9708bf33d0b34ea243172feebe60737e81522f487711e910568"
+    "sha512=d95c6b61ded3b5fff91a13ab2ea9df43ccec26f0f5fd52fe4f6561575313898947a24b591fb85ea697fd703bd402af494491de5d5e9e0b18c6954c33f92f439f"
+  ]
+}
+x-commit-hash: "4cc467d3d95ed0671688923ea1ec4df473626b9d"


### PR DESCRIPTION
SPF implementation in OCaml

- Project page: <a href="https://github.com/mirage/uspf">https://github.com/mirage/uspf</a>
- Documentation: <a href="https://mirage.github.io/uspf/">https://mirage.github.io/uspf/</a>

##### CHANGES:

- Add constraint on `fmt` (@kit-ty-kate, mirage/uspf#16)
- Be neutral when the DNS record does not give to us anything (@dinosaure, mirage/uspf#17)
- Fix `pp_mechanism` for `a` and `mx` if no domain-spec are present (no `:`)
  (@hannesm, @dinosaure, mirage/uspf#18)
- Update `ocamlformat` (@dinosaure, mirage/uspf#19, mirage/uspf#20)
- Use the last version of `mirage-crypto-rng` (@dinosaure, mirage/uspf#20)
- Lint dependencies and remove the `astring` dependency (@dinosaure, mirage/uspf#20)
- Update the documentation (@dinosaure, mirage/uspf#20)
- Split the libraries according to schedulers (@dinosaure, mirage/uspf#21)
