### PR TITLE
[new release] http-mirage-client (0.0.4)

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.4/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.4/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "HTTP client for MirageOS"
+maintainer: ["team@robur.coop"]
+authors: [
+  "Robur Team <team@robur.coop>"
+]
+license: "MIT"
+homepage: "https://github.com/roburio/http-mirage-client"
+bug-reports: "https://github.com/roburio/http-mirage-client/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "paf" {>= "0.2.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-time" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "lwt" {>= "5.5.0"}
+  "mimic-happy-eyeballs"
+  "httpaf"
+  "alcotest-lwt" {with-test}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test & >= "3.0.0"}
+  "h2" {>= "0.10.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # macOS is disabled due to restrictions in sandbox-exec
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roburio/http-mirage-client.git"
+url {
+  src:
+    "https://github.com/roburio/http-mirage-client/releases/download/v0.0.4/http-mirage-client-0.0.4.tbz"
+  checksum: [
+    "sha256=acc9f8e8a04f4ba1c7ba7087279cb0ef788251a69cd1d3e4c37d2653c6c59d7e"
+    "sha512=b8d1074a3e441d549980d7c6986189df96e59b178c5976df642f26821f242457889a9cce7cf71892d484b06849efb999a66801786f8d656b9e140590dcddb6ab"
+  ]
+}
+x-commit-hash: "b1160843c7895a9a9b8f56524ea8202dde743b09"


### PR DESCRIPTION
HTTP client for MirageOS

- Project page: <a href="https://github.com/roburio/http-mirage-client">https://github.com/roburio/http-mirage-client</a>

##### CHANGES:

* Always lowercase the header keys in HTTP2 (as in http-lwt-client#19, @hannesm)
