### PR TITLE
combine.0.6 does not build on ocaml 5

### DIFF
--- a/packages/combine/combine.0.6/opam
+++ b/packages/combine/combine.0.6/opam
@@ -12,7 +12,7 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "combine"]
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "num"


### PR DESCRIPTION
See #23989.

    #=== ERROR while compiling combine.0.6 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/combine.0.6
    # command              ~/.opam/opam-init/hooks/sandbox.sh build ./configure --prefix=/home/opam/.opam/5.0
    # exit-code            2
    # env-file             ~/.opam/log/combine-7-6e39f2.env
    # output-file          ~/.opam/log/combine-7-6e39f2.out
    ### output ###
    # File "./setup.ml", line 318, characters 20-36:
    # 318 |     String.compare (String.lowercase s1) (String.lowercase s2)
    #                           ^^^^^^^^^^^^^^^^
    # Error: Unbound value String.lowercase
