### PR TITLE
Add a missing lower-bound to dune >= 2.0.0

### DIFF
--- a/packages/dune/dune.2.0.0/opam
+++ b/packages/dune/dune.2.0.0/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.06" & < "4.12"} | ("ocaml" {< "4.06~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.06" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.06~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.0.1/opam
+++ b/packages/dune/dune.2.0.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.06" & < "4.12"} | ("ocaml" {< "4.06~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.06" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.06~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.1.1/opam
+++ b/packages/dune/dune.2.1.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.1.2/opam
+++ b/packages/dune/dune.2.1.2/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.1.3/opam
+++ b/packages/dune/dune.2.1.3/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.2.0/opam
+++ b/packages/dune/dune.2.2.0/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.3.0/opam
+++ b/packages/dune/dune.2.3.0/opam
@@ -39,7 +39,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.3.1/opam
+++ b/packages/dune/dune.2.3.1/opam
@@ -39,7 +39,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.4.0/opam
+++ b/packages/dune/dune.2.4.0/opam
@@ -39,7 +39,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.5.0/opam
+++ b/packages/dune/dune.2.5.0/opam
@@ -39,7 +39,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.5.1/opam
+++ b/packages/dune/dune.2.5.1/opam
@@ -39,7 +39,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.6.0/opam
+++ b/packages/dune/dune.2.6.0/opam
@@ -40,7 +40,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.6.1/opam
+++ b/packages/dune/dune.2.6.1/opam
@@ -40,7 +40,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.6.2/opam
+++ b/packages/dune/dune.2.6.2/opam
@@ -40,7 +40,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {< "4.07~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.07" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.07~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.7.0/opam
+++ b/packages/dune/dune.2.7.0/opam
@@ -40,7 +40,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .travis.yml, dune-project
   # and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "4.12"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.7.1/opam
+++ b/packages/dune/dune.2.7.1/opam
@@ -40,7 +40,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "4.12"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "4.12"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.8.0/opam
+++ b/packages/dune/dune.2.8.0/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.8.1/opam
+++ b/packages/dune/dune.2.8.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.8.2/opam
+++ b/packages/dune/dune.2.8.2/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.8.4/opam
+++ b/packages/dune/dune.2.8.4/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "4.13"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.8.5/opam
+++ b/packages/dune/dune.2.8.5/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.9.0/opam
+++ b/packages/dune/dune.2.9.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.9.1/opam
+++ b/packages/dune/dune.2.9.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.2.9.3/opam
+++ b/packages/dune/dune.2.9.3/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.0.2/opam
+++ b/packages/dune/dune.3.0.2/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.0.3/opam
+++ b/packages/dune/dune.3.0.3/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.1.0/opam
+++ b/packages/dune/dune.3.1.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.1.1/opam
+++ b/packages/dune/dune.3.1.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.2.0/opam
+++ b/packages/dune/dune.3.2.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08" & < "5.0"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.3.0/opam
+++ b/packages/dune/dune.3.3.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.3.1/opam
+++ b/packages/dune/dune.3.3.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.4.0/opam
+++ b/packages/dune/dune.3.4.0/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.4.1/opam
+++ b/packages/dune/dune.3.4.1/opam
@@ -44,7 +44,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.5.0/opam
+++ b/packages/dune/dune.3.5.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.6.0/opam
+++ b/packages/dune/dune.3.6.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.6.1/opam
+++ b/packages/dune/dune.3.6.1/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.6.2/opam
+++ b/packages/dune/dune.3.6.2/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]

--- a/packages/dune/dune.3.7.0/opam
+++ b/packages/dune/dune.3.7.0/opam
@@ -42,7 +42,7 @@ build: [
 depends: [
   # Please keep the lower bound in sync with .github/workflows/workflow.yml,
   # dune-project and min_ocaml_version in bootstrap.ml
-  ("ocaml" {>= "4.08"} | ("ocaml" {< "4.08~~"} & "ocamlfind-secondary"))
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
   "base-unix"
   "base-threads"
 ]


### PR DESCRIPTION
Ports https://github.com/ocaml/dune/pull/7396
Should only be merged after the next dune release to avoid rebuilds for people who use opam < 2.2

cc @emillon 