### PR TITLE
8 packages from ocaml/opam

### DIFF
--- a/packages/odep/odep.0.1.0/opam
+++ b/packages/odep/odep.0.1.0/opam
@@ -11,9 +11,9 @@ depends: [
   "sexplib"
   "ppx_sexp_conv" {>= "v0.13"}
   "parsexp"
-  "opam-core" {>= "2.1.0"}
-  "opam-state" {>= "2.1.0"}
-  "opam-format"
+  "opam-core" {>= "2.1.0" & < "2.2"}
+  "opam-state" {>= "2.1.0" & < "2.2"}
+  "opam-format" {< "2.2"}
   "ocamlfind" {>= "1.8.1"}
   "cmdliner" {>= "1.1.0"}
   "bos"

--- a/packages/opam-build/opam-build.0.1.0/opam
+++ b/packages/opam-build/opam-build.0.1.0/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
   "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
-  "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
   "cmdliner" {>= "1.0"}
 ]
 available: opam-version >= "2.1" & opam-version < "2.3"

--- a/packages/opam-client/opam-client.2.2.0~alpha/opam
+++ b/packages/opam-client/opam-client.2.2.0~alpha/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Client library for opam 2.2"
+description:
+  "Actions on the opam root, switches, installations, and front-end."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "base64" {>= "3.1.0"}
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.0.0"}
+]
+conflicts: [
+  "extlib" {< "1.7.8"}
+  "extlib-compat"
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-client/opam-client.2.2.0~alpha/opam
+++ b/packages/opam-client/opam-client.2.2.0~alpha/opam
@@ -46,3 +46,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-core/opam-core.2.2.0~alpha/opam
+++ b/packages/opam-core/opam-core.2.2.0~alpha/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Core library for opam 2.2"
+description:
+  "Small standard library extensions, and generic system interaction modules used by opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "base-bigarray"
+  "ocamlgraph"
+  "re" {>= "1.9.0"}
+  "dune" {>= "2.0.0"}
+  "sha" {>= "1.13"}
+  "jsonm"
+  "swhid_core"
+  "uutf"
+]
+conflicts: ["extlib-compat"]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-core/opam-core.2.2.0~alpha/opam
+++ b/packages/opam-core/opam-core.2.2.0~alpha/opam
@@ -45,3 +45,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-custom-install/opam-custom-install.0.2/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.2/opam
@@ -8,7 +8,7 @@ tags: ["org:ocamlpro" "org:opam"]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "1.5"}
-  "opam-client" {>= "2.1.2"}
+  "opam-client" {>= "2.1.2" & < "2.2"}
 ]
 homepage: "https://gitlab.ocamlpro.com/louis/opam-custom-install"
 bug-reports: "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/issues"

--- a/packages/opam-custom-install/opam-custom-install.0.3/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/OCamlPro/opam-custom-install"
 bug-reports: "https://github.com/OCamlPro/opam-custom-install/-/issues"
 depends: [
   "dune" {>= "1.5"}
-  "opam-client" {>= "2.1.2" & < "2.2.0"}
+  "opam-client" {>= "2.1.2" & < "2.2"}
 ]
 flags: plugin
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-devel/opam-devel.2.2.0~alpha/opam
+++ b/packages/opam-devel/opam-devel.2.2.0~alpha/opam
@@ -48,3 +48,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-devel/opam-devel.2.2.0~alpha/opam
+++ b/packages/opam-devel/opam-devel.2.2.0~alpha/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Bootstrapped development binary for opam 2.2"
+description:
+  "This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-client" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.0.0"}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+post-messages:
+  """\
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-format/opam-format.2.2.0~alpha/opam
+++ b/packages/opam-format/opam-format.2.2.0~alpha/opam
@@ -38,3 +38,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-format/opam-format.2.2.0~alpha/opam
+++ b/packages/opam-format/opam-format.2.2.0~alpha/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Format library for opam 2.2"
+description: "Definition of opam datastructures and its file interface."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.1.4"}
+  "re" {>= "1.9.0"}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.2.0~alpha/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~alpha/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """\
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-format" {= version}
+  "cmdliner" {>= "0.9.8"}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.2.0~alpha/opam
+++ b/packages/opam-installer/opam-installer.2.2.0~alpha/opam
@@ -40,3 +40,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -15,9 +15,9 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}
-  "opam-core" {>= "2.1.0~rc"}
-  "opam-format" {>= "2.1.0~rc"}
-  "opam-state" {>= "2.1.0~rc"}
+  "opam-core" {>= "2.1.0~rc" & < "2.2"}
+  "opam-format" {>= "2.1.0~rc" & < "2.2"}
+  "opam-state" {>= "2.1.0~rc" & < "2.2"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
 ]

