### PR TITLE
[new release] shuttle_http (0.10.0)

### DIFF
--- a/packages/shuttle_http/shuttle_http.0.10.0/opam
+++ b/packages/shuttle_http/shuttle_http.0.10.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle_http"
+bug-reports: "https://github.com/anuragsoni/shuttle_http/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "async" {>= "v0.16.0"}
+  "async_ssl" {>= "v0.16.0"}
+  "core" {>= "v0.16.0"}
+  "jane_rope" {>= "v0.16.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "re2" {>= "v0.16.0"}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle_http.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle_http/releases/download/0.10.0/shuttle_http-0.10.0.tbz"
+  checksum: [
+    "sha256=c89bfa5ca3c099e41e62c231eb6d6de096aef20f462d22c09a64908cd15fd5d2"
+    "sha512=6e4bdec3fa61c0526c3943748ce199abfb6b9a02905fdf079391a0ee6c1738fc006c33fa6f04a8ebfa4ce20b7604a729ada6b4d740182982e7623acba7726b2b"
+  ]
+}
+x-commit-hash: "10ca7aadb695b389fb8304aecce0753ece8102a4"


### PR DESCRIPTION
Async library for HTTP/1.1 servers and clients

- Project page: <a href="https://github.com/anuragsoni/shuttle_http">https://github.com/anuragsoni/shuttle_http</a>

##### CHANGES:

* Adapt to changes in async_kernel 0.16
* Only support OCaml 4.14 or newer
* Only support HTTP codec in the library
