### PR TITLE
[new release] dune (15 packages) (3.8.0~alpha2)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.8.0~alpha2/opam
+++ b/packages/chrome-trace/chrome-trace.3.8.0~alpha2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-action-plugin/dune-action-plugin.3.8.0~alpha2/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.8.0~alpha2/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-build-info/dune-build-info.3.8.0~alpha2/opam
+++ b/packages/dune-build-info/dune-build-info.3.8.0~alpha2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-configurator/dune-configurator.3.8.0~alpha2/opam
+++ b/packages/dune-configurator/dune-configurator.3.8.0~alpha2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.04.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-glob/dune-glob.3.8.0~alpha2/opam
+++ b/packages/dune-glob/dune-glob.3.8.0~alpha2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-private-libs/dune-private-libs.3.8.0~alpha2/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.8.0~alpha2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.8.0~alpha2/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.8.0~alpha2/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "dune-rpc" {= version}
+  "result" {>= "1.5"}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.3.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-rpc/dune-rpc.3.8.0~alpha2/opam
+++ b/packages/dune-rpc/dune-rpc.3.8.0~alpha2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune-site/dune-site.3.8.0~alpha2/opam
+++ b/packages/dune-site/dune-site.3.8.0~alpha2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dune/dune.3.8.0~alpha2/opam
+++ b/packages/dune/dune.3.8.0~alpha2/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/dyn/dyn.3.8.0~alpha2/opam
+++ b/packages/dyn/dyn.3.8.0~alpha2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/ocamlc-loc/ocamlc-loc.3.8.0~alpha2/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.8.0~alpha2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/ordering/ordering.3.8.0~alpha2/opam
+++ b/packages/ordering/ordering.3.8.0~alpha2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/stdune/stdune.3.8.0~alpha2/opam
+++ b/packages/stdune/stdune.3.8.0~alpha2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"

--- a/packages/xdg/xdg.3.8.0~alpha2/opam
+++ b/packages/xdg/xdg.3.8.0~alpha2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.5"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.8.0_alpha2/dune-3.8.0.alpha2.tbz"
+  checksum: [
+    "sha256=8fce380e29d9704eefb402f57b5b00da9b826b189bc0fa4e5cc15fd707a887a4"
+    "sha512=72fb7eaa9cb0db7592d0f290dbf2945457dc42e9c1b1025a82ad3f7a8cb3e693a13b6824254aa67dfe74685bdb47b728fb0d704496a42e625773a7da15a328fe"
+  ]
+}
+x-commit-hash: "8afa6ea0cf9ace1ef60fbda121c14f23fe02d13f"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Correctly set `MANPATH` in `dune exec`. Previously, we would use the `bin/`
  directory of the context. (ocaml/dune#7655, @rgrinberg)

- Allow overriding the `ocaml` binary with findlib configuration (ocaml/dune#7648,
  @rgrinberg)

- Modules that were declared in `(modules_without_implementation)`,
  `(private_modules)` or `(virtual_modules)` but not declared in `(modules)`
  will cause Dune to emit a warning which will become an error in 3.9. (ocaml/dune#7608,
  fixes ocaml/dune#7026, @Alizter)

- Dune can now detect Coq theories from outside the workspace. This allows for
  composition with installed theories (not necessarily installed with Dune).
  (ocaml/dune#7047, @Alizter, @ejgallego)

- Fix regression where Merlin was unable to handle filenames with uppercase
  letters under Windows. (ocaml/dune#7577, @nojb)

- On nix+macos, pass `-f` to the codesign hook to avoid errors when the binary
  is already signed (ocaml/dune#7183, fixes ocaml/dune#6265, @greedy)

- Fix bug where RPC clients built with dune-rpc-lwt would crash when closing
  their connection to the server (ocaml/dune#7581, @gridbugs)

- Introduce mdx stanza 0.4 requiring mdx >= 2.3.0 which updates the default
  list of files to include `*.mld` files (ocaml/dune#7582, @Leonidas-from-XIV)

- Fix RPC server on Windows (used for OCaml-LSP). (ocaml/dune#7666, @nojb)

- In `(executable)`, `(public_name -)` is now equivalent to no `(public_name)`.
  This is consistent with how `(executables)` handles this field.
  (ocaml/dune#7576 , fixes ocaml/dune#5852, @emillon)

- Change directory of odoc assets to `odoc.support` (was `_odoc_support`) so
  that it works with Github Pages out of the box. (ocaml/dune#7588, fixes ocaml/dune#7364,
  @emillon)
