### PR TITLE
OSCADml v0.2.1: cap OCADml vers < 0.5.0

### DIFF
--- a/packages/OSCADml/OSCADml.0.2.1/opam
+++ b/packages/OSCADml/OSCADml.0.2.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "gg" {>= "1.0.0"}
   "cairo2" {>= "0.6.2"}
-  "OCADml" {>= "0.4.0"}
+  "OCADml" {>= "0.4.0" & < "0.5.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Version 0.5.0 switch to triangular meshes means a small fix is needed (next version) to feed the faces into OpenSCAD polyhedron.