### PR TITLE
[new release] domain-local-timeout (0.1.0)

### DIFF
--- a/packages/domain-local-timeout/domain-local-timeout.0.1.0/opam
+++ b/packages/domain-local-timeout/domain-local-timeout.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A scheduler independent timeout mechanism"
+maintainer: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+authors: ["Vesa Karvonen <vesa.a.j.k@gmail.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/domain-local-timeout"
+bug-reports: "https://github.com/ocaml-multicore/domain-local-timeout/issues"
+depends: [
+  "dune" {>= "3.3"}
+  "ocaml" {>= "4.12.0"}
+  "psq" {>= "0.2.1"}
+  "mtime" {>= "2.0.0"}
+  "thread-table" {>= "0.1.0"}
+  "mdx" {>= "1.10.0" & with-test}
+  "domain-local-await" {>= "0.1.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domain-local-timeout.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domain-local-timeout/releases/download/0.1.0/domain-local-timeout-0.1.0.tbz"
+  checksum: [
+    "sha256=513a9c1dd18037f2ebbee98f856e02cba458f1127f8953b9cd324aae13d14e39"
+    "sha512=ceb9af7dec7a677d320ffbbe6e0d7f70d2501552f727a852d1d5e16d24c1ed441bea764cfc7ae52a60d4f185cebb2de5bee272769327415bdb546b78e2a189dc"
+  ]
+}
+x-commit-hash: "02ea9a2d268bdecd9a75ad200e7de84ab5e0ae4f"


### PR DESCRIPTION
A scheduler independent timeout mechanism

- Project page: <a href="https://github.com/ocaml-multicore/domain-local-timeout">https://github.com/ocaml-multicore/domain-local-timeout</a>

##### CHANGES:

All notable changes to this project will be documented in this file.

## 0.1.0

- Initial version of scheduler independent timeout mechanism (@polytypic)
