### PR TITLE
reason-react: add upper bound on melange

### DIFF
--- a/packages/reason-react/reason-react.0.11.0/opam
+++ b/packages/reason-react/reason-react.0.11.0/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/reasonml/reason-react/issues"
 depends: [
   "dune" {>= "3.8"}
   "ocaml" {>= "4.13.0"}
-  "melange" {>= "1.0.0"}
+  "melange" {>= "1.0.0" & < "2.0.0"}
   "reactjs-jsx-ppx"
   "reason" {>= "3.6.0"}
   "ocaml-lsp-server" {with-test}


### PR DESCRIPTION
reason-react won't be compatible with the upcoming melange release