### PR TITLE
[new release] cmdliner-stdlib (1.0)

### DIFF
--- a/packages/cmdliner-stdlib/cmdliner-stdlib.1.0/opam
+++ b/packages/cmdliner-stdlib/cmdliner-stdlib.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   ["thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire"  "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/cmdliner-stdlib"
+bug-reports:  "https://github.com/mirage/cmdliner-stdlib/issues/"
+dev-repo:     "git+https://github.com/mirage/cmdliner-stdlib.git"
+license:      "ISC"
+tags:         ["org:mirage"]
+doc:          "https://mirage.github.io/cmdliner-stdlib/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "cmdliner" {>= "1.0.0"}
+]
+synopsis: "A collection of cmdliner terms to control OCaml runtime parameters"
+description: """
+Cmdliner-stdlib is a package that provides a collection of cmdliner terms
+to control the OCaml runtime parameters. This is typically done with environment
+variables, but there are situations where such an environment is not accessible,
+like in MirageOS. This package enables the configuration and manipulation of
+runtime parameters in these contexts, improving the flexibility of applications
+built on these platforms.
+"""
+url {
+  src:
+    "https://github.com/mirage/cmdliner-stdlib/releases/download/1.0/cmdliner-stdlib-1.0.tbz"
+  checksum: [
+    "sha256=a0241892889e86bb6729edc45893bc7b1130758f95f8b3c79751648e7572e771"
+    "sha512=59d9a002aec3eaf49f3b8d56858513b1341f8d1fe9d8c97168a24656256e15b30fde944bc18bcc323f4f40fcc916425b43d8fe6c5f88c42c2f59f2dc77e133cf"
+  ]
+}
+x-commit-hash: "231c2a1572934f068f4145a9aa1f47c764e23704"


### PR DESCRIPTION
A collection of cmdliner terms to control OCaml runtime parameters

- Project page: <a href="https://github.com/mirage/cmdliner-stdlib">https://github.com/mirage/cmdliner-stdlib</a>
- Documentation: <a href="https://mirage.github.io/cmdliner-stdlib/">https://mirage.github.io/cmdliner-stdlib/</a>

##### CHANGES:

- Initial release
