### PR TITLE
[new release] multipart_form, multipart_form-lwt and multipart_form-cohttp-lwt (0.5.0)

### DIFF
--- a/packages/multipart_form-cohttp-lwt/multipart_form-cohttp-lwt.0.5.0/opam
+++ b/packages/multipart_form-cohttp-lwt/multipart_form-cohttp-lwt.0.5.0/opam
@@ -9,6 +9,7 @@ bug-reports: "https://github.com/dinosaure/multipart_form/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0.0"}
+  "lwt" {>= "5.4.0"}
   "cohttp-lwt"
   "multipart_form" {= version}
   "multipart_form-lwt" {= version}

--- a/packages/multipart_form-cohttp-lwt/multipart_form-cohttp-lwt.0.5.0/opam
+++ b/packages/multipart_form-cohttp-lwt/multipart_form-cohttp-lwt.0.5.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Multipart-form for CoHTTP"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cohttp-lwt"
+  "multipart_form" {= version}
+  "multipart_form-lwt" {= version}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.5.0/multipart_form-0.5.0.tbz"
+  checksum: [
+    "sha256=a8a36c1c0e2873ba1b3bd32ccdfb8fb6766e06612e52e36b3077a6a296a88a64"
+    "sha512=f1e95b201e5474687e31bb132ca17ab9799d9957cbc91d0d7fdc160bbcfb2b6f6a77e37fba802c5a41339cb699987667e029672d58096ebfd06fd932b352bd46"
+  ]
+}
+x-commit-hash: "f88dcd04dcea0c343914cd6fba199ac717d9175d"

--- a/packages/multipart_form-lwt/multipart_form-lwt.0.5.0/opam
+++ b/packages/multipart_form-lwt/multipart_form-lwt.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom"
+  "bigstringaf"
+  "ke"
+  "lwt"
+  "multipart_form" {= version}
+  "alcotest-lwt" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "unstrctrd" {with-test}
+  "logs" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.5.0/multipart_form-0.5.0.tbz"
+  checksum: [
+    "sha256=a8a36c1c0e2873ba1b3bd32ccdfb8fb6766e06612e52e36b3077a6a296a88a64"
+    "sha512=f1e95b201e5474687e31bb132ca17ab9799d9957cbc91d0d7fdc160bbcfb2b6f6a77e37fba802c5a41339cb699987667e029672d58096ebfd06fd932b352bd46"
+  ]
+}
+x-commit-hash: "f88dcd04dcea0c343914cd6fba199ac717d9175d"

--- a/packages/multipart_form/multipart_form.0.5.0/opam
+++ b/packages/multipart_form/multipart_form.0.5.0/opam
@@ -21,7 +21,7 @@ depends: [
   "prettym"
   "fmt" {>= "0.8.7"}
   "logs"
-  "ke" {>= "0.4"}
+  "ke" {>= "0.6"}
   "alcotest" {with-test}
   "rosetta" {with-test}
   "rresult" {with-test}

--- a/packages/multipart_form/multipart_form.0.5.0/opam
+++ b/packages/multipart_form/multipart_form.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Multipart-form: RFC2183, RFC2388 & RFC7578"
+description: """\
+Implementation of RFC7578 in OCaml
+
+Returning values from forms: multipart/form-data"""
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/multipart_form"
+doc: "https://dinosaure.github.io/multipart_form/"
+bug-reports: "https://github.com/dinosaure/multipart_form/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "angstrom" {>= "0.14.0"}
+  "base64" {>= "3.0.0"}
+  "unstrctrd" {>= "0.2"}
+  "uutf"
+  "pecu" {>= "0.4"}
+  "prettym"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ke" {>= "0.4"}
+  "alcotest" {with-test}
+  "rosetta" {with-test}
+  "rresult" {with-test}
+  "bigstringaf" {>= "0.9.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/multipart_form.git"
+url {
+  src:
+    "https://github.com/dinosaure/multipart_form/releases/download/v0.5.0/multipart_form-0.5.0.tbz"
+  checksum: [
+    "sha256=a8a36c1c0e2873ba1b3bd32ccdfb8fb6766e06612e52e36b3077a6a296a88a64"
+    "sha512=f1e95b201e5474687e31bb132ca17ab9799d9957cbc91d0d7fdc160bbcfb2b6f6a77e37fba802c5a41339cb699987667e029672d58096ebfd06fd932b352bd46"
+  ]
+}
+x-commit-hash: "f88dcd04dcea0c343914cd6fba199ac717d9175d"


### PR DESCRIPTION
Multipart-form: RFC2183, RFC2388 & RFC7578

- Project page: <a href="https://github.com/dinosaure/multipart_form">https://github.com/dinosaure/multipart_form</a>
- Documentation: <a href="https://dinosaure.github.io/multipart_form/">https://dinosaure.github.io/multipart_form/</a>

##### CHANGES:

- Introduce a new package `multipart_form-cohttp-lwt` which provides
  helpers to use `multipart_form` which CoHTTP (@dinosaure, @shonfeder, dinosaure/multipart_form#34)
