### PR TITLE
add coq-core.8.17.0, coq-stdlib.8.17.0, coq-server.8.17.0, coq.8.17.0

### DIFF
--- a/packages/coq-core/coq-core.8.17.0/opam
+++ b/packages/coq-core/coq-core.8.17.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "The Coq Proof Assistant -- Core Binaries and Tools"
+description: """
+Coq is a formal proof management system. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs.
+
+Typical applications include the certification of properties of
+programming languages (e.g. the CompCert compiler certification
+project, or the Bedrock verified low-level programming library), the
+formalization of mathematics (e.g. the full formalization of the
+Feit-Thompson theorem or homotopy type theory) and teaching.
+
+This package includes the Coq core binaries, plugins, and tools, but
+not the vernacular standard library.
+
+Note that in this setup, Coq needs to be started with the -boot and
+-noinit options, as will otherwise fail to find the regular Coq
+prelude, now living in the coq-stdlib package."""
+maintainer: ["The Coq development team <coqdev@inria.fr>"]
+authors: ["The Coq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://coq.inria.fr/"
+doc: "https://coq.github.io/doc/"
+bug-reports: "https://github.com/coq/coq/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.09.0"}
+  "ocamlfind" {>= "1.8.1"}
+  "zarith" {>= "1.11"}
+  "ounit2" {with-test}
+]
+conflicts: [
+  "coq"   { < "8.17" }
+  "ocaml-option-bytecode-only"
+]
+build: [
+  [ "./configure"
+    "-prefix" prefix
+    "-mandir" man
+    "-libdir" "%{lib}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/coq/coq.git"
+depopts: ["coq-native"]
+
+url {
+  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
+}

--- a/packages/coq-of-ocaml/coq-of-ocaml.2.5.3+4.14/opam
+++ b/packages/coq-of-ocaml/coq-of-ocaml.2.5.3+4.14/opam
@@ -28,6 +28,7 @@ depopts: [
 ]
 conflicts: [
   "coq" {< "8.11"}
+  "coq-core"
 ]
 tags: [
   "keyword:compilation"

--- a/packages/coq-stdlib/coq-stdlib.8.17.0/opam
+++ b/packages/coq-stdlib/coq-stdlib.8.17.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "The Coq Proof Assistant -- Standard Library"
+description: """
+Coq is a formal proof management system. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs.
+
+Typical applications include the certification of properties of
+programming languages (e.g. the CompCert compiler certification
+project, or the Bedrock verified low-level programming library), the
+formalization of mathematics (e.g. the full formalization of the
+Feit-Thompson theorem or homotopy type theory) and teaching.
+
+This package includes the Coq Standard Library, that is to say, the
+set of modules usually bound to the Coq.* namespace."""
+maintainer: ["The Coq development team <coqdev@inria.fr>"]
+authors: ["The Coq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://coq.inria.fr/"
+doc: "https://coq.github.io/doc/"
+bug-reports: "https://github.com/coq/coq/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "coq-core" {= version}
+]
+build: [
+  [ "./configure"
+    "-prefix" prefix
+    "-mandir" man
+    "-libdir" "%{lib}%/coq"
+    "-native-compiler" "yes" {coq-native:installed} "no" {!coq-native:installed}
+  ]
+  [ make "dunestrap" "COQ_DUNE_EXTRA_OPT=-split" ]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/coq/coq.git"
+depopts: ["coq-native"]
+
+url {
+  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
+}

--- a/packages/coq/coq.8.17.0/opam
+++ b/packages/coq/coq.8.17.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "The Coq Proof Assistant"
+description: """
+Coq is a formal proof management system. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs.
+
+Typical applications include the certification of properties of
+programming languages (e.g. the CompCert compiler certification
+project, or the Bedrock verified low-level programming library), the
+formalization of mathematics (e.g. the full formalization of the
+Feit-Thompson theorem or homotopy type theory) and teaching."""
+maintainer: ["The Coq development team <coqdev@inria.fr>"]
+authors: ["The Coq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://coq.inria.fr/"
+doc: "https://coq.github.io/doc/"
+bug-reports: "https://github.com/coq/coq/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "coq-core" {= version}
+  "coq-stdlib" {= version}
+  "coqide-server" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/coq/coq.git"
+
+url {
+  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
+}

--- a/packages/coqide-server/coqide-server.8.17.0/opam
+++ b/packages/coqide-server/coqide-server.8.17.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "The Coq Proof Assistant, XML protocol server"
+description: """
+Coq is a formal proof management system. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs.
+
+This package provides the `coqidetop` language server, an
+implementation of Coq's [XML protocol](https://github.com/coq/coq/blob/master/dev/doc/xml-protocol.md)
+which allows clients, such as CoqIDE, to interact with Coq in a
+structured way."""
+maintainer: ["The Coq development team <coqdev@inria.fr>"]
+authors: ["The Coq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://coq.inria.fr/"
+doc: "https://coq.github.io/doc/"
+bug-reports: "https://github.com/coq/coq/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "coq-core" {= version}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/coq/coq.git"
+
+url {
+  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
+}

--- a/packages/zenon/zenon.0.8.4/opam
+++ b/packages/zenon/zenon.0.8.4/opam
@@ -12,6 +12,7 @@ depopts: [
 ]
 conflicts: [
   "coq" {>= "8.9"}
+  "coq-core"
 ]
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--libdir" "%{zenon:lib}%"]

--- a/packages/zenon/zenon.0.8.5/opam
+++ b/packages/zenon/zenon.0.8.5/opam
@@ -8,9 +8,10 @@ depends: [
   "ocaml" {>= "4.07.0"}
 ]
 depopts: [
-  "coq" {>= "8.6"}
+  "coq"
 ]
 conflicts: [
+  "coq" {< "8.6"}
   "coq-core"
 ]
 build: [

--- a/packages/zenon/zenon.0.8.5/opam
+++ b/packages/zenon/zenon.0.8.5/opam
@@ -13,6 +13,7 @@ depopts: [
 conflicts: [
   "coq" {< "8.6"}
   "coq-core"
+  "ocaml-option-bytecode-only"
 ]
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--libdir" "%{zenon:lib}%"]

--- a/packages/zenon/zenon.0.8.5/opam
+++ b/packages/zenon/zenon.0.8.5/opam
@@ -10,6 +10,9 @@ depends: [
 depopts: [
   "coq" {>= "8.6"}
 ]
+conflicts: [
+  "coq-core"
+]
 build: [
   ["./configure" "--prefix" "%{prefix}%" "--libdir" "%{zenon:lib}%"]
   [make]


### PR DESCRIPTION
With the release of Coq 8.17, Coq was split into several opam packages, with the `coq` package in effect becoming a "compatibility package" that simply collects the split packages as dependencies.

CoqIDE will be handled as a followup PR.

cc: @Zimmi48 @MSoegtropIMC 