### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-lwt and js_of_ocaml-compiler (5.1.1)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ppxlib" {>= "0.15.0"}
   "re" {with-test}
   "cmdliner" {>= "1.1.0"}
-  "sedlex"
+  "sedlex" {>= "2.3"}
   "menhir"
   "menhirLib"
   "menhirSdk"

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.1.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08" & < "5.1"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex"
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.1.1/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.1.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.1.1/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.1.1/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.1.1/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.1.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.1.1/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.1.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"

--- a/packages/js_of_ocaml/js_of_ocaml.5.1.1/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license:
+  "GPL-2.0-or-later AND LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.1.1/js_of_ocaml-5.1.1.tbz"
+  checksum: [
+    "sha256=0feb4418d2e491d50f3cffd0f7bc94c8ac02531149a467d8966f89581f7e5ede"
+    "sha512=8e031336678dd0ebb53bc5460c123538e4a968153f8b724dab1520f98fce1e105f9dc287a6576644d527bfafc181d4d071f25cc73240ff1b512c3cccdc864fe2"
+  ]
+}
+x-commit-hash: "d7a67d3fba9cc45ae83ef4c58b17a8f44c41bccf"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Bug fixes
* Compiler: fix jsoo link in presence of --disable use-js-string (ocsigen/js_of_ocaml#1430)
