### PR TITLE
Bisect_ppx 2.8.3: code coverage for OCaml

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.2.8.3/opam
+++ b/packages/bisect_ppx/bisect_ppx.2.8.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+
+synopsis: "Code coverage for OCaml"
+license: "MIT"
+homepage: "https://github.com/aantron/bisect_ppx"
+doc: "https://github.com/aantron/bisect_ppx"
+bug-reports: "https://github.com/aantron/bisect_ppx/issues"
+
+dev-repo: "git+https://github.com/aantron/bisect_ppx.git"
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+]
+
+depends: [
+  "base-unix"
+  "cmdliner" {>= "1.0.0"}
+  "dune" {>= "2.7.0"}
+  "ocaml" {>= "4.03.0"}
+  "ppxlib" {>= "0.28.0"}
+
+  "dune" {with-test & >= "3.0.0"}
+  "ocamlformat" {with-test & = "0.16.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@compatible"] {with-test}
+]
+
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+url {
+  src: "https://github.com/aantron/bisect_ppx/archive/2.8.3.tar.gz"
+  checksum: "md5=8c755c13e8d90f665986d842a41669f5"
+}


### PR DESCRIPTION
[**Bisect_ppx**](https://github.com/aantron/bisect_ppx) is a code coverage tool for OCaml.

Release 2.8.3 is a maintenance release. From the [changelog](https://github.com/aantron/bisect_ppx/releases/tag/2.8.3):

> Additions
>
> - ppxlib 0.28.0 and higher compatibility (aantron/bisect_ppx#413).
> - ReScript 10 support (aantron/bisect_ppx#405, reported by Quinn Dougherty).
> - ReScript 11 support (aantron/bisect_ppx#422).
>
> Bugs fixed
>
> - Show sources of `.re` files in HTML view when build system is Dune (aantron/bisect_ppx#404, reported by Konstantin Olkhovskiy).
> - Respect `[@coverage off]` in or-patterns (aantron/bisect_ppx#414, reported by Nora Sandler).
> - Add `<packages>` to Cobertura format (aantron/bisect_ppx#420, Maxim Grankin).
> - Stack overflow in HTML generation (aantron/bisect_ppx#421, Allan Blanchard).
>
> Changes
>
> - Prebuilt binaries for npm are now built on Ubuntu 20.04 and macOS 11. They were previously built on Ubuntu 18.04 and macOS 10.