### PR TITLE
[new release] ssl (0.6.0)

### DIFF
--- a/packages/ssl/ssl.0.6.0/opam
+++ b/packages/ssl/ssl.0.6.0/opam
@@ -8,9 +8,6 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
-run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs]
-]
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.03.0"}

--- a/packages/ssl/ssl.0.6.0/opam
+++ b/packages/ssl/ssl.0.6.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+homepage: "https://github.com/savonet/ocaml-ssl"
+dev-repo: "git+https://github.com/savonet/ocaml-ssl.git"
+bug-reports: "https://github.com/savonet/ocaml-ssl/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.03.0"}
+  "dune-configurator"
+  "base-unix"
+  "conf-libssl"
+  "alcotest" {with-test}
+  "bisect_ppx" {dev & >= "2.5.0"}
+]
+synopsis: "Bindings for OpenSSL"
+authors: "Samuel Mimram <samuel.mimram@ens-lyon.org>"
+url {
+  src:
+    "https://github.com/savonet/ocaml-ssl/releases/download/0.6.0/ssl-0.6.0.tbz"
+  checksum: [
+    "sha256=39d1c8e69dbfdd4ea121bef52f8a30802e4baa556272ff1de43a66302960c051"
+    "sha512=8cd4a0d4efa947daaa98a55f3d1b7ef3533604f8b863c5f7cf3facfb7c9fafec9352c34d4cd86177294ecd499efb3f084e2afac9dc595451525c3cc214adb36f"
+  ]
+}
+x-commit-hash: "09c9ce9d28e4d592a4998b909bd1e5a524e84bd0"


### PR DESCRIPTION
Bindings for OpenSSL

- Project page: <a href="https://github.com/savonet/ocaml-ssl">https://github.com/savonet/ocaml-ssl</a>

##### CHANGES:

- Raise an error when `Ssl.flush` isn't successful (savonet/ocaml-ssl#104, savonet/ocaml-ssl#120)
- Add an API-compatible `Ssl.Runtime_lock` module. The functions in this module
  don't release the OCaml runtime lock. While they don't allow other OCaml
  threads to run concurrently, they don't perform any copying in the underlying
  data, leading certain workloads to be faster than their counterparts that
  release the lock. (savonet/ocaml-ssl#106)
- Guarantee `Ssl.output_string` writes the whole string by retrying the
  operation with unwritten bytes (savonet/ocaml-ssl#103, savonet/ocaml-ssl#116)
- Fix calls in C stubs that need to call `ERR_clear_error` before the underlying
  OpenSSL call (savonet/ocaml-ssl#118)
- Add a module `Ssl.Error` to retrieve OpenSSL errors in a structured way (savonet/ocaml-ssl#119)
- Deprecate Ssl.{SSLv23,SSLv3,TLSv1,TLSv1_1}, which were were formally
  deprecated in March 2021 and earlier (savonet/ocaml-ssl#115).
