### PR TITLE
fm-simplex-plugin.1.01 uses autoconf

### DIFF
--- a/packages/fm-simplex-plugin/fm-simplex-plugin.1.01/opam
+++ b/packages/fm-simplex-plugin/fm-simplex-plugin.1.01/opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml"
   "zarith"
   "alt-ergo" {= "1.01"}
+  "conf-autoconf"
 ]
 messages: [ "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements" ]
 synopsis:


### PR DESCRIPTION
In #24013:

    #=== ERROR while compiling fm-simplex-plugin.1.01 =============================#
    # context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
    # path                 ~/.opam/4.14/.opam-switch/build/fm-simplex-plugin.1.01
    # command              ~/.opam/opam-init/hooks/sandbox.sh build make fm-simplex
    # exit-code            2
    # env-file             ~/.opam/log/fm-simplex-plugin-7-a7c8da.env
    # output-file          ~/.opam/log/fm-simplex-plugin-7-a7c8da.out
    ### output ###
    # autoconf
    # make: autoconf: No such file or directory
    # Makefile.users:259: .depend: No such file or directory
    # make: *** [Makefile.users:370: configure] Error 127
