### PR TITLE
stdcompat >= 12 needs autoconf

### DIFF
--- a/packages/stdcompat/stdcompat.12/opam
+++ b/packages/stdcompat/stdcompat.12/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.07" & < "4.11.0"}
 ]
-depopts: ["result" "seq" "uchar" "ocamlfind"]
+depopts: ["result" "seq" "uchar" "ocamlfind" "conf-autoconf"]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/stdcompat/stdcompat.13/opam
+++ b/packages/stdcompat/stdcompat.13/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.07" & < "4.11.0"}
 ]
-depopts: ["result" "seq" "uchar" "ocamlfind"]
+depopts: ["result" "seq" "uchar" "ocamlfind" "conf-autoconf"]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make]

--- a/packages/stdcompat/stdcompat.14/opam
+++ b/packages/stdcompat/stdcompat.14/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.07" & < "4.12.0"}
 ]
-depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+depopts: [ "result" "seq" "uchar" "ocamlfind" "conf-autoconf" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "all" "test" {with-test}]

--- a/packages/stdcompat/stdcompat.15/opam
+++ b/packages/stdcompat/stdcompat.15/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.08" & < "5.0"}
 ]
-depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+depopts: [ "result" "seq" "uchar" "ocamlfind" "conf-autoconf" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "all" "test" {with-test}]

--- a/packages/stdcompat/stdcompat.16/opam
+++ b/packages/stdcompat/stdcompat.16/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.08" & < "5.0"}
 ]
-depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+depopts: [ "result" "seq" "uchar" "ocamlfind" "conf-autoconf" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "all" "test" {with-test}]

--- a/packages/stdcompat/stdcompat.17/opam
+++ b/packages/stdcompat/stdcompat.17/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.08" & < "5.0"}
 ]
-depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+depopts: [ "result" "seq" "uchar" "ocamlfind" "conf-autoconf" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "all" "test" {with-test}]

--- a/packages/stdcompat/stdcompat.18/opam
+++ b/packages/stdcompat/stdcompat.18/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/thierry-martinez/stdcompat/issues"
 depends: [
   "ocaml" {>= "3.08" & < "5.0"}
 ]
-depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+depopts: [ "result" "seq" "uchar" "ocamlfind" "conf-autoconf" ]
 build: [
   ["./configure" "--prefix=%{prefix}%"]
   [make "all" "test" {with-test}]

--- a/packages/stdcompat/stdcompat.19/opam
+++ b/packages/stdcompat/stdcompat.19/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "3.07"}
   "dune" {>= "2.0"}
 ]
-depopts: [ "result" "seq" "uchar" "ocamlfind" ]
+depopts: [ "result" "seq" "uchar" "ocamlfind" "conf-autoconf" ]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Otherwise it can fail with
```
=== ERROR while compiling stdcompat.18 =======================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/stdcompat.18
 command              ~/.opam/opam-init/hooks/sandbox.sh build make all
 exit-code            2
 env-file             ~/.opam/log/stdcompat-7-e9acad.env
 output-file          ~/.opam/log/stdcompat-7-e9acad.out
 CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/bash /home/opam/.opam/4.14/.opam-switch/build/stdcompat.18/missing autoconf
 /home/opam/.opam/4.14/.opam-switch/build/stdcompat.18/missing: line 81: autoconf: command not found
 WARNING: 'autoconf' is missing on your system.
          You should only need it if you modified 'configure.ac',
          or m4 files included by it.
          The 'autoconf' program is part of the GNU Autoconf package:
          <http://www.gnu.org/software/autoconf/>
          It also requires GNU m4 and Perl in order to run:
          <http://www.gnu.org/software/m4/>
          <http://www.perl.org/>
 Makefile:1792: .depend: No such file or directory
 make: *** [Makefile:921: configure] Error 127
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>