### PR TITLE
Fix bad SHAs for ezjs_fetch package

### DIFF
--- a/packages/ezjs_fetch/ezjs_fetch.0.1/opam
+++ b/packages/ezjs_fetch/ezjs_fetch.0.1/opam
@@ -31,7 +31,7 @@ dev-repo: "git+https://github.com/ocamlpro/ezjs_fetch.git"
 url {
   src: "https://github.com/OCamlPro/ezjs_fetch/archive/0.1.tar.gz"
   checksum: [
-    "sha256=7e1683758ddcf7489d58f05b0b5b7c7f018fc83567346e80cbde895fd2b3a3f9"
-    "sha512=280dd89ef575c78be49ddf10059a21ac09012ee33699256ee9cbf00e2b8e025fcca8c11a0fe12cbdf6b244990466510cb9b367734b6100d984f0def7f62117cc"
+    "sha256=e0f08d66fe38721710fbf139a6a4230edd71db39b0660020533b73a7c2cd77d3"
+    "sha512=3062bb9096d89a13b6cabf79760222e815d0588c6aaa73ee343763971429dd4f62002eb7f9de6d5cca85e2d48806b1d4a50f2a94318ccd44ccb0815db3f22152"
   ]
 }


### PR DESCRIPTION
I was getting bad checksum errors on this package. 
```
OpamSolution.Fetch_fail("https://github.com/OCamlPro/ezjs_fetch/archive/0.1.tar.gz (Bad checksum, expected sha256=7e1683758ddcf7489d58f05b0b5b7c7f018fc83567346e80cbde895fd2b3a3f9)")
```

I've recalculated them on macOS as:
``` shell
$ curl -sL https://github.com/OCamlPro/ezjs_fetch/archive/0.1.tar.gz |sha256sum
e0f08d66fe38721710fbf139a6a4230edd71db39b0660020533b73a7c2cd77d3  -
$ curl -sL https://github.com/OCamlPro/ezjs_fetch/archive/0.1.tar.gz | sha512sum
3062bb9096d89a13b6cabf79760222e815d0588c6aaa73ee343763971429dd4f62002eb7f9de6d5cca85e2d48806b1d4a50f2a94318ccd44ccb0815db3f22152  -
```

Please verify this is correct.