### PR TITLE
[new release] utop (2.12.1)

### DIFF
--- a/packages/utop/utop.2.12.1/opam
+++ b/packages/utop/utop.2.12.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/utop"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+doc: "https://ocaml-community.github.io/utop/"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "logs"
+  "lwt"
+  "lwt_react"
+  "zed" { >= "3.2.0" }
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+synopsis: "Universal toplevel for OCaml"
+description: """
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.
+"""
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.12.1/utop-2.12.1.tbz"
+  checksum: [
+    "sha256=67a4b7a54138458e50ee4791515490bb392291ec1680cfac44b81c47ef1b2253"
+    "sha512=a3957684b5124227ff5c18aa3221aa3cdfdffce345df49db7ac84005012bcdda6e12ad00466f592f3b42ead50626fc250713a91ca4500b7ab2e89b15d96a3f84"
+  ]
+}
+x-commit-hash: "ba0e2c7fffab33cf78e2f6e4c346f65e7c0949ae"


### PR DESCRIPTION
Universal toplevel for OCaml

- Project page: <a href="https://github.com/ocaml-community/utop">https://github.com/ocaml-community/utop</a>
- Documentation: <a href="https://ocaml-community.github.io/utop/">https://ocaml-community.github.io/utop/</a>

##### CHANGES:

* Fix regression with unit qualification when a `Unit` module is in scope with
  no `()` constructor (ocaml-community/utop#429, fixes ocaml-community/utop#428, @emillon)

* emacs: add completion-at-point implementation (ocaml-community/utop#406, fixes ocaml-community/utop#261, @j-shilling)
