### PR TITLE
ollvm-tapir.0.99.1 requires autoconf

### DIFF
--- a/packages/ollvm-tapir/ollvm-tapir.0.99.1/opam
+++ b/packages/ollvm-tapir/ollvm-tapir.0.99.1/opam
@@ -21,6 +21,7 @@ depends: [
   "ocaml" {>= "4.02"}
   "ocamlfind" {build}
   "menhir" {build & < "20211215"}
+  "conf-autoconf"
 ]
 depopts: "llvm"
 conflicts: [


### PR DESCRIPTION
In #24007:

    #=== ERROR while compiling ollvm-tapir.0.99.1 =================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/ollvm-tapir.0.99.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make
    # exit-code            2
    # env-file             ~/.opam/log/ollvm-tapir-6-365ad5.env
    # output-file          ~/.opam/log/ollvm-tapir-6-365ad5.out
    ### output ###
    # CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/bash /home/opam/.opam/4.14/.opam-switch/build/ollvm-tapir.0.99.1/missing autoconf
    # /home/opam/.opam/4.14/.opam-switch/build/ollvm-tapir.0.99.1/missing: line 81: autoconf: command not found
    # WARNING: 'autoconf' is missing on your system.
    #          You should only need it if you modified 'configure.ac',
    #          or m4 files included by it.
    #          The 'autoconf' program is part of the GNU Autoconf package:
    #          <http://www.gnu.org/software/autoconf/>
    #          It also requires GNU m4 and Perl in order to run:
    #          <http://www.gnu.org/software/m4/>
    #          <http://www.perl.org/>
    # make: *** [Makefile:268: configure] Error 127
