### PR TITLE
[new release] thread-table (0.1.0)

### DIFF
--- a/packages/thread-table/thread-table.0.1.0/opam
+++ b/packages/thread-table/thread-table.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A lock-free thread-safe integer keyed hash table"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "0BSD"
+homepage: "https://github.com/ocaml-multicore/thread-table"
+bug-reports: "https://github.com/ocaml-multicore/thread-table/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.08"}
+  "mdx" {>= "1.10.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/thread-table.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/thread-table/releases/download/0.1.0/thread-table-0.1.0.tbz"
+  checksum: [
+    "sha256=77ce01c02f56e6e75626062e690c260357b677aba4d2fdb5d0cee72bbd958d7b"
+    "sha512=99070ed6ee8b78846c6d8d718bf621d1c11f187aa12114d5ce15d2a9ee2cc593b3c8620cee59fc4e63313f61805508f302b3275d6d18b7f9bbc64c3836858e9f"
+  ]
+}
+x-commit-hash: "4dfe6f17b7166f1e608e73a4af815db31a7c78b3"


### PR DESCRIPTION
A lock-free thread-safe integer keyed hash table

- Project page: <a href="https://github.com/ocaml-multicore/thread-table">https://github.com/ocaml-multicore/thread-table</a>

## 0.1.0

- Initial version of lock-free thread-safe integer keyed hash table (@polytypic)
