### PR TITLE
Prevent install ocamlformat-rpc using a dummy package

### DIFF
--- a/packages/ocamlformat-rpc/ocamlformat-rpc.removed/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.removed/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: []
+build: []
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+messages: [
+  "DEPRECATED. OCamlFormat ships the RPC mode by default since version 0.22.4. This package is not necessary." {installed}
+]
+conflicts: [
+  "ocamlformat" {< "0.22.4"}
+]

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.removed/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.removed/opam
@@ -11,7 +11,7 @@ build: []
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 messages: [
-  "DEPRECATED. OCamlFormat ships the RPC mode by default since version 0.22.4. This package is not necessary." {installed}
+  "DEPRECATED. OCamlFormat ships the RPC mode by default since version 0.22.4. This package is no longer necessary." {installed}
 ]
 conflicts: [
   "ocamlformat" {< "0.22.4"}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.removed/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.removed/opam
@@ -11,7 +11,7 @@ build: []
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
 license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
 messages: [
-  "DEPRECATED. OCamlFormat ships the RPC mode by default since version 0.22.4. This package is no longer necessary." {installed}
+  "The `ocamlformat` package ships the RPC mode since version 0.22.4. This package is no longer necessary." {installed}
 ]
 conflicts: [
   "ocamlformat" {< "0.22.4"}


### PR DESCRIPTION
The RPC feature is now part of the main `ocamlformat` package and this package is no longer useful.

This has been noticed in https://github.com/ocamllabs/vscode-ocaml-platform/issues/1094. Users are instructed to install the package, which has the effect of downgrading ocamlformat.

I initially planned to add a message:
```
The following actions will be performed:
  ∗ install   odoc-parser         1.0.1            [required by ocamlformat]
  ↘ downgrade ocaml-version       3.6.1 to 3.5.0   [required by ocamlformat]
  ↘ downgrade ocamlformat-rpc-lib 0.25.1 to 0.21.0
          [required by ocamlformat-rpc]
  ↻ recompile ocamlformat-lib     0.25.1           [uses ocaml-version]
  ↘ downgrade ocamlformat         0.25.1 to 0.21.0
          [required by ocamlformat-rpc]
  ∗ install   ocamlformat-rpc     0.21.0           
          DEPRECATED. This package is not needed and not compatible with
          OCamlFormat >= 0.22.4
===== ∗ 2   ↻ 1   ↘ 3 =====
Do you want to continue? [Y/n] 
```

But this message is not precise (`ocamlformat-rpc.0.21.0` is not deprecated and is useful in combination of `ocamlformat.0.21.0`, if someone wants to use that) and the unwanted outcome is not prevented (the downgrade).

This adds a new `ocamlformat-rpc` version compatible with `ocamlformat >= 0.22.4` that does not install anything and show an information message.

This prevents the default behavior of downgrading `ocamlformat`, which is not the intention:
```
The following actions will be performed:
∗ install ocamlformat-rpc removed  DEPRECATED. OCamlFormat ships the RPC mode by default since version
                                   0.22.4. This package is not necessary.

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
∗ installed ocamlformat-rpc.removed
Done.
```

Though the inverse workflow is not idea as it requires an explicit version constraint:
```
The following actions will be performed:
  ↗ upgrade ocamlformat     0.21.0 to 0.25.1
  ∗ install ocamlformat-rpc removed           DEPRECATED. OCamlFormat ships the RPC mode by default since version 0.22.4. This package is not necessary.
===== ∗ 1   ↗ 1 =====
Do you want to continue? [Y/n] 
```

