### PR TITLE
[new release] awa and awa-mirage (0.3.0)

### DIFF
--- a/packages/awa-mirage/awa-mirage.0.3.0/opam
+++ b/packages/awa-mirage/awa-mirage.0.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-time" {>= "2.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "2.0.0"}
+  "mirage-clock" {>= "3.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.3.0/awa-0.3.0.tbz"
+  checksum: [
+    "sha256=06d6d17929e700dfaed55cbadda7ced7285ea03aac211536ae2834cb5403b6ec"
+    "sha512=7da1d86244fef433339ca7e091162d7556fee653d23d1bb03fffb84272d39c5c46987435d9242d79c15746fba6b1504b120279b56fd8dab6a01f8cd70ac2ab2b"
+  ]
+}
+x-commit-hash: "7f433100970d3767486eda22efd5555be42987aa"

--- a/packages/awa/awa.0.3.0/opam
+++ b/packages/awa/awa.0.3.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "0.8.1"}
+  "mirage-crypto-rng" {>= "0.11.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.0"}
+  "x509" {>= "0.15.2"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-unix"
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.3.0/awa-0.3.0.tbz"
+  checksum: [
+    "sha256=06d6d17929e700dfaed55cbadda7ced7285ea03aac211536ae2834cb5403b6ec"
+    "sha512=7da1d86244fef433339ca7e091162d7556fee653d23d1bb03fffb84272d39c5c46987435d9242d79c15746fba6b1504b120279b56fd8dab6a01f8cd70ac2ab2b"
+  ]
+}
+x-commit-hash: "7f433100970d3767486eda22efd5555be42987aa"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* FEATURE server: propagate window-change message (mirage/awa-ssh#55 @reynir)
* FEATURE server: implement ext-info and server-sig-algs extension (mirage/awa-ssh#56 @reynir)
* FEATURE server: support RFC 4419 (group key exchanges) and NIST ECDH key
  exchanges, and X25519 (mirage/awa-ssh#63 mirage/awa-ssh#67 @hannesm)
* FEATURE server: handle unknown public keys (instead of closing the connection,
  send a message back, allowing other public keys to be probeb) (mirage/awa-ssh#68 @reynir)
* BUGFIX server: fix rekey (avoid allocating lots of timeout tasks (mirage/awa-ssh#58 @reynir)
* BUGFIX server: filter advertised host key algorithms with used host key
  (mirage/awa-ssh#62 @hannesm)
* server: use logs instead of printf (mirage/awa-ssh#69 @hannesm)
* awa-lwt: drop package (unused, mirage/awa-ssh#61 @hannesm)
* drop Driver module, embed into awa_test_server.ml (mirage/awa-ssh#64 @hannesm)
