### PR TITLE
[new release] ocamlformat, ocamlformat-rpc-lib and ocamlformat-lib (0.26.0)

### DIFF
--- a/packages/ocamlformat-lib/ocamlformat-lib.0.26.0/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.26.0/opam
@@ -45,7 +45,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"] # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
 url {
   src:
     "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.0/ocamlformat-0.26.0.tbz"
@@ -54,4 +54,4 @@ url {
     "sha512=35c0131f04c2c8ceb94f0f400e4b56690405ddebb482aec0c9962163001d9fd5b593455df08b508394949f2740ba28f1714dff9e1f17b618bdec62fd26fae281"
   ]
 }
-x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a"

--- a/packages/ocamlformat-lib/ocamlformat-lib.0.26.0/opam
+++ b/packages/ocamlformat-lib/ocamlformat-lib.0.26.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.0/ocamlformat-0.26.0.tbz"
+  checksum: [
+    "sha256=031494ab770cef10a8f6aa1cbeb5660e46c3aa6c0cd457b110fec859a75e877d"
+    "sha512=35c0131f04c2c8ceb94f0f400e4b56690405ddebb482aec0c9962163001d9fd5b593455df08b508394949f2740ba28f1714dff9e1f17b618bdec62fd26fae281"
+  ]
+}
+x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.26.0/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.0.26.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08"}
+  "csexp" {>= "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.0/ocamlformat-0.26.0.tbz"
+  checksum: [
+    "sha256=031494ab770cef10a8f6aa1cbeb5660e46c3aa6c0cd457b110fec859a75e877d"
+    "sha512=35c0131f04c2c8ceb94f0f400e4b56690405ddebb482aec0c9962163001d9fd5b593455df08b508394949f2740ba28f1714dff9e1f17b618bdec62fd26fae281"
+  ]
+}
+x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a"

--- a/packages/ocamlformat/ocamlformat.0.26.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-lib" {= version}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.0/ocamlformat-0.26.0.tbz"
+  checksum: [
+    "sha256=031494ab770cef10a8f6aa1cbeb5660e46c3aa6c0cd457b110fec859a75e877d"
+    "sha512=35c0131f04c2c8ceb94f0f400e4b56690405ddebb482aec0c9962163001d9fd5b593455df08b508394949f2740ba28f1714dff9e1f17b618bdec62fd26fae281"
+  ]
+}
+x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license

--- a/packages/ocamlformat/ocamlformat.0.26.0/opam
+++ b/packages/ocamlformat/ocamlformat.0.26.0/opam
@@ -30,7 +30,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
-license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"] # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
 url {
   src:
     "https://github.com/ocaml-ppx/ocamlformat/releases/download/0.26.0/ocamlformat-0.26.0.tbz"
@@ -39,4 +39,4 @@ url {
     "sha512=35c0131f04c2c8ceb94f0f400e4b56690405ddebb482aec0c9962163001d9fd5b593455df08b508394949f2740ba28f1714dff9e1f17b618bdec62fd26fae281"
   ]
 }
-x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a" # OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+x-commit-hash: "fe70498a8982bef951311b37aa8568218ce8801a"


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

### Removed

