### PR TITLE
jupyter.2.8.2: require ppx_yojson_conv < 0.16

### DIFF
--- a/packages/jupyter/jupyter.2.8.2/opam
+++ b/packages/jupyter/jupyter.2.8.2/opam
@@ -27,7 +27,7 @@ depends: [
   "zmq" {>= "5.0.0"}
   "zmq-lwt" {>= "5.0.0"}
   "yojson" {>="1.6.0"}
-  "ppx_yojson_conv" {>= "v0.14.0"}
+  "ppx_yojson_conv" {>= "v1.14.0" & < "v0.16.0"}
   "ppx_deriving" {>= "5.2.1"}
   "cryptokit" {>= "1.12"}
   "dune" {>= "1.0.0"}


### PR DESCRIPTION
See https://github.com/janestreet/ppx_yojson_conv/commit/6a0456dc6c34946e5c65250bd30f7264ac2b905f

As seen in #23942:

    #=== ERROR while compiling jupyter.2.8.2 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/jupyter.2.8.2
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p jupyter -j 31
    # exit-code            1
    # env-file             ~/.opam/log/jupyter-7-10cde4.env
    # output-file          ~/.opam/log/jupyter-7-10cde4.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w A-4-31-33-34-39-41-42-43-44-45-48-49-50-58-66 -safe-string -strict-sequence -strict-formats -short-paths -g -bin-annot -I src/core/.jupyter.objs/byte -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Jupyter__ -o src/core/.jupyter.objs/byte/jupyter.cmo -c -impl src/core/jupyter.pp.ml)
    # File "src/core/jupyter.pp.ml", line 1:
    # Warning 70 [missing-mli]: Cannot find interface file.
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w A-4-31-33-34-39-41-42-43-44-45-48-49-50-58-66 -safe-string -strict-sequence -strict-formats -short-paths -g -bin-annot -I src/core/.jupyter.objs/byte -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Jupyter__ -o src/core/.jupyter.objs/byte/jupyter__AnsiCode.cmo -c -impl src/core/ansiCode.pp.ml)
    # File "src/core/ansiCode.pp.ml", line 1:
    # Warning 70 [missing-mli]: Cannot find interface file.
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w A-4-31-33-34-39-41-42-43-44-45-48-49-50-58-66 -safe-string -strict-sequence -strict-formats -short-paths -g -bin-annot -I src/core/.jupyter.objs/byte -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Jupyter__ -o src/core/.jupyter.objs/byte/jupyter__Version.cmo -c -impl src/core/version.pp.ml)
    # File "src/core/version.pp.ml", line 1:
    # Warning 70 [missing-mli]: Cannot find interface file.
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w A-4-31-33-34-39-41-42-43-44-45-48-49-50-58-66 -safe-string -strict-sequence -strict-formats -short-paths -g -bin-annot -I src/core/.jupyter.objs/byte -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Jupyter__ -o src/core/.jupyter.objs/byte/jupyter__Stdin.cmo -c -impl src/core/stdin.pp.ml)
    # File "src/core/stdin.ml", line 29, characters 19-25:
    # 29 |     stdin_prompt : string [@key "prompt"];
    #                         ^^^^^^
    # Error: Unbound value string_of_yojson
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w A-4-31-33-34-39-41-42-43-44-45-48-49-50-58-66 -safe-string -strict-sequence -strict-formats -short-paths -g -bin-annot -I src/core/.jupyter.objs/byte -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/uuidm -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Jupyter__ -o src/core/.jupyter.objs/byte/jupyter__Comm.cmo -c -impl src/core/comm.pp.ml)
    # File "src/core/comm.ml", line 26, characters 25-31:
    # 26 |     comm_target : string option [@key "target_name"] [@default None];
    #                               ^^^^^^
    # Error: Unbound value option_of_yojson
