### PR TITLE
[new release] piece_rope (0.9.1)

### DIFF
--- a/packages/piece_rope/piece_rope.0.9.1/opam
+++ b/packages/piece_rope/piece_rope.0.9.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A data structure for efficiently manipulating strings"
+description:
+  "Supports UTF-8, UTF-16 and UTF-32 for interacting with external systems. Provides extensibility points for you to implement domain-specific functions. Documented and designed to be simple to use."
+maintainer: ["Humza Shahid"]
+authors: ["Humza Shahid"]
+license: "MIT"
+tags: ["text" "piece table" "piece tree" "rope" "unicode"]
+homepage: "https://github.com/hummy123/ocaml-piecerope"
+bug-reports: "https://github.com/hummy123/ocaml-piecerope/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.6"}
+  "atdgen" {>= "2.11.0"}
+  "yojson" {>= "2.0.2"}
+  "alcotest" {>= "1.7.0"}
+  "bisect_ppx" {>= "2.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hummy123/ocaml-piecerope.git"
+url {
+  src:
+    "https://github.com/hummy123/ocaml-piecerope/releases/download/0.9.1/piece_rope-0.9.1.tbz"
+  checksum: [
+    "sha256=e8e799251c08ddead0fabe80244712143a0f8a75ceaf18e3bf7fceac27cc5fa4"
+    "sha512=0d4a61f65418170fcd90e5ef185a7b008ed051a0dfbce5cb222d5e7451f88336fad6f0795f75bae788663feaf463c5f1e88fd080a6bf86c542431b0a53288024"
+  ]
+}
+x-commit-hash: "bdcbeba6b3db969f56c57f2a9787ca0796d38d67"


### PR DESCRIPTION
A data structure for efficiently manipulating strings

- Project page: <a href="https://github.com/hummy123/ocaml-piecerope">https://github.com/hummy123/ocaml-piecerope</a>

##### CHANGES:

* Piece_rope.stats function now returns proper number of lines.
* More robust handling of \r\n line breaks.
  * If trying to insert in midle of \r\n, insert is moved to after this pair.
  * If either \r or \n is deleted in \r\n pair, deletes both.
  * If trying to retrieve line that ends with \r\n, returns the \r\n pair at the end.
  * If trying to retrieve line after a \r\n pair, now returns the line after the pair (previously returned \n at the start).
* Additional unit tests to verify proper functioning.
