### PR TITLE
Relax metrics-unix constraint on mtime

### DIFF
--- a/packages/metrics-unix/metrics-unix.0.4.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.4"}
   "uuidm" {>= "0.9.6"}
   "metrics" {= version}
-  "mtime" {>= "1.0.0" & < "1.4.0"}
+  "mtime" {>= "1.0.0"}
   "lwt" {>= "2.4.7"}
   "metrics-lwt" {= version & with-test}
   "conf-gnuplot"


### PR DESCRIPTION
I think this constraint can be removed, I tried it out locally and metrics-unix only makes use of `Mtime_clock.elapsed_ns`, `Mtime_clock.now` and `Mtime.to_uint64_ns` which I believe are all unchanged across versions of Mtime.