### PR TITLE
[new release] iomux (0.3)

### DIFF
--- a/packages/iomux/iomux.0.3/opam
+++ b/packages/iomux/iomux.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "IO Multiplexer bindings"
+description:
+  "Low level bindings for Unix IO Multiplexers (poll/ppoll/kevent/epoll)"
+maintainer: ["Christiano Haesbaert"]
+authors: ["Christiano Haesbaert"]
+license: "ISC"
+tags: ["io" "multiplexing" "poll" "ppoll" "epoll" "kevent" "kqueue"]
+homepage: "https://github.com/haesbaert/ocaml-iomux"
+doc: "https://haesbaert.github.io/ocaml-iomux"
+bug-reports: "https://github.com/haesbaert/ocaml-iomux/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.6"}
+  "dune-configurator"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/haesbaert/ocaml-iomux.git"
+url {
+  src:
+    "https://github.com/haesbaert/ocaml-iomux/releases/download/v0.3/iomux-0.3.tbz"
+  checksum: [
+    "sha256=ccd277bd53afd011291cb882f18eb5d05f3bba23257d8368dbc7a3d07f8453e7"
+    "sha512=9f7cfde9b97699946e36f7dbb19d04bdd943b45729d23797c5d3200f5e0dd93de7ba172fa03e060ca8379f01bf04c7cd1369bae87430d416c911270c3b586a90"
+  ]
+}
+x-commit-hash: "b456e181582e2bc08217291bd135d7b61a727a84"


### PR DESCRIPTION
IO Multiplexer bindings

- Project page: <a href="https://github.com/haesbaert/ocaml-iomux">https://github.com/haesbaert/ocaml-iomux</a>
- Documentation: <a href="https://haesbaert.github.io/ocaml-iomux">https://haesbaert.github.io/ocaml-iomux</a>

##### CHANGES:

* Round timeouts up, not down in Poll.poll (spotted by @talex5)
* Properly guard negative indexes (spotted by @talex5)
* Use half the maximum fds for the leak test (@haesbaert)
