### PR TITLE
[new release] zed (3.2.2)

### DIFF
--- a/packages/zed/zed.3.2.2/opam
+++ b/packages/zed/zed.3.2.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+maintainer: ["opam-devel@lists.ocaml.org"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/zed"
+bug-reports: "https://github.com/ocaml-community/zed/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.02.3"}
+  "react"
+  "result"
+  "uchar"
+  "uutf"
+  "uucp" {>= "2.0.0"}
+  "uuseg"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/zed.git"
+url {
+  src:
+    "https://github.com/ocaml-community/zed/releases/download/3.2.2/zed-3.2.2.tbz"
+  checksum: [
+    "sha256=096aecc8f22f1869ef085f0102bf5967917367086a612b7f8a6ea1b5d1ab772e"
+    "sha512=32b2c436250f988b63d6e34d242999265b767d53f16b120ee655b2faacea300d45abb8d99017faa3ee63e071a653673480c3eb440f8858121489e3f100e9a16a"
+  ]
+}
+x-commit-hash: "47ef02a5e28b2757e3728583b04d88281f6f36e6"


### PR DESCRIPTION
Abstract engine for text edition in OCaml

- Project page: <a href="https://github.com/ocaml-community/zed">https://github.com/ocaml-community/zed</a>

##### CHANGES:

* `Zed_utf8.next_error`: raise `Zed_utf8.Out_of_bounds` in case of invalid offset (@Lucccyo, ocaml-community/zed#52)
* `kill_next_word` should not raise `Out_of_bound` (@Lucccyo, ocaml-community/zed#55)
* `of_utf8`: add `Uchar.is_valid` to check the input (@Lucccyo, ocaml-community/zed#51)
