### PR TITLE
Github CI actions

### DIFF
--- a/.github/check-installable/action.yml
+++ b/.github/check-installable/action.yml
@@ -1,0 +1,35 @@
+name: Check if package is installable
+inputs:
+  opam:
+    required: true
+  package:
+    required: true
+outputs:
+  installable:
+    description: "Is the package installable?"
+    value: ${{ steps.installable.outputs.installable }}
+runs:
+  using: composite
+  steps:
+    - name: Get opam cli option
+      id: cli
+      shell: sh
+      run: |
+        if [ "${{ inputs.opam }}" = "opam-2.1" ]; then
+          echo 'cli=--cli=2.1' >> $GITHUB_OUTPUT
+        fi
+    - name: Check if package is installable
+      id: installable
+      shell: sh
+      run: |
+        if opam ${{ steps.cli.outputs.cli }} list --readonly --external --resolve=${{ inputs.package }} >/dev/null 2>&1; then
+          echo 'installable=true' >> $GITHUB_OUTPUT
+        else
+          echo "Package is not installable";
+        fi
+    - name: Annotate result
+      if: ${{ !steps.installable.outputs.installable }}
+      uses: actions/github-script@v5
+      with:
+        script: |
+          core.notice('${{ inputs.package }} is not installable');

--- a/.github/install-ocaml/action.yml
+++ b/.github/install-ocaml/action.yml
@@ -1,0 +1,14 @@
+name: Install OCaml
+inputs:
+  compiler:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup OCaml
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: ${{ inputs.compiler }}
+        opam-disable-sandboxing: true
+        opam-repositories: |
+          default: file://.

--- a/.github/install-package/action.yml
+++ b/.github/install-package/action.yml
@@ -1,0 +1,30 @@
+name: Install Package
+inputs:
+  opam:
+    required: true
+  package:
+    required: true
+  env:
+    default: '{}'
+runs:
+  using: composite
+  steps:
+    - name: Get opam cli option
+      id: cli
+      shell: sh
+      run: |
+        if [ "${{ inputs.opam }}" = "opam-2.1" ]; then
+          echo 'cli=--cli=2.1 --confirm-level=unsafe-yes' >> $GITHUB_OUTPUT
+        fi
+    - name: Install ${{ inputs.package }} depopts
+      if: inputs.opam == 'opam-2.0'
+      shell: sh
+      run: |
+        opam depext ${{ inputs.package }}
+    - name: Install ${{ inputs.package }}
+      shell: sh
+      env: ${{ fromJson(inputs.env) }}
+      run: |
+        opam install --deps-only ${{ steps.cli.outputs.cli }} ${{ inputs.package }}
+        opam install ${{ steps.cli.outputs.cli }} ${{ inputs.package }}
+        opam remove ${{ steps.cli.outputs.cli }} ${{ inputs.package }}

--- a/.github/install-system-packages/action.yml
+++ b/.github/install-system-packages/action.yml
@@ -1,0 +1,35 @@
+name: Install System Packages
+inputs:
+  distribution:
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install debian system packages
+      if: startsWith(inputs.distribution, 'debian') || startsWith(inputs.distribution, 'ubuntu')
+      shell: sh
+      env:
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        apt-get update
+        apt-get install -qq -yy curl darcs gcc git m4 make mercurial patch rsync sudo unzip bzip2
+    - name: Install alpine system packages
+      if: startsWith(inputs.distribution, 'alpine')
+      shell: sh
+      run: |
+        apk add build-base coreutils curl libgcc libstdc++ musl patch unzip bzip2 mercurial git rsync tar
+    - name: Install yum-based system packages
+      if: startsWith(inputs.distribution, 'centos') || startsWith(inputs.distribution, 'fedora') || startsWith(inputs.distribution, 'oraclelinux')
+      shell: sh
+      run: |
+        yum install -y curl diffutils gcc gcc-c++ tar git m4 make mercurial patch rsync sudo unzip gzip bzip2
+    - name: Install opensuse system packages
+      if: startsWith(inputs.distribution, 'opensuse')
+      shell: sh
+      run: |
+        zypper install -y curl diffutils gcc gcc-c++ tar git m4 make mercurial patch rsync sudo unzip gzip bzip2 which
+    - name: Install archlinux system packages
+      if: startsWith(inputs.distribution, 'archlinux')
+      shell: sh
+      run: |
+        pacman -Sy --noconfirm base-devel unzip git rsync

