### PR TITLE
Update links to old versions of omd

### DIFF
--- a/packages/omd/omd.0.3/opam
+++ b/packages/omd/omd.0.3/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.3.tar.gz"
   checksum: "md5=522e5c2937e77b48dcdc40d85437d29e"
 }
+available: false

--- a/packages/omd/omd.0.4/opam
+++ b/packages/omd/omd.0.4/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.4.tar.gz"
   checksum: "md5=8c81e10c2ae6f2f64aeb78bbdcfbd48e"
 }
+available: false

--- a/packages/omd/omd.0.5.4/opam
+++ b/packages/omd/omd.0.5.4/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.5.4.tar.gz"
   checksum: "md5=9e4e2a4a9348cb0260d170edb3e2ce9e"
 }
+available: false

--- a/packages/omd/omd.0.5.5/opam
+++ b/packages/omd/omd.0.5.5/opam
@@ -26,6 +26,6 @@ Omd targets the original Markdown with a few Github markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.5.5.tar.gz"
-  checksum: "md5=8de7bbba97c53ebad68eff9fa259200f"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.5.5.tar.gz"
+  checksum: "md5=fee3d2f5b160deecff1c5463a4ecddb4"
 }

--- a/packages/omd/omd.0.5/opam
+++ b/packages/omd/omd.0.5/opam
@@ -26,6 +26,6 @@ markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.5.tar.gz"
-  checksum: "md5=d343deacc270674828260b0fdc55f74c"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.5.tar.gz"
+  checksum: "md5=64e40582aa879f37c9867f0e10b6268e"
 }

--- a/packages/omd/omd.0.6.0/opam
+++ b/packages/omd/omd.0.6.0/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.6.0.tar.gz"
   checksum: "md5=9897520b96a67c332ed080b1bb67ba69"
 }
+available: false

--- a/packages/omd/omd.0.6.1/opam
+++ b/packages/omd/omd.0.6.1/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.6.1.tar.gz"
   checksum: "md5=7d86319b3bc0baccfbd1847e77bbbd10"
 }
+available: false

--- a/packages/omd/omd.0.6.2/opam
+++ b/packages/omd/omd.0.6.2/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.6.2.tar.gz"
   checksum: "md5=ca6cc7c7d212e66544bdb759f7de6628"
 }
+available: false

--- a/packages/omd/omd.0.6.3/opam
+++ b/packages/omd/omd.0.6.3/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.6.3.tar.gz"
   checksum: "md5=edcd051eac3fe7a7a624fde3fcba2b0e"
 }
+available: false

--- a/packages/omd/omd.0.6.4/opam
+++ b/packages/omd/omd.0.6.4/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.6.4.tar.gz"
   checksum: "md5=04e2c2eb9c7a0fc4cf5802f72b3eff6d"
 }
+available: false

--- a/packages/omd/omd.0.6.5/opam
+++ b/packages/omd/omd.0.6.5/opam
@@ -29,3 +29,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.6.5.tar.gz"
   checksum: "md5=552ec57d68f80caf4b5201520d33fc5a"
 }
+available: false

--- a/packages/omd/omd.0.7.0/opam
+++ b/packages/omd/omd.0.7.0/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.7.0.tar.gz"
   checksum: "md5=0cca249db75b96854e8ee45ac4914084"
 }
+available: false

--- a/packages/omd/omd.0.7.1/opam
+++ b/packages/omd/omd.0.7.1/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.7.1.tar.gz"
   checksum: "md5=8e2fa240123afadea1faa035ad82fa27"
 }
+available: false

--- a/packages/omd/omd.0.7.2/opam
+++ b/packages/omd/omd.0.7.2/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.7.2.tar.gz"
   checksum: "md5=00f9f7a27f5bdf9802045367c6f9a4d2"
 }
+available: false

--- a/packages/omd/omd.0.7.3/opam
+++ b/packages/omd/omd.0.7.3/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.7.3.tar.gz"
   checksum: "md5=d99071e9b799ab735bd802589f2c31fb"
 }
+available: false

--- a/packages/omd/omd.0.7.4/opam
+++ b/packages/omd/omd.0.7.4/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.7.4.tar.gz"
   checksum: "md5=76310910ecdd47f5e0f2a1ac33a133d0"
 }
+available: false

--- a/packages/omd/omd.0.7.5/opam
+++ b/packages/omd/omd.0.7.5/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.7.5.tar.gz"
   checksum: "md5=b2969c6706b90bbbc286187dead34f3b"
 }
+available: false

--- a/packages/omd/omd.0.8.0/opam
+++ b/packages/omd/omd.0.8.0/opam
@@ -28,6 +28,6 @@ Omd targets the original Markdown with a few Github markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.8.0.tar.gz"
-  checksum: "md5=46ae136e47fa2f9235ae336e0ab87df5"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.8.0.tar.gz"
+  checksum: "md5=03886978515e1d75c1584a1afab9fb18"
 }

