### PR TITLE
[new release] multicont (1.0.1)

### DIFF
--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/dhil/ocaml-multicont/issues"
 depends: [
   "ocaml" { >= "5.0.0"}
   "dune" {>= "3.8"}
+  "dune-configurator" { >= "3.8"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -5,7 +5,7 @@ description:
 maintainer: ["Daniel Hillerström"]
 authors: ["Daniel Hillerström"]
 license: "MIT"
-tags: ["topics" "multi-shot continuations" "effect handlers"]
+tags: ["multi-shot continuations" "effect handlers"]
 homepage: "https://github.com/dhil/ocaml-multicont"
 bug-reports: "https://github.com/dhil/ocaml-multicont/issues"
 depends: [

--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Multi-shot continuations in OCaml"
+description:
+  "This library provides facilities for programming with multi-shot continuations in OCaml"
+maintainer: ["Daniel Hillerström"]
+authors: ["Daniel Hillerström"]
+license: "MIT"
+tags: ["topics" "multi-shot continuations" "effect handlers"]
+homepage: "https://github.com/dhil/ocaml-multicont"
+bug-reports: "https://github.com/dhil/ocaml-multicont/issues"
+depends: [
+  "ocaml" { >= "5.0.0"}
+  "dune" {>= "3.8" &  >= "3.8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dhil/ocaml-multicont.git"
+url {
+  src:
+    "https://github.com/dhil/ocaml-multicont/releases/download/v1.0.1/multicont-1.0.1.tbz"
+  checksum: [
+    "sha256=430a27e8dc411aefeb0bacd119c676bd3e3c5a35015f8e8e27f31a49e011207b"
+    "sha512=9cbd81eb885533c42ebf0e8652fbf3f7a3658efe3512bd211d13eb004a8a31abf13d904e845dd9f40318fbcde65b9b0f5fcf63091dbc076c50934233032a9fa6"
+  ]
+}
+x-commit-hash: "65fc6cbc435640c1b5ddcc5e8615b3fa66dcd1a5"

--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -21,7 +21,8 @@ build: [
     "build"
     "-p"
     name
-    "-j 1"
+    "-j"
+    "1"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}

--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -22,7 +22,7 @@ build: [
     "-p"
     name
     "-j"
-    jobs
+    1
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
@@ -33,8 +33,8 @@ url {
   src:
     "https://github.com/dhil/ocaml-multicont/releases/download/v1.0.1/multicont-1.0.1.tbz"
   checksum: [
-    "sha256=430a27e8dc411aefeb0bacd119c676bd3e3c5a35015f8e8e27f31a49e011207b"
-    "sha512=9cbd81eb885533c42ebf0e8652fbf3f7a3658efe3512bd211d13eb004a8a31abf13d904e845dd9f40318fbcde65b9b0f5fcf63091dbc076c50934233032a9fa6"
+    "sha256=35d66b3d7f11af4dba7ab6363fdd29ddba983653bba73c355c06bc3ad3c18f54"
+    "sha512=439f67488963b90e2d904e62051213d090adbcd24e43d42f1fb06000f624e481c80861a14495654786f0ecda84d8f294f156c345e4471513a2596e6fd47c363c"
   ]
 }
 x-commit-hash: "65fc6cbc435640c1b5ddcc5e8615b3fa66dcd1a5"

--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -21,8 +21,7 @@ build: [
     "build"
     "-p"
     name
-    "-j"
-    1
+    "-j 1"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}

--- a/packages/multicont/multicont.1.0.1/opam
+++ b/packages/multicont/multicont.1.0.1/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/dhil/ocaml-multicont"
 bug-reports: "https://github.com/dhil/ocaml-multicont/issues"
 depends: [
   "ocaml" { >= "5.0.0"}
-  "dune" {>= "3.8" &  >= "3.8.0"}
+  "dune" {>= "3.8"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Multi-shot continuations in OCaml

- Project page: <a href="https://github.com/dhil/ocaml-multicont">https://github.com/dhil/ocaml-multicont</a>

##### CHANGES:

This release is a purely administrative release which ports the build infrastructure to [dune](https://github.com/ocaml/dune) in order to resolve the reported build issues (e.g. https://github.com/ocaml/opam-repository/pull/23972).
