### PR TITLE
[new release] eio-ssl (0.2.0)

### DIFF
--- a/packages/eio-ssl/eio-ssl.0.2.0/opam
+++ b/packages/eio-ssl/eio-ssl.0.2.0/opam
@@ -9,7 +9,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "5.0"}
   "ssl" {>= "0.5.13"}
-  "eio_main" {>= "0.7"}
+  "eio_main" {>= "0.10"}
   "odoc" {with-doc}
 ]
 build: [
@@ -26,7 +26,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+dev-repo: "git+https://github.com/anmonteiro/eio-ssl.git"
 url {
   src:
     "https://github.com/anmonteiro/eio-ssl/releases/download/0.2.0/eio-ssl-0.2.0.tbz"

--- a/packages/eio-ssl/eio-ssl.0.2.0/opam
+++ b/packages/eio-ssl/eio-ssl.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "OpenSSL binding to EIO"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LicenseRef-LGPL-WITH-OpenSSL-linking-exception"
+homepage: "https://github.com/anmonteiro/eio-ssl"
+bug-reports: "https://github.com/anmonteiro/eio-ssl/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "5.0"}
+  "ssl" {>= "0.5.13"}
+  "eio_main" {>= "0.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/melange-re/melange-compiler-libs.git"
+url {
+  src:
+    "https://github.com/anmonteiro/eio-ssl/releases/download/0.2.0/eio-ssl-0.2.0.tbz"
+  checksum: [
+    "sha256=616f08fc3e8488b7e62ed89a54521b235fada6b87e358a7b4339be79b494e046"
+    "sha512=c251b5bf379a5435f4d460468c3b31c1d85079fdad6fbc9bfef61b2dfb6b4889d09ea52c2066b79bbe2c30a5f4c7d0903c1c9186013b4c37a5dae396df482e13"
+  ]
+}
+x-commit-hash: "5927222848f981235b658e026183a5b606a379f8"


### PR DESCRIPTION
OpenSSL binding to EIO

- Project page: <a href="https://github.com/anmonteiro/eio-ssl">https://github.com/anmonteiro/eio-ssl</a>

##### CHANGES:

- Adapt to `eio` v0.10 ([anmonteiro/eio-ssl#14](https://github.com/anmonteiro/eio-ssl/pull/14),
  [anmonteiro/eio-ssl#15](https://github.com/anmonteiro/eio-ssl/pull/15))
