### PR TITLE
tyre 0.5 requires re 1.9.0

### DIFF
--- a/packages/tyre/tyre.0.5/opam
+++ b/packages/tyre/tyre.0.5/opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "ocaml" { >= "4.03.0" }
   "dune" {>= "1.0"}
-  "re" {>= "1.8.0"}
+  "re" {>= "1.9.0"}
   "alcotest" {with-test & >= "0.8.0"}
   "odoc" { with-doc }
   "result"


### PR DESCRIPTION
This is where Re.Seq was added. Currently fails with
```
#=== ERROR while compiling tyre.0.5 ===========================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/tyre.0.5
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tyre -j 255
# exit-code            1
# env-file             ~/.opam/log/tyre-7-1ec196.env
# output-file          ~/.opam/log/tyre-7-1ec196.out
### output ###
[...]
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlopt.opt -w -40 -g -O3 -I src/.tyre.objs/byte -I src/.tyre.objs/native -I /home/opam/.opam/4.08/lib/re -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/seq -intf-suffix .ml -no-alias-deps -o src/.tyre.objs/native/tyre.cmx -c -impl src/tyre.ml)
# File "src/tyre.ml", line 333, characters 19-29:
# 333 |     Seq.map aux @@ Re.Seq.all ~pos ~len re original
#                          ^^^^^^^^^^
# Error: Unbound module Re.Seq
# (cd _build/default && /home/opam/.opam/4.08/bin/ocamlc.opt -w -40 -g -bin-annot -I src/.tyre.objs/byte -I /home/opam/.opam/4.08/lib/re -I /home/opam/.opam/4.08/lib/result -I /home/opam/.opam/4.08/lib/seq -intf-suffix .ml -no-alias-deps -o src/.tyre.objs/byte/tyre.cmo -c -impl src/tyre.ml)
# File "src/tyre.ml", line 333, characters 19-29:
# 333 |     Seq.map aux @@ Re.Seq.all ~pos ~len re original
#                          ^^^^^^^^^^
# Error: Unbound module Re.Seq
```