### PR TITLE
[new release] merlin, merlin-lib and dot-merlin-reader (4.9-501preview)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.4.9-501preview/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.4.9-501preview/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.0" & < "6.0" }
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {>= "4.9"}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-501preview/merlin-4.9-501preview.tbz"
+  checksum: [
+    "sha256=815adb67854b611830646de59c6b10a827c53284a9bd0513585ee138d4818983"
+    "sha512=a2c5af7b9240bc44ffe2dcfc60466598d6447dac4754fdc93e684c80c43bcbcb8f5e86e291423daccc986242c1558af1ffa70cd5973150bf2920bbd29b8f9533"
+  ]
+}
+x-commit-hash: "d8eeaf265880340d6af4e04346d3b5ca318a0452"

--- a/packages/merlin-lib/merlin-lib.4.9-501preview/opam
+++ b/packages/merlin-lib/merlin-lib.4.9-501preview/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "csexp" {>= "1.5.1"}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-501preview/merlin-4.9-501preview.tbz"
+  checksum: [
+    "sha256=815adb67854b611830646de59c6b10a827c53284a9bd0513585ee138d4818983"
+    "sha512=a2c5af7b9240bc44ffe2dcfc60466598d6447dac4754fdc93e684c80c43bcbcb8f5e86e291423daccc986242c1558af1ffa70cd5973150bf2920bbd29b8f9533"
+  ]
+}
+x-commit-hash: "d8eeaf265880340d6af4e04346d3b5ca318a0452"

--- a/packages/merlin/merlin.4.9-501preview/opam
+++ b/packages/merlin/merlin.4.9-501preview/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.1" & < "5.2"}
+  "dune" {>= "2.9.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {>= "4.9"}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)))
+
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v4.9-501preview/merlin-4.9-501preview.tbz"
+  checksum: [
+    "sha256=815adb67854b611830646de59c6b10a827c53284a9bd0513585ee138d4818983"
+    "sha512=a2c5af7b9240bc44ffe2dcfc60466598d6447dac4754fdc93e684c80c43bcbcb8f5e86e291423daccc986242c1558af1ffa70cd5973150bf2920bbd29b8f9533"
+  ]
+}
+x-commit-hash: "d8eeaf265880340d6af4e04346d3b5ca318a0452"


### PR DESCRIPTION
Editor helper, provides completion, typing and source browsing in Vim and Emacs

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

unreleased

  + merlin binary
    - Preview support for OCaml 5.1-alpha1. Short path is temporary disabled and
      inline records might not behave as expected.
    - Allow monadic IO in dot protocol (ocaml/merlin#1581)
    - Add a `scope` option to the `occurrences` command in preparation for
      the upcoming `project-wide-occurrences` feature (ocaml/merlin#1596)
    - Construct bool-typed holes as `false` instead of `true` in the
      `construct` command, for consistency (ocaml/merlin#1599).
    - Add a hook to configure system command for spawning ppxes when Merlin is
      used as a library. (ocaml/merlin#1585)
    - Implement an all-or-nothing cache for the PPX phase (ocaml/merlin#1584)
    - Cleanup functors caches when backtracking, to avoid memory leaks
      (ocaml/merlin#1609, fixes ocaml/merlin#1529 and ocaml-lsp#1032)
    - Fix `construct` results ordering for sum types sand poly variants (ocaml/merlin#1603)
    - Fix object method completion not working (ocaml/merlin#1606, fixes ocaml/merlin#1575)
    - Improve context detection for package types (ocaml/merlin#1608, fixes ocaml/merlin#1607)
    - Fix incorrect locations for string literals (ocaml/merlin#1574)
    - Fixed an issue that caused `errors` to erroneously alert about missing
      `cmi` files (ocaml/merlin#1577)
    - Prevent destruct from crashing on closed variant types (ocaml/merlin#1602,
      fixes ocaml/merlin#1601)
    - Improve longident parsing (ocaml/merlin#1612, fixes ocaml/merlin#945)
  + editor modes
    - emacs: call the user's configured completion UI in
      `merlin-construct` (ocaml/merlin#1598)
  + test suite
    - Add missing dependency to a test using ppxlib (ocaml/merlin#1583)
    - Add tests for the new PPX phase cache (ocaml/merlin#1584)
    - Add and update tests for `construct` ordering (ocaml/merlin#1603)
