### PR TITLE
Add: cmarkit.0.1.0

### DIFF
--- a/packages/cmarkit/cmarkit.0.1.0/opam
+++ b/packages/cmarkit/cmarkit.0.1.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "CommonMark parser and renderer for OCaml"
+description: """\
+Cmarkit parses the [CommonMark specification]. It provides:
+
+- A CommonMark parser for UTF-8 encoded documents. Link label resolution
+  can be customized and a non-strict parsing mode can be activated to add: 
+  strikethrough, LaTeX math, footnotes, task items and tables.
+  
+- An extensible abstract syntax tree for CommonMark documents with
+  source location tracking and best-effort source layout preservation.
+
+- Abstract syntax tree mapper and folder abstractions for quick and
+  concise tree transformations.
+  
+- Extensible renderers for HTML, LaTeX and CommonMark with source
+  layout preservation.
+
+Cmarkit is distributed under the ISC license. It has no dependencies.
+
+[CommonMark specification]: https://spec.commonmark.org/
+
+Homepage: <https://erratique.ch/software/cmarkit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmarkit programmers"
+license: "ISC"
+tags: ["codec" "commonmark" "markdown" "org:erratique"]
+homepage: "https://erratique.ch/software/cmarkit"
+doc: "https://erratique.ch/software/cmarkit/doc"
+bug-reports: "https://github.com/dbuenzli/cmarkit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {dev}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/cmarkit.git"
+url {
+  src: "https://erratique.ch/software/cmarkit/releases/cmarkit-0.1.0.tbz"
+  checksum:
+    "sha512=d65ee4d62b2209fa06c2e30d2ff555636d176dcfebea5695a7d1c0aae965b5c3fb6cca57ab5b8d663d0c544ab0e646970b41b42af82ea16d6fa2c426161f2934"
+}


### PR DESCRIPTION
* Add: `cmarkit.0.1.0` [home](https://erratique.ch/software/cmarkit), [doc](https://erratique.ch/software/cmarkit/doc), [issues](https://github.com/dbuenzli/cmarkit/issues)  
  *CommonMark parser and renderer for OCaml*


---

#### `cmarkit` v0.1.0 2023-04-06 La Forclaz (VS)


First release.

Supported by a grant from the OCaml Software Foundation.


---

Use `b0 -- .opam.publish cmarkit.0.1.0` to update the pull request.