### PR TITLE
Package headache.1.07

### DIFF
--- a/packages/headache/headache.1.07/opam
+++ b/packages/headache/headache.1.07/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Automatic generation of files headers"
+description: """\
+Lightweight tool for managing headers in source code files. It can
+update in any source code files (OCaml, C, XML et al)."""
+maintainer: "frama-ci-bot@frama-c.com"
+authors: [
+  "Vincent Simonet"
+  "Patrick Baudin"
+  "Mehdi Dogguy"
+  "André Maroneze"
+  "François Pottier"
+  "Virgile Prevosto"
+  "Ralf Treinen"
+]
+license: "LGPL-2.0-only"
+homepage: "https://github.com/Frama-C/headache/"
+bug-reports: "https://github.com/Frama-C/headache/issues"
+depends: [
+  "ocaml" {>= "4.02"}
+  "camomile" {>= "2.0.0"}
+  "dune" {>= "3.4"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/Frama-C/headache.git"
+url {
+  src: "https://github.com/Frama-C/headache/archive/v1.07.tar.gz"
+  checksum: [
+    "md5=35081a1edd3e3d582877fca426eba5c9"
+    "sha512=546bf54e33ffe9cb34cd30b66f70be21b62c1174520a894818e3338c594b00941ad2905e235a09f660261ee667d7b5f43c1fe079123e024bfe37a7b0d0291c27"
+  ]
+}


### PR DESCRIPTION
### `headache.1.07`
Automatic generation of files headers
Lightweight tool for managing headers in source code files. It can
update in any source code files (OCaml, C, XML et al).



---
* Homepage: https://github.com/Frama-C/headache/
* Source repo: git+https://github.com/Frama-C/headache.git
* Bug tracker: https://github.com/Frama-C/headache/issues

---
:camel: Pull-request generated by opam-publish v2.1.0