### PR TITLE
[new release] plist-xml (0.5.0)

### DIFF
--- a/packages/plist-xml/plist-xml.0.5.0/opam
+++ b/packages/plist-xml/plist-xml.0.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Reading and writing of plist files in the XML format in pure OCaml"
+description: """
+Reading and writing of plist files in the XML format in pure OCaml.
+
+Implementation of https://www.apple.com/DTDs/PropertyList-1.0.dtd."""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+homepage: "https://github.com/alan-j-hu/ocaml-plist-xml"
+doc: "https://alan-j-hu.github.io/ocaml-plist-xml/"
+bug-reports: "https://github.com/alan-j-hu/ocaml-plist-xml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "base64" {>= "3.4"}
+  "cstruct" {>= "6.1"}
+  "ISO8601" {>= "0.2.6"}
+  "menhir" {>= "20220210"}
+  "ocaml" {>= "4.13"}
+  "xmlm" {>= "1.4"}
+  "eio" {>= "0.7" & with-test}
+  "eio_main" {>= "0.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-plist-xml.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-plist-xml/releases/download/0.5.0/plist-xml-0.5.0.tbz"
+  checksum: [
+    "sha256=b185065b626477ef5cdcbef598b350ed54199bc99e08f875b4a6dc8830a283c3"
+    "sha512=e24da7f6dc433a4fdfa2c66934f11c43eb23134b7630936793d0df72dc21ec8b24f5f4d40d021356af5ba88debd0329a2dc07e802468909f5937cb125ef31a3b"
+  ]
+}
+x-commit-hash: "db81fc05765a3a6f7b7f95a8780c72e07efd46e3"


### PR DESCRIPTION
Reading and writing of plist files in the XML format in pure OCaml

- Project page: <a href="https://github.com/alan-j-hu/ocaml-plist-xml">https://github.com/alan-j-hu/ocaml-plist-xml</a>
- Documentation: <a href="https://alan-j-hu.github.io/ocaml-plist-xml/">https://alan-j-hu.github.io/ocaml-plist-xml/</a>

##### CHANGES:

- Rename `of_channel` to `from_channel` and `of_string` to `from_string`. The
  new names reflect the naming convention across multiple popular OCaml file
  format libraries.
