### PR TITLE
[new release] metrics, metrics-unix, metrics-rusage, metrics-lwt and metrics-influx (0.4.1)

### DIFF
--- a/packages/metrics-influx/metrics-influx.0.4.1/opam
+++ b/packages/metrics-influx/metrics-influx.0.4.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "fmt" {>= "0.8.7"}
+  "duration"
+  "lwt" {>= "2.4.7"}
+]
+synopsis: "Influx reporter for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.1/metrics-0.4.1.tbz"
+  checksum: [
+    "sha256=77e0c20fb5c1d06103dbb0ec0bc6045bee3c61c00ad0423c97852ac7f3c6144d"
+    "sha512=8da6e5666a9196f7c6aa77de034a1410e2dd89ee717ffd179ed480c7d4cd9f9e2088abefc05ba8b53a6668bc36ff4fd2d5af2e5a1b79ecd00e2ec35592591dbf"
+  ]
+}
+x-commit-hash: "2459c6626c1e48a2b3a65e8a7f4991c5cf8bfddd"

--- a/packages/metrics-lwt/metrics-lwt.0.4.1/opam
+++ b/packages/metrics-lwt/metrics-lwt.0.4.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "lwt" {>= "2.4.7"}
+  "logs"
+]
+synopsis: "Lwt backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.1/metrics-0.4.1.tbz"
+  checksum: [
+    "sha256=77e0c20fb5c1d06103dbb0ec0bc6045bee3c61c00ad0423c97852ac7f3c6144d"
+    "sha512=8da6e5666a9196f7c6aa77de034a1410e2dd89ee717ffd179ed480c7d4cd9f9e2088abefc05ba8b53a6668bc36ff4fd2d5af2e5a1b79ecd00e2ec35592591dbf"
+  ]
+}
+x-commit-hash: "2459c6626c1e48a2b3a65e8a7f4991c5cf8bfddd"

--- a/packages/metrics-rusage/metrics-rusage.0.4.1/opam
+++ b/packages/metrics-rusage/metrics-rusage.0.4.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer:   "team@robur.coop"
+authors:      ["Reynir Bjoernsson" "Hannes Mehnert"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.4"}
+  "metrics" {= version}
+  "logs"
+  "fmt" {>= "0.8.7"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Resource usage (getrusage) sources for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.1/metrics-0.4.1.tbz"
+  checksum: [
+    "sha256=77e0c20fb5c1d06103dbb0ec0bc6045bee3c61c00ad0423c97852ac7f3c6144d"
+    "sha512=8da6e5666a9196f7c6aa77de034a1410e2dd89ee717ffd179ed480c7d4cd9f9e2088abefc05ba8b53a6668bc36ff4fd2d5af2e5a1b79ecd00e2ec35592591dbf"
+  ]
+}
+x-commit-hash: "2459c6626c1e48a2b3a65e8a7f4991c5cf8bfddd"

--- a/packages/metrics-unix/metrics-unix.0.4.1/opam
+++ b/packages/metrics-unix/metrics-unix.0.4.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.4"}
+  "uuidm" {>= "0.9.6"}
+  "metrics" {= version}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "2.4.7"}
+  "metrics-lwt" {= version & with-test}
+  "conf-gnuplot"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Unix backend for the Metrics library"
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.1/metrics-0.4.1.tbz"
+  checksum: [
+    "sha256=77e0c20fb5c1d06103dbb0ec0bc6045bee3c61c00ad0423c97852ac7f3c6144d"
+    "sha512=8da6e5666a9196f7c6aa77de034a1410e2dd89ee717ffd179ed480c7d4cd9f9e2088abefc05ba8b53a6668bc36ff4fd2d5af2e5a1b79ecd00e2ec35592591dbf"
+  ]
+}
+x-commit-hash: "2459c6626c1e48a2b3a65e8a7f4991c5cf8bfddd"

--- a/packages/metrics/metrics.0.4.1/opam
+++ b/packages/metrics/metrics.0.4.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:   "thomas@gazagnaire.org"
+authors:      ["Thomas Gazagnaire"]
+license:      "ISC"
+homepage:     "https://github.com/mirage/metrics"
+bug-reports:  "https://github.com/mirage/metrics/issues"
+dev-repo:     "git+https://github.com/mirage/metrics.git"
+doc:          "https://mirage.github.io/metrics/"
+
+build: [
+ ["dune" "subst"] {dev}
+ ["dune" "build" "-p" name "-j" jobs]
+ ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {>= "1.4"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+]
+synopsis: "Metrics infrastructure for OCaml"
+description: """
+Metrics provides a basic infrastructure to monitor and gather runtime
+metrics for OCaml program. Monitoring is performed on sources, indexed
+by tags, allowing users to enable or disable at runtime the gathering
+of data-points. As disabled metric sources have a low runtime cost
+(only a closure allocation), the library is designed to instrument
+production systems.
+
+Metric reporting is decoupled from monitoring and is handled by a
+custom reporter. A few reporters are (will be) provided by default.
+
+Metrics is heavily inspired by
+[Logs](http://erratique.ch/software/logs).
+"""
+url {
+  src:
+    "https://github.com/mirage/metrics/releases/download/v0.4.1/metrics-0.4.1.tbz"
+  checksum: [
+    "sha256=77e0c20fb5c1d06103dbb0ec0bc6045bee3c61c00ad0423c97852ac7f3c6144d"
+    "sha512=8da6e5666a9196f7c6aa77de034a1410e2dd89ee717ffd179ed480c7d4cd9f9e2088abefc05ba8b53a6668bc36ff4fd2d5af2e5a1b79ecd00e2ec35592591dbf"
+  ]
+}
+x-commit-hash: "2459c6626c1e48a2b3a65e8a7f4991c5cf8bfddd"


### PR DESCRIPTION
Metrics infrastructure for OCaml

- Project page: <a href="https://github.com/mirage/metrics">https://github.com/mirage/metrics</a>
- Documentation: <a href="https://mirage.github.io/metrics/">https://mirage.github.io/metrics/</a>

##### CHANGES:

- metrics-unix: adapt to mtime 2.0.0 changes (remove dependency on mtime.clock)
  (mirage/metrics#58 @adatario)
