### PR TITLE
[new release] mirage-kv (6.1.1)

### DIFF
--- a/packages/mirage-kv/mirage-kv.6.1.1/opam
+++ b/packages/mirage-kv/mirage-kv.6.1.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "Thomas Gazagnaire <thomas@gazagnaire.org>"
+authors:      ["Thomas Gazagnaire <thomas@gazagnaire.org>" "Stefanie Schirmer" "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/mirage-kv"
+doc:          "https://mirage.github.io/mirage-kv/"
+license:      "ISC"
+dev-repo:     "git+https://github.com/mirage/mirage-kv.git"
+bug-reports:  "https://github.com/mirage/mirage-kv/issues"
+tags:         ["org:mirage"]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune"
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "4.0.0"}
+  "optint" {>= "0.2.0"}
+  "ptime" {>= "1.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+]
+synopsis: "MirageOS signatures for key/value devices"
+description: """
+mirage-kv provides the `Mirage_kv.RO` and `Mirage_kv.RW`
+signatures the MirageOS key/value devices should implement.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-kv/releases/download/v6.1.1/mirage-kv-6.1.1.tbz"
+  checksum: [
+    "sha256=7cd5cd95a0e96f9cd4036ad3c22e61d63e2fe0b426a2fc46f809babbed60b8f4"
+    "sha512=b62a726a6ff81251219cea678b97eb8ab552cb9184afc17871c0a42d370020cb837c6c269f8fb36c3398340c21f52077d84dac3d34baeefd8f3d2dc7e99842ae"
+  ]
+}
+x-commit-hash: "b362f636c7515781245c80c71022d1f485c790eb"


### PR DESCRIPTION
MirageOS signatures for key/value devices

- Project page: <a href="https://github.com/mirage/mirage-kv">https://github.com/mirage/mirage-kv</a>
- Documentation: <a href="https://mirage.github.io/mirage-kv/">https://mirage.github.io/mirage-kv/</a>

##### CHANGES:

* Leave it up to implementations how to interpret `last_modified` for
  dictionaries, or even not implement it (then returning ``Error
  (`Value_expected _)``. The previous definition was not well founded when the
  dictionary doesn't contain any values directly, and some implementations
  implements `last_modified` differently from the description on dictionaries.
  (reported in mirage/mirage-kv#41, fixed in mirage/mirage-kv#42 by @reynir)
* Leave it up to implemetations how to interpret `digest` for dictionaries,
  or even not implement it (returning ``Error (`Value_expected _)``.
  (reported mirage/ocaml-tar#111, fixed in mirage/mirage-kv#43 by @reynir)
