### PR TITLE
conf-fts: fix package name for alpine 3.17

### DIFF
--- a/packages/conf-fts/conf-fts.1/opam
+++ b/packages/conf-fts/conf-fts.1/opam
@@ -11,5 +11,6 @@ build: [
 ]
 flags: conf
 depexts: [
-  ["fts-dev"] {os-distribution = "alpine"}
+  ["fts-dev"] {os-distribution = "alpine" & os-version < "3.17"}
+  ["musl-fts-dev"] {os-distribution = "alpine" & os-version >= "3.17"}
 ]


### PR DESCRIPTION
In 3.17, `fts.h` is available from `musl-fts-dev` instead of `fts-dev`.
