### PR TITLE
[new release] domain-local-await (0.1.0)

### DIFF
--- a/packages/domain-local-await/domain-local-await.0.1.0/opam
+++ b/packages/domain-local-await/domain-local-await.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent blocking mechanism"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "0BSD"
+homepage: "https://github.com/ocaml-multicore/domain-local-await"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-await.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-await/releases/download/0.1.0/domain-local-await-0.1.0.tbz"
+  checksum: [
+    "sha256=f024fe65646030010b330bf145e02e412eefaa5f7b838ce03906b9272701469d"
+    "sha512=f29996544b6ecf8355c87b328fc3f94563cd09b3f0557b99906b15df6c7f45785947f476c65efc0529da1c074836f6fbc821065c165bf009fc9e821569053253"
+  ]
+}
+x-commit-hash: "a88ba56ca0bc72039080a72d6276b17ea9c3b0fc"


### PR DESCRIPTION
A scheduler independent blocking mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-await">https://github.com/ocaml-multicore/domain-local-await</a>

## 0.1.0

- Initial version of scheduler independent blocking mechanism (@polytypic)
