### PR TITLE
conf-protoc: fix license

### DIFF
--- a/packages/conf-protoc/conf-protoc.1.0.0/opam
+++ b/packages/conf-protoc/conf-protoc.1.0.0/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 maintainer: "Issuu"
 authors: "Google"
-license: "https://github.com/protocolbuffers/protobuf/blob/master/LICENSE"
+license: "BSD-3-Clause"
 homepage: "https://developers.google.com/protocol-buffers/"
 bug-reports: "https://github.com/protocolbuffers/protobuf/issues"
 dev-repo: "git+https://github.com/protocolbuffers/protobuf.git"
@@ -20,6 +20,7 @@ depexts: [
   ["protobuf"]                              {os = "freebsd"}
   ["protobuf"]                              {os = "macos" & os-distribution = "homebrew"}
 ]
+
 x-ci-accept-failures: [
   "oraclelinux-7" # Package not available by default
   "oraclelinux-8" # Package not available by default


### PR DESCRIPTION
This backports the fix to the license to 1.0.0 and removes the new unnecessary package