### PR TITLE
8 packages from ocaml/opam at 2.1.5

### DIFF
--- a/packages/opam-client/opam-client.2.1.5/opam
+++ b/packages/opam-client/opam-client.2.1.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Client library for opam 2.1"
+description:
+  "Actions on the opam root, switches, installations, and front-end."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  ("base64" {>= "3.1.0"} | "base64" & "ocaml" {= "4.02.3"})
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "1.11.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-core/opam-core.2.1.5/opam
+++ b/packages/opam-core/opam-core.2.1.5/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Core library for opam 2.1"
+description:
+  "Small standard library extensions, and generic system interaction modules used by opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.9.0"}
+  "dune" {>= "1.11.0"}
+  "cppo" {build & >= "1.1.0"}
+]
+conflicts: ["extlib-compat"]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.1.5/opam
+++ b/packages/opam-devel/opam-devel.2.1.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Bootstrapped development binary for opam 2.1"
+description:
+  "This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-client" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.11.0"}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+post-messages:
+  """\
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-format/opam-format.2.1.5/opam
+++ b/packages/opam-format/opam-format.2.1.5/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Format library for opam 2.1"
+description: "Definition of opam datastructures and its file interface."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.1.4"}
+  "re" {>= "1.9.0"}
+  "dune" {>= "1.11.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.1.5/opam
+++ b/packages/opam-installer/opam-installer.2.1.5/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """\
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "1.11.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.1.5/opam
+++ b/packages/opam-repository/opam-repository.2.1.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Repository library for opam 2.1"
+description:
+  "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "dune" {>= "1.11.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.1.5/opam
+++ b/packages/opam-solver/opam-solver.2.1.5/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Solver library for opam 2.1"
+description:
+  "Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  ("dose3" {>= "6.1"} | "dose3" {>= "5"} & "ocaml" {= "4.02.3"})
+  "cudf" {>= "0.7"}
+  "dune" {>= "1.11.0"}
+]
+depopts: ["z3" "opam-0install-cudf"]
+conflicts: [
+  "z3" {< "4.8.4"}
+  "opam-0install-cudf" {< "0.4"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}

--- a/packages/opam-state/opam-state.2.1.5/opam
+++ b/packages/opam-state/opam-state.2.1.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "State library for opam 2.1"
+description:
+  "Handling of the ~/.opam hierarchy, repository and switch states."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "opam-repository" {= version}
+  "dune" {>= "1.11.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.1.5.tar.gz"
+  checksum: [
+    "md5=58f9fe5045c00c2a022a5b65d36be868"
+    "sha512=4395defe7df1d03ca889718b8eafd8161ff009710475f62673f19f012e0bde8ad2a919bd9d02d7f96b4c5a9bbf38e0ba9a256531c24de15cafabd4ef11f7c8e8"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-client.2.1.5`: Client library for opam 2.1
- `opam-core.2.1.5`: Core library for opam 2.1
- `opam-devel.2.1.5`: Bootstrapped development binary for opam 2.1
- `opam-format.2.1.5`: Format library for opam 2.1
- `opam-installer.2.1.5`: Installation of files to a prefix, following opam conventions
- `opam-repository.2.1.5`: Repository library for opam 2.1
- `opam-solver.2.1.5`: Solver library for opam 2.1
- `opam-state.2.1.5`: State library for opam 2.1



---
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.2.0