### PR TITLE
Use `?full_index=1` when referencing GitHub commits

### DIFF
--- a/packages/graphics/graphics.4.08.0/opam
+++ b/packages/graphics/graphics.4.08.0/opam
@@ -32,7 +32,7 @@ url {
 }
 extra-source "5bb4b7b8caba64e34553c3dbb53caf3954d1648c.patch" {
   src:
-    "https://github.com/ocaml/ocaml/commit/5bb4b7b8caba64e34553c3dbb53caf3954d1648c.patch"
-  checksum: "md5=2ad2f8ff3fbbfb2cd8f5f8968933e3af"
+    "https://github.com/ocaml/ocaml/commit/5bb4b7b8caba64e34553c3dbb53caf3954d1648c.patch?full_index=1"
+  checksum: "md5=64edfb907f12d69b32b7165ee19f27fa"
 }
 patches: ["5bb4b7b8caba64e34553c3dbb53caf3954d1648c.patch"]

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.0/opam
@@ -50,6 +50,6 @@ extra-source "fix-binutils.patch" {
 }
 available: arch != "arm64" & arch != "arm32" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/c90c2c8cf371faab293ff557868dfbda631518e7.patch"
-  checksum: "sha256=598079968ca4073ee670300e70b1e8345c53442eab8ab18d10d222f367be2474"
+  src: "https://github.com/ocaml/ocaml/commit/c90c2c8cf371faab293ff557868dfbda631518e7.patch?full_index=1"
+  checksum: "sha256=2d0a94ee460ba5c3ea19f8641e17a64b40e521d3adc97707b248977fdef97c5d"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.3.12.1/opam
@@ -43,6 +43,6 @@ url {
 available: arch != "arm64" & arch != "arm32" & arch != "ppc64"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/c90c2c8cf371faab293ff557868dfbda631518e7.patch"
-  checksum: "sha256=598079968ca4073ee670300e70b1e8345c53442eab8ab18d10d222f367be2474"
+  src: "https://github.com/ocaml/ocaml/commit/c90c2c8cf371faab293ff557868dfbda631518e7.patch?full_index=1"
+  checksum: "sha256=2d0a94ee460ba5c3ea19f8641e17a64b40e521d3adc97707b248977fdef97c5d"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.0/opam
@@ -36,6 +36,6 @@ patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
 extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
 available: arch != "arm64" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.00.1/opam
@@ -45,6 +45,6 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
 extra-files: ["fix-gcc10.patch" "md5=eb8555e57846757138861e14d2665ed1"]
 available: arch != "arm64" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.01.0/opam
@@ -57,6 +57,6 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
 extra-files: ["fix-gcc10.patch" "md5=a5ee5f90499987223ca8c13896fa2c4c"]
 available: arch != "arm64" & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.0/opam
@@ -50,10 +50,10 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.1/opam
@@ -50,11 +50,11 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.2/opam
@@ -50,11 +50,11 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.02.3/opam
@@ -49,11 +49,11 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64") & arch != "ppc64"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }
 

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.03.0/opam
@@ -49,10 +49,10 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch"
-  checksum: "sha256=a26be6793dff23a03ea9ab464b94eef802c2d08161de563564f6dd77e9f8bc6f"
+  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch?full_index=1"
+  checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.0/opam
@@ -49,10 +49,10 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.1/opam
@@ -49,10 +49,10 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.04.2/opam
@@ -49,10 +49,10 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.05.0/opam
@@ -49,10 +49,10 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.0/opam
@@ -47,6 +47,6 @@ patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=c9198adfe0c9d8e7e299b4f4fef5dfc5"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.06.1/opam
@@ -47,6 +47,6 @@ patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=171b510547baa777839b2ad50608a3ee"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.0/opam
@@ -56,6 +56,6 @@ patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=b054fa6b6651763edc8e16b6bc4c58f6"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.07.1/opam
@@ -56,6 +56,6 @@ patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.0/opam
@@ -47,6 +47,6 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.08.1/opam
@@ -47,6 +47,6 @@ extra-files: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.0/opam
@@ -47,6 +47,6 @@ post-messages: [
 ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.09.1/opam
@@ -47,6 +47,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.0/opam
@@ -44,6 +44,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.1/opam
@@ -44,6 +44,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.10.2/opam
@@ -43,6 +43,6 @@ post-messages: [
 ]
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.0/opam
@@ -44,6 +44,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.1/opam
@@ -44,6 +44,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.11.2/opam
@@ -44,6 +44,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.0/opam
@@ -43,6 +43,6 @@ post-messages: [
 ]
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
-  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch?full_index=1"
+  checksum: "sha256=7b23f163461d1ca7305a132edc5f014d5dc0d2b1027a34292043c7a3d1d43db9"
 }

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.12.1/opam
@@ -43,6 +43,6 @@ post-messages: [
 ]
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
-  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch?full_index=1"
+  checksum: "sha256=7b23f163461d1ca7305a132edc5f014d5dc0d2b1027a34292043c7a3d1d43db9"
 }

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1-1/opam
@@ -32,8 +32,8 @@ extra-files: [
   ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"]
 ]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 patches: [
   "0001-Don-t-build-manpages-for-stdlib-docs.patch"

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.08.1/opam
@@ -31,8 +31,8 @@ extra-files: [
   ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"]
 ]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }
 patches: [
   "0001-Don-t-build-manpages-for-stdlib-docs.patch"

--- a/packages/ocaml-variants/ocaml-variants.4.00.0+debug-runtime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.0+debug-runtime/opam
@@ -54,6 +54,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+BER/opam
@@ -52,6 +52,6 @@ url {
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+PIC/opam
@@ -52,6 +52,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+debug-runtime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+debug-runtime/opam
@@ -62,6 +62,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-unix/opam
@@ -51,6 +51,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+mirage-xen/opam
@@ -51,6 +51,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+open-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+open-types/opam
@@ -43,6 +43,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+raspberrypi/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+raspberrypi/opam
@@ -32,8 +32,8 @@ url {
 }
 extra-source "dc0776f55108a20dad5a9c06188545dc08dbf462.patch" {
   src:
-    "https://github.com/avsm/ocaml/commit/dc0776f55108a20dad5a9c06188545dc08dbf462.patch"
-  checksum: "md5=630fe085f491f7215aa2161d4fa36852"
+    "https://github.com/avsm/ocaml/commit/dc0776f55108a20dad5a9c06188545dc08dbf462.patch?full_index=1"
+  checksum: "md5=233d09fd3be42232f129b8354a3dfe3b"
 }
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
@@ -49,6 +49,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.00.1+short-types/opam
@@ -42,6 +42,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.00"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch"
-  checksum: "sha256=d69cda3080a56318e0fb7d3cfedeab300ed8df7ee15ce086620730104eea8e0a"
+  src: "https://github.com/ocaml/ocaml/commit/60b0cdaf2519d881947af4175ac4c6ff68901be3.patch?full_index=1"
+  checksum: "sha256=bb0e0e736ecc55c9f8cd8f74ca00a920bfe46e4200b82c5a45da952053b374da"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+32bit/opam
@@ -66,6 +66,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+BER/opam
@@ -59,6 +59,6 @@ extra-source "bd7fa181cb64742c3b6cbb8ee13436554eb18cd7...fix-clang-build.diff" {
 }
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+PIC/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+armv6-freebsd/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+armv6-freebsd/opam
@@ -52,6 +52,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+fp/opam
@@ -68,6 +68,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+lsb/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+lsb/opam
@@ -82,6 +82,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl+static/opam
@@ -65,6 +65,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+musl/opam
@@ -56,6 +56,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+open-types/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+open-types/opam
@@ -51,6 +51,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.01.0+profile/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.01.0+profile/opam
@@ -65,6 +65,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.01"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch"
-  checksum: "sha256=f2842b946a954e5202bb35ca630536f076584cfa3efbcf62b36e7fb42117cc3d"
+  src: "https://github.com/ocaml/ocaml/commit/d111407bf4ff71171598d30825c8e59ed5f75fd6.patch?full_index=1"
+  checksum: "sha256=cadeb58478a5ca998fdfa54dc99fbb31235a0ce7689a740338a8fdb391e9b436"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+PIC/opam
@@ -53,10 +53,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.0+improved-errors/opam
@@ -52,10 +52,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+BER/opam
@@ -50,10 +50,10 @@ patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+PIC/opam
@@ -53,10 +53,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+fp/opam
@@ -61,6 +61,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits-ber/opam
@@ -39,10 +39,10 @@ patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+modular-implicits/opam
@@ -50,10 +50,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl+static/opam
@@ -65,10 +65,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.1+musl/opam
@@ -56,10 +56,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.2+improved-errors/opam
@@ -56,10 +56,10 @@ dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 patches: ["fix-gcc10.patch" "alt-signal-stack.patch" "gpr1330.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4afa0ebb0a06b65e95e4906e1dced628"] ]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+32bit/opam
@@ -74,6 +74,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+PIC/opam
@@ -53,10 +53,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch"
-  checksum: "sha256=a26be6793dff23a03ea9ab464b94eef802c2d08161de563564f6dd77e9f8bc6f"
+  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch?full_index=1"
+  checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-1/opam
@@ -58,10 +58,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+buckle-master/opam
@@ -57,10 +57,10 @@ dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 patches: ["fix-gcc10.patch" "alt-signal-stack.patch" "gpr1330.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=4516183897da9033f49dd291fa198b8c"] ]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+bytecode-only/opam
@@ -54,6 +54,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+curried-constr/opam
@@ -122,10 +122,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+fp/opam
@@ -61,6 +61,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl+static/opam
@@ -65,10 +65,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.02.3+musl/opam
@@ -56,10 +56,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.02"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch"
-  checksum: "sha256=7c8eb7554b35c64d21210406589e16dd1b991651c662230784e5ba9a5f5ce1e3"
+  src: "https://github.com/ocaml/ocaml/commit/9de2b77472aee18a94b41cff70caee27fb901225.patch?full_index=1"
+  checksum: "sha256=91841447cc2d11ebe67a078ace677a18f06432ebf15c4c6d5a09e04b67dd041a"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch"
-  checksum: "sha256=8856c05677a7d58e0c161c964dcf00ea4a86ab656a99de9ec4d94170fd902745"
+  src: "https://github.com/ocaml/ocaml/commit/bcc7a767279ff70518b3f4219cc0b9bffec7dd43.patch?full_index=1"
+  checksum: "sha256=594d4dd6c192fe77e9fc025674b51e3de74d70326b2e750a249a09eeded68716"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fPIC/opam
@@ -52,10 +52,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch"
-  checksum: "sha256=a26be6793dff23a03ea9ab464b94eef802c2d08161de563564f6dd77e9f8bc6f"
+  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch?full_index=1"
+  checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+flambda/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch"
-  checksum: "sha256=a26be6793dff23a03ea9ab464b94eef802c2d08161de563564f6dd77e9f8bc6f"
+  src: "https://github.com/ocaml/ocaml/commit/c204f07bfb20174f9e1c9ff586fb7b2f42b8bf18.patch?full_index=1"
+  checksum: "sha256=a82eee28f3d10161010283267322c5779fcb7077ead14287d7b9e436ac16b730"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp+flambda/opam
@@ -62,6 +62,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+fp/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.03.0+statistical-memprof/opam
@@ -54,6 +54,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.03"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch"
-  checksum: "sha256=db21341fae44be2f9a429985d3c2849e1d87a883ed456ea74a076145bb2d1482"
+  src: "https://github.com/ocaml/ocaml/commit/a8b2cc3b40f5269ce8525164ec2a63b35722b22b.patch?full_index=1"
+  checksum: "sha256=dea675165192cbac93aa89e43e22ad47f7e99b5ba118f27ad7e1846aa7a2a8d4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+BER/opam
@@ -51,10 +51,10 @@ patches: ["fix-gcc10.patch" "gpr1330.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=8b0606a5733be21ee8ae2a19ce67059e"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+afl/opam
@@ -54,10 +54,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+bytecode-only/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fPIC/opam
@@ -52,10 +52,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+flambda/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp+flambda/opam
@@ -62,6 +62,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+fp/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+safe-string/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.0+spacetime/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+bytecode-only/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+copatterns/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+copatterns/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fPIC/opam
@@ -52,10 +52,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+flambda/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp+flambda/opam
@@ -62,6 +62,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+fp/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+safe-string/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.1+spacetime/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+bytecode-only/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fPIC/opam
@@ -52,10 +52,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+flambda/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp+flambda/opam
@@ -62,6 +62,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+fp/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+safe-string/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+spacetime/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch"
-  checksum: "sha256=78f6fc49d1210d66db104ce10bcb4b55cfd84fe4adefdbb7af0310bd58baf51f"
+  src: "https://github.com/ocaml/ocaml/commit/db11f141a0e35c7fbaec419a33c4c39d199e2635.patch?full_index=1"
+  checksum: "sha256=ba3e0b48250e66a08eef0a5162bfdea2e20e3cdefd098ee38f345ae8e8175ff4"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.04.2+statistical-memprof/opam
@@ -58,6 +58,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.04"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch"
-  checksum: "sha256=81820e9caefabab28563730b992905a8afea74158d46b65ab1c355fe425642fa"
+  src: "https://github.com/ocaml/ocaml/commit/6bcff7e6ce1a43e088469278eb3a9341e6a2ca5b.patch?full_index=1"
+  checksum: "sha256=dc1e56a04f557c751c7e09b8d70247181842cfd99f235eff6e4d143c9d892925"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+afl/opam
@@ -54,10 +54,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+bytecode-only/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+flambda/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+lto/opam
@@ -56,10 +56,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+flambda/opam
@@ -58,10 +58,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+musl+static+flambda/opam
@@ -67,10 +67,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+safe-string/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+spacetime/opam
@@ -55,10 +55,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }
 extra-source "gpr1330.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch"
