### PR TITLE
ocaml 5: restrict olinq releases

### DIFF
--- a/packages/olinq/olinq.0.1/opam
+++ b/packages/olinq/olinq.0.1/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "olinq"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/olinq/olinq.0.2/opam
+++ b/packages/olinq/olinq.0.2/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "olinq"]
 depends: [
-  "ocaml" {>= "4.00.0"}
+  "ocaml" {>= "4.00.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "base-bytes"

--- a/packages/olinq/olinq.0.3/opam
+++ b/packages/olinq/olinq.0.3/opam
@@ -9,7 +9,7 @@ depends: [
   "dune"
   "base-bytes"
   "seq"
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.02" & < "5.0.0"}
   "odoc" {with-doc}
   "qtest" {with-test}
   "qcheck" {with-test & < "0.14"}


### PR DESCRIPTION
See #23989

They rely on `Pervasives`:

    #=== ERROR while compiling olinq.0.3 ==========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/olinq.0.3
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p olinq -j 31
    # exit-code            1
    # env-file             ~/.opam/log/olinq-10-8f5692.env
    # output-file          ~/.opam/log/olinq-10-8f5692.out
    ### output ###
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -safe-string -short-paths -g -I src/.olinq.objs/byte -I src/.olinq.objs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/seq -intf-suffix .ml -no-alias-deps -o src/.olinq.objs/native/oLinq_table.cmx -c -impl src/OLinq_table.ml)
    # File "src/OLinq_table.ml", line 21, characters 16-34:
    # 21 |   let compare = Pervasives.compare
    #                      ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -short-paths -g -bin-annot -I src/.olinq.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/seq -intf-suffix .ml -no-alias-deps -o src/.olinq.objs/byte/oLinq_table.cmo -c -impl src/OLinq_table.ml)
    # File "src/OLinq_table.ml", line 21, characters 16-34:
    # 21 |   let compare = Pervasives.compare
    #                      ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -short-paths -g -bin-annot -I src/.olinq.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/seq -intf-suffix .ml -no-alias-deps -o src/.olinq.objs/byte/oLinq_map.cmo -c -impl src/OLinq_map.ml)
    # File "src/OLinq_map.ml", line 95, characters 30-48:
    # 95 |   let of_cmp (type key) ?(cmp=Pervasives.compare) () =
    #                                    ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlopt.opt -w -40 -safe-string -short-paths -g -I src/.olinq.objs/byte -I src/.olinq.objs/native -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/seq -intf-suffix .ml -no-alias-deps -o src/.olinq.objs/native/oLinq_map.cmx -c -impl src/OLinq_map.ml)
    # File "src/OLinq_map.ml", line 95, characters 30-48:
    # 95 |   let of_cmp (type key) ?(cmp=Pervasives.compare) () =
    #                                    ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
    # (cd _build/default && /home/opam/.opam/5.0/bin/ocamlc.opt -w -40 -safe-string -short-paths -g -bin-annot -I src/.olinq.objs/byte -I /home/opam/.opam/5.0/lib/bytes -I /home/opam/.opam/5.0/lib/seq -intf-suffix .ml -no-alias-deps -o src/.olinq.objs/byte/oLinq.cmo -c -impl src/OLinq.ml)
    # File "src/OLinq.ml", line 628, characters 15-33:
    # 628 | let sort ?(cmp=Pervasives.compare) () q = Unary (Sort cmp, q)
    #                      ^^^^^^^^^^^^^^^^^^
    # Error: Unbound module Pervasives
