### PR TITLE
Add afl-2.57b package.

### DIFF
--- a/packages/afl/afl.2.57b/files/add-uninstall-target.patch
+++ b/packages/afl/afl.2.57b/files/add-uninstall-target.patch
@@ -1,0 +1,21 @@
+--- a/Makefile	2023-06-20 16:54:27
++++ b/Makefile	2023-06-20 16:54:15
+@@ -137,6 +137,18 @@
+ 	cp -r testcases/ $${DESTDIR}$(MISC_PATH)
+ 	cp -r dictionaries/ $${DESTDIR}$(MISC_PATH)
+ 
++uninstall:
++	rm -rf $${DESTDIR}$(MISC_PATH)/dictionaries
++	rm -rf $${DESTDIR}$(MISC_PATH)/testcases
++	rm -f $${DESTDIR}$(DOC_PATH)/README $${DESTDIR}$(DOC_PATH)/ChangeLog $${DESTDIR}$(DOC_PATH)/*.txt
++	rm -f $${DESTDIR}$(HELPER_PATH)/as $${DESTDIR}$(HELPER_PATH)/afl-as
++	set -e; for i in afl-g++ afl-clang afl-clang++; do rm -f $${DESTDIR}$(BIN_PATH)/$$i; done
++	rm -f $${DESTDIR}$(HELPER_PATH)/afl-llvm-rt*.o
++	rm -f $${DESTDIR}$(BIN_PATH)/afl-clang-fast $${DESTDIR}$(BIN_PATH)/afl-clang-fast++
++	rm -f $${DESTDIR}$(BIN_PATH)/afl-qemu-trace
++	set -e; for prog in $(PROGS) $(SH_PROGS); do rm -f $${DESTDIR}$(BIN_PATH)/$$prog; done
++	rm -f $${DESTDIR}$(BIN_PATH)/afl-plot.sh
++
+ publish: clean
+ 	test "`basename $$PWD`" = "AFL" || exit 1
+ 	test -f ~/www/afl/releases/$(PROGNAME)-$(VERSION).tgz; if [ "$$?" = "0" ]; then echo; echo "Change program version in config.h, mmkay?"; echo; exit 1; fi

--- a/packages/afl/afl.2.57b/opam
+++ b/packages/afl/afl.2.57b/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "meetup@yomimono.org"
+homepage: "https://github.com/google/AFL"
+dev-repo: "git+https://github.com/google/AFL.git"
+bug-reports: "https://groups.google.com/forum/#!forum/afl-users"
+license: "Apache-2.0"
+build: [
+  [make] {arch = "x86_64"}
+  [make "AFL_NO_X86=1"] {arch != "x86_64"}
+]
+install: [
+  [make "PREFIX=%{prefix}%" "install"] {arch = "x86_64"}
+  [make "AFL_NO_X86=1" "PREFIX=%{prefix}%" "install"] {arch != "x86_64"}
+]
+remove: [
+  [make "PREFIX=%{prefix}%" "uninstall"]
+]
+patches: [
+  "add-uninstall-target.patch"
+]
+synopsis:
+    "American Fuzzy Lop fuzzer by Michal Zalewski, repackaged for convenient use in opam"
+authors: "Michal Zalewski"
+depends: ["ocaml"]
+extra-files: [
+  "add-uninstall-target.patch" "md5=2c41a9cb71830813fd4e700b5aacc3b5"
+]
+url {
+  src: "https://github.com/google/AFL/archive/v2.57b.tar.gz"
+       checksum: "sha256=6f05a6515c07abe49f6f292bd13c96004cc1e016bda0c3cc9c2769dd43f163ee"
+}


### PR DESCRIPTION
This is the last official release from https://github.com/google/AFL/releases.

It's not clear how I can test this locally within opam. I have applied the patch manually to the project source and that works ok. Submitting here to get testing on various platforms.