### PR TITLE
[new release] domain-local-await (0.2.1)

### DIFF
--- a/packages/domain-local-await/domain-local-await.0.2.1/opam
+++ b/packages/domain-local-await/domain-local-await.0.2.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent blocking mechanism"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "0BSD"
+homepage: "https://github.com/ocaml-multicore/domain-local-await"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-await/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "thread-table" {>= "0.1.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "mdx" {>= "1.10.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-await.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-await/releases/download/0.2.1/domain-local-await-0.2.1.tbz"
+  checksum: [
+    "sha256=2d0c6c855a64f449ced9a7465c16a617c1f0f0255303327b5b8c8a2244a62e6e"
+    "sha512=dfaec111a519125dfcef6afb1eef5f08b0699ebafc2f90edd9312a418297840abc47a2d81bfaecb0b3a5cb0c56b5683d4e7b9249d0dc1dda3c6316308ad94e67"
+  ]
+}
+x-commit-hash: "042dc337990f18d450421aa389a727dc20cb6c28"


### PR DESCRIPTION
A scheduler independent blocking mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-await">https://github.com/ocaml-multicore/domain-local-await</a>

## 0.2.1

- Support OCaml 4.12.0+ (@polytypic)
- Use lock-free thread-safe hash table for per thread configuration (@polytypic)
