### PR TITLE
[new release] letsencrypt, letsencrypt-mirage, letsencrypt-dns and letsencrypt-app (0.5.1)

### DIFF
--- a/packages/letsencrypt-app/letsencrypt-app.0.5.1/opam
+++ b/packages/letsencrypt-app/letsencrypt-app.0.5.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "letsencrypt-dns" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "ptime"
+  "bos"
+  "fpath"
+  "randomconv"
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.5.1/letsencrypt-0.5.1.tbz"
+  checksum: [
+    "sha256=b90387a5dc8f839926b3e9de831a503317e1a30e9ab99d22a6de64b285d8a35c"
+    "sha512=cc2fb7aeba6469d8a3ae20d5bb6857c4035300059149d53ddaee802f125e99dd3078ef699e34a052105533622797194ff80ee9f6b84a7aae5fef0e5866cfada7"
+  ]
+}
+x-commit-hash: "56a10de7baf223382856796d5dc2f75555a74efd"

--- a/packages/letsencrypt-dns/letsencrypt-dns.0.5.1/opam
+++ b/packages/letsencrypt-dns/letsencrypt-dns.0.5.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "DNS solver for ACME implementation in OCaml"
+description: "A DNS solver for the ACME implementation in OCaml."
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "2.6.0"}
+  "dns"
+  "dns-tsig"
+  "domain-name" {>= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.5.1/letsencrypt-0.5.1.tbz"
+  checksum: [
+    "sha256=b90387a5dc8f839926b3e9de831a503317e1a30e9ab99d22a6de64b285d8a35c"
+    "sha512=cc2fb7aeba6469d8a3ae20d5bb6857c4035300059149d53ddaee802f125e99dd3078ef699e34a052105533622797194ff80ee9f6b84a7aae5fef0e5866cfada7"
+  ]
+}
+x-commit-hash: "56a10de7baf223382856796d5dc2f75555a74efd"

--- a/packages/letsencrypt-mirage/letsencrypt-mirage.0.5.1/opam
+++ b/packages/letsencrypt-mirage/letsencrypt-mirage.0.5.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml for MirageOS"
+description: "An ACME client implementation of the ACME protocol (RFC 8555) for OCaml & MirageOS"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "letsencrypt" {= version}
+  "http-mirage-client"
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "3.0.0"}
+  "duration"
+  "emile" {>= "1.1"}
+  "paf" {>= "0.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.5.1/letsencrypt-0.5.1.tbz"
+  checksum: [
+    "sha256=b90387a5dc8f839926b3e9de831a503317e1a30e9ab99d22a6de64b285d8a35c"
+    "sha512=cc2fb7aeba6469d8a3ae20d5bb6857c4035300059149d53ddaee802f125e99dd3078ef699e34a052105533622797194ff80ee9f6b84a7aae5fef0e5866cfada7"
+  ]
+}
+x-commit-hash: "56a10de7baf223382856796d5dc2f75555a74efd"

--- a/packages/letsencrypt/letsencrypt.0.5.1/opam
+++ b/packages/letsencrypt/letsencrypt.0.5.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "ACME implementation in OCaml"
+description: "An implementation of the ACME protocol (RFC 8555) for OCaml"
+maintainer: "Michele Mu <maker@tumbolandia.net>"
+authors:
+  "Michele Mu <maker@tumbolandia.net>, Hannes Mehnert <hannes@mehnert.org>"
+license: "BSD-2-clause"
+homepage: "https://github.com/mmaker/ocaml-letsencrypt"
+bug-reports: "https://github.com/mmaker/ocaml-letsencrypt/issues"
+doc: "https://mmaker.github.io/ocaml-letsencrypt"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "base64" {>= "3.3.0"}
+  "logs"
+  "fmt" {>= "0.8.7"}
+  "uri"
+  "lwt" {>= "2.6.0"}
+  "mirage-crypto"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk"
+  "mirage-crypto-pk" {with-test & >= "0.8.9"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "x509" {>= "0.13.0"}
+  "yojson" {>= "1.6.0"}
+  "ounit" {with-test}
+  "ptime"
+  "domain-name" {>= "0.2.0"}
+  "cstruct" {>= "6.0.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mmaker/ocaml-letsencrypt.git"
+url {
+  src:
+    "https://github.com/mmaker/ocaml-letsencrypt/releases/download/v0.5.1/letsencrypt-0.5.1.tbz"
+  checksum: [
+    "sha256=b90387a5dc8f839926b3e9de831a503317e1a30e9ab99d22a6de64b285d8a35c"
+    "sha512=cc2fb7aeba6469d8a3ae20d5bb6857c4035300059149d53ddaee802f125e99dd3078ef699e34a052105533622797194ff80ee9f6b84a7aae5fef0e5866cfada7"
+  ]
+}
+x-commit-hash: "56a10de7baf223382856796d5dc2f75555a74efd"


### PR DESCRIPTION
ACME implementation in OCaml

- Project page: <a href="https://github.com/mmaker/ocaml-letsencrypt">https://github.com/mmaker/ocaml-letsencrypt</a>
- Documentation: <a href="https://mmaker.github.io/ocaml-letsencrypt">https://mmaker.github.io/ocaml-letsencrypt</a>

##### CHANGES:

* letsencrypt-mirage: allow alpn protocols to be specified (mmaker/ocaml-letsencrypt#33 @dinosaure)
