### PR TITLE
camlidl: fails to build on ocaml >= 5.0 bytecode-only compilers

### DIFF
--- a/packages/camlidl/camlidl.1.07/opam
+++ b/packages/camlidl/camlidl.1.07/opam
@@ -27,6 +27,9 @@ extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
   ["META" "md5=df2fdae08d486c43311b0a7b8a9ca38c"]
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 url {
   src:
     "https://github.com/xavierleroy/camlidl/archive/camlidl107.tar.gz"

--- a/packages/camlidl/camlidl.1.09/opam
+++ b/packages/camlidl/camlidl.1.09/opam
@@ -23,6 +23,9 @@ extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
   ["META" "md5=23b140345606a15a304212e930cadaa7"]
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 url {
   src:
     "https://github.com/xavierleroy/camlidl/archive/camlidl109.tar.gz"

--- a/packages/camlidl/camlidl.1.10/opam
+++ b/packages/camlidl/camlidl.1.10/opam
@@ -26,6 +26,9 @@ extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
   ["META" "md5=8ea7ab71c0457962a6382e94c2b5b8bc"]
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 url {
   src:
     "https://github.com/xavierleroy/camlidl/archive/camlidl110.tar.gz"

--- a/packages/camlidl/camlidl.1.11/opam
+++ b/packages/camlidl/camlidl.1.11/opam
@@ -26,6 +26,9 @@ extra-files: [
   ["camlidl.install" "md5=cf56e14faed046880b7c9d0f4cd737f1"]
   ["META" "md5=2e2f78ac8c3e9f5581a28b2cec6d755b"]
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 url {
   src:
     "https://github.com/xavierleroy/camlidl/archive/camlidl111.tar.gz"


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/23728

Failure:
```
=== ERROR while compiling camlidl.1.11 =======================================#
 context              2.2.0~alpha~dev | linux/arm32 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/camlidl.1.11
 command              ~/.opam/opam-init/hooks/sandbox.sh build make all
 exit-code            2
 env-file             ~/.opam/log/camlidl-7-486342.env
 output-file          ~/.opam/log/camlidl-7-486342.out
 cd compiler; make all
 make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.11/compiler'
 rm -f config.ml
 sed -e 's|%%CPP%%|cpp|' \
           config.mlp > config.ml
 chmod -w config.ml
 ocamlc -g -c config.mli
 ocamlc -g -c config.ml
 ocamlc -g -c utils.mli
 ocamlc -g -c utils.ml
 ocamlc -g -c clflags.ml
 ocamlc -g -c idltypes.mli
 ocamlc -g -c prefix.mli
 ocamlc -g -c prefix.ml
 ocamlc -g -c lexpr.mli
 ocamlc -g -c lexpr.ml
 ocamlc -g -c cvttyp.mli
 ocamlc -g -c cvttyp.ml
 ocamlc -g -c variables.mli
 ocamlc -g -c variables.ml
 ocamlc -g -c idlarray.mli
 ocamlc -g -c idlarray.ml
 ocamlc -g -c struct.mli
 ocamlc -g -c struct.ml
 ocamlc -g -c enum.mli
 ocamlc -g -c enum.ml
 ocamlc -g -c union.mli
 ocamlc -g -c union.ml
 ocamlc -g -c cvtval.mli
 ocamlc -g -c cvtval.ml
 ocamlc -g -c structdecl.mli
 ocamlc -g -c structdecl.ml
 ocamlc -g -c enumdecl.mli
 ocamlc -g -c enumdecl.ml
 ocamlc -g -c uniondecl.mli
 ocamlc -g -c uniondecl.ml
 ocamlc -g -c typedef.mli
 ocamlc -g -c typedef.ml
 ocamlc -g -c funct.mli
 ocamlc -g -c funct.ml
 ocamlc -g -c constdecl.mli
 ocamlc -g -c constdecl.ml
 ocamlc -g -c intf.mli
 ocamlc -g -c intf.ml
 ocamlc -g -c file.mli
 ocamlc -g -c file.ml
 ocamlc -g -c predef.mli
 ocamlc -g -c predef.ml
 ocamllex linenum.mll
 16 states, 331 transitions, table size 1420 bytes
 ocamlc -g -c linenum.mli
 ocamlc -g -c linenum.ml
 ocamlc -g -c parse_aux.mli
 ocamlc -g -c parse_aux.ml
 ocamlyacc -v parser_midl.mly
 12 shift/reduce conflicts, 4 reduce/reduce conflicts.
 ocamlc -g -c parser_midl.mli
 ocamlc -g -c parser_midl.ml
 ocamllex lexer_midl.mll
 129 states, 1747 transitions, table size 7762 bytes
 ocamlc -g -c lexer_midl.mli
 ocamlc -g -c lexer_midl.ml
 ocamlc -g -c parse.mli
 ocamlc -g -c parse.ml
 ocamlc -g -c fixlabels.mli
 ocamlc -g -c fixlabels.ml
 ocamlc -g -c normalize.mli
 ocamlc -g -c normalize.ml
 ocamlc -g -c main.ml
 ocamlc -g -o camlidl config.cmo utils.cmo clflags.cmo prefix.cmo lexpr.cmo cvttyp.cmo variables.cmo idlarray.cmo struct.cmo enum.cmo union.cmo cvtval.cmo structdecl.cmo enumdecl.cmo uniondecl.cmo typedef.cmo funct.cmo constdecl.cmo intf.cmo file.cmo predef.cmo linenum.cmo parse_aux.cmo parser_midl.cmo lexer_midl.cmo parse.cmo fixlabels.cmo normalize.cmo main.cmo
 make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.11/compiler'
 cd runtime; make all
 make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.11/runtime'
 ocamlc -g -ccopt "-Wall -g" idlalloc.c
 ocamlc -g -ccopt "-Wall -g" comintf.c
 ocamlc -g -ccopt "-Wall -g" comerror.c
 rm -f dllcamlidl.so
 ocamlmklib -o camlidl  idlalloc.o comintf.o comerror.o
 make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.11/runtime'
 cd lib; make all
 make[1]: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.11/lib'
 ocamlc -g -c com.mli
 ocamlc -g -c com.ml
 ocamlc -g -a -o com.cma -dllib -lcamlidl -cclib -lcamlidl com.cmo
 ocamlopt -c com.ml
 make[1]: ocamlopt: No such file or directory
 make[1]: *** [Makefile:42: com.cmx] Error 127
 make[1]: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/camlidl.1.11/lib'
 make: *** [Makefile:20: all] Error 2
```