### PR TITLE
hacl-star-raw requires ocamlopt

### DIFF
--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0-1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0-1/opam
@@ -21,6 +21,7 @@ x-ci-accept-failures: [
   "centos-7" # Default C compiler is too old
   "oraclelinux-7" # Default C compiler is too old
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: [ os-family != "bsd" & arch != "ppc64" & arch != "ppc32" & arch != "x86_32" ]
 build: [
   ["sh" "-exc" "cd gcc-compatible && ./configure"]

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.0/opam
@@ -17,6 +17,7 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 x-ci-accept-failures: [
   "centos-7" # Default C compiler is too old
   "oraclelinux-7" # Default C compiler is too old

--- a/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.3.2/opam
@@ -17,6 +17,7 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: os-family != "bsd"
 x-ci-accept-failures: [
   "centos-7" # GCC is too old

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.0/opam
@@ -18,6 +18,7 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: os-family != "bsd"
 x-ci-accept-failures: [
   "centos-7" # Default C compiler is too old

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.1/opam
@@ -18,6 +18,7 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: [
   os = "freebsd" | os-family != "bsd"
 ]

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.2/opam
@@ -18,6 +18,7 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: [
   os = "freebsd" | os-family != "bsd"
 ]

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.3/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.3/opam
@@ -18,6 +18,7 @@ depends: [
   "ctypes-foreign"
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: [
   os = "freebsd" | os-family != "bsd"
 ]

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.4/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.4/opam
@@ -17,6 +17,7 @@ depends: [
   "ctypes" { >= "0.18.0" }
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: [
   os = "freebsd" | os-family != "bsd"
 ]

--- a/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.4.5/opam
@@ -17,6 +17,7 @@ depends: [
   "ctypes" { >= "0.18.0" }
   "conf-which" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available: [
   arch != "ppc64" & arch != "ppc32" &
   (os = "freebsd" | os-family != "bsd")

--- a/packages/hacl-star-raw/hacl-star-raw.0.5.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.5.0/opam
@@ -18,6 +18,7 @@ depends: [
   "conf-which" {build}
   "conf-cmake" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available:
   arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
   (os = "freebsd" | os-family != "bsd")

--- a/packages/hacl-star-raw/hacl-star-raw.0.6.0/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.6.0/opam
@@ -18,6 +18,7 @@ depends: [
   "conf-which" {build}
   "conf-cmake" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available:
   arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
   (os = "freebsd" | os-family != "bsd")

--- a/packages/hacl-star-raw/hacl-star-raw.0.6.1/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.6.1/opam
@@ -18,6 +18,7 @@ depends: [
   "conf-which" {build}
   "conf-cmake" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available:
   arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
   (os = "freebsd" | os-family != "bsd")

--- a/packages/hacl-star-raw/hacl-star-raw.0.6.2/opam
+++ b/packages/hacl-star-raw/hacl-star-raw.0.6.2/opam
@@ -18,6 +18,7 @@ depends: [
   "conf-which" {build}
   "conf-cmake" {build}
 ]
+conflicts: ["ocaml-option-bytecode-only"]
 available:
   arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
   (os = "freebsd" | os-family != "bsd")


### PR DESCRIPTION
This is declared in the latest releases but old versions are affected too. By conflicting with ocaml-option-bytecode-only we prevent installation on bytecode-only architectures including ocaml 5.
