### PR TITLE
Package binaryen.0.21.0

### DIFF
--- a/packages/binaryen/binaryen.0.21.0/opam
+++ b/packages/binaryen/binaryen.0.21.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "4.1.0" & < "6.0.0"}
+  "libbinaryen" {>= "111.0.0" & < "112.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.21.0/binaryen-archive-v0.21.0.tar.gz"
+  checksum: [
+    "md5=42d4c25fbd227f9b76dca6aaa4422a6a"
+    "sha512=ce94aae8fb63eadb66371eb5842d51a3d831172f76c5192d24ac065f28c8eb9af9a9327d1a038097efe1f9255cb93fd2666204bcbc1ddab4d21a6a3fe35c5032"
+  ]
+}


### PR DESCRIPTION
### `binaryen.0.21.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
## [0.21.0](https://github.com/grain-lang/binaryen.ml/compare/v0.20.1...v0.21.0) (2023-07-04)


### ⚠ BREAKING CHANGES

* Remove typed_function_reference feature which was removed in Binaryen
* Add memory64 flag to `Memory.set_memory`
* Upgrade to libbinaryen v111 ([#184](https://github.com/grain-lang/binaryen.ml/issues/184))

### Features

* Add array, none, noext, and nofunc heap types ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add arrayref, nullref, null_externref, and null_funcref types ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add is_64 check for memory ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add memory64 flag to `Memory.set_memory` ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add multi_memories module feature ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add new BinaryenOps ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add new optimization passes ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add operations on array types ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add operations on heap types ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add operations on signature types ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Add operations on struct types ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Upgrade to libbinaryen v111 ([#184](https://github.com/grain-lang/binaryen.ml/issues/184)) ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))
* Widen version range for js_of_ocaml ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))


### Miscellaneous Chores

* Remove typed_function_reference feature which was removed in Binaryen ([f1c9fd7](https://github.com/grain-lang/binaryen.ml/commit/f1c9fd7a9aab97bd5f4e72d9c2b41bff88969128))

---
:camel: Pull-request generated by opam-publish v2.0.3