### PR TITLE
[new release] domain-local-await (0.1.0)

### DIFF
--- a/packages/domain-local-await/domain-local-await.0.1.0/opam
+++ b/packages/domain-local-await/domain-local-await.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent blocking mechanism"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "0BSD"
+homepage: "https://github.com/ocaml-multicore/domain-local-await"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-await.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-await/releases/download/0.1.0/domain-local-await-0.1.0.tbz"
+  checksum: [
+    "sha256=e49171693cb0c327513fed1a207240e833faec61aea07882eed1ac1b57bd4800"
+    "sha512=8662627ead41a202c9ecd765344327cf282f47a179065397ed94f8b0c7c87e55338103fe2aae874b40c9f8bd5df49c1660eaa85723306dd6b9991cc5f5551d2b"
+  ]
+}
+x-commit-hash: "a6cc332f8233ed4bae70429549ba16839ed86fd8"


### PR DESCRIPTION
A scheduler independent blocking mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-await">https://github.com/ocaml-multicore/domain-local-await</a>

## 0.1.0

- Initial version of scheduler independent blocking mechanism (@polytypic)
