### PR TITLE
[ANN] Add module-graph.0.1.0, computes the graph of dependencies between compiled modules 

### DIFF
--- a/packages/module-graph/module-graph.0.2.0/opam
+++ b/packages/module-graph/module-graph.0.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+synopsis:
+  "The module-graph tool generates a graph of dependencies between OCaml modules using compiled object files"
+description: """\
+The module-graph tool generates a graph of dependencies between OCaml modules using compiled object files. module-graph scans the current directory and sub-directories looking for .cmt/.cmti/.cmi files, creates a memory graph of dependencies between them, and uses `dot` to display the graph into a pdf/image file.
+"""
+authors: ["Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"]
+maintainer: ["Fabrice Le Fessant <fabrice.le_fessant@origin-labs.com>"]
+homepage: "https://ocamlpro.github.io/module-graph"
+doc: "https://ocamlpro.github.io/module-graph/sphinx"
+bug-reports: "https://github.com/ocamlpro/module-graph/issues"
+dev-repo: "git+https://github.com/ocamlpro/module-graph.git"
+tags: "org:ocamlpro"
+build: [
+  ["dune" "subst"] {dev}
+  ["sh" "-c" "./scripts/before.sh build '%{name}%'"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["sh" "-c" "./scripts/after.sh build '%{name}%'"]
+]
+install: [
+  ["sh" "-c" "./scripts/before.sh install '%{name}%'"]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml-base-compiler" {}
+  "ez_file" {>= "0.3"}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+  "ocamlformat" {with-test}
+]
+
+url {
+    src: "https://github.com/ocamlpro/module-graph/archive/v0.2.0.tar.gz"
+    checksum: [ "sha256=ec199626be52f5dd03a6ff13bc5053b42523ac0798bf7ca07f631bea2dc0df92" ]
+}

--- a/packages/module-graph/module-graph.0.2.0/opam
+++ b/packages/module-graph/module-graph.0.2.0/opam
@@ -36,6 +36,7 @@ depends: [
   "dune" {>= "2.7.0"}
   "ocaml-base-compiler" {}
   "ez_file" {>= "0.3"}
+  "ocplib_stuff" {>= "0.3"}
   "ppx_inline_test" {with-test}
   "ppx_expect" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
`module-graph` computes the graph of dependencies between modules using object files (`.cmt`, `.cmti`, `.cmi`) instead of `ocamldep`.