### PR TITLE
[new release] kcas (0.2.3)

### DIFF
--- a/packages/kcas/kcas.0.2.3/opam
+++ b/packages/kcas/kcas.0.2.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Multi-word compare-and-set library"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.3/kcas-0.2.3.tbz"
+  checksum: [
+    "sha256=546e90baa4f27fe06c4f7199f22cf03db27cb77bb83162283c9be7228f311d50"
+    "sha512=df08f35cad6b6e84b9e2689405813f9b3d057f86475e22b81abe0435ac36395fd0c8704285b6f05aa01b943258cdcbf01e6973a56870e65782c67cb0509beed8"
+  ]
+}
+x-commit-hash: "daf1db7044dfe5c0c615573760715ca03e3785ea"


### PR DESCRIPTION
Multi-word compare-and-set library

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.2.3

* Add support for post commit actions to transactions (@polytypic)
* Bring `Xt` and `Tx` access combinators to parity and add `compare_and_swap` (@polytypic)
