### PR TITLE
[new release] coq-serapi (8.17.0+0.17.0)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.17.0+0.17.0/opam
+++ b/packages/coq-serapi/coq-serapi.8.17.0+0.17.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               { >= "4.09.0"              }
+  "coq"                 { >= "8.17" & < "8.18"     }
+  "cmdliner"            { >= "1.1.0"               }
+  "ocamlfind"           { >= "1.8.0"               }
+  "sexplib"             { >= "v0.13.0"             }
+  "dune"                { >= "2.0.1"               }
+  "ppx_import"          { >= "1.5-3" & < "2.0"     }
+  "ppx_deriving"        { >= "4.2.1"               }
+  "ppx_sexp_conv"       { >= "v0.13.0"             }
+  "ppx_compare"         { >= "v0.13.0"             }
+  "ppx_hash"            { >= "v0.13.0"             }
+  "yojson"              { >= "1.7.0"               }
+  "ppx_deriving_yojson" { >= "3.4"                 }
+]
+
+conflicts: [
+  "result" {< "1.5"}
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.17.0%2B0.17.0/coq-serapi-8.17.0.0.17.0.tbz"
+  checksum: [
+    "sha256=fe717f2aa1394434ca3cd9f02a4227e512fb2517c01d4f2726d71f4e3a18756d"
+    "sha512=c070d3ebb7f76df7929b04ddb68d4d28751e8991fdb870f56a64168389ff217e75e118317dc8069a8acf98ac88c523d2211fd91fdc777f916d3184b56d235a7c"
+  ]
+}
+x-commit-hash: "0bd0772fe683d1dbfd3bd29db5ad652e74a70f66"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serlib] (!) Serialization format of generic arguments has changed
            to be conforming to usual `ppx_sexp_conv` conventions.
            (@ejgallego , fixes ejgallego/coq-serapi#273)
 - [serapi] (!) support for Coq 8.17, upstream structures seem pretty
            stable from 8.16, except for `Constr.Evar` (@ejgallego)
 - [serapi] SerAPI is now in Coq's CI (@ejgallego @alizter)
