### PR TITLE
why3: fix bounds on conf-autoconf

### DIFF
--- a/packages/why3/why3.1.4.0/opam
+++ b/packages/why3/why3.1.4.0/opam
@@ -41,7 +41,7 @@ install: [
 ]
 
 depends: [
-  "conf-autoconf" {build & dev}
+  "conf-autoconf" {build | dev}
   "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}

--- a/packages/why3/why3.1.4.1/opam
+++ b/packages/why3/why3.1.4.1/opam
@@ -41,7 +41,7 @@ install: [
 ]
 
 depends: [
-  "conf-autoconf" {build & dev}
+  "conf-autoconf" {build | dev}
   "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}

--- a/packages/why3/why3.1.5.0/opam
+++ b/packages/why3/why3.1.5.0/opam
@@ -40,7 +40,7 @@ install: [
 ]
 
 depends: [
-  "conf-autoconf" {build & dev}
+  "conf-autoconf" {build | dev}
   "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}

--- a/packages/why3/why3.1.5.1/opam
+++ b/packages/why3/why3.1.5.1/opam
@@ -40,7 +40,7 @@ install: [
 ]
 
 depends: [
-  "conf-autoconf" {build & dev}
+  "conf-autoconf" {build | dev}
   "ocaml" {>= "4.05.0" & < "5.0~"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}

--- a/packages/why3/why3.1.6.0/opam
+++ b/packages/why3/why3.1.6.0/opam
@@ -52,7 +52,7 @@ install: [
 ]
 
 depends: [
-  "conf-autoconf" {build & dev}
+  "conf-autoconf" {build | dev}
   "ocaml" {>= "4.08.0"}
   "ocamlfind" {build}
   "menhir" {>= "20170418"}


### PR DESCRIPTION
It is needed for all builds:
```
=== ERROR while compiling why3.1.4.0 =========================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/why3.1.4.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build make -j255 all opt byte
 exit-code            2
 env-file             ~/.opam/log/why3-7-1cafc8.env
 output-file          ~/.opam/log/why3-7-1cafc8.out
 Ocamldep src/trywhy3/worker_proto.ml
 Ocamldep src/trywhy3/why3_worker.ml
 Ocamldep src/trywhy3/trywhy3.ml
 Ocamldep src/trywhy3/shortener.ml
 Ocamldep src/trywhy3/bindings.ml
 Ocamldep src/trywhy3/alt_ergo_worker.ml
 Ocamllex src/why3doc/doc_lexer.mll
 autoconf -f
 make: autoconf: No such file or directory
```