### PR TITLE
[new release] OSCADml (0.2.3)

### DIFF
--- a/packages/OSCADml/OSCADml.0.2.3/opam
+++ b/packages/OSCADml/OSCADml.0.2.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml DSL for 3D solid modelling in OpenSCAD"
+description:
+  "OSCADml is an OCaml front-end to the OpenSCAD CAD programming language."
+maintainer: ["Geoff deRosenroll<geoffderosenroll@gmail.com"]
+authors: [
+  "Geoff deRosenroll<geoffderosenroll@gmail.com"
+  "Masaki Nakano<namachan10777@gmail.com>"
+]
+license: "GPL-2.0-or-later"
+tags: ["OCADml" "CAD" "OpenSCAD" "CSG"]
+homepage: "https://github.com/OCADml/OSCADml"
+doc: "https://ocadml.github.io/OSCADml"
+bug-reports: "https://github.com/OCADml/OSCADml/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.14.0"}
+  "gg" {>= "1.0.0"}
+  "cairo2" {>= "0.6.2"}
+  "OCADml" {>= "0.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/OCADml/OSCADml.git"
+url {
+  src:
+    "https://github.com/OCADml/OSCADml/releases/download/v0.2.3/OSCADml-0.2.3.tbz"
+  checksum: [
+    "sha256=61bc12919734a42004f9f54bb03aa5403eac9cdd645cad1fb97ddd2eba148583"
+    "sha512=9aca48afeb2c89ace6b07110b6aadedac7d877fb9b0d1990b0c0b622829ff45ced3841fdae30b5b869293dea1b3ae39f1b00fc767c8e3f69d7e78f6412801ffb"
+  ]
+}
+x-commit-hash: "09c94542a47f3aff548ff3d6a87a1d364a7fb63c"


### PR DESCRIPTION
OCaml DSL for 3D solid modelling in OpenSCAD

- Project page: <a href="https://github.com/OCADml/OSCADml">https://github.com/OCADml/OSCADml</a>
- Documentation: <a href="https://ocadml.github.io/OSCADml">https://ocadml.github.io/OSCADml</a>

##### CHANGES:

- bump OCADml dependency to v0.6.0
- add `Mesh.skline` example page
- minor cleanup of old examples with newer convenience functions
