### PR TITLE
[new release] ppx_minidebug (0.3.2-3)

### DIFF
--- a/packages/ppx_minidebug/ppx_minidebug.0.3.2-3/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.3.2-3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Debug logs for selected functions and let-bindings"
+description:
+  "A poor man's `ppx_debug` with formatted logs of let-bound values, function arguments and results."
+maintainer: ["Lukasz Stafiniak"]
+authors: ["Lukasz Stafiniak"]
+license: "LGPL-2.1-or-later"
+tags: ["logger" "debugger" "printf debugging"]
+homepage: "https://github.com/lukstafi/ppx_minidebug"
+doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
+bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.7"}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ppxlib" {>= "0.25.0"}
+  "printbox"
+  "printbox-text"
+  "printbox-html"
+  "ptime"
+  "sexplib0"
+  "ppx_expect" {with-test & >= "v0.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/lukstafi/ppx_minidebug.git"
+url {
+  src:
+    "https://github.com/lukstafi/ppx_minidebug/releases/download/0.3.2-3/ppx_minidebug-0.3.2-3.tbz"
+  checksum: [
+    "sha256=5717970267ece192db354bcc569b7cce80a0f4134f69db75a3cad5c634f35960"
+    "sha512=8ef7929d29f98dba67185eb2605f22a53d014fe8106988fd469b334656dbb03f18e769e1c491f9bd2cf07234568b518041068d0d8bb2bbf215b3e45fd27b4db4"
+  ]
+}
+x-commit-hash: "25b1fbce3584573a7487e7ad1f23ea1251953248"


### PR DESCRIPTION
Debug logs for selected functions and let-bindings

- Project page: <a href="https://github.com/lukstafi/ppx_minidebug">https://github.com/lukstafi/ppx_minidebug</a>
- Documentation: <a href="https://lukstafi.github.io/ppx_minidebug/ppx_minidebug">https://lukstafi.github.io/ppx_minidebug/ppx_minidebug</a>

##### CHANGES:

### Fixed

- Third time the charm! Missing version bounds on `ocaml` and `ppxlib` to make CI happy.
- BSD-compatible `sed` arguments to make CI happy.
