### PR TITLE
[new release] dune-release (2.0.0)

### DIFF
--- a/packages/dune-release/dune-release.2.0.0/opam
+++ b/packages/dune-release/dune-release.2.0.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "Release dune packages in opam"
+description: """
+`dune-release` is a tool to streamline the release of Dune packages in
+[opam](https://opam.ocaml.org). It supports projects built
+with [Dune](https://github.com/ocaml/dune) and hosted on
+[GitHub](https://github.com)."""
+maintainer: ["Nathan Rebours <nathan.p.rebours@gmail.com>"]
+authors: [
+  "Daniel Bünzli"
+  "Thomas Gazagnaire"
+  "Nathan Rebours"
+  "Guillaume Petiot"
+  "Sonja Heinze"
+]
+license: "ISC"
+homepage: "https://github.com/tarides/dune-release"
+bug-reports: "https://github.com/tarides/dune-release/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "dune" {>= "3.8" & with-test}
+  "curly" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "fpath" {>= "0.7.3"}
+  "bos" {>= "0.1.3"}
+  "cmdliner" {>= "1.1.0"}
+  "re" {>= "1.7.2"}
+  "astring"
+  "opam-file-format" {>= "2.1.2"}
+  "opam-format" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-core" {>= "2.1.0"}
+  "rresult" {>= "0.6.0"}
+  "logs"
+  "odoc"
+  "alcotest" {with-test}
+  "yojson" {>= "1.6"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/dune-release.git"
+url {
+  src:
+    "https://github.com/tarides/dune-release/releases/download/2.0.0/dune-release-2.0.0.tbz"
+  checksum: [
+    "sha256=d545a7907205d0c067db0d655e5c34ade8c80648a5f19c9e4052fdea50c89ce1"
+    "sha512=36f3aac78a0755dbef1be25f1104fa5f9209404ace5f21c5002c2b11a4974571e9c5bc6f3571da26bc38f5a26b6d63dccbfad85e99acc921f7632a1a5611b003"
+  ]
+}
+x-commit-hash: "701d6c1cf69e9ba3b2ebc8033b8466807e211070"


### PR DESCRIPTION
Release dune packages in opam

- Project page: <a href="https://github.com/tarides/dune-release">https://github.com/tarides/dune-release</a>

##### CHANGES:

### Added

- Adopt the OCaml Code of Conduct (tarides/dune-release#473, @rikusilvola)
- Added support for projects that have their OPAM files in the `opam/`
  subdirectory. (tarides/dune-release#466, @Leonidas-from-XIV)

### Changed

- Running `dune-release check` now attempts to discover and parse the change
  log, and a new flag `--skip-change-log` disables this behaviour. (tarides/dune-release#458,
  @gridbugs)
- List the main package and amount of subpackages when creating the PR to avoid
  very long package lists in PRs (tarides/dune-release#465, @emillon)

### Fixed

- Avoid collision between branch and tag name. Tag detection got confused when
  branch was named the same as tag. Now it searches only for tag refs, instead
  of all refs. (tarides/dune-release#452, @3Rafal)
- Fix project name detection from `dune-project`. The parser could get confused
  when opam file generation is used. Now it only considers the first `(name X)`
  in the file. (tarides/dune-release#445, @emillon)

### Removed

- Remove support for delegates.
  Previous users of this feature should now use `dune-release delegate-info`
  and wrap dune-release calls in a script. See tarides/dune-release#188 for details.
  (tarides/dune-release#428, @NathanReb)
- Removed support for the OPAM 1.2.2 client. This means `dune-release` expects
  the `opam` binary to be version 2.0 at least. (tarides/dune-release#406, tarides/dune-release#411,
  @Leonidas-from-XIV)
