### PR TITLE
Add release of Morbig 0.10.4

### DIFF
--- a/packages/morbig/morbig.0.10.4/opam
+++ b/packages/morbig/morbig.0.10.4/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+
+synopsis: "A trustworthy parser for POSIX shell"
+description: """
+Morbig is a parser for shell scripts written in the POSIX shell script
+language. It parses the scripts statically, that is without executing
+them, and constructs a concrete syntax tree for each of them. The
+concrete syntax trees are built using constructors according to the
+shell grammar of the POSIX standard.
+"""
+
+maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+  "Ralf Treinen <ralf.treinen@irif.fr>"
+  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+]
+license: "GPL-3.0-only"
+
+homepage: "https://github.com/colis-anr/morbig"
+bug-reports: "https://github.com/colis-anr/morbig/issues"
+dev-repo: "git+https://github.com/colis-anr/morbig.git"
+
+depends: [
+  "dune"                 {>= "1.4.0"}
+  "menhir"               {>= "20180538"}
+  "ocaml"                {>= "4.04"}
+  "odoc"                 {with-doc}
+  "ppx_deriving_yojson"
+  "visitors"             {>= "20180513"}
+  "yojson"               {>= "1.6.0" & < "2.0.0"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [make "check"]
+
+url {
+  src: "https://github.com/colis-anr/morbig/archive/0.10.4.tar.gz"
+  checksum: [
+    "md5=73ce60f81e41bee3cf4be45ed17c8be9"
+    "sha512=b059e2aaed40c468e6fcd4726ffeb4e35dd225be9edf81ddf327ba4fd52d7d2ea5ac1f5206fef13be6d3e0e0482dfa2288f21faf3717945cfed501658b28edd8"
+  ]
+}


### PR DESCRIPTION
It is an old release but it was never published to OPAM. Other software actually depend on that version so it is worth publishing now in my opinion.

### Morbig 0.10.4

Morbig is a parser for shell scripts written in the POSIX shell script language. It parses the scripts statically, that is without executing them, and constructs a concrete syntax tree for each of them. The concrete syntax trees are built using constructors according to the shell grammar of the POSIX standard.