### PR TITLE
[new release] ssl (0.6.0)

### DIFF
--- a/packages/ssl/ssl.0.6.0/opam
+++ b/packages/ssl/ssl.0.6.0/opam
@@ -13,7 +13,7 @@ run-test: [
 ]
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {>= "2.0.7"}
+  "dune" {>= "2.7"}
   "dune-configurator"
   "base-unix"
   "conf-libssl"

--- a/packages/ssl/ssl.0.6.0/opam
+++ b/packages/ssl/ssl.0.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {>= "2.0.7"}
+  "dune-configurator"
+  "base-unix"
+  "conf-libssl"
+  "alcotest" {with-test}
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+synopsis: "Bindings for OpenSSL"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+url {
+  src:
+    "https://github.com/savonet/ocaml-ssl/releases/download/0.6.0/ssl-0.6.0.tbz"
+  checksum: [
+    "sha256=8194a3838ca0f4c41ad52cd9578734a7299b716672c0839980e779534579314f"
+    "sha512=63306cc3622e0e6a03956f5366628ee0d9c79a103f1fb732a49b110ccd9c17a87b0fc9cdc73bb6aa8abe95880cb93e2493003289a4983ea6742ac478313c0f61"
+  ]
+}
+x-commit-hash: "5aa2402c1288c0734481c95aef3a9cf47e8e7100"

--- a/packages/ssl/ssl.0.6.0/opam
+++ b/packages/ssl/ssl.0.6.0/opam
@@ -8,9 +8,6 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
-run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs]
-]
 depends: [
   "ocaml" {>= "4.02.0"}
   "dune" {>= "2.7"}


### PR DESCRIPTION
Bindings for OpenSSL

- Project page: <a href="https://github.com/savonet/ocaml-ssl">https://github.com/savonet/ocaml-ssl</a>

##### CHANGES:

- Raise an error when `Ssl.flush` isn't successful (savonet/ocaml-ssl#104, savonet/ocaml-ssl#120)
- Add an API-compatible `Ssl.Runtime_lock` module. The functions in this module
  don't release the OCaml runtime lock. While they don't allow other OCaml
  threads to run concurrently, they don't perform any copying in the underlying
  data, leading certain workloads to be faster than their counterparts that
  release the lock. (savonet/ocaml-ssl#106)
- Guarantee `Ssl.output_string` writes the whole string by retrying the
  operation with unwritten bytes (savonet/ocaml-ssl#103, savonet/ocaml-ssl#116)
- Fix calls in C stubs that need to call `ERR_clear_error` before the underlying
  OpenSSL call (savonet/ocaml-ssl#118)
- Add a module `Ssl.Error` to retrieve OpenSSL errors in a structured way (savonet/ocaml-ssl#119)
- Deprecate Ssl.{SSLv23,SSLv3,TLSv1,TLSv1_1}, which were were formally
  deprecated in March 2021 and earlier (savonet/ocaml-ssl#115).
