### PR TITLE
2 packages from imandra-ai/ocaml-tracy at 0.1

### DIFF
--- a/packages/tracy-client/tracy-client.0.1/opam
+++ b/packages/tracy-client/tracy-client.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis:
+  "Actual bindings to the Tracy profiler (v0.9.1), implements `tracy`"
+maintainer: ["Simon Cruanes"]
+authors: ["Bartosz Taudul" "Simon Cruanes"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/imandra-ai/ocaml-tracy"
+bug-reports: "https://github.com/imandra-ai/ocaml-tracy/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "ocaml" {>= "4.08"}
+  "tracy" {= version}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/imandra-ai/ocaml-tracy/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=058fabf7e450ad3e074ab438d05a452b"
+    "sha512=9c154f054ab31a7dfbd158b3d65b7967176bd06970e4c87377faf3dff6c8c90eb1cf4d9de70bf0d6421f292f1c5d489279263f500ca1e4d1638db6e965b43baf"
+  ]
+}

--- a/packages/tracy/tracy.0.1/opam
+++ b/packages/tracy/tracy.0.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis:
+  "Virtual package for the Tracy profiler https://github.com/wolfpld/tracy"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/imandra-ai/ocaml-tracy"
+bug-reports: "https://github.com/imandra-ai/ocaml-tracy/issues"
+depends: [
+  "dune" {>= "2.6"}
+  "ocaml" {>= "4.08"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://github.com/imandra-ai/ocaml-tracy/archive/v0.1.tar.gz"
+  checksum: [
+    "md5=058fabf7e450ad3e074ab438d05a452b"
+    "sha512=9c154f054ab31a7dfbd158b3d65b7967176bd06970e4c87377faf3dff6c8c90eb1cf4d9de70bf0d6421f292f1c5d489279263f500ca1e4d1638db6e965b43baf"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`tracy.0.1`: Virtual package for the Tracy profiler https://github.com/wolfpld/tracy
-`tracy-client.0.1`: Actual bindings to the Tracy profiler (v0.9.1), implements `tracy`



---
* Homepage: https://github.com/imandra-ai/ocaml-tracy
* Bug tracker: https://github.com/imandra-ai/ocaml-tracy/issues

---
:camel: Pull-request generated by opam-publish v2.0.3