### PR TITLE
Update opam-test dependencies opam-client < 2.2

### DIFF
--- a/packages/opam-test/opam-test.0.1.0/opam
+++ b/packages/opam-test/opam-test.0.1.0/opam
@@ -11,9 +11,7 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.02"}
   "dune" {>= "2.0"}
-  "opam-client"
-  {opam-version >= "2.1" & opam-version < "2.2" & >= "2.1.0" & < "2.2"}
-  "opam-client" {>= "2.2" & < "2.3" & opam-version >= "2.2" & opam-version < "2.3"}
+  "opam-client" {opam-version >= "2.1" & opam-version < "2.2" & >= "2.1.0" & < "2.2"}
   "cmdliner" {>= "1.0"}
 ]
 available: opam-version >= "2.1" & opam-version < "2.3"

--- a/packages/opam-test/opam-test.0.1.0/opam
+++ b/packages/opam-test/opam-test.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "opam-client" {opam-version >= "2.1" & opam-version < "2.2" & >= "2.1.0" & < "2.2"}
   "cmdliner" {>= "1.0"}
 ]
-available: opam-version >= "2.1" & opam-version < "2.3"
+available: opam-version >= "2.1" & opam-version < "2.2"
 url {
   src: "https://github.com/kit-ty-kate/opam-build/archive/v0.1.0.tar.gz"
   checksum: [


### PR DESCRIPTION
It seems not compliant with opam 2.2
cf https://github.com/ocaml/opam-repository/pull/24060#issuecomment-1621658164
& #24026 #24021