### PR TITLE
[new release] eio-ssl (0.1.1)

### DIFF
--- a/packages/eio-ssl/eio-ssl.0.1.0/opam
+++ b/packages/eio-ssl/eio-ssl.0.1.0/opam
@@ -26,7 +26,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+dev-repo: "git+https://github.com/anmonteiro/eio-ssl.git"
 url {
   src:
     "https://github.com/anmonteiro/eio-ssl/releases/download/0.1.0/eio-ssl-0.1.0.tbz"

--- a/packages/eio-ssl/eio-ssl.0.1.1/opam
+++ b/packages/eio-ssl/eio-ssl.0.1.1/opam
@@ -26,7 +26,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+dev-repo: "git+https://github.com/anmonteiro/eio-ssl.git"
 url {
   src:
     "https://github.com/anmonteiro/eio-ssl/releases/download/0.1.1/eio-ssl-0.1.1.tbz"

--- a/packages/eio-ssl/eio-ssl.0.1.1/opam
+++ b/packages/eio-ssl/eio-ssl.0.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OpenSSL binding to EIO"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LicenseRef-LGPL-WITH-OpenSSL-linking-exception"
+homepage: "https://github.com/anmonteiro/eio-ssl"
+bug-reports: "https://github.com/anmonteiro/eio-ssl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.0"}
+  "ssl" {>= "0.5.13"}
+  "eio_main" {>= "0.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+url {
+  src:
+    "https://github.com/anmonteiro/eio-ssl/releases/download/0.1.1/eio-ssl-0.1.1.tbz"
+  checksum: [
+    "sha256=cb3461f5474667b8e1a9cccfa4e82144619c9cb7e01fd43bf31e025a079844ec"
+    "sha512=332d10e5b8b0e2c1148f004a781187ad5227ece407c6bb90f67d2f7e2c2332a19521af95d7b762c23a98ec9bbd2e5e136387df73f808a6fd49a8a5f3c651d5f4"
+  ]
+}
+x-commit-hash: "12ef4a5999685b0b55f960aeae47f16e26ac4c89"


### PR DESCRIPTION
OpenSSL binding to EIO

- Project page: <a href="https://github.com/anmonteiro/eio-ssl">https://github.com/anmonteiro/eio-ssl</a>

##### CHANGES:

- Set file descriptors in non-blocking mode
  ([anmonteiro/eio-ssl#12](https://github.com/anmonteiro/eio-ssl/pull/12))
  - OpenSSL requires file descriptors to be in non-blocking mode to avoid
    blocking the entire OCaml domain
