### PR TITLE
[new release] duff (0.5)

### DIFF
--- a/packages/duff/duff.0.5/opam
+++ b/packages/duff/duff.0.5/opam
@@ -30,8 +30,8 @@ depends: [
 url {
   src: "https://github.com/mirage/duff/releases/download/v0.5/duff-0.5.tbz"
   checksum: [
-    "sha256=d1eaa97cf58d38762391c8d74676544d4145d3f2fd13e4cda0ea8a0844cde612"
-    "sha512=f66ba0016327236c6bdd29cbd3c3d62b96dbe8aa5cdbc88be956a6152c1fd1dcb70ec1f7598bcf4b56126f0edb127566617f49898e50b412be2fecbe93ce85d4"
+    "sha256=f9453cf4aa3b6850efe8cc6f13f053ebe5f2111faf177ceabfbb03e5d9ad6ede"
+    "sha512=a063a549af860db2e66be5ec0c4bfb827e1fe7284c669562455cdd5ae5fa760cbeb878663ceadf93a8d7350f7eab926740fdef2e7bf7eaf2c2e605ec532eb70e"
   ]
 }
-x-commit-hash: "20259ac3021f9675f12972e04871a45f6651d483"
+x-commit-hash: "c82285ecc147ca5713d65c5c04a994a2245398a4"


### PR DESCRIPTION
Rabin's fingerprint and diff algorithm in OCaml

- Project page: <a href="https://github.com/mirage/duff">https://github.com/mirage/duff</a>
- Documentation: <a href="https://mirage.github.io/duff/">https://mirage.github.io/duff/</a>

##### CHANGES:

- Require OCaml 4.07 and remove compatibility packages (@hannesm, mirage/duff#11)
- Fix the compilation on OCaml 5.1 (@dinosaure, mirage/duff#12)
