### PR TITLE
openai.0.0.1: require ppx_yojson_conv < 0.16

### DIFF
--- a/packages/openai/openai.0.0.1/opam
+++ b/packages/openai/openai.0.0.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "dune" {>= "3.7.0"}
   "ppx_yojson"
-  "ppx_yojson_conv"
+  "ppx_yojson_conv" {< "v0.16.0"}
   "lwt_ppx"
   "conf-openssl"
   "ezcurl-lwt"


### PR DESCRIPTION
See https://github.com/janestreet/ppx_yojson_conv/commit/6a0456dc6c34946e5c65250bd30f7264ac2b905f

As seen in #23942:

    #=== ERROR while compiling openai.0.0.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/openai.0.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -j 127 -p openai
    # exit-code            1
    # env-file             ~/.opam/log/openai-7-c1afc6.env
    # output-file          ~/.opam/log/openai-7-c1afc6.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.openai.objs/byte -I src/.openai.objs/public_cmi -I /home/opam/.opam/4.14/lib/curl -I /home/opam/.opam/4.14/lib/ezcurl-lwt -I /home/opam/.opam/4.14/lib/ezcurl/core -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Openai -o src/.openai.objs/byte/openai__Edit.cmo -c -impl src/edit.pp.ml)
    # File "src/edit.ml", line 13, characters 40-56:
    # 13 |   let input = Json.to_field_opt "input" yojson_of_string input in
    #                                              ^^^^^^^^^^^^^^^^
    # Error: Unbound value yojson_of_string
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.openai.objs/byte -I src/.openai.objs/public_cmi -I /home/opam/.opam/4.14/lib/curl -I /home/opam/.opam/4.14/lib/ezcurl-lwt -I /home/opam/.opam/4.14/lib/ezcurl/core -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Openai -o src/.openai.objs/byte/openai__Chat_completion.cmo -c -impl src/chat_completion.pp.ml)
    # File "src/chat_completion.ml", line 16, characters 14-20:
    # 16 |   { content : string
    #                    ^^^^^^
    # Error: Unbound value yojson_of_string
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.openai.objs/byte -I src/.openai.objs/public_cmi -I /home/opam/.opam/4.14/lib/curl -I /home/opam/.opam/4.14/lib/ezcurl-lwt -I /home/opam/.opam/4.14/lib/ezcurl/core -I /home/opam/.opam/4.14/lib/lwt -I /home/opam/.opam/4.14/lib/lwt/unix -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocplib-endian -I /home/opam/.opam/4.14/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.14/lib/ppx_yojson_conv_lib -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/yojson -no-alias-deps -open Openai -o src/.openai.objs/byte/openai__Basic.cmo -c -impl src/basic.pp.ml)
    # File "src/basic.ml", line 57, characters 43-59:
    # 57 |     format |> string_of_response_format |> yojson_of_string
    #                                                 ^^^^^^^^^^^^^^^^
    # Error: Unbound value yojson_of_string
