### PR TITLE
Correct 32-bit architectures for 5.1 and 5.2

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha1/opam
@@ -14,7 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64" | arch = "s390x"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~alpha2/opam
@@ -14,7 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0~beta1/opam
@@ -14,7 +14,7 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-options-vanilla" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+trunk/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64" | arch = "s390x"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~alpha2+options/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0~beta1+options/opam
@@ -13,7 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
-  "ocaml-option-bytecode-only" {arch = "ppc64"}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+trunk/opam
@@ -13,6 +13,7 @@ depends: [
   "base-threads" {post}
   "base-domains" {post}
   "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
   "ocaml-beta" {opam-version < "2.1.0"}
 ]
 conflict-class: "ocaml-core-compiler"


### PR DESCRIPTION
Alas, in #24075 I correctly fixed the bytecode-only 64-bit architectures in 5.1 and 5.2 and incorrectly broke the 32-bit architectures.

32-bit architectures can be written as `arch = "x86_32" | arch = "arm32" | arch = "ppc32"`, but I think it's better to put what @Octachron had originally put in the 5.1.0~alpha2 package and have a conjunction of the _supported_ native architectures which is what I've done here (cf. also https://github.com/ocaml/opam/issues/4633).

cc @tmcgilchrist