### PR TITLE
[new release] http-mirage-client (0.0.5)

### DIFF
--- a/packages/http-mirage-client/http-mirage-client.0.0.5/opam
+++ b/packages/http-mirage-client/http-mirage-client.0.0.5/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "HTTP client for MirageOS"
+maintainer: ["team@robur.coop"]
+authors: [
+  "Robur Team <team@robur.coop>"
+]
+license: "MIT"
+homepage: "https://github.com/roburio/http-mirage-client"
+bug-reports: "https://github.com/roburio/http-mirage-client/issues"
+depends: [
+  "dune" {>= "2.3"}
+  "ocaml" {>= "4.11.0"}
+  "paf" {>= "0.2.0"}
+  "mirage-clock" {>= "4.0.0"}
+  "mirage-time" {>= "3.0.0"}
+  "tcpip" {>= "7.0.0"}
+  "lwt" {>= "5.5.0"}
+  "mimic-happy-eyeballs"
+  "httpaf"
+  "alcotest-lwt" {with-test}
+  "mirage-clock-unix" {with-test & >= "4.0.0"}
+  "mirage-crypto-rng" {with-test}
+  "mirage-time-unix" {with-test & >= "3.0.0"}
+  "h2" {>= "0.10.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # macOS is disabled due to restrictions in sandbox-exec
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/roburio/http-mirage-client.git"
+url {
+  src:
+    "https://github.com/roburio/http-mirage-client/releases/download/v0.0.5/http-mirage-client-0.0.5.tbz"
+  checksum: [
+    "sha256=c3f74cbf942f820953163f55e304680ea2bedfa61e134c562f1700552d281f3d"
+    "sha512=83545383d6f40ccaa721331ab6152f24ca1895f3b2781710033eda3aaa263247e374f14c211bd3283c7f5ad10b1ffe822191249cce582242a2a450ae4fe6bfcf"
+  ]
+}
+x-commit-hash: "17b3b23196257bf97df48c663dfc9f8fb798882c"


### PR DESCRIPTION
HTTP client for MirageOS

- Project page: <a href="https://github.com/roburio/http-mirage-client">https://github.com/roburio/http-mirage-client</a>

##### CHANGES:

* Order http2 headers appropriately to avoid malformed requests (as in http-lwt-client#20, @hannesm)
