### PR TITLE
cca: add missing dependency on num

### DIFF
--- a/packages/cca/cca.0.1/opam
+++ b/packages/cca/cca.0.1/opam
@@ -16,6 +16,7 @@ depends: [
   "camlzip"
   "cryptokit"
   "csv"
+  "num"
   "git-unix" {>= "3.2.0" & < "3.3.0"}
   "menhir"
   "ocamlnet"

--- a/packages/cca/cca.0.2/opam
+++ b/packages/cca/cca.0.2/opam
@@ -16,6 +16,7 @@ depends: [
   "camlzip"
   "cryptokit"
   "csv"
+  "num"
   "git-unix" {>= "3.3.0" & < "3.7.0"}
   "menhir"
   "ocamlnet"

--- a/packages/cca/cca.0.4/opam
+++ b/packages/cca/cca.0.4/opam
@@ -16,6 +16,7 @@ depends: [
   "camlzip"
   "cryptokit"
   "csv"
+  "num"
   "git-unix" {>= "3.3.0" & < "3.7.0"}
   "menhir" {>= "20170418"}
   "ocamlnet"

--- a/packages/cca/cca.0.5/opam
+++ b/packages/cca/cca.0.5/opam
@@ -16,6 +16,7 @@ depends: [
   "camlzip"
   "cryptokit"
   "csv"
+  "num"
   "git-unix" {>= "3.3.0" & < "3.7.0"}
   "menhir" {>= "20170418"}
   "ocamlnet"

--- a/packages/cca/cca.0.6.2/opam
+++ b/packages/cca/cca.0.6.2/opam
@@ -18,6 +18,7 @@ depends: [
   "camlzip"
   "cryptokit"
   "csv"
+  "num"
   "git-unix" {>= "3.9.1"}
   "menhir" {>= "20220210"}
   "ocamlnet"


### PR DESCRIPTION
```
#=== ERROR while compiling cca.0.6.2 ==========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/cca.0.6.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C src/util
# exit-code            2
# env-file             ~/.opam/log/cca-7-9d576c.env
# output-file          ~/.opam/log/cca-7-9d576c.out
### output ###
# make: Entering directory '/home/opam/.opam/4.14/.opam-switch/build/cca.0.6.2/src/util'
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN test_XML.ml > .dep/test_XML.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN test_HIS.ml > .dep/test_HIS.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN test_HCS.ml > .dep/test_HCS.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN test_SMP.ml > .dep/test_SMP.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN LLL.ml > .dep/LLL.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN inst.ml > .dep/inst.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN XML.ml > .dep/XML.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xchannel.ml > .dep/xchannel.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN compression.ml > .dep/compression.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN SMP.ml > .dep/SMP.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN HIS.ml > .dep/HIS.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN HCS.ml > .dep/HCS.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN weight.ml > .dep/weight.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN LCS.ml > .dep/LCS.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xhash.ml > .dep/xhash.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xfile.ml > .dep/xfile.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xprint.ml > .dep/xprint.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xoption.ml > .dep/xoption.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xqueue.ml > .dep/xqueue.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xarray.ml > .dep/xarray.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xlist.ml > .dep/xlist.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xstring.ml > .dep/xstring.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xset.ml > .dep/xset.d
# ocamlfind: Package `num' not found
# ocamlfind ocamldep  -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN xthread.ml > .dep/xthread.d
# ocamlfind: Package `num' not found
# ocamlfind ocamlopt -package unix,num,camlzip,cryptokit,netzip,netstring,pxp,volt -syntax camlp4o -ppopt -level -ppopt WARN  -O3 -g -c xthread.ml
# ocamlfind: Package `num' not found
# make: *** [../rules.mk:105: xthread.cmx] Error 2
# make: Leaving directory '/home/opam/.opam/4.14/.opam-switch/build/cca.0.6.2/src/util'
```
This dependency on `num` has always been there (was added in https://github.com/codinuum/cca/commit/ee8bcef98b02b309dd4f6f483e3b1b4cfc88b399) but never explicitly listed.

cc @codinuum 