### PR TITLE
Mark Dune 3.8.0 as incompatible with Coq < 8.13

### DIFF
--- a/packages/dune/dune.3.8.0/opam
+++ b/packages/dune/dune.3.8.0/opam
@@ -46,6 +46,7 @@ depends: [
   "base-unix"
   "base-threads"
 ]
+conflicts: [ "coq" {< "8.13"} ]
 url {
   src: "https://github.com/ocaml/dune/releases/download/3.8.0/dune-3.8.0.tbz"
   checksum: [


### PR DESCRIPTION
Due to a bug, the new release of Dune 3.8.0 is incompatible with any Coq package that depends on Coq < 8.13. See https://github.com/ocaml/dune/issues/7846 for details.
Even though Dune is technically compatible with these Coq versions itself, this doesn't seems very useful. An older version of Dune will do perfectly well for these use-cases and Dune 3.8.1 will be around soon. So I propose to mark a conflict with these versions of Coq. Otherwise, we end up with a large number of uninstallable packages with one particular version of Dune.