### PR TITLE
[new release] ethernet (3.2.0)

### DIFF
--- a/packages/ethernet/ethernet.3.2.0/opam
+++ b/packages/ethernet/ethernet.3.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer:   "mirageos-devel@lists.xenproject.org"
+homepage:     "https://github.com/mirage/ethernet"
+dev-repo:     "git+https://github.com/mirage/ethernet.git"
+bug-reports:  "https://github.com/mirage/ethernet/issues"
+doc:          "https://mirage.github.io/ethernet/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+depends: [
+  "dune"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" {>= "4.0.0"}
+  "lwt" {>= "3.0.0"}
+  "logs" {>= "0.6.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "OCaml Ethernet (IEEE 802.3) layer, used in MirageOS"
+description: """
+`ethernet` provides an [Ethernet](https://en.wikipedia.org/wiki/Ethernet)
+(specified by IEEE 802.3) layer implementation for the
+[Mirage operating system](https://mirage.io).
+"""
+url {
+  src:
+    "https://github.com/mirage/ethernet/releases/download/v3.2.0/ethernet-3.2.0.tbz"
+  checksum: [
+    "sha256=4c1da70214221d9d4393a9ffde2e3db3d1ca347f76c8d525df197de21072ac09"
+    "sha512=33bc592ca642b7b4cefbdb473ce21da80a4517d2ecf7b40614a19f5edaf309f5cae3f30b5e069ee3bb363ad778d72920c448679f086a2a1813b1db1b0cd8ddc3"
+  ]
+}
+x-commit-hash: "f566a7135d481302637587b566430cd66698d630"


### PR DESCRIPTION
OCaml Ethernet (IEEE 802.3) layer, used in MirageOS

- Project page: <a href="https://github.com/mirage/ethernet">https://github.com/mirage/ethernet</a>
- Documentation: <a href="https://mirage.github.io/ethernet/">https://mirage.github.io/ethernet/</a>

##### CHANGES:

* Remove mirage-profile dependency (mirage/ethernet#11 @hannesm)
