### PR TITLE
xmldiff.0.6.0 requires autoconf

### DIFF
--- a/packages/xmldiff/xmldiff.0.6.0/opam
+++ b/packages/xmldiff/xmldiff.0.6.0/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "ocamlfind" {build}
   "xmlm" {>= "1.3.0"}
+  "conf-autoconf"
 ]
 depopts: [
   "js_of_ocaml"


### PR DESCRIPTION
In #24007:

    #=== ERROR while compiling xmldiff.0.6.0 ======================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/xmldiff.0.6.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make all
    # exit-code            2
    # env-file             ~/.opam/log/xmldiff-7-225602.env
    # output-file          ~/.opam/log/xmldiff-7-225602.out
    ### output ###
    # autoconf
    # make: autoconf: No such file or directory
    # make: *** [Makefile:105: configure] Error 127
