### PR TITLE
[new release] x509 (0.16.5)

### DIFF
--- a/packages/x509/x509.0.16.5/opam
+++ b/packages/x509/x509.0.16.5/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.2"}
+  "cstruct" {>= "6.0.0"}
+  "asn1-combinators" {>= "0.2.0"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto"
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "0.11.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "cstruct-unix" {with-test & >= "3.0.0"}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "pbkdf"
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v0.16.5/x509-0.16.5.tbz"
+  checksum: [
+    "sha256=149e25a5fea37f619fb2690bee5c00f01c9dcf31d335f8ffcaab39a7538ccd99"
+    "sha512=6dd494dba799eab7edde2af1b63bac6035bf4ae06f3a36dd4fa9abcd13d0c3fe3e93dc5848b65405dc5401b1755fd30c71482cb91f7495bc9cfb7c5bf15ef6d7"
+  ]
+}
+x-commit-hash: "b00656d2952282323604765d504dfea067b17879"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Always embed local_key_id in PKCS12 bags (reported mirleft/ocaml-x509#163 by @NightBlues,
  revised and implemented by @hannesm)
