### PR TITLE
websocket-lwt-unix 2.14: not compatible with recent conduit

### DIFF
--- a/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
+++ b/packages/websocket-lwt-unix/websocket-lwt-unix.2.14/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.3.0"}
   "websocket" {= version}
   "lwt_log" {>= "1.1.1"}
-  "cohttp-lwt-unix" {>= "2.5.1" & < "5.0.0"}
+  "cohttp-lwt-unix" {>= "2.5.1" & < "4.1.0"}
 ]
 synopsis: "Websocket library (Lwt)"
 description: """


### PR DESCRIPTION
This is transitively used from cohttp-lwt-unix. Error:
```

#=== ERROR while compiling websocket-lwt-unix.2.14 ============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/websocket-lwt-unix.2.14
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -j 255 -p websocket-lwt-unix
# exit-code            1
# env-file             ~/.opam/log/websocket-lwt-unix-7-f908e5.env
# output-file          ~/.opam/log/websocket-lwt-unix-7-f908e5.out
### output ###
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I lwt/.websocket_lwt_unix.objs/byte -I lwt/.websocket_lwt_unix.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/websocket -intf-suffix .ml -no-alias-deps -o lwt/.websocket_lwt_unix.objs/native/websocket_lwt_unix.cmx -c -impl lwt/websocket_lwt_unix.ml)
# File "lwt/websocket_lwt_unix.ml", line 54, characters 30-33:
# 54 |     Conduit_lwt_unix.connect ~ctx client >>= fun (flow, ic, oc) ->
#                                    ^^^
# Error: This expression has type
#          Conduit_lwt_unix.ctx Lazy.t = Conduit_lwt_unix.ctx lazy_t
#        but an expression was expected of type Conduit_lwt_unix.ctx
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lwt/.wscat.eobjs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/websocket -I lwt/.websocket_lwt_unix.objs/byte -no-alias-deps -o lwt/.wscat.eobjs/byte/wscat.cmo -c -impl lwt/wscat.ml)
# File "lwt/wscat.ml", line 10, characters 40-51:
# 10 |   Conduit_lwt_unix.(endp_to_client ~ctx:default_ctx endp >>= fun client ->
#                                              ^^^^^^^^^^^
# Error: This expression has type
#          Conduit_lwt_unix.ctx Lazy.t = Conduit_lwt_unix.ctx lazy_t
#        but an expression was expected of type Conduit_lwt_unix.ctx
# (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I lwt/.websocket_lwt_unix.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/cohttp-lwt -I /home/opam/.opam/4.14/lib/cohttp-lwt-unix -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-lwt -I /home/opam/.opam/4.14/lib/conduit-lwt-unix -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/lwt_log -I /home/opam/.opam/4.14/lib/lwt_log/core -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/websocket -intf-suffix .ml -no-alias-deps -o lwt/.websocket_lwt_unix.objs/byte/websocket_lwt_unix.cmo -c -impl lwt/websocket_lwt_unix.ml)
# File "lwt/websocket_lwt_unix.ml", line 54, characters 30-33:
# 54 |     Conduit_lwt_unix.connect ~ctx client >>= fun (flow, ic, oc) ->
#                                    ^^^
# Error: This expression has type
#          Conduit_lwt_unix.ctx Lazy.t = Conduit_lwt_unix.ctx lazy_t
#        but an expression was expected of type Conduit_lwt_unix.ctx
```