### PR TITLE
Add alpine linux target for conf-pandoc

### DIFF
--- a/packages/conf-pandoc/conf-pandoc.0.1/opam
+++ b/packages/conf-pandoc/conf-pandoc.0.1/opam
@@ -7,6 +7,7 @@ license:      "GPL-3.0-only"
 build:        ["sh" "-exc" "echo | pandoc"]
 
 depexts: [
+  ["pandoc"] {os-family = "alpine"}
   ["pandoc"] {os-family = "debian"}
   ["pandoc" "epel-release"] {os-distribution = "centos"}
   ["pandoc"] {os-distribution = "fedora"}


### PR DESCRIPTION
Not sure if I need a new package version for this or I can add it to an existing one.

Alpine linux has pandoc available https://pkgs.alpinelinux.org/packages?name=pandoc