### PR TITLE
[new release] syslog-message (1.2.0)

### DIFF
--- a/packages/syslog-message/syslog-message.1.2.0/opam
+++ b/packages/syslog-message/syslog-message.1.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Jochen Bartl <jochenbartl@mailbox.org>"
+authors: [ "Jochen Bartl <jochenbartl@mailbox.org>" ]
+homepage: "https://github.com/verbosemode/syslog-message"
+doc: "https://verbosemode.github.io/syslog-message/doc"
+dev-repo: "git+https://github.com/verbosemode/syslog-message.git"
+bug-reports: "https://github.com/verbosemode/syslog-message/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "ptime"
+  "qcheck" {with-test}
+]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+
+synopsis: "Syslog message parser"
+description: """
+This is a library for parsing and generating [RFC3164](https://tools.ietf.org/html/rfc3164)
+compatible Syslog messages.
+"""
+url {
+  src:
+    "https://github.com/verbosemode/syslog-message/releases/download/1.2.0/syslog-message-1.2.0.tbz"
+  checksum: [
+    "sha256=f9eca2bfa26f0b410ab371b5b39aa816d2b46d4e18838d401e0e4d73ac43f70d"
+    "sha512=7bcf7d6b8085614a440c67a655c90353f56a55a7e0888fc9a1e7b7dec7a84bb32d36324fd157fd70942b0d868cc85e19272e7700ccc68362e15b5d4b6df66993"
+  ]
+}
+x-commit-hash: "160d94f9e3e4972b53042c5bd7c32a3ce1656082"


### PR DESCRIPTION
Syslog message parser

- Project page: <a href="https://github.com/verbosemode/syslog-message">https://github.com/verbosemode/syslog-message</a>
- Documentation: <a href="https://verbosemode.github.io/syslog-message/doc">https://verbosemode.github.io/syslog-message/doc</a>

##### CHANGES:

* remove dependency on astring (verbosemode/syslog-message#28, @hannesm)
* use OCaml-CI (verbosemode/syslog-message#27, @Leonidas-from-XIV, @verbosemode)
* bump required dune version to 2.0
* raise lower bound to ocaml 4.08.0; remove rresult dependency (verbosemode/syslog-message#25, by @hannesm)
