### PR TITLE
toplevel_expect_test.v0.15.0: use ocaml < 5

### DIFF
--- a/packages/toplevel_expect_test/toplevel_expect_test.v0.15.0/opam
+++ b/packages/toplevel_expect_test/toplevel_expect_test.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.08.0"}
+  "ocaml"               {>= "4.08.0" & < "5.0.0"}
   "core"                {>= "v0.15" & < "v0.16"}
   "core_unix"           {>= "v0.15" & < "v0.16"}
   "mlt_parser"          {>= "v0.15" & < "v0.16"}


### PR DESCRIPTION
See #23989

    #=== ERROR while compiling toplevel_expect_test.v0.15.0 =======================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/toplevel_expect_test.v0.15.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p toplevel_expect_test -j 47
    # exit-code            1
    # env-file             ~/.opam/log/toplevel_expect_test-7-8679e0.env
    # output-file          ~/.opam/log/toplevel_expect_test-7-8679e0.out
    ### output ###
    [...]
    # File "src/main.ml", line 526, characters 2-23:
    # 526 |   Clflags.unsafe_string   := Toplevel_backend.unsafe_string ();
    #         ^^^^^^^^^^^^^^^^^^^^^
    # Error: Unbound value Clflags.unsafe_string