--- a/.github/revdeps-matrix/action.yml
+++ b/.github/revdeps-matrix/action.yml
@@ -1,0 +1,69 @@
+name: Get revdeps matrix
+inputs:
+  revdeps:
+    required: true
+outputs:
+  shouldRun:
+    description: "Should run"
+    value:  ${{ fromJson(steps.revdeps_matrix.outputs.result).shouldRun }}
+  packages:
+    description: "Packages"
+    value: ${{ toJson(fromJson(steps.revdeps_matrix.outputs.result).packages) }}
+  revdeps:
+    description: "Revdeps"
+    value: ${{ toJson(fromJson(steps.revdeps_matrix.outputs.result).revdeps) }}
+  compilers:
+    description: "Compilers"
+    value: ${{ toJson(fromJson(steps.revdeps_matrix.outputs.result).compilers) }}
+  exclude:
+    description: "Exclude"
+    value: ${{ toJson(fromJson(steps.revdeps_matrix.outputs.result).exclude) }}
+runs:
+  using: composite
+  steps:
+    - name: Collect revdeps
+      id: revdeps_matrix
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const config = JSON.parse('${{ inputs.revdeps }}').revdeps;
+
+          const compilers = new Set();
+          const packages = new Set();
+          const revdeps = new Set(); 
+          const exclude = [];
+          const revdepsConfigs = {};
+
+          Object.keys(config).forEach((key) => {
+            const [p, compiler] = key.split("_");
+            compilers.add(compiler);
+            packages.add(p);
+            config[key].forEach((revdep) => {
+              revdeps.add(revdep);
+              revdepsConfigs[revdep] ||= { compilers: [], packages: [] }
+              revdepsConfigs[revdep].compilers.push(compiler);
+              revdepsConfigs[revdep].packages.push(p);
+            });
+          });
+
+          revdeps.forEach((revdep) =>
+            compilers.forEach((compiler) =>
+              packages.forEach((p) => {
+                if (!revdepsConfigs[revdep].compilers.includes(compiler) || 
+                    !revdepsConfigs[revdep].packages.includes(p)) {
+                  exclude.push({ revdep: revdep, package: p, compiler });
+                }
+              })
+            )
+          );
+
+          const matrix = {
+            shouldRun: packages.length !== 0,
+            compilers: [...compilers],
+            packages: [...packages],
+            revdeps: [...revdeps],
+            exclude
+          }
+
+          console.log(`Revdeps matrix: ${JSON.stringify(matrix, null, 2)}`);
+          return matrix; 

--- a/.github/scripts/packages.sh
+++ b/.github/scripts/packages.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+PACKAGES=`git diff --name-only origin/master..HEAD | grep '^packages' | cut -d'/' -f 3 | while read i; do echo "\"$i\""; done | paste -sd ',' -`
+
+echo "Packages to test: $PACKAGES"
+echo "packages=[${PACKAGES}]" >> $GITHUB_OUTPUT
+

