### PR TITLE
[new release] thread-table (0.1.0)

### DIFF
--- a/packages/thread-table/thread-table.0.1.0/opam
+++ b/packages/thread-table/thread-table.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A lock-free thread-safe integer keyed hash table"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "0BSD"
+homepage: "https://github.com/ocaml-multicore/thread-table"
+bug-reports: "https://github.com/ocaml-multicore/thread-table/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08"}
+  "mdx" {>= "1.10.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/thread-table.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/thread-table/releases/download/0.1.0/thread-table-0.1.0.tbz"
+  checksum: [
+    "sha256=1ceb357278f4961f343539cdd1648fad4e14f2d6cb957e683016787734417f56"
+    "sha512=b726841f0769085b1061f299947ee76ca5a1f3a489ac2f75b54a04f1407170674bfd7a9560a7332f2b9d07f1d19e94b4d9e2b569204b6fc4edf534c320ed1d41"
+  ]
+}
+x-commit-hash: "9c01f7ef79767ee7271de093d14c84f972f13020"


### PR DESCRIPTION
A lock-free thread-safe integer keyed hash table

- Project page: <a href="https://github.com/ocaml-multicore/thread-table">https://github.com/ocaml-multicore/thread-table</a>

## 0.1.0

- Initial version of lock-free thread-safe integer keyed hash table (@polytypic)
