### PR TITLE
[new release] kcas_data and kcas (0.5.2)

### DIFF
--- a/packages/kcas/kcas.0.5.2/opam
+++ b/packages/kcas/kcas.0.5.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Software transactional memory based on lock-free multi-word compare-and-set"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.5.2/kcas-0.5.2.tbz"
+  checksum: [
+    "sha256=7a3a66cda019904d7f9e566ebdf65bad5fdf060049a589d236a31e7960bf7bbb"
+    "sha512=3dde56e72dbc7534b824739354d4799ea42ca67fd54715d5e808590d797228600f9942a4326a0237395b9d914e73838b2744d1d01b6d018a8fabac4ad8807805"
+  ]
+}
+x-commit-hash: "d168d206485e2ec22ef7ddd74c7d7797038e2b98"

--- a/packages/kcas_data/kcas_data.0.5.2/opam
+++ b/packages/kcas_data/kcas_data.0.5.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Compositional lock-free data structures and primitives for communication and synchronization"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "multicore-magic" {>= "1.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.5.2/kcas-0.5.2.tbz"
+  checksum: [
+    "sha256=7a3a66cda019904d7f9e566ebdf65bad5fdf060049a589d236a31e7960bf7bbb"
+    "sha512=3dde56e72dbc7534b824739354d4799ea42ca67fd54715d5e808590d797228600f9942a4326a0237395b9d914e73838b2744d1d01b6d018a8fabac4ad8807805"
+  ]
+}
+x-commit-hash: "d168d206485e2ec22ef7ddd74c7d7797038e2b98"


### PR DESCRIPTION
Compositional lock-free data structures and primitives for communication and synchronization

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.5.2

- Improve `Hashtbl` read-write performance and add `swap` (@polytypic)
- Avoid some unnecessary verifies of read-only CMP operations (@polytypic)
