### PR TITLE
[new release] dream-html (0.0.3)

### DIFF
--- a/packages/dream-html/dream-html.0.0.3/opam
+++ b/packages/dream-html/dream-html.0.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v0.0.3/dream-html-0.0.3.tbz"
+  checksum: [
+    "sha256=0a68fb0f1ae6239e11909445b1986d0c158ac79d738fe82176a06c54470271da"
+    "sha512=1bb2b7daa13bec81dc30354f9a22d992a22b5e7eb3369e7b776c57e4820e95e72d60d561cf2dc58231ad18c1685b8ec0df566c79d4701ccd5e0f20c5214246d8"
+  ]
+}
+x-commit-hash: "3c0ef275218d99bd6524bface2de1a7d3da78e93"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
