### PR TITLE
[new release] moonpool (0.3)

### DIFF
--- a/packages/moonpool/moonpool.0.3/opam
+++ b/packages/moonpool/moonpool.0.3/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Pools of threads supported by a pool of domains"
+maintainer: ["Simon Cruanes"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["thread" "pool" "domain"]
+homepage: "https://github.com/c-cube/moonpool"
+bug-reports: "https://github.com/c-cube/moonpool/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "either" {>= "1.0"}
+  "trace" {with-test}
+  "qcheck-core" {with-test & >= "0.19"}
+  "odoc" {with-doc}
+  "mdx" {>= "1.9.0" & with-test}
+]
+depopts: [
+  "domain-local-await" {>= "0.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/moonpool.git"
+url {
+  src:
+    "https://github.com/c-cube/moonpool/releases/download/v0.3/moonpool-0.3.tbz"
+  checksum: [
+    "sha256=c021481a8dc146a1cff962f67e82bc92a38ba7ea606582d4ce05857eecf00057"
+    "sha512=4dc2dee45aa462b48e19be1a96ddbc9f63db64643e473e710892392151af7c493720d35f6f25d254532c889aa902d5ef9a7287504b0bd1cfaa7bfb3ff9d0884f"
+  ]
+}
+x-commit-hash: "8e9628ac818b02745b13c2cc3866f8fd62edd41e"


### PR DESCRIPTION
Pools of threads supported by a pool of domains

- Project page: <a href="https://github.com/c-cube/moonpool">https://github.com/c-cube/moonpool</a>

##### CHANGES:

- add `Fork_join` for parallelizing computations. This is only
    available on OCaml 5.x because it relies on effects.
- add `Fork_join.{for_,map_array,map_list}`
- add `Fork_join.all_{list,init}`
- add `Pool.with_`
- add a channel module
- add `Runner`, change `Pool` to produce a `Runner.t`
- add a `Lock` module
- add support for domain-local-await when installed
- add `Fut.await` for OCaml >= 5.0

- fix: Fork_join.both_ignore now has a more general type

- expose `Suspend_` and its internal effect with an unstability alert.
    This is intended for implementors of `Runner` only.
- port `cpp.ml` from containers, replace previous codegen with it.
    This will provide better flexibility for supporting multiple versions
    of OCaml in the future.
- add `Pool.run_wait_block`; rename `Pool.run` into `Pool.run_async`
- fix: in blocking queue, `pop` works on a non empty closed queue
