### PR TITLE
[new release] dockerfile, dockerfile-opam and dockerfile-cmd (8.2.0)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.2.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.2.0/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-cmd/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.0/dockerfile-8.2.0.tbz"
+  checksum: [
+    "sha256=965b664b8d0be4ef56116d81040a70d8d1743b3da1764a52146da38d0437ad84"
+    "sha512=8545c9791166a0dbf791819e3ea57afabd2e8990da52956b2f60956f319296fe75e2c084795e0cd9014d808baee405dfc06bdb2ae905c8f79185bd40ebb31ff8"
+  ]
+}
+x-commit-hash: "7da34b8a913f8d4684fdd3884636c3df4fc25b86"

--- a/packages/dockerfile-opam/dockerfile-opam.8.2.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.2.0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-opam/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring"
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.5.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.0/dockerfile-8.2.0.tbz"
+  checksum: [
+    "sha256=965b664b8d0be4ef56116d81040a70d8d1743b3da1764a52146da38d0437ad84"
+    "sha512=8545c9791166a0dbf791819e3ea57afabd2e8990da52956b2f60956f319296fe75e2c084795e0cd9014d808baee405dfc06bdb2ae905c8f79185bd40ebb31ff8"
+  ]
+}
+x-commit-hash: "7da34b8a913f8d4684fdd3884636c3df4fc25b86"

--- a/packages/dockerfile/dockerfile.8.2.0/opam
+++ b/packages/dockerfile/dockerfile.8.2.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.0/dockerfile-8.2.0.tbz"
+  checksum: [
+    "sha256=965b664b8d0be4ef56116d81040a70d8d1743b3da1764a52146da38d0437ad84"
+    "sha512=8545c9791166a0dbf791819e3ea57afabd2e8990da52956b2f60956f319296fe75e2c084795e0cd9014d808baee405dfc06bdb2ae905c8f79185bd40ebb31ff8"
+  ]
+}
+x-commit-hash: "7da34b8a913f8d4684fdd3884636c3df4fc25b86"


### PR DESCRIPTION
Dockerfile eDSL in OCaml

- Project page: <a href="https://github.com/ocurrent/ocaml-dockerfile">https://github.com/ocurrent/ocaml-dockerfile</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/">https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/</a>

##### CHANGES:

- Install system packages required by OCaml in the ocaml stage,
  starting with OCaml 5.1 and libzstd.
  (@MisterDA ocurrent/ocaml-dockerfile#149, review by @kit-ty-kate)
- Add OracleLinux 9. (@MisterDA ocurrent/ocaml-dockerfile#155)
- Optimize and fix Linux package install.
  (@MisterDA ocurrent/ocaml-dockerfile#147, ocurrent/ocaml-dockerfile#151, ocurrent/ocaml-dockerfile#153, ocurrent/ocaml-dockerfile#154, review by @kit-ty-kate)
- Switch to ocaml-opam/opam-repository-mingw#sunset for Windows images. (@MisterDA ocurrent/ocaml-dockerfile#152)
- Use DockerHub user risvc64/ubuntu. (@MisterDA, ocurrent/ocaml-dockerfile#150)
- Various LCU Updates (@mtelvers ocurrent/ocaml-dockerfile#144 ocurrent/ocaml-dockerfile#136 ocurrent/ocaml-dockerfile#135)
- Support mounts, networks, and security parameters in RUN
  commands, add buildkit_syntax helper function.
  (@MisterDA, @edwintorok, ocurrent/ocaml-dockerfile#137, ocurrent/ocaml-dockerfile#139, review by @edwintorok)
- Build and install opam master from source in Windows images.
  (@MisterDA ocurrent/ocaml-dockerfile#140, ocurrent/ocaml-dockerfile#142, ocurrent/ocaml-dockerfile#143)
- Include the ocaml-beta-repository in the images. (@kit-ty-kate ocurrent/ocaml-dockerfile#132, review by @MisterDA)
- Add OpenSUSE 15.4, deprecate OpenSUSE 15.3. (@MisterDA ocurrent/ocaml-dockerfile#138)
- Update to bubblewrap 0.8.0. (@MisterDA ocurrent/ocaml-dockerfile#131 ocurrent/ocaml-dockerfile#148)
- Add Alpine 3.17 (3.16 is now tier 2 and 3.15 is deprecated). Remove
  libexecinfo-dev from the list of apk packages as it is no longer
  available. Its symbols are only used in OCaml's self tests.
  (@MisterDA ocurrent/ocaml-dockerfile#129, ocurrent/ocaml-dockerfile#130)
- Fix location of Debian exotic architecture images (@dra27 ocurrent/ocaml-dockerfile#134)
- Fix passing of --platform to all stages of the Dockerfiles (@dra27 ocurrent/ocaml-dockerfile#134)
