### PR TITLE
[new release] kcas_test, kcas_data and kcas (0.2.4)

### DIFF
--- a/packages/kcas/kcas.0.2.4/opam
+++ b/packages/kcas/kcas.0.2.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Multi-word compare-and-set library"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.4/kcas-0.2.4.tbz"
+  checksum: [
+    "sha256=451781d7488c3824f504bd457592b987d9c7179be19c4039e217f3617615eba7"
+    "sha512=25b05bdfdc6b87856581a271be96281ed8b4e4849f235bfb81df9e28905591094798355b461efa0e1666217211cc7c720ba2dd49086c43803a2adc79331d1aa8"
+  ]
+}
+x-commit-hash: "790267cccda48391f5e02a8e55522c55f8e6ad8f"

--- a/packages/kcas_data/kcas_data.0.2.4/opam
+++ b/packages/kcas_data/kcas_data.0.2.4/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Compositional lock-free data structures"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.4/kcas-0.2.4.tbz"
+  checksum: [
+    "sha256=451781d7488c3824f504bd457592b987d9c7179be19c4039e217f3617615eba7"
+    "sha512=25b05bdfdc6b87856581a271be96281ed8b4e4849f235bfb81df9e28905591094798355b461efa0e1666217211cc7c720ba2dd49086c43803a2adc79331d1aa8"
+  ]
+}
+x-commit-hash: "790267cccda48391f5e02a8e55522c55f8e6ad8f"

--- a/packages/kcas_test/kcas_test.0.2.4/opam
+++ b/packages/kcas_test/kcas_test.0.2.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Test suite for the kcas packages"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "kcas_data" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.2.4/kcas-0.2.4.tbz"
+  checksum: [
+    "sha256=451781d7488c3824f504bd457592b987d9c7179be19c4039e217f3617615eba7"
+    "sha512=25b05bdfdc6b87856581a271be96281ed8b4e4849f235bfb81df9e28905591094798355b461efa0e1666217211cc7c720ba2dd49086c43803a2adc79331d1aa8"
+  ]
+}
+x-commit-hash: "790267cccda48391f5e02a8e55522c55f8e6ad8f"


### PR DESCRIPTION
- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.2.4

* Introduce `kcas_data` companion package of composable lock-free data structures (@polytypic)
* Add `is_in_log` operation to determine whether a location has been accessed by a transaction (@polytypic)
* Add `Loc.modify` (@polytypic)
* Add transactional `swap` operation to exchange contents of two locations (@polytypic)
* Injectivity `!'a Loc.t` and variance `+'a Tx.t` annotations (@polytypic)
