### PR TITLE
[new release] odep (0.2.0)

### DIFF
--- a/packages/odep/odep.0.2.0/opam
+++ b/packages/odep/odep.0.2.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Dependency graphs for OCaml modules, libraries and packages"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan"]
+license: "MIT"
+homepage: "https://github.com/sim642/odep"
+bug-reports: "https://github.com/sim642/odep/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "v0.13"}
+  "parsexp"
+  "opam-core" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
+  "opam-format"
+  "ocamlfind" {>= "1.8.1"}
+  "cmdliner" {>= "1.1.0"}
+  "bos"
+  "ppx_deriving"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/odep.git"
+url {
+  src:
+    "https://github.com/sim642/odep/releases/download/0.2.0/odep-0.2.0.tbz"
+  checksum: [
+    "sha256=3baaaef6b09fb90eb82e4567e7aa4e8958d0f8a2a3b6369bd1b61a1974595297"
+    "sha512=976d0d45a332eb045134610cc12121b8ab1ab3b192a5c2f1e4ef2eda4a94f3e346edc7b10311ee7a455197eea1ebf6e9016544fc459d8b9888359a5d4fea370b"
+  ]
+}
+x-commit-hash: "d2fdc38305d989be73061bafd634d0e948b4ff48"


### PR DESCRIPTION
Dependency graphs for OCaml modules, libraries and packages

- Project page: <a href="https://github.com/sim642/odep">https://github.com/sim642/odep</a>

##### CHANGES:

* Add package versions to nodes and clusters (sim642/odep#2).
* Add package dependency version constraints to edges (sim642/odep#3).
* Add package depexts (sim642/odep#5).
* Add `--with-pps` flag support for dune 3.7.0.
* Fix opam 2.2 compatibility.
* Fix non-subgraph nodes missing in Mermaid output.