--- a/packages/omd/omd.0.8.1/opam
+++ b/packages/omd/omd.0.8.1/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.8.1.tar.gz"
   checksum: "md5=15123ffeb2821a32efdefc03ad46fe6a"
 }
+available: false

--- a/packages/omd/omd.0.8.2/opam
+++ b/packages/omd/omd.0.8.2/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.8.2.tar.gz"
   checksum: "md5=bb241be2c9493b86f1a7a79dc91c58ec"
 }
+available: false

--- a/packages/omd/omd.0.9.0/opam
+++ b/packages/omd/omd.0.9.0/opam
@@ -31,3 +31,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-0.9.0.tar.gz"
   checksum: "md5=4a79c70faf4851e07af0fdcf1ec7aae2"
 }
+available: false

--- a/packages/omd/omd.0.9.1/opam
+++ b/packages/omd/omd.0.9.1/opam
@@ -28,6 +28,6 @@ Omd targets the original Markdown with a few Github markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.9.1.tar.gz"
-  checksum: "md5=5f846d2b03bc387c511d8a1dabb4b087"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.9.1.tar.gz"
+  checksum: "md5=9a9c9819acf20f6ef087449473cffe11"
 }

--- a/packages/omd/omd.0.9.3/opam
+++ b/packages/omd/omd.0.9.3/opam
@@ -28,6 +28,6 @@ Omd targets the original Markdown with a few Github markdown features."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.9.3.tar.gz"
-  checksum: "md5=4312371b107f575067ada0ac85487bcc"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.9.3.tar.gz"
+  checksum: "md5=fca8e5b514d2588bbc75734f13b4607a"
 }

--- a/packages/omd/omd.0.9.4/opam
+++ b/packages/omd/omd.0.9.4/opam
@@ -31,6 +31,6 @@ package installs both the Omd library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.9.4.tar.gz"
-  checksum: "md5=2fadfd967930e1c0f2029f9b5cd10575"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.9.4.tar.gz"
+  checksum: "md5=a304a9f9b53a027cd0cc34a11178eacc"
 }

--- a/packages/omd/omd.0.9.5/opam
+++ b/packages/omd/omd.0.9.5/opam
@@ -31,6 +31,6 @@ package installs both the Omd library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.9.5.tar.gz"
-  checksum: "md5=dd48b6f28f78da44cceff249b504196d"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.9.5.tar.gz"
+  checksum: "md5=5e3500b296814a3a97c1e8d3730e04c9"
 }

--- a/packages/omd/omd.0.9.6/opam
+++ b/packages/omd/omd.0.9.6/opam
@@ -31,6 +31,6 @@ package installs both the Omd library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.9.6.tar.gz"
-  checksum: "md5=5fe4a63f238b8be722d27a71df2c2712"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.9.6.tar.gz"
+  checksum: "md5=fa33bdb93a1ead7cf4a950590e1372b4"
 }

--- a/packages/omd/omd.0.9.7/opam
+++ b/packages/omd/omd.0.9.7/opam
@@ -31,6 +31,6 @@ package installs both the Omd library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-0.9.7.tar.gz"
-  checksum: "md5=43ba43fe8013d2d8ed747e6b81b96331"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/0.9.7.tar.gz"
+  checksum: "md5=ffd6d6f5ffa621f737de886f15102a19"
 }

--- a/packages/omd/omd.1.0.0/opam
+++ b/packages/omd/omd.1.0.0/opam
@@ -33,6 +33,6 @@ Note that The library interface of 1.0.0 is not compatible with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.0.0.tar.gz"
-  checksum: "md5=acb8ac3edd4b2e02e8b1d2594c6da597"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.0.0.tar.gz"
+  checksum: "md5=99ddf24ce1a72ae8549e9fcaf6f3dc71"
 }

--- a/packages/omd/omd.1.0.1/opam
+++ b/packages/omd/omd.1.0.1/opam
@@ -37,3 +37,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-1.0.1.tar.gz"
   checksum: "md5=684ee364e85c2245b5c74a1ac1aeef9b"
 }
+available: false

--- a/packages/omd/omd.1.1.0/opam
+++ b/packages/omd/omd.1.1.0/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.1.0.tar.gz"
-  checksum: "md5=2c13d75a7323c7e3f6fd23440cc62bb0"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.1.0.tar.gz"
+  checksum: "md5=96ea35e8bb30e6b3e735f6ca9007f989"
 }

--- a/packages/omd/omd.1.1.1/opam
+++ b/packages/omd/omd.1.1.1/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.1.1.tar.gz"
-  checksum: "md5=0f1a822400334eaa66659c15e3338742"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.1.1.tar.gz"
+  checksum: "md5=65de89894e22eecfbb5febcc69f9fea1"
 }

--- a/packages/omd/omd.1.1.2/opam
+++ b/packages/omd/omd.1.1.2/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.1.2.tar.gz"
-  checksum: "md5=876fe6da9286d12711f38c134b5eff00"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.1.2.tar.gz"
+  checksum: "md5=0dc27d2c70a98175ad1484c0fc237916"
 }

