### PR TITLE
[new release] ppx_minidebug (0.3.2)

### DIFF
--- a/packages/ppx_minidebug/ppx_minidebug.0.3.2/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.3.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Debug logs for selected functions and let-bindings"
+description:
+  "A poor man's `ppx_debug` with formatted logs of let-bound values, function arguments and results."
+maintainer: ["Lukasz Stafiniak"]
+authors: ["Lukasz Stafiniak"]
+license: "LGPL-2.1-or-later"
+tags: ["logger" "debugger" "printf debugging"]
+homepage: "https://github.com/lukstafi/ppx_minidebug"
+doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
+bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.7"}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppxlib" {>= "0.25.0"}
+  "printbox"
+  "printbox-text"
+  "printbox-html"
+  "ptime"
+  "sexplib0"
+  "ppx_expect" {with-test & >= "v0.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lukstafi/ppx_minidebug.git"
+url {
+  src:
+    "https://github.com/lukstafi/ppx_minidebug/releases/download/0.3.2/ppx_minidebug-0.3.2.tbz"
+  checksum: [
+    "sha256=5a5211aa1e05ef866c36151a28ac5e4b604bbc67d3cf339c67efca74501cb850"
+    "sha512=64ed4fc0f5ab2285e5b73765a24007b1adef4efced19fa6c09239c9ddb281b621a1cf4530d91c3526a5f75a5db37d6930bc099cb7f551ee93c72e3fe5de6c252"
+  ]
+}
+x-commit-hash: "27e27b3bced245ce729b346e67604dc74a2c00b2"


### PR DESCRIPTION
Debug logs for selected functions and let-bindings

- Project page: <a href="https://github.com/lukstafi/ppx_minidebug">https://github.com/lukstafi/ppx_minidebug</a>
- Documentation: <a href="https://lukstafi.github.io/ppx_minidebug/ppx_minidebug">https://lukstafi.github.io/ppx_minidebug/ppx_minidebug</a>

##### CHANGES:

### Fixed

- Third time the charm! Missing version bounds on `ocaml` and `ppxlib` to make CI happy.
- BSD-compatible `sed` arguments to make CI happy.
