### PR TITLE
Fix the checksums for package ctypes_stubs_js-0.1

### DIFF
--- a/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
+++ b/packages/ctypes_stubs_js/ctypes_stubs_js.0.1/opam
@@ -21,8 +21,8 @@ url {
   src:
     "https://gitlab.com/nomadic-labs/ctypes_stubs_js/-/archive/0.1/ctypes_stubs_js-0.1.tar.gz"
   checksum: [
-    "sha256=74ab170e064bff88eaa592efc992d24fa1665c67047fc822276eae52c0f3384d"
-    "sha512=935e7f89e2cea9022f1d10aadb7d992ed207c010f872f360a251c290e21678e86a686ebd102ca688b6a2c2b49ee575a4b30ede96897b830c0b9072ebe2717f89"
+    "sha256=7c40ffcfda29cb407cb05b7837fe0dc46e18acc8b9a023afb58aa8751ec795e1"
+    "sha512=53fad8d54914534c2b0af6f08e1a6ba03329aa927664895e040ce019e17a10b615e817e94c054b7e8ff11f7a100e9d1c10a511c916293b701f51f74fe17fba94"
   ]
 }
 x-commit-hash: "b704ba59a37f58759de847c811a8f94664e4026a"


### PR DESCRIPTION
I haven't checked the package contents. Is there an easy way to do so? I haven't been able to locate the old tarball cached by opam on my machine if there is one.
