### PR TITLE
Release patched LLVM 15

### DIFF
--- a/packages/llvm/llvm.15.0.0/files/META.patch
+++ b/packages/llvm/llvm.15.0.0/files/META.patch
@@ -1,0 +1,199 @@
+diff --git a/llvm/bindings/ocaml/backends/META.llvm_backend.in b/llvm/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/llvm/bindings/ocaml/backends/META.llvm_backend.in
++++ b/llvm/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,8 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte, -llvm.static) = "shared/llvm_@TARGET@.cma"
++archive(native, -llvm.static) = "shared/llvm_@TARGET@.cmxa"
++archive(byte, llvm.static) = "static/llvm_@TARGET@.cma"
++archive(native, llvm.static) = "static/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/llvm/bindings/ocaml/llvm/META.llvm.in b/llvm/bindings/ocaml/llvm/META.llvm.in
+index 991bbc0600..a118933875 100644
+--- a/llvm/bindings/ocaml/llvm/META.llvm.in
++++ b/llvm/bindings/ocaml/llvm/META.llvm.in
+@@ -1,118 +1,148 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte, -llvm.static) = "shared/llvm.cma"
++archive(native, -llvm.static) = "shared/llvm.cmxa"
++archive(byte, llvm.static) = "static/llvm.cma"
++archive(native, llvm.static) = "static/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_analysis.cma"
++    archive(native, -llvm.static) = "shared/llvm_analysis.cmxa"
++    archive(byte, llvm.static) = "static/llvm_analysis.cma"
++    archive(native, llvm.static) = "static/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitreader.cma"
++    archive(native, llvm.static) = "static/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_bitwriter.cma"
++    archive(native, -llvm.static) = "shared/llvm_bitwriter.cmxa"
++    archive(byte, llvm.static) = "static/llvm_bitwriter.cma"
++    archive(native, llvm.static) = "static/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_executionengine.cma"
++    archive(native, -llvm.static) = "shared/llvm_executionengine.cmxa"
++    archive(byte, llvm.static) = "static/llvm_executionengine.cma"
++    archive(native, llvm.static) = "static/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_ipo.cma"
++    archive(native, -llvm.static) = "shared/llvm_ipo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_ipo.cma"
++    archive(native, llvm.static) = "static/llvm_ipo.cmxa"
+ )
+ 
+ package "debuginfo" (
+     requires = "llvm"
+-    version = "@PACKAGE_VERSION@"
++    version  = "@PACKAGE_VERSION@"
+     description = "DebugInfo support for LLVM"
+-    archive(byte) = "llvm_debuginfo.cma"
+-    archive(native) = "llvm_debuginfo.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_debuginfo.cma"
++    archive(native, -llvm.static) = "shared/llvm_debuginfo.cmxa"
++    archive(byte, llvm.static) = "static/llvm_debuginfo.cma"
++    archive(native, llvm.static) = "static/llvm_debuginfo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_irreader.cma"
++    archive(native, -llvm.static) = "shared/llvm_irreader.cmxa"
++    archive(byte, llvm.static) = "static/llvm_irreader.cma"
++    archive(native, llvm.static) = "static/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_scalar_opts.cma"
++    archive(native, -llvm.static) = "shared/llvm_scalar_opts.cmxa"
++    archive(byte, llvm.static) = "static/llvm_scalar_opts.cma"
++    archive(native, llvm.static) = "static/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_transform_utils.cma"
++    archive(native, -llvm.static) = "shared/llvm_transform_utils.cmxa"
++    archive(byte, llvm.static) = "static/llvm_transform_utils.cma"
++    archive(native, llvm.static) = "static/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_vectorize.cma"
++    archive(native, -llvm.static) = "shared/llvm_vectorize.cmxa"
++    archive(byte, llvm.static) = "static/llvm_vectorize.cma"
++    archive(native, llvm.static) = "static/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_passmgr_builder.cma"
++    archive(native, -llvm.static) = "shared/llvm_passmgr_builder.cmxa"
++    archive(byte, llvm.static) = "static/llvm_passmgr_builder.cma"
++    archive(native, llvm.static) = "static/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_target.cma"
++    archive(native, -llvm.static) = "shared/llvm_target.cmxa"
++    archive(byte, llvm.static) = "static/llvm_target.cma"
++    archive(native, llvm.static) = "static/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_linker.cma"
++    archive(native, -llvm.static) = "shared/llvm_linker.cmxa"
++    archive(byte, llvm.static) = "static/llvm_linker.cma"
++    archive(native, llvm.static) = "static/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte, -llvm.static) = "shared/llvm_all_backends.cma"
++    archive(native, -llvm.static) = "shared/llvm_all_backends.cmxa"
++    archive(byte, llvm.static) = "static/llvm_all_backends.cma"
++    archive(native, llvm.static) = "static/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.15.0.0/files/fix-macos.patch
+++ b/packages/llvm/llvm.15.0.0/files/fix-macos.patch
@@ -1,0 +1,30 @@
+From 98ca3c8802d0ae92a5baf34ffdc454d680276845 Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Sat, 25 Dec 2021 18:21:57 +0000
+Subject: [PATCH 2/2] Fix support for building the OCaml binding on macOS
+
+The output of ocamlmklib is always .a and .so
+---
+ llvm-project/llvm/cmake/modules/AddOCaml.cmake | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/llvm-project/llvm/cmake/modules/AddOCaml.cmake b/llvm-project/llvm/cmake/modules/AddOCaml.cmake
+index b7e2ba430344..dc80abcc6e75 100644
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
+@@ -40,10 +40,10 @@ function(add_ocaml_library name)
+   set(ocaml_outputs "${bin}/${name}.cma")
+   if( ARG_C )
+     list(APPEND ocaml_outputs
+-         "${bin}/lib${name}${CMAKE_STATIC_LIBRARY_SUFFIX}")
++         "${bin}/lib${name}.a")
+     if ( BUILD_SHARED_LIBS )
+       list(APPEND ocaml_outputs
+-           "${bin}/dll${name}${CMAKE_SHARED_LIBRARY_SUFFIX}")
++           "${bin}/dll${name}.so")
+     endif()
+   endif()
+   if( HAVE_OCAMLOPT )
+-- 
+2.34.0
+

