### PR TITLE
[new release] mdx (2.3.0)

### DIFF
--- a/packages/mdx/mdx.2.3.0/opam
+++ b/packages/mdx/mdx.2.3.0/opam
@@ -18,7 +18,7 @@ homepage: "https://github.com/realworldocaml/mdx"
 bug-reports: "https://github.com/realworldocaml/mdx/issues"
 depends: [
   "dune" {>= "3.5"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.1.0"}
   "ocamlfind"
   "fmt" {>= "0.8.7"}
   "cppo" {build & >= "1.1.0"}

--- a/packages/mdx/mdx.2.3.0/opam
+++ b/packages/mdx/mdx.2.3.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Executable code blocks inside markdown files"
+description: """
+`ocaml-mdx` allows to execute code blocks inside markdown files.
+There are (currently) two sub-commands, corresponding
+to two modes of operations: pre-processing (`ocaml-mdx pp`)
+and tests (`ocaml-mdx test`).
+
+The pre-processor mode allows to mix documentation and code,
+and to practice "literate programming" using markdown and OCaml.
+
+The test mode allows to ensure that shell scripts and OCaml fragments
+in the documentation always stays up-to-date."""
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/realworldocaml/mdx"
+bug-reports: "https://github.com/realworldocaml/mdx/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind"
+  "fmt" {>= "0.8.7"}
+  "cppo" {build & >= "1.1.0"}
+  "csexp" {>= "1.3.2"}
+  "astring"
+  "logs" {>= "0.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "ocaml-version" {>= "2.3.0"}
+  "odoc-parser" {>= "1.0.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/realworldocaml/mdx.git"
+url {
+  src:
+    "https://github.com/realworldocaml/mdx/releases/download/2.3.0/mdx-2.3.0.tbz"
+  checksum: [
+    "sha256=32a08398100afd2d2e7988bc3b45c9b69971271f7ab708851ded3843c9470661"
+    "sha512=b16d257fa9e515318dba22a1eb7a19f59c40414cdbeaaee0e48b6384f74b56497fd0e547b234a1329b7334d2fbdbb7c256fdf8406ae1d1f85b49dd5c5025eba2"
+  ]
+}
+x-commit-hash: "3125899ce5c6c3bd0360b43697f0fd32def7fad5"


### PR DESCRIPTION
Executable code blocks inside markdown files

- Project page: <a href="https://github.com/realworldocaml/mdx">https://github.com/realworldocaml/mdx</a>

##### CHANGES:

#### Added

- Added support for `mld` files (realworldocaml/mdx#423, @jonludlam)

#### Changed

- Switch to using the parser that toplevel uses (found in a mutable
  `ref`, instead of always the official OCaml parser).  This allows
  Camlp5's parser to be used with MDX. (realworldocaml/mdx#417, @chetmurthy)
