### PR TITLE
Package ppx_subliner.0.1.2

### DIFF
--- a/packages/ppx_subliner/ppx_subliner.0.1.2/opam
+++ b/packages/ppx_subliner/ppx_subliner.0.1.2/opam
@@ -34,9 +34,9 @@ build: [
 dev-repo: "git+https://github.com/bn-d/ppx_subliner.git"
 url {
   src:
-    "https://github.com/bn-d/ppx_deriving_subliner/archive/refs/tags/v0.1.2.tar.gz"
+    "https://github.com/bn-d/ppx_deriving_subliner/archive/refs/tags/v0.1.3.tar.gz"
   checksum: [
-    "md5=23944ff2ed893b6c9d27b256a895b1b7"
-    "sha512=2756dccb41c8940685dc0d367f74fb60a9e776a2a1ebc4fa3e9909e311dced4e1031cb10e99aacecc1ecaa039fb2d6a017068e08e67fa3e6e5eccd95c4287053"
+    "md5=6b8bc45b5066d8fe25396fb10c9f8843"
+    "sha512=efdcc19812da282e44a6107b41da4e4da3f3f109030a30c5434e6e4a7d4e77bf7732f7dc52d94562a7d068018ee79afc2e2feb06360c2bf4352d07fadf01f800"
   ]
 }


### PR DESCRIPTION
### `ppx_subliner.0.1.2`
[@@deriving subliner] and [%%subliner] for Cmdliner
[@@deriving] plugin to generate Cmdliner sub-command groups and ppx rewriter to generate Cmdliner evaluations.



---
* Homepage: https://github.com/bn-d/ppx_subliner
* Source repo: git+https://github.com/bn-d/ppx_subliner.git
* Bug tracker: https://github.com/bn-d/ppx_subliner/issues

---
:camel: Pull-request generated by opam-publish v2.2.0