### PR TITLE
[new release] OCADml (0.6.0)

### DIFF
--- a/packages/OCADml/OCADml.0.6.0/opam
+++ b/packages/OCADml/OCADml.0.6.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Types and functions for building CAD packages in OCaml"
+description: "Types and functions for building CAD packages in OCaml"
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD"]
+homepage: "https://github.com/OCADml/OCADml"
+doc: "https://OCADml.github.io/OCADml"
+bug-reports: "https://github.com/OCADml/OCADml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.6"}
+  "gg" {>= "1.0.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+depopts: ["cairo2"]
+conflicts: [
+  "cairo2" {< "0.6.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OCADml/releases/download/v0.6.0/OCADml-0.6.0.tbz"
+  checksum: [
+    "sha256=2d93cd5f2a41c6c0a183c02ac93ed8c4113fbc42d5557c769adbdc30c6421049"
+    "sha512=a9450c05bb1b798a70655f76ae04e8a9c46cde0f255687959f1639d9691cd3822e52065014d8cc5d4bd6229057a8036c28d917afdadb283a397fc823cac1fd30"
+  ]
+}
+x-commit-hash: "f5dfbf55f9c19ad808daa0df4d76a55e58756e5f"


### PR DESCRIPTION
Types and functions for building CAD packages in OCaml

- Project page: <a href="https://github.com/OCADml/OCADml">https://github.com/OCADml/OCADml</a>
- Documentation: <a href="https://OCADml.github.io/OCADml">https://OCADml.github.io/OCADml</a>

##### CHANGES:

- add `Mesh.skline` for skinning over profiles with Bézier splines
- add `Mesh.of_stl` (load ascii and binary stls from file)
- remove `?eps` from `Mesh.to_stl` (dropped point merging step)
- add check in `Mesh.of_rows` allowing layers with uniform points (e.g. cone tip)
- fix handling of single point profiles in `Mesh.skin` (allow and duplicate properly)
- add `alcotest` testing dependency (+ tests for serialization/deserialization)
- bump `dune` dependency to `v3.6` for directory targets
- add usage example with image to docs
