### PR TITLE
Fix various Windows `depends`/`available` fields

### DIFF
--- a/packages/eio_main/eio_main.0.10/opam
+++ b/packages/eio_main/eio_main.0.10/opam
@@ -13,8 +13,8 @@ depends: [
   "kcas" {>= "0.3.0" & with-test}
   "yojson" {>= "2.0.2" & with-test}
   "eio_linux" {= version & os = "linux"}
-  "eio_posix" {= version & os-family != "windows"}
-  "eio_windows" {= version & os-family = "windows"}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_main/eio_main.0.9/opam
+++ b/packages/eio_main/eio_main.0.9/opam
@@ -12,7 +12,7 @@ depends: [
   "mdx" {>= "2.2.0" & with-test}
   "eio_linux" {= version & os = "linux"}
   "eio_posix" {= version & os != "win32"}
-  "eio_luv" {= version & os = "win32" | with-test}
+  "eio_luv" {= version & (os = "win32" | with-test)}
   "odoc" {with-doc}
 ]
 depopts: ["eio_luv"]

--- a/packages/eio_main/eio_main.0.9/opam
+++ b/packages/eio_main/eio_main.0.9/opam
@@ -11,8 +11,8 @@ depends: [
   "dune" {>= "3.7"}
   "mdx" {>= "2.2.0" & with-test}
   "eio_linux" {= version & os = "linux"}
-  "eio_posix" {= version & os != "windows"}
-  "eio_luv" {= version & os = "windows" | with-test}
+  "eio_posix" {= version & os != "win32"}
+  "eio_luv" {= version & os = "win32" | with-test}
   "odoc" {with-doc}
 ]
 depopts: ["eio_luv"]

--- a/packages/parany/parany.12.2.2/opam
+++ b/packages/parany/parany.12.2.2/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.6.0"}
   "ocaml" {>= "4.03.0"}
 ]
-available: [ os != "windows" ]
+available: os != "win32"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "src/test.exe"] {with-test}

--- a/packages/parany/parany.14.0.0/opam
+++ b/packages/parany/parany.14.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.6.0"}
   "ocaml" {>= "4.03.0"}
 ]
-available: [ os != "windows" ]
+available: os != "win32"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "-p" name "-j" jobs "src/test.exe"] {with-test}


### PR DESCRIPTION
opam running on Cygwin has `os = "cygwin"` and `os-family = "windows"`; opam running on native Windows itself has `os = "win32"` and `os-family = "windows"`. Using `os-family = "windows"` is normally a mistake. Cygwin is an implementation of Posix on top of Windows, so on the rare occasions that something is _actually_ common between the two (e.g. `.dll` extension for shared objects), I think it's actually better to be more explicit and have `(os = "win32" | os = "cygwin")`.

Both submitted upstream in https://github.com/ocaml-multicore/eio/pull/557 and https://github.com/UnixJunkie/parany/pull/75.