### PR TITLE
Add release of Morbig 0.11.0

### DIFF
--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"                {>= "4.04"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
-  "visitors"             {>= "20180513"}
+  "visitors"             {>= "20200207"}
   "yojson"               {< "2.0.0"}
 ]
 

--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -26,6 +26,7 @@ depends: [
   "menhir"               {>= "20180538"}
   "ocaml"                {>= "4.04"}
   "odoc"                 {with-doc}
+  "ppx_deriving"         {>= "5.0"}
   "ppx_deriving_yojson"
   "visitors"             {>= "20200207"}
   "yojson"               {< "2.0.0"}

--- a/packages/morbig/morbig.0.10.3/opam
+++ b/packages/morbig/morbig.0.10.3/opam
@@ -9,11 +9,11 @@ concrete syntax trees are built using constructors according to the
 shell grammar of the POSIX standard.
 """
 
-maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
 authors: [
   "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
   "Ralf Treinen <ralf.treinen@irif.fr>"
-  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+  "Nicolas Jeannerod <niols@niols.fr>"
 ]
 license: "GPL-3.0-only"
 

--- a/packages/morbig/morbig.0.10.4/opam
+++ b/packages/morbig/morbig.0.10.4/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"                {>= "4.04"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
-  "visitors"             {>= "20180513"}
+  "visitors"             {>= "20200207"}
   "yojson"               {>= "1.6.0" & < "2.0.0"}
 ]
 

--- a/packages/morbig/morbig.0.10.4/opam
+++ b/packages/morbig/morbig.0.10.4/opam
@@ -26,6 +26,7 @@ depends: [
   "menhir"               {>= "20180538"}
   "ocaml"                {>= "4.04"}
   "odoc"                 {with-doc}
+  "ppx_deriving"         {>= "5.0"}
   "ppx_deriving_yojson"
   "visitors"             {>= "20200207"}
   "yojson"               {>= "1.6.0" & < "2.0.0"}

--- a/packages/morbig/morbig.0.10.4/opam
+++ b/packages/morbig/morbig.0.10.4/opam
@@ -9,11 +9,11 @@ concrete syntax trees are built using constructors according to the
 shell grammar of the POSIX standard.
 """
 
-maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
 authors: [
   "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
   "Ralf Treinen <ralf.treinen@irif.fr>"
-  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+  "Nicolas Jeannerod <niols@niols.fr>"
 ]
 license: "GPL-3.0-only"
 

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -28,7 +28,7 @@ depends: [
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
   "visitors"             {>= "20200207"}
-  "yojson"               {>= "1.6.0" & < "2.0.0"}
+  "yojson"               {>= "1.6.0"}
   "conf-jq" {with-test}
 ]
 

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+
+synopsis: "A trustworthy parser for POSIX shell"
+description: """
+Morbig is a parser for shell scripts written in the POSIX shell script
+language. It parses the scripts statically, that is without executing
+them, and constructs a concrete syntax tree for each of them. The
+concrete syntax trees are built using constructors according to the
+shell grammar of the POSIX standard.
+"""
+
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
+authors: [
+  "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
+  "Ralf Treinen <ralf.treinen@irif.fr>"
+  "Nicolas Jeannerod <niols@niols.fr>"
+]
+license: "GPL-3.0-only"
+
+homepage: "https://github.com/colis-anr/morbig"
+bug-reports: "https://github.com/colis-anr/morbig/issues"
+dev-repo: "git+https://github.com/colis-anr/morbig.git"
+
+depends: [
+  "dune"                 {>= "1.4.0"}
+  "menhir"               {>= "20180538"}
+  "ocaml"                {>= "4.04"}
+  "odoc"                 {with-doc}
+  "ppx_deriving_yojson"
+  "visitors"             {>= "20180513"}
+  "yojson"               {>= "1.6.0" & < "2.0.0"}
+]
+
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: [make "check"]
+
+url {
+  src: "https://github.com/colis-anr/morbig/archive/v0.11.0.tar.gz"
+  checksum: [
+    "md5=8829a7d682d7182c3d066b9ee42dec40"
+    "sha512=ed3fc21e6e9840a1a11f57cc34e9cd7f767227281c5822dd324f4b583a6ed126a22c9b79f3b3cf7b0dbdf6ff9c065e2ca25984e56aff9bd7f6ca41ec393525f9"
+  ]
+}

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -23,7 +23,7 @@ dev-repo: "git+https://github.com/colis-anr/morbig.git"
 
 depends: [
   "dune"                 {>= "2.5.0"}
-  "menhir"               {>= "20180538"}
+  "menhir"               {>= "20200211"}
   "ocaml"                {>= "4.11"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -31,7 +31,7 @@ depends: [
   "yojson"               {>= "1.6.0" & < "2.0.0"}
 ]
 
-build: ["dune" "build" "-p" name "-j" jobs]
+build: [make "build"]
 run-test: [make "check"]
 
 url {

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -22,13 +22,14 @@ bug-reports: "https://github.com/colis-anr/morbig/issues"
 dev-repo: "git+https://github.com/colis-anr/morbig.git"
 
 depends: [
-  "dune"                 {>= "1.4.0"}
+  "dune"                 {>= "2.5.0"}
   "menhir"               {>= "20180538"}
   "ocaml"                {>= "4.04"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
   "visitors"             {>= "20180513"}
   "yojson"               {>= "1.6.0" & < "2.0.0"}
+  "conf-jq" {with-test}
 ]
 
 build: [make "build"]

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml"                {>= "4.11"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
-  "visitors"             {>= "20180513"}
+  "visitors"             {>= "20200207"}
   "yojson"               {>= "1.6.0" & < "2.0.0"}
   "conf-jq" {with-test}
 ]

--- a/packages/morbig/morbig.0.11.0/opam
+++ b/packages/morbig/morbig.0.11.0/opam
@@ -24,7 +24,7 @@ dev-repo: "git+https://github.com/colis-anr/morbig.git"
 depends: [
   "dune"                 {>= "2.5.0"}
   "menhir"               {>= "20180538"}
-  "ocaml"                {>= "4.04"}
+  "ocaml"                {>= "4.11"}
   "odoc"                 {with-doc}
   "ppx_deriving_yojson"
   "visitors"             {>= "20180513"}

--- a/packages/morbig/morbig.0.9.1/opam
+++ b/packages/morbig/morbig.0.9.1/opam
@@ -9,11 +9,11 @@ concrete syntax trees are built using constructors according to the
 shell grammar of the POSIX standard.
 """
 
-maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
 authors: [
   "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
   "Ralf Treinen <ralf.treinen@irif.fr>"
-  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+  "Nicolas Jeannerod <niols@niols.fr>"
 ]
 license: "GPL-3.0-only"
 

--- a/packages/morbig/morbig.0.9/opam
+++ b/packages/morbig/morbig.0.9/opam
@@ -9,11 +9,11 @@ concrete syntax trees are built using constructors according to the
 shell grammar of the POSIX standard.
 """
 
-maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
 authors: [
   "Yann Régis-Gianas <yann.regis-gianas@irif.fr>"
   "Ralf Treinen <ralf.treinen@irif.fr>"
-  "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
+  "Nicolas Jeannerod <niols@niols.fr>"
 ]
 license: "GPL-3.0-only"
 

--- a/packages/morsmall/morsmall.0.1/opam
+++ b/packages/morsmall/morsmall.0.1/opam
@@ -7,8 +7,8 @@ A concise AST for POSIX shell
 
 license: "GPL-3.0-only"
 
-maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
-authors: [ "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>" ]
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
+authors: [ "Nicolas Jeannerod <niols@niols.fr>" ]
 
 homepage: "https://github.com/colis-anr/morsmall"
 bug-reports: "https://github.com/colis-anr/morsmall/issues"

--- a/packages/morsmall/morsmall.0.2.0/opam
+++ b/packages/morsmall/morsmall.0.2.0/opam
@@ -15,7 +15,7 @@ dev-repo: "git+https://github.com/colis-anr/morsmall.git"
 
 depends: [
   "dune"
-  "morbig"        {>= "0.10.0"}
+  "morbig"        {>= "0.10.0" & < "0.11.0"}
   "ocaml"         {>= "4.04"}
   "ppx_deriving"
 ]

--- a/packages/morsmall/morsmall.0.2.0/opam
+++ b/packages/morsmall/morsmall.0.2.0/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"
   "morbig"        {>= "0.10.0" & < "0.11.0"}
   "ocaml"         {>= "4.04"}
-  "ppx_deriving"
+  "ppx_deriving"         {>= "5.0"}
 ]
 
 build: [

--- a/packages/morsmall/morsmall.0.2.0/opam
+++ b/packages/morsmall/morsmall.0.2.0/opam
@@ -5,8 +5,8 @@ description: """
 A concise AST for POSIX shell
 """
 
-maintainer: "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>"
-authors: [ "Nicolas Jeannerod <nicolas.jeannerod@irif.fr>" ]
+maintainer: "Nicolas Jeannerod <niols@niols.fr>"
+authors: [ "Nicolas Jeannerod <niols@niols.fr>" ]
 license: "GPL-3.0-only"
 
 homepage: "https://github.com/colis-anr/morsmall"


### PR DESCRIPTION
This adds the recent release of Morbig 0.11.0. While I was at it, I changed my email in the few packages I maintain, the `@irif.fr` one being now unreachable.