### PR TITLE
[new release] albatross (2.0.0)

### DIFF
--- a/packages/albatross/albatross.2.0.0/opam
+++ b/packages/albatross/albatross.2.0.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/roburio/albatross"
+dev-repo: "git+https://github.com/roburio/albatross.git"
+bug-reports: "https://github.com/roburio/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime"
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "0.13.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "mirage-crypto"
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "checkseum"
+  "metrics" {>= "0.2.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "hex"
+  "http-lwt-client" {>= "0.2.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.3"}
+  "owee" {>= "0.4"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+url {
+  src:
+    "https://github.com/roburio/albatross/releases/download/v2.0.0/albatross-2.0.0.tbz"
+  checksum: [
+    "sha256=fdc949f0db15b22ba42186ca26dcaf58b043f3901f1af2960fdc736849f1c037"
+    "sha512=907f83129a6110f13761f2278ae58a0395ee5cdf70e7ef9802c5f2252dcdfb2557363f27dc4dc54cce091c8aab959ddebc252f37ba49b644b8d926c8d87eddfd"
+  ]
+}
+x-commit-hash: "2fb15daf5a3f8fe68b3ea369c4571a5e302a802d"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/roburio/albatross">https://github.com/roburio/albatross</a>

##### CHANGES:

This is a breaking release since the binaries to be installed have been revised
and merged. The `albatross-client-local` is now `albatross-client [--socket]`,
`albatross-provision-ca` is now `albatross-client sign` or `albatross-client
generate`. The `albatross-client-remote` is now `albatross-client certificate`.
The `albatross-client-bistro` is now `albatross-client <command>
--destination <host> --ca ca.pem --ca-key ca.pem --server-ca cacert.pem`.

And finally, `albatross-tls-inetd` is now `albatross-tls-endpoint --inetd`.

- Document TLS usage (roburio/albatross#155, roburio/albatross#156 @TheLortex @hannesm)
- Improve TLS experience by providing more reasonable error messages and apply
  more checks before establishing a TLS session (roburio/albatross#157 @hannesm @reynir)
- Slim down binaries:
  - remove albatross-stat-client binary (roburio/albatross#161 @hannesm)
  - move X509 parts out of Albatross_cli (roburio/albatross#158 @reynir)
  - merge albatross-tls-inetd with albatross-tls-endpoint (roburio/albatross#160 @hannesm)
  - merge albatross-client-inspect-dump into albatross-client (roburio/albatross#161 @hannesm)
  - merge albatross-provision-ca and albatross-provision-request into
    albatross-client (roburio/albatross#159 @reynir @hannesm)
  - merge albatross-client-remote and albatross-client-bistro and
    albatross-client-local into albatross-client (roburio/albatross#162 @hannesm)
- Check solo5 ABI tender version, allow multiple solo5 tenders to exist (named
  as solo5-{s,h}vt.<ABI> (roburio/albatross#163 @hannesm)
- Improve documentation and manpages (roburio/albatross#164 @hannesm)
