### PR TITLE
Package minisat.0.5

### DIFF
--- a/packages/minisat/minisat.0.5/opam
+++ b/packages/minisat/minisat.0.5/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Bindings to Minisat-C-1.14.1, with the solver included"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+license: "BSD-2-clause"
+depends: [
+  "ocaml" {>= "4.03" }
+  "dune" {>= "1.0"}
+  "odoc" {with-doc}
+]
+tags: [ "minisat" "solver" "SAT" ]
+homepage: "https://github.com/c-cube/ocaml-minisat/"
+dev-repo: "git+https://github.com/c-cube/ocaml-minisat.git"
+bug-reports: "https://github.com/c-cube/ocaml-minisat/issues"
+authors: "simon.cruanes.2007@m4x.org"
+url {
+  src: "https://github.com/c-cube/ocaml-minisat/archive/v0.5.tar.gz"
+  checksum: [
+    "md5=ae4a6feb34787f8814671af796e8cf5b"
+    "sha512=41c6c4ba2149a1afed90c7e55122dfe7239fba7221d649152549f42285b887d0cd62ac434d76eac58527b635afa4adc9d1c183cbd921eb6f927baa76371559eb"
+  ]
+}


### PR DESCRIPTION
### `minisat.0.5`
Bindings to Minisat-C-1.14.1, with the solver included



---
* Homepage: https://github.com/c-cube/ocaml-minisat/
* Source repo: git+https://github.com/c-cube/ocaml-minisat.git
* Bug tracker: https://github.com/c-cube/ocaml-minisat/issues

---
:camel: Pull-request generated by opam-publish v2.0.3