### PR TITLE
[new release] dream-html (0.0.2)

### DIFF
--- a/packages/dream-html/dream-html.0.0.2/opam
+++ b/packages/dream-html/dream-html.0.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/api"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08.0"}
+  "dream"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v0.0.2/dream-html-0.0.2.tbz"
+  checksum: [
+    "sha256=db1643a3f5fcc6327f0948ad6719bf6f563f1a1c329e85c1b0c710ec8f13bd48"
+    "sha512=a5e6dec4498163c98ad650ec5500562e5045da8138a109711352c3c3e95e76e64ca2984ff8d963eb29efc479383cafb91f6a28fb39c14b79b8fa7311e4ac1f5b"
+  ]
+}
+x-commit-hash: "704e2dcfb56000da29fcc8c4e4787e926b0de825"

--- a/packages/dream-html/dream-html.0.0.2/opam
+++ b/packages/dream-html/dream-html.0.0.2/opam
@@ -6,7 +6,7 @@ maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
 authors: ["Yawar Amin <yawar.amin@gmail.com>"]
 license: "GPL-3.0-or-later"
 homepage: "https://github.com/yawaramin/dream-html"
-doc: "https://yawaramin.github.io/dream-html/api"
+doc: "https://yawaramin.github.io/dream-html/"
 bug-reports: "https://github.com/yawaramin/dream-html/issues"
 depends: [
   "dune" {>= "2.7"}

--- a/packages/dream-html/dream-html.0.0.2/opam
+++ b/packages/dream-html/dream-html.0.0.2/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/yawaramin/dream-html/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08.0"}
-  "dream"
+  "dream" {>= "1.0.0~alpha3"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/api">https://yawaramin.github.io/dream-html/api</a>

##### CHANGES:

Please refer to release notes in tags.
