### PR TITLE
[new release] awa, awa-mirage and awa-lwt (0.2.0)

### DIFF
--- a/packages/awa-lwt/awa-lwt.0.2.0/opam
+++ b/packages/awa-lwt/awa-lwt.0.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt"
+  "cstruct-unix"
+  "mirage-crypto-rng"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.2.0/awa-0.2.0.tbz"
+  checksum: [
+    "sha256=86c993ba8b9b05db04c867bcce67c6ec98a16342c5338944ae93ca515a1b217f"
+    "sha512=71aed67b4ab92e68d88f67a5162da2187b2596b40b4174e5be2232f0b466615ce10706c6aea85201bd6582dd6d674765d9ad76112289df06904d6f3bbb595226"
+  ]
+}
+x-commit-hash: "c6320326eeeaac1fa6f0d67f8a1cd50569fd48b9"

--- a/packages/awa-mirage/awa-mirage.0.2.0/opam
+++ b/packages/awa-mirage/awa-mirage.0.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: "Hannes Mehnert <hannes@mehnert.org>"
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-time" {>= "2.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.2.0/awa-0.2.0.tbz"
+  checksum: [
+    "sha256=86c993ba8b9b05db04c867bcce67c6ec98a16342c5338944ae93ca515a1b217f"
+    "sha512=71aed67b4ab92e68d88f67a5162da2187b2596b40b4174e5be2232f0b466615ce10706c6aea85201bd6582dd6d674765d9ad76112289df06904d6f3bbb595226"
+  ]
+}
+x-commit-hash: "c6320326eeeaac1fa6f0d67f8a1cd50569fd48b9"

--- a/packages/awa/awa.0.2.0/opam
+++ b/packages/awa/awa.0.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.15.2"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.2.0/awa-0.2.0.tbz"
+  checksum: [
+    "sha256=86c993ba8b9b05db04c867bcce67c6ec98a16342c5338944ae93ca515a1b217f"
+    "sha512=71aed67b4ab92e68d88f67a5162da2187b2596b40b4174e5be2232f0b466615ce10706c6aea85201bd6582dd6d674765d9ad76112289df06904d6f3bbb595226"
+  ]
+}
+x-commit-hash: "c6320326eeeaac1fa6f0d67f8a1cd50569fd48b9"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* server: be able to stop using a Lwt_switch.t (mirage/awa-ssh#52 @dinosaure)
* server: add Pty/Set_env/Start_shell events (mirage/awa-ssh#53 @dinosaure)
* client: support password authentication and keyboard-interactive (mirage/awa-ssh#51
  @hannesm, reported by @dgjustice mirage/awa-ssh#31)
* client: add NIST EC curves (mirage/awa-ssh#31 @hannesm)
* client: try public key authenticaion only once (mirage/awa-ssh#50 @reynir @hannesm)
* remove (partially implemented) hostbased authentication (mirage/awa-ssh#31 @hannesm)
* replace deprecated Cstruct.copy by Cstruct.to_string (mirage/awa-ssh#53 @dinosaure)
* remove ppx_cstruct and sexplib dependencies (mirage/awa-ssh#54 @hannesm)
