### PR TITLE
ocplib-simplex 0.4 is not compatbile with ocaml 5.1

### DIFF
--- a/packages/ocplib-simplex/ocplib-simplex.0.4/opam
+++ b/packages/ocplib-simplex/ocplib-simplex.0.4/opam
@@ -28,7 +28,7 @@ remove:[
 ]
 
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "4.01.0" & < "5.1~"}
   "ocamlfind" {build}
   "conf-autoconf" {build}
   "num"


### PR DESCRIPTION
Fails with
```
== ERROR while compiling ocplib-simplex.0.4 =================================#
context              2.2.0~alpha~dev | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
path                 ~/.opam/5.1/.opam-switch/build/ocplib-simplex.0.4
command              ~/.opam/opam-init/hooks/sandbox.sh build make
exit-code            2
env-file             ~/.opam/log/ocplib-simplex-7-b569d6.env
output-file          ~/.opam/log/ocplib-simplex-7-b569d6.out
\# output ###
cp src/extSigs.mli src/extSigs.ml
cp src/coreSig.mli src/coreSig.ml
ocamldep -I src src/*.ml* > .depend
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/version.mli
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/version.ml
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/extSigs.mli
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/rat2.mli
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/rat2.ml
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/extSigs.ml
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/polys.mli
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/polys.ml
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/coreSig.mli
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/coreSig.ml
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/core.mli
ocamlc.opt -c -annot -absname -bin-annot -short-paths -strict-sequence -w +A -g -I src -for-pack OcplibSimplex src/core.ml
File "/home/opam/.opam/5.1/.opam-switch/build/ocplib-simplex.0.4/src/core.ml", line 242, characters 14-75:
242 |               "%a   [ %a == (%4a , %4a) ]   %a   (computed %s) (flag %s)@."
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: invalid format "%a   [ %a == (%4a , %4a) ]   %a   (computed %s) (flag %s)@.": at character number 20, `padding' is incompatible with 'a' in sub-format "%4a"
make: *** [Makefile:131: src/core.cmo] Error 2
```
Seen on #24054

I tested it on ocaml 5.0 and it compiles fine there