### PR TITLE
multiconf 1.0.0~rc1 is incompatible with the released ocaml 5.0

### DIFF
--- a/packages/multicont/multicont.1.0.0~rc.1/opam
+++ b/packages/multicont/multicont.1.0.0~rc.1/opam
@@ -21,7 +21,7 @@ depends: [
   "ocaml" {>= "5.0"}
 ]
 
-available: arch = "x86_64" | arch = "arm64"
+available: false
 
 url {
   src:


### PR DESCRIPTION
Fails with
```
#=== ERROR while compiling multicont.1.0.0~rc.1 ===============================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/multicont.1.0.0~rc.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make all
# exit-code            2
# env-file             ~/.opam/log/multicont-7-30a70e.env
# output-file          ~/.opam/log/multicont-7-30a70e.out
### output ###
# ocamlc -c -strict-formats -strict-sequence -safe-string -bin-annot -warn-error -a multicont.mli multicont.ml
# ocamlc -c fiber_primitives.c
# fiber_primitives.c: In function 'alloc_size_class_stack_noexc':
# fiber_primitives.c:97:12: error: 'struct stack_info' has no member named 'size_bucket'; did you mean 'cache_bucket'?
#    97 |     stack->size_bucket = size_bucket;
#       |            ^~~~~~~~~~~
#       |            cache_bucket
# make: *** [Makefile:33: fiber_primitives.o-byte] Error 2
```