### PR TITLE
Mark conan.0.0.3 incompatible with OCaml 5.1+

### DIFF
--- a/packages/conan/conan.0.0.3/opam
+++ b/packages/conan/conan.0.0.3/opam
@@ -10,7 +10,7 @@ homepage: "https://github.com/mirage/conan"
 doc: "https://mirage.github.io/conan/"
 bug-reports: "https://github.com/mirage/conan/issues"
 depends: [
-  "ocaml"               {>= "4.08.0"}
+  "ocaml"               {>= "4.08.0" & < "5.1~"}
   "re"                  {>= "1.9.0"}
   "dune"                {>= "2.9.0"}
   "uutf"
@@ -29,6 +29,7 @@ depends: [
   "mirage-types-lwt"    {with-test}
   "mirage-runtime"      {with-test}
 ]
+available: ocaml
 conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/conan/conan.0.0.3/opam
+++ b/packages/conan/conan.0.0.3/opam
@@ -29,7 +29,6 @@ depends: [
   "mirage-types-lwt"    {with-test}
   "mirage-runtime"      {with-test}
 ]
-available: ocaml
 conflicts: ["ocaml-option-flambda"]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
It seems that conan.0.0.3 is incompatible with OCaml 5.1.
- ref: https://github.com/mirage/conan/pull/27

This is causing packages depending on conan failing on the opam-repository CI (e.g. [PR#24110](https://github.com/ocaml/opam-repository/pull/24110))

This PR add constraint to the OCaml package for conan.0.0.3 to mitigate this problem.