### PR TITLE
mosquitto.0.1-0 is incompatible with OCaml 5

### DIFF
--- a/packages/mosquitto/mosquitto.0.1-0/opam
+++ b/packages/mosquitto/mosquitto.0.1-0/opam
@@ -16,7 +16,7 @@ remove: [
   ["ocamlfind" "remove" "mosquitto"]
 ]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "result"
   "base-unix"
   "base-bytes"


### PR DESCRIPTION
In #23989:

    #=== ERROR while compiling mosquitto.0.1-0 ====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/mosquitto.0.1-0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml setup.ml -configure
    # exit-code            2
    # env-file             ~/.opam/log/mosquitto-8-f11d8d.env
    # output-file          ~/.opam/log/mosquitto-8-f11d8d.out
    ### output ###
    # File "./setup.ml", line 575, characters 4-15:
    # 575 |     Stream.from next
    #           ^^^^^^^^^^^
    # Error: Unbound module Stream
