### PR TITLE
Package libbinaryen.111.1.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.111.1.0/opam
+++ b/packages/libbinaryen/libbinaryen.111.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v111.1.0/libbinaryen-v111.1.0.tar.gz"
+  checksum: [
+    "md5=b64ed3898d813413afd945fa4d357465"
+    "sha512=7af90981c27955164246bede322a54697688dff966618934d3a04d422e5e1cb6a699f8c1580b9b6910cd5f627676957c9f9a505084d48a5b21ff13a9e2ba0be2"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.111.1.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [111.1.0](https://github.com/grain-lang/libbinaryen/compare/v111.0.0...v111.1.0) (2023-07-04)


### Features

* Relax the js_of_ocaml version range ([#78](https://github.com/grain-lang/libbinaryen/issues/78)) ([5863fe7](https://github.com/grain-lang/libbinaryen/commit/5863fe790b831c6e3888ce353598911ff17777c2))

---
:camel: Pull-request generated by opam-publish v2.0.3