### PR TITLE
Add: brr.0.0.5

### DIFF
--- a/packages/brr/brr.0.0.5/opam
+++ b/packages/brr/brr.0.0.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Browser programming toolkit for OCaml"
+description: """\
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* Note based reactive support (optional and experimental).
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on [Note][note]
+and on the `js_of_ocaml` compiler and runtime – but not on its
+libraries or syntax extension.
+
+[note]: https://erratique.ch/software/note
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: https://erratique.ch/software/brr"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The brr programmers"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "js_of_ocaml-compiler" {>= "4.1.0"}
+  "js_of_ocaml-toplevel" {>= "4.1.0"}
+  "note"
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.5.tbz"
+  checksum:
+    "sha512=5f91f33e8d41e47617bb31295458a8b69b520a40ea24f5ceab28f4c9e8ca85c5535e7ec8820929fd0dbbbd00f5bdc55a49d8533880721d066f15b025e204775f"
+}


### PR DESCRIPTION
* Add: `brr.0.0.5` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.5 2023-05-10 La Forclaz (VS)

- Add `Brr_webgpu`, bindings for WebGPU. Supported by 
  a grant from the OCaml Software Foundation.
- `Brr.El.scroll_into_view`, make `align_v` align according
  to specification (did the exact converse).
- `Brr_io.Fetch.cache` becomes a function taking `unit`. It seems 
  accessing it at initalisation time trips the (latest ?) Firefox 
  WebWorkers.
- Make the `Brr_canvas.Gl` module initialisation bits safe when there is
  no `WebGLRenderingContext`. Thanks to Haochen Kotoi-Xie for reporting.

---

Use `b0 -- .opam.publish brr.0.0.5` to update the pull request.