### PR TITLE
[new release] kcas_data and kcas (0.3.1)

### DIFF
--- a/packages/kcas/kcas.0.3.1/opam
+++ b/packages/kcas/kcas.0.3.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Software transactional memory based on lock-free multi-word compare-and-set"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.3.1/kcas-0.3.1.tbz"
+  checksum: [
+    "sha256=34cce66c950d01cfbf21aa94f1b2421e8c02ef9a546082dc955237bef840819e"
+    "sha512=2c4bc08825907b44ea124f2024b560a5f32b8dde6d3e080d2a6cf993e4d065f54cc8b3163e96303b27d14d9f026147a8ff892753aabcf80737396bbbbe668f2d"
+  ]
+}
+x-commit-hash: "377698c2058191d2374d1e8f6f7459134c0dc469"

--- a/packages/kcas_data/kcas_data.0.3.1/opam
+++ b/packages/kcas_data/kcas_data.0.3.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Compositional lock-free data structures and primitives for communication and synchronization"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.3.1/kcas-0.3.1.tbz"
+  checksum: [
+    "sha256=34cce66c950d01cfbf21aa94f1b2421e8c02ef9a546082dc955237bef840819e"
+    "sha512=2c4bc08825907b44ea124f2024b560a5f32b8dde6d3e080d2a6cf993e4d065f54cc8b3163e96303b27d14d9f026147a8ff892753aabcf80737396bbbbe668f2d"
+  ]
+}
+x-commit-hash: "377698c2058191d2374d1e8f6f7459134c0dc469"


### PR DESCRIPTION
Compositional lock-free data structures and primitives for communication and synchronization

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.3.1

- Added doubly-linked list `Dllist` to `kcas_data` (@polytypic)
- Minor optimizations (@polytypic)
