### PR TITLE
[new release] merlin, merlin-lib and dot-merlin-reader (4.9-414/500)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.6/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.6/opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.9.0"}
-  "merlin-lib" {>= "4.6"}
+  "merlin-lib" {>= "4.6" & < "4.9"}
   "ocamlfind" {>= "1.6.0"}
 ]
 description:

--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08" & < "6.0"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.9"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-414/merlin-4.9-414.tbz"
+  checksum: [
+    "sha256=e23fc47813591269ff9d27c820988e520a662c89dd0af7ea652b21517499cbfd"
+    "sha512=2199f963368597d10cc197e41ebb883f6a166018c9da3fe259c354550df41b713781003598a2fe5956b0a4ae96f8c07ba33831d3cf6f9d494b731944f87e491e"
+  ]
+}
+x-commit-hash: "df75a4550704c113ac29505fd68ef9b7893d4bf5"

--- a/packages/merlin-lib/merlin-lib.4.9-414/opam
+++ b/packages/merlin-lib/merlin-lib.4.9-414/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-414/merlin-4.9-414.tbz"
+  checksum: [
+    "sha256=e23fc47813591269ff9d27c820988e520a662c89dd0af7ea652b21517499cbfd"
+    "sha512=2199f963368597d10cc197e41ebb883f6a166018c9da3fe259c354550df41b713781003598a2fe5956b0a4ae96f8c07ba33831d3cf6f9d494b731944f87e491e"
+  ]
+}
+x-commit-hash: "df75a4550704c113ac29505fd68ef9b7893d4bf5"

--- a/packages/merlin-lib/merlin-lib.4.9-500/opam
+++ b/packages/merlin-lib/merlin-lib.4.9-500/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-500/merlin-4.9-500.tbz"
+  checksum: [
+    "sha256=b907c66b3a314f17251d28937e38e2fad289bfc30aa9174730f0ffc5f3199526"
+    "sha512=0ce829da06439aed378a1548538a0ecc5b8caa72bffd3b9ff7b70643ff4281306ba7e6de5b00559f93a8e5f5a4ee54c7177257a66fa6a90262ff3c405795ae38"
+  ]
+}
+x-commit-hash: "d203dd96b98079add79ae797ccec555c3b3750ac"

--- a/packages/merlin/merlin.4.9-414/opam
+++ b/packages/merlin/merlin.4.9-414/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.14" & < "4.15"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-414/merlin-4.9-414.tbz"
+  checksum: [
+    "sha256=e23fc47813591269ff9d27c820988e520a662c89dd0af7ea652b21517499cbfd"
+    "sha512=2199f963368597d10cc197e41ebb883f6a166018c9da3fe259c354550df41b713781003598a2fe5956b0a4ae96f8c07ba33831d3cf6f9d494b731944f87e491e"
+  ]
+}
+x-commit-hash: "df75a4550704c113ac29505fd68ef9b7893d4bf5"

--- a/packages/merlin/merlin.4.9-500/opam
+++ b/packages/merlin/merlin.4.9-500/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.0" & < "5.1"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-500/merlin-4.9-500.tbz"
+  checksum: [
+    "sha256=b907c66b3a314f17251d28937e38e2fad289bfc30aa9174730f0ffc5f3199526"
+    "sha512=0ce829da06439aed378a1548538a0ecc5b8caa72bffd3b9ff7b70643ff4281306ba7e6de5b00559f93a8e5f5a4ee54c7177257a66fa6a90262ff3c405795ae38"
+  ]
+}
+x-commit-hash: "d203dd96b98079add79ae797ccec555c3b3750ac"


### PR DESCRIPTION
CHANGES:

merlin 4.9
==========
Fri May 26 15:23:42 CEST 2023

  + merlin binary
    - Allow monadic IO in dot protocol (#1581)
    - Add a `scope` option to the `occurrences` command in preparation for
      the upcoming `project-wide-occurrences` feature (#1596)
    - Construct bool-typed holes as `false` instead of `true` in the
      `construct` command, for consistency (#1599).
    - Add a hook to configure system command for spawning ppxes when Merlin is
      used as a library. (#1585)
    - Implement an all-or-nothing cache for the PPX phase (#1584)
    - Cleanup functors caches when backtracking, to avoid memory leaks
      (#1609, fixes #1529 and ocaml-lsp#1032)
    - Fix `construct` results ordering for sum types sand poly variants (#1603)
    - Fix object method completion not working (#1606, fixes #1575)
    - Improve context detection for package types (#1608, fixes #1607)
    - Fix incorrect locations for string literals (#1574)
    - Fixed an issue that caused `errors` to erroneously alert about missing
      `cmi` files (#1577)
    - Prevent destruct from crashing on closed variant types (#1602,
      fixes #1601)
    - Improve longident parsing (#1612, fixes #945)
  + editor modes
    - emacs: call the user's configured completion UI in
      `merlin-construct` (#1598)
  + test suite
    - Add missing dependency to a test using ppxlib (#1583)
    - Add tests for the new PPX phase cache (#1584)
    - Add and update tests for `construct` ordering (#1603)