### PR TITLE
[new release] shuttle_ssl, shuttle_http and shuttle (0.9.4)

### DIFF
--- a/packages/shuttle/shuttle.0.9.4/opam
+++ b/packages/shuttle/shuttle.0.9.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Reasonably performant non-blocking channels for async"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "async" {>= "v0.15.0"}
+  "core" {>= "v0.15.0"}
+  "core_unix" {>= "v0.15.0"}
+  "ppx_jane" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.4/shuttle-0.9.4.tbz"
+  checksum: [
+    "sha256=d868723ab7d9b9c7239c30ce0692bc02c8f6ac3f3ff62ef31a0b8a014de45995"
+    "sha512=f831285927eae3da9bb6e233e296e0d9193a940faf81850a279d50a1639ad806717054f973e60436d9afa503ae5a800ddd6a5c4b3eaca8457b20ac5d810534f3"
+  ]
+}
+x-commit-hash: "86e713055877724ceb1ffacf5401df894e517547"

--- a/packages/shuttle_http/shuttle_http.0.9.4/opam
+++ b/packages/shuttle_http/shuttle_http.0.9.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "shuttle" {= version}
+  "shuttle_ssl" {= version}
+  "re2" {>= "v0.15.0"}
+  "ppx_jane" {with-test}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.4/shuttle-0.9.4.tbz"
+  checksum: [
+    "sha256=d868723ab7d9b9c7239c30ce0692bc02c8f6ac3f3ff62ef31a0b8a014de45995"
+    "sha512=f831285927eae3da9bb6e233e296e0d9193a940faf81850a279d50a1639ad806717054f973e60436d9afa503ae5a800ddd6a5c4b3eaca8457b20ac5d810534f3"
+  ]
+}
+x-commit-hash: "86e713055877724ceb1ffacf5401df894e517547"

--- a/packages/shuttle_ssl/shuttle_ssl.0.9.4/opam
+++ b/packages/shuttle_ssl/shuttle_ssl.0.9.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Async_ssl support for shuttle"
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["async" "reader" "writer" "ssl"]
+homepage: "https://github.com/anuragsoni/shuttle"
+bug-reports: "https://github.com/anuragsoni/shuttle/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.11.0"}
+  "shuttle" {= version}
+  "ppx_jane" {>= "v0.15.0"}
+  "async_ssl" {>= "v0.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle.git"
+available: [ arch != "s390x" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle/releases/download/0.9.4/shuttle-0.9.4.tbz"
+  checksum: [
+    "sha256=d868723ab7d9b9c7239c30ce0692bc02c8f6ac3f3ff62ef31a0b8a014de45995"
+    "sha512=f831285927eae3da9bb6e233e296e0d9193a940faf81850a279d50a1639ad806717054f973e60436d9afa503ae5a800ddd6a5c4b3eaca8457b20ac5d810534f3"
+  ]
+}
+x-commit-hash: "86e713055877724ceb1ffacf5401df894e517547"


### PR DESCRIPTION
Async_ssl support for shuttle

- Project page: <a href="https://github.com/anuragsoni/shuttle">https://github.com/anuragsoni/shuttle</a>

##### CHANGES:

* Allow setting an upper bound on buffer size.
