### PR TITLE
wamp.0.1 is not compatible with yojson >= 2.0

### DIFF
--- a/packages/wamp/wamp.0.1/opam
+++ b/packages/wamp/wamp.0.1/opam
@@ -25,6 +25,7 @@ depends: [
   "uri" {< "2.0.0"}
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.0"}
+  "yojson" {< "2.0"}
 ]
 synopsis: "The Web Application Messaging Protocol"
 url {


### PR DESCRIPTION
It expects Safe.json to be available.
```
#=== ERROR while compiling wamp.0.1 ===========================================#
# context              2.2.0~alpha | linux/x86_64 | ocaml-base-compiler.4.08.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.08/.opam-switch/build/wamp.0.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/build.ml native=true native-dynlink=true
# exit-code            10
# env-file             ~/.opam/log/wamp-8-f6cdb7.env
# output-file          ~/.opam/log/wamp-8-f6cdb7.out
### output ###
# ocamlfind ocamldep -package result -package ppx_deriving.std -package ppx_deriving_yojson -package uri -modules src/wamp.ml > src/wamp.ml.depends
# ocamlfind ocamldep -package result -package ppx_deriving.std -package ppx_deriving_yojson -package uri -modules src/wamp.mli > src/wamp.mli.depends
# ocamlfind ocamlc -c -g -bin-annot -package result -package ppx_deriving.std -package ppx_deriving_yojson -package uri -w -40 -I src -o src/wamp.cmi src/wamp.mli
# + ocamlfind ocamlc -c -g -bin-annot -package result -package ppx_deriving.std -package ppx_deriving_yojson -package uri -w -40 -I src -o src/wamp.cmi src/wamp.mli
# File "src/wamp.mli", line 1, characters 28-44:
# 1 | module WList : sig type t = Yojson.Safe.json list end
#                                 ^^^^^^^^^^^^^^^^
# Error: Unbound type constructor Yojson.Safe.json
# Command exited with code 2.
```