### PR TITLE
Package monolith.20230604

### DIFF
--- a/packages/monolith/monolith.20230604/opam
+++ b/packages/monolith/monolith.20230604/opam
@@ -1,0 +1,29 @@
+
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/monolith"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/monolith.git"
+bug-reports: "francois.pottier@inria.fr"
+license: "LGPL-3.0-or-later"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.08" }
+  "dune" { >= "2.0" }
+  "afl-persistent" { >= "1.3" }
+  "pprint" { >= "20200410" }
+  "seq"
+]
+synopsis: "A framework for testing a library using afl-fuzz"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/monolith/-/archive/20230604/archive.tar.gz"
+  checksum: [
+    "md5=69c351419c24fc48f45164d7c053795b"
+    "sha512=1012f468fb3f199fe2ba8ddc8f1ec74a6bb634f5dca76b1df33cbe12e7ab627e25d48b23aa4d9d376f5185a0ea85ab35ff0e6a190a0ae125466aa26557fc21b3"
+  ]
+}


### PR DESCRIPTION
### `monolith.20230604`
A framework for testing a library using afl-fuzz



---
* Homepage: https://gitlab.inria.fr/fpottier/monolith
* Source repo: git+https://gitlab.inria.fr/fpottier/monolith.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.2.0