### PR TITLE
[new release] OCADml (0.5.0)

### DIFF
--- a/packages/OCADml/OCADml.0.5.0/opam
+++ b/packages/OCADml/OCADml.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.3"}
+  "gg" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "cairo2" {>= "0.6.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.5.0/OCADml-0.5.0.tbz"
+  checksum: [
+    "sha256=fc0b0a0ff598ff06550dfe0a93b279dc2df018914cc7883872d676d7da4dc14c"
+    "sha512=e02d943fbed9334730223ea12447b2495812db0bab20302516891d24c088fa8c4a60c366d0e083f4e675a25b394d101d115d3595e05284298d5803acc92351cf"
+  ]
+}
+x-commit-hash: "aa6a869c3d48049057436a23feb45b36edcbf5c2"

--- a/packages/OCADml/OCADml.0.5.0/opam
+++ b/packages/OCADml/OCADml.0.5.0/opam
@@ -15,7 +15,10 @@ depends: [
   "odoc" {with-doc}
 ]
 depopts: [
-  "cairo2" {>= "0.6.2"}
+  "cairo2"
+]
+conflicts: [
+  "cairo2" {< "0.6.2"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- `Mesh.t` implentation changed from polygonal to triangular
- replace `Mesh.triangulate` with `of_polyhedron`
- add `Mesh.e` accessor to get points by index (points now stored as array)
- add `?no_check` to `Path3.to_plane` to avoid coplanarity check (defaults to `false`)
