### PR TITLE
mparser 1.2.1 is not compatible with ocaml 5.0

### DIFF
--- a/packages/mparser/mparser.1.2.1/opam
+++ b/packages/mparser/mparser.1.2.1/opam
@@ -6,7 +6,7 @@ license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 dev-repo: "git://https://github.com/cakeplus/mparser"
 bug-reports: "https://github.com/cakeplus/mparser/issues"
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0"}
   "base-bytes"
   "ocamlfind" {build}
   "ocamlbuild" {build}


### PR DESCRIPTION
Fails with:
```
=== ERROR while compiling mparser.1.2.1 ======================================#
 context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
 path                 ~/.opam/5.0/.opam-switch/build/mparser.1.2.1
 command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure --prefix /home/opam/.opam/5.0 --disable-re --disable-pcre
 exit-code            2
 env-file             ~/.opam/log/mparser-7-78c128.env
 output-file          ~/.opam/log/mparser-7-78c128.out
 File "./setup.ml", line 581, characters 4-15:
 581 |     Stream.from next
           ^^^^^^^^^^^
 Error: Unbound module Stream
```
Signed-off-by: Marcello Seri <marcello.seri@gmail.com>