### PR TITLE
[new release] rangeSet (0.2.1)

### DIFF
--- a/packages/rangeSet/rangeSet.0.2.1/opam
+++ b/packages/rangeSet/rangeSet.0.2.1/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://github.com/kandu/rangeSet/"
+bug-reports: "https://github.com/kandu/rangeSet/issues"
+license: "MIT"
+dev-repo: "git+https://https://github.com/kandu/rangeSet"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.1.0"}
+]
+synopsis: "rangeSet"
+description: """
+This module implements two range set data structure: continuous and discrete range set.
+
+The elements are represented as ranges internally, and is therefore efficient for large set of adjacent elements."""
+
+url {
+  src: "https://github.com/kandu/rangeSet/archive/refs/tags/0.2.1.tar.gz"
+  checksum: "md5=73528d7ba605b724022d6b7c605cf2cd"
+}

--- a/packages/rangeSet/rangeSet.0.2.1/opam
+++ b/packages/rangeSet/rangeSet.0.2.1/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.02.3"}
   "dune" {>= "1.1.0"}
 ]
-synopsis: "rangeSet"
+synopsis: "RangeSet: a library for sets over ordered ranges"
 description: """
 This module implements two range set data structure: continuous and discrete range set.
 


### PR DESCRIPTION
# RangeSet #

## Sets over ordered ranges

  This module implements two range set data structure: continuous and discrete range set.

  The elements are represented as ranges internally, and is therefore efficient for large set of adjacent elements.

## Document
  The document is available [here](https://kandu.github.io/caml_doc/rangeSet/RangeSet/index.html).