### PR TITLE
ocamldot.1.1 uses autoconf

### DIFF
--- a/packages/ocamldot/ocamldot.1.1/opam
+++ b/packages/ocamldot/ocamldot.1.1/opam
@@ -9,6 +9,7 @@ bug-reports: "https://framagit.org/zoggy/ocamldot/-/issues"
 depends: [
   "ocaml" {>= "4.12.0"}
   "ocamlfind" {build}
+  "conf-autoconf"
 ]
 depopts: ["lablgtk3"]
 conflicts: [


### PR DESCRIPTION
In #23989:

    #=== ERROR while compiling ocamldot.1.1 =======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
    # path                 ~/.opam/5.0/.opam-switch/build/ocamldot.1.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make all
    # exit-code            2
    # env-file             ~/.opam/log/ocamldot-7-fd3f72.env
    # output-file          ~/.opam/log/ocamldot-7-fd3f72.out
    ### output ###
    # /home/opam/.opam/5.0/bin/ocamlyacc -v odot_parser.mly
    # /home/opam/.opam/5.0/bin/ocamllex.opt odot_lexer.mll
    # 62 states, 621 transitions, table size 2856 bytes
    # rm -fr .depend
    # /home/opam/.opam/5.0/bin/ocamldep.opt *.ml *.mli > .depend
    # autoconf
    # make: autoconf: No such file or directory
    # make: *** [Makefile:103: configure] Error 127
