### PR TITLE
[new release] lacaml (11.0.9)

### DIFF
--- a/packages/lacaml/lacaml.11.0.9/opam
+++ b/packages/lacaml/lacaml.11.0.9/opam
@@ -19,7 +19,7 @@ authors: [
   "Oleg Trott <ot14@columbia.edu>"
   "Martin Willensdorfer <ma.wi@gmx.at>"
 ]
-license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 tags: ["clib:lapack" "clib:blas"]
 homepage: "https://mmottl.github.io/lacaml"
 doc: "https://mmottl.github.io/lacaml/api"

--- a/packages/lacaml/lacaml.11.0.9/opam
+++ b/packages/lacaml/lacaml.11.0.9/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "Lacaml - OCaml-bindings to BLAS and LAPACK"
+description: """
+Lacaml interfaces the BLAS-library (Basic Linear Algebra Subroutines) and
+LAPACK-library (Linear Algebra routines).  It also contains many additional
+convenience functions for vectors and matrices."""
+maintainer: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+authors: [
+  "Egbert Ammicht <eammicht@lucent.com>"
+  "Patrick Cousot <Patrick.Cousot@ens.fr>"
+  "Sam Ehrlichman <sehrlichman@janestreet.com>"
+  "Florent Hoareau <h.florent@gmail.com>"
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Liam Stewart <liam@cs.toronto.edu>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+  "Oleg Trott <ot14@columbia.edu>"
+  "Martin Willensdorfer <ma.wi@gmx.at>"
+]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+tags: ["clib:lapack" "clib:blas"]
+homepage: "https://mmottl.github.io/lacaml"
+doc: "https://mmottl.github.io/lacaml/api"
+bug-reports: "https://github.com/mmottl/lacaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "dune-configurator"
+  "conf-blas" {build}
+  "conf-lapack" {build}
+  "base-bytes"
+  "base-bigarray"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/lacaml.git"
+url {
+  src:
+    "https://github.com/mmottl/lacaml/releases/download/11.0.9/lacaml-11.0.9.tbz"
+  checksum: [
+    "sha256=202bc5356041a5d104cc8a3a7df1d91676e75f226f7ca5b61ce73b3f395f5743"
+    "sha512=c68b647c6f84367bfb432689c651b3ab1f665adeab8b21b15928d2a93dd322abf8d3ebd8031f98ba9fca9142b7b29d8a6559b2279841ff51ea6bd591b7cd8780"
+  ]
+}
+x-commit-hash: "41a697019f7215914672f19dac46e46a6adba072"


### PR DESCRIPTION
Lacaml - OCaml-bindings to BLAS and LAPACK

- Project page: <a href="https://mmottl.github.io/lacaml">https://mmottl.github.io/lacaml</a>
- Documentation: <a href="https://mmottl.github.io/lacaml/api">https://mmottl.github.io/lacaml/api</a>

##### CHANGES:

  * Fixed a bug in the bytecode bindings for `lamch`, which also affected
    `syevr`.  These functions should now not crash anymore when compiling
    to bytecode or using the OCaml interpreter.

    Thanks to Philippe Veber <philippe.veber@gmail.com> for the bug report!

  * Added support for Apple Silicon.

    Thanks to Marcello Seri <marcello.seri@gmail.com> for this contribution!

  * Improved Dune build rules
