### PR TITLE
2 packages from framagit.org/zoggy/ocaml-stk/-/archive/0.1.0/ocaml-stk-0.1.0.tar.bz2

### DIFF
--- a/packages/stk/stk.0.1.0/opam
+++ b/packages/stk/stk.0.1.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "SDL-based GUI toolkit"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "fmt" {>= "0.9.0"}
+  "higlo" {>= "0.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.2"}
+  "pcre" {>= "7.5.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "sedlex" {>= "1.2"}
+  "tsdl" {>= "1.0.0"}
+  "tsdl-image" {>= "0.3.2"}
+  "tsdl-ttf" {>= "0.3.2"}
+  "uunf" {>= "15.0.0"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-stk/-/archive/0.1.0/ocaml-stk-0.1.0.tar.bz2"
+  checksum: [
+    "md5=c334ffabde8b710f1eba6699db0f601a"
+    "sha512=7978e3f10bc196ee6177ded9ae0313a5ba65e1a74e501fbecbe5ebc216ca6ee7117deaff5bc4c414083a4a55851a81e5dedaa8d0a880ad72689b3f56f3b064f5"
+  ]
+}

--- a/packages/stk_iconv/stk_iconv.0.1.0/opam
+++ b/packages/stk_iconv/stk_iconv.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Bindings to GNU libiconv"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "GPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-stk/"
+doc: "https://zoggy.frama.io/ocaml-stk/"
+bug-reports: "https://framagit.org/zoggy/ocaml-stk/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ctypes" {>= "0.20.1"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-stk.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-stk/-/archive/0.1.0/ocaml-stk-0.1.0.tar.bz2"
+  checksum: [
+    "md5=c334ffabde8b710f1eba6699db0f601a"
+    "sha512=7978e3f10bc196ee6177ded9ae0313a5ba65e1a74e501fbecbe5ebc216ca6ee7117deaff5bc4c414083a4a55851a81e5dedaa8d0a880ad72689b3f56f3b064f5"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `stk.0.1.0`: SDL-based GUI toolkit
- `stk_iconv.0.1.0`: Bindings to GNU libiconv



---
* Homepage: https://zoggy.frama.io/ocaml-stk/
* Source repo: git+https://framagit.org/zoggy/ocaml-stk.git
* Bug tracker: https://framagit.org/zoggy/ocaml-stk/issues

---
:camel: Pull-request generated by opam-publish v2.2.0