### PR TITLE
[new release] ppx_minidebug (0.3.1)

### DIFF
--- a/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Debug logs for selected functions and let-bindings"
+description:
+  "A poor man's `ppx_debug` with formatted logs of let-bound values, function arguments and results."
+maintainer: ["Lukasz Stafiniak"]
+authors: ["Lukasz Stafiniak"]
+license: "LGPL-2.1-or-later"
+tags: ["logger" "debugger" "printf debugging"]
+homepage: "https://github.com/lukstafi/ppx_minidebug"
+doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
+bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.7"}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppxlib"
+  "printbox"
+  "printbox-text"
+  "printbox-html"
+  "ptime"
+  "sexplib0"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lukstafi/ppx_minidebug.git"
+url {
+  src:
+    "https://github.com/lukstafi/ppx_minidebug/releases/download/0.3.1/ppx_minidebug-0.3.1.tbz"
+  checksum: [
+    "sha256=c77f0c995e7ba7a86c5c4a1f882bd05d0e1e4ee4519dd80c00d947e5726a1206"
+    "sha512=23b3de8dbd01ca95de87da2e2722f44ca41bb6ba56a9efbd7034045ac11c4c9727ee2d297678416dc1e1d56a7686b8e271c3818ee45d747da02abfb4c99a977f"
+  ]
+}
+x-commit-hash: "93bfc2866c51e16b1438e255ec6e300358744740"

--- a/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "3.7"}
   "ppx_deriving"
   "ppx_sexp_conv"
-  "ppxlib"
+  "ppxlib" {>= "0.25.0"}
   "printbox"
   "printbox-text"
   "printbox-html"

--- a/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/lukstafi/ppx_minidebug"
 doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
 bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "dune" {>= "3.7"}
   "ppx_deriving"
   "ppx_sexp_conv"

--- a/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.3.1/opam
@@ -20,6 +20,7 @@ depends: [
   "printbox-html"
   "ptime"
   "sexplib0"
+  "ppx_expect" {with-test & >= "v0.9.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Debug logs for selected functions and let-bindings

- Project page: <a href="https://github.com/lukstafi/ppx_minidebug">https://github.com/lukstafi/ppx_minidebug</a>
- Documentation: <a href="https://lukstafi.github.io/ppx_minidebug/ppx_minidebug">https://lukstafi.github.io/ppx_minidebug/ppx_minidebug</a>

##### CHANGES:

### Fixed

- A small tweak to have `dune-release` work.
