### PR TITLE
[new release] tcpip (8.0.0)

### DIFF
--- a/packages/tcpip/tcpip.8.0.0/opam
+++ b/packages/tcpip/tcpip.8.0.0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+homepage:     "https://github.com/mirage/mirage-tcpip"
+dev-repo:     "git+https://github.com/mirage/mirage-tcpip.git"
+bug-reports:  "https://github.com/mirage/mirage-tcpip/issues"
+doc:          "https://mirage.github.io/mirage-tcpip/"
+authors: [
+  "Anil Madhavapeddy" "Balraj Singh" "Richard Mortier" "Nicolas Ojeda Bar"
+  "Thomas Gazagnaire" "Vincent Bernardoff" "Magnus Skjegstad" "Mindy Preston"
+  "Thomas Leonard" "David Scott" "Gabor Pali" "Hannes Mehnert" "Haris Rotsos"
+  "Kia" "Luke Dunstan" "Pablo Polvorin" "Tim Cuthbertson" "lnmx" "pqwy" ]
+license: "ISC"
+tags: ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+depends: [
+  "dune" {>= "2.7.0"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "mirage-net" {>= "3.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "ipaddr" {>= "5.0.0"}
+  "macaddr" {>="4.0.0"}
+  "macaddr-cstruct"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "lwt-dllist"
+  "logs" {>= "0.6.0"}
+  "duration"
+  "randomconv"
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-vnetif" {with-test & >= "0.5.0"}
+  "alcotest" {with-test & >="1.5.0"}
+  "pcap-format" {with-test}
+  "mirage-clock-unix" {with-test & >= "3.0.0"}
+  "mirage-random-test" {with-test & >= "0.1.0"}
+  "ipaddr-cstruct"
+  "macaddr-cstruct"
+  "lru" {>= "0.3.0"}
+  "metrics"
+  "cmdliner" {>= "1.1.0"}
+]
+synopsis: "OCaml TCP/IP networking stack, used in MirageOS"
+description: """
+`mirage-tcpip` provides a networking stack for the [Mirage operating
+system](https://mirage.io). It provides implementations for the following module types
+(which correspond with the similarly-named protocols):
+
+* IP (via the IPv4 and IPv6 modules)
+* ICMP
+* UDP
+* TCP
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-tcpip/releases/download/v8.0.0/tcpip-8.0.0.tbz"
+  checksum: [
+    "sha256=36b4c156be16702ba4c6d781a2da8ba1462b22370d15570e1116056cbf025233"
+    "sha512=56a1aab616349152beff7d0a504db15dc3d0010cb36322ce06b7abb43bd9d1a6ec0daa23fd6632fcc758c89737ba48046bb591d4a70021e273b80e716b55c44f"
+  ]
+}
+x-commit-hash: "efdfbfce071998b56f26cbef4e5227b8d98620fa"


### PR DESCRIPTION
OCaml TCP/IP networking stack, used in MirageOS

- Project page: <a href="https://github.com/mirage/mirage-tcpip">https://github.com/mirage/mirage-tcpip</a>
- Documentation: <a href="https://mirage.github.io/mirage-tcpip/">https://mirage.github.io/mirage-tcpip/</a>

##### CHANGES:

* TCP: add ID for PCB for connection tracking (mirage/mirage-tcpip#495 @TheLortex)
* Unix stack, UDP: copy buffer before passing it to client (mirage/mirage-tcpip#502 @reynir)

* API renamings (due to ppx_cstruct removal): accessors such as
  Icmpv4_wire.get_icmpv4_ty are now Icmpv4_wire.get_ty ("_icmpv4" is removed)
  (mirage/mirage-tcpip#505)

* API change: remove deprecated V4-only and V6-only stack
  The module types Stack.V4 and Stack.V6 no longer exist
  The bindings Stack.V4V6.listen_udp and listen_tcp have been removed
  (mirage/mirage-tcpip#494 @hannesm)

* Use Cstruct.to_string instead of deprecated Cstruct.copy (mirage/mirage-tcpip#506 @hannesm)
* Remove ppx_cstruct dependency (mirage/mirage-tcpip#505 @hannesm)
* Remove mirage-profile dependency (mirage/mirage-tcpip#504 @hannesm)
* Remove Mirage3 cross-compilation runes (mirage/mirage-tcpip#507 @hannesm)
* opam: add lower bounds for cmdliner and alcotest (mirage/mirage-tcpip#506 @hannesm)
