### PR TITLE
Add: cmdliner.1.2.0

### DIFF
--- a/packages/cmdliner/cmdliner.1.2.0/opam
+++ b/packages/cmdliner/cmdliner.1.2.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Declarative definition of command line interfaces for OCaml"
+description: """\
+Cmdliner allows the declarative definition of command line interfaces
+for OCaml.
+
+It provides a simple and compositional mechanism to convert command
+line arguments to OCaml values and pass them to your functions. The
+module automatically handles syntax errors, help messages and UNIX man
+page generation. It supports programs with single or multiple commands
+and respects most of the [POSIX][1] and [GNU][2] conventions.
+
+Cmdliner has no dependencies and is distributed under the ISC license.
+
+[1]: http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap12.html
+[2]: http://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+
+Home page: http://erratique.ch/software/cmdliner"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmdliner programmers"
+license: "ISC"
+tags: ["cli" "system" "declarative" "org:erratique"]
+homepage: "https://erratique.ch/software/cmdliner"
+doc: "https://erratique.ch/software/cmdliner/doc"
+bug-reports: "https://github.com/dbuenzli/cmdliner/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+]
+build: [make "all" "PREFIX=%{prefix}%"]
+install: [
+  [make "install" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+  [make "install-doc" "LIBDIR=%{_:lib}%" "DOCDIR=%{_:doc}%"]
+]
+dev-repo: "git+https://erratique.ch/repos/cmdliner.git"
+url {
+  src: "https://erratique.ch/software/cmdliner/releases/cmdliner-1.2.0.tbz"
+  checksum:
+    "sha512=6fcd6a59a6fbc6986b1aecdc3e4ce7a0dc43c65a16b427d6caa5504b10b51384f6b0bc703af646b09f5f1caeb6827b37d4480ce350ca8006204c850785f2810b"
+}


### PR DESCRIPTION
* Add: `cmdliner.1.2.0` [home](https://erratique.ch/software/cmdliner), [doc](https://erratique.ch/software/cmdliner/doc), [issues](https://github.com/dbuenzli/cmdliner/issues)  
  *Declarative definition of command line interfaces for OCaml*


---

#### `cmdliner` v1.2.0 2023-04-10 La Forclaz (VS)

- In manpage specification the new variable `$(iname)` substitutes the 
  command invocation (from program name to subcommand) in bold ([#168](https://github.com/dbuenzli/cmdliner/issues/168)). 
  This variable is now used in the default introduction of the `EXIT STATUS` 
  section. Thanks to Ali Caglayan for suggesting.
- Fix manpage rendering when `PAGER=less` is set ([#167](https://github.com/dbuenzli/cmdliner/issues/167)).
- Plain text manpage rendering: fix broken handling of `` `Noblank ``.
  Thanks to Michael Richards and Reynir Björnsson for the report ([#176](https://github.com/dbuenzli/cmdliner/issues/176)).
- Fix install to directory with spaces ([#172](https://github.com/dbuenzli/cmdliner/issues/172)). Thanks to 
  @ZSFactory for reporting and suggesting the fix.
- Fix manpage paging on Windows ([#166](https://github.com/dbuenzli/cmdliner/issues/166)). Thanks to Nicolás Ojeda Bär
  for the report and the solution.

---

Use `b0 -- .opam.publish cmdliner.1.2.0` to update the pull request.