### PR TITLE
Update conf-trexio

### DIFF
--- a/packages/conf-trexio/conf-trexio.0.1/opam
+++ b/packages/conf-trexio/conf-trexio.0.1/opam
@@ -5,7 +5,7 @@ homepage: "http://trex-coe.github.io/trexio"
 bug-reports: "https://github.com/trex-coe/trexio/issues"
 license: "BSD-3-Clause"
 build: [
-  ["sh" "-c" "cc test.c $(pkg-config --libs --cflags libtrexio)"]
+  ["sh" "-c" "cc test.c $(pkg-config --libs --cflags trexio)"]
 ]
 depends: ["conf-pkg-config" {build}]
 


### PR DESCRIPTION
pkg-config expects `trexio` and not `libtrexio`