### PR TITLE
[new release] shuttle_http (0.10.1)

### DIFF
--- a/packages/shuttle_http/shuttle_http.0.10.1/opam
+++ b/packages/shuttle_http/shuttle_http.0.10.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Async library for HTTP/1.1 servers and clients"
+description:
+  "Shuttle_http is a low level library for implementing HTTP/1.1 web services and clients in OCaml."
+maintainer: ["Anurag Soni <anurag@sonianurag.com>"]
+authors: ["Anurag Soni"]
+license: "MIT"
+tags: ["http-server" "http-client" "http" "http1.1" "async"]
+homepage: "https://github.com/anuragsoni/shuttle_http"
+bug-reports: "https://github.com/anuragsoni/shuttle_http/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "async" {>= "v0.16.0"}
+  "async_ssl" {>= "v0.16.0"}
+  "core" {>= "v0.16.0"}
+  "jane_rope" {>= "v0.16.0"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "re2" {>= "v0.16.0"}
+  "core_unix" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/anuragsoni/shuttle_http.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"}
+    "@doc" {with-doc}
+  ]
+]
+available: [ arch = "x86_64" | arch = "arm64" ]
+url {
+  src:
+    "https://github.com/anuragsoni/shuttle_http/releases/download/0.10.1/shuttle_http-0.10.1.tbz"
+  checksum: [
+    "sha256=e97c231524b722cb47553c9d03c1d1f17d0cd6b10ab9983cf14fc2ecc4813521"
+    "sha512=d9f4acbd04c0f57adaf8490bfb79f92494eac42d9a0e7ce64650bf760dba21cec863af78ece03038a02d6d4510a48ba57f17d4f712cd9257bb368cea3b42e43c"
+  ]
+}
+x-commit-hash: "06d597083c4b2ddc00f362aa55a825653b524dca"


### PR DESCRIPTION
Async library for HTTP/1.1 servers and clients

- Project page: <a href="https://github.com/anuragsoni/shuttle_http">https://github.com/anuragsoni/shuttle_http</a>

##### CHANGES:

* Accept a `(string * string) list` as http headers.
* Add a `Body.to_string` for reading entire bodies as string.
