### PR TITLE
[new release] eio_windows, eio_posix, eio_main, eio_linux and eio (0.10)

### DIFF
--- a/packages/eio-ssl/eio-ssl.0.1.1/opam
+++ b/packages/eio-ssl/eio-ssl.0.1.1/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "5.0"}
   "ssl" {>= "0.5.13"}
   "eio_main" {>= "0.7"}
+  "eio" {<"0.10"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio/eio.0.10/opam
+++ b/packages/eio/eio.0.10/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "5.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.2.0" & with-test}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-base-compiler" {< "5.0.0~beta1"}
+  "ocaml-variants" {< "5.0.0~beta1"}
+  "ocaml-system" {< "5.0.0~beta1"}
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.10/eio-0.10.tbz"
+  checksum: [
+    "sha256=390f7814507b8133d6c25e3a67a742d731c7ca66252b287b1fb0e3ad4d10eecc"
+    "sha512=9c0c9088b178df9799aaae9deb803a802228f1329cbe452479c90e80a13985d9c364ea86ee14e4e759133940f9f6065c7e8ece509d176fb1e347c5320f00a494"
+  ]
+}
+x-commit-hash: "687ebf99a6ab10ce5d85f4a3335d8e2e94c2b875"

--- a/packages/eio_linux/eio_linux.0.10/opam
+++ b/packages/eio_linux/eio_linux.0.10/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.2.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.10/eio-0.10.tbz"
+  checksum: [
+    "sha256=390f7814507b8133d6c25e3a67a742d731c7ca66252b287b1fb0e3ad4d10eecc"
+    "sha512=9c0c9088b178df9799aaae9deb803a802228f1329cbe452479c90e80a13985d9c364ea86ee14e4e759133940f9f6065c7e8ece509d176fb1e347c5320f00a494"
+  ]
+}
+x-commit-hash: "687ebf99a6ab10ce5d85f4a3335d8e2e94c2b875"

--- a/packages/eio_main/eio_main.0.10/opam
+++ b/packages/eio_main/eio_main.0.10/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "mdx" {>= "2.2.0" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux" {= version & os = "linux"}
+  "eio_posix" {= version & os-family != "windows"}
+  "eio_windows" {= version & os-family = "windows"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.10/eio-0.10.tbz"
+  checksum: [
+    "sha256=390f7814507b8133d6c25e3a67a742d731c7ca66252b287b1fb0e3ad4d10eecc"
+    "sha512=9c0c9088b178df9799aaae9deb803a802228f1329cbe452479c90e80a13985d9c364ea86ee14e4e759133940f9f6065c7e8ece509d176fb1e347c5320f00a494"
+  ]
+}
+x-commit-hash: "687ebf99a6ab10ce5d85f4a3335d8e2e94c2b875"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/eio_posix/eio_posix.0.10/opam
+++ b/packages/eio_posix/eio_posix.0.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.2.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.10/eio-0.10.tbz"
+  checksum: [
+    "sha256=390f7814507b8133d6c25e3a67a742d731c7ca66252b287b1fb0e3ad4d10eecc"
+    "sha512=9c0c9088b178df9799aaae9deb803a802228f1329cbe452479c90e80a13985d9c364ea86ee14e4e759133940f9f6065c7e8ece509d176fb1e347c5320f00a494"
+  ]
+}
+x-commit-hash: "687ebf99a6ab10ce5d85f4a3335d8e2e94c2b875"

--- a/packages/eio_windows/eio_windows.0.10/opam
+++ b/packages/eio_windows/eio_windows.0.10/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "eio" {= version}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.10/eio-0.10.tbz"
+  checksum: [
+    "sha256=390f7814507b8133d6c25e3a67a742d731c7ca66252b287b1fb0e3ad4d10eecc"
+    "sha512=9c0c9088b178df9799aaae9deb803a802228f1329cbe452479c90e80a13985d9c364ea86ee14e4e759133940f9f6065c7e8ece509d176fb1e347c5320f00a494"
+  ]
+}
+x-commit-hash: "687ebf99a6ab10ce5d85f4a3335d8e2e94c2b875"
+available: [os-family = "windows"]

