### PR TITLE
[new release] domainslib (0.5.1)

### DIFF
--- a/packages/domainslib/domainslib.0.5.1/opam
+++ b/packages/domainslib/domainslib.0.5.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Parallel Structures over Domains for Multicore OCaml"
+maintainer: ["KC Sivaramakrishnan <kc@kcsrk.info>" "Sudha Parimala"]
+authors: ["KC Sivaramakrishnan <kc@kcsrk.info>"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/domainslib"
+doc: "https://ocaml-multicore.github.io/domainslib/doc"
+bug-reports: "https://github.com/ocaml-multicore/domainslib/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "5.0"}
+  "saturn" {>= "0.4.0"}
+  "domain-local-await" {>= "0.1.0"}
+  "kcas" {>= "0.3.0" & with-test}
+  "mirage-clock-unix" {with-test & >= "4.2.0"}
+  "qcheck-core" {with-test & >= "0.20"}
+  "qcheck-multicoretests-util" {with-test & >= "0.1"}
+  "qcheck-stm" {with-test & >= "0.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/domainslib.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/domainslib/releases/download/0.5.1/domainslib-0.5.1.tbz"
+  checksum: [
+    "sha256=28c25dfba5d999449736c5d6fca5e0be716d818f6f383796def84befb9835d01"
+    "sha512=b5db7c33ca4ba39028855a0adaa83218a72cffc4eecfe12bde9c1ca8db864a10ae005379697510470ba16d1eb7e859fdd7fbc15c5ec4c5a6dcb8a6ec094341ec"
+  ]
+}
+x-commit-hash: "3c807b9cb81bfb5f0c911bb54c3af90c4132eb77"


### PR DESCRIPTION
Parallel Structures over Domains for Multicore OCaml

- Project page: <a href="https://github.com/ocaml-multicore/domainslib">https://github.com/ocaml-multicore/domainslib</a>
- Documentation: <a href="https://ocaml-multicore.github.io/domainslib/doc">https://ocaml-multicore.github.io/domainslib/doc</a>

##### CHANGES:

* Add parallel_find (ocaml-multicore/domainslib#90, @gasche)
* Update CI (ocaml-multicore/domainslib#93, @Sudha247)
* Optimisation to work-stealing (ocaml-multicore/domainslib#96, @art-w)
* Improve docs presentation (ocaml-multicore/domainslib#99, @metanivek)
* Property based tests (ocaml-multicore/domainslib#100, jmid)
* Task: avoid double handler installation (ocaml-multicore/domainslib#101, @gasche & @clef-men)
* Fix a benign data-race in Chan reported by ocaml-tsan (ocaml-multicore/domainslib#103, @art-w)
* Dune, opam, and GitHub Actions fixes (ocaml-multicore/domainslib#105, @MisterDA)
* domain local await support (ocaml-multicore/domainslib#107, @polytypic)
* Windows run on GitHub Actions (ocaml-multicore/domainslib#110, @Sudha247)
* Adjust PBTs based on recommended_domain_count (ocaml-multicore/domainslib#112, @jmid)
* Test condition tweaks (ocaml-multicore/domainslib#113, @jmid)
