### PR TITLE
[new release] paf and paf-cohttp (0.5.0)

### DIFF
--- a/packages/paf-cohttp/paf-cohttp.0.5.0/opam
+++ b/packages/paf-cohttp/paf-cohttp.0.5.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A CoHTTP client with its HTTP/AF implementation"
+description: "A compatible layer betweem CoHTTP and HTTP/AF."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "paf" {= version}
+  "cohttp-lwt"
+  "domain-name"
+  "httpaf"
+  "ipaddr"
+  "alcotest-lwt"      {with-test & >= "1.1.0"}
+  "fmt"               {with-test}
+  "logs"              {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-time-unix"  {with-test}
+  "tcpip"             {with-test & >= "6.0.0"}
+  "uri"               {with-test}
+  "lwt"               {with-test}
+  "astring"           {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.5.0/paf-0.5.0.tbz"
+  checksum: [
+    "sha256=a1646fc1bf0386d17796d59a67a9a82a681a74552782bba8d54388686355fe83"
+    "sha512=616f5b7c7090b5f9bba70969fce56ffc909ec31a6a9045d8093e4494e76607b4ebb957cc1b2318364d50f30e5414d058af46a23bf8ea0a0ee421dc94378b9c31"
+  ]
+}
+x-commit-hash: "bb905e992b036b9571955b177049b1ea48f4b709"

--- a/packages/paf/paf.0.5.0/opam
+++ b/packages/paf/paf.0.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "HTTP/AF and MirageOS"
+description: "A compatible layer for HTTP/AF and MirageOS."
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/paf-le-chien"
+doc: "https://dinosaure.github.io/paf-le-chien/"
+bug-reports: "https://github.com/dinosaure/paf-le-chien/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "tls-mirage" {>= "0.15.0"}
+  "mimic" {>= "0.0.5"}
+  "ke" {>= "0.4"}
+  "lwt" {with-test}
+  "base-unix" {with-test}
+  "logs" {with-test}
+  "fmt" {with-test}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "mirage-time-unix" {with-test}
+  "ptime" {with-test}
+  "uri" {with-test}
+  "alcotest-lwt" {with-test}
+  "bigstringaf" {>= "0.7.0"}
+  "httpaf" {>= "0.7.1"}
+  "h2" {>= "0.10.0"}
+  "faraday" {>= "0.7.2"}
+  "tls" {>= "0.15.0"}
+  "cstruct" {>= "6.0.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs] {os != "macos"}
+dev-repo: "git+https://github.com/dinosaure/paf-le-chien.git"
+url {
+  src:
+    "https://github.com/dinosaure/paf-le-chien/releases/download/0.5.0/paf-0.5.0.tbz"
+  checksum: [
+    "sha256=a1646fc1bf0386d17796d59a67a9a82a681a74552782bba8d54388686355fe83"
+    "sha512=616f5b7c7090b5f9bba70969fce56ffc909ec31a6a9045d8093e4494e76607b4ebb957cc1b2318364d50f30e5414d058af46a23bf8ea0a0ee421dc94378b9c31"
+  ]
+}
+x-commit-hash: "bb905e992b036b9571955b177049b1ea48f4b709"


### PR DESCRIPTION
HTTP/AF and MirageOS

- Project page: <a href="https://github.com/dinosaure/paf-le-chien">https://github.com/dinosaure/paf-le-chien</a>
- Documentation: <a href="https://dinosaure.github.io/paf-le-chien/">https://dinosaure.github.io/paf-le-chien/</a>

##### CHANGES:

- Upgrade to `mirage-crypto-rng.0.11.0` (@hannesm, @dinosaure, dinosaure/paf-le-chien#85)
- Be able to specify ALPN protocols (@kit-ty-kate, @dinosaure, dinosaure/paf-le-chien#86)
  Also merged into `ocaml-letsencrypt` (see mmaker/ocaml-letsencrypt#33)
- Set the default protocol used for the ALPN negotiation to "http/1.1" (@dinosaure, dinosaure/paf-le-chien#87)
  Also merged into `ocaml-letsencrypt` (see mmaker/ocaml-letsencrypt#33)
- Upgrade `paf` to `h2.0.10.0` (@kit-ty-kate, @dinosaure, dinosaure/paf-le-chien#83)
- Replace `Cstruct.copy` (deprecated) by `Cstruct.to_string` (@dinosaure, dinosaure/paf-le-chien#83)
- Delete `paf-le` package (@dinosaure, @hannesm, dinosaure/paf-le-chien#88)
  Implementations are available via the new package `letsencrypt-mirage`
