### PR TITLE
[new release] dockerfile, dockerfile-opam and dockerfile-cmd (8.2.1)

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.2.1/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.2.1/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-cmd/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.1/dockerfile-8.2.1.tbz"
+  checksum: [
+    "sha256=850e284288bbed08039e136eb4fea8cbec8d46c83b33b0b304c01ee7a6806e69"
+    "sha512=44a80d5397dfabbc82c39cc7ae0f9a108aa912a17ef939950219138d135c63d34559ed292987eea9ed95b7f34a534cfc48f5d7f248ae38fe7807ffd39d1156d6"
+  ]
+}
+x-commit-hash: "7933f0e647958408c934ca9b202a89e4779ba4c4"

--- a/packages/dockerfile-opam/dockerfile-opam.8.2.1/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.2.1/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile-opam/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "astring"
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.5.0"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.1/dockerfile-8.2.1.tbz"
+  checksum: [
+    "sha256=850e284288bbed08039e136eb4fea8cbec8d46c83b33b0b304c01ee7a6806e69"
+    "sha512=44a80d5397dfabbc82c39cc7ae0f9a108aa912a17ef939950219138d135c63d34559ed292987eea9ed95b7f34a534cfc48f5d7f248ae38fe7807ffd39d1156d6"
+  ]
+}
+x-commit-hash: "7933f0e647958408c934ca9b202a89e4779ba4c4"

--- a/packages/dockerfile/dockerfile.8.2.1/opam
+++ b/packages/dockerfile/dockerfile.8.2.1/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+"""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+doc: "https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.2.1/dockerfile-8.2.1.tbz"
+  checksum: [
+    "sha256=850e284288bbed08039e136eb4fea8cbec8d46c83b33b0b304c01ee7a6806e69"
+    "sha512=44a80d5397dfabbc82c39cc7ae0f9a108aa912a17ef939950219138d135c63d34559ed292987eea9ed95b7f34a534cfc48f5d7f248ae38fe7807ffd39d1156d6"
+  ]
+}
+x-commit-hash: "7933f0e647958408c934ca9b202a89e4779ba4c4"


### PR DESCRIPTION
Dockerfile eDSL in OCaml

- Project page: <a href="https://github.com/ocurrent/ocaml-dockerfile">https://github.com/ocurrent/ocaml-dockerfile</a>
- Documentation: <a href="https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/">https://ocurrent.github.io/ocaml-dockerfile/doc/dockerfile/</a>

##### CHANGES:

- Correct sexp generation for dockerfile-opam.
  (@benmandrew ocurrent/ocaml-dockerfile#158, review by @MisterDA)

- Switch to root and back to opam user when installing OCaml external
  dependencies in the ocaml stage; fixes depext installation.
  (@MisterDA ocurrent/ocaml-dockerfile#146, ocurrent/ocaml-dockerfile#157)
