### PR TITLE
wasm.2.0.0 is not compatible with OCaml 5.0

### DIFF
--- a/packages/wasm/wasm.2.0.0/opam
+++ b/packages/wasm/wasm.2.0.0/opam
@@ -10,7 +10,7 @@ build: [
 ]
 install: [make "-C" "interpreter" "install"]
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
 ]


### PR DESCRIPTION
It expects bigarray.cmxa to exist.
```
#=== ERROR while compiling wasm.2.0.0 =========================================#
# context              2.2.0~alpha | linux/x86_64 | ocaml-base-compiler.5.0.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.0/.opam-switch/build/wasm.2.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C interpreter opt unopt
# exit-code            2
# env-file             ~/.opam/log/wasm-8-416e61.env
# output-file          ~/.opam/log/wasm-8-416e61.out
### output ###
# make: Entering directory '/home/opam/.opam/5.0/.opam-switch/build/wasm.2.0.0/interpreter'
# echo >_tags "true: bin_annot"
# echo >>_tags "true: debug"
# echo >>_tags "<{util,syntax,binary,text,valid,runtime,exec,script,host,main,tests}/*.cmx>: for-pack(Wasm)"
# ocamlbuild -lexflags -ml -cflags '-w +a-4-27-42-44-45-70 -warn-error +a-3' -I util -I syntax -I binary -I text -I valid -I runtime -I exec -I script -I host -I main -I tests -libs bigarray -quiet main.native
# + /home/opam/.opam/5.0/bin/ocamlopt.opt bigarray.cmxa -g -I util -I binary -I exec -I syntax -I runtime -I host -I main -I script -I text -I valid util/lib.cmx binary/utf8.cmx exec/fxx.cmx exec/f32.cmx exec/f64.cmx exec/ixx.cmx exec/i32.cmx exec/i64.cmx exec/i32_convert.cmx exec/f32_convert.cmx exec/i64_convert.cmx exec/f64_convert.cmx exec/i16.cmx exec/i8.cmx syntax/types.cmx exec/v128.cmx syntax/values.cmx util/source.cmx syntax/ast.cmx syntax/free.cmx util/error.cmx binary/encode.cmx syntax/operators.cmx binary/decode.cmx exec/eval_num.cmx exec/eval_vec.cmx runtime/func.cmx runtime/global.cmx runtime/memory.cmx runtime/table.cmx runtime/instance.cmx exec/eval.cmx host/env.cmx host/spectest.cmx main/flags.cmx script/import.cmx script/script.cmx text/parser.cmx text/lexer.cmx text/parse.cmx script/js.cmx util/sexpr.cmx text/arrange.cmx text/print.cmx valid/valid.cmx script/run.cmx main/main.cmx -o main/main.native
# File "_none_", line 1:
# Error: Cannot find file bigarray.cmxa
# Command exited with code 2.
# make: *** [Makefile:70: main.native] Error 10
# rm _tags
# make: Leaving directory '/home/opam/.opam/5.0/.opam-switch/build/wasm.2.0.0/interpreter'
```