### PR TITLE
Mark utop.2.13.0 as not available on windows

### DIFF
--- a/packages/utop/utop.2.13.0/opam
+++ b/packages/utop/utop.2.13.0/opam
@@ -48,3 +48,4 @@ url {
   ]
 }
 x-commit-hash: "97e7ecfb4f2be71dcd270e13155797d0f873f437"
+available: os != "win32"


### PR DESCRIPTION
See ocaml-community/utop#447
