### PR TITLE
Dream: easy-to-use Web framework, alpha 5

### DIFF
--- a/packages/dream-httpaf/dream-httpaf.1.0.0~alpha2/opam
+++ b/packages/dream-httpaf/dream-httpaf.1.0.0~alpha2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis: "Internal: shared http/af stack for Dream (server) and Hyper (client)"
+description: "This package does not have a stable API."
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream-pure"
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "ocaml" {>= "4.08.0"}
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+
+  # Currently vendored.
+  # "gluten"
+  # "gluten-lwt-unix"
+  # "httpaf"
+  # "httpaf-lwt-unix"
+  # "h2"
+  # "h2-lwt-unix"
+  # "hpack"
+  # "websocketaf"
+
+  # Dependencies of vendored packages.
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "bigstringaf" {>= "0.5.0"}  # h2.
+  "digestif" {>= "0.7.2"}  # websocket/af, sha1, default implementation.
+  "faraday" {>= "0.6.1"}
+  "faraday-lwt-unix"
+  "ke" {>= "0.5"}  # Gluten.
+  "lwt_ssl" {>= "1.2.0"}  # Gluten.
+  "psq"  # h2.
+  "result"  # websocket/af.
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha5/dream-1.0.0-alpha5.tar.gz"
+  checksum: "md5=de6f6908ae899c9e85f2c751a0263932"
+}

