### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.4.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.4.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.4.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.4.0/tar-2.4.0.tbz"
+  checksum: [
+    "sha256=4e3594663a4ec93b046bd3bc546d1a81da1995f531f153138c6591084e25fbe3"
+    "sha512=81ec2fa08c3210eb1cf50be9483a9f9df9648ece34906c058d0a18c43236f138dde10bc190c11084e36dfdfe85b8ffa0e786c02930893e7bca18843770a37b0c"
+  ]
+}
+x-commit-hash: "fa05f168a83ddcd8906bb068e3b2f64388ddc95c"

--- a/packages/tar-unix/tar-unix.2.4.0/opam
+++ b/packages/tar-unix/tar-unix.2.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.4.0/tar-2.4.0.tbz"
+  checksum: [
+    "sha256=4e3594663a4ec93b046bd3bc546d1a81da1995f531f153138c6591084e25fbe3"
+    "sha512=81ec2fa08c3210eb1cf50be9483a9f9df9648ece34906c058d0a18c43236f138dde10bc190c11084e36dfdfe85b8ffa0e786c02930893e7bca18843770a37b0c"
+  ]
+}
+x-commit-hash: "fa05f168a83ddcd8906bb068e3b2f64388ddc95c"

--- a/packages/tar/tar.2.4.0/opam
+++ b/packages/tar/tar.2.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.4.0/tar-2.4.0.tbz"
+  checksum: [
+    "sha256=4e3594663a4ec93b046bd3bc546d1a81da1995f531f153138c6591084e25fbe3"
+    "sha512=81ec2fa08c3210eb1cf50be9483a9f9df9648ece34906c058d0a18c43236f138dde10bc190c11084e36dfdfe85b8ffa0e786c02930893e7bca18843770a37b0c"
+  ]
+}
+x-commit-hash: "fa05f168a83ddcd8906bb068e3b2f64388ddc95c"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Switch to alcotest for tests (@MisterDA, review by @reynir, mirage/ocaml-tar#121)
- **BREAKING**: fix ustar magic version. Previously, the version "0\000" was
  serialized instead of the correct version "00". This means tar archives may
  not be reproducable with older versions. (@reynir, @hannesm, mirage/ocaml-tar#117 and mirage/ocaml-tar#122)
- Remove `ppx_cstruct`dependency (@hannesm, review by @reynir, mirage/ocaml-tar#117)
- Properly skip Pax GlobalExtendedHeaders (@MisterDA, @reynir, mirage/ocaml-tar#116 and mirage/ocaml-tar#118)
