### PR TITLE
Package cryptoverif.2.07

### DIFF
--- a/packages/cryptoverif/cryptoverif.2.07/opam
+++ b/packages/cryptoverif/cryptoverif.2.07/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "CryptoVerif: Cryptographic protocol verifier in the computational model"
+description: """
+CryptoVerif is an automatic protocol prover sound in the computational model. It can prove
+
+  - secrecy;
+  - correspondences, which include in particular authentication;
+  - indistinguishability between two games.
+
+It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.
+
+The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).
+
+This software is under development; please use it at your own risk. Comments and bug reports welcome. 
+"""
+maintainer: "Bruno Blanchet <Bruno.Blanchet@inria.fr>"
+authors: "Bruno Blanchet <Bruno.Blanchet@inria.fr>, David Cadé <David.Cade@normalesup.org>, and Benjamin Lipp <Benjamin.Lipp@mpi-sp.org>"
+license: "CECILL-B"
+homepage: "https://cryptoverif.inria.fr"
+dev-repo: "git+https://gitlab.inria.fr/bblanche/CryptoVerif.git"
+bug-reports: "Bruno.Blanchet@inria.fr"
+depends: [ "ocaml" { >= "4.04" } "ocamlfind" { post } "cryptokit" { post } "conf-m4" { post } ]
+build: [
+       [ "./build" "byte" { !ocaml:native } ] 
+]
+install: [ "./build" "install" "%{prefix}%" ]
+url {
+  src: "http://cryptoverif.inria.fr/cryptoverif2.07.tar.gz"
+  checksum: [
+    "md5=b05495bf9320cf5647ae2054a3517c58"
+    "sha512=9605625a4c69950cb5407da236228d6a110c313c0db3f12b43527afc1c1d6ca8fc16582a8091d85a42229da0ea4ecb85433c3b28ff57dfd416c41f9180945c6d"
+  ]
+}


### PR DESCRIPTION
### `cryptoverif.2.07`
CryptoVerif: Cryptographic protocol verifier in the computational model
CryptoVerif is an automatic protocol prover sound in the computational model. It can prove

  - secrecy;
  - correspondences, which include in particular authentication;
  - indistinguishability between two games.

It provides a generic mechanism for specifying the security assumptions on cryptographic primitives, which can handle in particular symmetric encryption, message authentication codes, public-key encryption, signatures, hash functions.

The generated proofs are proofs by sequences of games, as used by cryptographers. These proofs are valid for a number of sessions polynomial in the security parameter, in the presence of an active adversary. CryptoVerif can also evaluate the probability of success of an attack against the protocol as a function of the probability of breaking each cryptographic primitive and of the number of sessions (exact security).

This software is under development; please use it at your own risk. Comments and bug reports welcome.



---
* Homepage: https://cryptoverif.inria.fr
* Source repo: git+https://gitlab.inria.fr/bblanche/CryptoVerif.git
* Bug tracker: Bruno.Blanchet@inria.fr

---
:camel: Pull-request generated by opam-publish v2.2.0