### PR TITLE
biotk.0.2.0 requires core < v0.16

### DIFF
--- a/packages/biotk/biotk.0.2.0/opam
+++ b/packages/biotk/biotk.0.2.0/opam
@@ -16,7 +16,7 @@ depends: [
   "angstrom-unix" {>= "0.15.0"}
   "binning"
   "camlzip" {>= "1.05"}
-  "core" {>= "v0.15.0"}
+  "core" {>= "v0.15.0" & < "v0.16.0"}
   "core_bench" {with-test}
   "core_kernel" {>= "v0.15.0"}
   "core_unix" {>= "v0.15.0"}


### PR DESCRIPTION
As seen in #23942:

    #=== ERROR while compiling biotk.0.2.0 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/biotk.0.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p biotk -j 127 @install
    # exit-code            1
    # env-file             ~/.opam/log/biotk-7-b4f27f.env
    # output-file          ~/.opam/log/biotk-7-b4f27f.out
    ### output ###
    [...]
    # (cd _build/default && /home/opam/.opam/4.14/bin/ocamlopt.opt -w -40 -short-paths -g -I lib/.biotk.objs/byte -I lib/.biotk.objs/native -I /home/opam/.opam/4.14/lib/angstrom -I /home/opam/.opam/4.14/lib/angstrom-unix -I /home/opam/.opam/4.14/lib/base -I /home/opam/.opam/4.14/lib/base/base_internalhash_types -I /home/opam/.opam/4.14/lib/base/caml -I /home/opam/.opam/4.14/lib/base/md5 -I /home/opam/.opam/4.14/lib/base/shadow_stdlib -I /home/opam/.opam/4.14/lib/base_bigstring -I /home/opam/.opam/4.14/lib/base_quickcheck -I /home/opam/.opam/4.14/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/4.14/lib/bigstringaf -I /home/opam/.opam/4.14/lib/bin_prot -I /home/opam/.opam/4.14/lib/bin_prot/shape -I /home/opam/.opam/4.14/lib/binning -I /home/opam/.opam/4.14/lib/core -I /home/opam/.opam/4.14/lib/core/base_for_tests -I /home/opam/.opam/4.14/lib/core/command -I /home/opam/.opam/4.14/lib/core/filename_base -I /home/opam/.opam/4.14/lib/core/heap_block -I /home/opam/.opam/4.14/lib/core/univ_map -I /home/opam/.opam/4.14/lib/core/validate -I /home/opam/.opam/4.14/lib/core_kernel -I /home/opam/.opam/4.14/lib/core_kernel/binary_packing -I /home/opam/.opam/4.14/lib/core_kernel/caml_threads -I /home/opam/.opam/4.14/lib/core_kernel/caml_unix -I /home/opam/.opam/4.14/lib/core_kernel/flags -I /home/opam/.opam/4.14/lib/core_unix -I /home/opam/.opam/4.14/lib/core_unix/error_checking_mutex -I /home/opam/.opam/4.14/lib/core_unix/signal_unix -I /home/opam/.opam/4.14/lib/csvfields -I /home/opam/.opam/4.14/lib/csvfields/csvlib -I /home/opam/.opam/4.14/lib/csvfields/xml-light -I /home/opam/.opam/4.14/lib/fieldslib -I /home/opam/.opam/4.14/lib/fmt -I /home/opam/.opam/4.14/lib/gg -I /home/opam/.opam/4.14/lib/gsl -I /home/opam/.opam/4.14/lib/int_repr -I /home/opam/.opam/4.14/lib/jane-street-headers -I /home/opam/.opam/4.14/lib/ocaml/threads -I /home/opam/.opam/4.14/lib/otfm -I /home/opam/.opam/4.14/lib/parsexp -I /home/opam/.opam/4.14/lib/ppx_assert/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_bench/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_deriving/runtime -I /home/opam/.opam/4.14/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_expect/collector -I /home/opam/.opam/4.14/lib/ppx_expect/common -I /home/opam/.opam/4.14/lib/ppx_expect/config -I /home/opam/.opam/4.14/lib/ppx_expect/config_types -I /home/opam/.opam/4.14/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_here/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_inline_test/config -I /home/opam/.opam/4.14/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_log/types -I /home/opam/.opam/4.14/lib/ppx_module_timer/runtime -I /home/opam/.opam/4.14/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.14/lib/ppx_stable_witness/runtime -I /home/opam/.opam/4.14/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/4.14/lib/re -I /home/opam/.opam/4.14/lib/result -I /home/opam/.opam/4.14/lib/rresult -I /home/opam/.opam/4.14/lib/seq -I /home/opam/.opam/4.14/lib/sexplib -I /home/opam/.opam/4.14/lib/sexplib/unix -I /home/opam/.opam/4.14/lib/sexplib0 -I /home/opam/.opam/4.14/lib/spawn -I /home/opam/.opam/4.14/lib/splittable_random -I /home/opam/.opam/4.14/lib/stdio -I /home/opam/.opam/4.14/lib/stringext -I /home/opam/.opam/4.14/lib/time_now -I /home/opam/.opam/4.14/lib/typerep -I /home/opam/.opam/4.14/lib/tyxml -I /home/opam/.opam/4.14/lib/tyxml/functor -I /home/opam/.opam/4.14/lib/uri -I /home/opam/.opam/4.14/lib/uutf -I /home/opam/.opam/4.14/lib/variantslib -I /home/opam/.opam/4.14/lib/vg -I /home/opam/.opam/4.14/lib/zip -I lib/croquis/.biotk_croquis.objs/native -I lib/croquis/.biotk_croquis.objs/public_cmi -intf-suffix .ml -no-alias-deps -open Biotk -o lib/.biotk.objs/native/biotk__Bam_iterator.cmx -c -impl lib/bam_iterator.pp.ml)
    # File "lib/bam_iterator.ml", line 16, characters 33-46:
    # 16 |     Array.iter bins ~f:(fun b -> Int.Table.set r ~key:b.Bai.bin ~data:b) ;
    #                                       ^^^^^^^^^^^^^
    # Error: Unbound value Int.Table.set