--- a/packages/opam-publish/opam-publish.2.2.0/opam
+++ b/packages/opam-publish/opam-publish.2.2.0/opam
@@ -18,9 +18,9 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}
-  "opam-core" {>= "2.1.0~rc"}
-  "opam-format" {>= "2.1.0~rc"}
-  "opam-state" {>= "2.1.0~rc"}
+  "opam-core" {>= "2.1.0~rc" & < "2.2"}
+  "opam-format" {>= "2.1.0~rc" & < "2.2"}
+  "opam-state" {>= "2.1.0~rc" & < "2.2"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
 ]

--- a/packages/opam-repository/opam-repository.2.2.0~alpha/opam
+++ b/packages/opam-repository/opam-repository.2.2.0~alpha/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Repository library for opam 2.2"
+description:
+  "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-format" {= version}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.2.0~alpha/opam
+++ b/packages/opam-repository/opam-repository.2.2.0~alpha/opam
@@ -37,3 +37,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-solver/opam-solver.2.2.0~alpha/opam
+++ b/packages/opam-solver/opam-solver.2.2.0~alpha/opam
@@ -46,3 +46,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-solver/opam-solver.2.2.0~alpha/opam
+++ b/packages/opam-solver/opam-solver.2.2.0~alpha/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Solver library for opam 2.2"
+description:
+  "Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+9"}
+  "dose3" {>= "6.1"}
+  "cudf" {>= "0.7"}
+  "re" {>= "1.9.0"}
+  "dune" {>= "2.0.0"}
+  "opam-0install-cudf" {>= "0.4"}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.4"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-state/opam-state.2.2.0~alpha/opam
+++ b/packages/opam-state/opam-state.2.2.0~alpha/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "State library for opam 2.2"
+description:
+  "Handling of the ~/.opam hierarchy, repository and switch states."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit.ty.kate@disroot.org>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "opam-repository" {= version}
+  "re" {>= "1.9.0"}
+  "spdx_licenses" {>= "1.0.0"}
+  "dune" {>= "2.0.0"}
+]
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.2.0-alpha.tar.gz"
+  checksum: [
+    "md5=6a69d82228899f73c5e3c04a3fb590f3"
+    "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
+  ]
+}

--- a/packages/opam-state/opam-state.2.2.0~alpha/opam
+++ b/packages/opam-state/opam-state.2.2.0~alpha/opam
@@ -39,3 +39,5 @@ url {
     "sha512=b7899244ab620213f2997409c9d8ac63e1a7ba99ff36abdd0acf41ae545ca7e0534e5e2f6c01a9700c10abf2df4f07944cc64fb5dd315a566f6c5b6b19464729"
   ]
 }
+available: opam-version >= "2.1.0"
+flags: avoid-version

--- a/packages/opam-test/opam-test.0.1.0/opam
+++ b/packages/opam-test/opam-test.0.1.0/opam
@@ -11,7 +11,8 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
-  "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
+  "opam-client"
+  {opam-version >= "2.1" & opam-version < "2.2" & >= "2.1.0" & < "2.2"}
   "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
   "cmdliner" {>= "1.0"}
 ]

--- a/packages/spectrum/spectrum.0.4.0/opam
+++ b/packages/spectrum/spectrum.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "color" {>= "0.2"}
   "pcre" {>= "7.5"}
-  "opam-state" {>= "2.1"}
+  "opam-state" {>= "2.1" & < "2.2"}
   "ppx_deriving" {>= "5.2"}
   "alcotest" {with-test & >= "1.4"}
   "junit_alcotest" {with-test & >= "2.0"}

--- a/packages/spectrum/spectrum.0.5.0/opam
+++ b/packages/spectrum/spectrum.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "color" {>= "0.2"}
   "pcre" {>= "7.5"}
-  "opam-state" {>= "2.1"}
+  "opam-state" {>= "2.1" & < "2.2"}
   "ppx_deriving" {>= "5.2"}
   "alcotest" {with-test & >= "1.4"}
   "junit_alcotest" {with-test & >= "2.0"}

--- a/packages/spectrum/spectrum.0.6.0/opam
+++ b/packages/spectrum/spectrum.0.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "color" {>= "0.2"}
   "pcre" {>= "7.5"}
-  "opam-state" {>= "2.1"}
+  "opam-state" {>= "2.1" & < "2.2"}
   "ppx_deriving" {>= "5.2"}
   "alcotest" {with-test & >= "1.4"}
   "junit_alcotest" {with-test & >= "2.0"}


### PR DESCRIPTION
This pull-request concerns:
- `opam-client.2.2.0~alpha`: Client library for opam 2.2
- `opam-core.2.2.0~alpha`: Core library for opam 2.2
- `opam-devel.2.2.0~alpha`: Bootstrapped development binary for opam 2.2
- `opam-format.2.2.0~alpha`: Format library for opam 2.2
- `opam-installer.2.2.0~alpha`: Installation of files to a prefix, following opam conventions
- `opam-repository.2.2.0~alpha`: Repository library for opam 2.2
- `opam-solver.2.2.0~alpha`: Solver library for opam 2.2
- `opam-state.2.2.0~alpha`: State library for opam 2.2



---
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v2.2.0