### PR TITLE
Add Topiary v0.2.3

### DIFF
--- a/packages/topiary/topiary.0.1.0/opam
+++ b/packages/topiary/topiary.0.1.0/opam
@@ -26,6 +26,14 @@ install: [
 ]
 
 synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+description: """
+Topiary is a tool in the Tree-sitter ecosystem, designed for formatter authors
+and formatter users. Authors can create a formatter without having to write
+their own engine or even their own parser. Users benefit from uniform code style
+and the convenience of using a single formatter tool across multiple languages.
+
+Topiary is written in Rust and developed by Tweag.
+"""
 
 url {
   src: "https://github.com/tweag/topiary-opam/releases/download/v0.1.0/source-code-with-submodules.tar.xz"

--- a/packages/topiary/topiary.0.1.0/opam
+++ b/packages/topiary/topiary.0.1.0/opam
@@ -3,7 +3,7 @@ opam-version: "2.0"
 maintainer: "hello@tweag.io"
 authors: [ "Tweag" ]
 
-homepage: "https://github.com/tweag/topiary"
+homepage: "https://topiary.tweag.io/"
 bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 

--- a/packages/topiary/topiary.0.2.0/opam
+++ b/packages/topiary/topiary.0.2.0/opam
@@ -28,6 +28,14 @@ install: [
 ]
 
 synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+description: """
+Topiary is a tool in the Tree-sitter ecosystem, designed for formatter authors
+and formatter users. Authors can create a formatter without having to write
+their own engine or even their own parser. Users benefit from uniform code style
+and the convenience of using a single formatter tool across multiple languages.
+
+Topiary is written in Rust and developed by Tweag.
+"""
 
 url {
   src: "https://github.com/tweag/topiary-opam/releases/download/v0.2.0/source-code-with-submodules.tar.xz"

--- a/packages/topiary/topiary.0.2.0/opam
+++ b/packages/topiary/topiary.0.2.0/opam
@@ -3,7 +3,7 @@ opam-version: "2.0"
 maintainer: "hello@tweag.io"
 authors: [ "Tweag" ]
 
-homepage: "https://github.com/tweag/topiary"
+homepage: "https://topiary.tweag.io/"
 bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 

--- a/packages/topiary/topiary.0.2.1/opam
+++ b/packages/topiary/topiary.0.2.1/opam
@@ -3,7 +3,7 @@ opam-version: "2.0"
 maintainer: "hello@tweag.io"
 authors: [ "Tweag" ]
 
-homepage: "https://github.com/tweag/topiary"
+homepage: "https://topiary.tweag.io/"
 bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 

--- a/packages/topiary/topiary.0.2.1/opam
+++ b/packages/topiary/topiary.0.2.1/opam
@@ -28,6 +28,14 @@ install: [
 ]
 
 synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+description: """
+Topiary is a tool in the Tree-sitter ecosystem, designed for formatter authors
+and formatter users. Authors can create a formatter without having to write
+their own engine or even their own parser. Users benefit from uniform code style
+and the convenience of using a single formatter tool across multiple languages.
+
+Topiary is written in Rust and developed by Tweag.
+"""
 
 url {
   src: "https://github.com/tweag/topiary-opam/releases/download/v0.2.1/source-code-with-submodules.tar.xz"

--- a/packages/topiary/topiary.0.2.2/opam
+++ b/packages/topiary/topiary.0.2.2/opam
@@ -28,6 +28,14 @@ install: [
 ]
 
 synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+description: """
+Topiary is a tool in the Tree-sitter ecosystem, designed for formatter authors
+and formatter users. Authors can create a formatter without having to write
+their own engine or even their own parser. Users benefit from uniform code style
+and the convenience of using a single formatter tool across multiple languages.
+
+Topiary is written in Rust and developed by Tweag.
+"""
 
 url {
   src: "https://github.com/tweag/topiary-opam/releases/download/v0.2.2/source-code-with-submodules.tar.xz"

--- a/packages/topiary/topiary.0.2.2/opam
+++ b/packages/topiary/topiary.0.2.2/opam
@@ -10,6 +10,8 @@ dev-repo: "git+https://github.com/tweag/topiary.git"
 license: "MIT"
 depends: ["conf-rust-2021"]
 
+available: broken
+
 build:[
   [ "cargo" "build"
       "--release"

--- a/packages/topiary/topiary.0.2.2/opam
+++ b/packages/topiary/topiary.0.2.2/opam
@@ -3,7 +3,7 @@ opam-version: "2.0"
 maintainer: "hello@tweag.io"
 authors: [ "Tweag" ]
 
-homepage: "https://github.com/tweag/topiary"
+homepage: "https://topiary.tweag.io/"
 bug-reports: "https://github.com/tweag/topiary/issues"
 dev-repo: "git+https://github.com/tweag/topiary.git"
 

--- a/packages/topiary/topiary.0.2.3/opam
+++ b/packages/topiary/topiary.0.2.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+
+maintainer: "hello@tweag.io"
+authors: [ "Tweag" ]
+
+homepage: "https://topiary.tweag.io/"
+bug-reports: "https://github.com/tweag/topiary/issues"
+dev-repo: "git+https://github.com/tweag/topiary.git"
+
+license: "MIT"
+depends: ["conf-rust-2021"]
+
+build:[
+  [ "cargo" "build"
+      "--release"
+      "--package" "topiary-cli" ]
+  [ "sh" "make-topiary-wrapper.sh"
+      "--language-dir" "%{share}%/topiary/languages"
+      "--topiary-wrapped" "%{bin}%/.topiary-wrapped"
+      "--output-file" "topiary-wrapper" ]
+]
+
+install: [
+  [ "cp" "target/release/topiary" "%{bin}%/.topiary-wrapped" ]
+  [ "cp" "topiary-wrapper" "%{bin}%/topiary" ]
+  [ "mkdir" "%{share}%/topiary" ]
+  [ "cp" "-R" "topiary/languages" "%{share}%/topiary/languages" ]
+]
+
+synopsis: "A formatter for OCaml based on the Topiary universal formatting engine"
+description: """
+Topiary is a tool in the Tree-sitter ecosystem, designed for formatter authors
+and formatter users. Authors can create a formatter without having to write
+their own engine or even their own parser. Users benefit from uniform code style
+and the convenience of using a single formatter tool across multiple languages.
+
+Topiary is written in Rust and developed by Tweag.
+"""
+
+url {
+  src: "https://github.com/tweag/topiary-opam/releases/download/v0.2.3/source-code-with-submodules.tar.xz"
+  checksum: [
+    "md5=fe4997d55ccf6c690e59932db9f118f1"
+    "sha512=a09b3dea64cd238b76f006dc1aedac58f221c2be260829467dd0c2600ea2ae16663312ed27626007b37c3e19cf24e8c8a86e11e587a52215f245e4484c1a2026"
+  ]
+}


### PR DESCRIPTION
Website: https://topiary.tweag.io/
Repository: https://github.com/tweag/topiary
Release: https://github.com/tweag/topiary/releases/tag/v0.2.3
Change log: https://github.com/tweag/topiary/blob/v0.2.3/CHANGELOG.md

Additionally:

- Update homepage of past versions to match https://topiary.tweag.io/
- Add description to all version to match the one on the website above.
- Mark Topiary v0.2.2 as broken (because of https://github.com/tweag/topiary/issues/519). The technique used was found in https://github.com/ocaml/opam/issues/2824.