### PR TITLE
dream-serve 1.0.1: live-reloading static site server

### DIFF
--- a/packages/dream-serve/dream-serve.1.0.1/opam
+++ b/packages/dream-serve/dream-serve.1.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+
+synopsis: "Static HTML website server with live reload"
+
+description: """
+dream-serve serves a static HTML site. It injects a small script which reloads
+Web pages when they are updated in the file system. This makes it great for
+static site development, including odoc documentation pages, and for viewing
+Bisect_ppx coverage reports across multiple test runs.
+"""
+
+license: "MIT"
+homepage: "https://github.com/aantron/dream-serve"
+doc: "https://github.com/aantron/dream-serve#readme"
+bug-reports: "https://github.com/aantron/dream-serve/issues"
+dev-repo: "git+https://github.com/aantron/dream-serve.git"
+
+author: "Anton Bachin <antonbachin@yahoo.com>"
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+
+depends: [
+  "dream" {>= "1.0.0~alpha3"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "0.6.1"}
+  "luv"
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/dream-serve/archive/refs/tags/1.0.1.tar.gz"
+  checksum: "md5=35c356143b82907a8e2afefe51cb29f1"
+}


### PR DESCRIPTION
dream-serve is a small static HTML website server that watches the file system and has the browser reload the website when it changes. It's great for viewing odoc documentation sites under development, and while working with Bisect_ppx coverage reports.

Version 1.0.1 makes dream-serve compatible with recent Dream releases and fixes a bug:

> - Adapt to Dream alpha 3 and higher (aantron/dream-serve@8e25b41).
> - Fix Ctrl+C handling (aantron/dream-serve@d8a477b).