### PR TITLE
Source ocamlcodoc from opam-source-achives

### DIFF
--- a/packages/ocamlcodoc/ocamlcodoc.1.0.0/opam
+++ b/packages/ocamlcodoc/ocamlcodoc.1.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.02.0" & < "4.08.0"}
   "stdcompat" { <= "8" }
   "cmdliner"
-  "dune" {>= "1.3"}]
+  "dune" {>= "1.4"}]
 url {
   src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/HEAD/ocamlcodoc-v1.0.0.tar.gz"
   checksum: "md5=d532194ae9393e745279b666f4b11942"

--- a/packages/ocamlcodoc/ocamlcodoc.1.0.0/opam
+++ b/packages/ocamlcodoc/ocamlcodoc.1.0.0/opam
@@ -14,6 +14,6 @@ depends: [
   "cmdliner"
   "dune" {>= "1.3"}]
 url {
-  src: "https://gitlab.inria.fr/tmartine/ocamlcodoc/-/archive/v1.0.0/ocamlcodoc-v1.0.0.tar.gz"
+  src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/HEAD/ocamlcodoc-v1.0.0.tar.gz"
   checksum: "md5=d532194ae9393e745279b666f4b11942"
 }

--- a/packages/ocamlcodoc/ocamlcodoc.1.0.1/opam
+++ b/packages/ocamlcodoc/ocamlcodoc.1.0.1/opam
@@ -26,6 +26,6 @@ depends: [
   "stdcompat" {>= "10"}
 ]
 url {
-  src: "https://gitlab.inria.fr/tmartine/ocamlcodoc/-/archive/v1.0.1/ocamlcodoc-v1.0.1.tar.gz"
+  src: "https://raw.githubusercontent.com/ocaml/opam-source-archives/HEAD/ocamlcodoc-v1.0.1.tar.gz"
   checksum: "sha512=c95ed76a2f654913c0cc8a128cdaea15923e0fb7ec82db96c5aa35cbdcd88ad316999a853c5bb247fc2d785918bb904193fd0b7e33b895ddddfeb140400608e5"
 }


### PR DESCRIPTION
This is to fix a problem where these package source urls went to a
gitlab login page.

Signed-off-by: Stephen Sherratt <stephen@sherra.tt>
