### PR TITLE
[new release] xapi-stdext-zerocheck, xapi-stdext-unix, xapi-stdext-threads, xapi-stdext-std, xapi-stdext-pervasives, xapi-stdext-encodings and xapi-stdext-date (4.22.0)

### DIFF
--- a/packages/xapi-stdext-date/xapi-stdext-date.4.22.0/opam
+++ b/packages/xapi-stdext-date/xapi-stdext-date.4.22.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Dates"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "alcotest" {with-test}
+  "astring"
+  "base-unix"
+  "ptime"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.22.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.22.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Encodings"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "alcotest" {>= "0.6.0" & with-test}
+  "bechamel" { with-test}
+  "bechamel-notty" { with-test}
+  "notty" { with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.22.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.22.0/opam
@@ -28,6 +28,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: arch != "arm32" & arch != "x86_32"
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 url {
   src:

--- a/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.22.0/opam
+++ b/packages/xapi-stdext-encodings/xapi-stdext-encodings.4.22.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/xapi-project/stdext"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml"
+  "ocaml" {>="4.13.0"}
   "alcotest" {>= "0.6.0" & with-test}
   "bechamel" { with-test}
   "bechamel-notty" { with-test}

--- a/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.22.0/opam
+++ b/packages/xapi-stdext-pervasives/xapi-stdext-pervasives.4.22.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Pervasives"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.08"}
+  "logs"
+  "odoc" {with-doc}
+  "xapi-backtrace"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.22.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.22.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/xapi-project/stdext"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml"
+  "ocaml" {>="4.08.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]

--- a/packages/xapi-stdext-std/xapi-stdext-std.4.22.0/opam
+++ b/packages/xapi-stdext-std/xapi-stdext-std.4.22.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Stdlib"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"

--- a/packages/xapi-stdext-threads/xapi-stdext-threads.4.22.0/opam
+++ b/packages/xapi-stdext-threads/xapi-stdext-threads.4.22.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Threads"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "base-threads"
+  "base-unix"
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.19.0/opam
@@ -27,6 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 url {
   src:

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.20.0/opam
@@ -27,6 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 url {
   src:

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.21.0/opam
@@ -28,6 +28,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 url {
   src:

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/xapi-project/stdext"
 bug-reports: "https://github.com/xapi-project/stdext/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml"
+  "ocaml" {>="4.12.0"}
   "base-unix"
   "fd-send-recv" {>= "2.0.0"}
   "odoc" {with-doc}

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Unix"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "base-unix"
+  "fd-send-recv" {>= "2.0.0"}
+  "odoc" {with-doc}
+  "xapi-stdext-pervasives" {= version}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"

--- a/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
+++ b/packages/xapi-stdext-unix/xapi-stdext-unix.4.22.0/opam
@@ -27,6 +27,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+depexts: ["linux-headers"] {os-distribution = "alpine"}
 dev-repo: "git+https://github.com/xapi-project/stdext.git"
 url {
   src:

--- a/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.22.0/opam
+++ b/packages/xapi-stdext-zerocheck/xapi-stdext-zerocheck.4.22.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Xapi's standard library extension, Zerocheck"
+maintainer: ["Xapi project maintainers"]
+authors: ["Jonathan Ludlam"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/xapi-project/stdext"
+bug-reports: "https://github.com/xapi-project/stdext/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/xapi-project/stdext.git"
+url {
+  src:
+    "https://github.com/xapi-project/stdext/releases/download/v4.22.0/xapi-stdext-4.22.0.tbz"
+  checksum: [
+    "sha256=928bf19dea4d38cf4e268d211958eb428a0ff3233a198a2aef074aefcb346039"
+    "sha512=033645b8ae3860a59c669c6b2d827acfea180aff75ca1466b63658ea9631693bbbb260ad88a7efca137d7c58364b7ee3d385dac77b516d38339b89cbaf7d0dbb"
+  ]
+}
+x-commit-hash: "059facbcd54b0da2f2df1de1bb3b5f728c6a35b7"


### PR DESCRIPTION
Xapi's standard library extension

- Project page: <a href="https://github.com/xapi-project/stdext">https://github.com/xapi-project/stdext</a>

##### CHANGES:

date, pervasive, std: remove deprecated code
    Optimize XML_UTF8.is_valid: avoid allocating an int32 for each unicode codepoint
