### PR TITLE
Package base.v0.16.1

### DIFF
--- a/packages/base/base.v0.16.1/opam
+++ b/packages/base/base.v0.16.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/base"
+bug-reports: "https://github.com/janestreet/base/issues"
+dev-repo: "git+https://github.com/janestreet/base.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/base/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.14.0"}
+  "sexplib0"          {>= "v0.16" & < "v0.17"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "Full standard library replacement for OCaml"
+description: "
+Full standard library replacement for OCaml
+
+Base is a complete and portable alternative to the OCaml standard
+library. It provides all standard functionalities one would expect
+from a language standard library. It uses consistent conventions
+across all of its module.
+
+Base aims to be usable in any context. As a result system dependent
+features such as I/O are not offered by Base. They are instead
+provided by companion libraries such as stdio:
+
+  https://github.com/janestreet/stdio
+"
+url {
+  src: "https://github.com/janestreet/base/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=ae1cc041c0f8ea3ca163bc904336e9aa"
+    "sha512=347ccc68be09ef207f0ac793f1c472688855ba53c317a35c95f7124be4105985b54f866b604a66a9d2e54bc320f7b29ffa3eb224622b1cce6ca504e1ee4888ff"
+  ]
+}


### PR DESCRIPTION
### `base.v0.16.1`
Full standard library replacement for OCaml
Full standard library replacement for OCaml

Base is a complete and portable alternative to the OCaml standard
library. It provides all standard functionalities one would expect
from a language standard library. It uses consistent conventions
across all of its module.

Base aims to be usable in any context. As a result system dependent
features such as I/O are not offered by Base. They are instead
provided by companion libraries such as stdio:

  https://github.com/janestreet/stdio



---
* Homepage: https://github.com/janestreet/base
* Source repo: git+https://github.com/janestreet/base.git
* Bug tracker: https://github.com/janestreet/base/issues

---
:camel: Pull-request generated by opam-publish v2.2.0