### PR TITLE
Package picasso.0.4.0

### DIFF
--- a/packages/absolute/absolute.0.1/opam
+++ b/packages/absolute/absolute.0.1/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "apron"
   "apronext" {>= "1.0.2"}
-  "picasso"
+  "picasso" {< "0.4"}
 ]
 depopts: [
   "vpl-core"

--- a/packages/absolute/absolute.0.2/opam
+++ b/packages/absolute/absolute.0.2/opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml" {>= "4.11"}
   "apron"
   "apronext" {>= "1.0.2"}
-  "picasso" {>= "0.3.0"}
+  "picasso" {>= "0.3.0" & < "0.4"}
   "menhir" {>= "20180528"}
   "libabsolute"
   "odoc" {with-doc}

--- a/packages/picasso/picasso.0.4.0/opam
+++ b/packages/picasso/picasso.0.4.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ghilesZ/picasso"
 bug-reports: "https://github.com/ghilesZ/picasso/issues"
 dev-repo: "git+https://github.com/ghilesZ/picasso"
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [

--- a/packages/picasso/picasso.0.4.0/opam
+++ b/packages/picasso/picasso.0.4.0/opam
@@ -7,6 +7,7 @@ authors: [
 homepage: "https://github.com/ghilesZ/picasso"
 bug-reports: "https://github.com/ghilesZ/picasso/issues"
 dev-repo: "git+https://github.com/ghilesZ/picasso"
+license: "LGPL-2.0-or-later"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/picasso/picasso.0.4.0/opam
+++ b/packages/picasso/picasso.0.4.0/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Ghiles Ziat <ghiles.ziat@epita.fr"
+authors: [
+  "Ghiles Ziat <ghiles.ziat@epita.fr"
+  "Matthieu Journault <Matthieu.journault@lip6.fr>"
+  ]
+homepage: "https://github.com/ghilesZ/picasso"
+bug-reports: "https://github.com/ghilesZ/picasso/issues"
+dev-repo: "git+https://github.com/ghilesZ/picasso"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune"  {>= "2.1"}
+  "ocaml" {>= "4.08"}
+  "apronext" {>= "1.0.3"}
+  "apron"
+]
+depopts: [
+  "lablgtk"
+  "graphics"
+  ]
+synopsis: "Abstract elements drawing library"
+description: "A toolbox for drawing abstract elements"
+url {
+  src: "https://github.com/ghilesZ/picasso/archive/0.4.tar.gz"
+  checksum: [
+    "md5=d6028ccae6933bf903f34137c335f5ce"
+    "sha512=d8adf3324a27f016d0f6a08ff4afa714185c31e6dcf176e36053564c5e66e3cb734115e11ce6b68a7ed118291ef47f108efea3e3a2272e35b946661ea88e5eff"
+  ]
+}


### PR DESCRIPTION
### `picasso.0.4.0`
Abstract elements drawing library
A toolbox for drawing abstract elements



---
* Homepage: https://github.com/ghilesZ/picasso
* Source repo: git+https://github.com/ghilesZ/picasso
* Bug tracker: https://github.com/ghilesZ/picasso/issues

---
:camel: Pull-request generated by opam-publish v2.1.0