### PR TITLE
Correct the bytecode architectures for OCaml 5.1 and OCaml 5.2 (trunk)

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
@@ -14,6 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
+  "ocaml-option-bytecode-only" {arch = "ppc64" | arch = "s390x"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
@@ -14,6 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
+  "ocaml-option-bytecode-only" {arch = "ppc64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
@@ -14,6 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
+  "ocaml-option-bytecode-only" {arch = "ppc64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-option-bytecode-only" {arch = "ppc64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-option-bytecode-only" {arch = "ppc64" | arch = "s390x"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv" }
+  "ocaml-option-bytecode-only" {arch = "ppc64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv" }
+  "ocaml-option-bytecode-only" {arch = "ppc64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
@@ -13,7 +13,6 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"


### PR DESCRIPTION
This PR fixes two small issues:
- The 5.1.0 beta does not correctly pull in the `ocaml-option-bytecode-only` package for ppc64
- The 5.2 (trunk) package still has the 5.0 native architecture restrictions, when it no longer needs any

I've extensively tested this (hopefully!) on amd64, ppc64 and s390x. The important details:
- This PR will cause 5.0 _bytecode-only_ switches to rebuild **but it does not affect amd64 and arm64** (which will only see a largely no-op rebuild of the `ocaml-options-vanilla` package)
- This PR does cause _all_ 5.1 switches to rebuild because of the change to the beta package itself (unless you're using opam 2.2 😇)
- Existing 5.2 (i.e. trunk switches) on ppc64, riscv or s390x will be unable to upgrade without manual intervention unless opam 2.2 is being used.