### PR TITLE
alt-ergo 0.99.1 uses autoconf

### DIFF
--- a/packages/alt-ergo/alt-ergo.0.99.1/opam
+++ b/packages/alt-ergo/alt-ergo.0.99.1/opam
@@ -26,6 +26,7 @@ depends: [
   "zarith"
   "ocamlgraph" {>= "1.8.2"}
   "num"
+  "conf-autoconf"
 ]
 messages: [ "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements" ]
 synopsis:


### PR DESCRIPTION
```
#=== ERROR while compiling alt-ergo.0.99.1 ====================================#
# context              2.2.0~alpha~dev | linux/x86_64 | ocaml-base-compiler.4.14.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/alt-ergo.0.99.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/alt-ergo-7-4674d6.env
# output-file          ~/.opam/log/alt-ergo-7-4674d6.out
### output ###
# autoconf 
# make: autoconf: No such file or directory
# Makefile.users:262: .depend: No such file or directory
# make: *** [Makefile.users:321: configure] Error 127
```