### PR TITLE
why3.1.2.1 requires autoconf

### DIFF
--- a/packages/why3/why3.1.2.1/opam
+++ b/packages/why3/why3.1.2.1/opam
@@ -44,6 +44,7 @@ depends: [
   "ocamlfind" {build}
   "menhir" {>= "20151112" & < "20200123"}
   "num"
+  "conf-autoconf"
 ]
 
 depopts: [


### PR DESCRIPTION
In #24007:

    #=== ERROR while compiling why3.1.2.1 =========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/why3.1.2.1
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make -j255 all opt byte
    # exit-code            2
    # env-file             ~/.opam/log/why3-7-b94c91.env
    # output-file          ~/.opam/log/why3-7-b94c91.out
    ### output ###
    # Ocamllex src/why3doc/doc_lexer.mll
    # autoconf -f
    # make: autoconf: No such file or directory
