### PR TITLE
http-mirage-client: add upper bound for h2

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.1/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.1/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-clock-unix" {with-test}
   "mirage-random-stdlib" {with-test}
   "mirage-time-unix" {with-test}
-  "h2"
+  "h2" {>= "0.9.0" & < "0.10.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/http-mirage-client/http-mirage-client.0.0.2/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.2/opam
@@ -22,7 +22,7 @@ depends: [
   "mirage-clock-unix" {with-test}
   "mirage-random-stdlib" {with-test}
   "mirage-time-unix" {with-test}
-  "h2"
+  "h2" {>= "0.9.0" & < "0.10.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
spotted in https://github.com/ocaml/opam-repository/pull/23548

```
=== ERROR while compiling http-mirage-client.0.0.1 ===========================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/http-mirage-client.0.0.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p http-mirage-client -j 127 @install
 exit-code            1
 env-file             ~/.opam/log/http-mirage-client-7-c4fe63.env
 output-file          ~/.opam/log/http-mirage-client-7-c4fe63.out
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I src/.http_mirage_client.objs/byte -I src/.http_mirage_client.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/ca-certs-nss -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/dns -I /home/opam/.opam/4.14/lib/dns-client -I /home/opam/.opam/4.14/lib/dns-client-mirage -I /home/opam/.opam/4.14/lib/dns/cache -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/h2 -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/hkdf -I /home/opam/.opam/4.14/lib/hpack -I /home/opam/.opam/4.14/lib/httpaf -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mimic-happy-eyeballs -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-random -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-mirage -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -o src/.http_mirage_client.objs/native/http_mirage_client.cmx -c -impl src/http_mirage_client.ml)
 File "src/http_mirage_client.ml", line 256, characters 33-37:
 256 |     H2.Client_connection.request conn req ~error_handler ~response_handler in
                                        ^^^^
 Error: This expression has type unit -> H2.Client_connection.t
        but an expression was expected of type H2.Client_connection.t
        Hint: Did you forget to provide `()' as argument?
 (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.http_mirage_client.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/asn1-combinators -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/ca-certs-nss -I /home/opam/.opam/4.14/lib/cstruct -I /home/opam/.opam/4.14/lib/dns -I /home/opam/.opam/4.14/lib/dns-client -I /home/opam/.opam/4.14/lib/dns-client-mirage -I /home/opam/.opam/4.14/lib/dns/cache -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/duration -I /home/opam/.opam/4.14/lib/eqaf -I /home/opam/.opam/4.14/lib/eqaf/bigstring -I /home/opam/.opam/4.14/lib/eqaf/cstruct -I /home/opam/.opam/4.14/lib/faraday -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gmap -I /home/opam/.opam/4.14/lib/h2 -I /home/opam/.opam/4.14/lib/happy-eyeballs -I /home/opam/.opam/4.14/lib/happy-eyeballs-mirage -I /home/opam/.opam/4.14/lib/hkdf -I /home/opam/.opam/4.14/lib/hpack -I /home/opam/.opam/4.14/lib/httpaf -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ke -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lru -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/metrics -I /home/opam/.opam/4.14/lib/mimic -I /home/opam/.opam/4.14/lib/mimic-happy-eyeballs -I /home/opam/.opam/4.14/lib/mirage-clock -I /home/opam/.opam/4.14/lib/mirage-crypto -I /home/opam/.opam/4.14/lib/mirage-crypto-ec -I /home/opam/.opam/4.14/lib/mirage-crypto-pk -I /home/opam/.opam/4.14/lib/mirage-crypto-rng -I /home/opam/.opam/4.14/lib/mirage-flow -I /home/opam/.opam/4.14/lib/mirage-kv -I /home/opam/.opam/4.14/lib/mirage-random -I /home/opam/.opam/4.14/lib/mirage-time -I /home/opam/.opam/4.14/lib/optint -I /home/opam/.opam/4.14/lib/paf -I /home/opam/.opam/4.14/lib/pbkdf -I /home/opam/.opam/4.14/lib/psq -I /home/opam/.opam/4.14/lib/ptime -I /home/opam/.opam/4.14/lib/randomconv -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/tcpip -I /home/opam/.opam/4.14/lib/tls -I /home/opam/.opam/4.14/lib/tls-mirage -I /home/opam/.opam/4.14/lib/x509 -I /home/opam/.opam/4.14/lib/zarith -intf-suffix .ml -no-alias-deps -o src/.http_mirage_client.objs/byte/http_mirage_client.cmo -c -impl src/http_mirage_client.ml)
 File "src/http_mirage_client.ml", line 256, characters 33-37:
 256 |     H2.Client_connection.request conn req ~error_handler ~response_handler in
                                        ^^^^
 Error: This expression has type unit -> H2.Client_connection.t
        but an expression was expected of type H2.Client_connection.t
        Hint: Did you forget to provide `()' as argument?
```