### PR TITLE
[new release] stdlib-random (1.1.0)

### DIFF
--- a/packages/stdlib-random/stdlib-random.1.1.0/opam
+++ b/packages/stdlib-random/stdlib-random.1.1.0/opam
@@ -11,7 +11,7 @@ Those PRNGs are available in the various libraries:
 All those libraries can be used together and the signature of their
 Random$n module has been extended to the latest signature whenever possible.
 """
-maintainer: ["Florian Angeletti, <octa@polychoron.fr>"]
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
 authors: ["Damien Doligez" "Xavier Leroy"]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/stdlib-random"

--- a/packages/stdlib-random/stdlib-random.1.1.0/opam
+++ b/packages/stdlib-random/stdlib-random.1.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Versioned Random module from the OCaml standard library"
+description: """
+The stdlib-random package provides a stable and compiler-independent
+implementation of all the PRNGs used in the Random module.
+Those PRNGs are available in the various libraries:
+- stdlib-random.v3: OCaml 3.07 to 3.11 PRNG
+- stdlib-random.v4: OCaml 3.12 to 4.14 PRNG
+- stdlib-random.v5: current OCaml 5.0 PRNG
+- stdlib-random.v5o: pure OCaml version of the OCaml 5 PRNG
+All those libraries can be used together and the signature of their
+Random$n module has been extended to the latest signature whenever possible.
+"""
+maintainer: ["Florian Angeletti, <octa@polychoron.fr>"]
+authors: ["Damien Doligez" "Xavier Leroy"]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/stdlib-random"
+bug-reports: "https://github.com/ocaml/stdlib-random/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "cppo" {>= "1.1.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/stdlib-random.git"
+url {
+  src:
+    "https://github.com/ocaml/stdlib-random/releases/download/1.1.0/stdlib-random-1.1.0.tbz"
+  checksum: [
+    "sha256=8b930182fe680b8b96ad1e082b87a17c8011d95a670f557c703035f04f812559"
+    "sha512=c406f3598664593676c0cfcc9f248c0c6114602ab0cd9f2c9ab03243debc534515ab61eb8de8c92bdbbed2a6c916441606263e7e577b1a989da41660315c12dc"
+  ]
+}
+x-commit-hash: "838fe6e045219b7cdacb5a53d8679d70a564f9b7"


### PR DESCRIPTION
This release synchronizes the `stdlib-random` compatibility library with the stdlib's `Random` module API that will be available in OCaml 5.1.0 by adding the new `State.to_binary_string` and `State.of_binary_string` functions to the various compiler independent implementations of the `Random` modules.


Changes in version 1.1.0:
-----------------------------------

   - `stdlib-random.v5` and `stdlib-random.v5o`: import `Random.state`
     serialization functions: `of_binary_string` and `to_binary_string` from
     OCaml 5.1.

   - `stdlib-random.v3` and `stdlib-random.v4` library: implement `Random.state`
     serialization functions: `of_binary_string` and `to_binary_string`.
