### PR TITLE
[new release] saturn_lockfree and saturn (0.4.0)

### DIFF
--- a/packages/saturn/saturn.0.4.0/opam
+++ b/packages/saturn/saturn.0.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:"KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage: "https://github.com/ocaml-multicore/saturn"
+doc: "https://ocaml-multicore.github.io/saturn"
+synopsis: "Parallelism-safe data structures for multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
+bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "3.0"}
+  "domain_shims" {>= "0.1.0"}
+  "qcheck" {with-test & >= "0.18.1"}
+  "qcheck-stm" {with-test & >= "0.2"}
+  "qcheck-alcotest" {with-test & >= "0.18.1"}
+  "alcotest" {with-test & >= "1.6.0"}
+  "yojson" {with-test &>= "2.0.2"}
+  "dscheck" {with-test & >= "0.1.0"}
+]
+available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/ocaml-multicore/saturn/releases/download/0.4.0/saturn-0.4.0.tbz"
+  checksum: [
+    "sha256=7c7bec95a27055b41aa83540fcc1c6a87c9b7ad61bc511a532b8605ea33788fb"
+    "sha512=5a95888ec9d8979ceca9b57589109f9c7df6d72e51482a3cbc99988863d0b95cc8cf7592f433efd840475e79394eacf761e3e8503c8b3bfdd1bd74d8485c584e"
+  ]
+}
+x-commit-hash: "8b9a688b53ca5330ce8fffc541c89f42d6c57089"

--- a/packages/saturn/saturn.0.4.0/opam
+++ b/packages/saturn/saturn.0.4.0/opam
@@ -19,7 +19,7 @@ depends: [
   "yojson" {with-test &>= "2.0.2"}
   "dscheck" {with-test & >= "0.1.0"}
 ]
-available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
+available: arch != "x86_32" & arch != "arm32"
 build: ["dune" "build" "-p" name "-j" jobs]
 url {
   src:

--- a/packages/saturn/saturn.0.4.0/opam
+++ b/packages/saturn/saturn.0.4.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.12"}
   "dune" {>= "3.0"}
   "domain_shims" {>= "0.1.0"}
-  "saturn_lockfree" {>= "0.4.0"}
+  "saturn_lockfree" {= version}
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-stm" {with-test & >= "0.2"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}

--- a/packages/saturn/saturn.0.4.0/opam
+++ b/packages/saturn/saturn.0.4.0/opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml" {>= "4.12"}
   "dune" {>= "3.0"}
   "domain_shims" {>= "0.1.0"}
+  "saturn_lockfree" {>= "0.4.0"}
   "qcheck" {with-test & >= "0.18.1"}
   "qcheck-stm" {with-test & >= "0.2"}
   "qcheck-alcotest" {with-test & >= "0.18.1"}

--- a/packages/saturn_lockfree/saturn_lockfree.0.4.0/opam
+++ b/packages/saturn_lockfree/saturn_lockfree.0.4.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:"KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"
+authors: ["KC Sivaramakrishnan <sk826@cl.cam.ac.uk>"]
+homepage: "https://github.com/ocaml-multicore/saturn"
+doc: "https://ocaml-multicore.github.io/saturn"
+synopsis: "Lock-free data structures for multicore OCaml"
+license: "ISC"
+dev-repo: "git+https://github.com/ocaml-multicore/saturn.git"
+bug-reports: "https://github.com/ocaml-multicore/saturn/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "dune" {>= "3.0"}
+  "domain_shims" {>= "0.1.0"}
+  "qcheck" {with-test & >= "0.18.1"}
+  "qcheck-stm" {with-test & >= "0.2"}
+  "qcheck-alcotest" {with-test & >= "0.18.1"}
+  "alcotest" {with-test & >= "1.6.0"}
+  "yojson" {with-test &>= "2.0.2"}
+  "dscheck" {with-test & >= "0.1.0"}
+]
+available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
+build: ["dune" "build" "-p" name "-j" jobs]
+url {
+  src:
+    "https://github.com/ocaml-multicore/saturn/releases/download/0.4.0/saturn-0.4.0.tbz"
+  checksum: [
+    "sha256=7c7bec95a27055b41aa83540fcc1c6a87c9b7ad61bc511a532b8605ea33788fb"
+    "sha512=5a95888ec9d8979ceca9b57589109f9c7df6d72e51482a3cbc99988863d0b95cc8cf7592f433efd840475e79394eacf761e3e8503c8b3bfdd1bd74d8485c584e"
+  ]
+}
+x-commit-hash: "8b9a688b53ca5330ce8fffc541c89f42d6c57089"

--- a/packages/saturn_lockfree/saturn_lockfree.0.4.0/opam
+++ b/packages/saturn_lockfree/saturn_lockfree.0.4.0/opam
@@ -18,7 +18,7 @@ depends: [
   "yojson" {with-test &>= "2.0.2"}
   "dscheck" {with-test & >= "0.1.0"}
 ]
-available: arch != "x86_32" & arch != "arm32" & arch != "ppc64"
+available: arch != "x86_32" & arch != "arm32"
 build: ["dune" "build" "-p" name "-j" jobs]
 url {
   src:


### PR DESCRIPTION
Lock-free data structures for multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/saturn">https://github.com/ocaml-multicore/saturn</a>
- Documentation: <a href="https://ocaml-multicore.github.io/saturn">https://ocaml-multicore.github.io/saturn</a>

##### CHANGES:

- Add docs and rename/refactor to add a lockfree package (@lyrm)
- CI clean up and set up Windows CI (@lyrm)
- Adopt OCaml Code of Conduct (@Sudha247)
- Mark alcotest as a test dependency (@Khady)
- Set QCHECK_MSG_INTERVAL to avoid clutter in CI logs (@jmid)
- Fix space leaks in MS Queue (@polytypic, @lyrm)
- Add STM tests for current data structures (@lyrm, @jmid)
