### PR TITLE
cohttp-async requires JS < 0.16

### DIFF
--- a/packages/cohttp-async/cohttp-async.2.5.8/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.8/opam
@@ -25,9 +25,10 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "async_kernel" {>= "v0.14.0" & < "v0.16.0"}
+  "async_kernel" {>= "v0.14.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
+  "async" {< "v0.16.0" & with-test}
   "base" {>= "v0.11.0"}
   "core" {with-test}
   "cohttp" {=version}

--- a/packages/cohttp-async/cohttp-async.2.5.8/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.8/opam
@@ -28,7 +28,7 @@ depends: [
   "async_kernel" {>= "v0.14.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
-  "async" {< "v0.16.0" & with-test}
+  "async" {< "v0.15.0" & with-test}
   "base" {>= "v0.11.0"}
   "core" {with-test}
   "cohttp" {=version}

--- a/packages/cohttp-async/cohttp-async.2.5.8/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.8/opam
@@ -25,7 +25,7 @@ bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "ocaml" {>= "4.04.1"}
   "dune" {>= "1.1.0"}
-  "async_kernel" {>= "v0.14.0"}
+  "async_kernel" {>= "v0.14.0" & < "v0.16.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
   "base" {>= "v0.11.0"}

--- a/packages/cohttp-async/cohttp-async.6.0.0~alpha1/opam
+++ b/packages/cohttp-async/cohttp-async.6.0.0~alpha1/opam
@@ -27,7 +27,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "http" {= version}
   "cohttp" {= version}
-  "async_kernel" {>= "v0.14.0"}
+  "async_kernel" {>= "v0.14.0" & < "v0.16.0"}
   "async_unix" {>= "v0.14.0"}
   "async" {>= "v0.14.0"}
   "base" {>= "v0.11.0"}


### PR DESCRIPTION
As seen in #23942:

    #=== ERROR while compiling cohttp-async.2.5.8 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/cohttp-async.2.5.8
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p cohttp-async -j 255
    # exit-code            1
    # env-file             ~/.opam/log/cohttp-async-7-8ae638.env
    # output-file          ~/.opam/log/cohttp-async-7-8ae638.out
    ### output ###
    [...]
    # File "cohttp-async/test/test_async_integration.ml", lines 88-93, characters 23-24:
    # 88 | .......................resps
    # 89 |                        |> Deferred.List.iter ~f:(fun (_resp, body) ->
    # 90 |                          let expected_body = body_q |> Queue.dequeue_exn in
    # 91 |                          body |> Body.to_string >>| fun body ->
    # 92 |                          assert_equal ~printer expected_body body
    # 93 |                        )...
    # Error: This expression has type
    #          how:Async_kernel.Monad_sequence.how ->
    #          unit Async_kernel__Deferred1.t
    #        but an expression was expected of type
    #          'a Async_kernel.Deferred.t = 'a Async_kernel__Types.Deferred.t

And:

    #=== ERROR while compiling cohttp-async.6.0.0~alpha1 ==========================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/cohttp-async.6.0.0~alpha1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p cohttp-async -j 255 @install
    # exit-code            1
    # env-file             ~/.opam/log/cohttp-async-7-7e06e8.env
    # output-file          ~/.opam/log/cohttp-async-7-7e06e8.out
    ### output ###
    [...]
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlc.opt -w -40 -g -bin-annot -I cohttp-async/src/.cohttp_async.objs/byte -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/astring -I /home/opam/.opam/4.14/lib/async -I /home/opam/.opam/4.14/lib/async/async_command -I /home/opam/.opam/4.14/lib/async/async_quickcheck -I /home/opam/.opam/4.14/lib/async/async_rpc -I /home/opam/.opam/4.14/lib/async_kernel -I /home/opam/.opam/4.14/lib/async_kernel/config -I /home/opam/.opam/4.14/lib/async_kernel/eager_deferred -I /home/opam/.opam/4.14/lib/async_kernel/persistent_connection_kernel -I /home/opam/.opam/4.14/lib/async_kernel/read_write_pair -I /home/opam/.opam/4.14/lib/async_rpc_kernel -I /home/opam/.opam/4.14/lib/async_unix -I /home/opam/.opam/4.14/lib/async_unix/thread_pool -I /home/opam/.opam/4.14/lib/async_unix/thread_safe_ivar -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base64 -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/cohttp -I /home/opam/.opam/4.14/lib/conduit -I /home/opam/.opam/4.14/lib/conduit-async -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/command -I /home/opam/.opam/4.14/lib/core/filename_base -I /home/opam/.opam/4.14/lib/core/heap_block -I /home/opam/.opam/4.14/lib/core/univ_map -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel/bounded_int_table -I /home/opam/.opam/4.14/lib/core_kernel/bus -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_kernel/iobuf -I /home/opam/.opam/4.14/lib/core_kernel/moption -I /home/opam/.opam/4.14/lib/core_kernel/pairing_heap -I /home/opam/.opam/4.14/lib/core_kernel/sexp_hidden_in_test -I /home/opam/.opam/4.14/lib/core_kernel/thread_pool_cpu_affinity -I /home/opam/.opam/4.14/lib/core_kernel/thread_safe_queue -I /home/opam/.opam/4.14/lib/core_kernel/timing_wheel -I /home/opam/.opam/4.14/lib/core_kernel/tuple_pool -I /home/opam/.opam/4.14/lib/core_kernel/uopt -I /home/opam/.opam/4.14/lib/core_kernel/uuid -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/bigstring_unix -I /home/opam/.opam/4.14/lib/core_unix/core_thread -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/filename_unix -I /home/opam/.opam/4.14/lib/core_unix/iobuf_unix -I /home/opam/.opam/4.14/lib/core_unix/linux_ext -I /home/opam/.opam/4.14/lib/core_unix/nano_mutex -I /home/opam/.opam/4.14/lib/core_unix/ocaml_c_utils -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/core_unix/squeue -I /home/opam/.opam/4.14/lib/core_unix/sys_unix -I /home/opam/.opam/4.14/lib/core_unix/time_float_unix -I /home/opam/.opam/4.14/lib/core_unix/time_ns_unix -I /home/opam/.opam/4.14/lib/core_unix/time_stamp_counter -I /home/opam/.opam/4.14/lib/core_unix/uuid -I /home/opam/.opam/4.14/lib/domain-name -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/http -I /home/opam/.opam/4.14/lib/http/__private__/http_bytebuffer/.public_cmi -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/ipaddr -I /home/opam/.opam/4.14/lib/ipaddr-sexp -I /home/opam/.opam/4.14/lib/ipaddr/unix -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/logs -I /home/opam/.opam/4.14/lib/macaddr -I /home/opam/.opam/4.14/lib/magic-mime -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/ocaml_intrinsics -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_stable_witness/runtime -I /home/opam/.opam/4.14/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/4.14/lib/protocol_version_header -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/timezone -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uri-sexp -I /home/opam/.opam/4.14/lib/uri/services -I /home/opam/.opam/4.14/lib/variantslib -intf-suffix .ml -no-alias-deps -open Cohttp_async__ -o cohttp-async/src/.cohttp_async.objs/byte/cohttp_async__Body.cmo -c -impl cohttp-async/src/body.pp.ml)
    # File "cohttp-async/src/body.ml", line 70, characters 19-63:
    # 70 |   | `Strings sl -> Deferred.List.iter sl ~f:(write_body writer)
    #                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    # Warning 5 [ignored-partial-application]: this function application is partial,
    # maybe some arguments are missing.
    # File "cohttp-async/src/body.ml", line 70, characters 19-63:
    # 70 |   | `Strings sl -> Deferred.List.iter sl ~f:(write_body writer)
    #                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    # Error: This expression has type
    #          how:Async_kernel.Monad_sequence.how ->
    #          unit Async_kernel__Deferred1.t
    #        but an expression was expected of type
    #          unit Async_kernel.Deferred.t = unit Async_kernel__Types.Deferred.t
