### PR TITLE
update pa_ppx_* packages (after pa_ppx.0.12)

### DIFF
--- a/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.10/opam
+++ b/packages/pa_ppx_hashcons/pa_ppx_hashcons.0.10/opam
@@ -1,0 +1,36 @@
+synopsis: "A PPX Rewriter for Hashconsing"
+description:
+"""
+This is a PPX Rewriter for generating hashconsing implementations
+of ASTs, mechanizing the ideas and code of Jean-Christophe Filliatre
+and Sylvain Conchon.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_hashcons"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_hashcons/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_hashcons.git"
+doc: "https://github.com/camlp5/pa_ppx_hashcons/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "pa_ppx_migrate"      { with-test & >= "0.10" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+  "fmt"
+  "hashcons"
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]

--- a/packages/pa_ppx_migrate/pa_ppx_migrate.0.10/opam
+++ b/packages/pa_ppx_migrate/pa_ppx_migrate.0.10/opam
@@ -1,0 +1,39 @@
+synopsis: "A PPX Rewriter for Migrating AST types (written using Camlp5)"
+description:
+"""
+This is a PPX Rewriter for generating "migrations" like those written
+by-hand (with some automated support) in "ocaml-migrate-parsetree".
+The goal here is that the input to the automated tool is the minimum
+possible, with no need for human massaging of output from the tool.
+
+There are two examples: a small one (in a unit-test) and a full set of
+migrations from Ocaml's AST 4.02 all the way up to 4.11, with all the
+intermediate ASTs, and migrations forward as well as backward.
+
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_migrate"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_migrate/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_migrate.git"
+doc: "https://github.com/camlp5/pa_ppx_migrate/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "fmt"
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]

--- a/packages/pa_ppx_quotation2extension/pa_ppx_quotation2extension.0.01/opam
+++ b/packages/pa_ppx_quotation2extension/pa_ppx_quotation2extension.0.01/opam
@@ -1,0 +1,31 @@
+synopsis: "A Camlp5 PPX Rewriter for treating PPX extensions as Camlp5 quotations  "
+description:
+"""
+This is a PPX Rewriter that processes PPX extensions with string payloads as
+Camlp5 quotations.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_quotation2extension"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_quotation2extension/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_quotation2extension.git"
+doc: "https://github.com/camlp5/pa_ppx_quotation2extension/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "pa_ppx_regexp" { >= "0.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" {with-test}
+  "fmt"
+  "mdx" {with-test}
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]

--- a/packages/pa_ppx_regexp/pa_ppx_regexp.0.01/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.0.01/opam
@@ -1,0 +1,34 @@
+synopsis: "A Camlp5 PPX Rewriter for Perl Regexp Workalikes "
+description:
+"""
+This is a PPX Rewriter for some workalikes to perl regexp operations,
+based on Camlp5 (so it's compatible with all the other Camlp5-based PPX rewriters).
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_regexp"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_regexp/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_regexp.git"
+doc: "https://github.com/camlp5/pa_ppx_regexp/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "pa_ppx_migrate"      { >= "0.10" }
+  "pa_ppx_static" { >= "0.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" {with-test}
+  "mdx" {with-test}
+  "fmt"
+  "pcre"
+  "re"
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]

--- a/packages/pa_ppx_static/pa_ppx_static.0.01/opam
+++ b/packages/pa_ppx_static/pa_ppx_static.0.01/opam
@@ -1,0 +1,32 @@
+synopsis: "A Camlp5 PPX Rewriter for static blocks "
+description:
+"""
+This is a PPX Rewriter to provide `static' blocks
+for OCaml, so you can write code that computes some
+expensive expression and mark it as static, so it'll
+be computed only once.  Like regexps.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_static"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_static/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_static.git"
+doc: "https://github.com/camlp5/pa_ppx_static/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" {with-test}
+  "fmt"
+  "mdx" {with-test}
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]

--- a/packages/pa_ppx_unique/pa_ppx_unique.0.10/opam
+++ b/packages/pa_ppx_unique/pa_ppx_unique.0.10/opam
@@ -1,0 +1,33 @@
+synopsis: "A PPX Rewriter for Uniqifying ASTs"
+description:
+"""
+This is a PPX Rewriter for uniqifying ASTs: inserting unique IDs
+systematically throughout an AST.
+"""
+opam-version: "2.0"
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_unique"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_unique/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_unique.git"
+doc: "https://github.com/camlp5/pa_ppx_unique/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" & < "5.01.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.01.00" }
+  "pa_ppx"      { >= "0.12" }
+  "pa_ppx_migrate"      { with-test & >= "0.10" }
+  "not-ocamlfind" { >= "0.10" }
+  "pcre" { >= "7.4.3" }
+  "ounit" {with-test}
+  "bos" { >= "0.2.0" }
+  "fmt"
+]
+build: [
+  [make "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]


### PR DESCRIPTION
New packages: pa_ppx_{static,regexp,quotation2extension}

updated packages: pa_ppx_{hashcons,unique,migrate}

Major change is to remove *all* dependency on Perl

Also Makefile reorganization