### PR TITLE
new release of pa_ppx 0.12

### DIFF
--- a/packages/pa_ppx/pa_ppx.0.12/opam
+++ b/packages/pa_ppx/pa_ppx.0.12/opam
@@ -1,0 +1,73 @@
+synopsis: "PPX Rewriters for Ocaml, written using Camlp5"
+description:
+"""
+This is a collection of PPX rewriters, re-implementing those based on ppxlib
+and other libraries, but instead based on Camlp5.  Included is also a collection
+of support libraries for writing new PPX rewriters.  Included are:
+
+pa_assert: ppx_assert
+pa_ppx.deriving, pa_ppx.deriving_plugins (enum, eq, fold, iter, make, map, ord, sexp, show, yojson):
+  ppx_deriving, plugins, ppx_sexp_conv, ppx_deriving_yojson
+pa_ppx.expect_test: ppx_expect_test
+pa_ppx.here: ppx_here
+pa_ppx.import: ppx_import
+pa_ppx.inline_test: ppx_inline_test
+
+pa_ppx.undo_deriving: pa_ppx.deriving expands [@@deriving ...] into code; this rewriter undoes that.
+pa_ppx.unmatched_vala: expands to match-cases (support library for camlp5-based PPX rewriters)
+pa_ppx.hashrecons: support for writing AST rewriters that automatically fills in hash-consing boilerplate
+pa_dock: implements doc-comment extraction for camlp5 preprocessors
+
+Many of the reimplementations in fact offer significant enhanced
+function, described in the pa_ppx documentation.  In addition, there
+is an extensive test-suite, much of it slightly modified versions of
+the tests for the respective PPX rewriters.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx.git"
+doc: "https://github.com/camlp5/pa_ppx/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "conf-perl"
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre" { >= "7.4.3" }
+  "result" { >= "1.5" }
+  "yojson" { >= "1.7.0" }
+  "sexplib0"
+  "bos" { >= "0.2.0" }
+  "fmt"
+  "uint" { >= "2.0.1" }
+  "ounit"
+  "sexplib" { with-test & >= "v0.14.0" }
+  "ppx_import" { with-test & >= "1.7.1" }
+  "ppx_deriving" { with-test }
+  "ppx_deriving_yojson" { with-test & >= "3.5.2" }
+  "ppx_here" { with-test & >= "v0.13.0" }
+  "ppx_sexp_conv" { with-test & >= "v0.13.0" }
+#  "expect_test_helpers" { with-test & >= "v0.13.0" }
+]
+conflicts: [
+  "base-effects"
+  "ocaml-option-bytecode-only"
+]
+build: [
+  [make "get-generated"]
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+  [make "DEBUG=-g" "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx/archive/refs/tags/0.12.tar.gz"
+  checksum: [
+    "sha512=3790e135ffccbd8b8777cc3357b72f2c6e881021d89ad0a8bfd2ca247aef0e623fa08c2935fb176adfb2bc7cdcdfa0a4901d93f6ec557fbe376b9f3ef6c98e0f"
+  ]
+}

--- a/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.09/opam
+++ b/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.09/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"
   "camlp5"      { >= "8.00" }
-  "pa_ppx"      { >= "0.08" }
+  "pa_ppx"      { >= "0.08" & < "0.12" }
   "pa_ppx_migrate"      { with-test & >= "0.08" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }

--- a/packages/pa_ppx_migrate/pa_ppx_migrate.0.09/opam
+++ b/packages/pa_ppx_migrate/pa_ppx_migrate.0.09/opam
@@ -26,7 +26,7 @@ depends: [
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"
   "camlp5"      { >= "8.00.04" }
-  "pa_ppx"      { >= "0.11" }
+  "pa_ppx"      { >= "0.11" & < "0.12" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }
   "ounit" {with-test}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.09/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.0.09/opam
@@ -21,7 +21,7 @@ depends: [
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"
   "camlp5"      { >= "8.00.04" }
-  "pa_ppx"      { >= "0.08" }
+  "pa_ppx"      { >= "0.08" & < "0.12" }
   "pa_ppx_migrate"      { with-test & >= "0.08" }
   "pa_ppx_hashcons"      { >= "0.08" }
   "pa_ppx_unique"      { >= "0.08" }

--- a/packages/pa_ppx_unique/pa_ppx_unique.0.09/opam
+++ b/packages/pa_ppx_unique/pa_ppx_unique.0.09/opam
@@ -19,7 +19,7 @@ depends: [
   "conf-perl-ipc-system-simple"
   "conf-perl-string-shellquote"
   "camlp5"      { >= "8.00" }
-  "pa_ppx"      { >= "0.08" }
+  "pa_ppx"      { >= "0.08" & < "0.12" }
   "pa_ppx_migrate"      { with-test & >= "0.08" }
   "not-ocamlfind" { >= "0.01" }
   "pcre" { >= "7.4.3" }


### PR DESCRIPTION
* compatible with camlp5 8.01.00

* remove all perl scripts that depend on conf-perl-* packages

  -- and all but one simple perl script