### PR TITLE
Package soupault.4.6.0

### DIFF
--- a/packages/soupault/soupault.4.6.0/opam
+++ b/packages/soupault/soupault.4.6.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Static website generator based on HTML rewriting"
+description: """\
+A website generator that works with page element tree rather than text
+and allows you to manipulate pages and retrieve metadata from
+existing HTML using arbitrary CSS selectors.
+
+With soupault you can:
+
+* Generate ToC and footnotes.
+* Insert file content or an HTML snippet in any element.
+* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
+* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
+* Export extracted metadata to JSON.
+
+Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
+similar to web browsers.
+
+The website generator mode is optional, you can use it as post-processor for existing sites."""
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: "Daniil Baturin <daniil+soupault@baturin.org>"
+license: "MIT"
+homepage: "https://www.soupault.app"
+bug-reports: "https://github.com/PataphysicalSociety/soupault/issues"
+depends: [
+  "ocaml" {>= "4.13"}
+  "dune" {>= "2.0.0"}
+  "lambdasoup" {>= "1.0.0"}
+  "markup" {>= "1.0.0-1"}
+  "otoml" {>= "1.0.4"}
+  "fileutils" {>= "0.6.3"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "re" {>= "1.9.0"}
+  "ezjsonm" {>= "1.2.0"}
+  "yaml" {>= "2.0.0"}
+  "containers" {>= "3.9"}
+  "odate" {>= "0.6"}
+  "spelll" {>= "0.4"}
+  "base64" {>= "3.0.0"}
+  "jingoo" {>= "1.4.2"}
+  "tsort" {>= "2.1.0"}
+  "lua-ml" {>= "0.9.3"}
+  "camomile" {>= "2.0.0"}
+  "digestif" {>= "0.7.3"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/PataphysicalSociety/soupault"
+url {
+  src:
+    "https://codeberg.org/PataphysicalSociety/soupault/archive/4.6.0.tar.gz"
+  checksum: [
+    "md5=93cef405e9be77a6b913485038736309"
+    "sha512=629d64a4492d0e82c05d3ae8a40055d0bc266ae7f891e3914662670aa5767a3981aca0fa41aea0f59de20efde51b8f794ab77e7e9a7b8c52feecfe4dafbc9ee6"
+  ]
+}


### PR DESCRIPTION
### `soupault.4.6.0`
Static website generator based on HTML rewriting
A website generator that works with page element tree rather than text
and allows you to manipulate pages and retrieve metadata from
existing HTML using arbitrary CSS selectors.

With soupault you can:

* Generate ToC and footnotes.
* Insert file content or an HTML snippet in any element.
* Preprocess element content with external programs (e.g. run `<pre>` tags through a highlighter)
* Extract page metadata (think microformats) and render it using a Jingoo template or an external script.
* Export extracted metadata to JSON.

Soupault is extensible with Lua (2.5) plugins and provides an API for element tree manipulation,
similar to web browsers.

The website generator mode is optional, you can use it as post-processor for existing sites.



---
* Homepage: https://www.soupault.app
* Source repo: git+https://github.com/PataphysicalSociety/soupault
* Bug tracker: https://github.com/PataphysicalSociety/soupault/issues

---
:camel: Pull-request generated by opam-publish v2.2.0