- Remove `--numeric` feature (ocaml-ppx/ocamlformat#2333, ocaml-ppx/ocamlformat#2357, @gpetiot)

### Deprecated

### Bug fixes

- Fix crash caused by `let f (type a) :> a M.u = ..` (ocaml-ppx/ocamlformat#2399, @Julow)
- Fix crash caused by `module T = (val (x : (module S)))` (ocaml-ppx/ocamlformat#2370, @Julow)
- Fix invalid formatting of `then begin end` (ocaml-ppx/ocamlformat#2369, @Julow)
- Protect match after `fun _ : _ ->` (ocaml-ppx/ocamlformat#2352, @Julow)
- Fix invalid formatting of `(::)` (ocaml-ppx/ocamlformat#2347, @Julow)
- Fix indentation of module-expr extensions (ocaml-ppx/ocamlformat#2323, @gpetiot)
* Remove double parentheses around tuples in a match (ocaml-ppx/ocamlformat#2308, @Julow)
* Remove extra parentheses around module packs (ocaml-ppx/ocamlformat#2305, @Julow, @gpetiot)
- Fix indentation of trailing double-semicolons (ocaml-ppx/ocamlformat#2295, @gpetiot)
- Fix formatting of comments in "disable" chunks (ocaml-ppx/ocamlformat#2279, @gpetiot)
- Fix non-stabilizing comments attached to private/virtual/mutable keywords (ocaml-ppx/ocamlformat#2272, ocaml-ppx/ocamlformat#2307, @gpetiot, @Julow)

### Changes

- Improve formatting of doc-comments (ocaml-ppx/ocamlformat#2338, ocaml-ppx/ocamlformat#2349, ocaml-ppx/ocamlformat#2376, ocaml-ppx/ocamlformat#2377, ocaml-ppx/ocamlformat#2379, ocaml-ppx/ocamlformat#2378, @Julow)
  Remove unnecessary escaping and preserve empty lines.
* Indent `as`-patterns that have parentheses (ocaml-ppx/ocamlformat#2359, @Julow)
- Don't print warnings related to odoc code-blocks when '--quiet' is set (ocaml-ppx/ocamlformat#2336, ocaml-ppx/ocamlformat#2373, @gpetiot, @Julow)
* Improve formatting of module arguments (ocaml-ppx/ocamlformat#2322, @Julow)
* Don't indent attributes after a let/val/external (ocaml-ppx/ocamlformat#2317, @Julow)
- Consistent indentation of `@@ let+ x = ...` (ocaml-ppx/ocamlformat#2315, ocaml-ppx/ocamlformat#2396, @Julow)
  It was formatted differently than `@@ let x = ...`.
* Improve formatting of class expressions and signatures (ocaml-ppx/ocamlformat#2301, ocaml-ppx/ocamlformat#2328, ocaml-ppx/ocamlformat#2387, @gpetiot, @Julow)
* Consistent indentation of `fun (type a) ->` following `fun x ->` (ocaml-ppx/ocamlformat#2294, @Julow)
* Restore short-form formatting of record field aliases (ocaml-ppx/ocamlformat#2282, ocaml-ppx/ocamlformat#2388, @gpetiot, @Julow)
* Restore short-form for first-class modules: `((module M) : (module S))` is formatted as `(module M : S)`) (ocaml-ppx/ocamlformat#2280, ocaml-ppx/ocamlformat#2300, @gpetiot, @Julow)
* Improve indentation of `~label:(fun ...` (ocaml-ppx/ocamlformat#2271, ocaml-ppx/ocamlformat#2291, ocaml-ppx/ocamlformat#2293, ocaml-ppx/ocamlformat#2298, ocaml-ppx/ocamlformat#2398, @Julow)
  The `fun` keyword is docked where possible and the arguments are indented to avoid confusion with the body.
- JaneStreet profile: treat comments as doc-comments (ocaml-ppx/ocamlformat#2261, ocaml-ppx/ocamlformat#2344, ocaml-ppx/ocamlformat#2354, ocaml-ppx/ocamlformat#2365, ocaml-ppx/ocamlformat#2392, @gpetiot, @Julow)
- Tweaks the JaneStreet profile to be more consistent with ocp-indent (ocaml-ppx/ocamlformat#2214, ocaml-ppx/ocamlformat#2281, ocaml-ppx/ocamlformat#2284, ocaml-ppx/ocamlformat#2289, ocaml-ppx/ocamlformat#2299, ocaml-ppx/ocamlformat#2302, ocaml-ppx/ocamlformat#2309, ocaml-ppx/ocamlformat#2310, ocaml-ppx/ocamlformat#2311, ocaml-ppx/ocamlformat#2313, ocaml-ppx/ocamlformat#2316, ocaml-ppx/ocamlformat#2362, ocaml-ppx/ocamlformat#2363, @gpetiot, @Julow)

### New features

- Handle short syntax for generative functor types (ocaml-ppx/ocamlformat#2348, @gpetiot)
- Improved error reporting for unstable or dropped comments (ocaml-ppx/ocamlformat#2292, @gpetiot)
