### PR TITLE
Constraint revdeps to `opam-* < "2.2"`

### DIFF
--- a/packages/odep/odep.0.1.0/opam
+++ b/packages/odep/odep.0.1.0/opam
@@ -11,9 +11,9 @@ depends: [
   "sexplib"
   "ppx_sexp_conv" {>= "v0.13"}
   "parsexp"
-  "opam-core" {>= "2.1.0"}
-  "opam-state" {>= "2.1.0"}
-  "opam-format"
+  "opam-core" {>= "2.1.0" & < "2.2"}
+  "opam-state" {>= "2.1.0" & < "2.2"}
+  "opam-format" {< "2.2"}
   "ocamlfind" {>= "1.8.1"}
   "cmdliner" {>= "1.1.0"}
   "bos"

--- a/packages/opam-build/opam-build.0.1.0/opam
+++ b/packages/opam-build/opam-build.0.1.0/opam
@@ -12,7 +12,6 @@ depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
   "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
-  "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
   "cmdliner" {>= "1.0"}
 ]
 available: opam-version >= "2.1" & opam-version < "2.3"

--- a/packages/opam-custom-install/opam-custom-install.0.2/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.2/opam
@@ -8,7 +8,7 @@ tags: ["org:ocamlpro" "org:opam"]
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 depends: [
   "dune" {>= "1.5"}
-  "opam-client" {>= "2.1.2"}
+  "opam-client" {>= "2.1.2" & < "2.2"}
 ]
 homepage: "https://gitlab.ocamlpro.com/louis/opam-custom-install"
 bug-reports: "https://gitlab.ocamlpro.com/louis/opam-custom-install/-/issues"

--- a/packages/opam-custom-install/opam-custom-install.0.3/opam
+++ b/packages/opam-custom-install/opam-custom-install.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/OCamlPro/opam-custom-install"
 bug-reports: "https://github.com/OCamlPro/opam-custom-install/-/issues"
 depends: [
   "dune" {>= "1.5"}
-  "opam-client" {>= "2.1.2" & < "2.2.0"}
+  "opam-client" {>= "2.1.2" & < "2.2"}
 ]
 flags: plugin
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/packages/opam-publish/opam-publish.2.1.0/opam
+++ b/packages/opam-publish/opam-publish.2.1.0/opam
@@ -15,9 +15,9 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}
-  "opam-core" {>= "2.1.0~rc"}
-  "opam-format" {>= "2.1.0~rc"}
-  "opam-state" {>= "2.1.0~rc"}
+  "opam-core" {>= "2.1.0~rc" & < "2.2"}
+  "opam-format" {>= "2.1.0~rc" & < "2.2"}
+  "opam-state" {>= "2.1.0~rc" & < "2.2"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
 ]

--- a/packages/opam-publish/opam-publish.2.2.0/opam
+++ b/packages/opam-publish/opam-publish.2.2.0/opam
@@ -18,9 +18,9 @@ depends: [
   "dune" {>= "1.0"}
   "lwt_ssl"
   "ocaml" {>= "4.03.0"}
-  "opam-core" {>= "2.1.0~rc"}
-  "opam-format" {>= "2.1.0~rc"}
-  "opam-state" {>= "2.1.0~rc"}
+  "opam-core" {>= "2.1.0~rc" & < "2.2"}
+  "opam-format" {>= "2.1.0~rc" & < "2.2"}
+  "opam-state" {>= "2.1.0~rc" & < "2.2"}
   "github" {>= "4.3.2"}
   "github-unix" {>= "4.3.2"}
 ]

--- a/packages/opam-test/opam-test.0.1.0/opam
+++ b/packages/opam-test/opam-test.0.1.0/opam
@@ -11,7 +11,8 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
-  "opam-client" {>= "2.1.0" & < "2.2" & opam-version >= "2.1" & opam-version < "2.2"}
+  "opam-client"
+  {opam-version >= "2.1" & opam-version < "2.2" & >= "2.1.0" & < "2.2"}
   "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
   "cmdliner" {>= "1.0"}
 ]

--- a/packages/spectrum/spectrum.0.4.0/opam
+++ b/packages/spectrum/spectrum.0.4.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "color" {>= "0.2"}
   "pcre" {>= "7.5"}
-  "opam-state" {>= "2.1"}
+  "opam-state" {>= "2.1" & < "2.2"}
   "ppx_deriving" {>= "5.2"}
   "alcotest" {with-test & >= "1.4"}
   "junit_alcotest" {with-test & >= "2.0"}

--- a/packages/spectrum/spectrum.0.5.0/opam
+++ b/packages/spectrum/spectrum.0.5.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "color" {>= "0.2"}
   "pcre" {>= "7.5"}
-  "opam-state" {>= "2.1"}
+  "opam-state" {>= "2.1" & < "2.2"}
   "ppx_deriving" {>= "5.2"}
   "alcotest" {with-test & >= "1.4"}
   "junit_alcotest" {with-test & >= "2.0"}

--- a/packages/spectrum/spectrum.0.6.0/opam
+++ b/packages/spectrum/spectrum.0.6.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "color" {>= "0.2"}
   "pcre" {>= "7.5"}
-  "opam-state" {>= "2.1"}
+  "opam-state" {>= "2.1" & < "2.2"}
   "ppx_deriving" {>= "5.2"}
   "alcotest" {with-test & >= "1.4"}
   "junit_alcotest" {with-test & >= "2.0"}


### PR DESCRIPTION
Packages

* odep.0.1.0
* opam-build.0.1.0
* opam-custom-install.0.2
* opam-custom-install.0.3
* opam-publish.2.1.0
* opam-publish.2.2.0
* opam-test.0.1.0
* spectrum.0.4.0
* spectrum.0.5.0
* spectrum.0.6.0