### PR TITLE
Packages conf-protoc.4.4.0 and ocaml-protoc-plugin.4.4.0

### DIFF
--- a/packages/conf-protoc/conf-protoc.4.4.0/opam
+++ b/packages/conf-protoc/conf-protoc.4.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Google"
+license: "BSD-3-Clause"
+homepage: "https://developers.google.com/protocol-buffers/"
+bug-reports: "https://github.com/protocolbuffers/protobuf/issues"
+dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
+build: [ "protoc" "--version" ]
+
+depexts: [
+  ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "debian"}
+  ["libprotobuf-dev" "protobuf-compiler"]   {os-family = "ubuntu"}
+  ["libprotobuf-devel" "protobuf-compiler"] {os-distribution = "mageia"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "centos"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "fedora"}
+  ["protobuf-devel" "protobuf-compiler"]    {os-distribution = "rhel"}
+  ["protobuf" "protobuf-dev"]               {os-family = "alpine"}
+  ["protobuf"]                              {os-family = "arch"}
+  ["protobuf-devel"]                        {os-family = "suse"}
+  ["protobuf"]                              {os = "freebsd"}
+  ["protobuf"]                              {os = "macos" & os-distribution = "homebrew"}
+]
+
+x-ci-accept-failures: [
+  "oraclelinux-7" # Package not available by default
+  "oraclelinux-8" # Package not available by default
+]
+
+available: (os-distribution != "ubuntu" | os-version >= "18.04") & (os-distribution != "centos" | os-version >= "8")
+synopsis: "Virtual package to install protoc compiler"
+description:
+  "This package will install the protoc compiler if invoked via `opam depext`"
+flags: conf

--- a/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.4.0/opam
+++ b/packages/ocaml-protoc-plugin/ocaml-protoc-plugin.4.4.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Issuu"
+authors: "Anders Fugmann <anders@fugmann.net>"
+license: "APACHE-2.0"
+homepage: "https://github.com/issuu/ocaml-protoc-plugin"
+dev-repo: "git+https://github.com/issuu/ocaml-protoc-plugin"
+bug-reports: "https://github.com/issuu/ocaml-protoc-plugin/issues"
+doc: "https://issuu.github.io/ocaml-protoc-plugin/"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+]
+
+depends: [
+  "conf-protoc" {>= "1.0.0"}
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_expect" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_deriving" {with-test}
+  "conf-pkg-config" {build}
+]
+
+
+synopsis: "Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file"
+
+description: """ The plugin generates ocaml type definitions,
+serialization and deserialization functions from a protobuf file.
+The types generated aims to create ocaml idiomatic types;
+- messages are mapped into modules
+- oneof constructs are mapped to polymorphic variants
+- enums are mapped to adt's
+- map types are mapped to assoc lists
+- all integer types are mapped to int by default (exact mapping is also possible)
+- all floating point types are mapped to float.
+- packages are mapped to nested modules
+"""
+url {
+  src:
+    "https://github.com/issuu/ocaml-protoc-plugin/archive/refs/tags/4.4.0.tar.gz"
+  checksum: [
+    "md5=33eec898e6b8b31ec1f8aed351a32b5d"
+    "sha512=3f7515c430bad3706dbe2fcfdbe0d5b33984dd6300adfc3cbbe912f033c3868eaa65d916eabac91195506f02f151cabb4f8173b732b020673ac7df04f9e48172"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `conf-protoc.4.4.0`: Virtual package to install protoc compiler
- `ocaml-protoc-plugin.4.4.0`: Plugin for protoc protobuf compiler to generate ocaml definitions from a .proto file



---

---
:camel: Pull-request generated by opam-publish v2.2.0