### PR TITLE
mirage doesn't work with dune 3.8.0

### DIFF
--- a/packages/mirage/mirage.4.0.0/opam
+++ b/packages/mirage/mirage.4.0.0/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
+  "dune" {(>= "2.9.0" | (with-test & >= "3.0.0")) & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.0.0~beta1/opam
+++ b/packages/mirage/mirage.4.0.0~beta1/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.8.0"}
+  "dune" {>= "2.8.0" & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.0.0~beta2/opam
+++ b/packages/mirage/mirage.4.0.0~beta2/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.8.0"}
+  "dune" {>= "2.8.0" & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.0.0~beta3/opam
+++ b/packages/mirage/mirage.4.0.0~beta3/opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.8.0"}
+  "dune" {>= "2.8.0" & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.1.0/opam
+++ b/packages/mirage/mirage.4.1.0/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
+  "dune" {(>= "2.9.0" | (with-test & >= "3.0.0")) & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.1.1/opam
+++ b/packages/mirage/mirage.4.1.1/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
+  "dune" {(>= "2.9.0" | (with-test & >= "3.0.0")) & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.2.0/opam
+++ b/packages/mirage/mirage.4.2.0/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0" | (with-test & >= "3.0.0")}
+  "dune" {(>= "2.9.0" | (with-test & >= "3.0.0")) & < "3.8.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}
   "bos"

--- a/packages/mirage/mirage.4.2.1/opam
+++ b/packages/mirage/mirage.4.2.1/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.0/opam
+++ b/packages/mirage/mirage.4.3.0/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.1/opam
+++ b/packages/mirage/mirage.4.3.1/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.2/opam
+++ b/packages/mirage/mirage.4.3.2/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.3/opam
+++ b/packages/mirage/mirage.4.3.3/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.4/opam
+++ b/packages/mirage/mirage.4.3.4/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.5/opam
+++ b/packages/mirage/mirage.4.3.5/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}

--- a/packages/mirage/mirage.4.3.6/opam
+++ b/packages/mirage/mirage.4.3.6/opam
@@ -19,7 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9.0"}
+  "dune" {>= "2.9.0" & < "3.8.0"}
   "dune" {with-test & >= "3.0.0"}
   "ipaddr" {>= "5.0.0"}
   "functoria" {= version}


### PR DESCRIPTION
see https://github.com/ocaml/dune/issues/7875 for further information. The compilation of mirage itself works nicely, but cross-compiling a unikernel that somewhere uses ppx does not work at all.