### PR TITLE
[new release] moonpool (0.2)

### DIFF
--- a/packages/moonpool/moonpool.0.2/opam
+++ b/packages/moonpool/moonpool.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.2/moonpool-0.2.tbz"
+  checksum: [
+    "sha256=cacf21d34364c97ab9827d6103f897e1d33878c5f70e84df524693b84459f7e8"
+    "sha512=de5300021641cb1f48bef521c23b04ed17d43ae942298c479c1d93f198f9e3c70183087c39fb5d9f9fd8525f9dd15dc1b58c178d6003a515c64f2c90cf230254"
+  ]
+}
+x-commit-hash: "7707a7c1ce33666d9134f4fa8b792f4fc347d162"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- add `Fut.for_list`
- add `around_task` to `Pool.create`
- add `Pool.shutdown_without_waiting`
- add `Pool.num_tasks`
- add `Fut.is_done`
- add `Blocking_queue.size`
- add `Fut.for_array` to easily iterate on an array in parallel
- add `Fut.get_or_fail{,_exn}`

- perf: limit number of work queues in pool
- perf: use multiple queues and non-blocking work-stealing from them, in pool
    this improves the behavior for many small tasks by reducing contention on
    each queue

- fix: fut: actually run all map/bind callbacks in pool if provided
