### PR TITLE
b0 < 0.0.5 is not compatible with OCaml 5.1

### DIFF
--- a/packages/b0/b0.0.0.2/opam
+++ b/packages/b0/b0.0.0.2/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://erratique.ch/repos/b0.git"
 bug-reports: "https://github.com/b0-system/b0/issues"
 license: ["ISC" "BSD-2-Clause"]
 tags: ["dev" "org:erratique" "org:b0-system" "build"]
-depends: ["ocaml" {>= "4.08.0"}
+depends: ["ocaml" {>= "4.08.0" & < "5.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "topkg" {build & >= "1.0.3"}

--- a/packages/b0/b0.0.0.3/opam
+++ b/packages/b0/b0.0.0.3/opam
@@ -8,7 +8,7 @@ dev-repo: "git+https://erratique.ch/repos/b0.git"
 bug-reports: "https://github.com/b0-system/b0/issues"
 license: ["ISC" "BSD-2-Clause"]
 tags: ["dev" "org:erratique" "org:b0-system" "build"]
-depends: ["ocaml" {>= "4.08.0"}
+depends: ["ocaml" {>= "4.08.0" & < "5.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "topkg" {build & >= "1.0.3"}

--- a/packages/b0/b0.0.0.4/opam
+++ b/packages/b0/b0.0.0.4/opam
@@ -29,7 +29,7 @@ homepage: "https://erratique.ch/software/b0"
 doc: "https://erratique.ch/software/b0/doc"
 bug-reports: "https://github.com/b0-system/b0/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}


### PR DESCRIPTION
Does not compile with `-strict-formats` on. Fixed upstream in https://github.com/b0-system/b0/commit/1d5a886c70649a2524195947d9c9bcb9caf9e173 (included in 0.0.5)
```
#=== ERROR while compiling b0.0.0.4 ===========================================#
# context              2.2.0~alpha | linux/x86_64 | ocaml-variants.5.1.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.1/.opam-switch/build/b0.0.0.4
# command              ~/.opam/opam-init/hooks/sandbox.sh build ocaml pkg/pkg.ml build --dev-pkg false
# exit-code            1
# env-file             ~/.opam/log/b0-9-9d0aae.env
# output-file          ~/.opam/log/b0-9-9d0aae.out
### output ###
# File "src/b00/kit/b00_cli.ml", line 169, characters 35-41:
# 169 |     let pp_size ppf s = Fmt.pf ppf "% 6s" (Fmt.str "%a" Fmt.byte_size s) in
#                                          ^^^^^^
# Error: invalid format "% 6s": at character number 0, ' ' is incompatible with 's' in sub-format "% 6s"
# Command exited with code 2.
```