--- a/packages/geojsone/geojsone.0.1.0/opam
+++ b/packages/geojsone/geojsone.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "mdx" {with-test}
   "ezjsonm" {with-test}
   "eio_main" {>= "0.6" & with-test}
-  "eio" {>= "0.6"}
+  "eio" {>= "0.6" & < "0.10"}
   "eio" {with-test & < "0.7"}
   "hex"
   "sexplib0"

--- a/packages/lwt_eio/lwt_eio.0.1/opam
+++ b/packages/lwt_eio/lwt_eio.0.1/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/talex5/lwt_eio/issues"
 depends: [
   "ocaml"
   "dune" {>= "2.9"}
-  "eio"
+  "eio" {< "0.10"}
   "lwt"
   "mdx" {>= "1.10.0" & with-test}
   "eio_main" {with-test}

--- a/packages/rawlink-eio/rawlink-eio.2.1/opam
+++ b/packages/rawlink-eio/rawlink-eio.2.1/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "dune" {>= "3.2"}
   "rawlink" {>= "2.1"}
-  "eio" {>= "0.4"}
+  "eio" {>= "0.4" & <"0.10"}
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}

--- a/packages/tls-eio/tls-eio.0.15.4/opam
+++ b/packages/tls-eio/tls-eio.0.15.4/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
   "x509" {>= "0.15.0"}
-  "eio" {>= "0.5"}
+  "eio" {>= "0.5" & <"0.10"}
   "eio_main" {>= "0.5" with-test}
   "mdx" {with-test}
 ]

--- a/packages/tls-eio/tls-eio.0.15.5/opam
+++ b/packages/tls-eio/tls-eio.0.15.5/opam
@@ -20,7 +20,7 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "mirage-crypto-rng-eio" {>= "0.8.0" with-test}
   "x509" {>= "0.15.0"}
-  "eio" {>= "0.6"}
+  "eio" {>= "0.6" & <"0.10"}
   "eio_main" {>= "0.6" with-test}
   "mdx" {with-test}
 ]

