### PR TITLE
bap-ghidra: accept failures in CI

### DIFF
--- a/packages/bap-ghidra/bap-ghidra.2.4.0/opam
+++ b/packages/bap-ghidra/bap-ghidra.2.4.0/opam
@@ -39,3 +39,4 @@ url {
   checksum: "md5=b8b1aff8c6846f2213eafc54de07b304"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.4.0/v2.4.0.tar.gz"
 }
+x-ci-accept-failures: ["debian-11"]

--- a/packages/bap-ghidra/bap-ghidra.2.5.0/opam
+++ b/packages/bap-ghidra/bap-ghidra.2.5.0/opam
@@ -39,3 +39,4 @@ url {
   checksum: "md5=5abd9b3628b43f797326034f31ca574f"
   mirrors: "https://mirrors.aegis.cylab.cmu.edu/bap/2.5.0/v2.5.0.tar.gz"
 }
+x-ci-accept-failures: ["debian-11"]


### PR DESCRIPTION
The package relies on <ghidra/loadimage.hh> without a corresponding
depext. So we allow it to fail in the common configuration.
