### PR TITLE
[new release] kcas_test, kcas_data and kcas (0.2.4)

### DIFF
--- a/packages/kcas/kcas.0.2.4/opam
+++ b/packages/kcas/kcas.0.2.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Multi-word compare-and-set library"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.4/kcas-0.2.4.tbz"
+  checksum: [
+    "sha256=d138a489bb82f7e441859b22147c78a4609fba34ed0d67dea0ae32f38bb5dfa4"
+    "sha512=ec6877f659abfe3915d0924b8688bb2b5b307cf1ef9f5a64afb402a4f8f223aa9b194f18f0b1dcdeac88a7b0ac7e01b2557a39598cb8bf78677d0bf029b73b90"
+  ]
+}
+x-commit-hash: "bc54df59e9fcfa1f51578ce6070da8822ab5f2df"

--- a/packages/kcas_data/kcas_data.0.2.4/opam
+++ b/packages/kcas_data/kcas_data.0.2.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Compositional lock-free data structures"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.4/kcas-0.2.4.tbz"
+  checksum: [
+    "sha256=d138a489bb82f7e441859b22147c78a4609fba34ed0d67dea0ae32f38bb5dfa4"
+    "sha512=ec6877f659abfe3915d0924b8688bb2b5b307cf1ef9f5a64afb402a4f8f223aa9b194f18f0b1dcdeac88a7b0ac7e01b2557a39598cb8bf78677d0bf029b73b90"
+  ]
+}
+x-commit-hash: "bc54df59e9fcfa1f51578ce6070da8822ab5f2df"

--- a/packages/kcas_test/kcas_test.0.2.4/opam
+++ b/packages/kcas_test/kcas_test.0.2.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Test suite for the kcas packages"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "kcas_data" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.4/kcas-0.2.4.tbz"
+  checksum: [
+    "sha256=d138a489bb82f7e441859b22147c78a4609fba34ed0d67dea0ae32f38bb5dfa4"
+    "sha512=ec6877f659abfe3915d0924b8688bb2b5b307cf1ef9f5a64afb402a4f8f223aa9b194f18f0b1dcdeac88a7b0ac7e01b2557a39598cb8bf78677d0bf029b73b90"
+  ]
+}
+x-commit-hash: "bc54df59e9fcfa1f51578ce6070da8822ab5f2df"


### PR DESCRIPTION
Test suite for the kcas packages

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.2.4

* Introduce `kcas_data` companion package of composable lock-free data structures (@polytypic)
* Add `is_in_log` operation to determine whether a location has been accessed by a transaction (@polytypic)
* Add `Loc.modify` (@polytypic)
* Add transactional `swap` operation to exchange contents of two locations (@polytypic)
* Injectivity `!'a Loc.t` and variance `+'a Tx.t` annotations (@polytypic)
