### PR TITLE
lablgl.1.07 uses camlp5

### DIFF
--- a/packages/lablgl/lablgl.1.07/opam
+++ b/packages/lablgl/lablgl.1.07/opam
@@ -24,6 +24,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "ocamlfind" {>= "1.2.1"}
   "camlp-streams" {build}
+  "camlp5"
 ]
 depexts: [
   ["freeglut3-dev" "libglu1-mesa-dev" "mesa-common-dev"]


### PR DESCRIPTION
In #24007:

    #=== ERROR while compiling lablgl.1.07 ========================================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/lablgl.1.07
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make INSTALLDIR=/home/opam/.opam/4.14/lib/lablgl glut
    # exit-code            2
    # env-file             ~/.opam/log/lablgl-7-dde7f3.env
    # output-file          ~/.opam/log/lablgl-7-dde7f3.out
    ### output ###
    # cd src && make all LIBDIR="`ocamlc -where`"
    # make[1]: Entering directory '/home/opam/.opam/4.14/.opam-switch/build/lablgl.1.07/src'
    # camlp5o pr_o.cmo -impl var2def.ml4 -o var2def.ml
    # make[1]: camlp5o: No such file or directory
    # make[1]: *** [../Makefile.common:64: var2def.ml] Error 127
    # make[1]: Leaving directory '/home/opam/.opam/4.14/.opam-switch/build/lablgl.1.07/src'
    # make: *** [Makefile:12: lib] Error 2
