### PR TITLE
[new release] kcas_data and kcas (0.5.3)

### DIFF
--- a/packages/kcas/kcas.0.5.3/opam
+++ b/packages/kcas/kcas.0.5.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Software transactional memory based on lock-free multi-word compare-and-set"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "5.0"}
+  "domain-local-await" {>= "0.2.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.5.3/kcas-0.5.3.tbz"
+  checksum: [
+    "sha256=2ee27b04a5ef1d36c28302da5bfbc67d34201b143d0b558b27743565aca2a39c"
+    "sha512=14bbad72d05936c96f0c93d08b5c13935438f02db55f72536e36641db86d2b84850434a761adb7f7ea861b3a99e37e6a7c8a5f248fbdc12fcaaa64ea59c07137"
+  ]
+}
+x-commit-hash: "bb2571cb7b431efd47c3007aef3b7ed6be4a1705"

--- a/packages/kcas_data/kcas_data.0.5.3/opam
+++ b/packages/kcas_data/kcas_data.0.5.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Compositional lock-free data structures and primitives for communication and synchronization"
+maintainer: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/kcas"
+bug-reports: "https://github.com/ocaml-multicore/kcas/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "kcas" {= version}
+  "mdx" {>= "1.10.0" & with-test}
+  "multicore-magic" {>= "1.0.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/kcas.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/kcas/releases/download/0.5.3/kcas-0.5.3.tbz"
+  checksum: [
+    "sha256=2ee27b04a5ef1d36c28302da5bfbc67d34201b143d0b558b27743565aca2a39c"
+    "sha512=14bbad72d05936c96f0c93d08b5c13935438f02db55f72536e36641db86d2b84850434a761adb7f7ea861b3a99e37e6a7c8a5f248fbdc12fcaaa64ea59c07137"
+  ]
+}
+x-commit-hash: "bb2571cb7b431efd47c3007aef3b7ed6be4a1705"


### PR DESCRIPTION
Compositional lock-free data structures and primitives for communication and synchronization

- Project page: <a href="https://github.com/ocaml-multicore/kcas">https://github.com/ocaml-multicore/kcas</a>

## 0.5.3

- Fix to also snapshot and rollback post commit actions (@polytypic)
- Fix `Loc.compare_and_set` to have strong semantics (@polytypic)
- Fix single location no-op updates to be strictly serializable (@polytypic)
- Add `Dllist.move_l node list` and `Dllist.move_r node list` (@polytypic)
