### PR TITLE
Jane Street packages v0.16.0: undo restrictions on 32-bit architectures

### DIFF
--- a/packages/base/base.v0.16.0/opam
+++ b/packages/base/base.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Full standard library replacement for OCaml"
 description: "
 Full standard library replacement for OCaml

--- a/packages/base_bigstring/base_bigstring.v0.16.0/opam
+++ b/packages/base_bigstring/base_bigstring.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "ppx_jane" {>= "v0.16" & < "v0.17"}
   "dune"     {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "String type based on [Bigarray], for use in I/O and C-bindings"
 description: "
 String type based on [Bigarray], for use in I/O and C-bindings.

--- a/packages/base_quickcheck/base_quickcheck.v0.16.0/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.16.0/opam
@@ -21,7 +21,6 @@ depends: [
   "dune"              {>= "2.0.0"}
   "ppxlib"            {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Randomized testing framework, designed for compatibility with Base"
 description: "
 Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,

--- a/packages/bin_prot/bin_prot.v0.16.0/opam
+++ b/packages/bin_prot/bin_prot.v0.16.0/opam
@@ -24,7 +24,6 @@ depends: [
 depopts: [
   "mirage-xen-ocaml"
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "A binary protocol generator"
 description: "
 Part of Jane Street's Core library

--- a/packages/core/core.v0.16.0/opam
+++ b/packages/core/core.v0.16.0/opam
@@ -34,7 +34,6 @@ depends: [
   "variantslib"         {>= "v0.16" & < "v0.17"}
   "dune"                {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Industrial strength alternative to OCaml's standard library"
 description: "
 The Core suite of libraries is an industrial strength alternative to

--- a/packages/fieldslib/fieldslib.v0.16.0/opam
+++ b/packages/fieldslib/fieldslib.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "base"  {>= "v0.16" & < "v0.17"}
   "dune"  {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Syntax extension to define first class values representing record fields, to get and set record fields, iterate and fold over all fields of a record and create new record values"
 description: "
 Part of Jane Street's Core library

--- a/packages/int_repr/int_repr.v0.16.0/opam
+++ b/packages/int_repr/int_repr.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "ppx_jane" {>= "v0.16" & < "v0.17"}
   "dune"     {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Integers of various widths"
 description: "
 Integers of various widths.

--- a/packages/jane-street-headers/jane-street-headers.v0.16.0/opam
+++ b/packages/jane-street-headers/jane-street-headers.v0.16.0/opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "dune"  {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Jane Street C header files"
 description: "
 C header files shared between the various Jane Street packages

--- a/packages/jst-config/jst-config.v0.16.0/opam
+++ b/packages/jst-config/jst-config.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"              {>= "2.0.0"}
   "dune-configurator"
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Compile-time configuration for Jane Street libraries"
 description: "
 Defines compile-time constants used in Jane Street libraries such as Base, Core, and

--- a/packages/parsexp/parsexp.v0.16.0/opam
+++ b/packages/parsexp/parsexp.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "sexplib0" {>= "v0.16" & < "v0.17"}
   "dune"     {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "S-expression parsing library"
 description: "
 This library provides generic parsers for parsing S-expressions from

--- a/packages/ppx_assert/ppx_assert.v0.16.0/opam
+++ b/packages/ppx_assert/ppx_assert.v0.16.0/opam
@@ -19,7 +19,6 @@ depends: [
   "dune"          {>= "2.0.0"}
   "ppxlib"        {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Assert-like extension nodes that raise useful errors on failure"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_base/ppx_base.v0.16.0/opam
+++ b/packages/ppx_base/ppx_base.v0.16.0/opam
@@ -20,7 +20,6 @@ depends: [
   "dune"          {>= "2.0.0"}
   "ppxlib"        {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Base set of ppx rewriters"
 description: "
 ppx_base is the set of ppx rewriters used for Base.

--- a/packages/ppx_bench/ppx_bench.v0.16.0/opam
+++ b/packages/ppx_bench/ppx_bench.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"            {>= "2.0.0"}
   "ppxlib"          {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.16.0/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.16.0/opam
@@ -17,7 +17,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "ppxlib"   {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of bin_prot readers and writers from types"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_cold/ppx_cold.v0.16.0/opam
+++ b/packages/ppx_cold/ppx_cold.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Expands [@cold] into [@inline never][@specialise never][@local never]"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_compare/ppx_compare.v0.16.0/opam
+++ b/packages/ppx_compare/ppx_compare.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of comparison functions from types"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_custom_printf/ppx_custom_printf.v0.16.0/opam
+++ b/packages/ppx_custom_printf/ppx_custom_printf.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"          {>= "2.0.0"}
   "ppxlib"        {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Printf-style format-strings for user-defined string conversion"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_disable_unused_warnings/ppx_disable_unused_warnings.v0.16.0/opam
+++ b/packages/ppx_disable_unused_warnings/ppx_disable_unused_warnings.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Expands [@disable_unused_warnings] into [@warning \"-20-26-32-33-34-35-36-37-38-39-60-66-67\"]"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_enumerate/ppx_enumerate.v0.16.0/opam
+++ b/packages/ppx_enumerate/ppx_enumerate.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generate a list containing all values of a finite type"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_expect/ppx_expect.v0.16.0/opam
+++ b/packages/ppx_expect/ppx_expect.v0.16.0/opam
@@ -19,7 +19,6 @@ depends: [
   "ppxlib"          {>= "0.28.0"}
   "re"              {>= "1.8.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Cram like framework for OCaml"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fields_conv/ppx_fields_conv.v0.16.0/opam
+++ b/packages/ppx_fields_conv/ppx_fields_conv.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"      {>= "2.0.0"}
   "ppxlib"    {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of accessor and iteration functions for ocaml records"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_fixed_literal/ppx_fixed_literal.v0.16.0/opam
+++ b/packages/ppx_fixed_literal/ppx_fixed_literal.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Simpler notation for fixed point literals"
 description: "
 A ppx rewriter that rewrites fixed point literal of the 

--- a/packages/ppx_globalize/ppx_globalize.v0.16.0/opam
+++ b/packages/ppx_globalize/ppx_globalize.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "A ppx rewriter that generates functions to copy local values to the global heap"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_hash/ppx_hash.v0.16.0/opam
+++ b/packages/ppx_hash/ppx_hash.v0.16.0/opam
@@ -17,7 +17,6 @@ depends: [
   "dune"          {>= "2.0.0"}
   "ppxlib"        {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "A ppx rewriter that generates hash functions from type expressions and definitions"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_here/ppx_here.v0.16.0/opam
+++ b/packages/ppx_here/ppx_here.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Expands [%here] into its location"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_ignore_instrumentation/ppx_ignore_instrumentation.v0.16.0/opam
+++ b/packages/ppx_ignore_instrumentation/ppx_ignore_instrumentation.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Ignore Jane Street specific instrumentation extensions"
 description: "
 Ignore Jane Street specific instrumentation extensions from internal PPXs or compiler 

--- a/packages/ppx_inline_test/ppx_inline_test.v0.16.0/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "ppxlib"   {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_jane/ppx_jane.v0.16.0/opam
+++ b/packages/ppx_jane/ppx_jane.v0.16.0/opam
@@ -40,7 +40,6 @@ depends: [
   "dune"                        {>= "2.0.0"}
   "ppxlib"                      {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Standard Jane Street ppx rewriters"
 description: "
 This package installs a ppx-jane executable, which is a ppx driver

--- a/packages/ppx_let/ppx_let.v0.16.0/opam
+++ b/packages/ppx_let/ppx_let.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "ppxlib"   {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Monadic let-bindings"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_log/ppx_log.v0.16.0/opam
+++ b/packages/ppx_log/ppx_log.v0.16.0/opam
@@ -19,7 +19,6 @@ depends: [
   "dune"             {>= "2.0.0"}
   "ppxlib"           {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Ppx_sexp_message-like extension nodes for lazily rendering log messages"
 description: "
 Part of the Jane Street's PPX rewriters collection. 

--- a/packages/ppx_module_timer/ppx_module_timer.v0.16.0/opam
+++ b/packages/ppx_module_timer/ppx_module_timer.v0.16.0/opam
@@ -18,7 +18,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "ppxlib"   {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Ppx rewriter that records top-level module startup times"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_optcomp/ppx_optcomp.v0.16.0/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Optional compilation for OCaml"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_optional/ppx_optional.v0.16.0/opam
+++ b/packages/ppx_optional/ppx_optional.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Pattern matching on flat options"
 description: "
 A ppx rewriter that rewrites simple match statements with an if then

--- a/packages/ppx_pipebang/ppx_pipebang.v0.16.0/opam
+++ b/packages/ppx_pipebang/ppx_pipebang.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "A ppx rewriter that inlines reverse application operators `|>` and `|!`"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.16.0/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "ppxlib"   {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_message/ppx_sexp_message.v0.16.0/opam
+++ b/packages/ppx_sexp_message/ppx_sexp_message.v0.16.0/opam
@@ -17,7 +17,6 @@ depends: [
   "dune"          {>= "2.0.0"}
   "ppxlib"        {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "A ppx rewriter for easy construction of s-expressions"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_value/ppx_sexp_value.v0.16.0/opam
+++ b/packages/ppx_sexp_value/ppx_sexp_value.v0.16.0/opam
@@ -17,7 +17,6 @@ depends: [
   "dune"          {>= "2.0.0"}
   "ppxlib"        {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "A ppx rewriter that simplifies building s-expressions from ocaml values"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_stable/ppx_stable.v0.16.0/opam
+++ b/packages/ppx_stable/ppx_stable.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Stable types conversions generator"
 description: "
 A ppx extension for easier implementation of conversion functions between almost

--- a/packages/ppx_stable_witness/ppx_stable_witness.v0.16.0/opam
+++ b/packages/ppx_stable_witness/ppx_stable_witness.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Ppx extension for deriving a witness that a type is intended to be stable.  In this\n   context, stable means that the serialization format will never change.  This allows\n   programs running at different versions of the code to safely communicate."
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_string/ppx_string.v0.16.0/opam
+++ b/packages/ppx_string/ppx_string.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "ppxlib"   {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Ppx extension for string interpolation"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_tydi/ppx_tydi.v0.16.0/opam
+++ b/packages/ppx_tydi/ppx_tydi.v0.16.0/opam
@@ -15,7 +15,6 @@ depends: [
   "dune"   {>= "2.0.0"}
   "ppxlib" {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Let expressions, inferring pattern type from expression."
 description: "
 Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope.

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.16.0/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"    {>= "2.0.0"}
   "ppxlib"  {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of runtime types from type declarations"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.16.0/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"        {>= "2.0.0"}
   "ppxlib"      {>= "0.28.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/sexplib/sexplib.v0.16.0/opam
+++ b/packages/sexplib/sexplib.v0.16.0/opam
@@ -16,7 +16,6 @@ depends: [
   "dune"     {>= "2.0.0"}
   "num"
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Library for serializing OCaml values to and from S-expressions"
 description: "
 Part of Jane Street's Core library

--- a/packages/sexplib0/sexplib0.v0.16.0/opam
+++ b/packages/sexplib0/sexplib0.v0.16.0/opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune"  {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Library containing the definition of S-expressions and some base converters"
 description: "
 Part of Jane Street's Core library

--- a/packages/splittable_random/splittable_random.v0.16.0/opam
+++ b/packages/splittable_random/splittable_random.v0.16.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppx_sexp_message" {>= "v0.16" & < "v0.17"}
   "dune"             {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "PRNG that can be split into independent streams"
 description: "
 PRNG that can be split into independent streams

--- a/packages/stdio/stdio.v0.16.0/opam
+++ b/packages/stdio/stdio.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "base"  {>= "v0.16" & < "v0.17"}
   "dune"  {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Standard IO library for OCaml"
 description: "
 Stdio implements simple input/output functionalities for OCaml.

--- a/packages/time_now/time_now.v0.16.0/opam
+++ b/packages/time_now/time_now.v0.16.0/opam
@@ -18,7 +18,6 @@ depends: [
   "ppx_optcomp"         {>= "v0.16" & < "v0.17"}
   "dune"                {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Reports the current time"
 description: "
 Provides a single function to report the current time in nanoseconds

--- a/packages/typerep/typerep.v0.16.0/opam
+++ b/packages/typerep/typerep.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "base"  {>= "v0.16" & < "v0.17"}
   "dune"  {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Typerep is a library for runtime types"
 description: "
 "

--- a/packages/variantslib/variantslib.v0.16.0/opam
+++ b/packages/variantslib/variantslib.v0.16.0/opam
@@ -14,7 +14,6 @@ depends: [
   "base"  {>= "v0.16" & < "v0.17"}
   "dune"  {>= "2.0.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
 synopsis: "Part of Jane Street's Core library"
 description: "
 The Core suite of libraries is an industrial strength alternative to


### PR DESCRIPTION
Hi! We have decided to lift the restriction on 32-bit platforms for our v0.16 release.