### PR TITLE
tezos-stdlib-unix < 11 is not compatibe with mtime >= 2.0.0

### DIFF
--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.10.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.10.2/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "domain-name" { < "0.3.1" }
   "ipaddr" { >= "4.0.0" }

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.0/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "lwt" { >= "3.0.0" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.1/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "lwt" { >= "3.0.0" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.2/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "lwt" { >= "3.0.0" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.8.3/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "lwt" { >= "3.0.0" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "re"

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.0/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.0/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
 ]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.1/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.1/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
 ]

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.2/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.2/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "ezjsonm" { >= "1.1.0" }

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.3/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.3/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "ezjsonm" { >= "1.1.0" }

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.4/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.4/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "ezjsonm" { >= "1.1.0" }

--- a/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.7/opam
+++ b/packages/tezos-stdlib-unix/tezos-stdlib-unix.9.7/opam
@@ -11,7 +11,7 @@ depends: [
   "tezos-event-logging" { = version }
   "re" { >= "1.7.2" }
   "ptime" { >= "0.8.4" }
-  "mtime" { >= "1.0.0" }
+  "mtime" { >= "1.0.0" & < "2.0.0" }
   "conf-libev"
   "ipaddr" { >= "4.0.0" }
   "ezjsonm" { >= "1.1.0" }


### PR DESCRIPTION
Uses `Span.to_ms`.
```
#=== ERROR while compiling tezos-stdlib-unix.10.2 =============================#
# context              2.2.0~alpha | linux/x86_64 | ocaml-base-compiler.4.11.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.11/.opam-switch/build/tezos-stdlib-unix.10.2
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p tezos-stdlib-unix -j 31
# exit-code            1
# env-file             ~/.opam/log/tezos-stdlib-unix-8-10f1e0.env
# output-file          ~/.opam/log/tezos-stdlib-unix-8-10f1e0.out
### output ###
# (cd _build/default && /home/opam/.opam/4.11/bin/ocamlopt.opt -w -40 -open Tezos_error_monad -open Tezos_error_monad.TzLwtreslib -open Tezos_event_logging -open Tezos_stdlib -open Data_encoding -g -I src/lib_stdlib_unix/.tezos_stdlib_unix.objs/byte -I src/lib_stdlib_unix/.tezos_stdlib_unix.objs/native -I /home/opam/.opam/4.11/lib/angstrom -I /home/opam/.opam/4.11/lib/astring -I /home/opam/.opam/4.11/lib/base -I /home/opam/.opam/4.11/lib/base/base_internalhash_types -I /home/opam/.opam/4.11/lib/base/caml -I /home/opam/.opam/4.11/lib/base/shadow_stdlib -I /home/opam/.opam/4.11/lib/bigstringaf -I /home/opam/.opam/4.11/lib/cstruct -I /home/opam/.opam/4.11/lib/data-encoding -I /home/opam/.opam/4.11/lib/domain-name -I /home/opam/.opam/4.11/lib/ezjsonm -I /home/opam/.opam/4.11/lib/fmt -I /home/opam/.opam/4.11/lib/hex -I /home/opam/.opam/4.11/lib/ipaddr -I /home/opam/.opam/4.11/lib/ipaddr/unix -I /home/opam/.opam/4.11/lib/jane-street-headers -I /home/opam/.opam/4.11/lib/json-data-encoding -I /home/opam/.opam/4.11/lib/json-data-encoding-bson -I /home/opam/.opam/4.11/lib/jsonm -I /home/opam/.opam/4.11/lib/lwt -I /home/opam/.opam/4.11/lib/lwt-canceler -I /home/opam/.opam/4.11/lib/lwt/unix -I /home/opam/.opam/4.11/lib/lwt_log -I /home/opam/.opam/4.11/lib/lwt_log/core -I /home/opam/.opam/4.11/lib/macaddr -I /home/opam/.opam/4.11/lib/mtime -I /home/opam/.opam/4.11/lib/mtime/clock/os -I /home/opam/.opam/4.11/lib/ocaml/threads -I /home/opam/.opam/4.11/lib/ocplib-endian -I /home/opam/.opam/4.11/lib/ocplib-endian/bigstring -I /home/opam/.opam/4.11/lib/ppx_compare/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_hash/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_inline_test/config -I /home/opam/.opam/4.11/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/4.11/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/4.11/lib/ptime -I /home/opam/.opam/4.11/lib/ptime/clock/os -I /home/opam/.opam/4.11/lib/re -I /home/opam/.opam/4.11/lib/seq -I /home/opam/.opam/4.11/lib/sexplib0 -I /home/opam/.opam/4.11/lib/stringext -I /home/opam/.opam/4.11/lib/tezos-error-monad -I /home/opam/.opam/4.11/lib/tezos-event-logging -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib/bare/functor-outputs -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib/bare/sigs -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib/bare/structs -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib/traced/functor-outputs -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib/traced/sigs -I /home/opam/.opam/4.11/lib/tezos-lwt-result-stdlib/traced/structs -I /home/opam/.opam/4.11/lib/tezos-stdlib -I /home/opam/.opam/4.11/lib/time_now -I /home/opam/.opam/4.11/lib/uri -I /home/opam/.opam/4.11/lib/uutf -I /home/opam/.opam/4.11/lib/zarith -intf-suffix .ml -no-alias-deps -open Tezos_stdlib_unix -o src/lib_stdlib_unix/.tezos_stdlib_unix.objs/native/tezos_stdlib_unix__Moving_average.cmx -c -impl src/lib_stdlib_unix/moving_average.ml)
# File "src/lib_stdlib_unix/moving_average.ml", line 56, characters 43-48:
# 56 |     let elapsed = int_of_float Mtime.Span.(to_ms now -. to_ms time_at_entry) in
#                                                 ^^^^^
# Error: Unbound value to_ms
```