-  checksum: "sha256=6971ca549352fc56be9cb4fe37e19bdc5ed871c013a5e394658c946aa54ed51c"
+  src: "https://github.com/ocaml/ocaml/commit/b00000c6679804731692362b0baac27fa3fddfd5.patch?full_index=1"
+  checksum: "sha256=e319f67b687499b7bdc3511eee0046dff7d81678c4d6fe4c760494d25c66af3e"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.05.0+statistical-memprof/opam
@@ -43,6 +43,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.05"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch"
-  checksum: "sha256=b4feab3494104d2da017ae46aaf5257d3f87fee60cfedcf022f40b23f3a40127"
+  src: "https://github.com/ocaml/ocaml/commit/50c2d1275e537906ea144bd557fde31e0bf16e5f.patch?full_index=1"
+  checksum: "sha256=22f9244e4d91c2a939594b79c41707acd75a4fc7c63feb0cb5528b43949844f8"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+afl/opam
@@ -54,6 +54,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+bytecode-only/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+default-unsafe-string/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda+no-flat-float-array/opam
@@ -63,6 +63,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+flambda/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+force-safe-string/opam
@@ -54,6 +54,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp+flambda/opam
@@ -62,6 +62,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+fp/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+flambda/opam
@@ -58,6 +58,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+musl+static+flambda/opam
@@ -67,6 +67,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+no-flat-float-array/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+spacetime/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.0+statistical-memprof/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+32bit/opam
@@ -73,6 +73,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+afl/opam
@@ -54,6 +54,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+bytecode-only/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+default-unsafe-string/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+flambda/opam
@@ -55,6 +55,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+force-safe-string/opam
@@ -54,6 +54,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp+flambda/opam
@@ -63,6 +63,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+fp/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+lto/opam
@@ -58,6 +58,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+flambda/opam
@@ -58,6 +58,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+musl+static+flambda/opam
@@ -67,6 +67,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-flat-float-array/opam
@@ -60,6 +60,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+no-naked-pointers+flambda/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+rescript/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+rescript/opam
@@ -59,6 +59,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+statistical-memprof/opam
@@ -57,6 +57,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.06.1+termux/opam
@@ -57,6 +57,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.06"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch"
-  checksum: "sha256=be16234f213207c9f5c52919d3e13d5ba38ca1cf6b1dba24a7d9baf59de8560b"
+  src: "https://github.com/ocaml/ocaml/commit/137a4ad167f25fe1bee792977ed89f30d19bcd74.patch?full_index=1"
+  checksum: "sha256=c0c1c64bed4cc2413be21ce8bfe52bb9caff4d1bcd7e7a72f9bcb113c231bc91"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+32bit/opam
@@ -82,6 +82,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+afl/opam
@@ -63,6 +63,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+bytecode-only/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+default-unsafe-string/opam
@@ -69,6 +69,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda+no-flat-float-array/opam
@@ -72,6 +72,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+flambda/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+force-safe-string/opam
@@ -63,6 +63,6 @@ homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp+flambda/opam
@@ -71,6 +71,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+fp/opam
@@ -69,6 +69,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+no-flat-float-array/opam
@@ -70,6 +70,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.0+spacetime/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+32bit/opam
@@ -82,6 +82,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+BER/opam
@@ -60,6 +60,6 @@ patches: ["fix-gcc10.patch" "alt-signal-stack.patch"]
 extra-files: [ ["fix-gcc10.patch" "md5=7f467849e5a4714f49a11517b187184f"] ]
 available: !(os = "macos" & arch = "arm64")
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+afl/opam
@@ -63,6 +63,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+bytecode-only/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+default-unsafe-string/opam
@@ -70,6 +70,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda+no-flat-float-array/opam
@@ -72,6 +72,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+flambda/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+force-safe-string/opam
@@ -65,6 +65,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp+flambda/opam
@@ -72,6 +72,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+fp/opam
@@ -69,6 +69,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+flambda/opam
@@ -69,6 +69,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+musl+static+flambda/opam
@@ -78,6 +78,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+no-flat-float-array/opam
@@ -70,6 +70,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+spacetime/opam
@@ -64,6 +64,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.07.1+statistical-memprof/opam
@@ -63,6 +63,6 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://ocaml.org"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.07"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch"
-  checksum: "sha256=179b30d63da15feb4afee40e6fe11cc8981cf3769361d3b5a06befa9945af212"
+  src: "https://github.com/ocaml/ocaml/commit/00b8c4d503732343d5d01761ad09650fe50ff3a0.patch?full_index=1"
+  checksum: "sha256=80e7d6be30d75f69199908101b513ed0ee525f702ff7d4f9b15b53d646f7f0c6"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+32bit/opam
@@ -55,6 +55,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+afl/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+bytecode-only/opam
@@ -45,6 +45,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+default-unsafe-string/opam
@@ -47,6 +47,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda+no-flat-float-array/opam
@@ -49,6 +49,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+flambda/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+force-safe-string/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp+flambda/opam
@@ -49,6 +49,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+fp/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+flambda/opam
@@ -50,6 +50,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+musl+static+flambda/opam
@@ -57,6 +57,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+no-flat-float-array/opam
@@ -47,6 +47,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.0+spacetime/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=f406119ae0091835cdf158d7d0ff53f7"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+32bit/opam
@@ -58,6 +58,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+afl/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+bytecode-only/opam
@@ -45,6 +45,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+default-unsafe-string/opam
@@ -47,6 +47,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda+no-flat-float-array/opam
@@ -49,6 +49,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+flambda/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+force-safe-string/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp+flambda/opam
@@ -49,6 +49,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+fp/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+flambda/opam
@@ -54,6 +54,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+musl+static+flambda/opam
@@ -57,6 +57,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+no-flat-float-array/opam
@@ -47,6 +47,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.08.1+spacetime/opam
@@ -46,6 +46,6 @@ extra-files: [ ["fix-gcc10.patch" "md5=17ecd696a8f5647a4c543280599f6974"] ]
 available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch"
