### PR TITLE
Mark dune.3.9.0 as unavailable on macos

### DIFF
--- a/packages/dune/dune.3.9.0/opam
+++ b/packages/dune/dune.3.9.0/opam
@@ -54,3 +54,4 @@ url {
   ]
 }
 x-commit-hash: "891fa5a7d72655634378425d51a1cf703ff93336"
+available: os != "macos"


### PR DESCRIPTION
This is due to ocaml/dune#8083 which is mitigated in 3.9.1.
