### PR TITLE
ojs-base needs autoconf

### DIFF
--- a/packages/ojs-base/ojs-base.0.6.0/opam
+++ b/packages/ojs-base/ojs-base.0.6.0/opam
@@ -22,6 +22,7 @@ depends: [
   "xtmpl" {= "0.18.0"}
   "magic-mime" {>= "1.0"}
   "base64" {>= "3.5.0"}
+  "conf-autoconf"
 ]
 build: [
   ["./configure" "--prefix" prefix]


### PR DESCRIPTION
    #=== ERROR while compiling ojs-base.0.6.0 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/ojs-base.0.6.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make all
    # exit-code            2
    # env-file             ~/.opam/log/ojs-base-7-0d31e3.env
    # output-file          ~/.opam/log/ojs-base-7-0d31e3.out
    ### output ###
    # autoconf
    # make: autoconf: No such file or directory
    # make: *** [Makefile:55: configure] Error 127
