### PR TITLE
ocamldsort.0.16.0 requires autoconf

### DIFF
--- a/packages/ocamldsort/ocamldsort.0.16.0/opam
+++ b/packages/ocamldsort/ocamldsort.0.16.0/opam
@@ -16,7 +16,7 @@ build: [
   ]
   [make]
 ]
-depends: ["ocaml" "camlp4"]
+depends: ["ocaml" "camlp4" "conf-autoconf"]
 install: [make "install"]
 synopsis: "Sorts a set of OCaml source files according to their dependencies"
 extra-files: ["ocamldsort.install" "md5=2559d16061178a281cd65ffc5af98243"]


### PR DESCRIPTION
In #24007:

    #=== ERROR while compiling ocamldsort.0.16.0 ==================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/ocamldsort.0.16.0
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/ocamldsort-7-f2a6d7.env
    # output-file          ~/.opam/log/ocamldsort-7-f2a6d7.out
    ### output ###
    # autoconf
    # make: autoconf: No such file or directory
    # make: *** [Makefile:92: configure] Error 127
