### PR TITLE
[new release] http-lwt-client (0.2.5)

### DIFF
--- a/packages/http-lwt-client/http-lwt-client.0.2.5/opam
+++ b/packages/http-lwt-client/http-lwt-client.0.2.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/roburio/http-lwt-client"
+dev-repo: "git+https://github.com/roburio/http-lwt-client.git"
+bug-reports: "https://github.com/roburio/http-lwt-client/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "logs"
+  "lwt"
+  "base64" {>= "3.1.0"}
+  "faraday-lwt-unix"
+  "httpaf" {>= "0.7.0"}
+  "tls" {>= "0.16.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ca-certs"
+  "fmt"
+  "bos"
+  "happy-eyeballs-lwt"
+  "h2" {>= "0.10.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+synopsis: "A simple HTTP client using http/af, h2, and lwt"
+url {
+  src:
+    "https://github.com/roburio/http-lwt-client/releases/download/v0.2.5/http-lwt-client-0.2.5.tbz"
+  checksum: [
+    "sha256=80c3f567eb20ebbe0f1bad8beacc3cf70d148bbca13f4e0021b6668e021fee5b"
+    "sha512=f18e12bcb4a4a99b046525d930b033337c108c29d726d97f69608633c581964c5029469ce8d2e7cf47e94f742f73717237149179506f8984c4ecf0d871cd9b7b"
+  ]
+}
+x-commit-hash: "7301db635c2234184cc2164cad22c33de3f3ee73"


### PR DESCRIPTION
A simple HTTP client using http/af, h2, and lwt

- Project page: <a href="https://github.com/roburio/http-lwt-client">https://github.com/roburio/http-lwt-client</a>

##### CHANGES:

* Order http2 headers appropriately to avoid malformed requests (roburio/http-lwt-client#20, @hannesm)
