### PR TITLE
Package fuzzy_compare.2.0.1

### DIFF
--- a/packages/fuzzy_compare/fuzzy_compare.2.0.1/opam
+++ b/packages/fuzzy_compare/fuzzy_compare.2.0.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Simon Grondin"
+authors: [
+  "Simon Grondin"
+]
+synopsis: "Fastest bounded Levenshtein comparator over generic structures"
+description: """
+This library does not calculate the edit distance.
+
+Rather, it provides extremely efficient automata that answer whether 2 values are within a predetermined number of edits of one another. Edits are: additions, deletions, replacements.
+
+Once generated, an automaton can be reused to compare any 2 values in around 2-8 µs.
+"""
+license: "MIT"
+homepage: "https://github.com/SGrondin/fuzzy_compare"
+dev-repo: "git://github.com/SGrondin/fuzzy_compare"
+doc: "https://github.com/SGrondin/fuzzy_compare"
+bug-reports: "https://github.com/SGrondin/fuzzy_compare/issues"
+depends: [
+  "ocaml" { >= "4.10.0" }
+  "dune" { >= "1.9.0" }
+
+  "core" { >= "v0.15.0" & < "v0.17.0"  }
+  # "ocamlformat" { = "0.25.1" } # Development
+  # "ocaml-lsp-server" # Development
+
+  "uuseg" { with-test }
+  "uunf" { with-test }
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/SGrondin/fuzzy_compare/archive/refs/tags/2.0.1.tar.gz"
+  checksum: [
+    "md5=90ba5dd28b12af0bb795f6bdbca34deb"
+    "sha512=7550a654b200d82eac9ccdc58bb21627e29ff78bb9f0b06dd75b7aeb3960f58b42632b6836ce09103b29f254fb628bab5418e0e34f08a79833c7e01c3709b094"
+  ]
+}


### PR DESCRIPTION
### `fuzzy_compare.2.0.1`
Fastest bounded Levenshtein comparator over generic structures
This library does not calculate the edit distance.

Rather, it provides extremely efficient automata that answer whether 2 values are within a predetermined number of edits of one another. Edits are: additions, deletions, replacements.

Once generated, an automaton can be reused to compare any 2 values in around 2-8 µs.



---
* Homepage: https://github.com/SGrondin/fuzzy_compare
* Source repo: git://github.com/SGrondin/fuzzy_compare
* Bug tracker: https://github.com/SGrondin/fuzzy_compare/issues

---
:camel: Pull-request generated by opam-publish v2.2.0