### PR TITLE
Add upper bounds for Zed in Utop

### DIFF
--- a/packages/utop/utop.2.10.0/opam
+++ b/packages/utop/utop.2.10.0/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "lwt"
   "lwt_react"
-  "zed" { >= "3.2.0" }
+  "zed" { >= "3.2.0" & < "3.2.2" }
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}
   "dune" {>= "1.0"}

--- a/packages/utop/utop.2.11.0/opam
+++ b/packages/utop/utop.2.11.0/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "lwt"
   "lwt_react"
-  "zed" { >= "3.2.0" }
+  "zed" { >= "3.2.0" & < "3.2.2" }
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}
   "dune" {>= "1.0"}

--- a/packages/utop/utop.2.12.0/opam
+++ b/packages/utop/utop.2.12.0/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "lwt"
   "lwt_react"
-  "zed" { >= "3.2.0" }
+  "zed" { >= "3.2.0" & < "3.2.2" }
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}
   "dune" {>= "1.0"}

--- a/packages/utop/utop.2.12.1/opam
+++ b/packages/utop/utop.2.12.1/opam
@@ -14,7 +14,7 @@ depends: [
   "logs"
   "lwt"
   "lwt_react"
-  "zed" { >= "3.2.0" }
+  "zed" { >= "3.2.0" & < "3.2.2" }
   "react" {>= "1.0.0"}
   "cppo" {build & >= "1.1.2"}
   "dune" {>= "1.0"}


### PR DESCRIPTION
The release of Zed 3.2.2 broke existing versions of Utop. A patch is in review at https://github.com/ocaml-community/utop/pull/442, but in the meantime, this adds upper bounds to Zed in existing Utop versions.

cc @emillon 