### PR TITLE
[new release] parse-argv (0.3.0)

### DIFF
--- a/packages/parse-argv/parse-argv.0.3.0/opam
+++ b/packages/parse-argv/parse-argv.0.3.0/opam
@@ -5,6 +5,7 @@ tags: "org:mirage"
 homepage: "https://github.com/mirage/parse-argv"
 doc: "https://mirage.github.io/parse-argv/"
 bug-reports: "https://github.com/mirage/parse-argv/issues"
+license:      "ISC"
 depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}

--- a/packages/parse-argv/parse-argv.0.3.0/opam
+++ b/packages/parse-argv/parse-argv.0.3.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <mindy.preston@docker.com>"
+authors: ["Jon Ludlam" "Magnus Skjegstad" "Mindy Preston"]
+tags: "org:mirage"
+homepage: "https://github.com/mirage/parse-argv"
+doc: "https://mirage.github.io/parse-argv/"
+bug-reports: "https://github.com/mirage/parse-argv/issues"
+depends: [
+  "ocaml" {>= "4.06.0"}
+  "dune" {>= "1.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/parse-argv.git"
+synopsis: "Process strings into sets of command-line arguments"
+description: """
+parse-argv is a small implementation of a simple argv parser.
+"""
+url {
+  src:
+    "https://github.com/mirage/parse-argv/releases/download/v0.3.0/parse-argv-0.3.0.tbz"
+  checksum: [
+    "sha256=ea1e9a59c2d020f4fe831b9d68145bf76b06e5dbc045146383ff1bb07566c8b4"
+    "sha512=22536d3fb3178641a9ce27375589d3f4b53c44b4f0cf14edaa7245936523d59f171b39fd3124582cfb16341420c58e22d62abeda3ec2bf38964ebf5515ffc83d"
+  ]
+}
+x-commit-hash: "84cb14c5ff6626ab42d174ed0e07dc74eb995206"


### PR DESCRIPTION
Process strings into sets of command-line arguments

- Project page: <a href="https://github.com/mirage/parse-argv">https://github.com/mirage/parse-argv</a>
- Documentation: <a href="https://mirage.github.io/parse-argv/">https://mirage.github.io/parse-argv/</a>

##### CHANGES:

* remove build directive on dune dependency (mirage/parse-argv#8 @CraigFE)
* remove astring dependency, simplify code (mirage/parse-argv#10 @hannesm)
