### PR TITLE
2 packages from c-cube/ezcurl at 0.2.3

### DIFF
--- a/packages/ezcurl-lwt/ezcurl-lwt.0.2.3/opam
+++ b/packages/ezcurl-lwt/ezcurl-lwt.0.2.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl, Lwt version"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "ezcurl" { = version }
+  "lwt"
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "mdx" {with-test}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" "lwt" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.2.3.tar.gz"
+  checksum: [
+    "md5=f4ca6b30671c23e96fcb33f412a6835c"
+    "sha512=417e8854b1457c50cd969502fd1879edfd03a442a7068573a2014826b495711b6c49a1267f022a9d8619404b2a771353453701073a659376a739bb58075cd66d"
+  ]
+}

--- a/packages/ezcurl/ezcurl.0.2.3/opam
+++ b/packages/ezcurl/ezcurl.0.2.3/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Friendly wrapper around OCurl"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  #["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocurl" {>= "0.8.0"}
+  "dune" { >= "1.0" }
+  "odoc" {with-doc}
+  "ocaml" { >= "4.03.0" }
+]
+tags: [ "curl" "web" "http" "client" ]
+homepage: "https://github.com/c-cube/ezcurl/"
+doc: "https://c-cube.github.io/ezcurl/doc/1.2"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src: "https://github.com/c-cube/ezcurl/archive/v0.2.3.tar.gz"
+  checksum: [
+    "md5=f4ca6b30671c23e96fcb33f412a6835c"
+    "sha512=417e8854b1457c50cd969502fd1879edfd03a442a7068573a2014826b495711b6c49a1267f022a9d8619404b2a771353453701073a659376a739bb58075cd66d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`ezcurl.0.2.3`: Friendly wrapper around OCurl
-`ezcurl-lwt.0.2.3`: Friendly wrapper around OCurl, Lwt version



---
* Homepage: https://github.com/c-cube/ezcurl/
* Source repo: git+https://github.com/c-cube/ezcurl.git
* Bug tracker: https://github.com/c-cube/ezcurl/issues

---
:camel: Pull-request generated by opam-publish v2.0.3