### PR TITLE
Release of Solo5.0.8.0

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.8.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.8.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.8.0/solo5-v0.8.0.tar.gz"
+  checksum: "sha512=d819d66407b84b56d46b5e534d5424903f15b124aa1c24d546abe1d9adb5a622ceee93cb1303a14ebf7811c7b5dad2d94a490cabbde489245efd66114617c39b"
+}

--- a/packages/solo5/solo5.0.8.0/opam
+++ b/packages/solo5/solo5.0.8.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+x-ci-accept-failures: [ "centos-7" ]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.8.0/solo5-v0.8.0.tar.gz"
+  checksum: "sha512=d819d66407b84b56d46b5e534d5424903f15b124aa1c24d546abe1d9adb5a622ceee93cb1303a14ebf7811c7b5dad2d94a490cabbde489245efd66114617c39b"
+}


### PR DESCRIPTION
* Be able to build `spt`, `virtio`, `muen` and `xen` targets on OpenBSD (@adamsteen, solo5/solo5#544). This change does not allow us to "run" these targets on OpenBSD
* Fix linker scripts with TLS (Thread Local Storage) sections (@palainp, @hannesm, @dinosaure, solo5/solo5#542)
* Export TLS symbols (@palainp, @hannesm, @dinosaure, solo5/solo5#546) **breaking change** due to solo5/solo5#542 & solo5/solo5#546, tenders must be **upgraded**. Indeed, solo5.0.7.* tenders will not be able to load correctly unikernels compiled with solo5.0.8.0. The internal ABI version for `solo5-hvt`/`solo5-spt` was upgraded accordingly.

  This version implements Thread Local Storage. The user can initialise a TLS block with `solo5_tls_init` on a pointer to `solo5_tls_size()` free bytes. Then, the user is able to set the `tp` (Thread Pointer) pointer via `solo5_set_tls_base(solo5_tls_tp_offset(tls_block))`. More details are available into `solo5.h`.

  Note: this change does not allow a Solo5 unikernel to use multiple cores! It only provides an API required by OCaml 5 / pthread to launch, at most, one thread.
* Fix tests reported by NixOS (@greydot, @ehmry, solo5/solo5#547)
* Split out the `time.c` implementation between Muen and HVT (@dinosaure, @Kensan, solo5/solo5#552)
* User hypercall instead of TSC-based clock when the user asks for the wall-clock (@dinosaure, @reynir, solo5/solo5#549, solo5/solo5#550)

  Note: only hvt & virtio are updated to avoid a clock drift on the wall-clock. Indeed, when the unikernel is suspended, the wall-clock is not updated. Muen & Xen still use a TSC-based wall-clock. The spt target was already in sync with the host's wall-clock.
* Improve the muen clock (@Kensan, solo5/solo5#553)
* Fix the `.bss` section according to solo5/solo5#542 & solo5/solo5#546. The `.bss` section is tagged with `PT_LOAD`. Tenders are available to load this section properly. (@Kensan, @dinosaure, solo5/solo5#551, solo5/solo5#554)
* Fix the cross-compilation of Solo5 for `aarch64` (@dinosaure, @palainp, @hannes, solo5/solo5#555)