### PR TITLE
Package libbinaryen.112.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.112.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.112.0.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "4.1.0" & < "6.0.0"}
+  "ocaml" {>= "4.12"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v112.0.0/libbinaryen-v112.0.0.tar.gz"
+  checksum: [
+    "md5=aea9423c415c6e3e6adf0580c595417e"
+    "sha512=cbf1ed479f244e427b1f9b52ea5ff0ba42f11aca663b3645e0623a6d6284329ffab285e4a0be8284a27a587e31972a6eb4ae355ea6a448e6f0d7ebdb2fb83138"
+  ]
+}


### PR DESCRIPTION
### `libbinaryen.112.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
## [112.0.0](https://github.com/grain-lang/libbinaryen/compare/v111.1.0...v112.0.0) (2023-07-06)


### ⚠ BREAKING CHANGES

* Upgrade to libbinaryen v112 ([#81](https://github.com/grain-lang/libbinaryen/issues/81))

### Features

* Upgrade to libbinaryen v112 ([#81](https://github.com/grain-lang/libbinaryen/issues/81)) ([541f674](https://github.com/grain-lang/libbinaryen/commit/541f674f6047ada25a88d666714d3266d5a38bd0))

---
:camel: Pull-request generated by opam-publish v2.0.3