### PR TITLE
Add: cmarkit.0.2.0

### DIFF
--- a/packages/cmarkit/cmarkit.0.2.0/opam
+++ b/packages/cmarkit/cmarkit.0.2.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "CommonMark parser and renderer for OCaml"
+description: """\
+Cmarkit parses the [CommonMark specification]. It provides:
+
+- A CommonMark parser for UTF-8 encoded documents. Link label resolution
+  can be customized and a non-strict parsing mode can be activated to add: 
+  strikethrough, LaTeX math, footnotes, task items and tables.
+  
+- An extensible abstract syntax tree for CommonMark documents with
+  source location tracking and best-effort source layout preservation.
+
+- Abstract syntax tree mapper and folder abstractions for quick and
+  concise tree transformations.
+  
+- Extensible renderers for HTML, LaTeX and CommonMark with source
+  layout preservation.
+
+Cmarkit is distributed under the ISC license. It has no dependencies.
+
+[CommonMark specification]: https://spec.commonmark.org/
+
+Homepage: <https://erratique.ch/software/cmarkit>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The cmarkit programmers"
+license: "ISC"
+tags: ["codec" "commonmark" "markdown" "org:erratique"]
+homepage: "https://erratique.ch/software/cmarkit"
+doc: "https://erratique.ch/software/cmarkit/doc"
+bug-reports: "https://github.com/dbuenzli/cmarkit/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.0.3"}
+  "uucp" {dev}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "1.1.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/cmarkit.git"
+url {
+  src: "https://erratique.ch/software/cmarkit/releases/cmarkit-0.2.0.tbz"
+  checksum:
+    "sha512=e56b738b01b81fc968fc1d0888eaf7c2bbdcb2b8fb70dbeb4475f60bae916a36c39b95caa7d91fcca35e1d9fe388379876549f74d0df6bcd1bece46ff7f5ae08"
+}


### PR DESCRIPTION
* Add: `cmarkit.0.2.0` [home](https://erratique.ch/software/cmarkit), [doc](https://erratique.ch/software/cmarkit/doc), [issues](https://github.com/dbuenzli/cmarkit/issues)  
  *CommonMark parser and renderer for OCaml*


---

#### `cmarkit` v0.2.0 2023-05-10 La Forclaz (VS)

- Fix bug in `Block_lines.list_of_string`. Thanks to Rafał Gwoździński
  for the report and the fix ([#7](https://github.com/dbuenzli/cmarkit/issues/7), [#8](https://github.com/dbuenzli/cmarkit/issues/8)).
- `Cmarkit.Mapper`. Fix non-sensical default map for `Image` nodes: do
  not delete `Image` nodes whose alt text maps to `None`, replace the
  alt text by `Inline.empty`. Thanks to Nicolás Ojeda Bär for the
  report and the fix ([#6](https://github.com/dbuenzli/cmarkit/issues/6)).

---

Use `b0 -- .opam.publish cmarkit.0.2.0` to update the pull request.