### PR TITLE
[new release] cucumber (1.0.4)

### DIFF
--- a/packages/cucumber/cucumber.1.0.4/opam
+++ b/packages/cucumber/cucumber.1.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Cucumber BDD for OCaml"
+description: "Cucumber BDD for OCaml using the gherkin-c library to parse"
+maintainer: ["cyocum@gmail.com"]
+authors: ["Christopher Guy Yocum"]
+license: "MIT"
+homepage: "https://github.com/cucumber/cucumber.ml"
+bug-reports: "https://github.com/cucumber/cucumber.ml/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "re" {>= "1.9.0"}
+  "base" {>= "v0.15.1"}
+  "cmdliner" {>= "1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/cucumber/cucumber.ml.git"
+url {
+  src:
+    "https://github.com/cucumber/cucumber.ml/releases/download/v1.0.4/cucumber-1.0.4.tbz"
+  checksum: [
+    "sha256=33f76b60aed4aa8789c9cce8647dac6bf60ea9f3071a8096dda456e20f5c8734"
+    "sha512=72aa34e95e05740f4205c3468c614dc8691e491ceed3d508cdc64d75549faff48e5587b4629bc515e4d43d7f4c55e00790898171213dd2d504f52253228ace93"
+  ]
+}
+x-commit-hash: "318a3d660ebfc2ba25d2bb0ba5966277973edc49"


### PR DESCRIPTION
Cucumber BDD for OCaml

- Project page: <a href="https://github.com/cucumber/cucumber.ml">https://github.com/cucumber/cucumber.ml</a>

##### CHANGES:

* before updating we need to init the submodule (cucumber/cucumber.ml#37).

* Add GitHub Actions CI (@tmcgilchrist cucumber/cucumber.ml#42 cucumber/cucumber.ml#44).

* Various fixes for OCaml cucumber (@tmcgilchrist cucumber/cucumber.ml#41).

* Improve odoc documentation and add an example.

* Update base to v0.15.1 updating OCaml lower bound to 4.10.0.

* Update README with a working example.

* Fixup linking against libgherkin.

* Adapt to the interface changes when updating to gherkin-c v23.

* Move git submodule to https://github.com/cucumber/gherkin monorepo.

* Fixup cmdliner deprecations and update dune.

* Updated README to read a bit better.

* Updated Readme to reflect the new build steps.

* Removed unnecessary submodule.

* Updated dune project information to get things ready for release.

* Updated dune files to use autogenerated opam.

* Updated test make file to work with new dune build stucture.

* Updated files to work with Dune's foreign lib interface.

* Added gherkin-c READ ONLY as a submodule.

* Updated based on rebase from master.

* Added dialect example in the README.

* Moved initialization of result code.

* Added whitespace for readability.

* Added the Dialect module to allow compile time checking of supported dialects of Cucumber

* Created a means for indicating feature file dialect.

* Removed unneeded flag in dune. * Removed unneeded flag in dune * Added freeing before caml_failwith just to ensure that everything is cleaned up before going back to OCaml runtime.

* Refactored long code block into function in gherkin_intf.c. * Refactored long code block into function in gherkin_intf.c * Fixed small memory leak due to TokenScanner not being deleted after it is done being used

* Added const qualifier to sFileName to fix cucumber/cucumber.ml#31.
