### PR TITLE
Package iri.0.7.0

### DIFF
--- a/packages/iri/iri.0.7.0/opam
+++ b/packages/iri/iri.0.7.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Implementation of Internationalized Resource Identifiers (IRIs)"
+maintainer: "zoggy@bat8.org"
+authors: "Zoggy <zoggy@bat8.org>"
+license: "LGPL-3.0-only"
+tags: ["iri" "web" "rfc3987"]
+homepage: "https://framagit.org/zoggy/ocaml-iri/"
+doc: "https://framagit.org/zoggy/ocaml-iri/"
+bug-reports: "https://framagit.org/zoggy/ocaml-iri/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.12.0"}
+  "sedlex" {>= "2.3"}
+  "uunf" {>= "0.9.7"}
+  "uutf" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://framagit.org/zoggy/ocaml-iri.git"
+url {
+  src:
+    "https://framagit.org/zoggy/ocaml-iri/-/archive/0.7.0/ocaml-iri-0.7.0.tar.bz2"
+  checksum: [
+    "md5=c6f5b156c6ffa182d4fbf248578da320"
+    "sha512=21f7d3766d1dab912b4115a9da578dc9fafb5191a25bc3e31940f1b0709caf8cdb652de812feed692a87e431b950013f007232170496b6d4f1834bd737b50994"
+  ]
+}


### PR DESCRIPTION
### `iri.0.7.0`
Implementation of Internationalized Resource Identifiers (IRIs)



---
* Homepage: https://framagit.org/zoggy/ocaml-iri/
* Source repo: git+https://framagit.org/zoggy/ocaml-iri.git
* Bug tracker: https://framagit.org/zoggy/ocaml-iri/issues

---
:camel: Pull-request generated by opam-publish v2.2.0