### PR TITLE
[new release] dune (15 packages) (3.9.0~alpha1)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.9.0~alpha1/opam
+++ b/packages/chrome-trace/chrome-trace.3.9.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-action-plugin/dune-action-plugin.3.9.0~alpha1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.9.0~alpha1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-build-info/dune-build-info.3.9.0~alpha1/opam
+++ b/packages/dune-build-info/dune-build-info.3.9.0~alpha1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-configurator/dune-configurator.3.9.0~alpha1/opam
+++ b/packages/dune-configurator/dune-configurator.3.9.0~alpha1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.04.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-glob/dune-glob.3.9.0~alpha1/opam
+++ b/packages/dune-glob/dune-glob.3.9.0~alpha1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "stdune" {= version}
+  "dyn"
+  "ordering"
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-private-libs/dune-private-libs.3.9.0~alpha1/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.9.0~alpha1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.9.0~alpha1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.9.0~alpha1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "dune-rpc" {= version}
+  "result" {>= "1.5"}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.3.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-rpc/dune-rpc.3.9.0~alpha1/opam
+++ b/packages/dune-rpc/dune-rpc.3.9.0~alpha1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune-site/dune-site.3.9.0~alpha1/opam
+++ b/packages/dune-site/dune-site.3.9.0~alpha1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dune/dune.3.9.0~alpha1/opam
+++ b/packages/dune/dune.3.9.0~alpha1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+dune supports multi-package development by simply dropping multiple
+repositories into the same directory.
+
+It also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.08"} | ("ocaml" {>= "4.02" & < "4.08~~"} & "ocamlfind-secondary"))
+  "base-unix"
+  "base-threads"
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/dyn/dyn.3.9.0~alpha1/opam
+++ b/packages/dyn/dyn.3.9.0~alpha1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/ocamlc-loc/ocamlc-loc.3.9.0~alpha1/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.9.0~alpha1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.15.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/ordering/ordering.3.9.0~alpha1/opam
+++ b/packages/ordering/ordering.3.9.0~alpha1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/stdune/stdune.3.9.0~alpha1/opam
+++ b/packages/stdune/stdune.3.9.0~alpha1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "dyn" {= version}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"

--- a/packages/xdg/xdg.3.9.0~alpha1/opam
+++ b/packages/xdg/xdg.3.9.0~alpha1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["rm" "-rf" "vendor/csexp"]
+  ["rm" "-rf" "vendor/pp"]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.9.0_alpha1/dune-3.9.0.alpha1.tbz"
+  checksum: [
+    "sha256=12a280fbf6c51bdd8f3506a4f9de615383f47086c778c447faa85518c8d9782c"
+    "sha512=a5923ac72572463eeb05230cf7b9da8cf832fc6c2e17fe9c262a899e989b93c0743bdae82837a50da72dab1a92328ea83999e0e53e5f2ba70e9441ddf21afe6e"
+  ]
+}
+x-commit-hash: "a3091d72eea667cf70d7e3823875042c9ec784ea"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

- Validate file extension for `$ dune ocaml top-module`. (ocaml/dune#8005, fixes ocaml/dune#8004, @3Rafal)

- Include the time it takes to read/write state files when `--trace-file` is
  enabled (ocaml/dune#7960, @rgrinberg)

- Add `dune show` command group which is an alias of `dune describe`. (ocaml/dune#7946,
  @Alizter)

- Include source tree scans in the traces produced by `--trace-file` (ocaml/dune#7937,
  @rgrinberg)

- Cinaps: The promotion rules for cinaps would only offer one file at a time no
  matter how many promotions were available. Now we offer all the promotions at
  once (ocaml/dune#7901, @rgrinberg)

- Do not re-run OCaml syntax files on every iteration of the watch mode. This
  is too memory consuming. (ocaml/dune#7894, fix ocaml/dune#6900, @rgrinberg)

- Remove some compatibility code for old version of dune that generated
  `.merlin` files. Now dune will never remove `.merlin` files automatically
  (ocaml/dune#7562)

- Add `dune show env` command and make `dune printenv` an alias of it. (ocaml/dune#7985,
  @Alizter)

- Add additional metadata to the traces provided by `--trace-file` whenever
  `--trace-extended` is passed (ocaml/dune#7778, @rleshchinskiy)

- Extensions used in `(dialect)` can contain periods (e.g., `cppo.ml`). (ocaml/dune#7782,
  fixes ocaml/dune#7777, @nojb)

- Allow `(include_subdirs qualified)` to be used when libraries define a
  `(modules ...)` field (ocaml/dune#7797, fixes ocaml/dune#7597, @anmonteiro)

- `$ dune describe` is now a command group, so arguments to subcommands must be
  passed after subcommand itself. (ocaml/dune#7919, @Alizter)

- The `interface` and `implementation` fields of a `(dialect)` are now optional
  (ocaml/dune#7757, @gpetiot)

- Add commands `dune show targets` and `dune show aliases` that display all the
  available targets and aliases in a given directory respectively. (ocaml/dune#7770,
  grants ocaml/dune#265, @Alizter)

- Allow multiple globs in library's `(stdlib (internal_modules ..))`
  (@anmonteiro, ocaml/dune#7878)

- Attach melange rules to the default alias (ocaml/dune#7926, @haochenx)

- In opam constraints, reject `(and)` and `(or)` with no arguments at parse
  time (ocaml/dune#7730, @emillon)

- Compute digests and manage sandboxes in background threads (ocaml/dune#7947,
  @rgrinberg)

- Add `(build_if)` to the `(test)` stanza. When it evaluates to false, the
  executable is not built. (ocaml/dune#7899, fixes ocaml/dune#6938, @emillon)

- Add necessary parentheses in generated opam constraints (ocaml/dune#7682, fixes ocaml/dune#3431,
  @Lucccyo)
