### PR TITLE
Package opam-file-format.2.1.6

### DIFF
--- a/packages/opam-file-format/opam-file-format.2.1.6/opam
+++ b/packages/opam-file-format/opam-file-format.2.1.6/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+synopsis: "Parser and printer for the opam file syntax"
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-file-format/issues"
+depends: [
+  "ocaml" {>= "3.09.0"}
+  "alcotest" {with-test}
+]
+depopts: ["dune"]
+conflicts: [
+  "dune" {< "1.3.0"}
+]
+build: [
+  [make "byte" {!ocaml:native} "all" {ocaml:native}] {!dune:installed}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+    {dune:installed}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:installed}
+]
+install: [make "install" "PREFIX=%{prefix}%"] {!dune:installed}
+dev-repo: "git+https://github.com/ocaml/opam-file-format"
+url {
+  src:
+    "https://github.com/ocaml/opam-file-format/archive/refs/tags/2.1.6.tar.gz"
+  checksum: [
+    "md5=706ce5fc3e77db746a4c8b11d79cefef"
+    "sha512=89148dceacc523bcd3b65ecc60cbef2270a9618f7d97c5655060adef5c99986fa37910c9622d328a6371a0409a371158cec919f5100cf6d85110cd7cfdf2bb85"
+  ]
+}


### PR DESCRIPTION
### `opam-file-format.2.1.6`
Parser and printer for the opam file syntax



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam-file-format
* Bug tracker: https://github.com/ocaml/opam-file-format/issues

---
:camel: Pull-request generated by opam-publish v2.2.0