### PR TITLE
mesh-triangle is not compatible with ocaml 5

### DIFF
--- a/packages/mesh-triangle/mesh-triangle.0.9.5/opam
+++ b/packages/mesh-triangle/mesh-triangle.0.9.5/opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0"}
   "dune"
   "base-bigarray"
   "base-bytes"


### PR DESCRIPTION
Fails with:
```
=== ERROR while compiling mesh-triangle.0.9.5 ================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/mesh-triangle.0.9.5
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p mesh-triangle -j 255
 exit-code            1
 env-file             ~/.opam/log/mesh-triangle-7-bda4c4.env
 output-file          ~/.opam/log/mesh-triangle-7-bda4c4.out
 File "triangle/dune", line 7, characters 10-27:
 7 |  (c_names libtriangle_stubs)
               ^^^^^^^^^^^^^^^^^
[...]
libtriangle_stubs.c:64:35: error: invalid type argument of '->' (have 'int')
    64 | #define VEC_OF_BA(ba) ((REAL *) ba->data)
       |                                   ^~
 triangulate_stub.c:42:27: note: in expansion of macro 'VEC_OF_BA'
    42 |     in.trianglearealist = VEC_OF_BA(Bigarray_val(triangle_area));
       |                           ^~~~~~~~~
[...]
libtriangle_stubs.c:19:14: error: 'BIGARRAY_FLOAT64' undeclared (first use in this function)
    19 | #define PREC BIGARRAY_FLOAT64
       |              ^~~~~~~~~~~~~~~~
 triangulate_stub.c:101:24: note: in expansion of macro 'PREC'
   101 |   vba = alloc_bigarray(PREC | LAYOUT | BIGARRAY_MANAGED,
       |                        ^~~~
[...]
```