### PR TITLE
[new release] minisat (0.6)

### DIFF
--- a/packages/minisat/minisat.0.6/opam
+++ b/packages/minisat/minisat.0.6/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "simon.cruanes.2007@m4x.org"
+synopsis: "Bindings to the SAT solver Minisat, with the solver included."
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+license: "BSD-2-clause"
+depends: [
+  "ocaml" {>= "4.03" }
+  "dune" {>= "2.0"}
+  "odoc" {with-doc}
+  "containers" {>= "3.0" & with-test}
+]
+tags: [ "minisat" "solver" "SAT" ]
+homepage: "https://github.com/c-cube/ocaml-minisat/"
+dev-repo: "git+https://github.com/c-cube/ocaml-minisat.git"
+bug-reports: "https://github.com/c-cube/ocaml-minisat/issues"
+authors: "simon.cruanes.2007@m4x.org"
+url {
+  src:
+    "https://github.com/c-cube/ocaml-minisat/releases/download/v0.6/minisat-0.6.tbz"
+  checksum: [
+    "sha256=e407a60be9c495d449be8a0ad955941ac1639515bad19fdbacd4a15d5aaf6605"
+    "sha512=17a5eafd2afb2cb3e829a0b7eb32c14de5ebeeaed12ecfc4f58410c9b582918595c6c31facbbda126e9fd394d3846e14f961cab529d41ac82b0775930246e5fa"
+  ]
+}
+x-commit-hash: "f140c0f7b692b1aa66ac1f3f7514b2484e42f901"

--- a/packages/touist/touist.3.0.0/opam
+++ b/packages/touist/touist.3.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" {>= "4.01.0" & < "5.0.0"}
   "fileutils" {build & >= "0.4.0"}
   "menhir" {build & >= "20150118"}
-  "minisat" {build}
+  "minisat" {build & < "0.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test & < "2.2.6"}

--- a/packages/touist/touist.3.1.0/opam
+++ b/packages/touist/touist.3.1.0/opam
@@ -36,7 +36,7 @@ depends: [
   "cppo_ocamlbuild" {build}
   "fileutils" {build & >= "0.4.0"}
   "menhir" {build & >= "20151023"}
-  "minisat" {build}
+  "minisat" {build & < "0.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test & < "2.2.6"}

--- a/packages/touist/touist.3.2.0/opam
+++ b/packages/touist/touist.3.2.0/opam
@@ -38,7 +38,7 @@ depends: [
   "cppo_ocamlbuild" {build}
   "fileutils" {build & >= "0.4.0"}
   "menhir" {build & >= "20151023"}
-  "minisat" {build}
+  "minisat" {build & < "0.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test & < "2.2.6"}

--- a/packages/touist/touist.3.2.1/opam
+++ b/packages/touist/touist.3.2.1/opam
@@ -38,7 +38,7 @@ depends: [
   "cppo_ocamlbuild" {build}
   "fileutils" {build & >= "0.4.0"}
   "menhir" {build & >= "20151023"}
-  "minisat" {build}
+  "minisat" {build & < "0.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test & < "2.2.6"}

--- a/packages/touist/touist.3.4.0/opam
+++ b/packages/touist/touist.3.4.0/opam
@@ -37,7 +37,7 @@ depends: [
   "cppo" {>= "0.9.4" & <= "1.5.0"}
   "fileutils" {>= "0.4.0"}
   "menhir" {>= "20151023"}
-  "minisat"
+  "minisat" {< "0.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/touist/touist.3.4.1/opam
+++ b/packages/touist/touist.3.4.1/opam
@@ -37,7 +37,7 @@ depends: [
   "cppo_ocamlbuild" {build & >= "1.6.0"}
   "cppo" {build & >= "0.9.4" & <= "1.5.0"}
   "menhir" {>= "20151023"}
-  "minisat" {build}
+  "minisat" {build & < "0.6"}
   "ocamlbuild" {build}
   "ocamlfind" {build}
   "ounit" {with-test}

--- a/packages/touist/touist.3.5.0/opam
+++ b/packages/touist/touist.3.5.0/opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "jbuilder" {>= "1.0+beta12"}
   "menhir" {>= "20151023"}
-  "minisat"
+  "minisat" {< "0.6"}
   "re"
   "cmdliner" {>= "0.9.8"}
   "ounit" {with-test & < "2.2.6"}


### PR DESCRIPTION
Bindings to Minisat-C-1.14.1, with the solver included

- Project page: <a href="https://github.com/c-cube/ocaml-minisat/">https://github.com/c-cube/ocaml-minisat/</a>

##### CHANGES:

- migrate from minisat-c 1.14 to minisat 2.2 (in C++); refactor it to build with C++11

- add `Lit.{apply_sign,hash,equal,compare}`
- add `ensure_lit_exists`
- do not call `simplify` implicitly before `solve`
- add `value_at_level_0`
- add `unsat_core`
- add `okay`
