### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.5.0)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.5.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.5.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/2.5.0/tar-2.5.0.tbz"
+  checksum: [
+    "sha256=06fd25f419fb65648cef70e363beead722a95f250165f4629b3f7ee283c1b85b"
+    "sha512=90e1d667cbf31ee3424280b0d6fddf5bcf51228b29eee48d45e81615706c25f3ea64fd403138875755ddeec44ae96be34d7852a1840fc7eabf88b3a6f3dd46dd"
+  ]
+}
+x-commit-hash: "1e3b706e948ce8ed3590d6c4849fcd2db539210c"

--- a/packages/tar-mirage/tar-mirage.2.5.0/opam
+++ b/packages/tar-mirage/tar-mirage.2.5.0/opam
@@ -52,7 +52,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-tar/releases/download/2.5.0/tar-2.5.0.tbz"
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.5.0/tar-2.5.0.tbz"
   checksum: [
     "sha256=06fd25f419fb65648cef70e363beead722a95f250165f4629b3f7ee283c1b85b"
     "sha512=90e1d667cbf31ee3424280b0d6fddf5bcf51228b29eee48d45e81615706c25f3ea64fd403138875755ddeec44ae96be34d7852a1840fc7eabf88b3a6f3dd46dd"

--- a/packages/tar-unix/tar-unix.2.5.0/opam
+++ b/packages/tar-unix/tar-unix.2.5.0/opam
@@ -39,7 +39,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-tar/releases/download/2.5.0/tar-2.5.0.tbz"
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.5.0/tar-2.5.0.tbz"
   checksum: [
     "sha256=06fd25f419fb65648cef70e363beead722a95f250165f4629b3f7ee283c1b85b"
     "sha512=90e1d667cbf31ee3424280b0d6fddf5bcf51228b29eee48d45e81615706c25f3ea64fd403138875755ddeec44ae96be34d7852a1840fc7eabf88b3a6f3dd46dd"

--- a/packages/tar-unix/tar-unix.2.5.0/opam
+++ b/packages/tar-unix/tar-unix.2.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/2.5.0/tar-2.5.0.tbz"
+  checksum: [
+    "sha256=06fd25f419fb65648cef70e363beead722a95f250165f4629b3f7ee283c1b85b"
+    "sha512=90e1d667cbf31ee3424280b0d6fddf5bcf51228b29eee48d45e81615706c25f3ea64fd403138875755ddeec44ae96be34d7852a1840fc7eabf88b3a6f3dd46dd"
+  ]
+}
+x-commit-hash: "1e3b706e948ce8ed3590d6c4849fcd2db539210c"

--- a/packages/tar/tar.2.5.0/opam
+++ b/packages/tar/tar.2.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/2.5.0/tar-2.5.0.tbz"
+  checksum: [
+    "sha256=06fd25f419fb65648cef70e363beead722a95f250165f4629b3f7ee283c1b85b"
+    "sha512=90e1d667cbf31ee3424280b0d6fddf5bcf51228b29eee48d45e81615706c25f3ea64fd403138875755ddeec44ae96be34d7852a1840fc7eabf88b3a6f3dd46dd"
+  ]
+}
+x-commit-hash: "1e3b706e948ce8ed3590d6c4849fcd2db539210c"

--- a/packages/tar/tar.2.5.0/opam
+++ b/packages/tar/tar.2.5.0/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-tar/releases/download/2.5.0/tar-2.5.0.tbz"
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.5.0/tar-2.5.0.tbz"
   checksum: [
     "sha256=06fd25f419fb65648cef70e363beead722a95f250165f4629b3f7ee283c1b85b"
     "sha512=90e1d667cbf31ee3424280b0d6fddf5bcf51228b29eee48d45e81615706c25f3ea64fd403138875755ddeec44ae96be34d7852a1840fc7eabf88b3a6f3dd46dd"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- File names and link names are used from PAX headers when parsing (reported by @gravicappa, fixed in mirage/ocaml-tar#128 by @reynir)
