### PR TITLE
[new release] kcas_data and kcas (0.3.0)

### DIFF
--- a/packages/kcas/kcas.0.3.0/opam
+++ b/packages/kcas/kcas.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Software transactional memory based on lock-free multi-word compare-and-set"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.3.0/kcas-0.3.0.tbz"
+  checksum: [
+    "sha256=dfb00c3871feb76470cf6806231e5ea82e1499783086ef7edd7bb7bc5b9dc156"
+    "sha512=ae5c02b371e62b1edaba9b684007d0895dc4c2fb92c3d851ba2df9c4e1905621e5ad0cbc2738ecf5ea38b01a0e2d80742f36324d31203a22fdd3b84f7cbbd28b"
+  ]
+}
+x-commit-hash: "0d0da070fc3b1fca2a03996e81400846f8a00613"

--- a/packages/kcas_data/kcas_data.0.3.0/opam
+++ b/packages/kcas_data/kcas_data.0.3.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Compositional lock-free data structures and primitives for communication and synchronization"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.3.0/kcas-0.3.0.tbz"
+  checksum: [
+    "sha256=dfb00c3871feb76470cf6806231e5ea82e1499783086ef7edd7bb7bc5b9dc156"
+    "sha512=ae5c02b371e62b1edaba9b684007d0895dc4c2fb92c3d851ba2df9c4e1905621e5ad0cbc2738ecf5ea38b01a0e2d80742f36324d31203a22fdd3b84f7cbbd28b"
+  ]
+}
+x-commit-hash: "0d0da070fc3b1fca2a03996e81400846f8a00613"


### PR DESCRIPTION
Compositional lock-free data structures and primitives for communication and synchronization

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.3.0

- Remove the `Tx` API (@polytypic)
- Add blocking support to turn kcas into a proper STM (@polytypic, review: @lyrm)
- Add periodic validation of transactions (@polytypic)
