### PR TITLE
[new release] moonpool (0.1.1)

### DIFF
--- a/packages/moonpool/moonpool.0.1.1/opam
+++ b/packages/moonpool/moonpool.0.1.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either"
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.1.1/moonpool-0.1.1.tbz"
+  checksum: [
+    "sha256=d97322642f3babf64595cce2152f218cf5e0655b151521771ddf3ec5e61c0aae"
+    "sha512=6914b957cdf359d3263119f3ba270f2d372a31362a52efd92201d972e2d45f9481d06503a212cd75931c3093424f1ecd016eb3f2eeafb2fce4d2eeeecfdd43a6"
+  ]
+}
+x-commit-hash: "d4a75280dedbf4c9d8f253e05916978f3d60e475"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- fix(fut): fix bug when calling `wait_list []`
- fix: join_array on arrays of length=1 had a bound error
