### PR TITLE
[new release] earlybird (1.2.0)

### DIFF
--- a/packages/dap/dap.1.0.0/opam
+++ b/packages/dap/dap.1.0.0/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.0/opam
+++ b/packages/dap/dap.1.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.1/opam
+++ b/packages/dap/dap.1.0.1/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/dap/dap.1.0.2/opam
+++ b/packages/dap/dap.1.0.2/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.2/opam
+++ b/packages/dap/dap.1.0.2/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/dap/dap.1.0.3/opam
+++ b/packages/dap/dap.1.0.3/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.3/opam
+++ b/packages/dap/dap.1.0.3/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/dap/dap.1.0.4/opam
+++ b/packages/dap/dap.1.0.4/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.4/opam
+++ b/packages/dap/dap.1.0.4/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/dap/dap.1.0.5/opam
+++ b/packages/dap/dap.1.0.5/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.5/opam
+++ b/packages/dap/dap.1.0.5/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/dap/dap.1.0.6/opam
+++ b/packages/dap/dap.1.0.6/opam
@@ -26,6 +26,9 @@ depends: [
   "angstrom-lwt-unix"
   "logs"
 ]
+conflicts: [
+  "result" {< "1.5"}
+]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/dap/dap.1.0.6/opam
+++ b/packages/dap/dap.1.0.6/opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_expect"
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"

--- a/packages/earlybird/earlybird.1.2.0/opam
+++ b/packages/earlybird/earlybird.1.2.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "OCaml debug adapter"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["hackwaly@qq.com"]
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocamlearlybird"
+bug-reports: "https://github.com/hackwaly/ocamlearlybird/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0" & < "5.1"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "menhir" {>= "20201216" & build}
+  "menhirLib" {>= "20201216"}
+  "ocaml-compiler-libs" {>= "0.12.3"}
+  "ppx_optcomp" {>= "0.11"}
+  "iter" {>= "1.2.1"}
+  "lwt" {>= "5.4.0"}
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react" {>= "1.1.3"}
+  "cmdliner" {>= "1.1.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "path_glob" {>= "0.2"}
+  "sexplib" {>= "0.14.0"}
+  "csexp" {>= "1.3.2"}
+  "lru" {>= "0.3.0"}
+  "dap" {>= "1.0.6"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hackwaly/ocamlearlybird.git"
+url {
+  src:
+    "https://github.com/hackwaly/ocamlearlybird/releases/download/1.2.0/earlybird-1.2.0.tbz"
+  checksum: [
+    "sha256=b86e31c7dd1bf18a3e8bcccac7011a4a27af6da9ecd14e446837a83fcd9eb83a"
+    "sha512=a150e7d10f5d7de57897f3e730f570d03803185325fb08b1ce15383f3dab6c2acae5340311ba26a84975542ccd267979cdad02f20055669c6d73d5c8af7c55e8"
+  ]
+}
+x-commit-hash: "eab4a4432495a969c57fb28c4cadbddbcb1d4352"


### PR DESCRIPTION
OCaml debug adapter

- Project page: <a href="https://github.com/hackwaly/ocamlearlybird">https://github.com/hackwaly/ocamlearlybird</a>

##### CHANGES:

### Added

* Add OCaml 4.13, 4.14 and 5.0 support.
* Add `--version` command line option.

### Changed

* Relicense under MIT (from GPL).
* Deprecate own VSCode extension in favor of VSCode OCaml Platform integration: https://github.com/ocamllabs/vscode-ocaml-platform/pull/1148.

### Fixed

* Fix being stuck if program doesn't exist (hackwaly/ocamlearlybird#49).

### Removed

* Remove OCaml 4.11 support.
