### PR TITLE
[new release] uri, uri-sexp, uri-re and uri-bench (4.3.0)

### DIFF
--- a/packages/uri-re/uri-re.4.3.0/opam
+++ b/packages/uri-re/uri-re.4.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "re" {>= "1.9.0"}
+  "stringext" {>= "1.4.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+messages: [ "Deprecated. This package is outdated, you should consider using uri instead" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.3.0/uri-4.3.0.tbz"
+  checksum: [
+    "sha256=5fadcf6d283e318959ab4a51462728c52c40ab5ddeb018c941831f48968e7311"
+    "sha512=08205a33aa8c163b130cc224c926e73a2730e33c5606484c1be2e9e51ad627b05f3ed01b64614994e10c58c6b9e701e30a8ce1f0329160f616ab95ede589c8c6"
+  ]
+}
+x-commit-hash: "d1dd27f60061cb3ee78c2ee15c6154fcaf09055f"

--- a/packages/uri-sexp/uri-sexp.4.3.0/opam
+++ b/packages/uri-sexp/uri-sexp.4.3.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+ocaml-uri with sexp support
+"""
+depends: [
+  "uri" {= version}
+  "dune" {>= "1.2.0"}
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "sexplib0"
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.3.0/uri-4.3.0.tbz"
+  checksum: [
+    "sha256=5fadcf6d283e318959ab4a51462728c52c40ab5ddeb018c941831f48968e7311"
+    "sha512=08205a33aa8c163b130cc224c926e73a2730e33c5606484c1be2e9e51ad627b05f3ed01b64614994e10c58c6b9e701e30a8ce1f0329160f616ab95ede589c8c6"
+  ]
+}
+x-commit-hash: "d1dd27f60061cb3ee78c2ee15c6154fcaf09055f"

--- a/packages/uri/uri.4.3.0/opam
+++ b/packages/uri/uri.4.3.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "anil@recoil.org"
+authors: ["Anil Madhavapeddy" "David Sheets" "Rudi Grinberg"]
+license: "ISC"
+tags: ["url" "uri" "org:mirage" "org:xapi-project"]
+homepage: "https://github.com/mirage/ocaml-uri"
+bug-reports: "https://github.com/mirage/ocaml-uri/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-uri.git"
+doc: "https://mirage.github.io/ocaml-uri/"
+synopsis: "An RFC3986 URI/URL parsing library"
+description: """
+This is an OCaml implementation of the [RFC3986](http://tools.ietf.org/html/rfc3986) specification
+for parsing URI or URLs.
+"""
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2.0"}
+  "ounit" {with-test & >= "1.0.2"}
+  "ppx_sexp_conv" {with-test & >= "v0.9.0"}
+  "crowbar" {with-test & >= "0.2"}
+  "stringext" {>= "1.4.0"}
+  "angstrom" {>= "0.14.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-uri/releases/download/v4.3.0/uri-4.3.0.tbz"
+  checksum: [
+    "sha256=5fadcf6d283e318959ab4a51462728c52c40ab5ddeb018c941831f48968e7311"
+    "sha512=08205a33aa8c163b130cc224c926e73a2730e33c5606484c1be2e9e51ad627b05f3ed01b64614994e10c58c6b9e701e30a8ce1f0329160f616ab95ede589c8c6"
+  ]
+}
+x-commit-hash: "d1dd27f60061cb3ee78c2ee15c6154fcaf09055f"


### PR DESCRIPTION
An RFC3986 URI/URL parsing library

- Project page: <a href="https://github.com/mirage/ocaml-uri">https://github.com/mirage/ocaml-uri</a>
- Documentation: <a href="https://mirage.github.io/ocaml-uri/">https://mirage.github.io/ocaml-uri/</a>

##### CHANGES:

* Add `Uri.Absolute_http`, an RFC9110-compliance specialization of a
  `Uri.t`. (mirage/ocaml-uri#164 mirage/ocaml-uri#162 @torinnd).
* Add a `uri-bench` package for the benchmarking dependencies in this
  repository (mirage/ocaml-uri#166 @tmcgilchrist).
