### PR TITLE
Luv 0.5.12: binding to libuv, the I/O library

### DIFF
--- a/packages/luv/luv.0.5.12/opam
+++ b/packages/luv/luv.0.5.12/opam
@@ -36,5 +36,5 @@ alternative to the standard module Unix."
 
 url {
   src: "https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz"
-  checksum: "md5=614435463a30b22c1ab157e428a53ebb"
+  checksum: "md5=a4fd3362abd9856c25337eb243291879"
 }

--- a/packages/luv/luv.0.5.12/opam
+++ b/packages/luv/luv.0.5.12/opam
@@ -36,5 +36,5 @@ alternative to the standard module Unix."
 
 url {
   src: "https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz"
-  checksum: "md5=a4fd3362abd9856c25337eb243291879"
+  checksum: "md5=57b2063e489cbbcfea3a238ced0dd297"
 }

--- a/packages/luv/luv.0.5.12/opam
+++ b/packages/luv/luv.0.5.12/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+
+synopsis: "Binding to libuv: cross-platform asynchronous I/O"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix" {build}
+  "ctypes" {>= "0.14.0"}
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.03.0"}
+
+  "alcotest" {with-test & >= "0.8.1"}
+  "base-unix" {with-test}
+  "odoc" {with-doc & = "2.2.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "Luv is a binding to libuv, the cross-platform C library that does
+asynchronous I/O in Node.js and runs its main loop.
+
+Besides asynchronous I/O, libuv also supports multiprocessing and
+multithreading. Multiple event loops can be run in different threads. libuv also
+exposes a lot of other functionality, amounting to a full OS API, and an
+alternative to the standard module Unix."
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz"
+  checksum: "md5=614435463a30b22c1ab157e428a53ebb"
+}

--- a/packages/luv_unix/luv_unix.0.5.1/opam
+++ b/packages/luv_unix/luv_unix.0.5.1/opam
@@ -16,7 +16,7 @@ depends: [
   "ctypes" {>= "0.14.0"}  # Ctypes.CArray.of_string.
   "dune" {>= "2.0.0"}
   "luv" {>= "0.5.8"}  # uv.h.
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.03.0"}
 ]
 
 build: [
@@ -25,5 +25,5 @@ build: [
 
 url {
   src: "https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz"
-  checksum: "md5=614435463a30b22c1ab157e428a53ebb"
+  checksum: "md5=a4fd3362abd9856c25337eb243291879"
 }

--- a/packages/luv_unix/luv_unix.0.5.1/opam
+++ b/packages/luv_unix/luv_unix.0.5.1/opam
@@ -25,5 +25,5 @@ build: [
 
 url {
   src: "https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz"
-  checksum: "md5=a4fd3362abd9856c25337eb243291879"
+  checksum: "md5=57b2063e489cbbcfea3a238ced0dd297"
 }

--- a/packages/luv_unix/luv_unix.0.5.1/opam
+++ b/packages/luv_unix/luv_unix.0.5.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for interfacing Luv and Unix"
+
+license: "MIT"
+homepage: "https://github.com/aantron/luv"
+doc: "https://aantron.github.io/luv"
+bug-reports: "https://github.com/aantron/luv/issues"
+
+authors: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/aantron/luv.git"
+
+depends: [
+  "base-unix"
+  "ctypes" {>= "0.14.0"}  # Ctypes.CArray.of_string.
+  "dune" {>= "2.0.0"}
+  "luv" {>= "0.5.8"}  # uv.h.
+  "ocaml" {>= "4.02.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/luv/releases/download/0.5.12/luv-0.5.12.tar.gz"
+  checksum: "md5=614435463a30b22c1ab157e428a53ebb"
+}


### PR DESCRIPTION
From the [changelog](https://github.com/aantron/luv/releases/tag/0.5.12):

> Breaking
>
> - [`Luv.Passwd.t.uid`](https://aantron.github.io/luv/luv/Luv/Passwd/index.html#type-t.uid) and [`Luv.Passwd.t.gid`](https://aantron.github.io/luv/luv/Luv/Passwd/index.html#type-t.gid) are now `unsigned long`s, in accordance with a [change](https://github.com/libuv/libuv/commit/f3e0bffcb147fcda65c27007d276cc95ca084a18) in libuv (aantron/luv#147).
>
> Additions
>
> - Upgrade vendored libuv to [1.44.2](https://github.com/libuv/libuv/releases/tag/v1.44.2) (aantron/luv#147).
> - Expose [`uv_available_parallelism`](http://docs.libuv.org/en/v1.x/misc.html#c.uv_available_parallelism) as [`Luv.System_info.available_parallelism`](https://aantron.github.io/luv/luv/Luv/System_info/index.html#val-available_parallelism) (aantron/luv#147).
>
> Bugs fixed
>
> - `uv_buf_t::len` is a `size_t` (Christiano Haesbaert, aantron/luv#133).
> - Parse `host:` config correctly during build (reported by Pablo Meier and Matthieu Gosset, aantron/luv#138).
> - Define `CAML_NAME_SPACE` before including OCaml headers (Antonin Décimo, aantron/luv#139).
> - Register references to callbacks in trampolines that allocate (reported by Thomas Leonard, aantron/luv#145). The way this bug was fixed requires OCaml 4.03.

The only difference in `luv_unix` is that it no longer requires `result`.