### PR TITLE
hashcons.1.0.1 requires autoconf

### DIFF
--- a/packages/hashcons/hashcons.1.0.1/opam
+++ b/packages/hashcons/hashcons.1.0.1/opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml" {< "5.0"}
   "ocamlfind" {build}
   "conf-which" {build}
+  "conf-autoconf"
 ]
 synopsis: "OCaml hash-consing library"
 description: """


### PR DESCRIPTION
In #24007:

    #=== ERROR while compiling hashcons.1.0.1 =====================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/hashcons.1.0.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make all
    # exit-code            2
    # env-file             ~/.opam/log/hashcons-8-072314.env
    # output-file          ~/.opam/log/hashcons-8-072314.out
    ### output ###
    # rm -f .depend
    # ocamldep *.mli *.ml > .depend
    # autoconf
    # make: autoconf: No such file or directory
    # make: *** [Makefile:123: configure] Error 127
