### PR TITLE
Fix awa revdeps in git-mirage:

### DIFF
--- a/packages/git-mirage/git-mirage.3.10.0/opam
+++ b/packages/git-mirage/git-mirage.3.10.0/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.10.1/opam
+++ b/packages/git-mirage/git-mirage.3.10.1/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.11.0/opam
+++ b/packages/git-mirage/git-mirage.3.11.0/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.12.0/opam
+++ b/packages/git-mirage/git-mirage.3.12.0/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.7.1/opam
+++ b/packages/git-mirage/git-mirage.3.7.1/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.8.0/opam
+++ b/packages/git-mirage/git-mirage.3.8.0/opam
@@ -13,8 +13,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.8.1/opam
+++ b/packages/git-mirage/git-mirage.3.8.1/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3" & < "6.4.0"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.9.0/opam
+++ b/packages/git-mirage/git-mirage.3.9.0/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls"

--- a/packages/git-mirage/git-mirage.3.9.1/opam
+++ b/packages/git-mirage/git-mirage.3.9.1/opam
@@ -14,8 +14,8 @@ depends: [
   "base64" {>= "3.5.0"}
   "git" {= version}
   "git-paf" {= version}
-  "awa" {>= "0.1.0"}
-  "awa-mirage" {>= "0.1.0"}
+  "awa" {>= "0.1.0" & < "0.2.0"}
+  "awa-mirage" {>= "0.1.0" & < "0.2.0"}
   "dns" {>= "6.1.3"}
   "dns-client" {>= "6.1.3"}
   "tls"


### PR DESCRIPTION
//cc @dinosaure 

```
=== ERROR while compiling git-mirage.3.9.1 ===================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/git-mirage.3.9.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p git-mirage -j 127
 exit-code            1
 env-file             ~/.opam/log/git-mirage-7-33331a.env
 output-file          ~/.opam/log/git-mirage-7-33331a.out
 (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -g -I src/git-mirage/.git_mirage_ssh.objs/byte -I src/git-mirage/.git_mirage_ssh.objs/native -I /home/opam/.opam/5.0/lib/awa -I /home/opam/.opam/5.0/lib/awa-mirage -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/git/nss/git -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/mimic -I /home/opam/.opam/5.0/lib/mimic-happy-eyeballs -I /home/opam/.opam/5.0/lib/mirage-clock -I /home/opam/.opam/5.0/lib/mirage-flow -I /home/opam/.opam/5.0/lib/mirage-time -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/tcpip -intf-suffix .ml -no-alias-deps -o src/git-mirage/.git_mirage_ssh.objs/native/git_mirage_ssh.cmx -c -impl src/git-mirage/git_mirage_ssh.ml)
 File "src/git-mirage/git_mirage_ssh.ml", line 67, characters 73-80:
 67 |           client_of_flow ?authenticator:edn.authenticator ~user:edn.user edn.key
                                                                               ^^^^^^^
 Error: This expression has type Awa.Hostkey.priv
        but an expression was expected of type
          [ `Password of string | `Pubkey of Awa.Hostkey.priv ]
 (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -g -bin-annot -I src/git-mirage/.git_mirage_ssh.objs/byte -I /home/opam/.opam/5.0/lib/awa -I /home/opam/.opam/5.0/lib/awa-mirage -I /home/opam/.opam/5.0/lib/fmt -I /home/opam/.opam/5.0/lib/git/nss/git -I /home/opam/.opam/5.0/lib/lwt -I /home/opam/.opam/5.0/lib/mimic -I /home/opam/.opam/5.0/lib/mimic-happy-eyeballs -I /home/opam/.opam/5.0/lib/mirage-clock -I /home/opam/.opam/5.0/lib/mirage-flow -I /home/opam/.opam/5.0/lib/mirage-time -I /home/opam/.opam/5.0/lib/result -I /home/opam/.opam/5.0/lib/tcpip -intf-suffix .ml -no-alias-deps -o src/git-mirage/.git_mirage_ssh.objs/byte/git_mirage_ssh.cmo -c -impl src/git-mirage/git_mirage_ssh.ml)
 File "src/git-mirage/git_mirage_ssh.ml", line 67, characters 73-80:
 67 |           client_of_flow ?authenticator:edn.authenticator ~user:edn.user edn.key
                                                                               ^^^^^^^
 Error: This expression has type Awa.Hostkey.priv
        but an expression was expected of type
          [ `Password of string | `Pubkey of Awa.Hostkey.priv ]
```