### PR TITLE
[new release] kcas_data and kcas (0.5.1)

### DIFF
--- a/packages/kcas/kcas.0.5.1/opam
+++ b/packages/kcas/kcas.0.5.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Software transactional memory based on lock-free multi-word compare-and-set"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.5.1/kcas-0.5.1.tbz"
+  checksum: [
+    "sha256=741b79a4ff6d7493ddb1112c38fc2d8e136b47511e7b9c5d323b6f733c871ce6"
+    "sha512=c7ef92a36d422f997f14519bae89f2eb2229469a9864389d8386caabf740cb9c149ac00e9aedde0726920a6f63ab86ed26ae04b7fe4a933e97fba2cf24a55c81"
+  ]
+}
+x-commit-hash: "0413e9bc3a37e328cbe119ba4df938d72332ba27"

--- a/packages/kcas_data/kcas_data.0.5.1/opam
+++ b/packages/kcas_data/kcas_data.0.5.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Compositional lock-free data structures and primitives for communication and synchronization"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.5.1/kcas-0.5.1.tbz"
+  checksum: [
+    "sha256=741b79a4ff6d7493ddb1112c38fc2d8e136b47511e7b9c5d323b6f733c871ce6"
+    "sha512=c7ef92a36d422f997f14519bae89f2eb2229469a9864389d8386caabf740cb9c149ac00e9aedde0726920a6f63ab86ed26ae04b7fe4a933e97fba2cf24a55c81"
+  ]
+}
+x-commit-hash: "0413e9bc3a37e328cbe119ba4df938d72332ba27"


### PR DESCRIPTION
Compositional lock-free data structures and primitives for communication and synchronization

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.5.1

- Add synchronizing variable `Mvar` to `kcas_data` (@polytypic)
- Fix to allow retry from within `Xt.update` and `Xt.modify` (@polytypic)
