### PR TITLE
[new release] eio (5 packages) (0.11)

### DIFF
--- a/packages/eio/eio.0.11/opam
+++ b/packages/eio/eio.0.11/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.0.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.2.0" & with-test}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-base-compiler" {< "5.0.0~beta1"}
+  "ocaml-variants" {< "5.0.0~beta1"}
+  "ocaml-system" {< "5.0.0~beta1"}
+  "seq" {< "0.3"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.11/eio-0.11.tbz"
+  checksum: [
+    "sha256=0c33742074562631677886f4fe4a02f9672cec94297ff85c2ed854db5baa71aa"
+    "sha512=590843cb5fb3906fd5ab9911d29206172d164a53c48e635871a23c95d4cdce8ae0999480471187fdddee8c9c523148911ca140feabde6a826c317671a3b33090"
+  ]
+}
+x-commit-hash: "3fe575538d162fa7df209085b693ddf1b8e3842f"

--- a/packages/eio_linux/eio_linux.0.11/opam
+++ b/packages/eio_linux/eio_linux.0.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.2.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.11/eio-0.11.tbz"
+  checksum: [
+    "sha256=0c33742074562631677886f4fe4a02f9672cec94297ff85c2ed854db5baa71aa"
+    "sha512=590843cb5fb3906fd5ab9911d29206172d164a53c48e635871a23c95d4cdce8ae0999480471187fdddee8c9c523148911ca140feabde6a826c317671a3b33090"
+  ]
+}
+x-commit-hash: "3fe575538d162fa7df209085b693ddf1b8e3842f"

--- a/packages/eio_main/eio_main.0.11/opam
+++ b/packages/eio_main/eio_main.0.11/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.2.0" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux" {= version & os = "linux"}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.11/eio-0.11.tbz"
+  checksum: [
+    "sha256=0c33742074562631677886f4fe4a02f9672cec94297ff85c2ed854db5baa71aa"
+    "sha512=590843cb5fb3906fd5ab9911d29206172d164a53c48e635871a23c95d4cdce8ae0999480471187fdddee8c9c523148911ca140feabde6a826c317671a3b33090"
+  ]
+}
+x-commit-hash: "3fe575538d162fa7df209085b693ddf1b8e3842f"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/eio_posix/eio_posix.0.11/opam
+++ b/packages/eio_posix/eio_posix.0.11/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.2.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.11/eio-0.11.tbz"
+  checksum: [
+    "sha256=0c33742074562631677886f4fe4a02f9672cec94297ff85c2ed854db5baa71aa"
+    "sha512=590843cb5fb3906fd5ab9911d29206172d164a53c48e635871a23c95d4cdce8ae0999480471187fdddee8c9c523148911ca140feabde6a826c317671a3b33090"
+  ]
+}
+x-commit-hash: "3fe575538d162fa7df209085b693ddf1b8e3842f"

--- a/packages/eio_windows/eio_windows.0.11/opam
+++ b/packages/eio_windows/eio_windows.0.11/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.4.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v0.11/eio-0.11.tbz"
+  checksum: [
+    "sha256=0c33742074562631677886f4fe4a02f9672cec94297ff85c2ed854db5baa71aa"
+    "sha512=590843cb5fb3906fd5ab9911d29206172d164a53c48e635871a23c95d4cdce8ae0999480471187fdddee8c9c523148911ca140feabde6a826c317671a3b33090"
+  ]
+}
+x-commit-hash: "3fe575538d162fa7df209085b693ddf1b8e3842f"
+available: [os = "win32"]

--- a/packages/lwt_eio/lwt_eio.0.2/opam
+++ b/packages/lwt_eio/lwt_eio.0.2/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/lwt_eio"
 bug-reports: "https://github.com/ocaml-multicore/lwt_eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "eio" {>= "0.2"}
+  "eio" {>= "0.2" & < "0.11"}
   "lwt"
   "mdx" {>= "1.10.0" & with-test}
   "eio_main" {with-test}

--- a/packages/lwt_eio/lwt_eio.0.3/opam
+++ b/packages/lwt_eio/lwt_eio.0.3/opam
@@ -10,7 +10,7 @@ doc: "https://ocaml-multicore.github.io/lwt_eio"
 bug-reports: "https://github.com/ocaml-multicore/lwt_eio/issues"
 depends: [
   "dune" {>= "2.9"}
-  "eio" {>= "0.7"}
+  "eio" {>= "0.7" & < "0.11"}
   "lwt"
   "mdx" {>= "1.10.0" & with-test}
   "eio_main" {with-test}


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features / API changes:

- Extend `Eio.Condition` API (@talex5 ocaml-multicore/eio#563).
  - `loop_no_mutex` is a simpler and more efficient way to way for a condition.
  - `register_immediate` allows integration with other IO libraries.

- Expose `Eio.Stdenv.backend_id` (@bord-o ocaml-multicore/eio#560, reviewed by @talex5).
  Useful in tests to report which backend is being used.

- Remove deprecated features (@talex5 ocaml-multicore/eio#552, reviewed by @avsm).
  These were all already marked as deprecated in v0.10 and are now gone completely:
  - `Fiber.fork_sub`
  - `Eio_unix.{FD,Ipaddr,socketpair,getnameinfo}`
  - `Eio_linux.{FD,get_fd,get_fd_opt}`
  - `Eio_posix.Low_level.Fd`

- Allow calling `close` more than once (@talex5 ocaml-multicore/eio#547, requested by @anmonteiro, reviewed by @patricoferris, @avsm).

- Add `close` to socket type (@talex5 ocaml-multicore/eio#549).
  Simplifies the type signatures a bit by avoiding having to mention this everywhere.

Bug fixes:

- Fix handling of empty path strings (@talex5 ocaml-multicore/eio#569, reported by @SGrondin).
  Using "" instead of "." in some places resulted in an error.

- eio_posix: fix update to watched FDs on cancel (@talex5 ocaml-multicore/eio#574, reported and reviewed by @quernd).
  Cancelling the last watcher of an FD didn't remove it from the set passed to `poll`,
  which could result in constant wake-ups.

- eio_posix: fix `pread` at end-of-file (@talex5 ocaml-multicore/eio#581, reported by @SGrondin).
  It tried to return 0 instead of `End_of_file`, triggering an assertion.

- eio_posix: don't reap non-Eio child processes (@talex5 ocaml-multicore/eio#562).
  This allows spawning processes with e.g. the stdlib or Lwt
  (but see https://github.com/ocaml-multicore/lwt_eio/pull/19 for Lwt support).

- Preserve backtraces across `Domain_manager.run` (@talex5 ocaml-multicore/eio#571).
  See https://github.com/ocaml/ocaml/issues/12362.

- Correct the backend selection for Cygwin (@dra27 ocaml-multicore/eio#557).
  Use `eio_posix`, not `eio_windows` in this case.

Other changes:

- Simplify dune files with dune 3.9's `build_if` (@talex5 ocaml-multicore/eio#582).

- Remove `Waiters` from `Eio_core` (@talex5 ocaml-multicore/eio#567).
  `Eio.Switch` no longer uses this so it can finally be removed.

- Use `Fmt.Dump.signal` to format signals (@talex5, @MisterDA ocaml-multicore/eio#543).

Documentation:

- Add some notes about thread-safety in the documentation (@talex5 ocaml-multicore/eio#568).
