### PR TITLE
Add package for Topiary v0.1.0

### DIFF
--- a/packages/topiary/topiary.0.1.0/opam
+++ b/packages/topiary/topiary.0.1.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+
+maintainer: "hello@tweag.io"
+authors: [ "Tweag" ]
+
+homepage: "https://github.com/tweag/topiary"
+bug-reports: "https://github.com/tweag/topiary/issues"
+dev-repo: "git+https://github.com/tweag/topiary.git"
+
+license: "MIT"
+depends: ["conf-rust-2021"]
+
+build:[
+  [ "cargo" "build" "--release" "--package" "topiary" ]
+  [ "sh" "make-topiary-wrapper.sh"
+      "--language-dir" "%{share}%/topiary/languages"
+      "--topiary-wrapped" "%{bin}%/.topiary-wrapped"
+      "--output-file" "topiary-wrapper" ]
+]
+
+install: [
+  [ "cp" "target/release/topiary" "%{bin}%/.topiary-wrapped" ]
+  [ "cp" "topiary-wrapper" "%{bin}%/topiary" ]
+  [ "mkdir" "%{share}%/topiary" ]
+  [ "cp" "-R" "topiary/languages" "%{share}%/topiary/languages" ]
+]
+
+synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+
+url {
+  src: "https://github.com/tweag/topiary-opam/releases/download/v0.1.0/source-code-with-submodules.tar.xz"
+  checksum: [
+    "md5=cd825a17db25cb94fd876eef055090e4"
+    "sha512=ae6946aaba0f784773cca71019f73aa62d9b976646ea25e451c220f45da49e6c7e4147e2dd57e3c4764a9038946c38b9de33ce5d463c46ea3f3271d5b98dd46f"
+  ]
+}


### PR DESCRIPTION
This pull requests adds a package for [Topiary](https://github.com/tweag/topiary) in version 0.1.0 (“Benevolent Beech”). From the point of view of opam-repository and OCaml users, Topiary is an alternative formatter for OCaml. The upstream changelog can be found [here](https://github.com/tweag/topiary/blob/556b2a10df3894a905f2654f774c39933c1f439a/CHANGELOG.md#010-benevolent-beech---2023-03-09).

The main point to note about this package is that is is _not_ an OCaml package: Topiary is written in Rust. However, it can be interesting to publish in opam-repository because it allows formatting OCaml files and could be useful for the community. Some context on this question as well as the idea behind the packaging solution can be found in [this discuss thread](https://discuss.ocaml.org/t/two-questions-about-what-is-appropriate-to-package-with-opam/12030/).

Apart from the problem of whether we accept packaging a Rust program in opam, there is also a technical issue: Topiary requires Cargo/Rustc in version at least 1.65. This version is fairly recent and might not be present in all distributions. In fact, the CI of the [tweag/topiary-opam](https://github.com/tweag/topiary-opam) repository keeps track of this. Out of 11 distributions provided by the `ocaml/opam` DockerHub images:

- 3 can install Topiary without issues (Fedora, Ubuntu and Ubuntu LTS)
- 5 cannot install Topiary due to not having a recent enough version of Cargo/Rustc (Alpine, Debian stable, Debian testing, Debian unstable, Oracle Linux)
- 3 cannot install Topiary due to other problems (Archlinux, CentOS, openSUSE) (The problem with Archlinux is only due to a download issue and I expect it to be resolved rather soon in the `ocaml/opam` DockerHub images.)

The errors are always fairly understandable. In the case of Debian stable that does not even have the 2021 edition of Cargo/Rustc:
```
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build conf-rust-2021 1
+- 
- No changes have been performed
[ERROR] The compilation of conf-rust-2021 failed at "/usr/bin/rustc --edition 2021 test.rs".

#=== ERROR while compiling conf-rust-2021.1 ===================================#
# context              2.0.10 | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/conf-rust-2021.1
# command              /usr/bin/rustc --edition 2021 test.rs
# exit-code            1
# env-file             ~/.opam/log/conf-rust-2021-7-ebe0e0.env
# output-file          ~/.opam/log/conf-rust-2021-7-ebe0e0.out
### output ###
# error: argument for `--edition` must be one of: 2015|2018. (instead was `2021`)
```
and in the other cases, eg. Debian unstable, that have the right edition but still not recent enough:
```
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
-> installed conf-rust-2021.1
[ERROR] The compilation of topiary failed at "/usr/bin/cargo build --release --package topiary".

#=== ERROR while compiling topiary.dev ========================================#
# context              2.0.10 | linux/x86_64 | ocaml-base-compiler.5.0.0 | pinned(git+file:///home/opam/topiary-opam#HEAD#e24ecacb)
# path                 ~/.opam/5.0/.opam-switch/build/topiary.dev
# command              /usr/bin/cargo build --release --package topiary
# exit-code            101
# env-file             ~/.opam/log/topiary-7-736596.env
# output-file          ~/.opam/log/topiary-7-736596.out
### output ###
# error: package `tree-sitter v0.20.10` cannot be built because it requires rustc 1.65 or newer, while the currently active rustc version is 1.63.0
# Either upgrade to rustc 1.65 or newer, or use
# cargo update -p tree-sitter@0.20.10 --precise ver
# where `ver` is the latest version of `tree-sitter` supporting rustc 1.63.0
```

I therefore expect the CI of opam-repository to report the same kind of issues.

Now I am still not convinced whether it is fine to publish a Rust executable in opam-repository but it is not really for me to decide. The discuss thread linked above seemed to show that people were indeed interested in getting Topiary distributed via opam, but we could also decide that it is not the right way and that Topiary should be acquired from other sources, be it via Nix, Cargo itself, or by `opam pin`ning the [tweag/topiary-opam](https://github.com/tweag/topiary-opam) repository. In a few years, after Topiary stabilises and after package sets get updated, Topiary should be available easily as a normal system dependency.