### PR TITLE
[new release] rescript-syntax, reactjs-jsx-ppx and melange (1.0.0)

### DIFF
--- a/packages/melange/melange.1.0.0/opam
+++ b/packages/melange/melange.1.0.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13.0"}
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "ounit" {with-test}
+  "reason" {with-test}
+  "ppxlib"
+  "menhir"
+  "reactjs-jsx-ppx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/1.0.0/melange-1.0.0.tbz"
+  checksum: [
+    "sha256=01ff3a2711b3812889313288f9e0c8bfe2e17464b6b85282c5113cfc3b740968"
+    "sha512=db9ac4554d0c9a8deabbdcd2ae05653964184916982c746ca794df6e2061444adaa6a0367bc1840825a007be3941643abd824aaff737a431b0e5347f7c558378"
+  ]
+}
+x-commit-hash: "c989a91761a9b1bcc8af80fb9653eab897360325"

--- a/packages/melange/melange.1.0.0/opam
+++ b/packages/melange/melange.1.0.0/opam
@@ -19,6 +19,7 @@ depends: [
   "reactjs-jsx-ppx" {with-test}
   "odoc" {with-doc}
 ]
+available: arch != "x86_32" & arch != "arm32"
 build: [
   ["dune" "subst"] {dev}
   [
@@ -29,7 +30,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/melange/melange.1.0.0/opam
+++ b/packages/melange/melange.1.0.0/opam
@@ -20,6 +20,9 @@ depends: [
   "odoc" {with-doc}
 ]
 available: arch != "x86_32" & arch != "arm32"
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/reactjs-jsx-ppx/reactjs-jsx-ppx.1.0.0/opam
+++ b/packages/reactjs-jsx-ppx/reactjs-jsx-ppx.1.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "ReactJS JSX PPX"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "ppxlib" {>= "0.28.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/1.0.0/melange-1.0.0.tbz"
+  checksum: [
+    "sha256=01ff3a2711b3812889313288f9e0c8bfe2e17464b6b85282c5113cfc3b740968"
+    "sha512=db9ac4554d0c9a8deabbdcd2ae05653964184916982c746ca794df6e2061444adaa6a0367bc1840825a007be3941643abd824aaff737a431b0e5347f7c558378"
+  ]
+}
+x-commit-hash: "c989a91761a9b1bcc8af80fb9653eab897360325"

--- a/packages/rescript-syntax/rescript-syntax.1.0.0/opam
+++ b/packages/rescript-syntax/rescript-syntax.1.0.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "ReScript syntax packaged as an opam library"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml"
+  "melange" {= version}
+  "ppxlib" {>= "0.28.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange.git"
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/1.0.0/melange-1.0.0.tbz"
+  checksum: [
+    "sha256=01ff3a2711b3812889313288f9e0c8bfe2e17464b6b85282c5113cfc3b740968"
+    "sha512=db9ac4554d0c9a8deabbdcd2ae05653964184916982c746ca794df6e2061444adaa6a0367bc1840825a007be3941643abd824aaff737a431b0e5347f7c558378"
+  ]
+}
+x-commit-hash: "c989a91761a9b1bcc8af80fb9653eab897360325"


### PR DESCRIPTION
ReScript syntax packaged as an opam library

- Project page: <a href="https://github.com/melange-re/melange">https://github.com/melange-re/melange</a>

##### CHANGES:

- melange: print an error message if `$MELANGELIB` is set to a directory that
  doesn't exist ([melange-re/melange#449](https://github.com/melange-re/melange/pull/449))
- melange: fix bug where `--bs-module-name` didn't always affect generated JS
  file casing ([melange-re/melange#446](https://github.com/melange-re/melange/pull/446))
- melange: fix bug where `-o output.js` didn't always write a JavaScript file
  ([melange-re/melange#454](https://github.com/melange-re/melange/pull/454))
- melange: remove the `-bs-read-cmi` flag in favor of the builtin
  `-intf-suffix` flag, standard in OCaml
  ([melange-re/melange#458](https://github.com/melange-re/melange/pull/458),
  [melange-re/melange#460](https://github.com/melange-re/melange/pull/460))
- melange: return an actionable error message when no output is specified
  with `-impl` / `-intf`
  ([melange-re/melange#465](https://github.com/melange-re/melange/pull/465),
  [melange-re/melange#466](https://github.com/melange-re/melange/pull/466))
- melange: use `Object.prototype.hasOwnProperty` in the `Caml_obj` runtime
  ([melange-re/melange#469](https://github.com/melange-re/melange/pull/469))
- melange: transform
  [`NonEscapeCharacter`](https://tc39.es/ecma262/#prod-NonEscapeCharacter)
  correctly in JS strings (those written using `{js|string here|js}`)
  ([melange-re/melange#469](https://github.com/melange-re/melange/pull/469))
- melange: define `MELANGE` conditional compilation variable
  ([melange-re/melange#472](https://github.com/melange-re/melange/pull/472))
- melange: Make `Pervasives` exactly match the `Stdlib` behavior
  ([melange-re/melange#476](https://github.com/melange-re/melange/pull/476))
- melange: fix unbound error when trying to use `Printexc.exn_slot_id`
  ([melange-re/melange#482](https://github.com/melange-re/melange/pull/482))
- melange: fix codegen issue accessing a nested module path that is also
  `include`d ([melange-re/melange#487](https://github.com/melange-re/melange/pull/487))
- melange: preserve the correct command-line order for load path directories
  ([melange-re/melange#492](https://github.com/melange-re/melange/pull/492))
- melange: respect the `-nostdlib` option; don't add stdlib / runtime to the
  load path in that case
  ([melange-re/melange#496](https://github.com/melange-re/melange/pull/496))
- melange: build the Melange runtime / stdlib / runtime tests with the dune
  integration ([melange-re/melange#493](https://github.com/melange-re/melange/pull/493)). Thus
  melange now requires Dune 3.8.
- melange: allow shadowing sub-modules of Stdlib in user projects
  ([melange-re/melange#512](https://github.com/melange-re/melange/pull/512))
- melange, reactjs-jsx-ppx: introduce a `reactjs-jsx-ppx` package, remove its
  dependency from melange
  ([melange-re/melange#517](https://github.com/melange-re/melange/pull/517))
- melange: remove the `--bs-jsx <version>` flag from `melc` now that
  `reactjs-jsx-ppx` is a separate package
  ([melange-re/melange#525](https://github.com/melange-re/melange/pull/525))
- melange: add `melpp` executable to preprocess `#if` conditionals with the
  melange parser ([melange-re/melange#539](https://github.com/melange-re/melange/pull/539))
- mel: delete the `mel` package. The dune integration is now the only
  officially supported workflow for orchestrating melange builds
  ([melange-re/melange#546](https://github.com/melange-re/melange/pull/546))
- melange: Extract `melange.ppx` from the melange package. This preprocessing
  step interprets extensions such as `%bs.obj`, `%bs.raw`, `%bs.re`, etc.
  ([melange-re/melange#534](https://github.com/melange-re/melange/pull/534))
- melange: allow installing melange in more OCaml versions and compiler
  switches. Melange now migrates binary AST to the version it understands
  ([melange-re/melange#548](https://github.com/melange-re/melange/pull/548))
- melange: don't run anonymous args function from
  `[@@@bs.config {flags = [| ... |]}]` attributes
  ([melange-re/melange#554](https://github.com/melange-re/melange/pull/554))
- melange: add `--preamble` flag to add a preamble to emitted JS. An example is
  `"use client";` in React Server Components, which needs to appear before
  imports ([melange-re/melange#545](https://github.com/melange-re/melange/pull/545),
  [melange-re/melange#574](https://github.com/melange-re/melange/pull/574))
- melange: turn off warning 20 (`ignore-extra-argument`) by default. This
  warning is rarely useful in Melange due to false positives when invoking
  functions defined with `%bs.raw`
  ([melange-re/melange#488](https://github.com/melange-re/melange/pull/488),
  [melange-re/melange#576](https://github.com/melange-re/melange/pull/576))
