### PR TITLE
2 packages from c-cube/tiny_httpd at 0.13

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.13/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.13/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Minimal HTTP server using good old threads"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "base-threads"
+  "result"
+  "seq"
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+  "conf-libcurl" {with-test}
+  "qcheck-core" {with-test & >= "0.9" }
+  "ptime" {with-test}
+]
+tags: [ "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+post-messages: "tiny http server, with blocking IOs. Also ships with a `http_of_dir` program."
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.13.tar.gz"
+  checksum: [
+    "md5=74b50eb122ac51e59b794179dbaaee13"
+    "sha512=3c3043a176939dc3c95a3a5c2af007ecd32ffb8d211210e0c7ea0d1f61914446f28e60891029506e19c131d3ebd14cc532d581a592ace0130538f58de6e6d9ef"
+  ]
+}

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.13/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.13/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+authors: ["Simon Cruanes"]
+maintainer: "simon.cruanes.2007@m4x.org"
+license: "MIT"
+synopsis: "Interface to camlzip for tiny_httpd"
+build: [
+  ["dune" "build" "@install" "-p" name "-j" jobs]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "dune" { >= "2.0" }
+  "camlzip" {>= "1.06"}
+  "tiny_httpd" { = version }
+  "ocaml" { >= "4.04.0" }
+  "odoc" {with-doc}
+]
+tags: [ "http" "thread" "server" "gzip" "camlzip" ]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+doc: "https://c-cube.github.io/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src: "https://github.com/c-cube/tiny_httpd/archive/v0.13.tar.gz"
+  checksum: [
+    "md5=74b50eb122ac51e59b794179dbaaee13"
+    "sha512=3c3043a176939dc3c95a3a5c2af007ecd32ffb8d211210e0c7ea0d1f61914446f28e60891029506e19c131d3ebd14cc532d581a592ace0130538f58de6e6d9ef"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`tiny_httpd.0.13`: Minimal HTTP server using good old threads
-`tiny_httpd_camlzip.0.13`: Interface to camlzip for tiny_httpd



---
* Homepage: https://github.com/c-cube/tiny_httpd/
* Source repo: git+https://github.com/c-cube/tiny_httpd.git
* Bug tracker: https://github.com/c-cube/tiny_httpd/issues

---
:camel: Pull-request generated by opam-publish v2.0.3