### PR TITLE
ocaml 5: restrict posixat

### DIFF
--- a/packages/posixat/posixat.v0.16.0/opam
+++ b/packages/posixat/posixat.v0.16.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "4.14.0"}
+  "ocaml"         {>= "4.14.0" & < "5.0"}
   "base"          {>= "v0.16" & < "v0.17"}
   "ppx_optcomp"   {>= "v0.16" & < "v0.17"}
   "ppx_sexp_conv" {>= "v0.16" & < "v0.17"}


### PR DESCRIPTION
Same as https://github.com/ocaml/opam-repository/commit/0a4351c78d9535e03c700b98d561a78f38f5c0e1
v.16.0 does not include relevant check: https://github.com/janestreet/posixat/blob/01683c24c7bf4f52b890351263538c7ac7d29262/src/posixat_stubs.c#L115