### PR TITLE
[new release] cohttp-async, cohttp-curl-async, cohttp-curl-lwt, cohttp-curl, cohttp-eio, cohttp-lwt-jsoo, cohttp-lwt-unix, cohttp-lwt, cohttp-mirage, cohttp-server-lwt-unix, cohttp-top, cohttp and http (6.0.0~alpha1)

### DIFF
--- a/packages/cohttp-async/cohttp-async.6.0.0~alpha1/opam
+++ b/packages/cohttp-async/cohttp-async.6.0.0~alpha1/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the Async concurrency library"
+description: """
+An implementation of an HTTP client and server using the Async
+concurrency library. See the `Cohttp_async` module for information
+on how to use this.  The package also installs `cohttp-curl-async`
+and a `cohttp-server-async` binaries for quick uses of a HTTP(S)
+client and server respectively.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "async_kernel" {>= "v0.14.0"}
+  "async_unix" {>= "v0.14.0"}
+  "async" {>= "v0.14.0"}
+  "base" {>= "v0.11.0"}
+  "core" {with-test}
+  "core_unix" {>= "v0.14.0"}
+  "conduit-async" {>= "1.2.0"}
+  "magic-mime"
+  "mirage-crypto" {with-test}
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "ounit" {with-test}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "ipaddr"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-async/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "s390x"
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-async/cohttp-async.6.0.0~alpha1/opam
+++ b/packages/cohttp-async/cohttp-async.6.0.0~alpha1/opam
@@ -61,7 +61,8 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-available: arch != "s390x"
+available: opam-version >= "2.1.0" & arch != "s390x"
+flags: [ avoid-version ]
 url {
   src:
     "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"

--- a/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha1/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Cohttp client using Curl & Async as the backend"
+description: """
+An HTTP client that relies on Curl + Async for the backend. Does not require
+conduit for SSL."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocurl"
+  "http" {= version}
+  "stringext"
+  "cohttp-curl" {= version}
+  "core"
+  "core_unix" {>= "v0.14.0"}
+  "async_kernel"
+  "async_unix"
+  "cohttp-async" {with-test & = version}
+  "uri" {with-test & >= "4.2.0"}
+  "fmt" {with-test}
+  "ounit" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-curl-async/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha1/opam
+++ b/packages/cohttp-curl-async/cohttp-curl-async.6.0.0~alpha1/opam
@@ -35,6 +35,8 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha1/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Cohttp client using Curl & Lwt as the backend"
+description: """
+An HTTP client that relies on Curl + Lwt for the backend. Does not require
+conduit for SSL."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "ocurl"
+  "http" {= version}
+  "cohttp-curl" {= version}
+  "stringext"
+  "lwt" {>= "5.3.0"}
+  "uri" {with-test & >= "4.2.0"}
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test & = version}
+  "cohttp" {with-test & = version}
+  "cohttp-lwt" {with-test & = version}
+  "conduit-lwt" {with-test}
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-curl-lwt/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha1/opam
+++ b/packages/cohttp-curl-lwt/cohttp-curl-lwt.6.0.0~alpha1/opam
@@ -35,6 +35,8 @@ depends: [
   "ounit" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-curl/cohttp-curl.6.0.0~alpha1/opam
+++ b/packages/cohttp-curl/cohttp-curl.6.0.0~alpha1/opam
@@ -24,6 +24,8 @@ depends: [
   "stringext"
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-curl/cohttp-curl.6.0.0~alpha1/opam
+++ b/packages/cohttp-curl/cohttp-curl.6.0.0~alpha1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Shared code between the individual cohttp-curl clients"
+description: "Use cohttp-curl-lwt or cohttp-curl-async"
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "ocurl"
+  "http" {= version}
+  "stringext"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-curl/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-eio/cohttp-eio.6.0.0~alpha1/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.0.0~alpha1/opam
@@ -29,6 +29,8 @@ depends: [
   "http" {= version}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-eio/cohttp-eio.6.0.0~alpha1/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.0.0~alpha1/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation with eio backend"
+description:
+  "A CoHTTP server and client implementation based on `eio` library. `cohttp-eio`features a multicore capable HTTP 1.1 server. The library promotes and is built with direct style of coding as opposed to a monadic."
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "base-domains"
+  "eio" {>= "0.7"}
+  "eio_main" {with-test}
+  "mdx" {with-test}
+  "uri" {with-test}
+  "fmt"
+  "ptime"
+  "http" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-eio/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the Js_of_ocaml JavaScript compiler"
+description: """
+An implementation of an HTTP client for JavaScript, but using the
+CoHTTP types.  This lets you build HTTP clients that can compile
+natively (using one of the other Cohttp backends such as `cohttp-lwt-unix`)
+and also to native JavaScript via js_of_ocaml.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "logs"
+  "lwt" {>= "3.0.0"}
+  "lwt_ppx" {with-test}
+  "conf-npm" {with-test}
+  "js_of_ocaml" {>= "3.3.0"}
+  "js_of_ocaml-ppx" {>= "3.3.0"}
+  "js_of_ocaml-lwt" {>= "3.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-lwt-jsoo/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.6.0.0~alpha1/opam
@@ -36,6 +36,8 @@ depends: [
   "js_of_ocaml-lwt" {>= "3.5.0"}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha1/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for Unix and Windows using Lwt"
+description: """
+An implementation of an HTTP client and server using the Lwt
+concurrency library. See the `Cohttp_lwt_unix` module for information
+on how to use this.  The package also installs `cohttp-curl-lwt`
+and a `cohttp-server-lwt` binaries for quick uses of a HTTP(S)
+client and server respectively.
+
+Although the name implies that this only works under Unix, it
+should also be fine under Windows too.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "cohttp-lwt" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "lwt" {>= "3.0.0"}
+  "conduit-lwt" {>= "5.0.0"}
+  "conduit-lwt-unix" {>= "5.0.0"}
+  "fmt" {>= "0.8.2"}
+  "base-unix"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "magic-mime"
+  "logs"
+  "ounit" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-lwt-unix/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.6.0.0~alpha1/opam
@@ -43,6 +43,8 @@ depends: [
   "ounit" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-lwt/cohttp-lwt.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.6.0.0~alpha1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation using the Lwt concurrency library"
+description: """
+This is a portable implementation of HTTP that uses the Lwt concurrency library
+to multiplex IO.  It implements as much of the logic in an OS-independent way
+as possible, so that more specialised modules can be tailored for different
+targets.  For example, you can install `cohttp-lwt-unix` or `cohttp-lwt-jsoo`
+for a Unix or JavaScript backend, or `cohttp-mirage` for the MirageOS unikernel
+version of the library. All of these implementations share the same IO logic
+from this module."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "cohttp" {= version}
+  "lwt" {>= "2.5.0"}
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "logs"
+  "uri" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-lwt/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-lwt/cohttp-lwt.6.0.0~alpha1/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.6.0.0~alpha1/opam
@@ -35,6 +35,8 @@ depends: [
   "uri" {>= "2.0.0"}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha1/opam
@@ -43,6 +43,8 @@ depends: [
   "cohttp" {= version}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha1/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.6.0.0~alpha1/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "CoHTTP implementation for the MirageOS unikernel"
+description: """
+This HTTP implementation uses the Cohttp portable implementaiton
+along with the Lwt threading library in order to provide a
+`Cohttp_mirage` functor that can be used in MirageOS unikernels
+to build very small and efficient HTTP clients and servers
+without having a hard dependency on an underlying operating
+system.
+
+Please see <https://mirage.io> for a self-hosted explanation
+and instructions on how to use this library."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-channel" {>= "4.0.0"}
+  "conduit" {>= "2.0.2"}
+  "conduit-mirage" {>= "2.3.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "lwt" {>= "2.4.3"}
+  "cohttp-lwt" {= version}
+  "cstruct" {>= "6.0.0"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "magic-mime"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "cohttp" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-mirage/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha1/opam
+++ b/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha1/opam
@@ -30,6 +30,8 @@ depends: [
   "lwt"
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha1/opam
+++ b/packages/cohttp-server-lwt-unix/cohttp-server-lwt-unix.6.0.0~alpha1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Lightweight Cohttp + Lwt based HTTP server"
+description: """
+This server implementation is faster than cohttp-lwt-unix and is independent of
+conduit.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "http" {= version}
+  "lwt" {>= "5.5.0"}
+  "conduit-lwt-unix" {with-test}
+  "cohttp-lwt-unix" {with-test & = version}
+  "cohttp-lwt" {with-test & = version}
+  "lwt"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-server-lwt-unix/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-top/cohttp-top.6.0.0~alpha1/opam
+++ b/packages/cohttp-top/cohttp-top.6.0.0~alpha1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "CoHTTP toplevel pretty printers for HTTP types"
+description: """
+This library installs toplevel prettyprinters for CoHTTP
+types such as the `Request`, `Response` and `Types` modules.
+Once this library has been loaded, you can directly see the
+values of those types in toplevels such as `utop` or `ocaml`.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "cohttp" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp-top/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp-top/cohttp-top.6.0.0~alpha1/opam
+++ b/packages/cohttp-top/cohttp-top.6.0.0~alpha1/opam
@@ -27,6 +27,8 @@ depends: [
   "cohttp" {= version}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/cohttp/cohttp.6.0.0~alpha1/opam
+++ b/packages/cohttp/cohttp.6.0.0~alpha1/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "An OCaml library for HTTP clients and servers"
+description: """
+Cohttp is an OCaml library for creating HTTP daemons. It has a portable
+HTTP parser, and implementations using various asynchronous programming
+libraries.
+
+See the cohttp-async, cohttp-lwt, cohttp-lwt-unix, cohttp-lwt-jsoo and
+cohttp-mirage libraries for concrete implementations for particular
+targets.
+
+You can implement other targets using the parser very easily. Look at the `IO`
+signature in `lib/s.mli` and implement that in the desired backend.
+
+You can activate some runtime debugging by setting `COHTTP_DEBUG` to any
+value, and all requests and responses will be written to stderr.  Further
+debugging of the connection layer can be obtained by setting `CONDUIT_DEBUG`
+to any value.
+"""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "http" {= version}
+  "ocaml" {>= "4.08"}
+  "re" {>= "1.9.0"}
+  "uri" {>= "2.0.0"}
+  "uri-sexp"
+  "sexplib0"
+  "ppx_sexp_conv" {>= "v0.13.0"}
+  "stringext"
+  "base64" {>= "3.1.0"}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@cohttp/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"

--- a/packages/cohttp/cohttp.6.0.0~alpha1/opam
+++ b/packages/cohttp/cohttp.6.0.0~alpha1/opam
@@ -47,6 +47,8 @@ depends: [
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/http/http.6.0.0~alpha1/opam
+++ b/packages/http/http.6.0.0~alpha1/opam
@@ -35,6 +35,8 @@ depends: [
   "sexplib0" {with-test}
   "odoc" {with-doc}
 ]
+available: opam-version >= "2.1.0"
+flags: [ avoid-version ]
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 build: [
   ["dune" "subst"] {dev}

--- a/packages/http/http.6.0.0~alpha1/opam
+++ b/packages/http/http.6.0.0~alpha1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Type definitions of HTTP essentials"
+description: """
+This package contains essential type definitions used in Cohttp. It is designed
+to have no dependencies and make it easy for other packages to easily
+interoperate with Cohttp."""
+maintainer: ["Anil Madhavapeddy <anil@recoil.org>"]
+authors: [
+  "Anil Madhavapeddy"
+  "Stefano Zacchiroli"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "David Scott"
+  "Rudi Grinberg"
+  "Andy Ray"
+  "Anurag Soni"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-cohttp"
+doc: "https://mirage.github.io/ocaml-cohttp/"
+bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "ppx_expect" {with-test}
+  "alcotest" {with-test}
+  "base_quickcheck" {with-test}
+  "ppx_assert" {with-test}
+  "ppx_sexp_conv" {with-test}
+  "ppx_compare" {with-test}
+  "ppx_here" {with-test}
+  "core" {with-test & >= "v0.13.0"}
+  "core_bench" {with-test}
+  "crowbar" {with-test & >= "0.2"}
+  "sexplib0" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@http/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v6.0.0_alpha1/cohttp-6.0.0.alpha1.tbz"
+  checksum: [
+    "sha256=4e3ece8ade6493fe731c0842f519cc0f8f564753d71c985aa4ed6de3f0753646"
+    "sha512=5db6f1ffab6fc2ab30baffb1fc82b7f50b11ddb31ec19fc4415dac40f04766f29e816a4cf99ddb152b93c8acbefade7779ad3dc3d092e2f88fa1deea3fc2721a"
+  ]
+}
+x-commit-hash: "16e991ec1f7e5f0c99615cd1f58b99b02e3d0499"


### PR DESCRIPTION
CoHTTP implementation for the Async concurrency library

- Project page: <a href="https://github.com/mirage/ocaml-cohttp">https://github.com/mirage/ocaml-cohttp</a>
- Documentation: <a href="https://mirage.github.io/ocaml-cohttp/">https://mirage.github.io/ocaml-cohttp/</a>

##### CHANGES:

- cohttp,cohttp-async server: correctly close broken streams (reported by Stéphane Glondu, fix by samhot and anuragsoni)
- cohttp-eio: remove unused code from tests to work with Eio 0.8 (talex5 mirage/ocaml-cohttp#967)
- Upgrade dune to v3.0 (bikallem mirage/ocaml-cohttp#947)
- cohttp-eio: allow client to optionally configure request pipelining (bikallem mirage/ocaml-cohttp#949)
- cohttp-eio: update to Eio 0.7 (talex5 mirage/ocaml-cohttp#952)
- cohttp-eio: update examples to use eio 0.7 primitives (bikallem mirage/ocaml-cohttp#957)
- cohttp-eio: generate Date header in responses (bikallem mirage/ocaml-cohttp#955)
- cohttp-eio: further improve Cohttp_eio.Client ergonomics (bikallem #?)
- cohttp-eio: server api improvements (bikallem mirage/ocaml-cohttp#962)
