### PR TITLE
[new release] mbr-format (2.0.0)

### DIFF
--- a/packages/mbr-format/mbr-format.2.0.0/opam
+++ b/packages/mbr-format/mbr-format.2.0.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   ["Reynir Björnsson <reynir@reynir.dk>" "dave.scott@eu.citrix.com"]
+authors:      "dave.scott@eu.citrix.com"
+license:      "ISC"
+homepage:     "https://github.com/mirage/ocaml-mbr"
+bug-reports:  "https://github.com/mirage/ocaml-mbr/issues"
+dev-repo:     "git+https://github.com/mirage/ocaml-mbr.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.4.0"}
+  "lwt"
+  "cstruct" {>= "6.0.0"}
+  "cstruct" {dev & >= "6.2.0"}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+synopsis: "A simple library for manipulating Master Boot Records"
+url {
+  src:
+    "https://github.com/mirage/ocaml-mbr/releases/download/v2.0.0/mbr-format-2.0.0.tbz"
+  checksum: [
+    "sha256=af317bbdba9e7a3c10c36216a711937e02fb44b4f107cf68372315e7544bbf50"
+    "sha512=881cc5a77882e21006d4c25f0375a97e08c8f13faadc434c88020ac705245ed114dbc33945530553a416a051e31066ad009b115e002489dadda7b05e68a7c7c8"
+  ]
+}
+x-commit-hash: "db8d07c042d9eea321b2f021ba210d03ea5d638f"


### PR DESCRIPTION
A simple library for manipulating Master Boot Records

- Project page: <a href="https://github.com/mirage/ocaml-mbr">https://github.com/mirage/ocaml-mbr</a>

##### CHANGES:

* Add optional argument `?disk_signature` to `Mbr.make` (@Burnleydev1, review by @reynir, mirage/ocaml-mbr#19)
* Make the partition type a required argument to `Mbr.Partition.make` and rename it `~partition_type` (@AryanGodara, review by @reynir, mirage/ocaml-mbr#20)
* Add tools for inspecting and modifying MBR, and reading/writing data to partitions. The command line tools are not installed as part of the opam package. The tools are `bin/mbr_inspect.exe`, `bin/read_partition.exe`, `bin/resize_partition.exe` and `bin/write_partition.exe`. (@PizieDust, review by @reynir, mirage/ocaml-mbr#22, mirage/ocaml-mbr#23, mirage/ocaml-mbr#24, mirage/ocaml-mbr#26)
* Remove dependency on `ppx_cstruct` (@reynir, mirage/ocaml-mbr#27)
