### PR TITLE
Exclude `mtime.1.4.0` for `metrics-unix`

### DIFF
--- a/packages/metrics-unix/metrics-unix.0.4.0/opam
+++ b/packages/metrics-unix/metrics-unix.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "dune" {>= "1.4"}
   "uuidm" {>= "0.9.6"}
   "metrics" {= version}
-  "mtime" {>= "1.0.0"}
+  "mtime" {>= "1.0.0" & != "1.4.0"}
   "lwt" {>= "2.4.7"}
   "metrics-lwt" {= version & with-test}
   "conf-gnuplot"


### PR DESCRIPTION
This specific version of `mtime` fails to build, but is now fixed in `mtime.2.0.0`.

See https://github.com/dbuenzli/mtime/issues/42

I just noticed this as `irmin` builds have started failing (after https://github.com/ocaml/opam-repository/pull/23856 merged) with the error in the above issue.

```
Error: Files /home/opam/.opam/5.0/lib/metrics-unix/metrics_gnuplot.cmxa
       and /home/opam/.opam/5.0/lib/mtime/clock/os/mtime_clock.cmxa
       make inconsistent assumptions over interface Mtime_clock
```