### PR TITLE
Fix for building capnproto on opensuse-tumbleweed.

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.2/opam
+++ b/packages/conf-capnproto/conf-capnproto.2/opam
@@ -23,6 +23,7 @@ depexts: [
   ["capnp"] {os-distribution = "homebrew" & os = "macos"}
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
   ["capnproto" "libcapnp-devel"] {os-family = "suse"}
+  ["capnproto" "libcapnp-devel"] {os-family = "opensuse"}
   ["capnproto"] {os = "freebsd"}
 ]
 x-ci-accept-failures: [


### PR DESCRIPTION
Fixes #23851 