### PR TITLE
new file:   packages/nlopt-ocaml/nlopt-ocaml.0.6.1/opam

### DIFF
--- a/packages/nlopt-ocaml/nlopt-ocaml.0.6.1/opam
+++ b/packages/nlopt-ocaml/nlopt-ocaml.0.6.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to the NLOpt optimization library"
+maintainer: ["Michał Kurcewicz <michal.kurcewicz@gmail.com>"]
+authors: [
+  "Michał Kurcewicz <michal.kurcewicz@gmail.com>"
+  "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: ["clib:nlopt"]
+homepage: "https://github.com/mkur/nlopt-ocaml"
+bug-reports: "https://github.com/mkur/nlopt-ocaml/issues"
+dev-repo: "git+https://github.com/mkur/nlopt-ocaml.git"
+doc: "https://github.com/mkur/nlopt-ocaml"
+build: [ "dune" "build" "-p" name "-j" jobs
+  "@runtest" {with-test}
+  "@doc" {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.9"}
+  "odoc" {with-doc}
+]
+depexts: [
+  ["libnlopt-dev"] {os-family = "debian"}
+  ["nlopt"] {os = "macos"}
+]
+x-ci-accept-failures: [
+  "centos-7" # Too old.. NLopt-devel only has libnlopt_cxx
+]
+url {
+  src: "https://github.com/mkur/nlopt-ocaml/archive/release-0.6.1.tar.gz"
+  checksum: "md5=bcd785a122301262ddcbbd77900ef9ed"
+}


### PR DESCRIPTION
the latest nlopt tag is compatible with ocaml-5.
So let's have it in opam-repository.
