### PR TITLE
Package ppx_bench.v0.15.1

### DIFF
--- a/packages/ppx_bench/ppx_bench.v0.15.1/opam
+++ b/packages/ppx_bench/ppx_bench.v0.15.1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ppx_bench"
+bug-reports: "https://github.com/janestreet/ppx_bench/issues"
+dev-repo: "git+https://github.com/janestreet/ppx_bench.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ppx_bench/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"           {>= "4.08.0"}
+  "ppx_inline_test" {>= "v0.15" & < "v0.16"}
+  "dune"            {>= "2.0.0"}
+  "ppxlib"          {>= "0.23.0"}
+]
+synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
+description: "
+Part of the Jane Street's PPX rewriters collection.
+"
+url {
+  src:
+    "https://github.com/janestreet/ppx_bench/archive/refs/tags/v0.15.1.tar.gz"
+  checksum: [
+    "md5=be2fa2db5dc1d74dfc58dd0956025424"
+    "sha512=3eb9eb071e0effd451e8733b7eb883e44c246ad75c8990cffba3596c1ec95784f57ac63c4cf3966004b83afca4dbf5728fd497e21b1a454116fbba41ff7b24ae"
+  ]
+}


### PR DESCRIPTION
### `ppx_bench.v0.15.1`
Syntax extension for writing in-line benchmarks in ocaml code
Part of the Jane Street's PPX rewriters collection.



---
* Homepage: https://github.com/janestreet/ppx_bench
* Source repo: git+https://github.com/janestreet/ppx_bench.git
* Bug tracker: https://github.com/janestreet/ppx_bench/issues

---
:camel: Pull-request generated by opam-publish v2.2.0