### PR TITLE
[new release] docteur, docteur-unix and docteur-solo5 (0.0.6)

### DIFF
--- a/packages/docteur-solo5/docteur-solo5.0.0.6/opam
+++ b/packages/docteur-solo5/docteur-solo5.0.0.6/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-solo5" {>= "0.7.0"}
+  "mirage-block-solo5"
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "hxd" {>= "0.3.1"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "6.1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.6/docteur-0.0.6.tbz"
+  checksum: [
+    "sha256=0fe4813df6d0447b154e4ce0f6de8ea2f541e9283bbdc7713a65134653d7ebea"
+    "sha512=7e407b30f14d64769857c3fb258ecd6629355ea61e9345efc01fa9b00b9c708c225d6f811d2d0ca15f073886098e986fed049c1cdf6f5ad1f61ace121c013f24"
+  ]
+}
+x-commit-hash: "2dc79ccb62ea8a296b244249e11cfa812f2894a8"

--- a/packages/docteur-unix/docteur-unix.0.0.6/opam
+++ b/packages/docteur-unix/docteur-unix.0.0.6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+description: "An opiniated file-system for MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "docteur" {= version}
+  "mirage-unix" {>= "5.0.0"}
+  "art" {>= "0.1.1"}
+  "bigstringaf" {>= "0.7.0"}
+  "carton" {>= "0.4.1"}
+  "digestif" {>= "1.0.0"}
+  "git" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mirage-kv" {>= "6.1.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.6/docteur-0.0.6.tbz"
+  checksum: [
+    "sha256=0fe4813df6d0447b154e4ce0f6de8ea2f541e9283bbdc7713a65134653d7ebea"
+    "sha512=7e407b30f14d64769857c3fb258ecd6629355ea61e9345efc01fa9b00b9c708c225d6f811d2d0ca15f073886098e986fed049c1cdf6f5ad1f61ace121c013f24"
+  ]
+}
+x-commit-hash: "2dc79ccb62ea8a296b244249e11cfa812f2894a8"

--- a/packages/docteur/docteur.0.0.6/opam
+++ b/packages/docteur/docteur.0.0.6/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A simple read-only Key/Value from Git to MirageOS"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/docteur"
+doc: "https://dinosaure.github.io/docteur/"
+bug-reports: "https://github.com/dinosaure/docteur/issues"
+description: """An opiniated file-system for MirageOS"""
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "dune" {>= "2.8.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "digestif" {>= "1.0.0"}
+  "fmt" {>= "0.8.9"}
+  "fpath" {>= "0.7.0"}
+  "git" {>= "3.7.0"}
+  "git-unix" {>= "3.7.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "5.4.0"}
+  "mtime" {>= "2.0.0"}
+  "result" {>= "1.5"}
+  "rresult" {>= "0.6.0"}
+  "carton" {>= "0.4.0"}
+  "art" {>= "0.1.1"}
+  "mmap"
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/dinosaure/docteur.git"
+url {
+  src:
+    "https://github.com/dinosaure/docteur/releases/download/v0.0.6/docteur-0.0.6.tbz"
+  checksum: [
+    "sha256=0fe4813df6d0447b154e4ce0f6de8ea2f541e9283bbdc7713a65134653d7ebea"
+    "sha512=7e407b30f14d64769857c3fb258ecd6629355ea61e9345efc01fa9b00b9c708c225d6f811d2d0ca15f073886098e986fed049c1cdf6f5ad1f61ace121c013f24"
+  ]
+}
+x-commit-hash: "2dc79ccb62ea8a296b244249e11cfa812f2894a8"


### PR DESCRIPTION
A simple read-only Key/Value from Git to MirageOS

- Project page: <a href="https://github.com/dinosaure/docteur">https://github.com/dinosaure/docteur</a>
- Documentation: <a href="https://dinosaure.github.io/docteur/">https://dinosaure.github.io/docteur/</a>

##### CHANGES:

- Fix how we record `weight` of PACK object (@dinosaure, dinosaure/docteur#25)
- Aggregate hidden files (@SaySayo, @dinosaure, dinosaure/docteur#26)
- Upgrade with `mirage-kv.6.0.0` and `mtime.2.0.0` (@dinosaure, dinosaure/docteur#28)
