### PR TITLE
Add cmdliner with-test constraints

### DIFF
--- a/packages/functoria/functoria.4.0.0/opam
+++ b/packages/functoria/functoria.4.0.0/opam
@@ -26,6 +26,7 @@ depends: [
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.1.0/opam
+++ b/packages/functoria/functoria.4.1.0/opam
@@ -26,6 +26,7 @@ depends: [
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.1.1/opam
+++ b/packages/functoria/functoria.4.1.1/opam
@@ -26,6 +26,7 @@ depends: [
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.2.0/opam
+++ b/packages/functoria/functoria.4.2.0/opam
@@ -26,6 +26,7 @@ depends: [
   "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.2.1/opam
+++ b/packages/functoria/functoria.4.2.1/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.0/opam
+++ b/packages/functoria/functoria.4.3.0/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.1/opam
+++ b/packages/functoria/functoria.4.3.1/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.2/opam
+++ b/packages/functoria/functoria.4.3.2/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.3/opam
+++ b/packages/functoria/functoria.4.3.3/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.4/opam
+++ b/packages/functoria/functoria.4.3.4/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.5/opam
+++ b/packages/functoria/functoria.4.3.5/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/functoria/functoria.4.3.6/opam
+++ b/packages/functoria/functoria.4.3.6/opam
@@ -27,6 +27,7 @@ depends: [
   "dune" {with-test & >= "3.0.0"}
   "base-unix"
   "cmdliner" {>= "1.1.1"}
+  "cmdliner" {with-test & < "1.2.0"}
   "rresult" {>= "0.7.0"}
   "result" {>= "1.5"}
   "astring"

--- a/packages/mirage/mirage.4.0.0/opam
+++ b/packages/mirage/mirage.4.0.0/opam
@@ -29,6 +29,8 @@ depends: [
   "opam-monorepo" {>= "0.2.6" & < "0.3.0"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.1.0/opam
+++ b/packages/mirage/mirage.4.1.0/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {= "0.3.0" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.1.1/opam
+++ b/packages/mirage/mirage.4.1.1/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {= "0.3.0" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.2.0/opam
+++ b/packages/mirage/mirage.4.2.0/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.2.1/opam
+++ b/packages/mirage/mirage.4.2.1/opam
@@ -31,6 +31,8 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.0/opam
+++ b/packages/mirage/mirage.4.3.0/opam
@@ -31,6 +31,8 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.1/opam
+++ b/packages/mirage/mirage.4.3.1/opam
@@ -31,6 +31,8 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.2/opam
+++ b/packages/mirage/mirage.4.3.2/opam
@@ -31,6 +31,8 @@ depends: [
   "opam-monorepo" {< "0.3.5" & with-test}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.3/opam
+++ b/packages/mirage/mirage.4.3.3/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.4/opam
+++ b/packages/mirage/mirage.4.3.4/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.5/opam
+++ b/packages/mirage/mirage.4.3.5/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """

--- a/packages/mirage/mirage.4.3.6/opam
+++ b/packages/mirage/mirage.4.3.6/opam
@@ -30,6 +30,8 @@ depends: [
   "opam-monorepo" {>= "0.3.2"}
   "alcotest" {with-test}
   "fmt" {>= "0.8.7" & with-test}
+  "cmdliner"
+  "cmdliner" {with-test & < "1.2.0"}
 ]
 synopsis: "The MirageOS library operating system"
 description: """


### PR DESCRIPTION
This PR attempts to fix version-compatibility issues from https://github.com/ocaml/opam-repository/pull/23654 

TL;DR: mirage and functoria test the exact output of cmdliner-generated documentation; these tests do not survive the 1.2.0 release of cmdliner

ping @hannesm @dinosaure 

Example of broken test:
```
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/69b5b4a762479f1764c1866418686122/default/test/mirage/help/build.t _build/.sandbox/69b5b4a762479f1764c1866418686122/default/test/mirage/help/build.t.corrected
# diff --git a/_build/.sandbox/69b5b4a762479f1764c1866418686122/default/test/mirage/help/build.t b/_build/.sandbox/69b5b4a762479f1764c1866418686122/default/test/mirage/help/build.t.corrected
# index 1d5c370..4decd93 100644
# --- a/_build/.sandbox/69b5b4a762479f1764c1866418686122/default/test/mirage/help/build.t
# +++ b/_build/.sandbox/69b5b4a762479f1764c1866418686122/default/test/mirage/help/build.t.corrected
# @@ -115,7 +115,7 @@ Help build --man-format=plain
#               Show version information.
#    
#    EXIT STATUS
# -         build exits with the following status:
# +         mirage build exits with:
#    
#           0   on success.
#    
# @@ -253,7 +253,7 @@ Help build --help=plain
#               Show version information.
#    
#    EXIT STATUS
# -         build exits with the following status:
# +         mirage build exits with:
#    
#           0   on success.
#    
# File "test/mirage/help/clean.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/9a15dc9d93eca1089c38cce9dffca15f/default/test/mirage/help/clean.t _build/.sandbox/9a15dc9d93eca1089c38cce9dffca15f/default/test/mirage/help/clean.t.corrected
# diff --git a/_build/.sandbox/9a15dc9d93eca1089c38cce9dffca15f/default/test/mirage/help/clean.t b/_build/.sandbox/9a15dc9d93eca1089c38cce9dffca15f/default/test/mirage/help/clean.t.corrected
# index c77e94e..852bb61 100644
# --- a/_build/.sandbox/9a15dc9d93eca1089c38cce9dffca15f/default/test/mirage/help/clean.t
# +++ b/_build/.sandbox/9a15dc9d93eca1089c38cce9dffca15f/default/test/mirage/help/clean.t.corrected
# @@ -116,7 +116,7 @@ Help clean --man-format=plain
#               Show version information.
#    
#    EXIT STATUS
# -         clean exits with the following status:
# +         mirage clean exits with:
#    
#           0   on success.
#    
# @@ -255,7 +255,7 @@ Help clean --help=plain
#               Show version information.
#    
#    EXIT STATUS
# -         clean exits with the following status:
# +         mirage clean exits with:
#    
#           0   on success.
#    
# File "test/mirage/help/configure-o.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/c20cb9889c61181b86403fa834a239f5/default/test/mirage/help/configure-o.t _build/.sandbox/c20cb9889c61181b86403fa834a239f5/default/test/mirage/help/configure-o.t.corrected
# diff --git a/_build/.sandbox/c20cb9889c61181b86403fa834a239f5/default/test/mirage/help/configure-o.t b/_build/.sandbox/c20cb9889c61181b86403fa834a239f5/default/test/mirage/help/configure-o.t.corrected
# index c5df992..bfa1e4c 100644
# --- a/_build/.sandbox/c20cb9889c61181b86403fa834a239f5/default/test/mirage/help/configure-o.t
# +++ b/_build/.sandbox/c20cb9889c61181b86403fa834a239f5/default/test/mirage/help/configure-o.t.corrected
# @@ -132,7 +132,7 @@ Help configure -o --man-format=plain
#               Show version information.
#    
#    EXIT STATUS
# -         configure exits with the following status:
# +         mirage configure exits with:
#    
#           0   on success.
#    
# @@ -290,7 +290,7 @@ Help configure -o --help=plain
#               Show version information.
#    
#    EXIT STATUS
# -         configure exits with the following status:
# +         mirage configure exits with:
#    
#           0   on success.
#    
# File "test/mirage/help/configure.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/2db6b9213a9b9f1528e1f6c56915f2ff/default/test/mirage/help/configure.t _build/.sandbox/2db6b9213a9b9f1528e1f6c56915f2ff/default/test/mirage/help/configure.t.corrected
# diff --git a/_build/.sandbox/2db6b9213a9b9f1528e1f6c56915f2ff/default/test/mirage/help/configure.t b/_build/.sandbox/2db6b9213a9b9f1528e1f6c56915f2ff/default/test/mirage/help/configure.t.corrected
# index 376798c..12a45fb 100644
# --- a/_build/.sandbox/2db6b9213a9b9f1528e1f6c56915f2ff/default/test/mirage/help/configure.t
# +++ b/_build/.sandbox/2db6b9213a9b9f1528e1f6c56915f2ff/default/test/mirage/help/configure.t.corrected
# @@ -132,7 +132,7 @@ Help configure --man-format=plain
#               Show version information.
#    
#    EXIT STATUS
# -         configure exits with the following status:
# +         mirage configure exits with:
#    
#           0   on success.
#    
# @@ -290,7 +290,7 @@ Configure help --help=plain
#               Show version information.
#    
#    EXIT STATUS
# -         configure exits with the following status:
# +         mirage configure exits with:
#    
#           0   on success.
#    
# File "test/mirage/help/query.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/64f823c180eeb08aea07e127c9366862/default/test/mirage/help/query.t _build/.sandbox/64f823c180eeb08aea07e127c9366862/default/test/mirage/help/query.t.corrected
# diff --git a/_build/.sandbox/64f823c180eeb08aea07e127c9366862/default/test/mirage/help/query.t b/_build/.sandbox/64f823c180eeb08aea07e127c9366862/default/test/mirage/help/query.t.corrected
# index 7af522d..a5d9ca7 100644
# --- a/_build/.sandbox/64f823c180eeb08aea07e127c9366862/default/test/mirage/help/query.t
# +++ b/_build/.sandbox/64f823c180eeb08aea07e127c9366862/default/test/mirage/help/query.t.corrected
# @@ -138,7 +138,7 @@ Help query --man-format=plain
#               Show version information.
#    
#    EXIT STATUS
# -         query exits with the following status:
# +         mirage query exits with:
#    
#           0   on success.
#    
# @@ -302,7 +302,7 @@ Help query --help=plain
#               Show version information.
#    
#    EXIT STATUS
# -         query exits with the following status:
# +         mirage query exits with:
#    
#           0   on success.
#    
# File "test/mirage/help/describe.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/c97273a2201f20fef63fda1a644b406d/default/test/mirage/help/describe.t _build/.sandbox/c97273a2201f20fef63fda1a644b406d/default/test/mirage/help/describe.t.corrected
# diff --git a/_build/.sandbox/c97273a2201f20fef63fda1a644b406d/default/test/mirage/help/describe.t b/_build/.sandbox/c97273a2201f20fef63fda1a644b406d/default/test/mirage/help/describe.t.corrected
# index 75c983b..9c781c4 100644
# --- a/_build/.sandbox/c97273a2201f20fef63fda1a644b406d/default/test/mirage/help/describe.t
# +++ b/_build/.sandbox/c97273a2201f20fef63fda1a644b406d/default/test/mirage/help/describe.t.corrected
# @@ -15,17 +15,15 @@ Help describe --man-format=plain
#           The dot output contains the following elements:
#           If vertices
#               Represented as circles. Branches are dotted, and the default
# -             branch is in bold.       Configurables
# -                                          Represented as rectangles. The order
# -                                          of the output arrows is the order of
# -                                          the functor arguments.       
# -                                                                Data
# -                                                                dependencies
# -                                                                           
# -                                                                Represented as
# -                                                                dashed arrows.
# +             branch is in bold.
# +         Configurables
# +             Represented as rectangles. The order of the output arrows is the
# +             order of the functor arguments.
# +         Data dependencies
# +             Represented as dashed arrows.
#           App vertices
#               Represented as diamonds. The bold arrow is the functor part.
# +  
#    UNIKERNEL PARAMETERS
#           -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
#               Be more or less verbose. LEVEL must be of the form
# @@ -147,7 +145,7 @@ Help describe --man-format=plain
#               Show version information.
#    
#    EXIT STATUS
# -         describe exits with the following status:
# +         mirage describe exits with:
#    
#           0   on success.
#    
# @@ -185,17 +183,15 @@ Help describe --help=plain
#           The dot output contains the following elements:
#           If vertices
#               Represented as circles. Branches are dotted, and the default
# -             branch is in bold.       Configurables
# -                                          Represented as rectangles. The order
# -                                          of the output arrows is the order of
# -                                          the functor arguments.       
# -                                                                Data
# -                                                                dependencies
# -                                                                           
# -                                                                Represented as
# -                                                                dashed arrows.
# +             branch is in bold.
# +         Configurables
# +             Represented as rectangles. The order of the output arrows is the
# +             order of the functor arguments.
# +         Data dependencies
# +             Represented as dashed arrows.
#           App vertices
#               Represented as diamonds. The bold arrow is the functor part.
# +  
#    UNIKERNEL PARAMETERS
#           -l LEVEL, --logs=LEVEL (absent MIRAGE_LOGS env)
#               Be more or less verbose. LEVEL must be of the form
# @@ -317,7 +313,7 @@ Help describe --help=plain
#               Show version information.
#    
#    EXIT STATUS
# -         describe exits with the following status:
# +         mirage describe exits with:
#    
#           0   on success.
#    
```