--- a/packages/omd/omd.1.1.3/opam
+++ b/packages/omd/omd.1.1.3/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.1.3.tar.gz"
-  checksum: "md5=33c1320f66910708be04bb314dd0db16"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.1.3.tar.gz"
+  checksum: "md5=a71880a4ca85736b8c684944ae6f46ca"
 }

--- a/packages/omd/omd.1.2.0/opam
+++ b/packages/omd/omd.1.2.0/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.0.tar.gz"
-  checksum: "md5=2a1aa5144466a466e33b34de855bcd1c"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.0.tar.gz"
+  checksum: "md5=77e39f06784a7c6d858a14207c289ca7"
 }

--- a/packages/omd/omd.1.2.1/opam
+++ b/packages/omd/omd.1.2.1/opam
@@ -34,6 +34,6 @@ with 0.9.x."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.1.tar.gz"
-  checksum: "md5=6784ba3dbdd9b56029a8ef0509d61690"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.1.tar.gz"
+  checksum: "md5=24064d5d9672514484518d2892809d6a"
 }

--- a/packages/omd/omd.1.2.2/opam
+++ b/packages/omd/omd.1.2.2/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.2.tar.gz"
-  checksum: "md5=3a3599c3c8241323d4ab30124deedab4"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.2.tar.gz"
+  checksum: "md5=65464568ccb65dcf150be74d53df301c"
 }

--- a/packages/omd/omd.1.2.3/opam
+++ b/packages/omd/omd.1.2.3/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.3.tar.gz"
-  checksum: "md5=31ed60d39aa0aaa337818fd62b56706b"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.3.tar.gz"
+  checksum: "md5=1da3688e5976d49bb42e9afa1e0743e1"
 }

--- a/packages/omd/omd.1.2.4/opam
+++ b/packages/omd/omd.1.2.4/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.4.tar.gz"
-  checksum: "md5=083a56364a7046c4be868ccd8cc0f487"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.4.tar.gz"
+  checksum: "md5=b27f92ecbee15bac011e8f72d5d08322"
 }

--- a/packages/omd/omd.1.2.5/opam
+++ b/packages/omd/omd.1.2.5/opam
@@ -32,6 +32,6 @@ package installs both the OMD library and the command line tool `omd`."""
 flags: light-uninstall
 extra-files: ["omd.install" "md5=0395736894a46f718a77f59ec6fbf1fd"]
 url {
-  src: "http://pw374.github.io/distrib/omd/omd-1.2.5.tar.gz"
-  checksum: "md5=93ea60ce9055a8568822202c910c1eb3"
+  src: "https://github.com/ocaml/omd/archive/refs/tags/1.2.5.tar.gz"
+  checksum: "md5=91d970193c4e0b98f544fd758c07f8f0"
 }

--- a/packages/omd/omd.1.2.6/opam
+++ b/packages/omd/omd.1.2.6/opam
@@ -35,3 +35,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-1.2.6.tar.gz"
   checksum: "md5=1e84c81ffc4c9680b762d0afe3a4e34f"
 }
+available: false

--- a/packages/omd/omd.1.3.0/opam
+++ b/packages/omd/omd.1.3.0/opam
@@ -42,3 +42,4 @@ url {
   src: "http://pw374.github.io/distrib/omd/omd-1.3.0.tar.gz"
   checksum: "md5=1a6492ce7511f528e3f2893dda06f56b"
 }
+available: false


### PR DESCRIPTION
Older versions of the omd package download their source from http://pw374.github.io/distrib/omd which appears to no longer be running. These releases also don't appear to be in the opam cache. Some of these releases have been moved to https://github.com/ocaml/omd. This change updates the urls of those versions to the new location and marks the remaining versions as unavailable.

I made this change by running this bash script:
```bash
#!/usr/bin/env bash
set -euo pipefail

grep -r packages -e 'pw374.github.io/distrib/omd' | while read f _ u; do
    f=$(echo $f | tr -d :);
    u=$(echo $u | tr -d '"');
    v=$(echo $f | sed -re 's/packages\/omd\/omd\.([0-9]\.[0-9](\.[0-9])?)\/opam/\1/')
    u_="https://github.com/ocaml/omd/archive/refs/tags/$v.tar.gz"
    resp=$(curl -LI "$u_" 2> /dev/null | grep '^HTTP' | tail -n1 | cut -f2 -d' ')
    echo "$f [$u] $v $resp";
    if [ $resp = 200 ]; then
        sed -i "s~$u~$u_~" $f
        newhash=$(curl -L $u_ | md5sum | cut -f1 -d' ')
        sed -i "s/checksum: .*/checksum: \"md5=$newhash\"/" $f
    elif [ $resp = 404 ]; then
        sed -i "$ a available: false" $f
    else
        echo unexpected
        exit 1
    fi
done

```