### PR TITLE
[new release] http-lwt-client (0.2.4)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.4/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.2.4/http-lwt-client-0.2.4.tbz"
+  checksum: [
+    "sha256=8064188c285b4cfbe275ca6cd5bb7d0a245b8cb084efedd9c2fb7f8f089abb6c"
+    "sha512=7acb6e5e8dfc155a6d1368cea5ab660d09445285712bba1699c4eebb4022258ba7e238cc97649871d16470b2e08d40ef85bfaed1aa93a3b8083bb8ed7f6029b9"
+  ]
+}
+x-commit-hash: "d657b1ac7e8dd1acd2ed8093daaa7fccc788da21"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* In HTTP/2, always lowercase the header keys (roburio/http-lwt-client#19 by @ScoreUnder,
  fixes roburio/http-lwt-client#7 by @kit-ty-kate)