--- a/.github/scripts/revdeps.sh
+++ b/.github/scripts/revdeps.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+PACKAGE=$1
+
+REVDEPS=`(opam --cli=2.1 list -s --color=never --depends-on "${PACKAGE}" --coinstallable-with "${PACKAGE}" --installable --all-versions --recursive --depopts && opam --cli=2.1 list -s --color=never --depends-on "${PACKAGE}" --coinstallable-with "${PACKAGE}" --installable --all-versions --with-test --depopts) | sort -u | grep -v "${PACKAGE}" | while read i; do echo "\"$i\""; done | paste -sd ',' -`
+
+echo "${PACKAGE} revdeps: [${REVDEPS}]"
+echo "revdeps=[${REVDEPS}]" >> "${GITHUB_OUTPUT}"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,256 @@
+name: CI
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      default_compiler: '5.0.0'
+      default_opam: 'opam-2.1'
+      revdeps_compilers: |
+        ["4.14", "5.0"]
+      compilers: |
+        ["4.02","4.03","4.04","4.05","4.06","4.07",
+         "4.08","4.09","4.10","4.11","4.12","4.13",
+         "4.14","5.0"]
+      distributions: |
+        ["alpine:3.17","alpine:3.18",
+         "archlinux",
+         "debian:testing","debian:unstable",
+         "fedora:37","fedora:38",
+         "oraclelinux:8",
+         "ubuntu:22.04","ubuntu:23.04"]
+      extras: |
+        ["afl", "flambda", "no-flat-float-array"]
+      opam_versions: |
+        ["opam-2.0", "opam-2.1"]
+      packages: ${{ steps.packages.outputs.packages }}
+      cache_key: v1-opam-${{ github.run_id }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: List packages to be tested
+        id: packages
+        run: |
+          ./.github/scripts/packages.sh
+
+  compilers:
+    runs-on: ubuntu-latest
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        opam:  ${{ fromJson(needs.config.outputs.opam_versions) }}
+        compiler: ${{ fromJson(needs.config.outputs.compilers) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ matrix.compiler }}
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ matrix.opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}
+      - name: Get ${{ matrix.package }} revdeps
+        id: revdeps
+        if: contains(needs.config.outputs.revdeps_compilers, matrix.compiler) && matrix.opam == needs.config.outputs.default_opam
+        run: |
+          ./.github/scripts/revdeps.sh ${{ matrix.package }}
+      - name: Save revdeps
+        uses: cloudposse/github-action-matrix-outputs-write@0.3.1
+        if: contains(needs.config.outputs.revdeps_compilers, matrix.compiler) && matrix.opam == needs.config.outputs.default_opam
+        with:
+          matrix-step-name: revdeps
+          matrix-key: ${{ matrix.package }}_${{ matrix.compiler }}
+          outputs: |-
+            revdeps: ${{ steps.revdeps.outputs.revdeps }}
+
+  revdeps_matrix:
+    runs-on: ubuntu-latest
+    needs: [compilers]
+    outputs:
+      shouldRun: ${{ steps.revdeps_matrix.outputs.shouldRun }}
+      packages: ${{ steps.revdeps_matrix.outputs.packages }}
+      revdeps: ${{ steps.revdeps_matrix.outputs.revdeps }}
+      compilers: ${{ steps.revdeps_matrix.outputs.compilers }}
+      exclude: ${{ steps.revdeps_matrix.outputs.exclude }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Fetch revdeps config matrix
+        id: fetch_revdeps
+        uses: cloudposse/github-action-matrix-outputs-read@main
+        with:
+          matrix-step-name: revdeps
+      - name: Process and export revdeps
+        id: revdeps_matrix
+        uses: ./.github/revdeps-matrix
+        with:
+          revdeps: "${{ steps.fetch_revdeps.outputs.result }}"
+
+  revdeps:
+    runs-on: ubuntu-latest
+    needs: [config, revdeps_matrix]
+    if: needs.revdeps_matrix.outputs.shouldRun
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.revdeps_matrix.outputs.packages) }}
+        revdep: ${{ fromJson(needs.revdeps_matrix.outputs.revdeps) }}
+        compiler: ${{ fromJson(needs.revdeps_matrix.outputs.compilers) }}
+        exclude: ${{ fromJson(needs.revdeps_matrix.outputs.exclude) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ matrix.compiler }}
+      - name: Install ${{ matrix.package }} and ${{ matrix.revdep }}
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }} ${{ matrix.revdep }}
+
+  distributions:
+    runs-on: ubuntu-latest
+    needs: config
+    container:
+      image: ${{ matrix.distribution }}
+    strategy:
+      fail-fast: false
+      matrix:
+        distribution: ${{ fromJson(needs.config.outputs.distributions) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install system packages
+        uses: ./.github/install-system-packages
+        with:
+          distribution: ${{ matrix.distribution }}
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ needs.config.outputs.default_compiler }}
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}
+
+  macos:
+    runs-on: macos-latest
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: ${{ needs.config.outputs.default_compiler }}
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}
+
+  extras:
+    runs-on: ubuntu-latest
+    needs: config
+    strategy:
+      fail-fast: false
+      matrix:
+        extra: ${{ fromJson(needs.config.outputs.extras) }}
+        package: ${{ fromJson(needs.config.outputs.packages) }}
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v1
+      - name: Compute OCaml options
+        id: ocaml_options
+        run: |
+          OCAML_OPTIONS=`echo "${{ matrix.extra }}" | tr '+' '\n' | while read i; do echo "ocaml-option-$i"; done | paste -sd ',' -`
+          echo "OCaml options: $OCAML_OPTIONS"
+          echo "ocaml_options=$OCAML_OPTIONS" >> $GITHUB_OUTPUT
+      - name: Install OCaml
+        uses: ./.github/install-ocaml
+        with:
+          compiler: 'ocaml-variants.${{ needs.config.outputs.default_compiler }}+options,${{ steps.ocaml_options.outputs.ocaml_options }}'
+      - name: Check if ${{ matrix.package }} is installable
+        id: installable
+        uses: ./.github/check-installable
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }}
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+      - name: Install ${{ matrix.package }} with tests
+        if: steps.installable.outputs.installable
+        uses: ./.github/install-package
+        with:
+          opam: ${{ needs.config.outputs.default_opam }}
+          package: ${{ matrix.package }}
+          env: |
+            {"OPAMWITHTEST": "1"}


### PR DESCRIPTION
Hi!

I noticed that the official CI is currently being rebuilt so I dusted off my old https://github.com/ocaml/opam-repository/pull/20322 PR. Hopefully, this can help move things forward while the regular CI is rebuilt?

The actions do not include everything that the official CI supports, in particular extra features and architectures but it does check against a bunch of OCaml compiler versions as well as platforms and revdeps, hopefully enough to start merging some PRs!

It should also be possible to cherry-pick the one commit from this PR, add it to another pending PR, check the result of the actions and remove it before the merge if y'all don't want to include the files in the main branch. Here's an example with the pending `ogg.0.7.4`: https://github.com/ocaml/opam-repository/actions/runs/4942730965

Example run with two packages (`faad.0.4.0` and (artificially picked) `liquidsoap.2.0.1`): https://github.com/savonet/opam-repository/actions/runs/4942469715

I tested it against the Janest PR https://github.com/ocaml/opam-repository/pull/23742 but, oh my, no this one is still way too big for it.. See: https://github.com/savonet/opam-repository/actions/runs/4942483639 🙂