### PR TITLE
Add package Topiary in version 0.2.1

### DIFF
--- a/packages/topiary/topiary.0.2.1/opam
+++ b/packages/topiary/topiary.0.2.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+
+maintainer: "hello@tweag.io"
+authors: [ "Tweag" ]
+
+homepage: "https://github.com/tweag/topiary"
+bug-reports: "https://github.com/tweag/topiary/issues"
+dev-repo: "git+https://github.com/tweag/topiary.git"
+
+license: "MIT"
+depends: ["conf-rust-2021"]
+
+build:[
+  [ "cargo" "build"
+      "--release"
+      "--package" "topiary-cli" ]
+  [ "sh" "make-topiary-wrapper.sh"
+      "--language-dir" "%{share}%/topiary/languages"
+      "--topiary-wrapped" "%{bin}%/.topiary-wrapped"
+      "--output-file" "topiary-wrapper" ]
+]
+
+install: [
+  [ "cp" "target/release/topiary" "%{bin}%/.topiary-wrapped" ]
+  [ "cp" "topiary-wrapper" "%{bin}%/topiary" ]
+  [ "mkdir" "%{share}%/topiary" ]
+  [ "cp" "-R" "topiary/languages" "%{share}%/topiary/languages" ]
+]
+
+synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+
+url {
+  src: "https://github.com/tweag/topiary-opam/releases/download/v0.2.1/source-code-with-submodules.tar.xz"
+  checksum: [
+    "md5=2fda078cd730f390e30573fbfe9f5df0"
+    "sha512=263efd04e3c331bdb6a569d68dd4f1df91d8aede561e0ba018deb92208c33e205fdae90aeced282c91f9eae2b58fe13b45732b01d11c6d35a261c25a9380f86f"
+  ]
+}


### PR DESCRIPTION
This is only a tiny release to fix the printing of the version number by Topiary. Still, if we want to follow all the versions in OPAM, here it comes.

- Project web page: https://topiary.tweag.io/
- Project repository: https://github.com/tweag/topiary
- Changelog: https://github.com/tweag/topiary/blob/v0.2.1/CHANGELOG.md
- For context: https://github.com/ocaml/opam-repository/pull/23771