### PR TITLE
[new release] gluten, gluten-mirage, gluten-lwt, gluten-lwt-unix, gluten-eio and gluten-async (0.4.1)

### DIFF
--- a/packages/gluten-async/gluten-async.0.4.1/opam
+++ b/packages/gluten-async/gluten-async.0.4.1/opam
@@ -15,7 +15,7 @@ depends: [
 ]
 depopts: ["async_ssl" "tls-async"]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/gluten-async/gluten-async.0.4.1/opam
+++ b/packages/gluten-async/gluten-async.0.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Async support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "faraday-async" {>= "0.7.3"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+]
+depopts: ["async_ssl" "tls-async"]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.1/gluten-0.4.1.tbz"
+  checksum: [
+    "sha256=78e6f33ed55666c1127bd71cf012c6a5f8b794cf4072505d0c0fcdb105673db4"
+    "sha512=48434a3086309fb59239e75a64b06a8128323cd88802b69aebccc6de3ae41719ee4ae82554c4fc022c87242bbaea182b306faf19ed4b73833d79274ebc78ec59"
+  ]
+}
+x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"

--- a/packages/gluten-eio/gluten-eio.0.4.1/opam
+++ b/packages/gluten-eio/gluten-eio.0.4.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "EIO runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "eio" {>= "0.7"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.1/gluten-0.4.1.tbz"
+  checksum: [
+    "sha256=78e6f33ed55666c1127bd71cf012c6a5f8b794cf4072505d0c0fcdb105673db4"
+    "sha512=48434a3086309fb59239e75a64b06a8128323cd88802b69aebccc6de3ae41719ee4ae82554c4fc022c87242bbaea182b306faf19ed4b73833d79274ebc78ec59"
+  ]
+}
+x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"

--- a/packages/gluten-eio/gluten-eio.0.4.1/opam
+++ b/packages/gluten-eio/gluten-eio.0.4.1/opam
@@ -12,7 +12,7 @@ depends: [
   "eio" {>= "0.7"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Lwt + Unix support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt-unix" {>= "0.7.3"}
+]
+depopts: [
+  "lwt_ssl" {>= "1.2.0"}
+  "tls-lwt"
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.1/gluten-0.4.1.tbz"
+  checksum: [
+    "sha256=78e6f33ed55666c1127bd71cf012c6a5f8b794cf4072505d0c0fcdb105673db4"
+    "sha512=48434a3086309fb59239e75a64b06a8128323cd88802b69aebccc6de3ae41719ee4ae82554c4fc022c87242bbaea182b306faf19ed4b73833d79274ebc78ec59"
+  ]
+}
+x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"

--- a/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
+++ b/packages/gluten-lwt-unix/gluten-lwt-unix.0.4.1/opam
@@ -16,7 +16,7 @@ depopts: [
   "tls-lwt"
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/gluten-lwt/gluten-lwt.0.4.1/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.4.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Lwt-specific runtime for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "gluten" {= version}
+  "lwt" {>= "5.1.1"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.1/gluten-0.4.1.tbz"
+  checksum: [
+    "sha256=78e6f33ed55666c1127bd71cf012c6a5f8b794cf4072505d0c0fcdb105673db4"
+    "sha512=48434a3086309fb59239e75a64b06a8128323cd88802b69aebccc6de3ae41719ee4ae82554c4fc022c87242bbaea182b306faf19ed4b73833d79274ebc78ec59"
+  ]
+}
+x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"

--- a/packages/gluten-lwt/gluten-lwt.0.4.1/opam
+++ b/packages/gluten-lwt/gluten-lwt.0.4.1/opam
@@ -12,7 +12,7 @@ depends: [
   "lwt" {>= "5.1.1"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/gluten-mirage/gluten-mirage.0.4.1/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"

--- a/packages/gluten-mirage/gluten-mirage.0.4.1/opam
+++ b/packages/gluten-mirage/gluten-mirage.0.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Mirage support for gluten"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "gluten-lwt" {= version}
+  "faraday-lwt" {>= "0.7.3"}
+  "conduit-mirage" {>= "2.0.2"}
+  "mirage-flow" {>= "2.0.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.1/gluten-0.4.1.tbz"
+  checksum: [
+    "sha256=78e6f33ed55666c1127bd71cf012c6a5f8b794cf4072505d0c0fcdb105673db4"
+    "sha512=48434a3086309fb59239e75a64b06a8128323cd88802b69aebccc6de3ae41719ee4ae82554c4fc022c87242bbaea182b306faf19ed4b73833d79274ebc78ec59"
+  ]
+}
+x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"

--- a/packages/gluten/gluten.0.4.1/opam
+++ b/packages/gluten/gluten.0.4.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A reusable runtime library for network protocols"
+description:
+  "gluten implements platform specific runtime code for driving network libraries based on state machines, such as http/af, h2 and websocketaf."
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "BSD-3-clause"
+homepage: "https://github.com/anmonteiro/gluten"
+bug-reports: "https://github.com/anmonteiro/gluten/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0"}
+  "bigstringaf" {>= "0.4.0"}
+  "faraday" {>= "0.7.3"}
+  "ke" {>= "0.5"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anmonteiro/gluten.git"
+url {
+  src:
+    "https://github.com/anmonteiro/gluten/releases/download/0.4.1/gluten-0.4.1.tbz"
+  checksum: [
+    "sha256=78e6f33ed55666c1127bd71cf012c6a5f8b794cf4072505d0c0fcdb105673db4"
+    "sha512=48434a3086309fb59239e75a64b06a8128323cd88802b69aebccc6de3ae41719ee4ae82554c4fc022c87242bbaea182b306faf19ed4b73833d79274ebc78ec59"
+  ]
+}
+x-commit-hash: "e0651eb76a03737782d367e7e2587734fca0c9b6"

--- a/packages/gluten/gluten.0.4.1/opam
+++ b/packages/gluten/gluten.0.4.1/opam
@@ -15,7 +15,7 @@ depends: [
   "ke" {>= "0.5"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"


### PR DESCRIPTION
A reusable runtime library for network protocols

- Project page: <a href="https://github.com/anmonteiro/gluten">https://github.com/anmonteiro/gluten</a>

##### CHANGES:

- gluten-lwt-unix: require tls-lwt `>= 0.16`
  ([anmonteiro/gluten#53](https://github.com/anmonteiro/gluten/pull/53))
- gluten-eio: adapt to `Eio.Io` errors
  ([anmonteiro/gluten#54](https://github.com/anmonteiro/gluten/pull/54))
- gluten-eio: return a `Eio.Promise.t` from `Gluten_eio.Client.shutdown`
  ([f8b88c485](https://github.com/anmonteiro/gluten/commit/f8b88c485beb473af97de7b39461fb60a56cff3f))
