### PR TITLE
[new release] mirage-logs (2.0.0)

### DIFF
--- a/packages/mirage-logs/mirage-logs.2.0.0/opam
+++ b/packages/mirage-logs/mirage-logs.2.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "talex5@gmail.com"
+authors: [ "Thomas Leonard" ]
+license: "ISC"
+homepage: "https://github.com/mirage/mirage-logs"
+dev-repo: "git+https://github.com/mirage/mirage-logs.git"
+bug-reports: "https://github.com/mirage/mirage-logs/issues"
+doc: "https://mirage.github.io/mirage-logs/"
+tags: ["org:mirage"]
+depends: [
+  "ocaml" { >= "4.06.0"}
+  "dune" {>= "3.0"}
+  "logs" { >= "0.5.0" }
+  "ptime" { >= "0.8.1" }
+  "mirage-clock" { >= "3.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "lwt" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+synopsis: "A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps"
+description: """
+The Logs reporter prefixes each entry with a timestamp, and writes it to stderr.
+"""
+url {
+  src:
+    "https://github.com/mirage/mirage-logs/releases/download/v2.0.0/mirage-logs-2.0.0.tbz"
+  checksum: [
+    "sha256=f2a67264aa86bea32444d58bbb56453477ec86c0f4b8cd76788d4a197521dd20"
+    "sha512=1c135a72ba8e7e6aba8c5f2e28e07565797eca3ce7724fc881872eef47169d156a2279d269ea503d4d8973b0b51e570648b130d76603826a5a565550bd32b2a2"
+  ]
+}
+x-commit-hash: "eea1b9fff899e0a63a48d310e8822cb8e5974212"


### PR DESCRIPTION
A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps

- Project page: <a href="https://github.com/mirage/mirage-logs">https://github.com/mirage/mirage-logs</a>
- Documentation: <a href="https://mirage.github.io/mirage-logs/">https://mirage.github.io/mirage-logs/</a>

##### CHANGES:

- Bump to Dune3 (mirage/mirage-logs#19, @samoht)
- Remove `create` optional `ring_size` `console_threshold` parameters
  (mirage/mirage-logs#21, @hannesm)
- use Ptime.pp_rfc3339 for nicer output (esp. if time zone offset is
  None) (mirage/mirage-logs#21, @hannesm)
- Remove custom types (`type t` / `set_reporter` / `unset_reporter` /
  `reporter`) (mirage/mirage-logs#21, @hannesm)
- Add mirage-logs.cli to define Cmdliner terms (mirage/mirage-logs#20, @samoht)
