### PR TITLE
dns-client: restrict happy eyeballs for preparation of a new release

### DIFF
--- a/packages/dns-client-lwt/dns-client-lwt.7.0.0/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.0/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"
 ]

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.1/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.1/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"
 ]

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.2/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.2/opam
@@ -21,7 +21,7 @@ depends: [
   "lwt" {>= "4.2.1"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng-lwt" {>= "0.11.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "tls-lwt" {>= "0.16.0"}
   "ca-certs"
 ]

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.0/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.0/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "tls-mirage" {>= "0.16.0"}
   "x509" {>= "0.16.0"}
   "ca-certs-nss"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.1/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.1/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "tls-mirage" {>= "0.16.0"}
   "x509" {>= "0.16.0"}
   "ca-certs-nss"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.2/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.2/opam
@@ -23,7 +23,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-time" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "tls-mirage" {>= "0.16.0"}
   "x509" {>= "0.16.0"}
   "ca-certs-nss"

--- a/packages/dns-client/dns-client.6.4.1/opam
+++ b/packages/dns-client/dns-client.6.4.1/opam
@@ -29,7 +29,7 @@ depends: [
   "mirage-clock" {>= "3.0.0"}
   "mtime" {>= "1.2.0"}
   "mirage-crypto-rng" {>= "0.8.0"}
-  "happy-eyeballs" {>= "0.4.0"}
+  "happy-eyeballs" {>= "0.4.0" & < "0.6.0"}
   "alcotest" {with-test}
   "tls" {>= "0.15.0" & < "0.16.0"}
   "tls-mirage" {>= "0.15.0"}


### PR DESCRIPTION
this change does not do anything in the current opam-repository state, but there's an upcoming API breaking change. I checked the other users of happy-eyeballs, and they should be fine.