### PR TITLE
[new release] utop (2.12.0)

### DIFF
--- a/packages/utop/utop.2.12.0/opam
+++ b/packages/utop/utop.2.12.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/utop"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+doc: "https://ocaml-community.github.io/utop/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "logs"
+  "lwt"
+  "lwt_react"
+  "zed" { >= "3.2.0" }
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+synopsis: "Universal toplevel for OCaml"
+description: """
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.
+"""
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.12.0/utop-2.12.0.tbz"
+  checksum: [
+    "sha256=ad19c859a783bec573cd91e810c54d0e6b70f339d0a4fed55ec672ae408aa1ea"
+    "sha512=cd55cfb49178bec60b39df5b15df9090d9a316b81ddd5e564daaaa04c3c896c2e1ccf24a15ebce5b41ad3e22db56cfc95cc3f1a6808ee8e09f1c685284cdfb71"
+  ]
+}
+x-commit-hash: "c50173caf9b147eae637cb44e302e2077778afb4"


### PR DESCRIPTION
Universal toplevel for OCaml

- Project page: <a href="https://github.com/ocaml-community/utop">https://github.com/ocaml-community/utop</a>
- Documentation: <a href="https://ocaml-community.github.io/utop/">https://ocaml-community.github.io/utop/</a>

##### CHANGES:

* Add support for OCaml 5.1 (ocaml-community/utop#421, @emillon)

* Mark `prompt_continue`, `prompt_comment`, `smart_accept`, `new_prompt_hooks`,
  `at_new_prompt` as deprecated (they have been documented as such since 2012
  and most of them are ignored) (ocaml-community/utop#415, @emillon)

* Qualify `()` constructor in generated expressions. (ocaml-community/utop#418, fixes ocaml-community/utop#417, @emillon)
