### PR TITLE
Resto-cohttp-server is incompatible with cohttp-lwt.5.1.0

### DIFF
--- a/packages/resto-cohttp-server/resto-cohttp-server.0.10/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.10/opam
@@ -12,7 +12,7 @@ depends: [
   "resto-directory" {= version}
   "resto-cohttp" {= version}
   "resto-acl" {= version}
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "lwt" {>= "3.0.0" & < "6.0.0"}
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.2/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" { >= "1.7" }
   "resto-directory" {= version }
   "resto-cohttp" {= version }
-  "cohttp-lwt-unix" {>= "1.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "5.1.0"}
   "lwt" { >= "3.0.0" & <= "5.0.0" }
 ]
 url {

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.3/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" { >= "1.7" }
   "resto-directory" {= version }
   "resto-cohttp" {= version }
-  "cohttp-lwt-unix" {>= "1.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "5.1.0"}
   "lwt" { >= "3.0.0" & <= "5.0.0" }
 ]
 url {

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.4/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.4/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" { >= "1.7" }
   "resto-directory" {= version }
   "resto-cohttp" {= version }
-  "cohttp-lwt-unix" {>= "1.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "5.1.0"}
   "lwt" { >= "3.0.0" }
 ]
 url {

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.5/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.5/opam
@@ -13,7 +13,7 @@ build: [
 
 depends: [
   "ocaml" { >= "4.07" }
-  "dune" { >= "1.7" }
+  "dune" { >= "1.11" }
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "cohttp-lwt-unix" {>= "1.0.0" & < "5.1.0"}

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.5/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.5/opam
@@ -16,7 +16,7 @@ depends: [
   "dune" { >= "1.7" }
   "resto-directory" {= version }
   "resto-cohttp" {= version }
-  "cohttp-lwt-unix" {>= "1.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "1.0.0" & < "5.1.0"}
   "lwt" { >= "3.0.0" & < "6.0.0" }
 ]
 url {

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.6.1/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.6.1/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" { >= "2.0.0" }
   "lwt" { >= "3.0.0" & < "5.6.0" }
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.6/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.6/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" { >= "2.0.0" & < "3.0.0" }
   "lwt" { >= "3.0.0" & < "5.6.0" }
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.7/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.7/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" { >= "2.0.0" }
   "lwt" { >= "3.0.0" & < "5.6.0" }
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.8/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.8/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" { >= "2.0.0" }
   "lwt" { >= "3.0.0" & < "5.6.0" }
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.0.9/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.0.9/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" { >= "2.0.0" }
   "lwt" { >= "3.0.0" & < "6.0.0" }
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.1.0/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.1.0/opam
@@ -17,7 +17,7 @@ depends: [
   "resto-directory" {= version }
   "resto-cohttp" {= version }
   "resto-acl" {= version }
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" { >= "2.0.0" }
   "lwt" { >= "3.0.0" & < "6.0.0" }
 ]

--- a/packages/resto-cohttp-server/resto-cohttp-server.1.1/opam
+++ b/packages/resto-cohttp-server/resto-cohttp-server.1.1/opam
@@ -12,7 +12,7 @@ depends: [
   "resto-directory" {= version}
   "resto-cohttp" {= version}
   "resto-acl" {= version}
-  "cohttp-lwt-unix" {>= "2.0.0" & < "6.0.0~"}
+  "cohttp-lwt-unix" {>= "2.0.0" & < "5.1.0"}
   "conduit-lwt-unix" {>= "2.0.0"}
   "lwt" {>= "3.0.0" & < "6.0.0"}
 ]


### PR DESCRIPTION
Because of mirage/ocaml-cohttp#982, a file descriptor is leaked for each never ending streaming RPC opened because the connection is never closed.