### PR TITLE
Package core.v0.16.1

### DIFF
--- a/packages/core/core.v0.16.1/opam
+++ b/packages/core/core.v0.16.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/core"
+bug-reports: "https://github.com/janestreet/core/issues"
+dev-repo: "git+https://github.com/janestreet/core.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"               {>= "4.14.0"}
+  "base"                {>= "v0.16" & < "v0.17"}
+  "base_bigstring"      {>= "v0.16" & < "v0.17"}
+  "base_quickcheck"     {>= "v0.16" & < "v0.17"}
+  "bin_prot"            {>= "v0.16" & < "v0.17"}
+  "fieldslib"           {>= "v0.16" & < "v0.17"}
+  "jane-street-headers" {>= "v0.16" & < "v0.17"}
+  "jst-config"          {>= "v0.16" & < "v0.17"}
+  "ppx_assert"          {>= "v0.16" & < "v0.17"}
+  "ppx_base"            {>= "v0.16" & < "v0.17"}
+  "ppx_hash"            {>= "v0.16" & < "v0.17"}
+  "ppx_inline_test"     {>= "v0.16" & < "v0.17"}
+  "ppx_jane"            {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"         {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_conv"       {>= "v0.16" & < "v0.17"}
+  "ppx_sexp_message"    {>= "v0.16" & < "v0.17"}
+  "sexplib"             {>= "v0.16" & < "v0.17"}
+  "splittable_random"   {>= "v0.16" & < "v0.17"}
+  "stdio"               {>= "v0.16" & < "v0.17"}
+  "time_now"            {>= "v0.16" & < "v0.17"}
+  "typerep"             {>= "v0.16" & < "v0.17"}
+  "variantslib"         {>= "v0.16" & < "v0.17"}
+  "dune"                {>= "2.0.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Industrial strength alternative to OCaml's standard library"
+description: "
+The Core suite of libraries is an industrial strength alternative to
+OCaml's standard library that was developed by Jane Street, the
+largest industrial user of OCaml.
+
+This is the system-independent part of Core. Unix-specific parts were moved to [core-unix].
+"
+url {
+  src: "https://github.com/janestreet/core/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=98b40c39c9be584c22a48d40ed3ffe57"
+    "sha512=5f9f4400b6e42b74ffd57223cb67884368d324739565bbb20162547ede8bd6d0ece3cc265503b674829f9cf373784e8036d4c73e26e9196aa5446de69b63e181"
+  ]
+}


### PR DESCRIPTION
### `core.v0.16.1`
Industrial strength alternative to OCaml's standard library
The Core suite of libraries is an industrial strength alternative to
OCaml's standard library that was developed by Jane Street, the
largest industrial user of OCaml.

This is the system-independent part of Core. Unix-specific parts were moved to [core-unix].



---
* Homepage: https://github.com/janestreet/core
* Source repo: git+https://github.com/janestreet/core.git
* Bug tracker: https://github.com/janestreet/core/issues

---
:camel: Pull-request generated by opam-publish v2.2.0