### PR TITLE
[new release] runtime_events_tools (0.4.0)

### DIFF
--- a/packages/runtime_events_tools/runtime_events_tools.0.4.0/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.4.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "5.0.0~"}
   "ocamlfind"
   "hdr_histogram"
-  "cmdliner"
+  "cmdliner" {>="1.2.0"}
   "tracing"
   "menhir" {with-test}
   "odoc" {with-doc}

--- a/packages/runtime_events_tools/runtime_events_tools.0.4.0/opam
+++ b/packages/runtime_events_tools/runtime_events_tools.0.4.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Tools for the runtime events tracing system in OCaml"
+description: "Various tools for the runtime events tracing system in OCaml"
+maintainer: ["Sadiq Jaffer" "KC Sivaramakrishnan" "Sudha Parimala"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/tarides/runtime_events_tools"
+bug-reports: "https://github.com/tarides/runtime_events_tools/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "5.0.0~"}
+  "ocamlfind"
+  "hdr_histogram"
+  "cmdliner"
+  "tracing"
+  "menhir" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/runtime_events_tools.git"
+url {
+  src:
+    "https://github.com/tarides/runtime_events_tools/releases/download/0.4.0/runtime_events_tools-0.4.0.tbz"
+  checksum: [
+    "sha256=4926bf40e8194da7eac524daaf09a32d2a5ded822f0e0fb6928bc47409f7afa0"
+    "sha512=791b534427d18f361734645e601b4ce981811b006bb5483b22104d3ebac9894497523931917ae9f4de4b6fdf8a4feeeaf16a68acb1846db0adea00803cd27874"
+  ]
+}
+x-commit-hash: "1ba3fd985d5f8a3247179d1487077a2aac097dbd"


### PR DESCRIPTION
Tools for the runtime events tracing system in OCaml

- Project page: <a href="https://github.com/tarides/runtime_events_tools">https://github.com/tarides/runtime_events_tools</a>

##### CHANGES:

* Fix dependencies (tarides/runtime_events_tools#14, @Sudha247)
* Improve JSON output produced by olly gc-stats (tarides/runtime_events_tools#13, @punchagan)
* Mention Fuchsia format in the README (tarides/runtime_events_tools#11, @Sudha247)
* Gc subcommand (tarides/runtime_events_tools#10, @Sudha247)
* Add Fuchsia Trace Format output to olly (tarides/runtime_events_tools#6, @tomjridge)
* Added --output option to redirect olly printing (tarides/runtime_events_tools#5, @ElectreAAS)
* Added json printing option (tarides/runtime_events_tools#4, @ElectreAAS)
