### PR TITLE
[new release] coq-serapi (8.15.0+0.15.4)

### DIFF
--- a/packages/coq-serapi/coq-serapi.8.15.0+0.15.4/opam
+++ b/packages/coq-serapi/coq-serapi.8.15.0+0.15.4/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer:   "e@x80.org"
+homepage:     "https://github.com/ejgallego/coq-serapi"
+bug-reports:  "https://github.com/ejgallego/coq-serapi/issues"
+dev-repo:     "git+https://github.com/ejgallego/coq-serapi.git"
+license:      "GPL-3.0-or-later"
+doc:          "https://ejgallego.github.io/coq-serapi/"
+
+synopsis:     "Serialization library and protocol for machine interaction with the Coq proof assistant"
+description:  """
+SerAPI is a library for machine-to-machine interaction with the
+Coq proof assistant, with particular emphasis on applications in IDEs,
+code analysis tools, and machine learning. SerAPI provides automatic
+serialization of Coq's internal OCaml datatypes from/to JSON or
+S-expressions (sexps).
+"""
+
+authors: [
+  "Emilio Jesús Gallego Arias"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Kaiyu Yang"
+]
+
+depends: [
+  "ocaml"               {  >= "4.07.0"              }
+  "coq"                 {  >= "8.15" & < "8.16"     }
+  "cmdliner"            {  >= "1.1.0"               }
+  "ocamlfind"           {  >= "1.8.0"               }
+  "sexplib"             {  >= "v0.13.0"             }
+  "dune"                {  >= "2.0.1"               }
+  "ppx_import"          {  >= "1.5-3"               }
+  "ppx_deriving"        {  >= "4.2.1"               }
+  "ppx_sexp_conv"       {  >= "v0.13.0" & < "v0.16" }
+  "ppx_compare"         {  >= "v0.13.0" & < "v0.16" }
+  "ppx_hash"            {  >= "v0.13.0" & < "v0.16" }
+  "result"              {  >= "1.5"                 }
+  "yojson"              {  >= "1.7.0"               }
+  "ppx_deriving_yojson" {  >= "3.4"                 }
+]
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+url {
+  src:
+    "https://github.com/ejgallego/coq-serapi/releases/download/8.15.0%2B0.15.4/coq-serapi-8.15.0.0.15.4.tbz"
+  checksum: [
+    "sha256=cffb0eacd9d155434f7cf384418c78a9d1cf189b65b080a456f50d9d3c3dcf5c"
+    "sha512=77eada7c9f2979ee8b00704ed49e65f6e0aadb1a24b73bb89581bf624f330d141340e0dfecd8b1517a11b2a9d823d8f84fcbdea419cc99536557019c5951b80e"
+  ]
+}
+x-commit-hash: "bc271f33a4c70c9675c97831ce3908bf5c9836cc"


### PR DESCRIPTION
Serialization library and protocol for machine interaction with the Coq proof assistant

- Project page: <a href="https://github.com/ejgallego/coq-serapi">https://github.com/ejgallego/coq-serapi</a>
- Documentation: <a href="https://ejgallego.github.io/coq-serapi/">https://ejgallego.github.io/coq-serapi/</a>

##### CHANGES:

 - [serlib] Fix crash when serializing projections (@ejgallego, ejgallego/coq-serapi#332,
   reported by @rwhender, fixes ejgallego/coq-serapi#331).
