### PR TITLE
[new release] textmate-language (0.3.4)

### DIFF
--- a/packages/textmate-language/textmate-language.0.3.4/opam
+++ b/packages/textmate-language/textmate-language.0.3.4/opam
@@ -18,7 +18,7 @@ depends: [
   "plist-xml" {>= "0.5" & with-test}
   "alcotest" {>= "1.4" & < "2" & with-test}
   "ezjsonm" {>= "1.2" & < "2" & with-test}
-  "yojson" {>= "1.7" & < "2" & with-test}
+  "yojson" {>= "1.7" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/textmate-language/textmate-language.0.3.4/opam
+++ b/packages/textmate-language/textmate-language.0.3.4/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Tokenizing code with TextMate grammars for syntax highlighting"
+description: """
+
+This package provides functions for reading TextMate grammars and tokenizing
+code on a line-by-line basis. `textmate-language` can read grammars from the
+document types of the `plist-xml`, `ezjsonm`, and `yojson` libraries."""
+maintainer: ["Alan Hu <alanh@ccs.neu.edu>"]
+authors: ["Alan Hu <alanh@ccs.neu.edu>"]
+license: "MIT"
+tags: ["highlighting"]
+homepage: "https://github.com/alan-j-hu/ocaml-textmate-language"
+bug-reports: "https://github.com/alan-j-hu/ocaml-textmate-language/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "oniguruma" {>= "0.1.2" & < "0.2.0"}
+  "ocaml" {>= "4.08"}
+  "plist-xml" {>= "0.5" & with-test}
+  "alcotest" {>= "1.4" & < "2" & with-test}
+  "ezjsonm" {>= "1.2" & < "2" & with-test}
+  "yojson" {>= "1.7" & < "2" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alan-j-hu/ocaml-textmate-language.git"
+url {
+  src:
+    "https://github.com/alan-j-hu/ocaml-textmate-language/releases/download/0.3.4/textmate-language-0.3.4.tbz"
+  checksum: [
+    "sha256=c3bcfc9a9c46fe09dc96b5a15c300b29f6685a1cf5fe2c0e43f4e3df1a20859d"
+    "sha512=8b1ff02d62d10c79af8a547e4e00e7c0a8a668256672dcb607662aa1a310bf849824597b9e41ac66d89b0c99ab760ae35793d063ac868cf54c46fe466d8cd313"
+  ]
+}
+x-commit-hash: "45f6a5d8b6ef45847fa02dac80c6f75c6126c1f1"


### PR DESCRIPTION
Tokenizing code with TextMate grammars for syntax highlighting

- Project page: <a href="https://github.com/alan-j-hu/ocaml-textmate-language">https://github.com/alan-j-hu/ocaml-textmate-language</a>

##### CHANGES:

- Update the test dependency `plist-xml` to version 0.5.
