### PR TITLE
[new release] ppxlib and ppxlib-bench (0.30.0)

### DIFF
--- a/packages/ppxlib/ppxlib.0.30.0/opam
+++ b/packages/ppxlib/ppxlib.0.30.0/opam
@@ -20,7 +20,7 @@ doc: "https://ocaml-ppx.github.io/ppxlib/"
 bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
 depends: [
   "dune" {>= "2.7"}
-  "ocaml" {>= "4.04.1" & != "5.1.0~alpha1"}
+  "ocaml" {>= "4.04.1" & < "5.2.0" & != "5.1.0~alpha1"}
   "ocaml-compiler-libs" {>= "v0.11.0"}
   "ppx_derivers" {>= "1.0"}
   "sexplib0" {>= "v0.12"}

--- a/packages/ppxlib/ppxlib.0.30.0/opam
+++ b/packages/ppxlib/ppxlib.0.30.0/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Standard infrastructure for ppx rewriters"
+description: """
+Ppxlib is the standard infrastructure for ppx rewriters
+and other programs that manipulate the in-memory representation of
+OCaml programs, a.k.a the "Parsetree".
+
+It also comes bundled with two ppx rewriters that are commonly used to
+write tools that manipulate and/or generate Parsetree values;
+`ppxlib.metaquot` which allows to construct Parsetree values using the
+OCaml syntax directly and `ppxlib.traverse` which provides various
+ways of automatically traversing values of a given type, in particular
+allowing to inject a complex structured value into generated code.
+"""
+maintainer: ["opensource@janestreet.com"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppxlib"
+doc: "https://ocaml-ppx.github.io/ppxlib/"
+bug-reports: "https://github.com/ocaml-ppx/ppxlib/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.04.1" & != "5.1.0~alpha1"}
+  "ocaml-compiler-libs" {>= "v0.11.0"}
+  "ppx_derivers" {>= "1.0"}
+  "sexplib0" {>= "v0.12"}
+  "sexplib0" {with-test & >= "v0.15"}
+  "stdlib-shims"
+  "ocamlfind" {with-test}
+  "re" {with-test & >= "1.9.0"}
+  "cinaps" {with-test & >= "v0.12.1"}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-migrate-parsetree" {< "2.0.0"}
+  "base-effects"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ppxlib.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppxlib/releases/download/0.30.0/ppxlib-0.30.0.tbz"
+  checksum: [
+    "sha256=dd4a63bde9d29b49810e04d7653937c932f177a941ca0e1982b6ad53ac442110"
+    "sha512=0a8c4fa894aaf445cb93213eaa32afb2772235da44aa28c917aba237731a44d5c2687bd960fca49bff62bbe0f9b3fdd9c15730313b429214ae281069f862ffdc"
+  ]
+}
+x-commit-hash: "f0496c9ce731dcffbd26e208b0596627607a496b"


### PR DESCRIPTION
Standard infrastructure for ppx rewriters

- Project page: <a href="https://github.com/ocaml-ppx/ppxlib">https://github.com/ocaml-ppx/ppxlib</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppxlib/">https://ocaml-ppx.github.io/ppxlib/</a>

##### CHANGES:

- Adopt the OCaml Code of Conduct on the repo (ocaml-ppx/ppxlib#426, @pitag-ha)

- Clean up misleading attribute hints when declared for proper context. (ocaml-ppx/ppxlib#425, @ceastlund)

- Ast_pattern now has ebool, pbool helper, and a new map.(ocaml-ppx/ppxlib#402, @burnleydev1)

- multiple errors are now reported in `metaquot`. (ocaml-ppx/ppxlib#397, @burnleydev1)

- Add `Attribute.declare_with_attr_loc` (ocaml-ppx/ppxlib#396, @dvulakh)

- Add "ns" and "res" as reserved namespaces(ocaml-ppx/ppxlib#388, @davesnx)

- Make quoter `let` binding non-recursive (ocaml-ppx/ppxlib#401, @sim642)

- Fix failure of 'lift_map_with_context' in traverse by compile-time
  evaluation of 'fst' and 'snd' (ocaml-ppx/ppxlib#390, @smuenzel)

- Driver: Bias the mapping from magic to version towards the current version,
  as it is usually the common case and it helps when magic numbers are
  ambiguous (such as on development versions) (ocaml-ppx/ppxlib#409, @shym)

- Remove unnecessary test dependencies towards base and stdio (ocaml-ppx/ppxlib#421, @kit-ty-kate)

- Update description to reflect that `ppxlib` contains more than a library
  (ocaml-ppx/ppxlib#422, @pitag-ha)

- Add support for OCaml 5.1, excluding OCaml `5.1.0~alpha1` (ocaml-ppx/ppxlib#428, @shym, @Octachron , @pitag-ha, @panglesd)
- Driver: Fix `-locations-check` option for coercions with ground  (ocaml-ppx/ppxlib#428, @Octachron)
