### PR TITLE
Release dns v7.0.3 and happy-eyeballs 0.6.0

### DIFF
--- a/packages/dns-certify/dns-certify.7.0.3/opam
+++ b/packages/dns-certify/dns-certify.7.0.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-tsig" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "x509" {>= "0.15.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "logs"
+  "mirage-crypto-ec"
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.8.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "MirageOS let's encrypt certificate retrieval"
+description: """
+A function to retrieve a certificate when providing a hostname, TSIG key, server
+IP, and an optional key seed. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-cli/dns-cli.7.0.3/opam
+++ b/packages/dns-cli/dns-cli.7.0.3/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dnssec" {= version}
+  "dns-tsig" {= version}
+  "dns-client-lwt" {= version}
+  "dns-server" {= version}
+  "dns-certify" {= version}
+  "bos" {>= "0.2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.2"}
+  "x509" {>= "0.13.0"}
+  "mirage-crypto" {>= "0.8.0"}
+  "mirage-crypto-pk" {>= "0.8.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "hex" {>= "1.4.0"}
+  "ptime" {>= "0.8.5"}
+  "mtime" {>= "1.2.0"}
+  "logs" {>= "0.6.3"}
+  "fmt" {>= "0.8.8"}
+  "ipaddr" {>= "4.0.0"}
+  "lwt" {>= "4.0.0"}
+  "randomconv"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Unix command line utilities using uDNS"
+description: """
+'oupdate' sends a DNS update frome to a DNS server that sets 'hostname A ip'.
+For authentication via TSIG, a hmac secret needs to be provided.
+
+'ocertify' updates DNS with a certificate signing request, and polls a matching
+certificate. Best used with an letsencrypt unikernel.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-client-lwt/dns-client-lwt.7.0.3/opam
+++ b/packages/dns-client-lwt/dns-client-lwt.7.0.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns-client" {= version}
+  "dns" {= version}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng-lwt" {>= "0.11.0"}
+  "happy-eyeballs" {>= "0.6.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+]
+synopsis: "DNS client API using lwt"
+description: """
+A client implementation using uDNS and lwt for side effects.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-client-mirage/dns-client-mirage.7.0.3/opam
+++ b/packages/dns-client-mirage/dns-client-mirage.7.0.3/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns-client" {= version}
+  "domain-name" {>= "0.4.0"}
+  "ipaddr" {>= "5.3.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "happy-eyeballs" {>= "0.6.0"}
+  "tls-mirage" {>= "0.16.0"}
+  "x509" {>= "0.16.0"}
+  "ca-certs-nss"
+]
+synopsis: "DNS client API for MirageOS"
+description: """
+A client implementation using uDNS using MirageOS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-client/dns-client.7.0.3/opam
+++ b/packages/dns-client/dns-client.7.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Joe Hill"]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+license: "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+
+depends: [
+  "dune" {>="2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "randomconv" {>= "0.1.2"}
+  "domain-name" {>= "0.4.0"}
+  "mtime" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "alcotest" {with-test}
+]
+synopsis: "DNS client API"
+description: """
+A client implementation using uDNS.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-mirage/dns-mirage.7.0.3/opam
+++ b/packages/dns-mirage/dns-mirage.7.0.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "ipaddr" {>= "5.2.0"}
+  "lwt" {>= "4.2.1"}
+  "tcpip" {>= "7.0.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-resolver/dns-resolver.7.0.3/opam
+++ b/packages/dns-resolver/dns-resolver.7.0.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "dns" {= version}
+  "dns-server" {= version}
+  "dns-mirage" {= version}
+  "dnssec" {= version}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "alcotest" {with-test}
+  "tls" "tls-mirage"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS resolver business logic"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-server/dns-server.7.0.3/opam
+++ b/packages/dns-server/dns-server.7.0.3/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-mirage" {= version}
+  "randomconv" {>= "0.1.2"}
+  "duration" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "alcotest" {with-test}
+  "dns-tsig" {with-test}
+  "base64" {with-test & >= "3.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS server, primary and secondary"
+description: """
+Primary and secondary DNS server implemented in value-passing style. Needs an
+effectful layer to be useful.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-stub/dns-stub.7.0.3/opam
+++ b/packages/dns-stub/dns-stub.7.0.3/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "dns-client-mirage" {= version}
+  "dns-mirage" {= version}
+  "dns-resolver" {= version}
+  "dns-tsig" {= version}
+  "dns-server" {= version}
+  "duration" {>= "0.1.2"}
+  "randomconv" {>= "0.1.2"}
+  "lwt" {>= "4.2.1"}
+  "mirage-time" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "metrics"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNS stub resolver"
+description: """
+Forwarding and recursive resolvers as value-passing functions. To be used with
+an effectful layer.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns-tsig/dns-tsig.7.0.3/opam
+++ b/packages/dns-tsig/dns-tsig.7.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "mirage-crypto"
+  "base64" {>= "3.0.0"}
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "TSIG support for DNS"
+description: """
+TSIG is used to authenticate nsupdate frames using a HMAC.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dns/dns.7.0.3/opam
+++ b/packages/dns/dns.7.0.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs" "ptime"
+  "fmt" {>= "0.8.8"}
+  "domain-name" {>= "0.4.0"}
+  "gmap" {>= "0.3.0"}
+  "cstruct" {>= "6.0.0"}
+  "ipaddr" {>= "5.2.0"}
+  "alcotest" {with-test}
+  "lru" {>= "0.3.0"}
+  "duration" {>= "0.1.2"}
+  "metrics"
+  "base64" {>= "3.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An opinionated Domain Name System (DNS) library"
+description: """
+µDNS supports most of the domain name system used in the wild.  It adheres to
+strict conventions.  Failing early and hard.  It is mostly implemented in the
+pure fragment of OCaml (no mutation, isolated IO, no exceptions).
+
+Legacy resource record types are not dealt with, and there is no plan to support
+`ISDN`, `MAILA`, `MAILB`, `WKS`, `MB`, `NULL`, `HINFO`, ... .  `AXFR` is only
+handled via TCP connections.  The only resource class supported is `IN` (the
+Internet).  Truncated hmac in `TSIG` are not supported (always the full length
+of the hash algorithm is used).
+
+Please read [the blog article](https://hannes.nqsb.io/Posts/DNS) for a more
+detailed overview.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/dnssec/dnssec.7.0.3/opam
+++ b/packages/dnssec/dnssec.7.0.3/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer: "team AT robur dot io"
+authors: ["Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>"]
+homepage: "https://github.com/mirage/ocaml-dns"
+doc: "https://mirage.github.io/ocaml-dns/"
+dev-repo: "git+https://github.com/mirage/ocaml-dns.git"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "BSD-2-Clause"
+
+depends: [
+  "dune" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "dns" {= version}
+  "alcotest" {with-test}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec"
+  "domain-name" {>= "0.4.0"}
+  "base64" {with-test & >= "3.0.0"}
+  "logs" {>= "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "DNSSec support for OCaml-DNS"
+description: """
+DNSSec (DNS security extensions) for OCaml-DNS, including
+signing and verifying of RRSIG records.
+"""
+url {
+  src:
+    "https://github.com/mirage/ocaml-dns/releases/download/v7.0.3/dns-7.0.3.tbz"
+  checksum: [
+    "sha256=36afa54678979acb27a8760d3bc361e9970da7b12110f373685f7400002e16c4"
+    "sha512=71e1f6a4f7ee334de419dda2d9ef23efd2ac1a9a27194d99952a3f9f03025adcb113f8ca1de0ae41e44fa4201ff92dc77134a772356167edd70a199e2df16149"
+  ]
+}
+x-commit-hash: "8072297d4b2f38d80a2b2ebd35682f2baad7c44c"

--- a/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.6.0/opam
+++ b/packages/happy-eyeballs-lwt/happy-eyeballs-lwt.0.6.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "cmdliner" {>= "1.1.0"}
+  "duration"
+  "dns-client-lwt" {>= "7.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mtime" {>= "1.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Lwt_unix"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Lwt_unix for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.6.0/happy-eyeballs-0.6.0.tbz"
+  checksum: [
+    "sha256=e587908776ac52603740363efd625b0767162521ab2d63b745e64056184c0429"
+    "sha512=2de6632aa32eea4ca865747fad7db1043baca8f9e14ab798224873926636d11c233c3c093237222118731a5dd00a0de804c3942bfe003f18c8f2c39159883018"
+  ]
+}
+x-commit-hash: "f744de78a274e777c8b761a6fb229f62dfd422a0"

--- a/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.6.0/opam
+++ b/packages/happy-eyeballs-mirage/happy-eyeballs-mirage.0.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "happy-eyeballs" {=version}
+  "duration"
+  "dns-client" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
+  "domain-name"
+  "ipaddr"
+  "fmt"
+  "logs"
+  "lwt"
+  "mirage-clock" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "mirage-random" {>= "2.0.0"}
+  "mirage-time" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using Mirage"
+description: """
+Happy eyeballs is an implementation of RFC 8305 which specifies how to connect
+to a remote host using either IP protocol version 4 or IP protocol version 6.
+This uses Lwt and Mirage for side effects.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.6.0/happy-eyeballs-0.6.0.tbz"
+  checksum: [
+    "sha256=e587908776ac52603740363efd625b0767162521ab2d63b745e64056184c0429"
+    "sha512=2de6632aa32eea4ca865747fad7db1043baca8f9e14ab798224873926636d11c233c3c093237222118731a5dd00a0de804c3942bfe003f18c8f2c39159883018"
+  ]
+}
+x-commit-hash: "f744de78a274e777c8b761a6fb229f62dfd422a0"

--- a/packages/happy-eyeballs/happy-eyeballs.0.6.0/opam
+++ b/packages/happy-eyeballs/happy-eyeballs.0.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/happy-eyeballs"
+dev-repo: "git+https://github.com/roburio/happy-eyeballs.git"
+bug-reports: "https://github.com/roburio/happy-eyeballs/issues"
+doc: "https://roburio.github.io/happy-eyeballs/"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "duration"
+  "domain-name" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6"
+description: """
+Happy eyeballs is an implementation of
+[RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305) which specifies how
+to connect to a remote host using either IP protocol version 4 or IP protocol
+version 6. This is the core of the algorithm in value passing style, with a
+slick dependency cone.
+"""
+url {
+  src:
+    "https://github.com/roburio/happy-eyeballs/releases/download/v0.6.0/happy-eyeballs-0.6.0.tbz"
+  checksum: [
+    "sha256=e587908776ac52603740363efd625b0767162521ab2d63b745e64056184c0429"
+    "sha512=2de6632aa32eea4ca865747fad7db1043baca8f9e14ab798224873926636d11c233c3c093237222118731a5dd00a0de804c3942bfe003f18c8f2c39159883018"
+  ]
+}
+x-commit-hash: "f744de78a274e777c8b761a6fb229f62dfd422a0"


### PR DESCRIPTION
## happy-eyeballs v0.6.0 (2023-06-15)

* Fix connection establishment: parallelize connection attempts, deal with
  servers dropping packets (such as the Azure DNS resolver)
* Introduce connect_delay (when to start the next connection attempt)
* Deal with connect_timeout properly
* Revise log output (IP vs domain name, fewer logs on debug level)

All in roburio/happy-eyeballs#34, @hannesm, reviewed by @reynir -- sponsored by Semgrep Inc

## dns v7.0.3 (2023-06-15)

* dns-client-lwt, dns-client-mirage: adapt to happy-eyeballs 0.6 changes,
  also avoid unnecessary recursion (mirage/ocaml-dns#340 @hannesm, @reynir)