### PR TITLE
[new release] ez-conf-lib, conf-gmp, conf-mpfr

### DIFF
--- a/packages/conf-gmp/conf-gmp.5/files/test-gmp.c
+++ b/packages/conf-gmp/conf-gmp.5/files/test-gmp.c
@@ -1,0 +1,7 @@
+#include <gmp.h>
+int main () {
+  mpz_t n;
+  mpz_init (n);
+  mpz_clear (n);
+  return 1;
+}

--- a/packages/conf-gmp/conf-gmp.5/opam
+++ b/packages/conf-gmp/conf-gmp.5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Virtual package relying on a GMP lib system installation"
+description:
+  "This package can only install if the GMP lib is installed on the system."
+maintainer: "Nicolas Berthier <m@nberth.space>"
+authors: "https://gmplib.org/manual/Contributors"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  ["sh" ez-conf-lib:exe "gmp" "gmp.h" "test-gmp.c" "--"
+        "/usr/local" {os != "macos" & os != "win32"}
+        "/opt/homebrew" {os = "macos"}
+        "/opt/local" {os = "macos"} ]
+]
+depends: [
+  "ez-conf-lib" {build}
+]
+depexts: [
+  ["libgmp-dev"] {os-family = "debian"}
+  ["libgmp-dev"] {os-family = "ubuntu"}
+  ["gmp"] {os = "macos" & os-distribution = "homebrew"}
+  ["gmp"] {os-distribution = "macports" & os = "macos"}
+  ["gmp" "gmp-devel"] {os-distribution = "centos"}
+  ["gmp" "gmp-devel"] {os-distribution = "fedora"}
+  ["gmp" "gmp-devel"] {os-distribution = "ol"}
+  ["gmp"] {os = "openbsd"}
+  ["gmp"] {os = "freebsd"}
+  ["gmp-dev"] {os-distribution = "alpine"}
+  ["gmp-devel"] {os-family = "suse"}
+  ["gmp"] {os = "win32" & os-distribution = "cygwinports"}
+  ["gmp"] {os-distribution = "nixos"}
+]
+extra-files: ["test-gmp.c" "md5=f87da5edbfcb8f70ef0297d78ca37aef"]
+flags: conf

--- a/packages/conf-mpfr/conf-mpfr.4/files/test-mpfr.c
+++ b/packages/conf-mpfr/conf-mpfr.4/files/test-mpfr.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <mpfr.h>
+
+int main (void) {
+  printf ("MPFR library: %-12s\nMPFR header:  %s (based on %d.%d.%d)\n",
+          mpfr_get_version (), MPFR_VERSION_STRING, MPFR_VERSION_MAJOR,
+          MPFR_VERSION_MINOR, MPFR_VERSION_PATCHLEVEL);
+  return 0;
+}

--- a/packages/conf-mpfr/conf-mpfr.4/opam
+++ b/packages/conf-mpfr/conf-mpfr.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Virtual package relying on library MPFR installation"
+description:
+  "This package can only install if the MPFR library is installed on the system."
+maintainer: "Nicolas Berthier <m@nberth.space>"
+authors: "http://www.mpfr.org/credit.html"
+homepage: "http://gmplib.org/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-1.0-or-later"
+build: [
+  [ "sh" ez-conf-lib:exe "mpfr" "mpfr.h" "test-mpfr.c"
+         "CPPFLAGS+=-I%{conf-gmp:incdir}%" { conf-gmp:incdir != "" }
+         "LDFLAGS+=-L%{conf-gmp:libdir}%"  { conf-gmp:libdir != "" }
+         "LIBS+=-lgmp"
+         "--"
+         "/usr/local" {os != "macos" & os != "win32"}
+         "/opt/homebrew" {os = "macos"}
+         "/opt/local" {os = "macos"} ]
+]
+depends: [
+  "ez-conf-lib" {build}
+  "conf-gmp" {>= "5" & build}
+]
+depexts: [
+  ["libmpfr-dev"] {os-family = "debian"}
+  ["libmpfr-dev"] {os-family = "ubuntu"}
+  ["mpfr-devel"] {os-distribution = "fedora"}
+  ["mpfr-devel"] {os-distribution = "ol"}
+  ["mpfr-devel"] {os-distribution = "centos"}
+  ["mpfr"] {os = "macos" & os-distribution = "homebrew"}
+  ["mpfr"] {os = "macos" & os-distribution = "macports"}
+  ["mpfr"] {os = "freebsd"}
+  ["mpfr"] {os = "openbsd"}
+  ["mpfr"] {os-family = "arch"}
+  ["mpfr-dev"] {os-family = "alpine"}
+  ["mpfr-devel"] {os-family = "suse"}
+  ["mpfr"] {os = "win32" & os-distribution = "cygwinports"}
+]
+extra-files: ["test-mpfr.c" "md5=60677273f1781840669e5a897df5d645"]
+flags: conf

--- a/packages/ez-conf-lib/ez-conf-lib.1/opam
+++ b/packages/ez-conf-lib/ez-conf-lib.1/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+synopsis: "Simple generator of conf-<pkg>.config files"
+description:
+    "This package provides a simplistic utility that \
+     helps writing virtual packages used to detect system libraries"
+authors: ["Nicolas Berthier"]
+maintainer: "Nicolas Berthier <m@nberth.space>"
+homepage: "https://github.com/nberth/ez-conf-lib"
+dev-repo: "git+https://github.com/nberth/ez-conf-lib.git"
+bug-reports: "https://github.com/nberth/ez-conf-lib/issues"
+license: "GPL-3.0-only"
+build: [
+  [ "sh" "-ecx" "sed -e 's_@@ez-conf-lib:lib@@_%{_:lib}%_g' \
+                     ez-conf-lib.config.in > ez-conf-lib.config" ]
+]
+depends: [
+  "ocaml"
+  "conf-findutils"
+]
+url {
+  src: "https://github.com/nberth/ez-conf-lib/archive/1.0.tar.gz"
+  checksum: "sha512=dbe5e3a81fc007b929c6ab87757eaa30ce26ca6929fab84d747dbad6c38a4b18b37797ed1cc38f74366e5c6ffff5c7fbf590ed93fb8552935c2219558465ae33"
+}


### PR DESCRIPTION
These new versions of `conf-gmp` and `conf-mpfr` make use of a new helper package `ez-conf-lib`. The latter provides a script that generates a `conf-<pkg>.config` file that defines `libdir` and `incdir` package variables that inform where header and library files are located.