### PR TITLE
Fix ppx_cstubs version constraints

### DIFF
--- a/packages/ppx_cstubs/ppx_cstubs.0.7.0/opam
+++ b/packages/ppx_cstubs/ppx_cstubs.0.7.0/opam
@@ -11,13 +11,13 @@ build: [
 ]
 depends: [
   "bigarray-compat"
-  "ctypes" {>= "0.13.0" & < "0.21"}
+  "ctypes" {>= "0.13.0"}
   "integers"
   "num"
   "result"
   "containers" {>= "2.2"}
   "cppo" {build & >= "1.3"}
-  "ocaml" {>= "4.04.2" & < "4.15"}
+  "ocaml" {>= "4.04.2"}
   "ppxlib" {>= "0.22.0"}
   "ocamlfind" {>= "1.7.2"} # not only a build dependency, it depends on findlib.top
   "dune" {>= "1.6"}


### PR DESCRIPTION
The one in the opam repo has two version constraints which make it impossible to use with OCaml 5. The opam file in the ppx_cstubs repo at the 0.7 tag doesn't have
them (https://github.com/fdopen/ppx_cstubs/blob/0.7.0/ppx_cstubs.opam). This PR removes the version constraint to fix this, see relevant discussion here https://github.com/fdopen/ppx_cstubs/issues/10