### PR TITLE
[new release] bechamel, bechamel-perf, bechamel-notty and bechamel-js (0.4.0)

### DIFF
--- a/packages/bechamel-js/bechamel-js.0.4.0/opam
+++ b/packages/bechamel-js/bechamel-js.0.4.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "HTML generator for bechamel's output"
+description: """A simple tool to generate a standalone HTML
+page which shows results from bechamel's benchmarks."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "bechamel"   {= version}
+  "rresult"
+  "json-data-encoding"
+  "jsonm"
+  "fmt"        {>= "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.4.0/bechamel-0.4.0.tbz"
+  checksum: [
+    "sha256=e9d26f9201fd98f860e9b3afad7a5d520f04ae9c95bea070f5d0ac2c26abff4d"
+    "sha512=eac5f8aa192d66ba70a28ce44bdbf6a849ff1a82a8efbaab87067e2ee06c00bcc04e6f16923948857eec41cb171e3915d1e4cb751be7cf95d4521d5dbe4dd858"
+  ]
+}
+x-commit-hash: "9c495cd4b431b040b42ae64ce74458eb931aed61"

--- a/packages/bechamel-notty/bechamel-notty.0.4.0/opam
+++ b/packages/bechamel-notty/bechamel-notty.0.4.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "CLI generator for bechamel's output"
+description: """A simple tool to generate a CLI output with notty
+which shows results from bechamel's benchmarks (as core_bench)."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "bechamel"   {= version}
+  "notty"
+  "fmt"        {>= "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.4.0/bechamel-0.4.0.tbz"
+  checksum: [
+    "sha256=e9d26f9201fd98f860e9b3afad7a5d520f04ae9c95bea070f5d0ac2c26abff4d"
+    "sha512=eac5f8aa192d66ba70a28ce44bdbf6a849ff1a82a8efbaab87067e2ee06c00bcc04e6f16923948857eec41cb171e3915d1e4cb751be7cf95d4521d5dbe4dd858"
+  ]
+}
+x-commit-hash: "9c495cd4b431b040b42ae64ce74458eb931aed61"

--- a/packages/bechamel-perf/bechamel-perf.0.4.0/opam
+++ b/packages/bechamel-perf/bechamel-perf.0.4.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "Linux perf's metrics for bechamel"
+description: """A simple layer on Linux perf's metrics for
+bechamel to record and analyze them."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "mperf"
+  "bechamel"   {= version}
+  "fmt"        {>= "0.9.0"}
+  "base-unix"
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.4.0/bechamel-0.4.0.tbz"
+  checksum: [
+    "sha256=e9d26f9201fd98f860e9b3afad7a5d520f04ae9c95bea070f5d0ac2c26abff4d"
+    "sha512=eac5f8aa192d66ba70a28ce44bdbf6a849ff1a82a8efbaab87067e2ee06c00bcc04e6f16923948857eec41cb171e3915d1e4cb751be7cf95d4521d5dbe4dd858"
+  ]
+}
+x-commit-hash: "9c495cd4b431b040b42ae64ce74458eb931aed61"

--- a/packages/bechamel/bechamel.0.4.0/opam
+++ b/packages/bechamel/bechamel.0.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/bechamel"
+bug-reports:  "https://github.com/mirage/bechamel/issues"
+dev-repo:     "git+https://github.com/mirage/bechamel.git"
+doc:          "https://mirage.github.io/bechamel/"
+license:      "MIT"
+synopsis:     "Yet Another Benchmark in OCaml"
+description: """BEnchmark for a CHAMEL/camel/caml which
+is agnostic to the system. It's a micro-benchmark tool
+which lets the user to re-analyzes and prints samples."""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "ocaml"      {>= "4.08.0"}
+  "dune"       {>= "2.0.0"}
+  "fmt"        {>= "0.9.0"}
+]
+url {
+  src:
+    "https://github.com/mirage/bechamel/releases/download/v0.4.0/bechamel-0.4.0.tbz"
+  checksum: [
+    "sha256=e9d26f9201fd98f860e9b3afad7a5d520f04ae9c95bea070f5d0ac2c26abff4d"
+    "sha512=eac5f8aa192d66ba70a28ce44bdbf6a849ff1a82a8efbaab87067e2ee06c00bcc04e6f16923948857eec41cb171e3915d1e4cb751be7cf95d4521d5dbe4dd858"
+  ]
+}
+x-commit-hash: "9c495cd4b431b040b42ae64ce74458eb931aed61"


### PR DESCRIPTION
Yet Another Benchmark in OCaml

- Project page: <a href="https://github.com/mirage/bechamel">https://github.com/mirage/bechamel</a>
- Documentation: <a href="https://mirage.github.io/bechamel/">https://mirage.github.io/bechamel/</a>

##### CHANGES:

- Fix the support of OCaml 5.0 (@avsm, mirage/bechamel#38)
- Add a CI on Windows (@avsm, mirage/bechamel#38)
- Add a documentation about `Bechamel_perf` (@dinosaure, @OliverNicole, mirage/bechamel#39)
