### PR TITLE
7 packages from framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2

### DIFF
--- a/packages/ldp/ldp.0.1.0/opam
+++ b/packages/ldp/ldp.0.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "cohttp-lwt" {>= "4.0.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.3"}
+  "ocaml" {>= "4.14.0"}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "rdf" {>= "0.13.0"}
+  "rdf_ppx" {>= "0.13.0"}
+  "sedlex" {>= "2.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}

--- a/packages/ldp_curl/ldp_curl.0.1.0/opam
+++ b/packages/ldp_curl/ldp_curl.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using Curl"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ocurl" {>= "0.9.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}

--- a/packages/ldp_js/ldp_js.0.1.0/opam
+++ b/packages/ldp_js/ldp_js.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications in JS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "js_of_ocaml" {>= "3.9.0"}
+  "js_of_ocaml-ppx" {>= "3.9.0"}
+  "cohttp-lwt-jsoo" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}

--- a/packages/ldp_tls/ldp_tls.0.1.0/opam
+++ b/packages/ldp_tls/ldp_tls.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Library to build LDP applications using TLS"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "tls" {>= "0.16.0"}
+  "ppx_sexp_conv"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}

--- a/packages/solid/solid.0.1.0/opam
+++ b/packages/solid/solid.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID applications"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ldp" {= version}
+  "ocaml" {>= "4.14.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}

--- a/packages/solid_server/solid_server.0.1.0/opam
+++ b/packages/solid_server/solid_server.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "SOLID server under development"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "calendar" {>= "2.04"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "cryptokit" {>= "1.16.1"}
+  "fpath" {>= "0.7.3"}
+  "git-unix" {>= "3.4.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "ocaml" {>= "4.14.0"}
+  "ppx_blob" {>= "0.7.2"}
+  "solid" {= version}
+  "webmachine" {>= "0.7.0"}
+  "xtmpl" {>= "0.19.0"}
+  "xtmpl_ppx" {>= "0.19.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}

--- a/packages/solid_tools/solid_tools.0.1.0/opam
+++ b/packages/solid_tools/solid_tools.0.1.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Library to build SOLID tools"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["rdf" "semantic web" "solid" "ldp"]
+homepage: "https://zoggy.frama.io/ocaml-ldp/"
+doc: "https://zoggy.frama.io/ocaml-ldp/"
+bug-reports: "https://framagit.org/zoggy/ocaml-ldp/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.14.0"}
+  "ldp_curl" {= version}
+  "ldp_tls" {= version}
+  "solid" {= version}
+  "ocf" {>= "0.8.0"}
+  "ocf_ppx" {>= "0.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-ldp.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-ldp/-/archive/0.1.0/ocaml-ldp-0.1.0.tar.bz2"
+  checksum: [
+    "md5=a5400f9f16b8140dac263e026515d317"
+    "sha512=f6e8410363be8948f5c59704c4c635d398249e8378c0184323fccddac145f7e3c59b90da2b3a0e195478b279ec07a007af49daee1e18a53f2072d0b25c1f6bc3"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `ldp.0.1.0`: Library to build LDP applications
- `ldp_curl.0.1.0`: Library to build LDP applications using Curl
- `ldp_js.0.1.0`: Library to build LDP applications in JS
- `ldp_tls.0.1.0`: Library to build LDP applications using TLS
- `solid.0.1.0`: Library to build SOLID applications
- `solid_server.0.1.0`: SOLID server under development
- `solid_tools.0.1.0`: Library to build SOLID tools



---
* Homepage: https://zoggy.frama.io/ocaml-ldp/
* Source repo: git+https://framagit.org/zoggy/ocaml-ldp.git
* Bug tracker: https://framagit.org/zoggy/ocaml-ldp/issues

---
:camel: Pull-request generated by opam-publish v2.2.0