### PR TITLE
menhir 20220210 is not compatible with ocaml 5.1

### DIFF
--- a/packages/menhir/menhir.20220210/opam
+++ b/packages/menhir/menhir.20220210/opam
@@ -13,7 +13,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.1~"}
   "dune" {>= "2.8.0"}
   "menhirLib" {= version}
   "menhirSdk" {= version}


### PR DESCRIPTION
Fails with
```
== ERROR while compiling menhir.20220210 ====================================#
context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
path                 ~/.opam/5.1/.opam-switch/build/menhir.20220210
command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p menhir -j 255
exit-code            1
env-file             ~/.opam/log/menhir-7-34d49d.env
output-file          ~/.opam/log/menhir-7-34d49d.out
\# output ###
(cd _build/default && /home/opam/.opam/5.1/bin/ocamlopt.opt -w -40 -safe-string -g -open MenhirSdk -g -I src/stage1/.main.eobjs/byte -I src/stage1/.main.eobjs/native -I /home/opam/.opam/5.1/lib/menhirLib -I /home/opam/.opam/5.1/lib/menhirSdk -I /home/opam/.opam/5.1/lib/ocaml/unix -I fix/src/.vendored_fix.objs/byte -I fix/src/.vendored_fix.objs/native -I pprint/src/.vendored_pprint.objs/byte -I pprint/src/.vendored_pprint.objs/native -intf-suffix .ml -no-alias-deps -open Dune__exe -o src/stage1/.main.eobjs/native/dune__exe__Back.cmx -c -impl src/stage1/back.ml)
File "src/back.ml", line 50, characters 21-39:
Error: The functor was expected to be applicative at this position
```

Seen on #24054  