### PR TITLE
add upper bounds to logs-syslog due to new syslog-message release 1.2.0

### DIFF
--- a/packages/logs-syslog/logs-syslog.0.2.0/opam
+++ b/packages/logs-syslog/logs-syslog.0.2.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "logs"
   "ptime"
-  "syslog-message" {>= "1.0.0"}
+  "syslog-message" {>= "1.0.0" & < "1.2.0"}
 ]
 
 depopts: [

--- a/packages/logs-syslog/logs-syslog.0.2.1/opam
+++ b/packages/logs-syslog/logs-syslog.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "logs"
   "ptime"
-  "syslog-message" {>= "1.0.0"}
+  "syslog-message" {>= "1.0.0" & < "1.2.0"}
 ]
 
 depopts: [

--- a/packages/logs-syslog/logs-syslog.0.2.2/opam
+++ b/packages/logs-syslog/logs-syslog.0.2.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "logs"
   "ptime"
-  "syslog-message" {>= "1.0.0"}
+  "syslog-message" {>= "1.0.0" & < "1.2.0"}
 ]
 
 depopts: [

--- a/packages/logs-syslog/logs-syslog.0.3.0/opam
+++ b/packages/logs-syslog/logs-syslog.0.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "logs"
   "ptime"
-  "syslog-message" {>= "1.0.0"}
+  "syslog-message" {>= "1.0.0" & < "1.2.0"}
 ]
 
 depopts: [

--- a/packages/logs-syslog/logs-syslog.0.3.1/opam
+++ b/packages/logs-syslog/logs-syslog.0.3.1/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "logs"
   "ptime"
-  "syslog-message" {>= "1.0.0"}
+  "syslog-message" {>= "1.0.0" & < "1.2.0"}
 ]
 
 depopts: [

--- a/packages/logs-syslog/logs-syslog.0.3.2/opam
+++ b/packages/logs-syslog/logs-syslog.0.3.2/opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "1.1.0"}
   "logs" {>= "0.5.0"}
   "ptime"
-  "syslog-message" {>= "1.0.0"}
+  "syslog-message" {>= "1.0.0" & < "1.2.0"}
 ]
 
 depopts: [


### PR DESCRIPTION
* syslog-message 1.2.0 drops astring support
* fix CI reverse dependency failures in #23870