### PR TITLE
[new release] js_of_ocaml, js_of_ocaml-tyxml, js_of_ocaml-toplevel, js_of_ocaml-ppx_deriving_json, js_of_ocaml-ppx, js_of_ocaml-lwt and js_of_ocaml-compiler (5.2.0)

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.2.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.5.2.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08" & < "5.1"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15.0"}
+  "re" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "sedlex" {>= "2.3"}
+  "menhir"
+  "menhirLib"
+  "menhirSdk"
+  "yojson"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.2.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.5.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.2.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.5.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15.0"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.2.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.5.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.2.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.5.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "cohttp-lwt-unix" {with-test}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.15" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.2.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.5.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.1"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.3"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.22.0" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"

--- a/packages/js_of_ocaml/js_of_ocaml.5.2.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.5.2.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version}
+  "ppxlib" {>= "0.15"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/5.2.0/js_of_ocaml-5.2.0.tbz"
+  checksum: [
+    "sha256=650ab0a4ffa6a505716b73adb293428fa7bfd6a0293349bf186123338a7fceb5"
+    "sha512=f1b12ed23ffd653fc1199f208d7ba61ea3d15c81baecf5d195893ae3422dd09670d077467c2e6d910b400b96000ed6261d5ee820acc0ed1b316715fd1da0b323"
+  ]
+}
+x-commit-hash: "3b3f66ba0f2755ff96c5f0a5ae41d2fb2fb1f8ea"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/manual/overview">https://ocsigen.org/js_of_ocaml/latest/manual/overview</a>

##### CHANGES:

## Features/Changes
* Compiler: jsoo link archive with -a (ocsigen/js_of_ocaml#1428)

## Bug fixes
* Compiler: put custom header at the top of the output file (fix ocsigen/js_of_ocaml#1441)
* Compiler (js parser): fix parsing of js labels (fix ocsigen/js_of_ocaml#1440)
* Compiler: fix simplification of js with let and const
* Compiler: reduce memory consumption when parsing js
* Compiler: parsing js can return a list of token, the list was sometime incorrect
* Sourcemap: stop producing sourcemaps mappings with negative lines or columns
* Runtime: fix marshalling with sharing and string (use-js-string)
