### PR TITLE
Add: tsdl.1.0.0

### DIFF
--- a/packages/tsdl/tsdl.1.0.0/opam
+++ b/packages/tsdl/tsdl.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Thin bindings to SDL for OCaml"
+description: """\
+Tsdl is an OCaml library providing thin bindings to the cross-platform
+SDL C library.
+
+Tsdl depends on the [SDL 2.0.10][sdl] C library (or later),
+[ocaml-ctypes][ctypes] and the `result` compatibility package.
+Tsdl is distributed under the ISC license.
+
+[sdl]: http://www.libsdl.org/
+[ctypes]: https://github.com/ocamllabs/ocaml-ctypes
+
+Home page: http://erratique.ch/software/tsdl"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The tsdl programmers"
+license: "ISC"
+tags: [
+  "audio"
+  "bindings"
+  "graphics"
+  "media"
+  "opengl"
+  "input"
+  "hci"
+  "org:erratique"
+]
+homepage: "https://erratique.ch/software/tsdl"
+doc: "https://erratique.ch/software/tsdl/doc/"
+bug-reports: "https://github.com/dbuenzli/tsdl/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "conf-sdl2"
+  "ctypes" {>= "0.14.0"}
+  "ctypes-foreign"
+]
+available: os-distribution != "opensuse-leap" | os-version >= "16"
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/tsdl.git"
+url {
+  src: "https://erratique.ch/software/tsdl/releases/tsdl-1.0.0.tbz"
+  checksum:
+    "sha512=70ba93a07d8add11d29cf94ce173c022a52a7d57af7b9dad3abdae7fde6314d4690d3aacc8f75e598b6af2e692568399638813664db0331e0a898bdc14bfe670"
+}


### PR DESCRIPTION
* Add: `tsdl.1.0.0` [home](https://erratique.ch/software/tsdl), [doc](https://erratique.ch/software/tsdl/doc/), [issues](https://github.com/dbuenzli/tsdl/issues)  
  *Thin bindings to SDL for OCaml*


---

#### `tsdl` v1.0.0 2023-03-16 La Forclaz (VS)

- Sdl.gl_get_swap_interval: -1 is a valid return value (adaptive vsync)
  ([#90](https://github.com/dbuenzli/tsdl/issues/90)). Thanks to Edwin Török for the patch.
- Sdl.render_present: release runtime lock (useful for 'presentvsync', 
  [#90](https://github.com/dbuenzli/tsdl/issues/90)). Thanks to Edwin Török for the patch.
- Use `CArray.length` on arrays constructed via `CArray.of_list` to
  avoid a double call to `List.length`. Thanks to Vu Ngoc San 
  for the patch.
- Use implicit linking on MSVC to let ctypes-foreign find SDL2
  functions on Windows. Thanks to Jonah Beckford for the patch.
- Add binding to `SDL_SetWindowInputFocus`.
  Thanks to Maxence Guesdon for the patch.
- Add (-) operation for flags in `Init`, `Renderer` and `Window`.
  Thanks to Maxence Guesdon for the patch.
- Add `Hint.mouse_focus_clickthrough`.
  Thanks to Maxence Guesdon for the patch.
- Add `rw_from_const_mem`.
  Thanks to Maxence Guesdon for the patch.
- Use `.obj` and other non-`.o` object extensions for compilers
  like MSVC.
  Thanks to Jonah Beckford for the patch.
- Remove binding `Sdl.game_controller_add_mapping_from_file`, it's 
  a C macro ([#85](https://github.com/dbuenzli/tsdl/issues/85)).
  Thanks to Jonah Beckford for the report.

---

Use `b0 -- .opam.publish tsdl.1.0.0` to update the pull request.