### PR TITLE
[new release] tar, tar-unix and tar-mirage (2.5.1)

### DIFF
--- a/packages/tar-mirage/tar-mirage.2.5.1/opam
+++ b/packages/tar-mirage/tar-mirage.2.5.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "1.9.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.5.1/tar-2.5.1.tbz"
+  checksum: [
+    "sha256=d3440f488667a05be16449c371d103254aa1134b8a2f134c336a5413c68c3df4"
+    "sha512=b1ca0988a9f68aa6fd5b96c13ee50c67c011a6ff545b3b6bef99129aa0e606cb6c354e6efd76854a21f8e565047279f7b012cfc0efc899db811fa98588ce13dd"
+  ]
+}
+x-commit-hash: "95bd151a9237db1f8b7b4339245139ccd6f7886d"

--- a/packages/tar-unix/tar-unix.2.5.1/opam
+++ b/packages/tar-unix/tar-unix.2.5.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "cstruct-lwt"
+  "lwt"
+  "tar" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.5.1/tar-2.5.1.tbz"
+  checksum: [
+    "sha256=d3440f488667a05be16449c371d103254aa1134b8a2f134c336a5413c68c3df4"
+    "sha512=b1ca0988a9f68aa6fd5b96c13ee50c67c011a6ff545b3b6bef99129aa0e606cb6c354e6efd76854a21f8e565047279f7b012cfc0efc899db811fa98588ce13dd"
+  ]
+}
+x-commit-hash: "95bd151a9237db1f8b7b4339245139ccd6f7886d"

--- a/packages/tar/tar.2.5.1/opam
+++ b/packages/tar/tar.2.5.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a simple library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["dave@recoil.org"]
+authors: ["Dave Scott" "Thomas Gazagnaire" "David Allsopp" "Antonin Décimo"]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "camlp-streams"
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v2.5.1/tar-2.5.1.tbz"
+  checksum: [
+    "sha256=d3440f488667a05be16449c371d103254aa1134b8a2f134c336a5413c68c3df4"
+    "sha512=b1ca0988a9f68aa6fd5b96c13ee50c67c011a6ff545b3b6bef99129aa0e606cb6c354e6efd76854a21f8e565047279f7b012cfc0efc899db811fa98588ce13dd"
+  ]
+}
+x-commit-hash: "95bd151a9237db1f8b7b4339245139ccd6f7886d"


### PR DESCRIPTION
Decode and encode tar format files in pure OCaml

- Project page: <a href="https://github.com/mirage/ocaml-tar">https://github.com/mirage/ocaml-tar</a>
- Documentation: <a href="https://mirage.github.io/ocaml-tar/">https://mirage.github.io/ocaml-tar/</a>

##### CHANGES:

- Treat headers with link indicator '0' or '\000' (`Normal`) as directories for backward compatibility (reported in mirage/ocaml-tar#129, fix by @reynir)
