### PR TITLE
[new release] ethernet (3.1.0)

### DIFF
--- a/packages/ethernet/ethernet.3.1.0/opam
+++ b/packages/ethernet/ethernet.3.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "mirage-profile" {>= "0.5"}
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v3.1.0/ethernet-3.1.0.tbz"
+  checksum: [
+    "sha256=f2d5549c7c5d18d6edace6cc71f08ae121662cda96ef8f682ae118b50c46c712"
+    "sha512=7d796e994e9340404eb20471b155991f1878df4317303eccbb49116f178474b226041802b93b82c988178f964098f55f84f428a2281bdf51c8aa3127113d42aa"
+  ]
+}
+x-commit-hash: "b0b7c99d2d4d9e8c69bbf8e0d8553a25b238a21a"


### PR DESCRIPTION
OCaml Ethernet (IEEE 802.3) layer, used in MirageOS

- Project page: <a href="https://github.com/mirage/ethernet">https://github.com/mirage/ethernet</a>
- Documentation: <a href="https://mirage.github.io/ethernet/">https://mirage.github.io/ethernet/</a>

##### CHANGES:

* Remove ppx_cstruct usage, include Ethernet_wire in Ethernet_packet (mirage/ethernet#10 @hannesm)
