### PR TITLE
Remove Homebrew 4.0.0 & 4.0.1 workaround (HOMEBREW_NO_INSTALL_FROM_API)

### DIFF
--- a/packages/conf-bison/conf-bison.2/opam
+++ b/packages/conf-bison/conf-bison.2/opam
@@ -15,7 +15,6 @@ authors: [
   "Paul Eggert"
 ]
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-flex/conf-flex.2/opam
+++ b/packages/conf-flex/conf-flex.2/opam
@@ -5,7 +5,6 @@ bug-reports: "https://github.com/westes/flex/issues"
 license: "https://github.com/westes/flex/blob/master/COPYING"
 authors: "The Flex Project"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.1.0.0/opam
+++ b/packages/conf-libclang/conf-libclang.1.0.0/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.10/opam
+++ b/packages/conf-libclang/conf-libclang.10/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.11/opam
+++ b/packages/conf-libclang/conf-libclang.11/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.12/opam
+++ b/packages/conf-libclang/conf-libclang.12/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.13/opam
+++ b/packages/conf-libclang/conf-libclang.13/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.14/opam
+++ b/packages/conf-libclang/conf-libclang.14/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libclang/conf-libclang.15/opam
+++ b/packages/conf-libclang/conf-libclang.15/opam
@@ -5,7 +5,6 @@ homepage: "http://llvm.org"
 bug-reports: "https://llvm.org/bugs/"
 license: "MIT"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libssl/conf-libssl.1/opam
+++ b/packages/conf-libssl/conf-libssl.1/opam
@@ -5,7 +5,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libssl/conf-libssl.2/opam
+++ b/packages/conf-libssl/conf-libssl.2/opam
@@ -5,7 +5,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libssl/conf-libssl.3/opam
+++ b/packages/conf-libssl/conf-libssl.3/opam
@@ -5,7 +5,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-libssl/conf-libssl.4/opam
+++ b/packages/conf-libssl/conf-libssl.4/opam
@@ -5,7 +5,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://www.openssl.org/"
 license: "Apache-1.0"
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [

--- a/packages/conf-qt/conf-qt.5.2.1/opam
+++ b/packages/conf-qt/conf-qt.5.2.1/opam
@@ -11,7 +11,6 @@ dev-repo: "git+https://github.com/Kakadu/lablqml.git"
 
 extra-files: [ "configure.sh" "md5=78ed05ba24ce4c1f929276bdefef8818" ]
 build-env: [
-  [HOMEBREW_NO_INSTALL_FROM_API = "1"]
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [


### PR DESCRIPTION
See https://github.com/Homebrew/brew/issues/15147