### PR TITLE
extism-manifest is incompatible with ppx_yojson_conv v0.16

### DIFF
--- a/packages/extism-manifest/extism-manifest.0.3.0/opam
+++ b/packages/extism-manifest/extism-manifest.0.3.0/opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/extism/extism/issues"
 depends: [
   "ocaml" {>= "4.14.1"}
   "dune" {>= "3.2"}
-  "ppx_yojson_conv" {>= "v0.15.0"}
+  "ppx_yojson_conv" {>= "v0.15.0" & < "v0.16.0"}
   "ppx_inline_test" {>= "v0.15.0"}
   "base64" {>= "3.5.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
See https://github.com/janestreet/ppx_yojson_conv/commit/6a0456dc6c34946e5c65250bd30f7264ac2b905f

As seen in #23942:

    #=== ERROR while compiling extism-manifest.0.3.0 ==============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/extism-manifest.0.3.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p extism-manifest -j 71 @install
    # exit-code            1
    # env-file             ~/.opam/log/extism-manifest-7-3814db.env
    # output-file          ~/.opam/log/extism-manifest-7-3814db.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I ocaml/manifest/.extism_manifest.objs/byte -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -o ocaml/manifest/.extism_manifest.objs/byte/extism_manifest.cmo -c -impl ocaml/manifest/extism_manifest.pp.ml)
    # File "ocaml/manifest/extism_manifest.ml", line 6, characters 36-39:
    # 6 | type memory_options = { max_pages : int option [@yojson.option] }
    #                                         ^^^
    # Error: Unbound value int_of_yojson
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -g -I ocaml/manifest/.extism_manifest.objs/byte -I ocaml/manifest/.extism_manifest.objs/native -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/yojson -intf-suffix .ml -no-alias-deps -o ocaml/manifest/.extism_manifest.objs/native/extism_manifest.cmx -c -impl ocaml/manifest/extism_manifest.pp.ml)
    # File "ocaml/manifest/extism_manifest.ml", line 6, characters 36-39:
    # 6 | type memory_options = { max_pages : int option [@yojson.option] }
    #                                         ^^^
    # Error: Unbound value int_of_yojson
