### PR TITLE
[new release] http-lwt-client (0.2.3)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.3/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.2.3/http-lwt-client-0.2.3.tbz"
+  checksum: [
+    "sha256=952f0c06556e587bc29530a93fecaa285cbc9f68e89bd9a0fc2e7d284cf63767"
+    "sha512=ea8869d96f70af36c56357069542809d404bc60ef539fe377ae6d2af9d3c33c7ab579ec1387152bbb8cdfd742ad532ddaf7607627e9edab39ba19d1a241360fb"
+  ]
+}
+x-commit-hash: "b1deccba81bdfbb4de85e756dee73622725a16d5"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Adapt to h2 0.10.0 API change (roburio/http-lwt-client#18 by @hannesm)
