### PR TITLE
[new release] mirage-nat (3.0.2)

### DIFF
--- a/packages/mirage-nat/mirage-nat.3.0.2/opam
+++ b/packages/mirage-nat/mirage-nat.3.0.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ipaddr"
+  "cstruct" {>= "6.0.0"}
+  "lru" {>= "0.3.0"}
+  "dune" {>= "1.0"}
+  "tcpip" { >= "8.0.0" }
+  "ethernet" { >= "3.0.0" }
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+  "logs" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v3.0.2/mirage-nat-3.0.2.tbz"
+  checksum: [
+    "sha256=675837a9bdbac7f4ba6ac62feaba135bbeebe35487cbb38637b328649fc4f08b"
+    "sha512=dc951a1ad3b832c60d9dfdece8d42cd8b19d62d8f412eb58e21384d68100cfa993b5542af451e6d18619c0e9a38d0677f4d346382d7881edf35dc3816faf9945"
+  ]
+}
+x-commit-hash: "8df31ecd0de2a447fede93311da48f0bb0c664f1"


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- adapt to tcpip 8.0.0 API change (mirage/mirage-nat#49 @hannesm)
