### PR TITLE
Package ppx_inline_test.v0.15.1

### DIFF
--- a/packages/ppx_inline_test/ppx_inline_test.v0.15.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.15.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_inline_test"
+bug-reports: "https://github.com/janestreet/ppx_inline_test/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_inline_test.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_inline_test/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"    {>= "4.08.0"}
+  "base"     {>= "v0.15" & < "v0.16"}
+  "time_now" {>= "v0.15" & < "v0.16"}
+  "dune"     {>= "2.0.0"}
+  "ppxlib"   {>= "0.23.0"}
+]
+synopsis: "Syntax extension for writing in-line tests in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_inline_test/archive/refs/tags/v0.15.1.tar.gz"
+  checksum: [
+    "md5=91d1cf7489d35864381d9a435b46bb64"
+    "sha512=27dd4a4b9f0e8f7b22a7de4016ab0b8733e1ad4fe9e9e19cd98d321c071dd8662830a4e83579a2595d53b0a47c2ba03c1165df95312d6effc46c8aa13c0324b6"
+  ]
+}


### PR DESCRIPTION
### `ppx_inline_test.v0.15.1`
Syntax extension for writing in-line tests in ocaml code
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_inline_test
* Source repo: git+https://github.com/janestreet/ppx_inline_test.git
* Bug tracker: https://github.com/janestreet/ppx_inline_test/issues

---
:camel: Pull-request generated by opam-publish v2.2.0