### PR TITLE
[new release] macaddr, macaddr-sexp, macaddr-cstruct, ipaddr, ipaddr-sexp and ipaddr-cstruct (5.4.0)

### DIFF
--- a/packages/ipaddr-cstruct/ipaddr-cstruct.5.4.0/opam
+++ b/packages/ipaddr-cstruct/ipaddr-cstruct.5.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.4.0/ipaddr-5.4.0.tbz"
+  checksum: [
+    "sha256=5a66291bf710b45f7e9550ecd562227af519d5fefe899da1b9fb1d0f51c735ea"
+    "sha512=c0c564529bceeb1263a6200f5f86c53ee38874a7cd3ba6dd4b435cb87e0247ba85b0ee46ab5f517ef81aa05f4187d2ba20d10013d3faa2763b64daf85046ae96"
+  ]
+}
+x-commit-hash: "3c8d00a371b07bac6184bce97b37fc68cf5a8d5d"

--- a/packages/ipaddr-sexp/ipaddr-sexp.5.4.0/opam
+++ b/packages/ipaddr-sexp/ipaddr-sexp.5.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP address representations using sexp"
+description: """
+Sexp convertions for ipaddr
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ipaddr" {= version}
+  "ipaddr-cstruct" {with-test & = version}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.4.0/ipaddr-5.4.0.tbz"
+  checksum: [
+    "sha256=5a66291bf710b45f7e9550ecd562227af519d5fefe899da1b9fb1d0f51c735ea"
+    "sha512=c0c564529bceeb1263a6200f5f86c53ee38874a7cd3ba6dd4b435cb87e0247ba85b0ee46ab5f517ef81aa05f4187d2ba20d10013d3faa2763b64daf85046ae96"
+  ]
+}
+x-commit-hash: "3c8d00a371b07bac6184bce97b37fc68cf5a8d5d"

--- a/packages/ipaddr/ipaddr.5.4.0/opam
+++ b/packages/ipaddr/ipaddr.5.4.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of IP (and MAC) address representations"
+description: """
+Features:
+ * Depends only on sexplib (conditionalization under consideration)
+ * ounit2-based tests
+ * IPv4 and IPv6 support
+ * IPv4 and IPv6 CIDR prefix support
+ * IPv4 and IPv6 [CIDR-scoped address](http://tools.ietf.org/html/rfc4291#section-2.3) support
+ * `Ipaddr.V4` and `Ipaddr.V4.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr.V6` and `Ipaddr.V6.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr` and `Ipaddr.Prefix` modules are `Map.OrderedType`
+ * `Ipaddr_unix` in findlib subpackage `ipaddr.unix` provides compatibility with the standard library `Unix` module
+ * `Ipaddr_top` in findlib subpackage `ipaddr.top` provides top-level pretty printers (requires compiler-libs default since OCaml 4.0)
+ * IP address scope classification
+ * IPv4-mapped addresses in IPv6 (::ffff:0:0/96) are an embedding of IPv4
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers
+"""
+
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "domain-name" {>= "0.3.0"}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.4.0/ipaddr-5.4.0.tbz"
+  checksum: [
+    "sha256=5a66291bf710b45f7e9550ecd562227af519d5fefe899da1b9fb1d0f51c735ea"
+    "sha512=c0c564529bceeb1263a6200f5f86c53ee38874a7cd3ba6dd4b435cb87e0247ba85b0ee46ab5f517ef81aa05f4187d2ba20d10013d3faa2763b64daf85046ae96"
+  ]
+}
+x-commit-hash: "3c8d00a371b07bac6184bce97b37fc68cf5a8d5d"

--- a/packages/macaddr-cstruct/macaddr-cstruct.5.4.0/opam
+++ b/packages/macaddr-cstruct/macaddr-cstruct.5.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using Cstructs"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Cstruct convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.4.0/ipaddr-5.4.0.tbz"
+  checksum: [
+    "sha256=5a66291bf710b45f7e9550ecd562227af519d5fefe899da1b9fb1d0f51c735ea"
+    "sha512=c0c564529bceeb1263a6200f5f86c53ee38874a7cd3ba6dd4b435cb87e0247ba85b0ee46ab5f517ef81aa05f4187d2ba20d10013d3faa2763b64daf85046ae96"
+  ]
+}
+x-commit-hash: "3c8d00a371b07bac6184bce97b37fc68cf5a8d5d"

--- a/packages/macaddr-sexp/macaddr-sexp.5.4.0/opam
+++ b/packages/macaddr-sexp/macaddr-sexp.5.4.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations using sexp"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "macaddr" {= version}
+  "macaddr-cstruct" {with-test & = version}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+Sexp convertions for macaddr
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.4.0/ipaddr-5.4.0.tbz"
+  checksum: [
+    "sha256=5a66291bf710b45f7e9550ecd562227af519d5fefe899da1b9fb1d0f51c735ea"
+    "sha512=c0c564529bceeb1263a6200f5f86c53ee38874a7cd3ba6dd4b435cb87e0247ba85b0ee46ab5f517ef81aa05f4187d2ba20d10013d3faa2763b64daf85046ae96"
+  ]
+}
+x-commit-hash: "3c8d00a371b07bac6184bce97b37fc68cf5a8d5d"

--- a/packages/macaddr/macaddr.5.4.0/opam
+++ b/packages/macaddr/macaddr.5.4.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["David Sheets" "Anil Madhavapeddy" "Hugo Heuzard"]
+synopsis: "A library for manipulation of MAC address representations"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-ipaddr"
+doc: "https://mirage.github.io/ocaml-ipaddr/"
+bug-reports: "https://github.com/mirage/ocaml-ipaddr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.9.0"}
+  "ounit2" {with-test}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+]
+conflicts: [ "ipaddr" {< "3.0.0"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-ipaddr.git"
+description: """
+A library for manipulation of MAC address representations.
+
+Features:
+
+ * ounit2-based tests
+ * MAC-48 (Ethernet) address support
+ * `Macaddr` is a `Map.OrderedType`
+ * All types have sexplib serializers/deserializers optionally via the `Macaddr_sexp` library.
+ """
+url {
+  src:
+    "https://github.com/mirage/ocaml-ipaddr/releases/download/v5.4.0/ipaddr-5.4.0.tbz"
+  checksum: [
+    "sha256=5a66291bf710b45f7e9550ecd562227af519d5fefe899da1b9fb1d0f51c735ea"
+    "sha512=c0c564529bceeb1263a6200f5f86c53ee38874a7cd3ba6dd4b435cb87e0247ba85b0ee46ab5f517ef81aa05f4187d2ba20d10013d3faa2763b64daf85046ae96"
+  ]
+}
+x-commit-hash: "3c8d00a371b07bac6184bce97b37fc68cf5a8d5d"


### PR DESCRIPTION
A library for manipulation of MAC address representations

- Project page: <a href="https://github.com/mirage/ocaml-ipaddr">https://github.com/mirage/ocaml-ipaddr</a>
- Documentation: <a href="https://mirage.github.io/ocaml-ipaddr/">https://mirage.github.io/ocaml-ipaddr/</a>

##### CHANGES:

* Use Bytes.t for IPv6 addresses (mirage/ocaml-ipaddr#115 @verbosemode, fixes mirage/ocaml-ipaddr#16 @dsheets)
* Also fixes V6.to_int64 (reported by @RyanGibb in mirage/ocaml-ipaddr#113)
