### PR TITLE
[new release] domain-local-await (0.2.0)

### DIFF
--- a/packages/domain-local-await/domain-local-await.0.2.0/opam
+++ b/packages/domain-local-await/domain-local-await.0.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent blocking mechanism"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "0BSD"
+homepage: "https://github.com/ocaml-multicore/domain-local-await"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-await.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-await/releases/download/0.2.0/domain-local-await-0.2.0.tbz"
+  checksum: [
+    "sha256=d83089b08de718fb5b5e753c8d1bf347588d02436e7a4572e0b89dd6a9c75c3a"
+    "sha512=3266dafda9b0d9b212edfc55d208eac980649f5474b09125acb688b4e31f850e90b02e0c4a7a2de93260d54cf40053bc8f87be1e76c897691ba5105ec1e685bb"
+  ]
+}
+x-commit-hash: "cd73c143d79d662aeb954dbf0b1dff26ca58db61"


### PR DESCRIPTION
A scheduler independent blocking mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-await">https://github.com/ocaml-multicore/domain-local-await</a>

## 0.2.0

- Avoid unnecessary type alias for `(module Thread)` (@polytypic)
- Fix to update per thread configuration atomically (@polytypic)
