### PR TITLE
Add a constraint on odoc on OCaml 5.1

### DIFF
--- a/packages/odoc/odoc.2.1.1/opam
+++ b/packages/odoc/odoc.2.1.1/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "2.9.1"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.1"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"

--- a/packages/odoc/odoc.2.2.0/opam
+++ b/packages/odoc/odoc.2.2.0/opam
@@ -29,7 +29,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "3.0.2"}
   "fpath"
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.02.0" & < "5.1"}
   "result"
   "tyxml" {>= "4.3.0"}
   "fmt"
@@ -45,9 +45,6 @@ depends: [
 
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
   ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
-]
-conflicts: [
-  "ocaml" {>= "5.1"}
 ]
 
 build: [

--- a/packages/odoc/odoc.2.2.0/opam
+++ b/packages/odoc/odoc.2.2.0/opam
@@ -46,6 +46,9 @@ depends: [
   ("ocaml" {< "4.07.0" & with-test} | "bisect_ppx" {with-test & > "2.5.0"})
   ("ocaml" {< "4.03.0" & with-test} | "mdx" {with-test})
 ]
+conflicts: [
+  "ocaml" {>= "5.1"}
+]
 
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
I strongly assume that other versions of odoc are affected as well but I had [this failure](https://ocaml.ci.dev/github/tarides/dune-release/commit/a9158a15fc386b9106eed6c3dcac49f5d4f16848/variant/debian-11-5.1_opam-2.1) when building odoc on OCaml 5.1:

```
    (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.1/lib/astring -I /home/opam/.opam/5.1/lib/camlp-streams -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/odoc-parser -I /home/opam/.opam/5.1/lib/result -I src/model/.odoc_model.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Ident_env.cmo -c -impl src/loader/ident_env.pp.ml)
    File "src/loader/ident_env.cppo.ml", line 214, characters 16-30:
    Error: Unbound record field ci_id_typehash
    (cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -w -18-53 -g -bin-annot -I src/loader/.odoc_loader.objs/byte -I /home/opam/.opam/5.1/lib/astring -I /home/opam/.opam/5.1/lib/camlp-streams -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/odoc-parser -I /home/opam/.opam/5.1/lib/result -I src/model/.odoc_model.objs/byte -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/byte/odoc_loader__Cmt.cmo -c -impl src/loader/cmt.pp.ml)
    File "src/loader/cmt.ml", lines 349-395, characters 4-75:
    Warning 8 [partial-match]: this pattern-matching is not exhaustive.
    Here is an example of a case that is not matched:
    Tmod_apply_unit _
    (cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -w -18-53 -g -I src/loader/.odoc_loader.objs/byte -I src/loader/.odoc_loader.objs/native -I /home/opam/.opam/5.1/lib/astring -I /home/opam/.opam/5.1/lib/camlp-streams -I /home/opam/.opam/5.1/lib/ocaml/compiler-libs -I /home/opam/.opam/5.1/lib/odoc-parser -I /home/opam/.opam/5.1/lib/result -I src/model/.odoc_model.objs/byte -I src/model/.odoc_model.objs/native -intf-suffix .ml -no-alias-deps -open Odoc_loader__ -o src/loader/.odoc_loader.objs/native/odoc_loader__Ident_env.cmx -c -impl src/loader/ident_env.pp.ml)
    File "src/loader/ident_env.cppo.ml", line 214, characters 16-30:
    Error: Unbound record field ci_id_typehash
```