### PR TITLE
Remove constraints on package versions in conflicts, it's unsupported

### DIFF
--- a/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
+++ b/packages/ocaml-options-vanilla/ocaml-options-vanilla.1/opam
@@ -8,12 +8,7 @@ depends: [
 conflicts: [
   "ocaml-option-32bit"
   "ocaml-option-afl"
-  "ocaml-option-bytecode-only"
-    {ocaml-system:version < "5" |
-     ocaml-base-compiler:version < "5" |
-     ocaml-variants:version < "5" |
-     arch = "arm64" |
-     arch = "x86_64" }
+  "ocaml-option-bytecode-only" {arch = "arm64" | arch = "x86_64" }
   "ocaml-option-default-unsafe-string"
   "ocaml-option-flambda"
   "ocaml-option-fp"


### PR DESCRIPTION
After a debugging session with @kit-ty-kate as part of fixing https://github.com/tarides/opam-monorepo/issues/349 and https://github.com/ocaml-opam/opam-0install-solver/pull/46 we realized that OPAM doesn't support resolving package variables in `conflicts` fields (the linter complains about this in `depends` fileds but not in `conflicts` fields, but the solver never resolves these variables). So this constraint doesn't do anything in OPAM and it causes issues in the opam-0install-solver which attempts to resolve them.