### PR TITLE
core v0.15* is not compatible with ocaml 5.1

### DIFF
--- a/packages/core/core.v0.15.0/opam
+++ b/packages/core/core.v0.15.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.11.0"}
+  "ocaml"               {>= "4.11.0" & < "5.1~"}
   "base"                {>= "v0.15" & < "v0.16"}
   "base_bigstring"      {>= "v0.15" & < "v0.16"}
   "base_quickcheck"     {>= "v0.15" & < "v0.16"}

--- a/packages/core/core.v0.15.1/opam
+++ b/packages/core/core.v0.15.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "4.11.0"}
+  "ocaml"               {>= "4.11.0" & < "5.1~"}
   "base"                {>= "v0.15.1" & < "v0.16"}
   "base_bigstring"      {>= "v0.15" & < "v0.16"}
   "base_quickcheck"     {>= "v0.15" & < "v0.16"}


### PR DESCRIPTION
Fails with
```
== ERROR while compiling core.v0.15.1 =======================================#
context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
path                 ~/.opam/5.1/.opam-switch/build/core.v0.15.1
command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p core -j 255
exit-code            1
env-file             ~/.opam/log/core-7-0fb426.env
output-file          ~/.opam/log/core-7-0fb426.out
\### output ###
File "core/src/dune", line 10, characters 48-56:
10 |  (c_names bigstring_stubs md5_stubs array_stubs gc_stubs time_ns_stubs
                                                     ^^^^^^^^
(cd _build/default/core/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_LARGEFILE64_SOURCE -g -I /home/opam/.opam/5.1/lib/ocaml -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/md5 -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/base_bigstring -I /home/opam/.opam/5.1/lib/base_quickcheck -I /home/opam/.opam/5.1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.1/lib/bin_prot -I /home/opam/.opam/5.1/lib/bin_prot/shape -I /home/opam/.opam/5.1/lib/fieldslib -I /home/opam/.opam/5.1/lib/int_repr -I /home/opam/.opam/5.1/lib/jane-street-headers -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_expect/collector -I /home/opam/.opam/5.1/lib/ppx_expect/common -I /home/opam/.opam/5.1/lib/ppx_expect/config -I /home/opam/.opam/5.1/lib/ppx_expect/config_types -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_inline_test/config -I /home/opam/.opam/5.1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_log/types -I /home/opam/.opam/5.1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/splittable_random -I /home/opam/.opam/5.1/lib/stdio -I /home/opam/.opam/5.1/lib/time_now -I /home/opam/.opam/5.1/lib/typerep -I /home/opam/.opam/5.1/lib/variantslib -I ../../base_for_tests/src -I ../../validate/src -o gc_stubs.o -c gc_stubs.c)
In file included from /home/opam/.opam/5.1/lib/ocaml/caml/gc.h:20,
                 from /home/opam/.opam/5.1/lib/ocaml/caml/memory.h:23,
                 from gc_stubs.c:2:
gc_stubs.c: In function 'core_gc_minor_collections':
gc_stubs.c:40:19: error: 'caml_stat_minor_collections' undeclared (first use in this function); did you mean 'caml_stat_major_collections'?
   40 |   return Val_long(caml_stat_minor_collections);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/opam/.opam/5.1/lib/ocaml/caml/mlvalues.h:76:47: note: in definition of macro 'Val_long'
   76 | #define Val_long(x)     ((intnat) (((uintnat)(x) << 1)) + 1)
      |                                               ^
gc_stubs.c:40:19: note: each undeclared identifier is reported only once for each function it appears in
   40 |   return Val_long(caml_stat_minor_collections);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/opam/.opam/5.1/lib/ocaml/caml/mlvalues.h:76:47: note: in definition of macro 'Val_long'
   76 | #define Val_long(x)     ((intnat) (((uintnat)(x) << 1)) + 1)
      |                                               ^
(cd _build/default/core/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_LARGEFILE64_SOURCE -g -I /home/opam/.opam/5.1/lib/ocaml -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/md5 -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/base_bigstring -I /home/opam/.opam/5.1/lib/base_quickcheck -I /home/opam/.opam/5.1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.1/lib/bin_prot -I /home/opam/.opam/5.1/lib/bin_prot/shape -I /home/opam/.opam/5.1/lib/fieldslib -I /home/opam/.opam/5.1/lib/int_repr -I /home/opam/.opam/5.1/lib/jane-street-headers -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_expect/collector -I /home/opam/.opam/5.1/lib/ppx_expect/common -I /home/opam/.opam/5.1/lib/ppx_expect/config -I /home/opam/.opam/5.1/lib/ppx_expect/config_types -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_inline_test/config -I /home/opam/.opam/5.1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_log/types -I /home/opam/.opam/5.1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/splittable_random -I /home/opam/.opam/5.1/lib/stdio -I /home/opam/.opam/5.1/lib/time_now -I /home/opam/.opam/5.1/lib/typerep -I /home/opam/.opam/5.1/lib/variantslib -I ../../base_for_tests/src -I ../../validate/src -o array_stubs.o -c array_stubs.c)
array_stubs.c: In function 'core_array_unsafe_int_blit':
array_stubs.c:14:11: warning: passing argument 1 of 'memmove' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
   14 |   memmove(&Field(dst, Long_val(dst_pos)),
In file included from array_stubs.c:2:
/usr/include/string.h:47:29: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
   47 | extern void *memmove (void *__dest, const void *__src, size_t __n)
      |                       ~~~~~~^~~~~~
array_stubs.c:15:11: warning: passing argument 2 of 'memmove' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
   15 |           &Field(src, Long_val(src_pos)),
In file included from array_stubs.c:2:
/usr/include/string.h:47:49: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
   47 | extern void *memmove (void *__dest, const void *__src, size_t __n)
      |                                     ~~~~~~~~~~~~^~~~~
(cd _build/default/core/src && /usr/bin/gcc -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_FILE_OFFSET_BITS=64 -O2 -fno-strict-aliasing -fwrapv -pthread -fPIC -D_LARGEFILE64_SOURCE -g -I /home/opam/.opam/5.1/lib/ocaml -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/md5 -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/base_bigstring -I /home/opam/.opam/5.1/lib/base_quickcheck -I /home/opam/.opam/5.1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.1/lib/bin_prot -I /home/opam/.opam/5.1/lib/bin_prot/shape -I /home/opam/.opam/5.1/lib/fieldslib -I /home/opam/.opam/5.1/lib/int_repr -I /home/opam/.opam/5.1/lib/jane-street-headers -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_expect/collector -I /home/opam/.opam/5.1/lib/ppx_expect/common -I /home/opam/.opam/5.1/lib/ppx_expect/config -I /home/opam/.opam/5.1/lib/ppx_expect/config_types -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_inline_test/config -I /home/opam/.opam/5.1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_log/types -I /home/opam/.opam/5.1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/splittable_random -I /home/opam/.opam/5.1/lib/stdio -I /home/opam/.opam/5.1/lib/time_now -I /home/opam/.opam/5.1/lib/typerep -I /home/opam/.opam/5.1/lib/variantslib -I ../../base_for_tests/src -I ../../validate/src -o bigstring_stubs.o -c bigstring_stubs.c)
In file included from bigstring_stubs.c:54:
bigstring_stubs.c: In function 'core_bigstring_destroy':
/home/opam/.opam/5.1/lib/ocaml/caml/custom.h:48:27: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   48 | #define Custom_ops_val(v) (*((const struct custom_operations **) (v)))
      |                           ^
bigstring_stubs.c:116:35: note: in expansion of macro 'Custom_ops_val'
  116 |   struct custom_operations* ops = Custom_ops_val(v);
      |                                   ^~~~~~~~~~~~~~
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlc.opt -w -40 -g -bin-annot -I core/src/.core.objs/byte -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/md5 -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/base_bigstring -I /home/opam/.opam/5.1/lib/base_quickcheck -I /home/opam/.opam/5.1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.1/lib/bin_prot -I /home/opam/.opam/5.1/lib/bin_prot/shape -I /home/opam/.opam/5.1/lib/fieldslib -I /home/opam/.opam/5.1/lib/int_repr -I /home/opam/.opam/5.1/lib/jane-street-headers -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_expect/collector -I /home/opam/.opam/5.1/lib/ppx_expect/common -I /home/opam/.opam/5.1/lib/ppx_expect/config -I /home/opam/.opam/5.1/lib/ppx_expect/config_types -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_inline_test/config -I /home/opam/.opam/5.1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_log/types -I /home/opam/.opam/5.1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/splittable_random -I /home/opam/.opam/5.1/lib/stdio -I /home/opam/.opam/5.1/lib/time_now -I /home/opam/.opam/5.1/lib/typerep -I /home/opam/.opam/5.1/lib/variantslib -I base_for_tests/src/.base_for_tests.objs/byte -I validate/src/.validate.objs/byte -intf-suffix .ml -no-alias-deps -open Core__ -o core/src/.core.objs/byte/core__String_id.cmo -c -impl core/src/string_id.pp.ml)
File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.

File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.

File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.

File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -g -I core/src/.core.objs/byte -I core/src/.core.objs/native -I /home/opam/.opam/5.1/lib/base -I /home/opam/.opam/5.1/lib/base/base_internalhash_types -I /home/opam/.opam/5.1/lib/base/caml -I /home/opam/.opam/5.1/lib/base/md5 -I /home/opam/.opam/5.1/lib/base/shadow_stdlib -I /home/opam/.opam/5.1/lib/base_bigstring -I /home/opam/.opam/5.1/lib/base_quickcheck -I /home/opam/.opam/5.1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.1/lib/bin_prot -I /home/opam/.opam/5.1/lib/bin_prot/shape -I /home/opam/.opam/5.1/lib/fieldslib -I /home/opam/.opam/5.1/lib/int_repr -I /home/opam/.opam/5.1/lib/jane-street-headers -I /home/opam/.opam/5.1/lib/parsexp -I /home/opam/.opam/5.1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_expect/collector -I /home/opam/.opam/5.1/lib/ppx_expect/common -I /home/opam/.opam/5.1/lib/ppx_expect/config -I /home/opam/.opam/5.1/lib/ppx_expect/config_types -I /home/opam/.opam/5.1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_inline_test/config -I /home/opam/.opam/5.1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.1/lib/ppx_log/types -I /home/opam/.opam/5.1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.1/lib/sexplib -I /home/opam/.opam/5.1/lib/sexplib0 -I /home/opam/.opam/5.1/lib/splittable_random -I /home/opam/.opam/5.1/lib/stdio -I /home/opam/.opam/5.1/lib/time_now -I /home/opam/.opam/5.1/lib/typerep -I /home/opam/.opam/5.1/lib/variantslib -I base_for_tests/src/.base_for_tests.objs/byte -I base_for_tests/src/.base_for_tests.objs/native -I validate/src/.validate.objs/byte -I validate/src/.validate.objs/native -intf-suffix .ml -no-alias-deps -open Core__ -o core/src/.core.objs/native/core__String_id.cmx -c -impl core/src/string_id.pp.ml)
File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.

File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.

File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.

File "_none_", line 1:
Warning 73 [generative-application-expects-unit]: A generative functor
should be applied to '()'; using '(struct end)' is deprecated.
```

Seen on #24054 