### PR TITLE
[new release] cmdliner-stdlib (1.0.0)

### DIFF
--- a/packages/cmdliner-stdlib/cmdliner-stdlib.1.0.0/opam
+++ b/packages/cmdliner-stdlib/cmdliner-stdlib.1.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   ["thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire"  "Hannes Mehnert"]
+homepage:     "https://github.com/mirage/cmdliner-stdlib"
+bug-reports:  "https://github.com/mirage/cmdliner-stdlib/issues/"
+dev-repo:     "git+https://github.com/mirage/cmdliner-stdlib.git"
+license:      "ISC"
+tags:         ["org:mirage"]
+doc:          "https://mirage.github.io/cmdliner-stdlib/"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.9.0"}
+  "cmdliner" {>= "1.0.0"}
+]
+synopsis: "A collection of cmdliner terms to control OCaml runtime parameters"
+description: """
+Cmdliner-stdlib is a package that provides a collection of cmdliner terms
+to control the OCaml runtime parameters. This is typically done with environment
+variables, but there are situations where such an environment is not accessible,
+like in MirageOS. This package enables the configuration and manipulation of
+runtime parameters in these contexts, improving the flexibility of applications
+built on these platforms.
+"""
+url {
+  src:
+    "https://github.com/mirage/cmdliner-stdlib/releases/download/1.0.0/cmdliner-stdlib-1.0.0.tbz"
+  checksum: [
+    "sha256=5e8986fd8d86a6df0e5031e58ac2dafd738c41767ce4ca08059659246ce8313a"
+    "sha512=c693e60d79f0977122afad7b5dc1a273db692985c47b40d9a47372b3c3fbbfbce1a33d5808dcd0df21c45b4341d993c145e0033716cf07dfd20dd2ad5ba21d8f"
+  ]
+}
+x-commit-hash: "6494fb865e0596e4db11a8c4c824eaa87ffd4db6"


### PR DESCRIPTION
A collection of cmdliner terms to control OCaml runtime parameters

- Project page: <a href="https://github.com/mirage/cmdliner-stdlib">https://github.com/mirage/cmdliner-stdlib</a>
- Documentation: <a href="https://mirage.github.io/cmdliner-stdlib/">https://mirage.github.io/cmdliner-stdlib/</a>

##### CHANGES:

- Initial release
