### PR TITLE
nlopt: all current versions have naked pointers, incompatible with OCaml 5.0

### DIFF
--- a/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.4/opam
@@ -8,11 +8,15 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "ocaml" {< "4.06.0"}
+  "ocaml" {< "4.06.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "oasis" {build}
   "conf-nlopt"
+]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nppchecker"
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings to the NLOpt optimization library"

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5.1/opam
@@ -11,11 +11,15 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "ocaml" {>= "3.12"}
+  "ocaml" {>= "3.12" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "oasis" {build}
   "conf-nlopt"
+]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nppchecker"
 ]
 x-ci-accept-failures: [
   "centos-7" # Too old.. NLopt-devel only has libnlopt_cxx

--- a/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.5/opam
@@ -8,11 +8,15 @@ build: [
   ["ocaml" "setup.ml" "-build"]
 ]
 depends: [
-  "ocaml" {< "4.06.0"}
+  "ocaml" {< "4.06.0" & < "5.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "oasis" {build}
   "conf-nlopt"
+]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nppchecker"
 ]
 install: ["ocaml" "setup.ml" "-install"]
 synopsis: "OCaml bindings to the NLOpt optimization library"

--- a/packages/nlopt/nlopt.0.6.1/opam
+++ b/packages/nlopt/nlopt.0.6.1/opam
@@ -16,10 +16,14 @@ build: [ "dune" "build" "-p" name "-j" jobs
   "@doc" {with-doc}
 ]
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.0"}
   "dune" {>= "2.9"}
   "conf-nlopt"
   "odoc" {with-doc}
+]
+conflicts: [
+  "base-nnp"
+  "ocaml-option-nppchecker"
 ]
 url {
   src: "https://github.com/mkur/nlopt-ocaml/archive/refs/tags/release-0.6.1.tar.gz"


### PR DESCRIPTION
OCaml 4.14.1+nnpchecker says on `dune exec examples/tutorial.exe`:
```
Out-of-heap pointer at 0x7f5205a97c38 of value 0x1eb46c0 has non-black head (tag=33)
Out-of-heap pointer at 0x7f5205a97b58 of value 0x1eb45f0 has non-black head (tag=33)
Optimization status NLOPT_XTOL_REACHED
Constrained optimum x=0.333333 y=0.296296 f=0.544331

Out-of-heap pointers were detected by the runtime.
The process would otherwise have terminated normally.
```

And attempting to use this in OCaml 5 in a larger application eventually leads to C heap corruption.

There is a PR upstream to fix the C stubs, so I assume the next version will fix this:
https://github.com/mkur/nlopt-ocaml/pull/13

Meanwhile mark existing versions as incompatible to save others time tracking down the source of segfaults.