### PR TITLE
Revdeps tcpip 8 0 0

### DIFF
--- a/packages/mirage-nat/mirage-nat.2.2.5/opam
+++ b/packages/mirage-nat/mirage-nat.2.2.5/opam
@@ -18,7 +18,7 @@ depends: [
   "lru" {>= "0.3.0"}
   "ppx_deriving" {>= "4.2"}
   "dune" {>= "1.0"}
-  "tcpip" {>= "7.0.0"}
+  "tcpip" {>= "7.0.0" & < "8.0.0"}
   "ethernet" {>= "3.0.0"}
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.3.0.0/opam
+++ b/packages/mirage-nat/mirage-nat.3.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "lru" {>= "0.3.0"}
   "dune" {>= "1.0"}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "7.0.0" & < "8.0.0"}
   "ethernet" { >= "3.0.0" }
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-nat/mirage-nat.3.0.1/opam
+++ b/packages/mirage-nat/mirage-nat.3.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "cstruct" {>= "6.0.0"}
   "lru" {>= "0.3.0"}
   "dune" {>= "1.0"}
-  "tcpip" { >= "7.0.0" }
+  "tcpip" { >= "7.0.0" & < "8.0.0"}
   "ethernet" { >= "3.0.0" }
   "alcotest" {with-test}
   "mirage-clock-unix" {with-test}

--- a/packages/mirage-stack/mirage-stack.4.0.0/opam
+++ b/packages/mirage-stack/mirage-stack.4.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/mirage-stack/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.0"}
-  "tcpip" {>= "7.0.0"}
+  "tcpip" {>= "7.0.0" & < "8.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.0/opam
+++ b/packages/mirage-vnetif-stack/mirage-vnetif-stack.0.6.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-net" {>= "3.0.0"}
   "mirage-random"
   "mirage-vnetif" {= version}
-  "tcpip" {>= "7.0.0"}
+  "tcpip" {>= "7.0.0" & < "8.0.0"}
   "ethernet"
   "cstruct" {>="6.0.0"}
   "ipaddr" {>= "5.0.0"}


### PR DESCRIPTION
this contains various upper bounds for tcpip 8.0.0, see individual commit messages for the errors. the issues were encountered in the CI for #23532