### PR TITLE
[new release] checkseum (0.5.1)

### DIFF
--- a/packages/checkseum/checkseum.0.5.0/opam
+++ b/packages/checkseum/checkseum.0.5.0/opam
@@ -52,3 +52,4 @@ url {
   ]
 }
 x-commit-hash: "b68d57c053f08314cc23fc7505f2bb981d360379"
+available: false

--- a/packages/checkseum/checkseum.0.5.1/opam
+++ b/packages/checkseum/checkseum.0.5.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/checkseum"
+bug-reports:  "https://github.com/mirage/checkseum/issues"
+dev-repo:     "git+https://github.com/mirage/checkseum.git"
+doc:          "https://mirage.github.io/checkseum/"
+license:      "MIT"
+synopsis:     "Adler-32, CRC32 and CRC32-C implementation in C and OCaml"
+description: """
+Checkseum is a library to provide implementation of Adler-32, CRC32 and CRC32-C
+in C and OCaml.
+
+This library use the linking trick to choose between the C implementation
+(checkseum.c) or the OCaml implementation (checkseum.ocaml). This library is on
+top of optint to get the best representation of an int32. """
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+install: [
+  [ "dune" "install" "-p" name ] {with-test}
+  [ "ocaml" "./test/test_runes.ml" ] {with-test}
+]
+
+depends: [
+  "ocaml"         {>= "4.07.0"}
+  "dune"          {>= "2.6.0"}
+  "dune-configurator"
+  "optint"        {>= "0.3.0"}
+  "alcotest"      {with-test}
+  "bos"           {with-test}
+  "astring"       {with-test}
+  "fmt"           {with-test}
+  "fpath"         {with-test}
+  "rresult"       {with-test}
+  "ocamlfind"     {with-test}
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+]
+url {
+  src:
+    "https://github.com/mirage/checkseum/releases/download/v0.5.1/checkseum-0.5.1.tbz"
+  checksum: [
+    "sha256=8037e2b3eeb7cbbe57fbd1b539f5be7c738bbbbdb2c305209bff13ac22ab7946"
+    "sha512=e8c7e8eb144e500e2b778451c24ffbfdfab529268605f3c00a57817004c53e10953797f354ba31aff773e09c142ce084012ea7fa6cd415b8a65b747b41994d9e"
+  ]
+}
+x-commit-hash: "98fb84079629e1c79f12985e70676361ae88cb0e"


### PR DESCRIPTION
Adler-32, CRC32 and CRC32-C implementation in C and OCaml

- Project page: <a href="https://github.com/mirage/checkseum">https://github.com/mirage/checkseum</a>
- Documentation: <a href="https://mirage.github.io/checkseum/">https://mirage.github.io/checkseum/</a>

##### CHANGES:

- Fix regression on `adler32` (the OCaml version) introduced by mirage/checkseum#76 and spotted
  by @balat (@dinosaure, mirage/checkseum#80). We advise the user to upgrade as soon as he/she
  can `checkseum`. `checkseum.0.5.0` will be disabled with this release.
- Fix the CI on Windows (@dinosaure, @MisterDA, mirage/checkseum#79)
  See (mirage/bechamel#41 for more details)
