### PR TITLE
camlp5-buildscripts: bugfixes and cleanups (0.02)

### DIFF
--- a/packages/camlp5-buildscripts/camlp5-buildscripts.0.02/opam
+++ b/packages/camlp5-buildscripts/camlp5-buildscripts.0.02/opam
@@ -1,0 +1,36 @@
+synopsis: "Camlp5 Build scripts (written in OCaml)"
+description:
+"""
+These are build-scripts that are helpful in building Camlp5 and packages based on Camlp5.
+As such, they need to *not* depend on Camlp5.  The command are *not* installed in a
+bin-directory, but in the package-directory, hence invoked via the "ocamlfind package/exe"
+method.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/camlp5-buildscripts"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/camlp5-buildscripts/issues"
+dev-repo: "git+https://github.com/camlp5/camlp5-buildscripts.git"
+doc: "https://github.com/camlp5/camlp5-buildscripts/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "not-ocamlfind" { >= "0.01" }
+  "mdx" { with-test & >= "2.2.1" }
+  "fmt"
+  "re" { >= "1.10.4" }
+  "bos" { >= "0.2.1" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+   src: "https://github.com/camlp5/camlp5-buildscripts/archive/refs/tags/0.02.tar.gz"
+  checksum: [
+    "sha512=8d503ac0f1c820a6cb0746553280dbce579e139baa3dc98eb1c5a26ca3eccd0ca8089949bed4e1d6567d7170ca7fb79578de76a280290cd3020d060e8e7128c9"
+  ]
+}


### PR DESCRIPTION
most important fix is to change header-comment syntax