-  checksum: "sha256=16ad0b9a6f901dd26aa64ff8708a3f24d36237cbf4b34d9eb68a88ed00b96cf3"
+  src: "https://github.com/ocaml/ocaml/commit/17df117b4939486d3285031900587afce5262c8c.patch?full_index=1"
+  checksum: "sha256=92d747e6a9edffbe178d7c356a271c34f1c9e7597548ae8d6defc0815c56315a"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+32bit/opam
@@ -57,6 +57,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+afl/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+bytecode-only/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+default-unsafe-string/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda+no-flat-float-array/opam
@@ -48,6 +48,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+flambda/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+force-safe-string/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp+flambda/opam
@@ -48,6 +48,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+fp/opam
@@ -45,6 +45,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+flambda/opam
@@ -52,6 +52,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+musl+static+flambda/opam
@@ -55,6 +55,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+no-flat-float-array/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.0+spacetime/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+32bit/opam
@@ -57,8 +57,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl+flambda/opam
@@ -46,8 +46,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+afl/opam
@@ -45,8 +45,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+bytecode-only/opam
@@ -44,8 +44,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+default-unsafe-string/opam
@@ -46,8 +46,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda+no-flat-float-array/opam
@@ -48,8 +48,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+flambda/opam
@@ -45,8 +45,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+force-safe-string/opam
@@ -46,8 +46,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp+flambda/opam
@@ -48,8 +48,8 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+fp/opam
@@ -45,8 +45,8 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+flambda/opam
@@ -52,8 +52,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+musl+static+flambda/opam
@@ -55,8 +55,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+no-flat-float-array/opam
@@ -46,8 +46,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.09.1+spacetime/opam
@@ -45,8 +45,8 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch" "0001-Re-generate-configure.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch"
-  checksum: "sha256=a76506f98450971c954d9322344da592dbf1c38e5bca91ec75c4f9c2889ba637"
+  src: "https://github.com/ocaml/ocaml/commit/8eed2e441222588dc385a98ae8bd6f5820eb0223.patch?full_index=1"
+  checksum: "sha256=86c02c75580da678ad0b0647ece043661be471a72751e8b49e674d17b9f17206"
 }
 extra-files: [
   ["0001-Re-generate-configure.patch" "md5=3e01b702dcdce9e5fc41f7eb66290501"]

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+32bit/opam
@@ -57,6 +57,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+afl/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+bytecode-only/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+default-unsafe-string/opam
@@ -51,6 +51,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda+no-flat-float-array/opam
@@ -48,6 +48,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+flambda/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp+flambda/opam
@@ -48,6 +48,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+fp/opam
@@ -45,6 +45,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+flambda/opam
@@ -52,6 +52,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+musl+static+flambda/opam
@@ -55,6 +55,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+nnpcheck/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+no-flat-float-array/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.0+spacetime/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+32bit/opam
@@ -57,6 +57,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+afl/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+bytecode-only/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+default-unsafe-string/opam
@@ -51,6 +51,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda+no-flat-float-array/opam
@@ -48,6 +48,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+flambda/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp+flambda/opam
@@ -48,6 +48,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+fp/opam
@@ -45,6 +45,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+flambda/opam
@@ -52,6 +52,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+musl+static+flambda/opam
@@ -55,6 +55,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+no-flat-float-array/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.1+spacetime/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+32bit/opam
@@ -56,6 +56,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+afl/opam
@@ -44,6 +44,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+bytecode-only/opam
@@ -43,6 +43,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+default-unsafe-string/opam
@@ -50,6 +50,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda+no-flat-float-array/opam
@@ -47,6 +47,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+flambda/opam
@@ -44,6 +44,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp+flambda/opam
@@ -48,6 +48,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+fp/opam
@@ -45,6 +45,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+flambda/opam
@@ -51,6 +51,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+musl+static+flambda/opam
@@ -54,6 +54,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+no-flat-float-array/opam
@@ -45,6 +45,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+rescript/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+rescript/opam
@@ -45,6 +45,6 @@ post-messages: [
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.10.2+spacetime/opam
@@ -44,6 +44,6 @@ post-messages: [
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch"
-  checksum: "sha256=793f0c092b560d6f944fc3caf382f40017969e37e4fddde366437d7554e00b82"
+  src: "https://github.com/ocaml/ocaml/commit/4b4c643d1d5d28738f6d900cd902851ed9dc5364.patch?full_index=1"
+  checksum: "sha256=355fa7bd55ce5646db1365b116082aee31f9b466f0ffc27723f5971d03c14a53"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+32bit/opam
@@ -57,6 +57,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+afl/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+bytecode-only/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+default-unsafe-string/opam
@@ -51,6 +51,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda+no-flat-float-array/opam
@@ -48,6 +48,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+flambda/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp+flambda/opam
@@ -48,6 +48,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+fp/opam
@@ -45,6 +45,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+flambda/opam
@@ -52,6 +52,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+musl+static+flambda/opam
@@ -55,6 +55,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+no-flat-float-array/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.0+spacetime/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+32bit/opam
@@ -57,6 +57,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER+flambda/opam
@@ -52,6 +52,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+BER/opam
@@ -51,6 +51,6 @@ post-messages: [
 available: !(os = "macos" & arch = "arm64")
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+afl/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+bytecode-only/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+default-unsafe-string/opam
@@ -51,6 +51,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda+no-flat-float-array/opam
@@ -48,6 +48,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+flambda/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp+flambda/opam
@@ -48,6 +48,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+fp/opam
@@ -45,6 +45,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+flambda/opam
@@ -52,6 +52,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+musl+static+flambda/opam
@@ -55,6 +55,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+no-flat-float-array/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.1+spacetime/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+32bit/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+32bit/opam
@@ -57,6 +57,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+afl/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+afl/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+bytecode-only/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+bytecode-only/opam
@@ -44,6 +44,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+default-unsafe-string/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+default-unsafe-string/opam
@@ -51,6 +51,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+flambda+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+flambda+no-flat-float-array/opam
@@ -48,6 +48,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+flambda/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+fp+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+fp+flambda/opam
@@ -48,6 +48,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+fp/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+fp/opam
@@ -45,6 +45,6 @@ available: os = "linux" & arch = "x86_64"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+musl+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+musl+flambda/opam
@@ -52,6 +52,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+musl+static+flambda/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+musl+static+flambda/opam
@@ -55,6 +55,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+no-flat-float-array/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+no-flat-float-array/opam
@@ -46,6 +46,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.11.2+spacetime/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.11.2+spacetime/opam
@@ -45,6 +45,6 @@ available: !(os = "macos" & arch = "arm64")
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch"
-  checksum: "sha256=7563fcc6f931b5b20269ac2b3f14a0f336fe87dbdb6b2c6a0de181aed019a39d"
+  src: "https://github.com/ocaml/ocaml/commit/dd28ac0cf4365bd0ea1bcc374cbc5e95a6f39bea.patch?full_index=1"
+  checksum: "sha256=e94ff6043dbd47594599a7743b8e97080aef85a1541c5731c04494d19bdabaa7"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.0+options/opam
@@ -77,6 +77,6 @@ depopts: [
 ]
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
-  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch?full_index=1"
+  checksum: "sha256=7b23f163461d1ca7305a132edc5f014d5dc0d2b1027a34292043c7a3d1d43db9"
 }

--- a/packages/ocaml-variants/ocaml-variants.4.12.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.12.1+options/opam
@@ -77,6 +77,6 @@ depopts: [
 ]
 patches: ["alt-signal-stack.patch"]
 extra-source "alt-signal-stack.patch" {
-  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch"
-  checksum: "sha256=59de25b95409c1927c4b607fb4b1218ff7623fca45474448c8e114a42853e3ad"
+  src: "https://github.com/ocaml/ocaml/commit/1eeb0e7fe595f5f9e1ea1edbdf785ff3b49feeeb.patch?full_index=1"
+  checksum: "sha256=7b23f163461d1ca7305a132edc5f014d5dc0d2b1027a34292043c7a3d1d43db9"
 }


### PR DESCRIPTION
Fixes #23837. I've checked all affected packages in a container with `opam source`.