### PR TITLE
[new release] dream-html (0.1.0)

### DIFF
--- a/packages/dream-html/dream-html.0.1.0/opam
+++ b/packages/dream-html/dream-html.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "HTML generator eDSL for Dream"
+description:
+  "Write HTML directly in your OCaml source files with editor support."
+maintainer: ["Yawar Amin <yawar.amin@gmail.com>"]
+authors: ["Yawar Amin <yawar.amin@gmail.com>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/yawaramin/dream-html"
+doc: "https://yawaramin.github.io/dream-html/"
+bug-reports: "https://github.com/yawaramin/dream-html/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "dream" {>= "1.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/yawaramin/dream-html.git"
+url {
+  src:
+    "https://github.com/yawaramin/dream-html/releases/download/v0.1.0/dream-html-0.1.0.tbz"
+  checksum: [
+    "sha256=54ac36b27c1b8a35173d1e9fefd6ebf578d7a4b540cc209bfcca361436e2d159"
+    "sha512=821bab87b61ed0549b032713ab22d0b2498baa085e195c3093a3d8bc0c869e60f2a8feeb72c87a480379f9aea48f826ca5ed8abf88715767717cb96a3bd591cd"
+  ]
+}
+x-commit-hash: "ff4c3305eefffed8eb1abb4a1e8b8251125a3db1"


### PR DESCRIPTION
HTML generator eDSL for Dream

- Project page: <a href="https://github.com/yawaramin/dream-html">https://github.com/yawaramin/dream-html</a>
- Documentation: <a href="https://yawaramin.github.io/dream-html/">https://yawaramin.github.io/dream-html/</a>

##### CHANGES:

Please refer to release notes in tags.
