### PR TITLE
ocsfml does not build with ocaml 5

### DIFF
--- a/packages/ocsfml/ocsfml.2.0/opam
+++ b/packages/ocsfml/ocsfml.2.0/opam
@@ -6,7 +6,7 @@ build: [
 ]
 remove: [[make "uninstall"]]
 depends: [
-  "ocaml"
+  "ocaml" {< "5.0.0"}
   "ocamlfind"
   "ocamlbuild"
   "conf-cmake"


### PR DESCRIPTION
In #23989:

    #=== ERROR while compiling ocsfml.2.0 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocsfml.2.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/ocsfml-7-35c5e6.env
    # output-file          ~/.opam/log/ocsfml-7-35c5e6.out
    ### output ###
    # Scanning dependencies of target ocsfml
    # ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
    # + ocamlfind ocamlopt unix.cmxa -I /home/opam/.opam/5.0/lib/ocamlbuild /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuildlib.cmxa -linkpkg myocamlbuild.ml /home/opam/.opam/5.0/lib/ocamlbuild/ocamlbuild.cmx -o myocamlbuild
    # File "myocamlbuild.ml", line 119, characters 14-31:
    # 119 |   "Ocsfml" ^ (String.capitalize s)
    #                     ^^^^^^^^^^^^^^^^^
    # Error: Unbound value String.capitalize
    # Command exited with code 2.
    # make[2]: *** [CMakeFiles/ocsfml.dir/build.make:76: CMakeFiles/ocsfml] Error 10
    # make[1]: *** [CMakeFiles/Makefile2:364: CMakeFiles/ocsfml.dir/all] Error 2
    # make: *** [Makefile:103: all] Error 2