--- a/packages/dream/dream.1.0.0~alpha3/opam
+++ b/packages/dream/dream.1.0.0~alpha3/opam
@@ -54,7 +54,7 @@ depends: [
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
   "dream-pure" {< "1.0.0~alpha2"}
-  "dream-httpaf"
+  "dream-httpaf" {< "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.
   "graphql_parser"

--- a/packages/dream/dream.1.0.0~alpha4/opam
+++ b/packages/dream/dream.1.0.0~alpha4/opam
@@ -54,7 +54,7 @@ depends: [
   "caqti-lwt"
   "conf-libev" {os != "win32"}
   "cstruct" {>= "6.0.0"}
-  "dream-httpaf"
+  "dream-httpaf" {< "1.0.0~alpha2"}
   "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}  # --instrument-with.
   "fmt" {>= "0.8.7"}  # `Italic.

--- a/packages/dream/dream.1.0.0~alpha5/opam
+++ b/packages/dream/dream.1.0.0~alpha5/opam
@@ -1,0 +1,106 @@
+opam-version: "2.0"
+
+synopsis: "Tidy, feature-complete Web framework"
+tags: ["http" "web" "framework" "websocket" "graphql" "server" "http2" "tls"]
+
+description: """
+Dream is a feature-complete Web framework with a simple programming
+model and no boilerplate. It provides only two data types, request and
+response.
+
+Almost everything else is either a built-in OCaml type, or an
+abbreviation for a bare function. For example, a Web app, known in
+Dream as a handler, is just an ordinary function from requests to
+responses. And a middleware is then just a function from handlers to
+handlers.
+
+Within this model, Dream adds:
+
+- Session management with pluggable back ends.
+- A fully composable router.
+- Support for HTTP/1.1, HTTP/2, and HTTPS.
+- WebSockets.
+- GraphQL, including subscriptions and a built-in GraphiQL editor.
+- SQL connection pool helpers.
+- Server-side HTML templates.
+- Automatic secure handling of cookies and forms.
+- Unified, internationalization-friendly error handling.
+- A neat log, and OCaml runtime configuration.
+- Helpers for Web formats, such as Base64url, and a modern cipher.
+
+Because of the simple programming model, everything is optional and
+composable. It is trivailly possible to strip Dream down to just a
+bare driver of the various HTTP protocols.
+
+Dream is presented as a single module, whose API is documented on one
+page. In addition, Dream comes with a large number of examples.
+Security topics are introduced throughout, wherever they are
+applicable."""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream"
+doc: "https://aantron.github.io/dream"
+bug-reports: "https://github.com/aantron/dream/issues"
+dev-repo: "git+https://github.com/aantron/dream.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "base-unix"
+  "bigarray-compat"
+  "camlp-streams"
+  "caqti" {>= "1.8.0"}  # Infix operators.
+  "caqti-lwt"
+  "conf-libev" {os != "win32"}
+  "cstruct" {>= "6.0.0"}
+  "dream-httpaf" {>= "1.0.0~alpha2"}
+  "dream-pure" {>= "1.0.0~alpha2"}
+  "dune" {>= "2.7.0"}  # --instrument-with.
+  "fmt" {>= "0.8.7"}  # `Italic.
+  "graphql_parser"
+  "graphql-lwt"
+  "lwt"
+  "lwt_ppx" {>= "1.2.2"}
+  "lwt_ssl"
+  "logs" {>= "0.5.0"}
+  "magic-mime"
+  "mirage-clock" {>= "3.0.0"}  # now_d_ps : unit -> int * int64.
+  "mirage-crypto" {>= "0.8.1"}  # AES-256-GCM.
+  "mirage-crypto-rng"
+  "mirage-crypto-rng-lwt"
+  "multipart_form" {>= "0.4.0"}
+  "multipart_form-lwt"
+  "ocaml" {>= "4.08.0"}
+  "ptime" {>= "0.8.1"}  # Ptime.v.
+  "ssl" {>= "0.5.8"}  # Ssl.get_negotiated_alpn_protocol.
+  "uri" {>= "4.2.0"}
+  "yojson"  # ...
+
+  # Testing, development.
+  "alcotest" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "caqti-driver-postgresql" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "crunch" {with-test}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-ppx" {with-test}
+  "lambdasoup" {with-test}
+  "ppx_expect" {with-test & >= "v0.15.0"}  # Formatting changes.
+  "ppx_yojson_conv" {with-test}
+  "reason" {with-test}
+  "tyxml" {with-test & >= "4.5.0"}
+
+  # Blocked until https://github.com/ocsigen/tyxml/pull/312.
+  # "tyxml-jsx" {with-test & >= "4.5.0"}
+  # "tyxml-ppx" {with-test & >= "4.5.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream/releases/download/1.0.0-alpha5/dream-1.0.0-alpha5.tar.gz"
+  checksum: "md5=de6f6908ae899c9e85f2c751a0263932"
+}

--- a/packages/hyper/hyper.1.0.0~alpha1/opam
+++ b/packages/hyper/hyper.1.0.0~alpha1/opam
@@ -13,7 +13,7 @@ author: "Anton Bachin <antonbachin@yahoo.com>"
 maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 
 depends: [
-  "dream-httpaf"
+  "dream-httpaf" {< "1.0.0~alpha2"}
   "dream-pure"
   "lwt_ppx"
   "ocaml"

--- a/packages/hyper/hyper.1.0.0~alpha2/opam
+++ b/packages/hyper/hyper.1.0.0~alpha2/opam
@@ -14,7 +14,7 @@ maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 
 depends: [
   "dream-httpaf" {>= "1.0.0~alpha2"}
-  "dream-pure"
+  "dream-pure" {>= "1.0.0~alpha2"}
   "dune" {>= "2.7.0"}
   "lwt_ppx"
   "mirage-crypto-rng"

--- a/packages/hyper/hyper.1.0.0~alpha2/opam
+++ b/packages/hyper/hyper.1.0.0~alpha2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+synopsis: "Web client with HTTP/1, HTTP/2, TLS, and WebSocket support"
+tags: ["http" "web" "client" "websocket" "http2" "tls" "dream"]
+
+license: "MIT"
+homepage: "https://github.com/aantron/hyper"
+doc: "https://aantron.github.io/hyper"
+bug-reports: "https://github.com/aantron/hyper/issues"
+dev-repo: "git+https://github.com/aantron/hyper.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream-httpaf" {>= "1.0.0~alpha2"}
+  "dream-pure"
+  "dune" {>= "2.7.0"}
+  "lwt_ppx"
+  "mirage-crypto-rng"
+  "mirage-crypto-rng-lwt"
+  "ocaml" {>= "4.08.0"}
+  "uri"
+
+  "bisect_ppx" {with-test & >= "2.5.0"}  # --instrument-with.
+  "dream" {with-test}
+  "ppx_expect" {with-test}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/hyper/archive/refs/tags/1.0.0-alpha2.tar.gz"
+  checksum: "md5=214f88044d1589314ba4d2bb248a9633"
+}


### PR DESCRIPTION
This is a maintenance release of [Dream](https://github.com/aantron/dream), the Web framework, that makes it compatible with OCaml 5 and all the latest upstream packages, and improves how Dream does vendoring, so as not to conflict with packages installed by opam. The changelog is [here](https://github.com/aantron/dream/releases/tag/1.0.0-alpha5).

The PR also includes a release of [Hyper](https://github.com/aantron/hyper), a Web client that uses the same internal machinery as Dream. Hyper is unannounced, but it is affected by updates in the core of Dream, so it seems correct to include its release here.