--- a/packages/topojsone/topojsone.0.1.0/opam
+++ b/packages/topojsone/topojsone.0.1.0/opam
@@ -15,6 +15,7 @@ depends: [
   "mdx" {>= "1.10.0" & with-test}
   "alcotest" {with-test}
   "ezjsonm" {with-test}
+  "eio" {>="0.7" & <"0.10"}
   "eio_main" {>= "0.7" & with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Eio

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features / API changes:

- Add `Eio.Process` for cross-platform subprocess support (@patricoferris @talex5 [#499](https://github.com/ocaml-multicore/eio/issues/499), reviewed by @anmonteiro @avsm @haesbaert).

- Add `Eio_unix.Net module` (@talex5 [#516](https://github.com/ocaml-multicore/eio/issues/516), reviewed by @avsm).  
  The Unix network APIs have been cleaned up and moved here, and some missing datagram operations have been added.
  `send` now takes an iovec, not just a single buffer.

- Add support for domain local await (@polytypic @talex5 [#494](https://github.com/ocaml-multicore/eio/issues/494) [#503](https://github.com/ocaml-multicore/eio/issues/503)).  
  Allows sharing e.g. kcas data-structures across Eio and Domainslib domains.

- Add initial eio_windows backend (@patricoferris @talex5 [#497](https://github.com/ocaml-multicore/eio/issues/497) [#530](https://github.com/ocaml-multicore/eio/issues/530) [#511](https://github.com/ocaml-multicore/eio/issues/511) [#523](https://github.com/ocaml-multicore/eio/issues/523) [#509](https://github.com/ocaml-multicore/eio/issues/509), reviewed by @avsm @polytypic).  

- Remove eio_luv backend (@talex5 [#485](https://github.com/ocaml-multicore/eio/issues/485)).  
  It was only used on Windows, and has been replaced by eio_windows.

- Unify `Eio_linux.FD` and `Eio_posix.Fd` as `Eio_unix.Fd` (@talex5 [#491](https://github.com/ocaml-multicore/eio/issues/491)).  
  Now that eio_luv is gone, there is no need for different backends to have different types for wrapped file descriptors.

- Move `Eio.Stdenv.t` to `Eio_unix.Stdenv.base` (@talex5 [#498](https://github.com/ocaml-multicore/eio/issues/498)).  
  Note that the rest of `Eio.Stdenv` is still there; only the definition of a full Unix-like environment has moved.

- Deprecation cleanups (@talex5 [#508](https://github.com/ocaml-multicore/eio/issues/508)).  
  Removed some APIs that were already marked as deprecated in Eio 0.8.

Bug fixes:

- eio_linux: fall back to `fork` if `clone3` is unavailable (@talex5 [#524](https://github.com/ocaml-multicore/eio/issues/524), reported by @smondet, reviewed by @avsm).  
  Docker's default security policy blocks `clone3`.

- Don't call `accept_fork`'s error handler on cancellation (@talex5 [#520](https://github.com/ocaml-multicore/eio/issues/520)).  
  This isn't an error and should not be reported.

- Fix `eio_unix_is_blocking` C stub (@patricoferris [#505](https://github.com/ocaml-multicore/eio/issues/505), reviewed by @talex5).

- Fix `Condition.await bug` when cancelling (@polytypic @talex5 [#487](https://github.com/ocaml-multicore/eio/issues/487)).

- Buf_write: fix flush returning too early (@talex5 [#539](https://github.com/ocaml-multicore/eio/issues/539), reported by @cometkim).

- Ignore `ENOTCONN` errors on socket shutdown (@avsm [#533](https://github.com/ocaml-multicore/eio/issues/533), reported by @patricoferris, reviewed by @talex5).

Documentation:

- Link to developer meetings information (@talex5 @Sudha247 [#515](https://github.com/ocaml-multicore/eio/issues/515)).

- Adopt OCaml Code of Conduct (@Sudha247 [#501](https://github.com/ocaml-multicore/eio/issues/501)).

- Add README links to Meio and Lambda Capabilities blog post (@talex5 [#496](https://github.com/ocaml-multicore/eio/issues/496)).

- Document mirage `Ipaddr` conversion (@RyanGibb @patricoferris @talex5 [#492](https://github.com/ocaml-multicore/eio/issues/492)).

- Document how to use Domainslib from Eio (@talex5 [#489](https://github.com/ocaml-multicore/eio/issues/489), reviewed by @polytypic @patricoferris).

Other changes:

- Run benchmarks with current-bench (@Sudha247 @talex5 [#500](https://github.com/ocaml-multicore/eio/issues/500)).

- Fix MDX tests on OCaml 5.1 (@talex5 [#526](https://github.com/ocaml-multicore/eio/issues/526)).

- Add stress test for spawning processes (@talex5 [#519](https://github.com/ocaml-multicore/eio/issues/519)).  
  This was an attempt to track down the https://github.com/ocaml/ocaml/issues/12253 signals bug.

- `Eio.Process.pp_status` should be polymorphic (@talex5 [#518](https://github.com/ocaml-multicore/eio/issues/518)).

- eio_posix: probe for existence of some flags (@talex5 [#507](https://github.com/ocaml-multicore/eio/issues/507), reported by @hannesm).  
  FreeBSD 12 didn't have `O_DSYNC`. Also, add `O_RESOLVE_BENEATH` and `O_PATH` if available.

- Fix race in ctf tests (@talex5 [#493](https://github.com/ocaml-multicore/eio/issues/493)).
