### PR TITLE
Ocplib-endian uses bytes

### DIFF
--- a/packages/ocplib-endian/ocplib-endian.1.2/opam
+++ b/packages/ocplib-endian/ocplib-endian.1.2/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "cppo" {>= "1.1.0" & build}
   "dune" {>= "1.0"}
+  "base-bytes"
 ]
 build: [
   "dune"


### PR DESCRIPTION
Without this patch, the compilation (on OCaml5) fails with:

```
  #=== ERROR while compiling ocplib-endian.1.2 ==================================#
  # context     2.1.4 | macos/arm64 |  | https://opam.ocaml.org#f38d24d2
  # path        ~/git/mirage-crypto/_opam/.opam-switch/build/ocplib-endian.1.2
  # command     ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ocplib-endian -j 9 @install
  # exit-code   1
  # env-file    ~/.opam/log/ocplib-endian-989-8ac923.env
  # output-file ~/.opam/log/ocplib-endian-989-8ac923.out
  ### output ###
  # [...]
  # -> required by _build/install/default/lib/ocplib-endian/META
  # -> required by _build/default/ocplib-endian.install
  # -> required by alias install
  # File "src/dune", line 75, characters 35-40:
  # 75 |  (libraries ocplib_endian bigarray bytes))
  #                                         ^^^^^
  # Error: Library "bytes" not found.
  # -> required by library "ocplib-endian.bigstring" in _build/default/src
  # -> required by _build/default/META.ocplib-endian
  # -> required by _build/install/default/lib/ocplib-endian/META
  # -> required by _build/default/ocplib-endian.install
  # -> required by alias install
  ```
  
  /cc @chambart 