--- a/packages/llvm/llvm.15.0.0/files/fix-rhel.patch
+++ b/packages/llvm/llvm.15.0.0/files/fix-rhel.patch
@@ -1,0 +1,45 @@
+From 58e8402f9000d0dfe67b3df99ed8cd21b8325acd Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Sun, 26 Dec 2021 05:09:10 +0000
+Subject: [PATCH] Handle RHEL-based distributions (do not have
+ libLLVM-<VERSION>.so, only libLLVM.so)
+
+---
+ llvm/cmake/modules/AddOCaml.cmake | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+index dc80abcc6e75..f51a339f084b 100644
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
+@@ -66,20 +66,22 @@ function(add_ocaml_library name)
+     list(APPEND ocaml_flags "-custom")
+   endif()
+ 
++  if(LLVM_OCAML_OUT_OF_TREE)
++    list(APPEND ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
++  endif()
++
+   if(LLVM_LINK_LLVM_DYLIB)
+     list(APPEND ocaml_flags "-lLLVM")
+   else()
+     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-    if( BUILD_SHARED_LIBS )
+-      list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
++
++    if(BUILD_SHARED_LIBS AND LLVM_OCAML_OUT_OF_TREE)
++      list(APPEND ocaml_flags ${LLVM_OCAML_EXTERNAL_LLVM_LIBS})
+     else()
+       foreach( llvm_lib ${llvm_libs} )
+         list(APPEND ocaml_flags "-l${llvm_lib}" )
+       endforeach()
+     endif()
+-    if(LLVM_OCAML_OUT_OF_TREE)
+-      list(APPEND ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
+-    endif()
+ 
+     get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+     foreach(system_lib ${system_libs})
+-- 
+2.34.0
+

--- a/packages/llvm/llvm.15.0.0/files/fix-shared.patch
+++ b/packages/llvm/llvm.15.0.0/files/fix-shared.patch
@@ -1,0 +1,37 @@
+From 7eaf48ca7f0b2ba0b5871b48fbe4a1b1460afbef Mon Sep 17 00:00:00 2001
+From: Kate <kit.ty.kate@disroot.org>
+Date: Sat, 25 Dec 2021 18:21:00 +0000
+Subject: [PATCH 1/2] Add support for out-of-tree shared linked OCaml LLVM
+ binding
+
+---
+ llvm/cmake/modules/AddOCaml.cmake | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/llvm/cmake/modules/AddOCaml.cmake b/llvm/cmake/modules/AddOCaml.cmake
+index 891c9e6d618c..b7e2ba430344 100644
+--- a/llvm/cmake/modules/AddOCaml.cmake
++++ b/llvm/cmake/modules/AddOCaml.cmake
+@@ -70,9 +70,16 @@ function(add_ocaml_library name)
+     list(APPEND ocaml_flags "-lLLVM")
+   else()
+     explicit_map_components_to_libraries(llvm_libs ${ARG_LLVM})
+-    foreach( llvm_lib ${llvm_libs} )
+-      list(APPEND ocaml_flags "-l${llvm_lib}" )
+-    endforeach()
++    if( BUILD_SHARED_LIBS )
++      list(APPEND ocaml_flags "-lLLVM-${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")
++    else()
++      foreach( llvm_lib ${llvm_libs} )
++        list(APPEND ocaml_flags "-l${llvm_lib}" )
++      endforeach()
++    endif()
++    if(LLVM_OCAML_OUT_OF_TREE)
++      list(APPEND ocaml_flags "-L${LLVM_OCAML_EXTERNAL_LLVM_LIBDIR}" )
++    endif()
+ 
+     get_property(system_libs TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
+     foreach(system_lib ${system_libs})
+-- 
+2.34.0
+

--- a/packages/llvm/llvm.15.0.0/files/install.sh
+++ b/packages/llvm/llvm.15.0.0/files/install.sh
@@ -1,0 +1,78 @@
+#!/bin/bash -ex
+
+llvm_config="$1"
+libdir="$2"
+cmake="$3"
+make="$4"
+action="$5"
+
+function filter_experimental_targets {
+    sed 's/AVR//g' | sed 's/M68k//g' | sed 's/Nios2//g' | xargs
+}
+
+function llvm_build {
+    cd llvm
+
+    # Copy the required Common LLVM CMake modules to the source tree
+    cp ../cmake/Modules/* cmake/
+
+    mkdir "build-$1"
+    cd "build-$1"
+
+    "$cmake" \
+        -DCMAKE_BUILD_TYPE="`"$llvm_config" --build-mode`" \
+        -DLLVM_TARGETS_TO_BUILD="`"$llvm_config" --targets-built | filter_experimental_targets | sed 's/ /;/g'`" \
+        -DLLVM_OCAML_EXTERNAL_LLVM_LIBDIR="`"$llvm_config" --libdir`" \
+        -DBUILD_SHARED_LIBS=`[ $1 = "shared" ] && echo TRUE || echo FALSE` \
+        -DLLVM_OCAML_OUT_OF_TREE=TRUE \
+        -DLLVM_OCAML_INSTALL_PATH="${libdir}" \
+        -DLLVM_OCAML_EXTERNAL_LLVM_LIBS="`"$llvm_config" --libs`" \
+        ..
+    $make ocaml_all
+
+    cd ../..
+}
+
+function llvm_install {
+  cd llvm
+  if test -d "build-$1"; then
+    cd "build-$1"
+
+    "$cmake" -P bindings/ocaml/cmake_install.cmake
+
+    mkdir "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cma "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/*.cmxa "${libdir}"/llvm/$1
+    mv "${libdir}"/llvm/llvm*.a "${libdir}"/llvm/$1
+
+    cd ..
+  fi
+  cd ..
+}
+
+case "$action" in
+"build")
+  if "$llvm_config" --link-static --libs && "$llvm_config" --link-shared --libs; then
+    patch -p1 < META.patch
+    llvm_build static
+    llvm_build shared
+  elif "$llvm_config" --link-static --libs; then
+    sed "s,%%LINKAGE%%,static," link-META.patch | patch -p1
+    llvm_build static
+  elif "$llvm_config" --link-shared --libs; then
+    sed "s,%%LINKAGE%%,shared," link-META.patch | patch -p1
+    llvm_build shared
+  else
+    echo "Link mode not recognized"
+    exit 1
+  fi
+  ;;
+"install")
+  llvm_install static
+  llvm_install shared
+  ;;
+*)
+  echo "Action not recognized"
+  exit 1
+  ;;
+esac

--- a/packages/llvm/llvm.15.0.0/files/link-META.patch
+++ b/packages/llvm/llvm.15.0.0/files/link-META.patch
@@ -1,0 +1,166 @@
+diff --git a/llvm/bindings/ocaml/backends/META.llvm_backend.in b/llvm/bindings/ocaml/backends/META.llvm_backend.in
+index bd23abe0ca4..053e7a4f2e8 100644
+--- a/llvm/bindings/ocaml/backends/META.llvm_backend.in
++++ b/llvm/bindings/ocaml/backends/META.llvm_backend.in
+@@ -2,6 +2,6 @@ name = "llvm_@TARGET@"
+ version = "@PACKAGE_VERSION@"
+ description = "@TARGET@ Backend for LLVM"
+ requires = "llvm"
+-archive(byte) = "llvm_@TARGET@.cma"
+-archive(native) = "llvm_@TARGET@.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm_@TARGET@.cma"
++archive(native) = "%%LINKAGE%%/llvm_@TARGET@.cmxa"
+ directory = "llvm"
+diff --git a/llvm/bindings/ocaml/llvm/META.llvm.in b/llvm/bindings/ocaml/llvm/META.llvm.in
+index 991bbc0600..255be6dfa3 100644
+--- a/llvm/bindings/ocaml/llvm/META.llvm.in
++++ b/llvm/bindings/ocaml/llvm/META.llvm.in
+@@ -1,118 +1,118 @@
+ name = "llvm"
+ version = "@PACKAGE_VERSION@"
+ description = "LLVM OCaml bindings"
+-archive(byte) = "llvm.cma"
+-archive(native) = "llvm.cmxa"
++archive(byte) = "%%LINKAGE%%/llvm.cma"
++archive(native) = "%%LINKAGE%%/llvm.cmxa"
+ directory = "llvm"
+ 
+ package "analysis" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Intermediate representation analysis for LLVM"
+-    archive(byte) = "llvm_analysis.cma"
+-    archive(native) = "llvm_analysis.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_analysis.cma"
++    archive(native) = "%%LINKAGE%%/llvm_analysis.cmxa"
+ )
+ 
+ package "bitreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Bitcode reader for LLVM"
+-    archive(byte) = "llvm_bitreader.cma"
+-    archive(native) = "llvm_bitreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitreader.cmxa"
+ )
+ 
+ package "bitwriter" (
+     requires = "llvm,unix"
+     version = "@PACKAGE_VERSION@"
+     description = "Bitcode writer for LLVM"
+-    archive(byte) = "llvm_bitwriter.cma"
+-    archive(native) = "llvm_bitwriter.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_bitwriter.cma"
++    archive(native) = "%%LINKAGE%%/llvm_bitwriter.cmxa"
+ )
+ 
+ package "executionengine" (
+     requires = "llvm,llvm.target,ctypes.foreign"
+     version = "@PACKAGE_VERSION@"
+     description = "JIT and Interpreter for LLVM"
+-    archive(byte) = "llvm_executionengine.cma"
+-    archive(native) = "llvm_executionengine.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_executionengine.cma"
++    archive(native) = "%%LINKAGE%%/llvm_executionengine.cmxa"
+ )
+ 
+ package "ipo" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IPO Transforms for LLVM"
+-    archive(byte) = "llvm_ipo.cma"
+-    archive(native) = "llvm_ipo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_ipo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_ipo.cmxa"
+ )
+ 
+ package "debuginfo" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "DebugInfo support for LLVM"
+-    archive(byte) = "llvm_debuginfo.cma"
+-    archive(native) = "llvm_debuginfo.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_debuginfo.cma"
++    archive(native) = "%%LINKAGE%%/llvm_debuginfo.cmxa"
+ )
+ 
+ package "irreader" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "IR assembly reader for LLVM"
+-    archive(byte) = "llvm_irreader.cma"
+-    archive(native) = "llvm_irreader.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_irreader.cma"
++    archive(native) = "%%LINKAGE%%/llvm_irreader.cmxa"
+ )
+ 
+ package "scalar_opts" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Scalar Transforms for LLVM"
+-    archive(byte) = "llvm_scalar_opts.cma"
+-    archive(native) = "llvm_scalar_opts.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_scalar_opts.cma"
++    archive(native) = "%%LINKAGE%%/llvm_scalar_opts.cmxa"
+ )
+ 
+ package "transform_utils" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Transform utilities for LLVM"
+-    archive(byte) = "llvm_transform_utils.cma"
+-    archive(native) = "llvm_transform_utils.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_transform_utils.cma"
++    archive(native) = "%%LINKAGE%%/llvm_transform_utils.cmxa"
+ )
+ 
+ package "vectorize" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Vector Transforms for LLVM"
+-    archive(byte) = "llvm_vectorize.cma"
+-    archive(native) = "llvm_vectorize.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_vectorize.cma"
++    archive(native) = "%%LINKAGE%%/llvm_vectorize.cmxa"
+ )
+ 
+ package "passmgr_builder" (
+     requires = "llvm"
+     version = "@PACKAGE_VERSION@"
+     description = "Pass Manager Builder for LLVM"
+-    archive(byte) = "llvm_passmgr_builder.cma"
+-    archive(native) = "llvm_passmgr_builder.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_passmgr_builder.cma"
++    archive(native) = "%%LINKAGE%%/llvm_passmgr_builder.cmxa"
+ )
+ 
+ package "target" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Target Information for LLVM"
+-    archive(byte) = "llvm_target.cma"
+-    archive(native) = "llvm_target.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_target.cma"
++    archive(native) = "%%LINKAGE%%/llvm_target.cmxa"
+ )
+ 
+ package "linker" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "Intermediate Representation Linker for LLVM"
+-    archive(byte) = "llvm_linker.cma"
+-    archive(native) = "llvm_linker.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_linker.cma"
++    archive(native) = "%%LINKAGE%%/llvm_linker.cmxa"
+ )
+ 
+ package "all_backends" (
+     requires = "llvm"
+     version  = "@PACKAGE_VERSION@"
+     description = "All backends for LLVM"
+-    archive(byte) = "llvm_all_backends.cma"
+-    archive(native) = "llvm_all_backends.cmxa"
++    archive(byte) = "%%LINKAGE%%/llvm_all_backends.cma"
++    archive(native) = "%%LINKAGE%%/llvm_all_backends.cmxa"
+ )

--- a/packages/llvm/llvm.15.0.0/opam
+++ b/packages/llvm/llvm.15.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Kate <kit.ty.kate@disroot.org>"
+authors: [
+  "whitequark <whitequark@whitequark.org>"
+  "The LLVM team"
+]
+license: "MIT"
+doc: "http://llvm.moe/ocaml"
+bug-reports: "http://llvm.org/bugs/"
+dev-repo: "git+http://llvm.org/git/llvm.git"
+homepage: "http://llvm.moe"
+build: ["bash" "-ex" "install.sh" "%{conf-llvm:config}%" lib "%{conf-cmake:cmd}%" make "build"]
+install: ["bash" "-ex" "install.sh" "%{conf-llvm:config}%" lib "%{conf-cmake:cmd}%" make "install"]
+depends: [
+  "ocaml" {>= "4.00.0"}
+  "ctypes" {>= "0.4"}
+  "ounit" {with-test}
+  "ocamlfind" {build}
+  "conf-llvm" {build & = version}
+  "conf-python-3" {build}
+  "conf-cmake" {build}
+]
+patches: [
+  "fix-shared.patch"
+  "fix-macos.patch"
+  "fix-rhel.patch"
+]
+synopsis: "The OCaml bindings distributed with LLVM"
+description: "Note: LLVM should be installed first."
+extra-files: [
+  ["link-META.patch" "md5=bbb99db647b80baaa34054e1a957f218"]
+  ["install.sh" "md5=2db75a6673ad476cdb464dd90021d51a"]
+  ["META.patch" "md5=c63515a9c59101ebf71ecf83ddf6ec9f"]
+  ["fix-macos.patch" "md5=86664021a2819e4a0a9ebe5f3cafe819"]
+  ["fix-shared.patch" "md5=bdc3f688681e9c56d92514ba4ef68cb9"]
+  ["fix-rhel.patch" "md5=e1db49b76f8795f3d3e276fd9e10db72"]
+]
+url {
+  src: "https://github.com/alan-j-hu/llvm-project/archive/refs/tags/release/15.x+nnp+depr.1.tar.gz"
+  checksum: "sha256=5831ee20bc5455b73859d8c36c013875888eca03d3c65735aa6e7cb401f203e3"
+}


### PR DESCRIPTION
I talked with @jberdine  and we think that getting the LLVM 15 fork with the OCaml 5 support released on OPAM is more important than details of specific build systems. We think that LLVM 15 should just be released now in the same manner that LLVM 14 was.

My personal feeling after looking into Dune is that:

- Integrating Dune into LLVM upstream will make life harder for the predominantly C++ programmers maintaining LLVM. Therefore, I don't see a path going forward that would transition away from a separate Dune LLVM repo.
- Having the option of dynamic versus static linking to LLVM is much hackier with Dune than with OCamlbuild. In general, I think Dune is opinionated in a way that is not good for multi-language projects. Perhaps this should be feedback for the Dune developers.

The ball is in the court of @kit-ty-kate to decide whether to accept this PR. Please let me know if you have any disagreement or concerns.