### PR TITLE
[new release] oseq (0.5)

### DIFF
--- a/packages/oseq/oseq.0.5/opam
+++ b/packages/oseq/oseq.0.5/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "BSD-2-clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "1.0" }
+  "qcheck" {with-test}
+  "qtest" {with-test}
+  "gen" {with-test}
+  "containers" {with-test}
+  "odoc" {with-doc}
+  "ocaml" { >= "4.08.0" }
+]
+tags: [ "sequence" "iterator" "seq" "pure" "list" ]
+homepage: "https://github.com/c-cube/oseq/"
+doc: "https://c-cube.github.io/oseq/"
+bug-reports: "https://github.com/c-cube/oseq/issues"
+dev-repo: "git+https://github.com/c-cube/oseq.git"
+synopsis: "Simple list of suspensions, as a composable lazy iterator that behaves like a value"
+description: "Extends the new standard library's `Seq` module with many useful combinators."
+authors: "Simon Cruanes"
+url {
+  src: "https://github.com/c-cube/oseq/releases/download/v0.5/oseq-0.5.tbz"
+  checksum: [
+    "sha256=ae1c17bf42c50e7a1f2ba9cb5e2903d3342d70cb5259e60716bfafe610c523ea"
+    "sha512=f3109e20938267e075e360b7386dbe18b648ee7a9110ffb60456b8f9f799eca5dfc8797d12ec36ad2d2f9bf02dcf1196e683a223d1219b1eae1a58dcc8a8dc63"
+  ]
+}
+x-commit-hash: "14ca0062ca89ebe795f2001b16083fad9c27170b"


### PR DESCRIPTION
Simple list of suspensions, as a composable lazy iterator that behaves like a value

- Project page: <a href="https://github.com/c-cube/oseq/">https://github.com/c-cube/oseq/</a>
- Documentation: <a href="https://c-cube.github.io/oseq/">https://c-cube.github.io/oseq/</a>

##### CHANGES:

- use ocamlformat
- add let-operators
- require OCaml 4.08
- breaking: remove most labels, ensure compatibility with extended Seq
