### PR TITLE
[new release] lambdapi (2.3.1)

### DIFF
--- a/packages/lambdapi/lambdapi.2.3.1/opam
+++ b/packages/lambdapi/lambdapi.2.3.1/opam
@@ -1,0 +1,87 @@
+opam-version: "2.0"
+synopsis: "Proof assistant for the λΠ-calculus modulo rewriting"
+description: """
+This package provides:
+- A lambdapi command for checking .lp or .dk files,
+translating .dk files to .lp files and vice versa,
+or launching an LSP server for editing .lp files.
+- A library of logic definitions and basic definitions and proofs
+on natural numbers and polymorphic lists.
+- A rich Emacs mode based on LSP (available on MELPA too).
+- A basic mode for Vim.
+- OCaml libraries.
+A VSCode extension is also available on the VSCode Marketplace.
+
+Find Lambdapi user manual on https://lambdapi.readthedocs.io/.
+
+Lambdapi provides a rich type system with dependent types.
+In Lambdapi, one can define both type and function symbols
+by using rewriting rules (oriented equations).
+A symbol can be declared associative and commutative.
+Lambdapi supports unicode symbols and infix operators.
+The declaration of symbols and rewriting rules is separated
+so that one can easily define inductive-recursive types.
+
+Lambdapi checks that rules are locally confluent (by checking
+the joinability of critical pairs) and preserve typing.
+Rewrite rules can also be exported to the TRS and XTC formats
+for checking confluence and termination with external tools.
+
+Lambdapi does not come with a pre-defined logic. It is a
+powerful logical framework in which one can easily define
+its own logic and build and check proofs in this logic.
+There exist .lp files defining first or higher-order logic
+and complex type systems like in Coq or Agda.
+
+Lambdapi provides a basic module and package system,
+interactive modes for proving both unification goals
+and typing goals, and tactics for solving them step by step.
+In particular, a rewrite tactic like in SSReflect, and
+a why3 tactic for calling external automated provers through
+the Why3 platform."""
+maintainer: ["dedukti-dev@inria.fr"]
+authors: ["Deducteam"]
+license: "CECILL-2.1"
+homepage: "https://github.com/Deducteam/lambdapi"
+bug-reports: "https://github.com/Deducteam/lambdapi/issues"
+dev-repo: "git+https://github.com/Deducteam/lambdapi.git"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08.0"}
+  "menhir" {>= "20200624"}
+  "sedlex" {>= "2.2"}
+  "alcotest" {with-test}
+  "dedukti" {with-test & >= "2.7"}
+  "bindlib" {>= "6.0.0"}
+  "timed" {>= "1.0"}
+  "pratter" {>= "2.0.0"}
+  "camlp-streams" {>= "5.0"}
+  "why3" {>= "1.6.0" & < "1.7~"}
+  "yojson" {>= "1.6.0"}
+  "cmdliner" {>= "1.1.0"}
+  "stdlib-shims" {>= "0.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/Deducteam/lambdapi/releases/download/2.3.1/lambdapi-2.3.1.tbz"
+  checksum: [
+    "sha256=ef0c364e355c6c44327e62e79c484b1808d6e144bd6b899d39f0c9c3a351d5f2"
+    "sha512=b8b01a1203ea75ae79c59f67e787097f3df7603fc814776fbdd867625165dd00c70918d6edbfdc05c3a63fe7686f95e0523ad106f9da63234a2db33c4d42837e"
+  ]
+}
+x-commit-hash: "60243e461f2d1e393265f46fcd290b0a64a0b1c4"

--- a/packages/lambdapi/lambdapi.2.3.1/opam
+++ b/packages/lambdapi/lambdapi.2.3.1/opam
@@ -76,6 +76,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: arch != "ppc64"
 url {
   src:
     "https://github.com/Deducteam/lambdapi/releases/download/2.3.1/lambdapi-2.3.1.tbz"


### PR DESCRIPTION
Proof assistant for the λΠ-calculus modulo rewriting

- Project page: <a href="https://github.com/Deducteam/lambdapi">https://github.com/Deducteam/lambdapi</a>

##### CHANGES:

### Fixed

- Opaque definitions are not kept in memory and in lpo files anymore
- A few bug fixes.

### Changed

- Why3 dependency updated to 1.6.
