### PR TITLE
[new release] reason-react (0.11.0)

### DIFF
--- a/packages/reason-react/reason-react.0.11.0/opam
+++ b/packages/reason-react/reason-react.0.11.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Reason bindings for React.js"
+description: """
+ReasonReact helps you use Reason to build React components with deeply integrated, strong, static type safety.
+
+It is designed and built by people using Reason and React in large, mission critical production React codebases."""
+maintainer: [
+  "David Sancho <dsnxmoreno@gmail.com>"
+  "Antonio Monteiro <anmonteiro@gmail.com>"
+]
+authors: [
+  "Cheng Lou <chenglou92@gmail.com>" "Ricky Vetter <rickywvetter@gmail.com>"
+]
+license: "MIT"
+homepage: "https://reasonml.github.io/reason-react"
+doc: "https://reasonml.github.io/reason-react"
+bug-reports: "https://github.com/reasonml/reason-react/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.13.0"}
+  "melange" {>= "1.0.0"}
+  "reactjs-jsx-ppx"
+  "reason" {>= "3.6.0"}
+  "ocaml-lsp-server" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason-react.git"
+url {
+  src:
+    "https://github.com/reasonml/reason-react/releases/download/0.11.0/reason-react-0.11.0.tbz"
+  checksum: [
+    "sha256=6df6cc4c0f18890ceada8ce3d6693ce6bcaebdc660fa7278134140267694f6bf"
+    "sha512=e3bd72fecec885cfaafc9240721156dfd6393f1444bc05980b4a9341bdaf16409f72f38c4a43c47031de3d37bcc755d0ea5c7e2df61f8b9b75b7de2e47c10f6d"
+  ]
+}
+x-commit-hash: "dbc2f61f6626de47dd607609f13a678ecd59e462"


### PR DESCRIPTION
Reason bindings for React.js

- Project page: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>
- Documentation: <a href="https://reasonml.github.io/reason-react">https://reasonml.github.io/reason-react</a>

##### CHANGES:

* It's the first release of reason-react in opam, but we published to npm previously that's why starts as 0.11.0. 
* All changes file here: https://github.com/reasonml/reason-react/blob/main/CHANGES.md
* Setup repo with Melange [@davesnx in reasonml/reason-react#711](https://github.com/reasonml/reason-react/pull/711)

---

Previous PR: https://github.com/ocaml/opam-repository/pull/23880